### PR TITLE
Update py-sqlparse port.

### DIFF
--- a/python/py-sqlparse/Portfile
+++ b/python/py-sqlparse/Portfile
@@ -1,33 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-sqlparse
-version             0.1.19
-python.versions     27 34 35
-categories-append   textproc
+version             0.2.1
 license             BSD
 platforms           darwin
 supported_archs     noarch
-maintainers         nomaintainer
+maintainers         gmail.com:xeron.oskom openmaintainer
 description         Non-validating SQL parser
-long_description    \
-    ${description} that provides support for parsing, splitting and \
-    formatting SQL statements.
+long_description    ${description} that provides support for parsing, splitting \
+                    and formatting SQL statements.
 
-homepage            https://pypi.python.org/pypi/sqlparse/
-master_sites        pypi:s/sqlparse/
-distname            sqlparse-${version}
+python.versions     27 34 35
 
-checksums           rmd160  cebc888c1226efc5c9deda6e2dc16475daad1b94 \
-                    sha256  d896be1a1c7f24bffe08d7a64e6f0176b260e281c5f3685afe7826f8bada4ee8
+categories-append   textproc
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  2b74f2e72e7d009869d7fb3269d5a5d5146b453a \
+                    sha256  1c98a2bdffe67f1bb817b72a7ba4d38be592e0f07c5acea4adebcec12c4377d1
 
 if {${name} ne ${subport}} {
-    livecheck.type      none
+    depends_build-append    port:py${python.version}-setuptools
+    livecheck.type  none
 } else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     "sqlparse (\\d+\\.\\d+(?:\\.\\d+))"
+    livecheck.type  pypi
 }


### PR DESCRIPTION
* new version 0.2.1
* add myself as maintainer
* remove Id line
* use python portgroup variables
* use pypi livecheck
* indentation cleanup and small reorder

Latest version is 0.2.2 but I'm using 0.2.1 for now because `mycli` depends on `<=0.2.1`.