### PR TITLE
Apache Ivy

### DIFF
--- a/devel/apache-ivy/Portfile
+++ b/devel/apache-ivy/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           java 1.0
 
 name                apache-ivy
-version             2.3.0
+version             2.4.0
 categories          devel java
 platforms           darwin freebsd
 license             Apache-2
@@ -24,10 +25,10 @@ depends_build       port:apache-ant
 master_sites        apache:ant/ivy/${version}
 distname            ${name}-${version}-src
 
-checksums           md5     53f27c8ef5da2eff5039efa6c45b84e7 \
-                    sha1    244213bd0d0f344e17678ccbc72b341db6c5b9a3 \
-                    sha256  20f9ba64b6f24328497394d8b3e24b8e15e12ad230958be9c76d6f8cccf081de \
-                    rmd160  b1cc2f95658209937960e26725b39ccbed431655
+checksums           md5     bd16ef9a402859522606ed9edd468f1f \
+                    sha1    1efa73e73b5fc14ef003ff2fcb182f039db33ce2 \
+                    sha256  202f08ca41f4bdf1c081aa8b2e531565be6c73e9e5e0d68137f454f14eb16ef6 \
+                    rmd160  f878b4c76d1fc6b42419eee47eb1bf28008408a8
 
 worksrcdir          ${name}-${version}
 
@@ -45,8 +46,4 @@ destroot {
     file delete -force ${worksrcpath}/build/artifact
     move ${worksrcpath}/doc ${docdir}/${name}
     # move ${worksrcpath} ${javadir}/${name}
-}
-
-platform darwin {
-    build.env       JAVA_HOME=/Library/Java/Home
 }

--- a/devel/apache-ivy/Portfile
+++ b/devel/apache-ivy/Portfile
@@ -1,37 +1,38 @@
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 
 name                apache-ivy
 version             2.3.0
 categories          devel java
+platforms           darwin freebsd
 license             Apache-2
 maintainers         nomaintainer
+
 description         Dependency manager for Apache Ant
-long_description    \
-    Apache Ivy is a transitive dependency manager that is designed to \
-    integrate with Apache Ant. An external XML file defines project \
-    dependencies and lists the resources necessary to build a project. \
-    Ivy then resolves and downloads resources from an artifact repository: \
-    either a private repository or one publicly available on the Internet.
-    
-homepage            http://ant.apache.org/ivy/
-
-platforms           darwin freebsd
-
-distname            ${name}-${version}-src
-master_sites        apache:ant/ivy/
-master_sites.mirror_subdir  ${version}
-worksrcdir          ${name}-${version}
+long_description    Apache Ivy is a transitive dependency manager that \
+                    is designed to integrate with Apache Ant. An \
+                    external XML file defines project dependencies and \
+                    lists the resources necessary to build a project. \
+                    Ivy then resolves and downloads resources from an \
+                    artifact repository: either a private repository \
+                    or one publicly available on the Internet.
+homepage            http://ant.apache.org/ivy
 
 depends_build       port:apache-ant
+
+master_sites        apache:ant/ivy/
+master_sites.mirror_subdir  ${version}
+distname            ${name}-${version}-src
 
 checksums           md5     53f27c8ef5da2eff5039efa6c45b84e7 \
                     sha1    244213bd0d0f344e17678ccbc72b341db6c5b9a3 \
                     sha256  20f9ba64b6f24328497394d8b3e24b8e15e12ad230958be9c76d6f8cccf081de \
                     rmd160  b1cc2f95658209937960e26725b39ccbed431655
 
-use_configure       no                    
+worksrcdir          ${name}-${version}
+
+use_configure       no
 build.cmd           ant
 build.target        /localivy jar
 
@@ -39,7 +40,7 @@ destroot {
     set javadir ${destroot}${prefix}/share/java/
     set docdir ${destroot}${prefix}/share/doc/
     xinstall -d ${javadir}/apache-ant/lib/ ${docdir}
-    
+
     xinstall ${worksrcpath}/build/artifact/jars/ivy.jar ${javadir}
     ln -s ${prefix}/share/java/ivy.jar ${javadir}/apache-ant/lib/ivy.jar
     file delete -force ${worksrcpath}/build/artifact
@@ -50,4 +51,3 @@ destroot {
 platform darwin {
     build.env       JAVA_HOME=/Library/Java/Home
 }
-

--- a/devel/apache-ivy/Portfile
+++ b/devel/apache-ivy/Portfile
@@ -21,8 +21,7 @@ homepage            http://ant.apache.org/ivy
 
 depends_build       port:apache-ant
 
-master_sites        apache:ant/ivy/
-master_sites.mirror_subdir  ${version}
+master_sites        apache:ant/ivy/${version}
 distname            ${name}-${version}-src
 
 checksums           md5     53f27c8ef5da2eff5039efa6c45b84e7 \


### PR DESCRIPTION
Two changes:

- Update to 2.4.0
- Fix `JAVA_HOME` used in the build phase to correctly detect the user's installed Java. The hard-coded path causes failure when the user has the JDK installed but not the JRE.