### PR TITLE
Science/ALPSCore: portfile fixes; upgrade

### DIFF
--- a/science/ALPSCore/Portfile
+++ b/science/ALPSCore/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        ALPSCore ALPSCore 0.5.4 v
+github.setup        ALPSCore ALPSCore 0.5.6-alpha3 v
 categories          science
 platforms           darwin
 license             GPL-2
@@ -19,22 +19,28 @@ long_description    ALPSCore contains the core libraries of the applications and
 
 homepage            http://alpscore.org
 
-checksums           rmd160  0f75dd2cdd96e9e063e081d54f6a3c163ce8e004 \
-                    sha256  9d3e10ced8bb1284bb29e216b668dccf1d9ff3e2f91f74d1d6b1e2ecc3d00b06
+checksums           rmd160  4d3e625b51396e6407223cd743307a3650f9c9ee \
+                    sha256  ab0c10168cc5403d40688ef44fe1429d78fcd4536c819a5524d7c97d656b5d3a
 
 compiler.blacklist  gcc-4.2
 
 depends_lib         port:boost \
                     port:hdf5
 
-mpi.setup
+compilers.choose    cc cxx
+mpi.setup           -gcc -dragonegg
+
 configure.args      -DTesting=ON \
                     -DExtensiveTesting=OFF \
                     -DBOOST_ROOT=${prefix} \
-                    -DENABLE_MPI=TRUE \
+                    -DENABLE_MPI=OFF\
                     -DMPIEXEC:STRING="${mpi.exec}" \
                     -DBuildPython=OFF \
                     -DTestXMLOutput=TRUE \
                     -DDocumentation=OFF
+
+if {[mpi_variant_isset]} {
+  configure.args-replace -DENABLE_MPI=OFF -DENABLE_MPI=ON
+}
 
 cmake.out_of_source yes


### PR DESCRIPTION
Changes:
1. Implicit dependency on MPI removed.
2. Only "stock" `clang` is used to compile.
3. The latest upstream release (0.5.6-alpha3) is fetched.