### PR TITLE
New port: munge @0.5.12

### DIFF
--- a/net/munge/Portfile
+++ b/net/munge/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        dun munge 0.5.12 munge-
+categories          net security
+license             {GPL-3+ LGPL-3+}
+maintainers         kornel.us:karl openmaintainer
+description         Creating and validating credentials in HPC clusters.
+long_description    MUNGE (MUNGE Uid 'N' Gid Emporium) is an authentication \
+                    service for creating and validating credentials.  It is \
+                    designed to be highly scalable for use in an HPC cluster \
+                    environment.  It allows a process to authenticate the UID \
+                    and GID of another local or remote process within a group \
+                    of hosts having common users and groups.  These hosts form \
+                    a security realm that is defined by a shared cryptographic \
+                    key.  Clients within this security realm can create and \
+                    validate credentials without the use of root privileges, \
+                    reserved ports, or platform-specific methods.
+homepage            https://dun.github.io/munge/
+
+platforms           darwin
+checksums           rmd160 0bc366a2d0a49875e7cf35ea2aebeef33490ed0c \
+                    sha256 23585c1da3f4ea7c2882511c0a08220a2be13d9c03e54486bb8546791fa6c89b
+
+# We can either use OpenSSL or libgcrypt.  Let's default to OpenSSL.
+depends_lib-append  path:lib/libssl.dylib:openssl
+configure.args      --with-crypto-lib=openssl \
+                    --with-openssl-prefix=${prefix}
+
+# Allow using libgcrypt instead of OpenSSL.
+variant libgcrypt description {Use libgcrypt for cryptographic routines} {
+    depends_lib-replace     path:lib/libssl.dylib:openssl port:libgcrypt
+    depends_lib-append      port:libgcrypt
+    configure.args-delete   --with-crypto-lib=openssl \
+                            --with-openssl-prefix=${prefix}
+    configure.args-append   --with-crypto-lib=libgcrypt \
+                            --with-libgcrypt-prefix=${prefix}
+}
+
+# Allow doing testing
+test.run            yes
+test.target         check
+
+# Create some directories, with MUNGE-required permissions.
+post-destroot {
+    xinstall -m 700 -d ${destroot}${prefix}/etc/munge
+    xinstall -m 711 -d ${destroot}${prefix}/var/lib/munge
+    xinstall -m 755 -d ${destroot}${prefix}/var/run/munge
+}
+destroot.keepdirs-append    ${destroot}${prefix}/etc/munge \
+                            ${destroot}${prefix}/var/lib/munge \
+                            ${destroot}${prefix}/var/run/munge
+
+# When activating, if a MUNGE key doesn't already exist, create a new one.
+post-activate {
+    if {![file exists ${prefix}/etc/munge/munge.key]} {
+        system "dd if=/dev/urandom of=${prefix}/etc/munge/munge.key bs=1 count=1024"
+        file attributes ${prefix}/etc/munge/munge.key -permissions 0600
+    }
+}
+notes "Once munge is activated, a random key will be generated and placed at ${prefix}/etc/munge/munge.key.  If you put in your own key, make sure only root can access it, and remember to restart munged!"
+
+# Create a startup item for munge
+startupitem.create      yes
+startupitem.name        munged 
+startupitem.executable  ${prefix}/sbin/munged --foreground
+startupitem.logfile     ${prefix}/var/log/munged.log
+startupitem.logevents   yes
+startupitem.netchange   yes


### PR DESCRIPTION
Hello!  I have a new Portfile, for a tool called [MUNGE](https://dun.github.io/munge/).  This is related to Trac ticket #50421.

munge is a tool to generate authentication credentials that can be passed from system to system. Credentials are generated using a shared key, and include generation time, UID, and GID.

munge is most noticeably used by the SLURM job-scheduler system.  Since SLURM relies on munge, this needs to go in first.

munge can use either OpenSSL or libgcrypt for the actual cryptographic work.  The current Portfile defaults to OpenSSL (with libgcrypt available as a variant), but I can flip that if you want!

Here is how you can test it:

1) Install MUNGE, using `sudo port install munge`.
2) Start the MUNGE daemon, using `sudo port load munge`.
3) Generate a sample message and authentication credential, and write it to a file, using `echo 'Hello' | munge > credential`.
4) Validate the credential, using `unmunge < credential`.

The output of Step 3 will be a Base64-encoded blob, starting with 'MUNGE:'.  The output of Step 4 will be something like this:

STATUS:           Success (0)
ENCODE_HOST:      blargh.stanford.edu (171.64.18.103)
ENCODE_TIME:      2016-10-31 12:46:53 -0700 (1477943213)
DECODE_TIME:      2016-10-31 12:47:20 -0700 (1477943240)
TTL:              300
CIPHER:           aes128 (4)
MAC:              sha1 (3)
ZIP:              none (0)
UID:              akkornel (501)
GID:              staff (20)
LENGTH:           6

Hello