### PR TITLE
[php] add postgresql96 support

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1,5 +1,4 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem              1.0
 PortGroup               php 1.1
@@ -1076,71 +1075,114 @@ subport ${php}-postgresql {
     
     long_description        ${description}
     
-    variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 description {Use PostgreSQL 8.2 libraries} {
+    variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 \
+            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 8.2 libraries" {
         depends_lib-append      port:postgresql82
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
     }
     
-    variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 description {Use PostgreSQL 8.3 libraries} {
+    variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 \
+            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 8.3 libraries" {
         depends_lib-append      port:postgresql83
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
     }
     
-    variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 description {Use PostgreSQL 8.4 libraries} {
+    variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 \
+            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 8.4 libraries" {
         depends_lib-append      port:postgresql84
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
     }
     
-    variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 description {Use PostgreSQL 9.0 libraries} {
+    variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 9.0 libraries" {
         depends_lib-append      port:postgresql90
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
     }
     
-    variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 description {Use PostgreSQL 9.1 libraries} {
+    variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 9.1 libraries" {
         depends_lib-append      port:postgresql91
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
     }
     
-    variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 description {Use PostgreSQL 9.2 libraries} {
+    variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 9.2 libraries" {
         depends_lib-append      port:postgresql92
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
     }
     
-    variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 description {Use PostgreSQL 9.3 libraries} {
+    variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 9.3 libraries" {
         depends_lib-append      port:postgresql93
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
     }
     
-    variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 description {Use PostgreSQL 9.4 libraries} {
+    variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 \
+            postgresql96 \
+            description "Use PostgreSQL 9.4 libraries" {
         depends_lib-append      port:postgresql94
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
     }
     
-    variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 description {Use PostgreSQL 9.5 libraries} {
+    variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
+            postgresql96 \
+            description "Use PostgreSQL 9.5 libraries" {
         depends_lib-append      port:postgresql95
         
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
     }
     
-    if {![variant_isset postgresql82] && ![variant_isset postgresql83] && ![variant_isset postgresql84] && ![variant_isset postgresql90] && ![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95]} {
-        default_variants +postgresql94
+    variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 \
+            postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
+            postgresql95 \
+            description "Use PostgreSQL 9.6 libraries" {
+        depends_lib-append      port:postgresql96
+        
+        configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
+                                --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
+    }
+    
+    if {
+        ![variant_isset postgresql82] && ![variant_isset postgresql83] &&
+        ![variant_isset postgresql84] && ![variant_isset postgresql90] &&
+        ![variant_isset postgresql91] && ![variant_isset postgresql92] &&
+        ![variant_isset postgresql93] && ![variant_isset postgresql94] &&
+        ![variant_isset postgresql95] && ![variant_isset postgresql96]
+    } {
+        default_variants +postgresql95
     }
 }
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -150,13 +150,13 @@ if {[vercmp ${major} 5] > 0} {
 }
 
 if {[is_sapi_subport]} {
-    
+
     depends_build       port:pkgconfig
-    
+
     if {${subport} ne ${php}} {
         depends_lib     port:${php}
     }
-    
+
     depends_lib-append  path:bin/gsed:gsed \
                         port:libiconv \
                         port:libxml2 \
@@ -164,11 +164,11 @@ if {[is_sapi_subport]} {
                         port:mhash \
                         port:pcre \
                         port:zlib
-    
+
     # Use -p1 to accommodate the Suhosin patch
     patch.pre_args      -p1
     patchfiles          patch-${php}-scripts-php-config.in.diff
-    
+
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append \
                         patch-${php}-libxml-2.9.diff \
@@ -179,10 +179,10 @@ if {[is_sapi_subport]} {
     # Tested all subports (except oracle) and they built with clang-425.  The reported failure was with Xcode 4.2.
     # Xcode 4.3 may work, but leaving it blacklisted due to lack of testing
     compiler.blacklist  {clang < 400}
-    
+
     set phpinidir       ${prefix}/etc/${php}
     set extraphpinidir  ${prefix}/var/db/${php}
-    
+
     configure.args      --mandir=${prefix}/share/man \
                         --infodir=${prefix}/share/info \
                         --program-suffix=[php.suffix_from_branch ${branch}] \
@@ -213,33 +213,33 @@ if {[is_sapi_subport]} {
                         --without-pear \
                         --disable-cgi \
                         --disable-cli
-    
+
     if {[vercmp ${branch} 5.3] >= 0} {
         configure.args-append \
                         --enable-fileinfo \
                         --enable-phar \
                         --disable-fpm
-        
+
         # ${php}-mysql +mysqlnd needs mysqlnd support compiled into the SAPI
         configure.env-append \
                         PHP_MYSQLND_ENABLED=yes
     }
-    
+
     if {[vercmp ${branch} 5.4] == 0} {
         # https://bugs.php.net/bug.php?id=68114
         configure.args-append ac_cv_decimal_fp_supported=no
     }
-    
+
     configure.universal_args-delete --disable-dependency-tracking
-    
+
     test.run            yes
-    
+
     destroot.args       INSTALL_ROOT=${destroot}
-    
+
     variant debug description {Enable debug support (useful to analyze a PHP-related core dump)} {
         configure.args-append   --enable-debug
     }
-    
+
     if {[vercmp ${branch} 5.3] <= 0} {
     variant suhosin description {Add Suhosin patch} {
         pre-fetch {
@@ -269,11 +269,11 @@ if {[is_sapi_subport]} {
         }
     }
     }
-    
+
     if {${subport} ne ${php}} {
         notes-append "If this is your first install, you need to enable ${subport} in your web server."
     }
-    
+
 }
 
 }
@@ -282,23 +282,23 @@ if {[is_sapi_subport]} {
 
 subport ${php} {
     PortGroup               select 1.0
-    
+
     switch -- ${version} {
         5.2.17              {revision 11}
         5.3.29              {revision 1}
     }
-    
+
     depends_run             port:php_select
-    
+
     select.group            php
     select.file             ${filespath}/${subport}
-    
+
     configure.args-replace  --disable-cli --enable-cli
-    
+
     destroot.target         install-cli install-build install-headers install-programs
-    
+
     destroot.keepdirs       ${destroot}${extraphpinidir}
-    
+
     post-destroot {
         # Copy the default php.ini files.
         xinstall -m 755 -d ${destroot}${phpinidir}
@@ -313,14 +313,14 @@ subport ${php} {
                 php.ini-recommended \
                 ${destroot}${phpinidir}
         }
-        
+
         if {[vercmp ${branch} 5.3] >= 0} {
             # Copy mysqlnd headers.
             xinstall -d ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
             xinstall -m 644 {*}[glob ${worksrcpath}/ext/mysqlnd/*.h] ${destroot}${prefix}/include/${php}/php/ext/mysqlnd
         }
     }
-    
+
     # Include the readline extension http://www.php.net/readline directly in
     # the PHP CLI SAPI because until PHP 6 the interactive mode "php -a" won't
     # work with a separately built readline extension.
@@ -340,7 +340,7 @@ subport ${php} {
     if {![variant_isset readline]} {
         default_variants +libedit
     }
-    
+
     if {[vercmp ${branch} 5.5] < 0} {
         notes-append "
 PHP ${branch} has reached end-of-life. Please upgrade to PHP 5.5 or newer. The newest stable version is ${php.latest_stable_branch}.
@@ -352,11 +352,11 @@ To learn how to update your code, please read the following guides:
 
 "
     }
-    
+
     if {[vercmp ${branch} ${php.latest_stable_branch}] > 0} {
         notes-append "${php} @${version}_${revision} is a development preview—do not use it in production!\n\n\n"
     }
-    
+
     if {![file exists ${phpinidir}/php.ini]} {
         if {[vercmp ${branch} 5.3] >= 0} {
             notes-append "
@@ -387,7 +387,7 @@ ${phpinidir}/php.ini-recommended.
 "
         }
     }
-    
+
     # Enable livecheck for the two most recent stable PHP branches and the development branch.
     if {[vercmp ${branch} [lindex ${php.branches} end-2]] >= 0} {
         livecheck.type      regex
@@ -400,34 +400,34 @@ ${phpinidir}/php.ini-recommended.
 
 subport ${php}-apache2handler {
     PortGroup               active_variants 1.1
-    
+
     description             ${php} Apache 2 Handler SAPI
-    
+
     long_description        ${description}
-    
+
     homepage                http://www.php.net/install.unix.apache2
-    
+
     depends_lib-append      port:apache2
-    
+
     require_active_variants apache2 preforkmpm
-    
+
     set apxs ${prefix}/apache2/bin/apxs
     set confdir ${prefix}/apache2/conf
     set moduledir ${prefix}/apache2/modules
-    
+
     configure.args-append   --with-apxs2=${apxs}
-    
+
     build.target            libs/libphp${major}.bundle
-    
+
     destroot.violate_mtree  yes
-    
+
     destroot {
         xinstall -m 755 -d ${destroot}${moduledir} ${destroot}${confdir}/extra
         xinstall -m 644 ${worksrcpath}/libs/libphp${major}.so ${destroot}${moduledir}/mod_${php}.so
         xinstall -m 644 ${filespath}/mod_php.conf.in ${destroot}${confdir}/extra/mod_${php}.conf
         reinplace s/@MAJOR@/${major}/g ${destroot}${confdir}/extra/mod_${php}.conf
     }
-    
+
     notes-append "
 
 To enable ${subport}, run:
@@ -441,18 +441,18 @@ To enable ${subport}, run:
 
 subport ${php}-cgi {
     description             ${php} CGI SAPI
-    
+
     long_description        ${description}
-    
+
     homepage                http://www.php.net/install.unix.commandline
-    
+
     configure.args-delete   --disable-cgi
     if {[vercmp ${branch} 5.3] >= 0} {
         configure.args-append --enable-cgi
     } else {
         configure.args-append --enable-fastcgi --enable-force-cgi-redirect
     }
-    
+
     if {[vercmp ${branch} 5.4] >= 0} {
         build.target        cgi
         destroot.target     install-cgi
@@ -461,7 +461,7 @@ subport ${php}-cgi {
             xinstall ${worksrcpath}/sapi/cgi/php-cgi ${destroot}${prefix}/bin/php-cgi[php.suffix_from_branch ${branch}]
         }
     }
-    
+
 }
 
 ### FPM SAPI ###
@@ -469,40 +469,40 @@ subport ${php}-cgi {
 if {[vercmp ${branch} 5.3] >= 0} {
 subport ${php}-fpm {
     description             ${php} FPM SAPI
-    
+
     long_description        ${description}
-    
+
     homepage                http://www.php.net/install.fpm
-    
+
     set fpmuser             nobody
     set fpmgroup            nobody
-    
+
     patchfiles-append       patch-${php}-sapi-fpm-php-fpm.conf.in.diff
-    
+
     post-patch {
         reinplace "s|@PHP@|${php}|g" ${worksrcpath}/sapi/fpm/php-fpm.conf.in
     }
-    
+
     configure.args-replace  --disable-fpm --enable-fpm
     configure.args-append   --datadir=${prefix}/share/examples/${php} \
                             --sysconfdir=${phpinidir} \
                             --with-fpm-user=${fpmuser} \
                             --with-fpm-group=${fpmgroup}
-    
+
     build.target            fpm
-    
+
     destroot.target         install-fpm
-    
+
     destroot.keepdirs       ${destroot}${prefix}/var/log/${php} \
                             ${destroot}${prefix}/var/run/${php}
-    
+
     post-destroot {
         xinstall -d -o ${fpmuser} -g ${fpmgroup} ${destroot}${prefix}/var/log/${php} ${destroot}${prefix}/var/run/${php}
     }
-    
+
     startupitem.create      yes
     startupitem.executable  ${prefix}/sbin/php-fpm[php.suffix_from_branch ${branch}]
-    
+
     if {![file exists ${phpinidir}/php-fpm.conf]} {
         notes-append "
 
@@ -526,36 +526,36 @@ ${phpinidir}/php-fpm.conf.default.
 subport ${php}-calendar {
     description             a PHP extension for converting between different \
                             calendar formats
-    
+
     long_description        ${description}
 }
 
 subport ${php}-curl {
     categories-append       net www
-    
+
     description             a PHP interface to the curl library, which lets you \
                             download files from servers with a variety of protocols
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:curl
-    
+
     configure.args-append   --with-curl=${prefix}
 }
 
 subport ${php}-dba {
     categories-append       databases
-    
+
     description             a PHP interface for accessing DBM databases such as \
                             BerkeleyDB
-    
+
     long_description        ${description}
-    
+
     variant gdbm conflicts qdbm description {Add GDBM support} {
         depends_lib-append      port:gdbm
         configure.args-append   --with-gdbm=${prefix}
     }
-    
+
     variant qdbm conflicts gdbm description {Add QDBM support} {
         depends_lib-append      port:qdbm
         configure.args-append   --with-qdbm=${prefix}
@@ -565,20 +565,20 @@ subport ${php}-dba {
 if {[vercmp ${branch} 5.3] >= 0} {
 subport ${php}-enchant {
     categories-append       textproc devel
-    
+
     description             a PHP interface to enchant
-    
+
     long_description        ${name} is ${description}, a common API for many spell libraries.
-    
+
     depends_lib-append      port:enchant
-    
+
     configure.args-append   --with-enchant=${prefix}
-    
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
-        
+
         set examplesdir ${prefix}/share/examples/${subport}
         xinstall -d ${destroot}${examplesdir}
         xinstall -m 644 ${destroot.dir}/docs/examples/example1.php \
@@ -589,39 +589,39 @@ subport ${php}-enchant {
 
 subport ${php}-exif {
     categories-append       graphics
-    
+
     description             a PHP interface to the EXIF image metadata functions
-    
+
     long_description        ${description}
 }
 
 subport ${php}-ftp {
     categories-append       net
-    
+
     description             a PHP extension for accessing file servers using the \
                             File Transfer Protocol
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      path:lib/libssl.dylib:openssl
-    
+
     configure.args-append   --with-openssl-dir=${prefix}
 }
 
 subport ${php}-gd {
     categories-append       graphics
-    
+
     description             a PHP interface to the gd library
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:freetype \
                             port:jpeg \
                             port:libpng \
                             port:zlib
-    
+
     patchfiles-append       patch-${php}-ext-gd-config.m4.diff
-    
+
     configure.args-append   --with-freetype-dir=${prefix} \
                             --with-jpeg-dir=${prefix} \
                             --with-png-dir=${prefix} \
@@ -632,7 +632,7 @@ subport ${php}-gd {
         depends_lib-append  port:webp
         configure.args-append --with-webp-dir=${prefix}
     }
-    
+
     if {[vercmp ${branch} 7] < 0} {
     variant t1lib description {Add PostScript Type 1 font support with t1lib} {
         depends_lib-append      port:t1lib
@@ -643,60 +643,60 @@ subport ${php}-gd {
 
 subport ${php}-gettext {
     categories-append       devel
-    
+
     description             a PHP interface to the gettext natural language \
                             support functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:gettext
-    
+
     configure.args-append   --with-gettext=${prefix}
 }
 
 subport ${php}-gmp {
     categories-append       devel math
-    
+
     description             a PHP interface to GMP, the GNU multiprocessing \
                             library through which you can work with \
                             arbitrary-length integers
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:gmp
-    
+
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append   patch-${php}-ext-gmp-gmp.c.diff
     }
-    
+
     configure.args-append   --with-gmp=${prefix}
 }
 
 subport ${php}-iconv {
     categories-append       textproc
-    
+
     description             a PHP interface to the libiconv character encoding \
                             conversion functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libiconv
-    
+
     configure.args-append   --with-iconv=${prefix}
 }
 
 subport ${php}-imap {
     categories-append       mail
-    
+
     description             a PHP interface to the IMAP protocol
-    
+
     long_description        ${description}
-    
+
     depends_build-append    port:cclient
-    
+
     depends_lib-append      port:kerberos5 \
                             port:libcomerr
-    
+
     configure.args-append   --with-imap=${prefix} \
                             --with-imap-ssl=${prefix} \
                             --with-kerberos=${prefix}
@@ -707,82 +707,82 @@ subport ${php}-intl {
     switch -- ${version} {
         5.3.29              {revision 2}
     }
-    
+
     categories-append       devel
-    
+
     description             internationalization extension for PHP
-    
+
     long_description        Internationalization extension implements ICU \
                             library functionality in PHP.
-    
+
     depends_lib-append      port:icu
 }
 }
 
 subport ${php}-ipc {
     php.extensions          shmop sysvmsg sysvsem sysvshm
-    
+
     description             interprocess communication extensions for PHP
-    
+
     long_description        PHP extensions for interprocess communication (IPC), including the \
                             shmop, sysvmsg, sysvsem, and sysvshm extensions.
 }
 
 subport ${php}-ldap {
     categories-append       databases
-    
+
     description             a PHP interface to LDAP
 
     long_description        ${subport} is ${description}, the Lightweight Directory \
                             Access Protocol, which is used to access Directory \
                             Servers.
-    
+
     depends_lib-append      port:openldap \
                             port:cyrus-sasl2
-    
+
     configure.args-append   --with-ldap=${prefix} \
                             --with-ldap-sasl=${prefix}
 }
 
 subport ${php}-mbstring {
     categories-append       textproc
-    
+
     description             a PHP extension for manipulating strings in multibyte \
                             encodings
-    
+
     long_description        ${description}
 }
 
 subport ${php}-mcrypt {
     categories-append       security
-    
+
     description             a PHP interface to the mcrypt library, which offers \
                             a wide variety of algorithms
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libmcrypt
-    
+
     # The mcrypt extension may be using libtool unnecessarily; monitor
     # https://bugs.php.net/bug.php?id=54500
     depends_lib-append      port:libtool
-    
+
     configure.args-append   --with-mcrypt=${prefix}
 }
 
 if {[vercmp ${branch} 7] < 0} {
 subport ${php}-mssql {
     php.extensions          mssql pdo_dblib
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to MSSQL using FreeTDS, including \
                             the mssql and pdo_dblib extensions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:freetds
-    
+
     configure.args-append   --with-mssql=${prefix} \
                             --with-pdo-dblib=${prefix}
 }
@@ -793,29 +793,29 @@ subport ${php}-mysql {
     if {[vercmp ${branch} 7] < 0} {
         php.extensions-prepend mysql
     }
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to MySQL databases, including the
     if {[vercmp ${branch} 7] < 0} {
         description-append  mysql,
     }
     description-append      mysqli and pdo_mysql extensions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:zlib
-    
+
     configure.args-append   --with-zlib-dir=${prefix}
-    
+
     if {[vercmp ${branch} 5.3] >= 0} {
     variant mysqlnd conflicts mysql4 mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL Native Driver} {
         configure.args-append   --with-mysql=mysqlnd \
                                 --with-mysqli=mysqlnd \
                                 --with-pdo-mysql=mysqlnd
-        
+
         configure.cppflags-append   -I${worksrcpath}
-        
+
         set phpini ${prefix}/etc/${php}/php.ini
         notes "
 To use mysqlnd with a local MySQL server, edit ${phpini} and set\
@@ -831,104 +831,104 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 "
     }
     }
-    
+
     variant mysql4 conflicts mysqlnd mysql5 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 4 libraries} {
         depends_lib-append      port:mysql4
-        
+
         configure.args-append   --with-mysql=${prefix} \
                                 --with-pdo-mysql=${prefix}
     }
-    
+
     variant mysql5 conflicts mysqlnd mysql4 mysql51 mysql55 mysql56 mariadb percona description {Use MySQL 5 libraries} {
         depends_lib-append      path:bin/mysql_config5:mysql5
-        
+
         post-extract {
             file mkdir ${workpath}/mysql5
             file link -symbolic ${workpath}/mysql5/lib ${prefix}/lib/mysql5
             file link -symbolic ${workpath}/mysql5/include ${prefix}/include/mysql5
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql5 \
                                 --with-mysqli=${prefix}/bin/mysql_config5 \
                                 --with-pdo-mysql=${prefix}/bin/mysql_config5 \
                                 --with-mysql-sock=${prefix}/var/run/mysql5/mysqld.sock
     }
-    
+
     variant mysql51 conflicts mysqlnd mysql4 mysql5 mysql55 mysql56 mariadb percona description {Use MySQL 5.1 libraries} {
         depends_lib-append      port:mysql51
-        
+
         post-extract {
             file mkdir ${workpath}/mysql51
             file link -symbolic ${workpath}/mysql51/lib ${prefix}/lib/mysql51
             file link -symbolic ${workpath}/mysql51/include ${prefix}/include/mysql51
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql51 \
                                 --with-mysqli=${prefix}/lib/mysql51/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mysql51/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mysql51/mysqld.sock
     }
-    
+
     variant mysql55 conflicts mysqlnd mysql4 mysql5 mysql51 mysql56 mariadb percona description {Use MySQL 5.5 libraries} {
         depends_lib-append      port:mysql55
-        
+
         post-extract {
             file mkdir ${workpath}/mysql55
             file link -symbolic ${workpath}/mysql55/lib ${prefix}/lib/mysql55
             file link -symbolic ${workpath}/mysql55/include ${prefix}/include/mysql55
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql55 \
                                 --with-mysqli=${prefix}/lib/mysql55/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mysql55/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mysql55/mysqld.sock
     }
-    
+
     variant mysql56 conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mariadb percona description {Use MySQL 5.6 libraries} {
         depends_lib-append      port:mysql56
-        
+
         post-extract {
             file mkdir ${workpath}/mysql56
             file link -symbolic ${workpath}/mysql56/lib ${prefix}/lib/mysql56
             file link -symbolic ${workpath}/mysql56/include ${prefix}/include/mysql56
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mysql56 \
                                 --with-mysqli=${prefix}/lib/mysql56/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mysql56/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mysql56/mysqld.sock
     }
-    
+
     variant mariadb conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 percona description {Use MariaDB libraries} {
         depends_lib-append      port:mariadb
-        
+
         post-extract {
             file mkdir ${workpath}/mariadb
             file link -symbolic ${workpath}/mariadb/lib ${prefix}/lib/mariadb
             file link -symbolic ${workpath}/mariadb/include ${prefix}/include/mariadb
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/mariadb \
                                 --with-mysqli=${prefix}/lib/mariadb/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/mariadb/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/mariadb/mysqld.sock
     }
-    
+
     variant percona conflicts mysqlnd mysql4 mysql5 mysql51 mysql55 mysql56 mariadb description {Use Percona libraries} {
         depends_lib-append      port:percona
-        
+
         post-extract {
             file mkdir ${workpath}/percona
             file link -symbolic ${workpath}/percona/lib ${prefix}/lib/percona
             file link -symbolic ${workpath}/percona/include ${prefix}/include/percona
         }
-        
+
         configure.args-append   --with-mysql=${workpath}/percona \
                                 --with-mysqli=${prefix}/lib/percona/bin/mysql_config \
                                 --with-pdo-mysql=${prefix}/lib/percona/bin/mysql_config \
                                 --with-mysql-sock=${prefix}/var/run/percona/mysqld.sock
     }
-    
+
     if {![variant_isset mysql4] && ![variant_isset mysql5] && ![variant_isset mysql51] && ![variant_isset mysql55] && ![variant_isset mysql56] && ![variant_isset mariadb] && ![variant_isset percona]} {
         if {[vercmp ${branch} 5.3] >= 0} {
             default_variants +mysqlnd
@@ -940,32 +940,32 @@ For percona, use ${prefix}/var/run/percona/mysqld.sock
 
 subport ${php}-odbc {
     php.extensions          odbc pdo_odbc
-    
+
     categories-append       databases
-    
+
     description             a PHP interface for accessing databases via Open \
                             DataBase Connectivity (ODBC)
-    
+
     long_description        ${description}
-    
+
     variant iodbc conflicts unixodbc description {Use iODBC} {
         depends_lib-append      port:libiodbc
-        
+
         patchfiles-append       patch-${php}-iODBC.diff
-        
+
         configure.args-append   --with-iODBC=${prefix} \
                                 --with-pdo-odbc=iODBC,${prefix}
     }
-    
+
     variant unixodbc conflicts iodbc description {Use unixODBC} {
         depends_lib-append      port:unixODBC
-        
+
         patchfiles-append       patch-${php}-unixODBC.diff
-        
+
         configure.args-append   --with-unixODBC=${prefix} \
                                 --with-pdo-odbc=unixODBC,${prefix}
     }
-    
+
     if {![variant_isset iodbc] && ![variant_isset unixodbc]} {
         default_variants +unixodbc
     }
@@ -974,15 +974,15 @@ subport ${php}-odbc {
 if {[vercmp ${branch} 5.5] >= 0} {
     subport ${php}-opcache {
         php.extensions.zend opcache
-        
+
         description         OPcache improves PHP performance by storing precompiled \
                             script bytecode in shared memory, thereby removing the \
                             need for PHP to load and parse scripts on each request.
-        
+
         long_description    ${description}
-        
+
         configure.args-append --enable-opcache
-        
+
         post-destroot {
             set docdir ${destroot}${prefix}/share/doc/${subport}
             xinstall -d ${docdir}
@@ -993,41 +993,41 @@ if {[vercmp ${branch} 5.5] >= 0} {
 
 subport ${php}-openssl {
     categories-append       devel security
-    
+
     description             a PHP interface to OpenSSL signature-generation \
                             and -verification and data-encryption and \
                             -decryption functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:kerberos5 \
                             port:libcomerr \
                             path:lib/libssl.dylib:openssl
-    
+
     post-extract {
         move ${php.build_dirs}/config0.m4 ${php.build_dirs}/config.m4
     }
-    
+
     configure.args-append   --with-kerberos=${prefix} \
                             --with-openssl=${prefix}
 }
 
 subport ${php}-oracle {
     php.extensions          oci8 pdo_oci
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to Oracle, including the oci8 and \
                             pdo_oci extensions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:oracle-instantclient
-    
+
     if {[vercmp ${branch} 5.2] <= 0} {
         patchfiles-append   patch-${php}-ext-pdo_oci-config.m4.diff
     }
-    
+
     set lib_dir             ${prefix}/lib/oracle
     pre-configure {
         regexp {\.dylib\.(.+)$} [glob -directory ${lib_dir} libclntsh.dylib.*] -> library_version
@@ -1039,13 +1039,13 @@ subport ${php}-oracle {
 
 subport ${php}-pcntl {
     categories-append       sysutils
-    
+
     description             a PHP interface to Unix-style process creation, \
                             program execution, signal handling and process \
                             termination functions
-    
+
     long_description        ${description}
-    
+
     notes "
 ${subport} should not be enabled within a web server environment.\
 Unexpected results may occur if any process control functions are used within\
@@ -1055,9 +1055,9 @@ a web server environment.
 
 subport ${php}-posix {
     categories-append       sysutils
-    
+
     description             a PHP interface to additional POSIX functions
-    
+
     long_description        a PHP interface to those functions defined in the \
                             IEEE 1003.1 (POSIX.1) standards document which are \
                             not accessible through other means
@@ -1065,116 +1065,116 @@ subport ${php}-posix {
 
 subport ${php}-postgresql {
     php.extensions          pgsql pdo_pgsql
-    
+
     categories-append       databases
-    
+
     homepage                http://www.php.net/pgsql
-    
+
     description             a PHP interface to PostgreSQL, including \
                             the pgsql and pdo_pgsql extensions
-    
+
     long_description        ${description}
-    
+
     variant postgresql82 conflicts postgresql83 postgresql84 postgresql90 \
             postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 8.2 libraries" {
         depends_lib-append      port:postgresql82
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql82/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql82/bin
     }
-    
+
     variant postgresql83 conflicts postgresql82 postgresql84 postgresql90 \
             postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 8.3 libraries" {
         depends_lib-append      port:postgresql83
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql83/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql83/bin
     }
-    
+
     variant postgresql84 conflicts postgresql82 postgresql83 postgresql90 \
             postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 8.4 libraries" {
         depends_lib-append      port:postgresql84
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql84/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql84/bin
     }
-    
+
     variant postgresql90 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 9.0 libraries" {
         depends_lib-append      port:postgresql90
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql90/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql90/bin
     }
-    
+
     variant postgresql91 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql90 postgresql92 postgresql93 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 9.1 libraries" {
         depends_lib-append      port:postgresql91
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql91/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql91/bin
     }
-    
+
     variant postgresql92 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql90 postgresql91 postgresql93 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 9.2 libraries" {
         depends_lib-append      port:postgresql92
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql92/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql92/bin
     }
-    
+
     variant postgresql93 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql90 postgresql91 postgresql92 postgresql94 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 9.3 libraries" {
         depends_lib-append      port:postgresql93
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql93/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql93/bin
     }
-    
+
     variant postgresql94 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql90 postgresql91 postgresql92 postgresql93 postgresql95 \
             postgresql96 \
             description "Use PostgreSQL 9.4 libraries" {
         depends_lib-append      port:postgresql94
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql94/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql94/bin
     }
-    
+
     variant postgresql95 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
             postgresql96 \
             description "Use PostgreSQL 9.5 libraries" {
         depends_lib-append      port:postgresql95
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql95/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql95/bin
     }
-    
+
     variant postgresql96 conflicts postgresql82 postgresql83 postgresql84 \
             postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
             postgresql95 \
             description "Use PostgreSQL 9.6 libraries" {
         depends_lib-append      port:postgresql96
-        
+
         configure.args-append   --with-pgsql=${prefix}/lib/postgresql96/bin \
                                 --with-pdo-pgsql=${prefix}/lib/postgresql96/bin
     }
-    
+
     if {
         ![variant_isset postgresql82] && ![variant_isset postgresql83] &&
         ![variant_isset postgresql84] && ![variant_isset postgresql90] &&
@@ -1188,73 +1188,73 @@ subport ${php}-postgresql {
 
 subport ${php}-pspell {
     categories-append       textproc
-    
+
     description             a PHP interface to the aspell library, which lets you \
                             check spelling and offer spelling suggestions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:aspell
-    
+
     configure.args-append   --with-pspell=${prefix}
 }
 
 subport ${php}-snmp {
     categories-append       sysutils
-    
+
     description             a PHP interface to the Simple Network Management \
                             Protocol (SNMP)
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:net-snmp
-    
+
     configure.args-append   --with-snmp=${prefix}
 }
 
 subport ${php}-soap {
     categories-append       net
-    
+
     description             a PHP extension for writing SOAP clients and servers
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libxml2
-    
+
     configure.args-append   --with-libxml-dir=${prefix}
 }
 
 subport ${php}-sockets {
     categories-append       net
-    
+
     description             a PHP interface to BSD socket communication \
                             functions
-    
+
     long_description        ${description}
 }
 
 if {[vercmp ${branch} 5.3] >= 0} {
 subport ${php}-sqlite {
     php.extensions          sqlite sqlite3 pdo_sqlite
-    
+
     categories-append       databases
-    
+
     description             a PHP interface to SQLite, including the sqlite, sqlite3 \
                             and pdo_sqlite extensions
-    
+
     if {[vercmp ${branch} 5.4] >= 0} {
         php.extensions-delete sqlite
         description-delete "sqlite,"
     }
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:sqlite3
-    
+
     post-extract {
         move ${worksrcpath}/ext/sqlite3/config0.m4 ${worksrcpath}/ext/sqlite3/config.m4
     }
-    
+
     configure.args-append   --with-sqlite3=${prefix} \
                             --with-pdo-sqlite=${prefix} \
                             --enable-sqlite-utf8
@@ -1267,53 +1267,53 @@ subport ${php}-tidy {
         5.3.29              {revision 2}
         5.4.45              {revision 1}
     }
-    
+
     categories-append       www
-    
+
     description             a PHP interface to tidy, the HTML cleaning and \
                             repair utility
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:tidy
-    
+
     if {[vercmp ${branch} 7.0] <= 0} {
         patchfiles-append   patch-${php}-ext-tidy-tidy.c.diff
     }
-    
+
     configure.args-append   --with-tidy=${prefix}
 }
 
 subport ${php}-wddx {
     categories-append       textproc
-    
+
     description             a PHP interface to Web Distributed Data Exchange
-    
+
     long_description        ${description}
-    
+
     depends_build-append    port:expat \
                             port:libxml2
-    
+
     configure.args-append   --with-libexpat-dir=${prefix} \
                             --with-libxml-dir=${prefix}
 }
 
 subport ${php}-xmlrpc {
     categories-append       textproc
-    
+
     description             a PHP extension for writing XML-RPC clients and servers
-    
+
     long_description        ${description}
-    
+
     depends_build-append    port:libiconv \
                             port:libxml2
-    
+
     depends_lib-append      port:expat
-    
+
     configure.args-append   --with-iconv-dir=${prefix} \
                             --with-libexpat-dir=${prefix} \
                             --with-libxml-dir=${prefix}
-    
+
     pre-configure {
         configure.cppflags-append [exec ${prefix}/bin/xml2-config --cflags]
     }
@@ -1321,28 +1321,28 @@ subport ${php}-xmlrpc {
 
 subport ${php}-xsl {
     categories-append       textproc
-    
+
     description             a PHP interface to libxslt, which implements the XSL \
                             standard and lets you perform XSL transformations
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:libxslt
-    
+
     configure.args-append   --with-xsl=${prefix}
-    
+
     configure.cppflags-append   -I${prefix}/include/${php}/php/ext/dom
 }
 
 subport ${php}-zip {
     categories-append       archivers
-    
+
     description             PHP zip functions
-    
+
     long_description        ${description}
-    
+
     depends_lib-append      port:zlib
-    
+
     configure.args-append   --with-zlib-dir=${prefix}
 }
 
@@ -1383,7 +1383,7 @@ proc get_default_php_extensions {} {
 if {[is_extension_subport]} {
     default php.extensions {[get_default_php_extensions]}
     default homepage    http://www.php.net/${php.rootname}
-    
+
     php.build_dirs
     set pdo no
     foreach extension [concat ${php.extensions} ${php.extensions.zend}] {
@@ -1395,19 +1395,19 @@ if {[is_extension_subport]} {
                 ln -s ${worksrcpath}/ext/pdo ${worksrcpath}/ext/${extension}/ext
             }
         }
-        
+
         # Speed up extraction by extracting only the modules we're going to be building.
         extract.post_args-append ${worksrcdir}/ext/${extension}
-        
+
         # Run phpize, configure, build and destroot in each extension's directory.
         php.build_dirs-append ${worksrcpath}/ext/${extension}
     }
-    
+
     if {${pdo}} {
         # The PDO extensions need the PDO headers.
         extract.post_args-append ${worksrcdir}/ext/pdo
     }
-    
+
     pre-configure {
         set php_version [exec ${php.config} --version 2>/dev/null]
         if {${version} ne ${php_version}} {
@@ -1415,8 +1415,8 @@ if {[is_extension_subport]} {
             return -code error "incompatible ${php} installation"
         }
     }
-    
+
     destroot.target     install-modules install-headers
-    
+
     php.add_port_code
 }


### PR DESCRIPTION
php port update for postgresql96.
    
* add `postgresql96` variant
* reformat all postgresql variants to make it easier to maintain

Second commit is only trailing whitespace removal. I can remove it if you don't like this whitespace changes.

@ryandesign 