### PR TITLE
New port for wallet @1.3

### DIFF
--- a/net/wallet/Portfile
+++ b/net/wallet/Portfile
@@ -1,0 +1,245 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+perl5.branches      5.24
+
+name                wallet
+version             1.3
+revision            0
+categories          net security
+license             MIT
+maintainers         kornel.us:karl openmaintainer
+description         Kerberos-authenticated secure data management
+long_description    The wallet is a system for managing secure data, \
+                    authorization rules to retrieve or change that data, \
+                    and audit rules for documenting actions taken on that \
+                    data.  Objects of various types may be stored in the \
+                    wallet or generated on request and retrieved by \
+                    authorized users.  The wallet tracks ACLs, metadata, \
+                    and trace information.  It uses Kerberos \
+                    authentication.  One of the object types it supports \
+                    is Kerberos keytabs, making it suitable as a \
+                    user-accessible front-end to Kerberos kadmind with \
+                    richer ACL and metadata operations.
+homepage            http://eyrie.org/~eagle/software/wallet/
+
+platforms           darwin
+master_sites        http://archives.eyrie.org/software/kerberos/ \
+                    http://archives.eyrie.org/software/ARCHIVE/wallet/
+checksums           rmd160 188b3561fcffe99342fcfb1312b58df3f3d919b5 \
+                    sha256 676d3d6e407509fc9da1dd87d98fadc71920dabfbc4bdeb8cde5e2bc937268b8
+
+# Start with the dependencies we know we need
+depends_lib-append  port:kerberos5 \
+                    port:remctl
+
+# Add a dependency on Module::Build
+if {${perl5.major} != ""} {
+    depends_lib-append	port:p${perl5.major}-module-build
+}
+
+# wallet 1.3 does not support Perl paths other than /usr/bin/perl, nor does it
+# support perl binaries not named "perl".  The perl/Build.PL script is also
+# missing some testing prerequisites.
+# Since we are patching autoconf and automake files, we need autoreconf.
+patchfiles          patch-autogen.diff \
+                    patch-configure.ac.diff \
+                    patch-Makefile.am.diff \
+                    patch-README.diff \
+                    patch-perl-Build.PL.diff \
+                    patch-portable-system.h.diff \
+                    patch-rename-server-keytab-backend.diff \
+                    patch-rename-server-wallet-admin.diff \
+                    patch-rename-server-wallet-backend.diff \
+                    patch-rename-server-wallet-report.diff \
+                    patch-tests-client-full-t.in.diff \
+                    patch-tests-client-prompt-t.in.diff
+use_autoreconf      yes
+
+# Use configure, and pass in the paths to MacPorts kerberos5, remctl, and perl.
+configure.args      --enable-reduced-depends \
+                    --with-remctl=${prefix} \
+                    PATH_KRB5_CONFIG=${prefix}/bin/krb5-config \
+                    PERL=${prefix}/bin/perl${perl5.major} 
+
+# Our top-level port installs the Wallet client.
+# The Wallet client is just a couple of binaries, plus man pages and docs.
+# We override the destroot to just install client stuff.
+destroot {
+    # First, install common files from the distribution
+    xinstall -d ${destroot}${prefix}/share/doc/wallet
+    xinstall -m 644 ${worksrcpath}/LICENSE \
+        ${worksrcpath}/NEWS \
+        ${worksrcpath}/README \
+        ${worksrcpath}/TODO \
+        ${destroot}${prefix}/share/doc/wallet
+
+    # Install the wallet client executables
+    # ${destroot}${prefix}/bin already exists
+    xinstall -m 755 ${worksrcpath}/client/wallet \
+        ${worksrcpath}/client/wallet-rekey \
+        ${destroot}${prefix}/bin
+
+    # Install the wallet client man pages
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 644 ${worksrcpath}/client/wallet.1 \
+        ${worksrcpath}/client/wallet-rekey.1 \
+        ${destroot}${prefix}/share/man/man1
+}
+
+# The Wallet server is entirely Perl, spawned by the remctl daemon.
+# TODO: Patch wallet remctl config files to use ${destroot}${prefix}
+subport wallet-server {
+    # We can't use perl5.setup because it overrides alot of settings that
+    # we need.
+    #perl5.setup		Wallet 1.003
+
+    long_description-append The wallet server, run by remctld, maintains \
+                            the database of object metadata and secure \
+                            objects, and responds to requests from the \
+                            wallet client.
+
+    if {${perl5.major} != ""} {
+        depends_lib-append      port:p${perl5.major}-datetime \
+                                port:p${perl5.major}-dbi \
+                                port:p${perl5.major}-dbix-class \
+                                port:p${perl5.major}-digest-md5 \
+                                port:p${perl5.major}-sql-translator \
+                                port:p${perl5.major}-timedate
+        depends_build-append    port:p${perl5.major}-crypt-generatepassword \
+                                port:p${perl5.major}-datetime-format-sqlite
+    }
+
+    # TODO: Tests have a Stanford-specific part, and a NetDB-verifier part,
+    # which need to be disabled.
+    # test.run      yes
+    # test.target   check
+
+    # We have our own destroot process, to install just server bits.
+    destroot {
+        # First, install common files from the distribution
+        xinstall -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 644 ${worksrcpath}/LICENSE \
+            ${worksrcpath}/NEWS \
+            ${worksrcpath}/README \
+            ${worksrcpath}/TODO \
+            ${destroot}${prefix}/share/doc/${subport}
+
+        # If installing the server or kdc variants, make common directories
+        # These are also created by wallet-kdc
+        xinstall -d ${destroot}${prefix}/etc/remctl/acl
+        xinstall -d ${destroot}${prefix}/etc/remctl/conf.d
+
+        # Install a set of starter remctl ACLs and configurations
+        # ${destroot}${prefix}/etc/remctl/acl is created above
+        xinstall -m 644 ${worksrcpath}/config/wallet-report.acl \
+            ${destroot}${prefix}/etc/remctl/acl/wallet-report
+
+        # ${destroot}${prefix}/etc/remctl/conf.d is created above
+        xinstall -m 644 ${worksrcpath}/config/wallet \
+            ${destroot}${prefix}/etc/remctl/conf.d/wallet
+
+        # Install the wallet server executables
+        # ${destroot}${prefix}/sbin already exists
+        xinstall -m 755 ${worksrcpath}/server/wallet-admin \
+            ${worksrcpath}/server/wallet-backend \
+            ${worksrcpath}/server/wallet-report \
+            ${destroot}${prefix}/sbin
+
+        # Install the wallet server man pages
+        # ${destroot}${prefix}/share/man/man8 already exists
+        xinstall -m 644 ${worksrcpath}/server/wallet-admin.8 \
+            ${worksrcpath}/server/wallet-backend.8 \
+            ${worksrcpath}/server/wallet-report.8 \
+            ${destroot}${prefix}/share/man/man8
+
+        # Install protocol documentataion
+        xinstall -m 644 {*}[glob ${worksrcpath}/docs/*] \
+        ${destroot}${prefix}/share/doc/${subport}
+
+        # The Perl components of Wallet server are installed by a
+        # Module::Build installer that is normally run by the Makefile.
+        # PERL_INSTALL_ROOT is used to set the destroot path; we don't
+        # set a prefix because that is already configured into MacPorts
+        # Perl, and so Module::Build uses it automatically.
+        system "env 'PERL_INSTALL_ROOT=${destroot}' '${prefix}/bin/perl${perl5.major}' '${worksrcpath}/perl/Build' 'install'"
+    }
+
+    # We have some post-activation setup that the user needs to do.
+    notes-append "
+Before using the Wallet server, you will need to choose a database
+backend to use.  MySQL, Postgres, and SQLite are known to work.
+Then you will need to install the p5-datetime-format-* and p5-dbd-*
+ports that match the database backend you chose.
+
+If you want to support getting keytabs through Wallet, then your KDC
+will need to have the wallet port installed with the +kdc variant.
+
+Other Perl modules may be required, depending on what you want to
+support.  Read ${prefix}/share/doc/wallet/setup
+for additional server configuration instructions.
+
+Wallet server runs via remctl, so be sure that remctld is running,
+and is configured correctly!
+"
+}
+
+# wallet-kdc just installs a couple of helper files that a Kerberos 5 KDC
+# can use to generate unchanging keytabs for a Wallet server.
+# TODO: Patch keytab and wallet remctl config files to use ${destroot}${prefix}
+subport wallet-kdc {
+    long_description-append This port contains a remctl script, to be \
+                            run on the Kerberos 5 KDC, that will generate \
+                            keytabs at the request of a Wallet server.  This \
+                            variant is only meant to be installed on a KDC, \
+                            and does not include Wallet server or client.
+
+    # We have our own destroot process, to install just KDC bits.
+    destroot {
+        # First, install common files from the distribution
+        xinstall -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 644 ${worksrcpath}/LICENSE \
+            ${worksrcpath}/NEWS \
+            ${worksrcpath}/README \
+            ${worksrcpath}/TODO \
+            ${destroot}${prefix}/share/doc/${subport}
+
+        # Create some common directories.
+        # (These are also created by wallet-server)
+        xinstall -d ${destroot}${prefix}/etc/remctl/acl
+        xinstall -d ${destroot}${prefix}/etc/remctl/conf.d
+
+        # Install a stub KDC ACL that keytab-backend will use
+        xinstall -d ${destroot}${prefix}/etc/krb5kdc
+        xinstall -m 640 ${worksrcpath}/config/allow-extract \
+            ${destroot}${prefix}/etc/krb5kdc/allow-extract
+
+        # Install example remctl ACLs and configurations
+        # ${destroot}${prefix}/etc/remctl/acl is created above
+        xinstall -m 644 ${worksrcpath}/config/keytab.acl \
+        ${destroot}${prefix}/etc/remctl/acl/keytab
+
+        # ${destroot}${prefix}/etc/remctl/conf.d is created above
+        xinstall -m 644 ${worksrcpath}/config/keytab \
+        ${destroot}${prefix}/etc/remctl/conf.d/keytab
+
+        # Install the keytab-backend executable
+        # ${destroot}${prefix}/sbin already exists
+        xinstall -m 755 ${worksrcpath}/server/keytab-backend \
+        ${destroot}${prefix}/sbin
+
+        # Install the keytab-backend man page
+        # ${destroot}${prefix}/share/man/man8 already exists
+        xinstall -m 644 ${worksrcpath}/server/keytab-backend.8 \
+            ${destroot}${prefix}/share/man/man8/keytab-backend.8
+    }
+
+    # We have soe post-activation setup that the user needs to do.
+    notes-append "
+To configure your KDC to generate keytabs for the Wallet server,
+you will need to configure etc/krb5kdc/allow-extract, as well as
+/etc/remctl/acl/keytab.  This uses remctl, so remctld must also
+be running and configured properly.
+"
+}

--- a/net/wallet/files/patch-Makefile.am.diff
+++ b/net/wallet/files/patch-Makefile.am.diff
@@ -1,0 +1,118 @@
+--- Makefile.am.orig
++++ Makefile.am
+@@ -100,34 +100,36 @@ PERL_DIRECTORIES = perl perl/lib perl/lib/Wallet perl/lib/Wallet/ACL	    \
+ 	perl/t/policy perl/t/style perl/t/util perl/t/verifier
+ 
+ ACLOCAL_AMFLAGS = -I m4
+-EXTRA_DIST = .gitignore .travis.yml LICENSE autogen client/wallet.pod	    \
+-	client/wallet-rekey.pod config/allow-extract config/keytab	    \
+-	config/keytab.acl config/wallet config/wallet-report.acl	    \
+-	docs/design contrib/README contrib/commerzbank/wallet-history	    \
+-	contrib/convert-srvtab-db contrib/used-principals		    \
+-	contrib/wallet-contacts contrib/wallet-rekey-periodic		    \
+-	contrib/wallet-rekey-periodic.8 contrib/wallet-summary		    \
+-	contrib/wallet-summary.8 contrib/wallet-unknown-hosts		    \
+-	contrib/wallet-unknown-hosts.8 docs/design-acl docs/design-api	    \
+-	docs/netdb-role-api docs/notes docs/objects-and-schemes docs/setup  \
+-	docs/stanford-naming examples/stanford.conf tests/HOWTO tests/TESTS \
+-	tests/config/README tests/data/allow-extract tests/data/basic.conf  \
+-	tests/data/cmd-fake tests/data/cmd-wrapper tests/data/fake-data	    \
+-	tests/data/fake-kadmin tests/data/fake-keytab			    \
+-	tests/data/fake-keytab-2 tests/data/fake-keytab-foreign		    \
+-	tests/data/fake-keytab-merge tests/data/fake-keytab-old		    \
+-	tests/data/fake-keytab-partial					    \
+-	tests/data/fake-keytab-partial-result tests/data/fake-keytab-rekey  \
+-	tests/data/fake-keytab-unknown tests/data/fake-srvtab		    \
+-	tests/data/full.conf tests/data/perl.conf tests/data/wallet.conf    \
+-	tests/docs/pod-spelling-t tests/docs/pod-t			    \
+-	tests/perl/minimum-version-t tests/perl/module-version-t	    \
+-	tests/perl/strict-t tests/server/admin-t tests/server/backend-t	    \
+-	tests/server/keytab-t tests/server/report-t tests/tap/kerberos.sh   \
+-	tests/tap/libtap.sh tests/tap/perl/Test/RRA.pm			    \
+-	tests/tap/perl/Test/RRA/Automake.pm				    \
+-	tests/tap/perl/Test/RRA/Config.pm				    \
+-	tests/tap/perl/Test/RRA/ModuleVersion.pm tests/tap/remctl.sh	    \
++EXTRA_DIST = .gitignore .travis.yml LICENSE autogen client/wallet.pod	   \
++	client/wallet-rekey.pod config/allow-extract config/keytab	   \
++	config/keytab.acl config/wallet config/wallet-report.acl	   \
++	docs/design contrib/README contrib/commerzbank/wallet-history	   \
++	contrib/convert-srvtab-db contrib/used-principals		   \
++	contrib/wallet-contacts contrib/wallet-rekey-periodic		   \
++	contrib/wallet-rekey-periodic.8 contrib/wallet-summary		   \
++	contrib/wallet-summary.8 contrib/wallet-unknown-hosts		   \
++	contrib/wallet-unknown-hosts.8 docs/design-acl docs/design-api	   \
++	docs/netdb-role-api docs/notes docs/objects-and-schemes docs/setup \
++	docs/stanford-naming examples/stanford.conf			   \
++	server/keytab-backend.in server/wallet-admin.in			   \
++	server/wallet-backend.in server/wallet-report.in tests/HOWTO	   \
++	tests/TESTS tests/config/README tests/data/allow-extract	   \
++	tests/data/basic.conf tests/data/cmd-fake tests/data/cmd-wrapper   \
++	tests/data/fake-data tests/data/fake-kadmin tests/data/fake-keytab \
++	tests/data/fake-keytab-2 tests/data/fake-keytab-foreign		   \
++	tests/data/fake-keytab-merge tests/data/fake-keytab-old		   \
++	tests/data/fake-keytab-partial					   \
++	tests/data/fake-keytab-partial-result tests/data/fake-keytab-rekey \
++	tests/data/fake-keytab-unknown tests/data/fake-srvtab		   \
++	tests/data/full.conf tests/data/perl.conf tests/data/wallet.conf   \
++	tests/docs/pod-spelling-t tests/docs/pod-t			   \
++	tests/perl/minimum-version-t tests/perl/module-version-t	   \
++	tests/perl/strict-t tests/server/admin-t tests/server/backend-t	   \
++	tests/server/keytab-t tests/server/report-t tests/tap/kerberos.sh  \
++	tests/tap/libtap.sh tests/tap/perl/Test/RRA.pm			   \
++	tests/tap/perl/Test/RRA/Automake.pm				   \
++	tests/tap/perl/Test/RRA/Config.pm				   \
++	tests/tap/perl/Test/RRA/ModuleVersion.pm tests/tap/remctl.sh	   \
+ 	tests/util/xmalloc-t $(PERL_FILES)
+ 
+ # Supporting convenience libraries used by other targets.
+@@ -150,7 +152,7 @@ client_libwallet_a_CPPFLAGS = $(REMCTL_CPPFLAGS) $(KRB5_CPPFLAGS)
+ 
+ # The client and server programs.
+ bin_PROGRAMS = client/wallet client/wallet-rekey
+-dist_sbin_SCRIPTS = server/keytab-backend server/wallet-admin \
++sbin_SCRIPTS = server/keytab-backend server/wallet-admin \
+ 	server/wallet-backend server/wallet-report
+ client_wallet_CPPFLAGS = $(REMCTL_CPPFLAGS) $(KRB5_CPPFLAGS)
+ client_wallet_LDFLAGS = $(REMCTL_LDFLAGS) $(KRB5_LDFLAGS)
+@@ -209,14 +211,30 @@ warnings:
+ 	    KRB5_CPPFLAGS='$(KRB5_CPPFLAGS_GCC)' $(check_PROGRAMS)
+ 
+ # Remove some additional files.
+-CLEANFILES = perl/t/lib/Test/RRA.pm perl/t/lib/Test/RRA/Automake.pm \
+-	perl/t/lib/Test/RRA/Config.pm
++CLEANFILES = perl/t/lib/Test/RRA.pm perl/t/lib/Test/RRA/Automake.pm	\
++	perl/t/lib/Test/RRA/Config.pm server/keytab-backend		\
++	server/wallet-admin server/wallet-backend server/wallet-report
+ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 build-aux/compile		     \
+ 	build-aux/depcomp build-aux/install-sh build-aux/missing	     \
+ 	client/wallet.1 config.h.in config.h.in~ configure		     \
+ 	contrib/wallet-report.8 server/keytab-backend.8			     \
+ 	server/wallet-admin.8 server/wallet-backend.8 server/wallet-report.8
+ 
++# For each of the Perl scripts, we need to fill in the path to the Perl
++# binary that was located during configuration.
++server/keytab-backend: $(srcdir)/server/keytab-backend.in Makefile
++	sed 's|\@PERL\@|$(PERL)|' <$(srcdir)/server/keytab-backend.in >$@
++	chmod a+x $@
++server/wallet-admin: $(srcdir)/server/wallet-admin.in Makefile
++	sed 's|\@PERL\@|$(PERL)|' <$(srcdir)/server/wallet-admin.in >$@
++	chmod a+x $@
++server/wallet-backend: $(srcdir)/server/wallet-backend.in Makefile
++	sed 's|\@PERL\@|$(PERL)|' <$(srcdir)/server/wallet-backend.in >$@
++	chmod a+x $@
++server/wallet-report: $(srcdir)/server/wallet-report.in Makefile
++	sed 's|\@PERL\@|$(PERL)|' <$(srcdir)/server/wallet-report.in >$@
++	chmod a+x $@
++
+ # Take appropriate actions in the Perl directory as well.  We don't want to
+ # always build the Perl directory in all-local, since otherwise Automake does
+ # this for every target, which overrides some hacks we have to do for Debian
+@@ -236,7 +254,7 @@ perl/blib/lib/Wallet/Config.pm: $(srcdir)/perl/lib/Wallet/Config.pm
+ 	$(INSTALL_DATA) $(srcdir)/tests/tap/perl/Test/RRA.pm perl/t/lib/Test/
+ 	$(INSTALL_DATA) $(srcdir)/tests/tap/perl/Test/RRA/Config.pm \
+ 	    perl/t/lib/Test/RRA/
+-	cd perl && perl Build.PL $(WALLET_PERL_FLAGS)
++	cd perl && $(PERL) Build.PL $(WALLET_PERL_FLAGS)
+ 	cd perl && ./Build
+ 
+ # This is a really ugly hack to only honor prefix when running make install

--- a/net/wallet/files/patch-README.diff
+++ b/net/wallet/files/patch-README.diff
@@ -1,0 +1,28 @@
+--- README.orig
++++ README
+@@ -183,14 +183,21 @@ BUILD AND INSTALLATION
+   must be specified either in krb5.conf configuration or on the wallet
+   command line or the client will exit with an error.
+ 
++  By default, wallet uses whatever perl executable exists in the current $PATH.
++  That Perl's path is what the server scripts will use, and that Perl's
++  configuration will be used to determine where the server Perl modules will be
++  installed.
++
++  To specify a particular Perl executable to use, either set the PERL
++  environment variable or pass it to configure like:
++
++      ./configure PERL=/path/to/my/perl
++
+   By default, wallet installs itself under /usr/local except for the
+   server Perl modules, which are installed into whatever default site
+   module path is used by your Perl installation.  To change the
+   installation location of the files other than the Perl modules, pass the
+-  --prefix=DIR argument to configure.  To change the Perl module
+-  installation location, you will need to run perl on Makefile.PL in the
+-  perl subdirectory of the build tree with appropriate options and rebuild
+-  the module after running make and before running make install.
++  --prefix=DIR argument to configure.
+ 
+   If remctl was installed in a path not normally searched by your
+   compiler, you must specify its installation prefix to configure with the

--- a/net/wallet/files/patch-autogen.diff
+++ b/net/wallet/files/patch-autogen.diff
@@ -1,0 +1,22 @@
+--- autogen.orig
++++ autogen
+@@ -13,10 +13,15 @@ for doc in client/wallet client/wallet-rekey ; do
+     pod2man --release="$version" --center=wallet \
+         --name=`basename "$doc" | tr a-z A-Z` "$doc".pod > "$doc".1
+ done
+-for doc in contrib/wallet-rekey-periodic contrib/wallet-summary \
+-           contrib/wallet-unknown-hosts server/keytab-backend   \
+-           server/wallet-admin server/wallet-backend            \
+-           server/wallet-report ; do
++for doc in contrib/wallet-rekey-periodic contrib/wallet-summary  \
++           contrib/wallet-unknown-hosts ; do
+     pod2man --release="$version" --center=wallet --section=8 \
+         --name=`basename "$doc" | tr a-z A-Z` "$doc" > "$doc".8
+ done
++for doc in server/keytab-backend server/wallet-admin \
++           server/wallet-admin server/wallet-backend \
++           server/wallet-report ; do
++    pod2man --release="$version" --center=wallet --section=8 \
++        --name=`basename "$doc" | tr a-z A-Z` "$doc.in" > "$doc".8
++done
++

--- a/net/wallet/files/patch-configure.ac.diff
+++ b/net/wallet/files/patch-configure.ac.diff
@@ -1,0 +1,25 @@
+--- configure.ac.orig
++++ configure.ac
+@@ -45,6 +45,14 @@ AC_ARG_WITH([wallet-port],
+         [AC_DEFINE_UNQUOTED([WALLET_PORT], [$withval],
+             [Define to the default server port.])])])
+ 
++dnl Determine the path to the Perl binary.
++AC_ARG_VAR([PERL], [Path to the Perl binary])
++AC_PATH_PROG([PERL], [perl])
++AS_IF([test -z "$PERL"],
++    [AC_MSG_ERROR([Could not find Perl binary (set PERL to the full path)])])
++AS_IF(["$PERL" -e 'require 5.008'], [:],
++    [AC_MSG_ERROR([Perl 5.8 or better is required])])
++
+ dnl Probe for required libraries.
+ RRA_LIB_REMCTL
+ RRA_LIB_KRB5
+@@ -90,6 +98,7 @@ AC_CONFIG_FILES([tests/client/basic-t], [chmod +x tests/client/basic-t])
+ AC_CONFIG_FILES([tests/client/full-t], [chmod +x tests/client/full-t])
+ AC_CONFIG_FILES([tests/client/prompt-t], [chmod +x tests/client/prompt-t])
+ AC_CONFIG_FILES([tests/client/rekey-t], [chmod +x tests/client/rekey-t])
++AC_CONFIG_COMMANDS([server], [test -d server || mkdir server])
+ AC_CONFIG_COMMANDS([tests/config],
+     [test -d tests/config || mkdir tests/config])
+ AC_OUTPUT

--- a/net/wallet/files/patch-perl-Build.PL.diff
+++ b/net/wallet/files/patch-perl-Build.PL.diff
@@ -1,0 +1,13 @@
+--- perl/Build.PL.orig
++++ perl/Build.PL
+@@ -48,6 +48,10 @@ my $build = Module::Build->new(
+         'Net::Remctl'              => 0,
+         WebAuth                    => 0,
+     },
++    test_requires => {
++        'Crypt::GeneratePassword'  => 0,
++        'DateTime::Format::SQLite' => 0,
++    },
+ );
+ 
+ # Generate the build script.

--- a/net/wallet/files/patch-portable-system.h.diff
+++ b/net/wallet/files/patch-portable-system.h.diff
@@ -1,0 +1,15 @@
+--- portable/system.h.orig
++++ portable/system.h
+@@ -136,12 +136,6 @@ extern void *reallocarray(void *, size_t, size_t);
+ #if !HAVE_SETENV
+ extern int setenv(const char *, const char *, int);
+ #endif
+-#if !HAVE_DECL_STRLCAT
+-extern size_t strlcat(char *, const char *, size_t);
+-#endif
+-#if !HAVE_DECL_STRLCPY
+-extern size_t strlcpy(char *, const char *, size_t);
+-#endif
+ 
+ /* Undo default visibility change. */
+ #pragma GCC visibility pop

--- a/net/wallet/files/patch-rename-server-keytab-backend.diff
+++ b/net/wallet/files/patch-rename-server-keytab-backend.diff
@@ -1,0 +1,496 @@
+--- server/keytab-backend	2016-01-17 19:13:02.000000000 -0800
++++ /dev/null	2016-01-23 13:57:05.000000000 -0800
+@@ -1,245 +0,0 @@
+-#!/usr/bin/perl
+-#
+-# Extract keytabs from the KDC without changing the key.
+-#
+-# This is a remctl backend that extracts existing keys from a KDC database
+-# using kadmin.local.  It requires a patched version of kadmin.local that
+-# supports the -norandkey option.  It expects a configuration file in
+-# /etc/krb5kdc/allow-extract that contains a list of regexes, one per line,
+-# matching principals that may be extracted in this fashion.  (Generally you
+-# do not want to list user principals here.)  It also expects to be able to
+-# write to a directory named /var/lib/keytabs; that's where it puts the
+-# keytabs temporarily before sending them back to via remctl.
+-#
+-# remctl should handle authorization restrictions on this script.  It doesn't
+-# do any additional authorization checks itself.
+-#
+-# The keytab for the extracted principal will be printed to standard output.
+-
+-use 5.008;
+-use strict;
+-use warnings;
+-
+-use Sys::Syslog qw(openlog syslog);
+-
+-# Path to configuration file listing principals that may be extracted.
+-our $CONFIG = '/etc/krb5kdc/allow-extract';
+-
+-# The full path to a kadmin.local that supports -norandkey.
+-our $KADMIN = '/usr/sbin/kadmin.local';
+-
+-# A temporary area into which keytabs should be written.
+-our $TMP = '/var/lib/keytabs';
+-
+-# Set to zero to suppress syslog logging, which is used only for testing.  Set
+-# to a reference to a string to append messages to that string instead.
+-our $SYSLOG;
+-$SYSLOG = 1 unless defined $SYSLOG;
+-
+-##############################################################################
+-# Logging
+-##############################################################################
+-
+-# Initialize logging.
+-sub log_init {
+-    if (ref $SYSLOG) {
+-        $$SYSLOG = '';
+-    } elsif ($SYSLOG) {
+-        openlog ('keytab-backend', 'pid', 'auth');
+-    }
+-}
+-
+-# Log a failure message to both syslog and to stderr and exit with a non-zero
+-# status.
+-sub error {
+-    my $message = join ('', @_);
+-    if (ref $SYSLOG) {
+-        $$SYSLOG .= $message . "\n";
+-    } elsif ($SYSLOG) {
+-        syslog ('err', '%s', $message);
+-    }
+-    die "keytab-backend: $message\n";
+-}
+-
+-# Log a regular message, generally for success.
+-sub info {
+-    my $message = join ('', @_);
+-    if (ref $SYSLOG) {
+-        $$SYSLOG .= $message . "\n";
+-    } elsif ($SYSLOG) {
+-        syslog ('info', '%s', $message);
+-    }
+-}
+-
+-##############################################################################
+-# Implementation
+-##############################################################################
+-
+-# Check and download the keytab.  This is in a subroutine call for easier
+-# testing.  We separately log actions unless $SYSLOG is set to 0.  remctld
+-# keeps some logs, but it won't tell us whether the download is successful or
+-# not.
+-sub download {
+-    my (@args) = @_;
+-    log_init;
+-
+-    # Set up a default identity if run from the command line.
+-    $ENV{REMOTE_USER} = getpwnam ($<) || 'UNKNOWN' unless $ENV{REMOTE_USER};
+-
+-    # Read the regexes of valid principals into memory.
+-    open (CONFIG, '<', $CONFIG) or error "cannot open $CONFIG: $!";
+-    my @valid;
+-    while (<CONFIG>) {
+-        next if /^\s*\#/;
+-        next if /^\s*$/;
+-        s/^\s+//;
+-        s/\s+$//;
+-        s/\s*\#.*//;
+-        push (@valid, qr/$_/);
+-    }
+-    close CONFIG;
+-
+-    # The first argument will be the remctl service, so skip it.
+-    if (@args == 2) {
+-        shift @args;
+-    }
+-    if (@args != 1) {
+-        error "invalid arguments: @args";
+-    }
+-    my $principal = $args[0];
+-
+-    # Ensure that we're allowed to retrieve this principal.
+-    unless ($principal =~ m%^[\w-]+(?:/[\w.-]+)?\@[\w.-]+\z%) {
+-        error "bad principal name $principal";
+-    }
+-    my $okay;
+-    for my $regex (@valid) {
+-        if ($principal =~ /$regex/) {
+-            $okay = 1;
+-            last;
+-        }
+-    }
+-    unless ($okay) {
+-        error "permission denied: $ENV{REMOTE_USER} may not retrieve"
+-            . " $principal";
+-    }
+-
+-    # Do the actual work.
+-    my $filename = "$TMP/keytab$$";
+-    my $command = "ktadd -k $filename -q -norandkey $principal";
+-    my $output = `$KADMIN -q '$command' 2>&1`;
+-    if ($? != 0) {
+-        my $status = ($? >> 8);
+-        warn $output;
+-        error "retrieve of $principal failed for $ENV{REMOTE_USER}:"
+-            . " kadmin.local exited with status $status";
+-    }
+-    open (KEYTAB, '<', $filename)
+-        or error "cannot open temporary keytab $filename: $!";
+-    print while <KEYTAB>;
+-    close KEYTAB;
+-    unlink $filename;
+-    info ("keytab $principal retrieved by $ENV{REMOTE_USER}");
+-}
+-download (@ARGV);
+-__END__
+-
+-##############################################################################
+-# Documentation
+-##############################################################################
+-
+-=for stopwords
+-keytab-backend keytabs KDC keytab kadmin.local -norandkey ktadd remctld
+-auth Allbery rekeying MERCHANTABILITY NONINFRINGEMENT sublicense
+-kadmin.local.
+-
+-=head1 NAME
+-
+-keytab-backend - Extract keytabs from the KDC without changing the key
+-
+-=head1 SYNOPSIS
+-
+-B<keytab-backend> retrieve I<principal>
+-
+-=head1 DESCRIPTION
+-
+-B<keytab-backend> retrieves a keytab for an existing principal from the
+-KDC database without changing the current key.  It allows generation of a
+-keytab for a service without rekeying that service.  It requires a
+-B<kadmin.local> patched to support the B<-norandkey> option to B<ktadd>.
+-
+-This script is intended to run under B<remctld>.  On success, it prints
+-the keytab to standard output, logs a success message to syslog (facility
+-auth, priority info), and exits with status 0.  On failure, it prints out
+-an error message, logs an error to syslog (facility auth, priority err),
+-and exits with a non-zero status.
+-
+-The principal is checked for basic sanity (only accepting alphanumerics,
+-C<_>, and C<-> with an optional instance and then only alphanumerics,
+-C<_>, C<->, and C<.> in the realm) and then checked against a
+-configuration file that lists regexes of principals that can be retrieved.
+-When deploying this software, limit as tightly as possible which
+-principals can be downloaded in this fashion.  Generally only shared
+-service principals used on multiple systems should be made available in
+-this way.
+-
+-B<keytab-backend> does not do any authorization checks.  Those should be
+-done by B<remctld> before it is called.
+-
+-=head1 FILES
+-
+-=over 4
+-
+-=item F</etc/krb5kdc/allow-extract>
+-
+-The configuration file that controls which principals can have their
+-keytabs retrieved.  Blank lines and lines starting with C<#>, as well as
+-anything after C<#> on a line, are ignored.  All other lines should be
+-Perl regular expressions, one per line, that match principals whose
+-keytabs can be retrieved by B<keytab-backend>.  Any principal that does
+-not match one of those regular expressions cannot be retrieved.
+-
+-=item F</var/lib/keytabs>
+-
+-The temporary directory used for creating keytabs.  B<keytab-backend> will
+-create the keytab in this directory, make sure that was successful, and
+-then delete the temporary file after the results have been sent to
+-standard output.
+-
+-=back
+-
+-=head1 AUTHOR
+-
+-Russ Allbery <eagle@eyrie.org>
+-
+-=head1 COPYRIGHT AND LICENSE
+-
+-Copyright 2006, 2007, 2008, 2010, 2013 The Board of Trustees of the Leland
+-Stanford Junior University
+-
+-Permission is hereby granted, free of charge, to any person obtaining a
+-copy of this software and associated documentation files (the "Software"),
+-to deal in the Software without restriction, including without limitation
+-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+-and/or sell copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in
+-all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+-DEALINGS IN THE SOFTWARE.
+-
+-=head1 SEE ALSO
+-
+-kadmin.local(8), remctld(8)
+-
+-This program is part of the wallet system.  The current version is
+-available from L<http://www.eyrie.org/~eagle/software/wallet/>.
+-
+-=cut
+--- /dev/null	2016-01-23 13:57:05.000000000 -0800
++++ server/keytab-backend.in	2016-01-17 19:13:02.000000000 -0800
+@@ -0,0 +1,245 @@
++#!@PERL@
++#
++# Extract keytabs from the KDC without changing the key.
++#
++# This is a remctl backend that extracts existing keys from a KDC database
++# using kadmin.local.  It requires a patched version of kadmin.local that
++# supports the -norandkey option.  It expects a configuration file in
++# /etc/krb5kdc/allow-extract that contains a list of regexes, one per line,
++# matching principals that may be extracted in this fashion.  (Generally you
++# do not want to list user principals here.)  It also expects to be able to
++# write to a directory named /var/lib/keytabs; that's where it puts the
++# keytabs temporarily before sending them back to via remctl.
++#
++# remctl should handle authorization restrictions on this script.  It doesn't
++# do any additional authorization checks itself.
++#
++# The keytab for the extracted principal will be printed to standard output.
++
++use 5.008;
++use strict;
++use warnings;
++
++use Sys::Syslog qw(openlog syslog);
++
++# Path to configuration file listing principals that may be extracted.
++our $CONFIG = '/etc/krb5kdc/allow-extract';
++
++# The full path to a kadmin.local that supports -norandkey.
++our $KADMIN = '/usr/sbin/kadmin.local';
++
++# A temporary area into which keytabs should be written.
++our $TMP = '/var/lib/keytabs';
++
++# Set to zero to suppress syslog logging, which is used only for testing.  Set
++# to a reference to a string to append messages to that string instead.
++our $SYSLOG;
++$SYSLOG = 1 unless defined $SYSLOG;
++
++##############################################################################
++# Logging
++##############################################################################
++
++# Initialize logging.
++sub log_init {
++    if (ref $SYSLOG) {
++        $$SYSLOG = '';
++    } elsif ($SYSLOG) {
++        openlog ('keytab-backend', 'pid', 'auth');
++    }
++}
++
++# Log a failure message to both syslog and to stderr and exit with a non-zero
++# status.
++sub error {
++    my $message = join ('', @_);
++    if (ref $SYSLOG) {
++        $$SYSLOG .= $message . "\n";
++    } elsif ($SYSLOG) {
++        syslog ('err', '%s', $message);
++    }
++    die "keytab-backend: $message\n";
++}
++
++# Log a regular message, generally for success.
++sub info {
++    my $message = join ('', @_);
++    if (ref $SYSLOG) {
++        $$SYSLOG .= $message . "\n";
++    } elsif ($SYSLOG) {
++        syslog ('info', '%s', $message);
++    }
++}
++
++##############################################################################
++# Implementation
++##############################################################################
++
++# Check and download the keytab.  This is in a subroutine call for easier
++# testing.  We separately log actions unless $SYSLOG is set to 0.  remctld
++# keeps some logs, but it won't tell us whether the download is successful or
++# not.
++sub download {
++    my (@args) = @_;
++    log_init;
++
++    # Set up a default identity if run from the command line.
++    $ENV{REMOTE_USER} = getpwnam ($<) || 'UNKNOWN' unless $ENV{REMOTE_USER};
++
++    # Read the regexes of valid principals into memory.
++    open (CONFIG, '<', $CONFIG) or error "cannot open $CONFIG: $!";
++    my @valid;
++    while (<CONFIG>) {
++        next if /^\s*\#/;
++        next if /^\s*$/;
++        s/^\s+//;
++        s/\s+$//;
++        s/\s*\#.*//;
++        push (@valid, qr/$_/);
++    }
++    close CONFIG;
++
++    # The first argument will be the remctl service, so skip it.
++    if (@args == 2) {
++        shift @args;
++    }
++    if (@args != 1) {
++        error "invalid arguments: @args";
++    }
++    my $principal = $args[0];
++
++    # Ensure that we're allowed to retrieve this principal.
++    unless ($principal =~ m%^[\w-]+(?:/[\w.-]+)?\@[\w.-]+\z%) {
++        error "bad principal name $principal";
++    }
++    my $okay;
++    for my $regex (@valid) {
++        if ($principal =~ /$regex/) {
++            $okay = 1;
++            last;
++        }
++    }
++    unless ($okay) {
++        error "permission denied: $ENV{REMOTE_USER} may not retrieve"
++            . " $principal";
++    }
++
++    # Do the actual work.
++    my $filename = "$TMP/keytab$$";
++    my $command = "ktadd -k $filename -q -norandkey $principal";
++    my $output = `$KADMIN -q '$command' 2>&1`;
++    if ($? != 0) {
++        my $status = ($? >> 8);
++        warn $output;
++        error "retrieve of $principal failed for $ENV{REMOTE_USER}:"
++            . " kadmin.local exited with status $status";
++    }
++    open (KEYTAB, '<', $filename)
++        or error "cannot open temporary keytab $filename: $!";
++    print while <KEYTAB>;
++    close KEYTAB;
++    unlink $filename;
++    info ("keytab $principal retrieved by $ENV{REMOTE_USER}");
++}
++download (@ARGV);
++__END__
++
++##############################################################################
++# Documentation
++##############################################################################
++
++=for stopwords
++keytab-backend keytabs KDC keytab kadmin.local -norandkey ktadd remctld
++auth Allbery rekeying MERCHANTABILITY NONINFRINGEMENT sublicense
++kadmin.local.
++
++=head1 NAME
++
++keytab-backend - Extract keytabs from the KDC without changing the key
++
++=head1 SYNOPSIS
++
++B<keytab-backend> retrieve I<principal>
++
++=head1 DESCRIPTION
++
++B<keytab-backend> retrieves a keytab for an existing principal from the
++KDC database without changing the current key.  It allows generation of a
++keytab for a service without rekeying that service.  It requires a
++B<kadmin.local> patched to support the B<-norandkey> option to B<ktadd>.
++
++This script is intended to run under B<remctld>.  On success, it prints
++the keytab to standard output, logs a success message to syslog (facility
++auth, priority info), and exits with status 0.  On failure, it prints out
++an error message, logs an error to syslog (facility auth, priority err),
++and exits with a non-zero status.
++
++The principal is checked for basic sanity (only accepting alphanumerics,
++C<_>, and C<-> with an optional instance and then only alphanumerics,
++C<_>, C<->, and C<.> in the realm) and then checked against a
++configuration file that lists regexes of principals that can be retrieved.
++When deploying this software, limit as tightly as possible which
++principals can be downloaded in this fashion.  Generally only shared
++service principals used on multiple systems should be made available in
++this way.
++
++B<keytab-backend> does not do any authorization checks.  Those should be
++done by B<remctld> before it is called.
++
++=head1 FILES
++
++=over 4
++
++=item F</etc/krb5kdc/allow-extract>
++
++The configuration file that controls which principals can have their
++keytabs retrieved.  Blank lines and lines starting with C<#>, as well as
++anything after C<#> on a line, are ignored.  All other lines should be
++Perl regular expressions, one per line, that match principals whose
++keytabs can be retrieved by B<keytab-backend>.  Any principal that does
++not match one of those regular expressions cannot be retrieved.
++
++=item F</var/lib/keytabs>
++
++The temporary directory used for creating keytabs.  B<keytab-backend> will
++create the keytab in this directory, make sure that was successful, and
++then delete the temporary file after the results have been sent to
++standard output.
++
++=back
++
++=head1 AUTHOR
++
++Russ Allbery <eagle@eyrie.org>
++
++=head1 COPYRIGHT AND LICENSE
++
++Copyright 2006, 2007, 2008, 2010, 2013 The Board of Trustees of the Leland
++Stanford Junior University
++
++Permission is hereby granted, free of charge, to any person obtaining a
++copy of this software and associated documentation files (the "Software"),
++to deal in the Software without restriction, including without limitation
++the rights to use, copy, modify, merge, publish, distribute, sublicense,
++and/or sell copies of the Software, and to permit persons to whom the
++Software is furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in
++all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++DEALINGS IN THE SOFTWARE.
++
++=head1 SEE ALSO
++
++kadmin.local(8), remctld(8)
++
++This program is part of the wallet system.  The current version is
++available from L<http://www.eyrie.org/~eagle/software/wallet/>.
++
++=cut

--- a/net/wallet/files/patch-rename-server-wallet-admin.diff
+++ b/net/wallet/files/patch-rename-server-wallet-admin.diff
@@ -1,0 +1,356 @@
+--- server/wallet-admin	2016-01-17 19:13:02.000000000 -0800
++++ /dev/null	2016-01-23 14:00:27.000000000 -0800
+@@ -1,175 +0,0 @@
+-#!/usr/bin/perl
+-#
+-# Wallet server administrative commands.
+-
+-use 5.008;
+-use strict;
+-use warnings;
+-
+-use Wallet::Admin;
+-
+-##############################################################################
+-# Implementation
+-##############################################################################
+-
+-# Parse and execute a command.  We wrap this in a subroutine call for easier
+-# testing.
+-sub command {
+-    die "Usage: wallet-admin <command> [<args> ...]\n" unless @_;
+-    my $admin = Wallet::Admin->new;
+-
+-    # Parse command-line options and dispatch to the appropriate calls.
+-    my ($command, @args) = @_;
+-    if ($command eq 'destroy') {
+-        die "too many arguments to destroy\n" if @args;
+-        print 'This will delete all data in the wallet database.  Are you'
+-            . ' sure (N/y)? ';
+-        my $response = <STDIN>;
+-        unless ($response and $response =~ /^y/i) {
+-            die "Aborted\n";
+-        }
+-        $admin->destroy or die $admin->error, "\n";
+-    } elsif ($command eq 'initialize') {
+-        die "too many arguments to initialize\n" if @args > 1;
+-        die "too few arguments to initialize\n" if @args < 1;
+-        die "invalid admin principal $args[0]\n"
+-            unless $args[0] =~ /^[^\@\s]+\@\S+$/;
+-        $admin->initialize (@args) or die $admin->error, "\n";
+-    } elsif ($command eq 'register') {
+-        die "too many arguments to register\n" if @args > 3;
+-        die "too few arguments to register\n" if @args < 3;
+-        my ($object, $type, $class) = @args;
+-        if ($object eq 'object') {
+-            unless ($admin->register_object ($type, $class)) {
+-                die $admin->error, "\n";
+-            }
+-        } elsif ($object eq 'verifier') {
+-            unless ($admin->register_verifier ($type, $class)) {
+-                die $admin->error, "\n";
+-            }
+-        } else {
+-            die "only object or verifier is supported for register\n";
+-        }
+-    } elsif ($command eq 'upgrade') {
+-        die "too many arguments to upgrade\n" if @args;
+-        $admin->upgrade or die $admin->error, "\n";
+-    } else {
+-        die "unknown command $command\n";
+-    }
+-}
+-command (@ARGV);
+-__END__
+-
+-##############################################################################
+-# Documentation
+-##############################################################################
+-
+-=for stopwords
+-metadata ACL hostname backend acl acls wildcard SQL Allbery verifier
+-MERCHANTABILITY NONINFRINGEMENT sublicense
+-
+-=head1 NAME
+-
+-wallet-admin - Wallet server administrative commands
+-
+-=head1 SYNOPSIS
+-
+-B<wallet-admin> I<command> [I<args> ...]
+-
+-=head1 DESCRIPTION
+-
+-B<wallet-admin> provides a command-line interface for performing
+-administrative actions for the wallet system, such as setting up a new
+-database or running reports.  It is intended to be run on the wallet
+-server as a user with access to the wallet database and configuration.
+-
+-This program is a fairly thin wrapper around Wallet::Admin that translates
+-command strings into method calls and returns the results.
+-
+-=head1 OPTIONS
+-
+-B<wallet-admin> takes no traditional options.
+-
+-=head1 COMMANDS
+-
+-=over 4
+-
+-=item destroy
+-
+-Deletes all data in the wallet database and drops all of the
+-wallet-created tables, restoring the database to its state prior to an
+-C<initialize> command.  Since this command is destructive and cannot be
+-easily recovered from, B<wallet-admin> will prompt first to be sure the
+-user intends to do this.
+-
+-=item initialize <principal>
+-
+-Given an empty database, initializes it for use with the wallet server by
+-creating the necessary tables and initial metadata.  Also creates an ACL
+-with the name ADMIN, used for administrative privileges to the wallet
+-system, and adds an ACL entry to it with a scheme of C<krb5> and an
+-instance of <principal>.  This bootstraps the authentication system and
+-allows that user to make further changes to the ADMIN ACL and the rest of
+-the wallet database.  C<initialize> uses C<localhost> as the hostname and
+-<principal> as the user when logging the history of the ADMIN ACL creation
+-and for any subsequent actions required to initialize the database.
+-
+-Before running C<initialize>, the wallet system has to be configured.  See
+-Wallet::Config(3) for more details.  Depending on the database backend
+-used, the database may also have to be created in advance.
+-
+-=item register (object | verifier) <type> <class>
+-
+-Registers an implementation of a wallet object or ACL verifier in the
+-wallet database.  The Perl class <class> is registered as the
+-implementation of an object of type <type> or an ACL verifier of scheme
+-<type>, allowing creation of objects with that type or ACL lines with that
+-scheme.
+-
+-All object and ACL implementations that come with wallet are registered by
+-default as part of database initialization, so this command is used
+-primarily to register local implementations of additional object types or
+-ACL schemes.
+-
+-=item upgrade
+-
+-Upgrades the database to the latest schema version, preserving data as
+-much as possible.
+-
+-=back
+-
+-=head1 AUTHOR
+-
+-Russ Allbery <eagle@eyrie.org>
+-
+-=head1 COPYRIGHT AND LICENSE
+-
+-Copyright 2008, 2009, 2010, 2011, 2013 The Board of Trustees of the Leland
+-Stanford Junior University
+-
+-Permission is hereby granted, free of charge, to any person obtaining a
+-copy of this software and associated documentation files (the "Software"),
+-to deal in the Software without restriction, including without limitation
+-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+-and/or sell copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in
+-all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+-DEALINGS IN THE SOFTWARE.
+-
+-=head1 SEE ALSO
+-
+-Wallet::Admin(3), Wallet::Config(3), wallet-backend(8)
+-
+-This program is part of the wallet system.  The current version is
+-available from L<http://www.eyrie.org/~eagle/software/wallet/>.
+-
+-=cut
+--- /dev/null	2016-01-23 14:00:27.000000000 -0800
++++ server/wallet-admin.in	2016-01-17 19:13:02.000000000 -0800
+@@ -0,0 +1,175 @@
++#!@PERL@
++#
++# Wallet server administrative commands.
++
++use 5.008;
++use strict;
++use warnings;
++
++use Wallet::Admin;
++
++##############################################################################
++# Implementation
++##############################################################################
++
++# Parse and execute a command.  We wrap this in a subroutine call for easier
++# testing.
++sub command {
++    die "Usage: wallet-admin <command> [<args> ...]\n" unless @_;
++    my $admin = Wallet::Admin->new;
++
++    # Parse command-line options and dispatch to the appropriate calls.
++    my ($command, @args) = @_;
++    if ($command eq 'destroy') {
++        die "too many arguments to destroy\n" if @args;
++        print 'This will delete all data in the wallet database.  Are you'
++            . ' sure (N/y)? ';
++        my $response = <STDIN>;
++        unless ($response and $response =~ /^y/i) {
++            die "Aborted\n";
++        }
++        $admin->destroy or die $admin->error, "\n";
++    } elsif ($command eq 'initialize') {
++        die "too many arguments to initialize\n" if @args > 1;
++        die "too few arguments to initialize\n" if @args < 1;
++        die "invalid admin principal $args[0]\n"
++            unless $args[0] =~ /^[^\@\s]+\@\S+$/;
++        $admin->initialize (@args) or die $admin->error, "\n";
++    } elsif ($command eq 'register') {
++        die "too many arguments to register\n" if @args > 3;
++        die "too few arguments to register\n" if @args < 3;
++        my ($object, $type, $class) = @args;
++        if ($object eq 'object') {
++            unless ($admin->register_object ($type, $class)) {
++                die $admin->error, "\n";
++            }
++        } elsif ($object eq 'verifier') {
++            unless ($admin->register_verifier ($type, $class)) {
++                die $admin->error, "\n";
++            }
++        } else {
++            die "only object or verifier is supported for register\n";
++        }
++    } elsif ($command eq 'upgrade') {
++        die "too many arguments to upgrade\n" if @args;
++        $admin->upgrade or die $admin->error, "\n";
++    } else {
++        die "unknown command $command\n";
++    }
++}
++command (@ARGV);
++__END__
++
++##############################################################################
++# Documentation
++##############################################################################
++
++=for stopwords
++metadata ACL hostname backend acl acls wildcard SQL Allbery verifier
++MERCHANTABILITY NONINFRINGEMENT sublicense
++
++=head1 NAME
++
++wallet-admin - Wallet server administrative commands
++
++=head1 SYNOPSIS
++
++B<wallet-admin> I<command> [I<args> ...]
++
++=head1 DESCRIPTION
++
++B<wallet-admin> provides a command-line interface for performing
++administrative actions for the wallet system, such as setting up a new
++database or running reports.  It is intended to be run on the wallet
++server as a user with access to the wallet database and configuration.
++
++This program is a fairly thin wrapper around Wallet::Admin that translates
++command strings into method calls and returns the results.
++
++=head1 OPTIONS
++
++B<wallet-admin> takes no traditional options.
++
++=head1 COMMANDS
++
++=over 4
++
++=item destroy
++
++Deletes all data in the wallet database and drops all of the
++wallet-created tables, restoring the database to its state prior to an
++C<initialize> command.  Since this command is destructive and cannot be
++easily recovered from, B<wallet-admin> will prompt first to be sure the
++user intends to do this.
++
++=item initialize <principal>
++
++Given an empty database, initializes it for use with the wallet server by
++creating the necessary tables and initial metadata.  Also creates an ACL
++with the name ADMIN, used for administrative privileges to the wallet
++system, and adds an ACL entry to it with a scheme of C<krb5> and an
++instance of <principal>.  This bootstraps the authentication system and
++allows that user to make further changes to the ADMIN ACL and the rest of
++the wallet database.  C<initialize> uses C<localhost> as the hostname and
++<principal> as the user when logging the history of the ADMIN ACL creation
++and for any subsequent actions required to initialize the database.
++
++Before running C<initialize>, the wallet system has to be configured.  See
++Wallet::Config(3) for more details.  Depending on the database backend
++used, the database may also have to be created in advance.
++
++=item register (object | verifier) <type> <class>
++
++Registers an implementation of a wallet object or ACL verifier in the
++wallet database.  The Perl class <class> is registered as the
++implementation of an object of type <type> or an ACL verifier of scheme
++<type>, allowing creation of objects with that type or ACL lines with that
++scheme.
++
++All object and ACL implementations that come with wallet are registered by
++default as part of database initialization, so this command is used
++primarily to register local implementations of additional object types or
++ACL schemes.
++
++=item upgrade
++
++Upgrades the database to the latest schema version, preserving data as
++much as possible.
++
++=back
++
++=head1 AUTHOR
++
++Russ Allbery <eagle@eyrie.org>
++
++=head1 COPYRIGHT AND LICENSE
++
++Copyright 2008, 2009, 2010, 2011, 2013 The Board of Trustees of the Leland
++Stanford Junior University
++
++Permission is hereby granted, free of charge, to any person obtaining a
++copy of this software and associated documentation files (the "Software"),
++to deal in the Software without restriction, including without limitation
++the rights to use, copy, modify, merge, publish, distribute, sublicense,
++and/or sell copies of the Software, and to permit persons to whom the
++Software is furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in
++all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++DEALINGS IN THE SOFTWARE.
++
++=head1 SEE ALSO
++
++Wallet::Admin(3), Wallet::Config(3), wallet-backend(8)
++
++This program is part of the wallet system.  The current version is
++available from L<http://www.eyrie.org/~eagle/software/wallet/>.
++
++=cut

--- a/net/wallet/files/patch-rename-server-wallet-backend.diff
+++ b/net/wallet/files/patch-rename-server-wallet-backend.diff
@@ -1,0 +1,1396 @@
+--- server/wallet-backend	2016-01-17 19:13:02.000000000 -0800
++++ /dev/null	2016-01-23 14:00:27.000000000 -0800
+@@ -1,695 +0,0 @@
+-#!/usr/bin/perl
+-#
+-# Wallet server for storing and retrieving secure data.
+-
+-use 5.008;
+-use strict;
+-use warnings;
+-
+-use Getopt::Long qw(GetOptions);
+-use Sys::Syslog qw(openlog syslog);
+-use Wallet::Server;
+-
+-# Set to zero to suppress syslog logging, which is used for testing and for
+-# the -q option.  Set to a reference to a string to append messages to that
+-# string instead.
+-our $SYSLOG;
+-$SYSLOG = 1 unless defined $SYSLOG;
+-
+-##############################################################################
+-# Logging
+-##############################################################################
+-
+-# Initialize logging.
+-sub log_init {
+-    if (ref $SYSLOG) {
+-        $$SYSLOG = '';
+-    } elsif ($SYSLOG) {
+-        openlog ('wallet-backend', 'pid', 'auth');
+-    }
+-}
+-
+-# Get an identity string for the user suitable for including in log messages.
+-sub identity {
+-    my $identity = '';
+-    if ($ENV{REMOTE_USER}) {
+-        $identity = $ENV{REMOTE_USER};
+-        my $host = $ENV{REMOTE_HOST} || $ENV{REMOTE_ADDR};
+-        $identity .= " ($host)" if $host;
+-    }
+-    return $identity;
+-}
+-
+-# Log an error message to both syslog and to stderr and exit with a non-zero
+-# status.
+-sub error {
+-    my $message = join ('', @_);
+-    if ($SYSLOG) {
+-        my $identity = identity;
+-        my $log;
+-        if ($identity) {
+-            $log = "error for $identity: $message";
+-        } else {
+-            $log = "error: $message";
+-        }
+-        $log =~ s/[^\x20-\x7e]/_/g;
+-        if (ref $SYSLOG) {
+-            $$SYSLOG .= "$log\n";
+-        } else {
+-            syslog ('err', "%s", $log);
+-        }
+-    }
+-    die "$message\n";
+-}
+-
+-# Log a wallet failure message for a given command to both syslog and to
+-# stderr and exit with a non-zero status.  Takes the message and the command
+-# that was being run.
+-sub failure {
+-    my ($message, @command) = @_;
+-    if ($SYSLOG) {
+-        my $log = "command @command from " . identity . " failed: $message";
+-        $log =~ s/[^\x20-\x7e]/_/g;
+-        if (ref $SYSLOG) {
+-            $$SYSLOG .= "$log\n";
+-        } else {
+-            syslog ('err', "%s", $log);
+-        }
+-    }
+-    die "$message\n";
+-}
+-
+-# Log a wallet success message for a given command.
+-sub success {
+-    my (@command) = @_;
+-    if ($SYSLOG) {
+-        my $log = "command @command from " . identity . " succeeded";
+-        $log =~ s/[^\x20-\x7e]/_/g;
+-        if (ref $SYSLOG) {
+-            $$SYSLOG .= "$log\n";
+-        } else {
+-            syslog ('info', "%s", $log);
+-        }
+-    }
+-}
+-
+-##############################################################################
+-# Parameter checking
+-##############################################################################
+-
+-# Check all arguments against a very restricted set of allowed characters and
+-# to ensure the right number of arguments are taken.  The arguments are the
+-# number of arguments expected (minimum and maximum), a reference to an array
+-# of which argument numbers shouldn't be checked, and then the arguments.
+-#
+-# This function is probably temporary and will be replaced with something that
+-# knows more about the syntax of each command and can check more things.
+-sub check_args {
+-    my ($min, $max, $exclude, @args) = @_;
+-    if (@args < $min) {
+-        error "insufficient arguments";
+-    } elsif (@args > $max and $max != -1) {
+-        error "too many arguments";
+-    }
+-    my %exclude = map { $_ => 1 } @$exclude;
+-    for (my $i = 1; $i <= @args; $i++) {
+-        next if $exclude{$i};
+-        unless ($args[$i - 1] =~ m,^[\w_/\@.-]*\z,) {
+-            error "invalid characters in argument: $args[$i - 1]";
+-        }
+-    }
+-}
+-
+-##############################################################################
+-# Implementation
+-##############################################################################
+-
+-# Parse and execute a command.  We wrap this in a subroutine call for easier
+-# testing.
+-sub command {
+-    log_init;
+-    my $user = $ENV{REMOTE_USER} or error "REMOTE_USER not set";
+-    my $host = $ENV{REMOTE_HOST} || $ENV{REMOTE_ADDR}
+-        or error "neither REMOTE_HOST nor REMOTE_ADDR set";
+-
+-    # Instantiate the server object.
+-    my $server = Wallet::Server->new ($user, $host);
+-
+-    # Parse command-line options and dispatch to the appropriate calls.
+-    my ($command, @args) = @_;
+-    if ($command eq 'acl') {
+-        my $action = shift @args;
+-        if ($action eq 'add') {
+-            check_args (3, 3, [3], @args);
+-            $server->acl_add (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'check') {
+-            check_args (1, 1, [], @args);
+-            my $status = $server->acl_check (@args);
+-            if (!defined ($status)) {
+-                failure ($server->error, @_);
+-            } else {
+-                print $status ? "yes\n" : "no\n";
+-            }
+-        } elsif ($action eq 'create') {
+-            check_args (1, 1, [], @args);
+-            $server->acl_create (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'destroy') {
+-            check_args (1, 1, [], @args);
+-            $server->acl_destroy (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'history') {
+-            check_args (1, 1, [], @args);
+-            my $output = $server->acl_history (@args);
+-            if (defined $output) {
+-                print $output;
+-            } else {
+-                failure ($server->error, @_);
+-            }
+-        } elsif ($action eq 'remove') {
+-            check_args (3, 3, [3], @args);
+-            $server->acl_remove (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'rename') {
+-            check_args (2, 2, [], @args);
+-            $server->acl_rename (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'replace') {
+-            check_args (2, 2, [], @args);
+-            $server->acl_replace (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'show') {
+-            check_args (1, 1, [], @args);
+-            my $output = $server->acl_show (@args);
+-            if (defined $output) {
+-                print $output;
+-            } else {
+-                failure ($server->error, @_);
+-            }
+-        } else {
+-            error "unknown command acl $action";
+-        }
+-    } elsif ($command eq 'autocreate') {
+-        check_args (2, 2, [], @args);
+-        $server->autocreate (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'check') {
+-        check_args (2, 2, [], @args);
+-        my $status = $server->check (@args);
+-        if (!defined ($status)) {
+-            failure ($server->error, @_);
+-        } else {
+-            print $status ? "yes\n" : "no\n";
+-        }
+-    } elsif ($command eq 'comment') {
+-        check_args (2, 3, [3], @args);
+-        if (@args > 2) {
+-            $server->comment (@args) or failure ($server->error, @_);
+-        } else {
+-            my $output = $server->comment (@args);
+-            if (defined $output) {
+-                print $output, "\n";
+-            } elsif (not $server->error) {
+-                print "No comment set\n";
+-            } else {
+-                failure ($server->error, @_);
+-            }
+-        }
+-    } elsif ($command eq 'create') {
+-        check_args (2, 2, [], @args);
+-        $server->create (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'destroy') {
+-        check_args (2, 2, [], @args);
+-        $server->destroy (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'expires') {
+-        check_args (2, 3, [], @args);
+-        if (@args > 2) {
+-            $server->expires (@args) or failure ($server->error, @_);
+-        } else {
+-            my $output = $server->expires (@args);
+-            if (defined $output) {
+-                print $output, "\n";
+-            } elsif (not $server->error) {
+-                print "No expiration set\n";
+-            } else {
+-                failure ($server->error, @_);
+-            }
+-        }
+-    } elsif ($command eq 'flag') {
+-        my $action = shift @args;
+-        check_args (3, 3, [], @args);
+-        if ($action eq 'clear') {
+-            $server->flag_clear (@args) or failure ($server->error, @_);
+-        } elsif ($action eq 'set') {
+-            $server->flag_set (@args) or failure ($server->error, @_);
+-        } else {
+-            error "unknown command flag $action";
+-        }
+-    } elsif ($command eq 'get') {
+-        check_args (2, 2, [], @args);
+-        my $output = $server->get (@args);
+-        if (defined $output) {
+-            print $output;
+-        } else {
+-            failure ($server->error, @_);
+-        }
+-    } elsif ($command eq 'getacl') {
+-        check_args (3, 3, [], @args);
+-        my $output = $server->acl (@args);
+-        if (defined $output) {
+-            print $output, "\n";
+-        } elsif (not $server->error) {
+-            print "No ACL set\n";
+-        } else {
+-            failure ($server->error, @_);
+-        }
+-    } elsif ($command eq 'getattr') {
+-        check_args (3, 3, [], @args);
+-        my @result = $server->attr (@args);
+-        if (not @result and $server->error) {
+-            failure ($server->error, @_);
+-        } elsif (@result) {
+-            print join ("\n", @result, '');
+-        }
+-    } elsif ($command eq 'history') {
+-        check_args (2, 2, [], @args);
+-        my $output = $server->history (@args);
+-        if (defined $output) {
+-            print $output;
+-        } else {
+-            failure ($server->error, @_);
+-        }
+-    } elsif ($command eq 'owner') {
+-        check_args (2, 3, [], @args);
+-        if (@args > 2) {
+-            $server->owner (@args) or failure ($server->error, @_);
+-        } else {
+-            my $output = $server->owner (@args);
+-            if (defined $output) {
+-                print $output, "\n";
+-            } elsif (not $server->error) {
+-                print "No owner set\n";
+-            } else {
+-                failure ($server->error, @_);
+-            }
+-        }
+-    } elsif ($command eq 'rename') {
+-        check_args (3, 3, [], @args);
+-        $server->rename (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'setacl') {
+-        check_args (4, 4, [], @args);
+-        $server->acl (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'setattr') {
+-        check_args (4, -1, [], @args);
+-        $server->attr (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'show') {
+-        check_args (2, 2, [], @args);
+-        my $output = $server->show (@args);
+-        if (defined $output) {
+-            print $output;
+-        } else {
+-            failure ($server->error, @_);
+-        }
+-    } elsif ($command eq 'store') {
+-        check_args (2, 3, [3], @args);
+-        if (@args == 2) {
+-            local $/;
+-            $args[2] = <STDIN>;
+-        }
+-        splice (@_, 3);
+-        $server->store (@args) or failure ($server->error, @_);
+-    } elsif ($command eq 'update') {
+-        check_args (2, 2, [], @args);
+-        my $output = $server->update (@args);
+-        if (defined $output) {
+-            print $output;
+-        } else {
+-            failure ($server->error, @_);
+-        }
+-    } else {
+-        error "unknown command $command";
+-    }
+-    success (@_);
+-}
+-
+-# Parse command-line options.
+-my ($quiet);
+-Getopt::Long::config ('require_order');
+-GetOptions ('q|quiet' => \$quiet) or exit 1;
+-$SYSLOG = 0 if $quiet;
+-
+-# Run the command.
+-command (@ARGV);
+-
+-__END__
+-
+-##############################################################################
+-# Documentation
+-##############################################################################
+-
+-# The commands section of this document is duplicated from the documentation
+-# for wallet and should be kept in sync.
+-
+-=for stopwords
+-wallet-backend backend backend-specific remctld ACL acl timestamp getacl
+-setacl metadata keytab keytabs enctypes enctype ktadd KDC Allbery
+-autocreate MERCHANTABILITY NONINFRINGEMENT sublicense
+-
+-=head1 NAME
+-
+-wallet-backend - Wallet server for storing and retrieving secure data
+-
+-=head1 SYNOPSIS
+-
+-B<wallet-backend> [B<-q>] I<command> [I<args> ...]
+-
+-=head1 DESCRIPTION
+-
+-B<wallet-backend> implements the interface between B<remctld> and the
+-wallet system.  It is written to run under B<remctld> and expects the
+-authenticated identity of the remote user in the REMOTE_USER environment
+-variable.  It uses REMOTE_HOST or REMOTE_ADDR if REMOTE_HOST isn't set for
+-additional trace information.  It accepts the command from B<remctld> on
+-the command line, creates a Wallet::Server object, and calls the
+-appropriate methods.
+-
+-This program is a fairly thin wrapper around Wallet::Server that
+-translates command strings into method calls and returns the results.  It
+-does check all arguments except for the <data> argument to the store
+-command and rejects any argument not matching C<^[\w_/.-]+\z>; in other
+-words, only alphanumerics, underscore (C<_>), slash (C</>), period (C<.>),
+-and hyphen (C<->) are permitted in arguments.  This provides some
+-additional security over and above the checking already done by the rest
+-of the wallet code.
+-
+-=head1 OPTIONS
+-
+-=over 4
+-
+-=item B<--quiet>, B<-q>
+-
+-If this option is given, B<wallet-backend> will not log its actions to
+-syslog.
+-
+-=back
+-
+-=head1 COMMANDS
+-
+-Most commands are only available to wallet administrators (users on the
+-C<ADMIN> ACL).  The exceptions are C<acl check>, C<check>, C<get>,
+-C<store>, C<show>, C<destroy>, C<flag clear>, C<flag set>, C<getattr>,
+-C<setattr>, and C<history>.  C<acl check> and C<check> can be run by
+-anyone.  All of the rest of those commands have their own ACLs except
+-C<getattr> and C<history>, which use the C<show> ACL, C<setattr>, which
+-uses the C<store> ACL, and C<comment>, which uses the owner or C<show> ACL
+-depending on whether one is setting or retrieving the comment.  If the
+-appropriate ACL is set, it alone is checked to see if the user has access.
+-Otherwise, C<destroy>, C<get>, C<store>, C<show>, C<getattr>, C<setattr>,
+-C<history>, and C<comment> access is permitted if the user is authorized
+-by the owner ACL of the object.
+-
+-Administrators can run any command on any object or ACL except for C<get>
+-and C<store>.  For C<get> and C<store>, they must still be authorized by
+-either the appropriate specific ACL or the owner ACL.
+-
+-If the locked flag is set on an object, no commands can be run on that
+-object that change data except the C<flags> commands, nor can the C<get>
+-command be used on that object.  C<show>, C<history>, C<getacl>,
+-C<getattr>, and C<owner>, C<comment>, or C<expires> without an argument
+-can still be used on that object.
+-
+-For more information on attributes, see L<ATTRIBUTES>.
+-
+-=over 4
+-
+-=item acl add <id> <scheme> <identifier>
+-
+-Add an entry with <scheme> and <identifier> to the ACL <id>.  <id> may be
+-either the name of an ACL or its numeric identifier.
+-
+-=item acl check <id>
+-
+-Check whether an ACL with the ID <id> already exists.  If it does, prints
+-C<yes>; if not, prints C<no>.
+-
+-=item acl create <name>
+-
+-Create a new, empty ACL with name <name>.  When setting an ACL on an
+-object with a set of entries that don't match an existing ACL, first
+-create a new ACL with C<acl create>, add the appropriate entries to it
+-with C<acl add>, and then set the ACL on an object with the C<owner> or
+-C<setacl> commands.
+-
+-=item acl destroy <id>
+-
+-Destroy the ACL <id>.  This ACL must no longer be referenced by any object
+-or the ACL destruction will fail.  The special ACL named C<ADMIN> cannot
+-be destroyed.
+-
+-=item acl history <id>
+-
+-Display the history of the ACL <id>.  Each change to the ACL (not
+-including changes to the name of the ACL) will be represented by two
+-lines.  The first line will have a timestamp of the change followed by a
+-description of the change, and the second line will give the user who made
+-the change and the host from which the change was made.
+-
+-=item acl remove <id> <scheme> <identifier>
+-
+-Remove the entry with <scheme> and <identifier> from the ACL <id>.  <id>
+-may be either the name of an ACL or its numeric identifier.  The last
+-entry in the special ACL C<ADMIN> cannot be removed to protect against
+-accidental lockout, but administrators can remove themselves from the
+-C<ADMIN> ACL and can leave only a non-functioning entry on the ACL.  Use
+-caution when removing entries from the C<ADMIN> ACL.
+-
+-=item acl rename <id> <name>
+-
+-Renames the ACL identified by <id> to <name>.  This changes the
+-human-readable name, not the underlying numeric ID, so the ACL's
+-associations with objects will be unchanged.  The C<ADMIN> ACL may not be
+-renamed.  <id> may be either the current name or the numeric ID.  <name>
+-must not be all-numeric.  To rename an ACL, the current user must be
+-authorized by the C<ADMIN> ACL.
+-
+-=item acl replace <id> <new-id>
+-
+-Find any objects owned by <id>, and then change their ownership to
+-<new_id> instead.  <new-id> should already exist, and may already have
+-some objects owned by it.  <id> is not deleted afterwards, though in
+-most cases that is probably your next step.  The C<ADMIN> ACL may not be
+-replaced from.  <id> and <new-id> may be either the current name or the
+-numeric ID.  To replace an ACL, the current user must be authorized by
+-the C<ADMIN> ACL.
+-
+-=item acl show <id>
+-
+-Display the name, numeric ID, and entries of the ACL <id>.
+-
+-=item autocreate <type> <name>
+-
+-Create a new object of type <type> with name <name>.  The user must be
+-listed in the default ACL for an object with that type and name, and the
+-object will be created with that default ACL set as the object owner.
+-
+-=item check <type> <name>
+-
+-Check whether an object of type <type> and name <name> already exists.  If
+-it does, prints C<yes>; if not, prints C<no>.
+-
+-=item comment <type> <name> [<comment>]
+-
+-If <comment> is not given, displays the current comment for the object
+-identified by <type> and <name>, or C<No comment set> if none is set.
+-
+-If <comment> is given, sets the comment on the object identified by
+-<type> and <name> to <comment>.  If <comment> is the empty string, clears
+-the comment.
+-
+-=item create <type> <name>
+-
+-Create a new object of type <type> with name <name>.  With some backends,
+-this will trigger creation of an entry in an external system as well.
+-The new object will have no ACLs and no owner set, so usually the
+-administrator will want to then set an owner with C<owner> so that the
+-object will be usable.
+-
+-=item destroy <type> <name>
+-
+-Destroy the object identified by <type> and <name>.  With some backends,
+-this will trigger destruction of an object in an external system as well.
+-
+-=item expires <type> <name> [<date> [<time>]]
+-
+-If <date> is not given, displays the current expiration of the object
+-identified by <type> and <name>, or C<No expiration set> if none is set.
+-The expiration will be displayed in seconds since epoch.
+-
+-If <date> is given, sets the expiration on the object identified by <type>
+-and <name> to <date> and (if given) <time>.  <date> and <time> must be in
+-some format that can be parsed by the Perl Date::Parse module.  Most
+-common formats are supported; if in doubt, use C<YYYY-MM-DD HH:MM:SS>.  If
+-<date> is the empty string, clears the expiration of the object.
+-
+-Currently, the expiration of an object is not used.
+-
+-=item flag clear <type> <name> <flag>
+-
+-Clears the flag <flag> on the object identified by <type> and <name>.
+-
+-=item flag set <type> <name> <flag>
+-
+-Sets the flag <flag> on the object identified by <type> and <name>.
+-Recognized flags are C<locked>, which prevents all further actions on that
+-object until the flag is cleared, and C<unchanging>, which tells the
+-object backend to not generate new data on get but instead return the same
+-data as previously returned.  The C<unchanging> flag is not meaningful for
+-objects that do not generate new data on the fly.
+-
+-=item get <type> <name>
+-
+-Prints to standard output the data associated with the object identified
+-by <type> and <name>.  This may trigger generation of new data and
+-invalidate old data for that object depending on the object type.
+-
+-=item getacl <type> <name> <acl>
+-
+-Prints the ACL <acl>, which must be one of C<get>, C<store>, C<show>,
+-C<destroy>, or C<flags>, for the object identified by <type> and <name>.
+-Prints C<No ACL set> if that ACL isn't set on that object.  Remember that
+-if the C<get>, C<store>, or C<show> ACLs aren't set, authorization falls
+-back to checking the owner ACL.  See the C<owner> command for displaying
+-or setting it.
+-
+-=item getattr <type> <name> <attr>
+-
+-Prints the object attribute <attr> for the object identified by <type> and
+-<name>.  Attributes are used to store backend-specific information for a
+-particular object type, and <attr> must be an attribute type known to the
+-underlying object implementation.  The attribute values, if any, are
+-printed one per line.  If the attribute is not set on this object, nothing
+-is printed.
+-
+-=item history <type> <name>
+-
+-Displays the history for the object identified by <type> and <name>.  This
+-human-readable output will have two lines for each action that changes the
+-object, plus for any get action.  The first line has the timestamp of the
+-action and the action, and the second line gives the user who performed
+-the action and the host from which they performed it.
+-
+-=item owner <type> <name> [<owner>]
+-
+-If <owner> is not given, displays the current owner ACL of the object
+-identified by <type> and <name>, or C<No owner set> if none is set.  The
+-result will be the name of an ACL.
+-
+-If <owner> is given, sets the owner of the object identified by <type> and
+-<name> to <owner>.  If <owner> is the empty string, clears the owner of
+-the object.
+-
+-=item rename <type> <name> <new-name>
+-
+-Renames an existing object.  This currently only supports file objects,
+-where it renames the object itself, then the name and location of the
+-object in the file store.
+-
+-=item setacl <type> <name> <acl> <id>
+-
+-Sets the ACL <acl>, which must be one of C<get>, C<store>, C<show>,
+-C<destroy>, or C<flags>, to <id> on the object identified by <type> and
+-<name>.  If <id> is the empty string, clears that ACL on the object.
+-
+-=item setattr <type> <name> <attr> <value> [<value> ...]
+-
+-Sets the object attribute <attr> for the object identified by <type> and
+-<name>.  Attributes are used to store backend-specific information for a
+-particular object type, and <attr> must be an attribute type known to the
+-underlying object implementation.  To clear the attribute for this object,
+-pass in a <value> of the empty string (C<''>).
+-
+-=item show <type> <name>
+-
+-Displays the current object metadata for the object identified by <type>
+-and <name>.  This human-readable output will show the object type and
+-name, the owner, any specific ACLs set on the object, the expiration if
+-any, and the user, remote host, and time when the object was created, last
+-stored, and last downloaded.
+-
+-=item store <type> <name> [<data>]
+-
+-Stores <data> for the object identified by <type> and <name> for later
+-retrieval with C<get>.  Not all object types support this.  If <data> is
+-not given as an argument, it will be read from standard input.
+-
+-=item update <type> <name>
+-
+-Prints to standard output the data associated with the object identified
+-by <type> and <name>.  If the object is one that can have changing
+-information, such as a keytab or password, then we generate new data for
+-that object regardless of whether there is current data or the unchanging
+-flag is set.
+-
+-=back
+-
+-=head1 ATTRIBUTES
+-
+-Object attributes store additional properties and configuration
+-information for objects stored in the wallet.  They are displayed as part
+-of the object data with C<show>, retrieved with C<getattr>, and set with
+-C<setattr>.
+-
+-=head2 Keytab Attributes
+-
+-Keytab objects support the following attributes:
+-
+-=over 4
+-
+-=item enctypes
+-
+-Restricts the generated keytab to a specific set of encryption types.  The
+-values of this attribute must be enctype strings recognized by Kerberos
+-(strings like C<aes256-cts-hmac-sha1-96> or C<des-cbc-crc>).  Note that
+-the salt should not be included; since the salt is irrelevant for keytab
+-keys, it will always be set to C<normal> by the wallet.
+-
+-If this attribute is set, the specified enctype list will be passed to
+-ktadd when get() is called for that keytab.  If it is not set, the default
+-set in the KDC will be used.
+-
+-This attribute is ignored if the C<unchanging> flag is set on a keytab.
+-Keytabs retrieved with C<unchanging> set will contain all keys present in
+-the KDC for that Kerberos principal and therefore may contain different
+-enctypes than those requested by this attribute.
+-
+-=back
+-
+-=head1 AUTHOR
+-
+-Russ Allbery <eagle@eyrie.org>
+-
+-=head1 COPYRIGHT AND LICENSE
+-
+-Copyright 2007, 2008, 2010, 2011, 2012, 2013 The Board of Trustees of the
+-Leland Stanford Junior University
+-
+-Permission is hereby granted, free of charge, to any person obtaining a
+-copy of this software and associated documentation files (the "Software"),
+-to deal in the Software without restriction, including without limitation
+-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+-and/or sell copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in
+-all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+-DEALINGS IN THE SOFTWARE.
+-
+-=head1 SEE ALSO
+-
+-Wallet::Server(3), remctld(8)
+-
+-This program is part of the wallet system.  The current version is
+-available from L<http://www.eyrie.org/~eagle/software/wallet/>.
+-
+-=cut
+--- /dev/null	2016-01-23 14:00:27.000000000 -0800
++++ server/wallet-backend.in	2016-01-17 19:13:02.000000000 -0800
+@@ -0,0 +1,695 @@
++#!@PERL@
++#
++# Wallet server for storing and retrieving secure data.
++
++use 5.008;
++use strict;
++use warnings;
++
++use Getopt::Long qw(GetOptions);
++use Sys::Syslog qw(openlog syslog);
++use Wallet::Server;
++
++# Set to zero to suppress syslog logging, which is used for testing and for
++# the -q option.  Set to a reference to a string to append messages to that
++# string instead.
++our $SYSLOG;
++$SYSLOG = 1 unless defined $SYSLOG;
++
++##############################################################################
++# Logging
++##############################################################################
++
++# Initialize logging.
++sub log_init {
++    if (ref $SYSLOG) {
++        $$SYSLOG = '';
++    } elsif ($SYSLOG) {
++        openlog ('wallet-backend', 'pid', 'auth');
++    }
++}
++
++# Get an identity string for the user suitable for including in log messages.
++sub identity {
++    my $identity = '';
++    if ($ENV{REMOTE_USER}) {
++        $identity = $ENV{REMOTE_USER};
++        my $host = $ENV{REMOTE_HOST} || $ENV{REMOTE_ADDR};
++        $identity .= " ($host)" if $host;
++    }
++    return $identity;
++}
++
++# Log an error message to both syslog and to stderr and exit with a non-zero
++# status.
++sub error {
++    my $message = join ('', @_);
++    if ($SYSLOG) {
++        my $identity = identity;
++        my $log;
++        if ($identity) {
++            $log = "error for $identity: $message";
++        } else {
++            $log = "error: $message";
++        }
++        $log =~ s/[^\x20-\x7e]/_/g;
++        if (ref $SYSLOG) {
++            $$SYSLOG .= "$log\n";
++        } else {
++            syslog ('err', "%s", $log);
++        }
++    }
++    die "$message\n";
++}
++
++# Log a wallet failure message for a given command to both syslog and to
++# stderr and exit with a non-zero status.  Takes the message and the command
++# that was being run.
++sub failure {
++    my ($message, @command) = @_;
++    if ($SYSLOG) {
++        my $log = "command @command from " . identity . " failed: $message";
++        $log =~ s/[^\x20-\x7e]/_/g;
++        if (ref $SYSLOG) {
++            $$SYSLOG .= "$log\n";
++        } else {
++            syslog ('err', "%s", $log);
++        }
++    }
++    die "$message\n";
++}
++
++# Log a wallet success message for a given command.
++sub success {
++    my (@command) = @_;
++    if ($SYSLOG) {
++        my $log = "command @command from " . identity . " succeeded";
++        $log =~ s/[^\x20-\x7e]/_/g;
++        if (ref $SYSLOG) {
++            $$SYSLOG .= "$log\n";
++        } else {
++            syslog ('info', "%s", $log);
++        }
++    }
++}
++
++##############################################################################
++# Parameter checking
++##############################################################################
++
++# Check all arguments against a very restricted set of allowed characters and
++# to ensure the right number of arguments are taken.  The arguments are the
++# number of arguments expected (minimum and maximum), a reference to an array
++# of which argument numbers shouldn't be checked, and then the arguments.
++#
++# This function is probably temporary and will be replaced with something that
++# knows more about the syntax of each command and can check more things.
++sub check_args {
++    my ($min, $max, $exclude, @args) = @_;
++    if (@args < $min) {
++        error "insufficient arguments";
++    } elsif (@args > $max and $max != -1) {
++        error "too many arguments";
++    }
++    my %exclude = map { $_ => 1 } @$exclude;
++    for (my $i = 1; $i <= @args; $i++) {
++        next if $exclude{$i};
++        unless ($args[$i - 1] =~ m,^[\w_/\@.-]*\z,) {
++            error "invalid characters in argument: $args[$i - 1]";
++        }
++    }
++}
++
++##############################################################################
++# Implementation
++##############################################################################
++
++# Parse and execute a command.  We wrap this in a subroutine call for easier
++# testing.
++sub command {
++    log_init;
++    my $user = $ENV{REMOTE_USER} or error "REMOTE_USER not set";
++    my $host = $ENV{REMOTE_HOST} || $ENV{REMOTE_ADDR}
++        or error "neither REMOTE_HOST nor REMOTE_ADDR set";
++
++    # Instantiate the server object.
++    my $server = Wallet::Server->new ($user, $host);
++
++    # Parse command-line options and dispatch to the appropriate calls.
++    my ($command, @args) = @_;
++    if ($command eq 'acl') {
++        my $action = shift @args;
++        if ($action eq 'add') {
++            check_args (3, 3, [3], @args);
++            $server->acl_add (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'check') {
++            check_args (1, 1, [], @args);
++            my $status = $server->acl_check (@args);
++            if (!defined ($status)) {
++                failure ($server->error, @_);
++            } else {
++                print $status ? "yes\n" : "no\n";
++            }
++        } elsif ($action eq 'create') {
++            check_args (1, 1, [], @args);
++            $server->acl_create (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'destroy') {
++            check_args (1, 1, [], @args);
++            $server->acl_destroy (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'history') {
++            check_args (1, 1, [], @args);
++            my $output = $server->acl_history (@args);
++            if (defined $output) {
++                print $output;
++            } else {
++                failure ($server->error, @_);
++            }
++        } elsif ($action eq 'remove') {
++            check_args (3, 3, [3], @args);
++            $server->acl_remove (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'rename') {
++            check_args (2, 2, [], @args);
++            $server->acl_rename (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'replace') {
++            check_args (2, 2, [], @args);
++            $server->acl_replace (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'show') {
++            check_args (1, 1, [], @args);
++            my $output = $server->acl_show (@args);
++            if (defined $output) {
++                print $output;
++            } else {
++                failure ($server->error, @_);
++            }
++        } else {
++            error "unknown command acl $action";
++        }
++    } elsif ($command eq 'autocreate') {
++        check_args (2, 2, [], @args);
++        $server->autocreate (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'check') {
++        check_args (2, 2, [], @args);
++        my $status = $server->check (@args);
++        if (!defined ($status)) {
++            failure ($server->error, @_);
++        } else {
++            print $status ? "yes\n" : "no\n";
++        }
++    } elsif ($command eq 'comment') {
++        check_args (2, 3, [3], @args);
++        if (@args > 2) {
++            $server->comment (@args) or failure ($server->error, @_);
++        } else {
++            my $output = $server->comment (@args);
++            if (defined $output) {
++                print $output, "\n";
++            } elsif (not $server->error) {
++                print "No comment set\n";
++            } else {
++                failure ($server->error, @_);
++            }
++        }
++    } elsif ($command eq 'create') {
++        check_args (2, 2, [], @args);
++        $server->create (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'destroy') {
++        check_args (2, 2, [], @args);
++        $server->destroy (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'expires') {
++        check_args (2, 3, [], @args);
++        if (@args > 2) {
++            $server->expires (@args) or failure ($server->error, @_);
++        } else {
++            my $output = $server->expires (@args);
++            if (defined $output) {
++                print $output, "\n";
++            } elsif (not $server->error) {
++                print "No expiration set\n";
++            } else {
++                failure ($server->error, @_);
++            }
++        }
++    } elsif ($command eq 'flag') {
++        my $action = shift @args;
++        check_args (3, 3, [], @args);
++        if ($action eq 'clear') {
++            $server->flag_clear (@args) or failure ($server->error, @_);
++        } elsif ($action eq 'set') {
++            $server->flag_set (@args) or failure ($server->error, @_);
++        } else {
++            error "unknown command flag $action";
++        }
++    } elsif ($command eq 'get') {
++        check_args (2, 2, [], @args);
++        my $output = $server->get (@args);
++        if (defined $output) {
++            print $output;
++        } else {
++            failure ($server->error, @_);
++        }
++    } elsif ($command eq 'getacl') {
++        check_args (3, 3, [], @args);
++        my $output = $server->acl (@args);
++        if (defined $output) {
++            print $output, "\n";
++        } elsif (not $server->error) {
++            print "No ACL set\n";
++        } else {
++            failure ($server->error, @_);
++        }
++    } elsif ($command eq 'getattr') {
++        check_args (3, 3, [], @args);
++        my @result = $server->attr (@args);
++        if (not @result and $server->error) {
++            failure ($server->error, @_);
++        } elsif (@result) {
++            print join ("\n", @result, '');
++        }
++    } elsif ($command eq 'history') {
++        check_args (2, 2, [], @args);
++        my $output = $server->history (@args);
++        if (defined $output) {
++            print $output;
++        } else {
++            failure ($server->error, @_);
++        }
++    } elsif ($command eq 'owner') {
++        check_args (2, 3, [], @args);
++        if (@args > 2) {
++            $server->owner (@args) or failure ($server->error, @_);
++        } else {
++            my $output = $server->owner (@args);
++            if (defined $output) {
++                print $output, "\n";
++            } elsif (not $server->error) {
++                print "No owner set\n";
++            } else {
++                failure ($server->error, @_);
++            }
++        }
++    } elsif ($command eq 'rename') {
++        check_args (3, 3, [], @args);
++        $server->rename (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'setacl') {
++        check_args (4, 4, [], @args);
++        $server->acl (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'setattr') {
++        check_args (4, -1, [], @args);
++        $server->attr (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'show') {
++        check_args (2, 2, [], @args);
++        my $output = $server->show (@args);
++        if (defined $output) {
++            print $output;
++        } else {
++            failure ($server->error, @_);
++        }
++    } elsif ($command eq 'store') {
++        check_args (2, 3, [3], @args);
++        if (@args == 2) {
++            local $/;
++            $args[2] = <STDIN>;
++        }
++        splice (@_, 3);
++        $server->store (@args) or failure ($server->error, @_);
++    } elsif ($command eq 'update') {
++        check_args (2, 2, [], @args);
++        my $output = $server->update (@args);
++        if (defined $output) {
++            print $output;
++        } else {
++            failure ($server->error, @_);
++        }
++    } else {
++        error "unknown command $command";
++    }
++    success (@_);
++}
++
++# Parse command-line options.
++my ($quiet);
++Getopt::Long::config ('require_order');
++GetOptions ('q|quiet' => \$quiet) or exit 1;
++$SYSLOG = 0 if $quiet;
++
++# Run the command.
++command (@ARGV);
++
++__END__
++
++##############################################################################
++# Documentation
++##############################################################################
++
++# The commands section of this document is duplicated from the documentation
++# for wallet and should be kept in sync.
++
++=for stopwords
++wallet-backend backend backend-specific remctld ACL acl timestamp getacl
++setacl metadata keytab keytabs enctypes enctype ktadd KDC Allbery
++autocreate MERCHANTABILITY NONINFRINGEMENT sublicense
++
++=head1 NAME
++
++wallet-backend - Wallet server for storing and retrieving secure data
++
++=head1 SYNOPSIS
++
++B<wallet-backend> [B<-q>] I<command> [I<args> ...]
++
++=head1 DESCRIPTION
++
++B<wallet-backend> implements the interface between B<remctld> and the
++wallet system.  It is written to run under B<remctld> and expects the
++authenticated identity of the remote user in the REMOTE_USER environment
++variable.  It uses REMOTE_HOST or REMOTE_ADDR if REMOTE_HOST isn't set for
++additional trace information.  It accepts the command from B<remctld> on
++the command line, creates a Wallet::Server object, and calls the
++appropriate methods.
++
++This program is a fairly thin wrapper around Wallet::Server that
++translates command strings into method calls and returns the results.  It
++does check all arguments except for the <data> argument to the store
++command and rejects any argument not matching C<^[\w_/.-]+\z>; in other
++words, only alphanumerics, underscore (C<_>), slash (C</>), period (C<.>),
++and hyphen (C<->) are permitted in arguments.  This provides some
++additional security over and above the checking already done by the rest
++of the wallet code.
++
++=head1 OPTIONS
++
++=over 4
++
++=item B<--quiet>, B<-q>
++
++If this option is given, B<wallet-backend> will not log its actions to
++syslog.
++
++=back
++
++=head1 COMMANDS
++
++Most commands are only available to wallet administrators (users on the
++C<ADMIN> ACL).  The exceptions are C<acl check>, C<check>, C<get>,
++C<store>, C<show>, C<destroy>, C<flag clear>, C<flag set>, C<getattr>,
++C<setattr>, and C<history>.  C<acl check> and C<check> can be run by
++anyone.  All of the rest of those commands have their own ACLs except
++C<getattr> and C<history>, which use the C<show> ACL, C<setattr>, which
++uses the C<store> ACL, and C<comment>, which uses the owner or C<show> ACL
++depending on whether one is setting or retrieving the comment.  If the
++appropriate ACL is set, it alone is checked to see if the user has access.
++Otherwise, C<destroy>, C<get>, C<store>, C<show>, C<getattr>, C<setattr>,
++C<history>, and C<comment> access is permitted if the user is authorized
++by the owner ACL of the object.
++
++Administrators can run any command on any object or ACL except for C<get>
++and C<store>.  For C<get> and C<store>, they must still be authorized by
++either the appropriate specific ACL or the owner ACL.
++
++If the locked flag is set on an object, no commands can be run on that
++object that change data except the C<flags> commands, nor can the C<get>
++command be used on that object.  C<show>, C<history>, C<getacl>,
++C<getattr>, and C<owner>, C<comment>, or C<expires> without an argument
++can still be used on that object.
++
++For more information on attributes, see L<ATTRIBUTES>.
++
++=over 4
++
++=item acl add <id> <scheme> <identifier>
++
++Add an entry with <scheme> and <identifier> to the ACL <id>.  <id> may be
++either the name of an ACL or its numeric identifier.
++
++=item acl check <id>
++
++Check whether an ACL with the ID <id> already exists.  If it does, prints
++C<yes>; if not, prints C<no>.
++
++=item acl create <name>
++
++Create a new, empty ACL with name <name>.  When setting an ACL on an
++object with a set of entries that don't match an existing ACL, first
++create a new ACL with C<acl create>, add the appropriate entries to it
++with C<acl add>, and then set the ACL on an object with the C<owner> or
++C<setacl> commands.
++
++=item acl destroy <id>
++
++Destroy the ACL <id>.  This ACL must no longer be referenced by any object
++or the ACL destruction will fail.  The special ACL named C<ADMIN> cannot
++be destroyed.
++
++=item acl history <id>
++
++Display the history of the ACL <id>.  Each change to the ACL (not
++including changes to the name of the ACL) will be represented by two
++lines.  The first line will have a timestamp of the change followed by a
++description of the change, and the second line will give the user who made
++the change and the host from which the change was made.
++
++=item acl remove <id> <scheme> <identifier>
++
++Remove the entry with <scheme> and <identifier> from the ACL <id>.  <id>
++may be either the name of an ACL or its numeric identifier.  The last
++entry in the special ACL C<ADMIN> cannot be removed to protect against
++accidental lockout, but administrators can remove themselves from the
++C<ADMIN> ACL and can leave only a non-functioning entry on the ACL.  Use
++caution when removing entries from the C<ADMIN> ACL.
++
++=item acl rename <id> <name>
++
++Renames the ACL identified by <id> to <name>.  This changes the
++human-readable name, not the underlying numeric ID, so the ACL's
++associations with objects will be unchanged.  The C<ADMIN> ACL may not be
++renamed.  <id> may be either the current name or the numeric ID.  <name>
++must not be all-numeric.  To rename an ACL, the current user must be
++authorized by the C<ADMIN> ACL.
++
++=item acl replace <id> <new-id>
++
++Find any objects owned by <id>, and then change their ownership to
++<new_id> instead.  <new-id> should already exist, and may already have
++some objects owned by it.  <id> is not deleted afterwards, though in
++most cases that is probably your next step.  The C<ADMIN> ACL may not be
++replaced from.  <id> and <new-id> may be either the current name or the
++numeric ID.  To replace an ACL, the current user must be authorized by
++the C<ADMIN> ACL.
++
++=item acl show <id>
++
++Display the name, numeric ID, and entries of the ACL <id>.
++
++=item autocreate <type> <name>
++
++Create a new object of type <type> with name <name>.  The user must be
++listed in the default ACL for an object with that type and name, and the
++object will be created with that default ACL set as the object owner.
++
++=item check <type> <name>
++
++Check whether an object of type <type> and name <name> already exists.  If
++it does, prints C<yes>; if not, prints C<no>.
++
++=item comment <type> <name> [<comment>]
++
++If <comment> is not given, displays the current comment for the object
++identified by <type> and <name>, or C<No comment set> if none is set.
++
++If <comment> is given, sets the comment on the object identified by
++<type> and <name> to <comment>.  If <comment> is the empty string, clears
++the comment.
++
++=item create <type> <name>
++
++Create a new object of type <type> with name <name>.  With some backends,
++this will trigger creation of an entry in an external system as well.
++The new object will have no ACLs and no owner set, so usually the
++administrator will want to then set an owner with C<owner> so that the
++object will be usable.
++
++=item destroy <type> <name>
++
++Destroy the object identified by <type> and <name>.  With some backends,
++this will trigger destruction of an object in an external system as well.
++
++=item expires <type> <name> [<date> [<time>]]
++
++If <date> is not given, displays the current expiration of the object
++identified by <type> and <name>, or C<No expiration set> if none is set.
++The expiration will be displayed in seconds since epoch.
++
++If <date> is given, sets the expiration on the object identified by <type>
++and <name> to <date> and (if given) <time>.  <date> and <time> must be in
++some format that can be parsed by the Perl Date::Parse module.  Most
++common formats are supported; if in doubt, use C<YYYY-MM-DD HH:MM:SS>.  If
++<date> is the empty string, clears the expiration of the object.
++
++Currently, the expiration of an object is not used.
++
++=item flag clear <type> <name> <flag>
++
++Clears the flag <flag> on the object identified by <type> and <name>.
++
++=item flag set <type> <name> <flag>
++
++Sets the flag <flag> on the object identified by <type> and <name>.
++Recognized flags are C<locked>, which prevents all further actions on that
++object until the flag is cleared, and C<unchanging>, which tells the
++object backend to not generate new data on get but instead return the same
++data as previously returned.  The C<unchanging> flag is not meaningful for
++objects that do not generate new data on the fly.
++
++=item get <type> <name>
++
++Prints to standard output the data associated with the object identified
++by <type> and <name>.  This may trigger generation of new data and
++invalidate old data for that object depending on the object type.
++
++=item getacl <type> <name> <acl>
++
++Prints the ACL <acl>, which must be one of C<get>, C<store>, C<show>,
++C<destroy>, or C<flags>, for the object identified by <type> and <name>.
++Prints C<No ACL set> if that ACL isn't set on that object.  Remember that
++if the C<get>, C<store>, or C<show> ACLs aren't set, authorization falls
++back to checking the owner ACL.  See the C<owner> command for displaying
++or setting it.
++
++=item getattr <type> <name> <attr>
++
++Prints the object attribute <attr> for the object identified by <type> and
++<name>.  Attributes are used to store backend-specific information for a
++particular object type, and <attr> must be an attribute type known to the
++underlying object implementation.  The attribute values, if any, are
++printed one per line.  If the attribute is not set on this object, nothing
++is printed.
++
++=item history <type> <name>
++
++Displays the history for the object identified by <type> and <name>.  This
++human-readable output will have two lines for each action that changes the
++object, plus for any get action.  The first line has the timestamp of the
++action and the action, and the second line gives the user who performed
++the action and the host from which they performed it.
++
++=item owner <type> <name> [<owner>]
++
++If <owner> is not given, displays the current owner ACL of the object
++identified by <type> and <name>, or C<No owner set> if none is set.  The
++result will be the name of an ACL.
++
++If <owner> is given, sets the owner of the object identified by <type> and
++<name> to <owner>.  If <owner> is the empty string, clears the owner of
++the object.
++
++=item rename <type> <name> <new-name>
++
++Renames an existing object.  This currently only supports file objects,
++where it renames the object itself, then the name and location of the
++object in the file store.
++
++=item setacl <type> <name> <acl> <id>
++
++Sets the ACL <acl>, which must be one of C<get>, C<store>, C<show>,
++C<destroy>, or C<flags>, to <id> on the object identified by <type> and
++<name>.  If <id> is the empty string, clears that ACL on the object.
++
++=item setattr <type> <name> <attr> <value> [<value> ...]
++
++Sets the object attribute <attr> for the object identified by <type> and
++<name>.  Attributes are used to store backend-specific information for a
++particular object type, and <attr> must be an attribute type known to the
++underlying object implementation.  To clear the attribute for this object,
++pass in a <value> of the empty string (C<''>).
++
++=item show <type> <name>
++
++Displays the current object metadata for the object identified by <type>
++and <name>.  This human-readable output will show the object type and
++name, the owner, any specific ACLs set on the object, the expiration if
++any, and the user, remote host, and time when the object was created, last
++stored, and last downloaded.
++
++=item store <type> <name> [<data>]
++
++Stores <data> for the object identified by <type> and <name> for later
++retrieval with C<get>.  Not all object types support this.  If <data> is
++not given as an argument, it will be read from standard input.
++
++=item update <type> <name>
++
++Prints to standard output the data associated with the object identified
++by <type> and <name>.  If the object is one that can have changing
++information, such as a keytab or password, then we generate new data for
++that object regardless of whether there is current data or the unchanging
++flag is set.
++
++=back
++
++=head1 ATTRIBUTES
++
++Object attributes store additional properties and configuration
++information for objects stored in the wallet.  They are displayed as part
++of the object data with C<show>, retrieved with C<getattr>, and set with
++C<setattr>.
++
++=head2 Keytab Attributes
++
++Keytab objects support the following attributes:
++
++=over 4
++
++=item enctypes
++
++Restricts the generated keytab to a specific set of encryption types.  The
++values of this attribute must be enctype strings recognized by Kerberos
++(strings like C<aes256-cts-hmac-sha1-96> or C<des-cbc-crc>).  Note that
++the salt should not be included; since the salt is irrelevant for keytab
++keys, it will always be set to C<normal> by the wallet.
++
++If this attribute is set, the specified enctype list will be passed to
++ktadd when get() is called for that keytab.  If it is not set, the default
++set in the KDC will be used.
++
++This attribute is ignored if the C<unchanging> flag is set on a keytab.
++Keytabs retrieved with C<unchanging> set will contain all keys present in
++the KDC for that Kerberos principal and therefore may contain different
++enctypes than those requested by this attribute.
++
++=back
++
++=head1 AUTHOR
++
++Russ Allbery <eagle@eyrie.org>
++
++=head1 COPYRIGHT AND LICENSE
++
++Copyright 2007, 2008, 2010, 2011, 2012, 2013 The Board of Trustees of the
++Leland Stanford Junior University
++
++Permission is hereby granted, free of charge, to any person obtaining a
++copy of this software and associated documentation files (the "Software"),
++to deal in the Software without restriction, including without limitation
++the rights to use, copy, modify, merge, publish, distribute, sublicense,
++and/or sell copies of the Software, and to permit persons to whom the
++Software is furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in
++all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++DEALINGS IN THE SOFTWARE.
++
++=head1 SEE ALSO
++
++Wallet::Server(3), remctld(8)
++
++This program is part of the wallet system.  The current version is
++available from L<http://www.eyrie.org/~eagle/software/wallet/>.
++
++=cut

--- a/net/wallet/files/patch-rename-server-wallet-report.diff
+++ b/net/wallet/files/patch-rename-server-wallet-report.diff
@@ -1,0 +1,726 @@
+--- server/wallet-report	2016-01-17 19:13:02.000000000 -0800
++++ /dev/null	2016-01-23 14:00:27.000000000 -0800
+@@ -1,360 +0,0 @@
+-#!/usr/bin/perl
+-#
+-# Wallet server reporting interface.
+-
+-use 5.008;
+-use strict;
+-use warnings;
+-
+-use Wallet::Report;
+-
+-# The help output, sent in reply to the help command.  Lists each supported
+-# report command with a brief description of what it does.
+-our $HELP = <<'EOH';
+-Wallet reporting help:
+-  acls                          All ACLs
+-  acls duplicate                ACLs that duplicate another
+-  acls empty                    All empty ACLs
+-  acls entry <scheme> <id>      ACLs containing this entry (wildcarded)
+-  acls nesting <acl>            ACLs containing this ACL as a nested entry
+-  acls unused                   ACLs that are not referenced by any object
+-  audit acls name               ACLs failing the naming policy
+-  audit objects name            Objects failing the naming policy
+-  objects                       All objects
+-  objects acl <acl>             Objects granting permissions to that ACL
+-  objects flag <flag>           Objects with that flag set
+-  objects history               History of all objects
+-  objects host <hostname>       All host-based objects for a specific host
+-  objects owner <owner>         Objects owned by that owner
+-  objects type <type>           Objects of that type
+-  objects unused                Objects that have never been gotten
+-  objects unstored              Objects that have never been stored
+-  owners <type> <name>          All ACL entries owning matching objects
+-  schemes                       All configured ACL schemes
+-  types                         All configured wallet types
+-EOH
+-
+-##############################################################################
+-# Implementation
+-##############################################################################
+-
+-# Parse and execute a command.  We wrap this in a subroutine call for easier
+-# testing.
+-sub command {
+-    die "Usage: wallet-report <command> [<args> ...]\n" unless @_;
+-    my $report = Wallet::Report->new;
+-
+-    # Parse command-line options and dispatch to the appropriate calls.
+-    my ($command, @args) = @_;
+-    if ($command eq 'acls') {
+-        die "too many arguments to acls\n" if @args > 3;
+-        my @acls = $report->acls (@args);
+-        if (!@acls and $report->error) {
+-            die $report->error, "\n";
+-        }
+-        if (@args && $args[0] eq 'duplicate') {
+-            for my $group (@acls) {
+-                print join (' ', @$group), "\n";
+-            }
+-        } else {
+-            for my $acl (sort { $$a[1] cmp $$b[1] } @acls) {
+-                print "$$acl[1] (ACL ID: $$acl[0])\n";
+-            }
+-        }
+-    } elsif ($command eq 'audit') {
+-        die "too many arguments to audit\n" if @args > 2;
+-        die "too few arguments to audit\n" if @args < 2;
+-        my @result = $report->audit (@args);
+-        if (!@result and $report->error) {
+-            die $report->error, "\n";
+-        }
+-        for my $item (@result) {
+-            if ($args[0] eq 'acls') {
+-                print "$$item[1] (ACL ID: $$item[0])\n";
+-            } else {
+-                print join (' ', @$item), "\n";
+-            }
+-        }
+-    } elsif ($command eq 'help') {
+-        print $HELP;
+-    } elsif ($command eq 'objects') {
+-        die "too many arguments to objects\n" if @args > 2;
+-        my @objects;
+-        if (@args && $args[0] eq 'history') {
+-            @objects = $report->objects_history (@args);
+-        } elsif (@args && $args[0] eq 'host') {
+-            @objects = $report->objects_hostname (@args);
+-        } else {
+-            @objects = $report->objects (@args);
+-        }
+-        if (!@objects and $report->error) {
+-            die $report->error, "\n";
+-        }
+-        for my $object (@objects) {
+-            print join (' ', @$object), "\n";
+-        }
+-    } elsif ($command eq 'owners') {
+-        die "too many arguments to owners\n" if @args > 2;
+-        die "too few arguments to owners\n" if @args < 2;
+-        my @entries = $report->owners (@args);
+-        if (!@entries and $report->error) {
+-            die $report->error, "\n";
+-        }
+-        for my $entry (@entries) {
+-            print join (' ', @$entry), "\n";
+-        }
+-    } elsif ($command eq 'schemes') {
+-        die "too many arguments to schemes\n" if @args > 0;
+-        my @schemes = $report->acl_schemes;
+-        for my $entry (@schemes) {
+-            print join (' ', @$entry), "\n";
+-        }
+-
+-    } elsif ($command eq 'types') {
+-        die "too many arguments to types\n" if @args > 0;
+-        my @types = $report->types;
+-        for my $entry (@types) {
+-            print join (' ', @$entry), "\n";
+-        }
+-
+-    } else {
+-        die "unknown command $command\n";
+-    }
+-}
+-command (@ARGV);
+-__END__
+-
+-##############################################################################
+-# Documentation
+-##############################################################################
+-
+-=head1 NAME
+-
+-wallet-report - Wallet server reporting interface
+-
+-=for stopwords
+-metadata ACL hostname backend acl acls wildcard SQL Allbery remctl
+-MERCHANTABILITY NONINFRINGEMENT sublicense unstored
+-
+-=head1 SYNOPSIS
+-
+-B<wallet-report> I<type> [I<args> ...]
+-
+-=head1 DESCRIPTION
+-
+-B<wallet-report> provides a command-line interface for running reports on
+-the wallet database.  It is intended to be run on the wallet server as a
+-user with access to the wallet database and configuration, but can also be
+-made available via remctl to users who should have reporting privileges.
+-
+-This program is a fairly thin wrapper around Wallet::Report that
+-translates command strings into method calls and returns the results.
+-
+-=head1 OPTIONS
+-
+-B<wallet-report> takes no traditional options.
+-
+-=head1 COMMANDS
+-
+-=over 4
+-
+-=item acls
+-
+-=item acls duplicate
+-
+-=item acls empty
+-
+-=item acls entry <scheme> <identifier>
+-
+-=item acls unused
+-
+-Returns a list of ACLs in the database.  Except for the C<duplicate>
+-report, ACLs will be listed in the form:
+-
+-    <name> (ACL ID: <id>)
+-
+-where <name> is the human-readable name and <id> is the numeric ID.  The
+-numeric ID is what's used internally by the wallet system.  There will be
+-one line per ACL.
+-
+-For the C<duplicate> report, the output will instead be one duplicate set
+-per line.  This will be a set of ACLs that all have the same entries.
+-Only the names will be given, separated by spaces.
+-
+-If no search type is given, all the ACLs in the database will be returned.
+-If a search type (and possible search arguments) are given, then the ACLs
+-will be limited to those that match the search.
+-
+-The currently supported ACL search types are:
+-
+-=over 4
+-
+-=item acls duplicate
+-
+-Returns all sets of ACLs that are duplicates, meaning that they contain
+-exactly the same entries.  Each line will be the names of the ACLs in a
+-set of duplicates, separated by spaces.
+-
+-=item acls empty
+-
+-Returns all ACLs which have no entries, generally so that abandoned ACLs
+-can be destroyed.
+-
+-=item acls entry <scheme> <identifier>
+-
+-Returns all ACLs containing an entry with given scheme and identifier.
+-The scheme must be an exact match, but the <identifier> string will match
+-any identifier containing that string.
+-
+-=item acls nested <acl>
+-
+-Returns all ACLs that contain this ACL as a nested entry.
+-
+-=item acls unused
+-
+-Returns all ACLs that are not referenced by any of the objects in the
+-wallet database, either as an owner or on one of the more specific ACLs.
+-
+-=back
+-
+-=item audit acls name
+-
+-=item audit objects name
+-
+-Returns all ACLs or objects that violate the current site naming policy.
+-Objects will be listed in the form:
+-
+-    <type> <name>
+-
+-and ACLs in the form:
+-
+-    <name> (ACL ID: <id>)
+-
+-where <name> is the human-readable name and <id> is the numeric ID.  The
+-numeric ID is what's used internally by the wallet system.  There will be
+-one line per object or ACL.
+-
+-=item help
+-
+-Displays a summary of all available commands.
+-
+-=item objects
+-
+-=item objects acl <acl>
+-
+-=item objects flag <flag>
+-
+-=item objects owner <owner>
+-
+-=item objects type <type>
+-
+-=item objects unused
+-
+-=item objects unstored
+-
+-Returns a list of objects in the database.  Objects will be listed in the
+-form:
+-
+-    <type> <name>
+-
+-There will be one line per object.
+-
+-If no search type is given, all objects in the database will be returned.
+-If a search type (and possible search arguments) are given, the objects
+-will be limited to those that match the search.
+-
+-The currently supported object search types are:
+-
+-=over 4
+-
+-=item objects acl <acl>
+-
+-Returns all objects for which the given ACL name or ID has any
+-permissions.  This includes those objects owned by the ACL as well as
+-those where that ACL has any other, more limited permissions.
+-
+-=item objects flag <flag>
+-
+-Returns all objects which have the given flag set.
+-
+-=item objects host <hostname>
+-
+-Returns all objects that belong to the given host.  This requires adding
+-local configuration to identify objects that belong to a given host.  See
+-L<Wallet::Config/"OBJECT HOST-BASED NAMES"> for more information.
+-
+-=item objects owner <acl>
+-
+-Returns all objects owned by the given ACL name or ID.
+-
+-=item objects type <type>
+-
+-Returns all objects of the given type.
+-
+-=item objects unused
+-
+-Returns all objects that have never been downloaded (have never been the
+-target of a get command).
+-
+-=back
+-
+-=item owners <type-pattern> <name-pattern>
+-
+-Returns a list of all ACL entries in owner ACLs for all objects matching
+-both <type-pattern> and <name-pattern>.  These can be the type or name of
+-objects or they can be patterns using C<%> as the wildcard character
+-following the normal rules of SQL patterns.
+-
+-The output will be one line per ACL line in the form:
+-
+-    <scheme> <identifier>
+-
+-with duplicates suppressed.
+-
+-=item schemes
+-
+-Returns a list of all registered ACL schemes.
+-
+-=item types
+-
+-Returns a list of all registered object types.
+-
+-=back
+-
+-=head1 AUTHOR
+-
+-Russ Allbery <eagle@eyrie.org>
+-
+-=head1 COPYRIGHT AND LICENSE
+-
+-Copyright 2016 Russ Allbery <eagle@eyrie.org>
+-
+-Copyright 2008, 2009, 2010, 2013, 2015 The Board of Trustees of the Leland
+-Stanford Junior University
+-
+-Permission is hereby granted, free of charge, to any person obtaining a
+-copy of this software and associated documentation files (the "Software"),
+-to deal in the Software without restriction, including without limitation
+-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+-and/or sell copies of the Software, and to permit persons to whom the
+-Software is furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in
+-all copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+-DEALINGS IN THE SOFTWARE.
+-
+-=head1 SEE ALSO
+-
+-Wallet::Config(3), Wallet::Report(3), wallet-backend(8)
+-
+-This program is part of the wallet system.  The current version is
+-available from L<http://www.eyrie.org/~eagle/software/wallet/>.
+-
+-=cut
+--- /dev/null	2016-01-23 14:00:27.000000000 -0800
++++ server/wallet-report.in	2016-01-17 19:13:02.000000000 -0800
+@@ -0,0 +1,360 @@
++#!@PERL@
++#
++# Wallet server reporting interface.
++
++use 5.008;
++use strict;
++use warnings;
++
++use Wallet::Report;
++
++# The help output, sent in reply to the help command.  Lists each supported
++# report command with a brief description of what it does.
++our $HELP = <<'EOH';
++Wallet reporting help:
++  acls                          All ACLs
++  acls duplicate                ACLs that duplicate another
++  acls empty                    All empty ACLs
++  acls entry <scheme> <id>      ACLs containing this entry (wildcarded)
++  acls nesting <acl>            ACLs containing this ACL as a nested entry
++  acls unused                   ACLs that are not referenced by any object
++  audit acls name               ACLs failing the naming policy
++  audit objects name            Objects failing the naming policy
++  objects                       All objects
++  objects acl <acl>             Objects granting permissions to that ACL
++  objects flag <flag>           Objects with that flag set
++  objects history               History of all objects
++  objects host <hostname>       All host-based objects for a specific host
++  objects owner <owner>         Objects owned by that owner
++  objects type <type>           Objects of that type
++  objects unused                Objects that have never been gotten
++  objects unstored              Objects that have never been stored
++  owners <type> <name>          All ACL entries owning matching objects
++  schemes                       All configured ACL schemes
++  types                         All configured wallet types
++EOH
++
++##############################################################################
++# Implementation
++##############################################################################
++
++# Parse and execute a command.  We wrap this in a subroutine call for easier
++# testing.
++sub command {
++    die "Usage: wallet-report <command> [<args> ...]\n" unless @_;
++    my $report = Wallet::Report->new;
++
++    # Parse command-line options and dispatch to the appropriate calls.
++    my ($command, @args) = @_;
++    if ($command eq 'acls') {
++        die "too many arguments to acls\n" if @args > 3;
++        my @acls = $report->acls (@args);
++        if (!@acls and $report->error) {
++            die $report->error, "\n";
++        }
++        if (@args && $args[0] eq 'duplicate') {
++            for my $group (@acls) {
++                print join (' ', @$group), "\n";
++            }
++        } else {
++            for my $acl (sort { $$a[1] cmp $$b[1] } @acls) {
++                print "$$acl[1] (ACL ID: $$acl[0])\n";
++            }
++        }
++    } elsif ($command eq 'audit') {
++        die "too many arguments to audit\n" if @args > 2;
++        die "too few arguments to audit\n" if @args < 2;
++        my @result = $report->audit (@args);
++        if (!@result and $report->error) {
++            die $report->error, "\n";
++        }
++        for my $item (@result) {
++            if ($args[0] eq 'acls') {
++                print "$$item[1] (ACL ID: $$item[0])\n";
++            } else {
++                print join (' ', @$item), "\n";
++            }
++        }
++    } elsif ($command eq 'help') {
++        print $HELP;
++    } elsif ($command eq 'objects') {
++        die "too many arguments to objects\n" if @args > 2;
++        my @objects;
++        if (@args && $args[0] eq 'history') {
++            @objects = $report->objects_history (@args);
++        } elsif (@args && $args[0] eq 'host') {
++            @objects = $report->objects_hostname (@args);
++        } else {
++            @objects = $report->objects (@args);
++        }
++        if (!@objects and $report->error) {
++            die $report->error, "\n";
++        }
++        for my $object (@objects) {
++            print join (' ', @$object), "\n";
++        }
++    } elsif ($command eq 'owners') {
++        die "too many arguments to owners\n" if @args > 2;
++        die "too few arguments to owners\n" if @args < 2;
++        my @entries = $report->owners (@args);
++        if (!@entries and $report->error) {
++            die $report->error, "\n";
++        }
++        for my $entry (@entries) {
++            print join (' ', @$entry), "\n";
++        }
++    } elsif ($command eq 'schemes') {
++        die "too many arguments to schemes\n" if @args > 0;
++        my @schemes = $report->acl_schemes;
++        for my $entry (@schemes) {
++            print join (' ', @$entry), "\n";
++        }
++
++    } elsif ($command eq 'types') {
++        die "too many arguments to types\n" if @args > 0;
++        my @types = $report->types;
++        for my $entry (@types) {
++            print join (' ', @$entry), "\n";
++        }
++
++    } else {
++        die "unknown command $command\n";
++    }
++}
++command (@ARGV);
++__END__
++
++##############################################################################
++# Documentation
++##############################################################################
++
++=head1 NAME
++
++wallet-report - Wallet server reporting interface
++
++=for stopwords
++metadata ACL hostname backend acl acls wildcard SQL Allbery remctl
++MERCHANTABILITY NONINFRINGEMENT sublicense unstored
++
++=head1 SYNOPSIS
++
++B<wallet-report> I<type> [I<args> ...]
++
++=head1 DESCRIPTION
++
++B<wallet-report> provides a command-line interface for running reports on
++the wallet database.  It is intended to be run on the wallet server as a
++user with access to the wallet database and configuration, but can also be
++made available via remctl to users who should have reporting privileges.
++
++This program is a fairly thin wrapper around Wallet::Report that
++translates command strings into method calls and returns the results.
++
++=head1 OPTIONS
++
++B<wallet-report> takes no traditional options.
++
++=head1 COMMANDS
++
++=over 4
++
++=item acls
++
++=item acls duplicate
++
++=item acls empty
++
++=item acls entry <scheme> <identifier>
++
++=item acls unused
++
++Returns a list of ACLs in the database.  Except for the C<duplicate>
++report, ACLs will be listed in the form:
++
++    <name> (ACL ID: <id>)
++
++where <name> is the human-readable name and <id> is the numeric ID.  The
++numeric ID is what's used internally by the wallet system.  There will be
++one line per ACL.
++
++For the C<duplicate> report, the output will instead be one duplicate set
++per line.  This will be a set of ACLs that all have the same entries.
++Only the names will be given, separated by spaces.
++
++If no search type is given, all the ACLs in the database will be returned.
++If a search type (and possible search arguments) are given, then the ACLs
++will be limited to those that match the search.
++
++The currently supported ACL search types are:
++
++=over 4
++
++=item acls duplicate
++
++Returns all sets of ACLs that are duplicates, meaning that they contain
++exactly the same entries.  Each line will be the names of the ACLs in a
++set of duplicates, separated by spaces.
++
++=item acls empty
++
++Returns all ACLs which have no entries, generally so that abandoned ACLs
++can be destroyed.
++
++=item acls entry <scheme> <identifier>
++
++Returns all ACLs containing an entry with given scheme and identifier.
++The scheme must be an exact match, but the <identifier> string will match
++any identifier containing that string.
++
++=item acls nested <acl>
++
++Returns all ACLs that contain this ACL as a nested entry.
++
++=item acls unused
++
++Returns all ACLs that are not referenced by any of the objects in the
++wallet database, either as an owner or on one of the more specific ACLs.
++
++=back
++
++=item audit acls name
++
++=item audit objects name
++
++Returns all ACLs or objects that violate the current site naming policy.
++Objects will be listed in the form:
++
++    <type> <name>
++
++and ACLs in the form:
++
++    <name> (ACL ID: <id>)
++
++where <name> is the human-readable name and <id> is the numeric ID.  The
++numeric ID is what's used internally by the wallet system.  There will be
++one line per object or ACL.
++
++=item help
++
++Displays a summary of all available commands.
++
++=item objects
++
++=item objects acl <acl>
++
++=item objects flag <flag>
++
++=item objects owner <owner>
++
++=item objects type <type>
++
++=item objects unused
++
++=item objects unstored
++
++Returns a list of objects in the database.  Objects will be listed in the
++form:
++
++    <type> <name>
++
++There will be one line per object.
++
++If no search type is given, all objects in the database will be returned.
++If a search type (and possible search arguments) are given, the objects
++will be limited to those that match the search.
++
++The currently supported object search types are:
++
++=over 4
++
++=item objects acl <acl>
++
++Returns all objects for which the given ACL name or ID has any
++permissions.  This includes those objects owned by the ACL as well as
++those where that ACL has any other, more limited permissions.
++
++=item objects flag <flag>
++
++Returns all objects which have the given flag set.
++
++=item objects host <hostname>
++
++Returns all objects that belong to the given host.  This requires adding
++local configuration to identify objects that belong to a given host.  See
++L<Wallet::Config/"OBJECT HOST-BASED NAMES"> for more information.
++
++=item objects owner <acl>
++
++Returns all objects owned by the given ACL name or ID.
++
++=item objects type <type>
++
++Returns all objects of the given type.
++
++=item objects unused
++
++Returns all objects that have never been downloaded (have never been the
++target of a get command).
++
++=back
++
++=item owners <type-pattern> <name-pattern>
++
++Returns a list of all ACL entries in owner ACLs for all objects matching
++both <type-pattern> and <name-pattern>.  These can be the type or name of
++objects or they can be patterns using C<%> as the wildcard character
++following the normal rules of SQL patterns.
++
++The output will be one line per ACL line in the form:
++
++    <scheme> <identifier>
++
++with duplicates suppressed.
++
++=item schemes
++
++Returns a list of all registered ACL schemes.
++
++=item types
++
++Returns a list of all registered object types.
++
++=back
++
++=head1 AUTHOR
++
++Russ Allbery <eagle@eyrie.org>
++
++=head1 COPYRIGHT AND LICENSE
++
++Copyright 2016 Russ Allbery <eagle@eyrie.org>
++
++Copyright 2008, 2009, 2010, 2013, 2015 The Board of Trustees of the Leland
++Stanford Junior University
++
++Permission is hereby granted, free of charge, to any person obtaining a
++copy of this software and associated documentation files (the "Software"),
++to deal in the Software without restriction, including without limitation
++the rights to use, copy, modify, merge, publish, distribute, sublicense,
++and/or sell copies of the Software, and to permit persons to whom the
++Software is furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in
++all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++DEALINGS IN THE SOFTWARE.
++
++=head1 SEE ALSO
++
++Wallet::Config(3), Wallet::Report(3), wallet-backend(8)
++
++This program is part of the wallet system.  The current version is
++available from L<http://www.eyrie.org/~eagle/software/wallet/>.
++
++=cut

--- a/net/wallet/files/patch-tests-client-full-t.in.diff
+++ b/net/wallet/files/patch-tests-client-full-t.in.diff
@@ -1,0 +1,9 @@
+--- tests/client/full-t.in
++++ tests/client/full-t.in
+@@ -1,4 +1,5 @@
+-#!/usr/bin/perl
++#!@PERL@
++# -*- perl -*-
+ #
+ # End-to-end tests for the wallet client.
+ #

--- a/net/wallet/files/patch-tests-client-prompt-t.in.diff
+++ b/net/wallet/files/patch-tests-client-prompt-t.in.diff
@@ -1,0 +1,9 @@
+--- tests/client/prompt-t.in.orig
++++ tests/client/prompt-t.in
+@@ -1,4 +1,5 @@
+-#!/usr/bin/perl
++#!@PERL@
++# -*- perl -*-
+ #
+ # Password prompting tests for the wallet client.
+ #


### PR DESCRIPTION
Hello!  This is a pull request for a new port.

wallet is a Kerberos-authenticated file storage & retrieval engine, which has support for automatically generating things like Kerberos keytabs and random passwords. Authentication is via Kerberos, and client-server communication is via remctl.  On the client side, user's don't really notice anything; on the server side, you have to have the remctl daemon configured properly (this is noted in a Portfile note).  You also have to do post-install database configuration (also noted in the Portfile note).

Almost all of the patches are due to scripts hard-coding paths (to things like Perl).  The patch files change the paths so that they are figured out by `configure`, and are set in stone when `make` is run.  The wallet maintainer, @rra, has already accepted these changes into his repository, so (assuming nothing else pops up) these patches should disappear in the next release.  They can be seen here: https://github.com/rra/wallet/commits/master (look for the commits from January and August of this year).

Testing won't be the easiest thing to do, because you need to have a working Wallet server.  However, once you've done `sudo port install wallet`, you should at least be able to get some simple help text when you run `wallet -h`.

The Trac ticket for this is here: https://trac.macports.org/ticket/50421