### PR TITLE
Added pkgconfig as build dependency

### DIFF
--- a/science/ldas-tools-al/Portfile
+++ b/science/ldas-tools-al/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 fc50f9c7911463fabd79f55e59fbcc8519bd45b1 \
               sha256 5583e511bd680a43023b1d9a1c05d3e0c11ac70624032e8c918bdb47dd7a4b8e
 
+depends_build  port:pkgconfig
 depends_lib    port:lib/libssl.dylib:openssl \
                port:zlib \
                port:bzip2 \

--- a/science/ldas-tools-diskcacheAPI/Portfile
+++ b/science/ldas-tools-diskcacheAPI/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 580e1ffbafbd039906622a5b72c591a2ff8fcd9b \
               sha256 22790bbd2437c190168fe1b137bdcd3b0179ba8ef53cad3d826788f70995907f
 
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-ldasgen
 
 configure.args --disable-warnings-as-errors \

--- a/science/ldas-tools-filters/Portfile
+++ b/science/ldas-tools-filters/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 ef9771271586b6b31c2f70687d5750ef5a61f276 \
               sha256 44d475e625f5a59c9846a85d79419ef1303d3d9011bae56780156cab1a55f3b4
 
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-al
 
 configure.args --disable-warnings-as-errors \

--- a/science/ldas-tools-frameAPI/Portfile
+++ b/science/ldas-tools-frameAPI/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 d8ca30fc0d10b05015591a87951ee7e0333218e0 \
               sha256 c7d58952e213a024dd6ac33dd907862b2c96baa7a4fb2ac4bb47ceef6bc45d50
 
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-ldasgen \
                port:ldas-tools-filters \
                port:ldas-tools-framecpp

--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 53853b72a57db344437b8ab7b8d199c6cee91495 \
               sha256 54783c5ae235b8016adbc02d95aedcbd5f1256ae3b74b27ae516d9dee3cbe11b
 
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-al \
                port:openssl \
                port:zlib \

--- a/science/ldas-tools-ldasgen/Portfile
+++ b/science/ldas-tools-ldasgen/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 b8f7600b992f599b183146732967582a942b4ad8 \
               sha256 48b410aeb1b9718c5185c74fc9cba11c79da08f8bdc78a140db72b07a8ba099f
 
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-al
 
 configure.args --disable-warnings-as-errors \

--- a/science/ldas-tools-utilities/Portfile
+++ b/science/ldas-tools-utilities/Portfile
@@ -18,6 +18,7 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 e81be56d8d8e079ded4547f0dbe6bafe1cecac93 \
               sha256 cd19fcb17927173133d81777aa598c928f2854c998e82653fbc4922e72df771d
 
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-frameAPI \
                port:ldas-tools-diskcacheAPI
 


### PR DESCRIPTION
ldas-tools-al, ldas-tools-filters, ldas-tools-framecpp, ldas-tools-ldasgen, ldas-tools-frameAPI, ldas-tools-diskcacheAPI, ldas-tools-utilities: Fixes build dependency

This addresses all 7 ldas-tools packages when needed pkgconfig added as a build dependency

Closes: https://trac.macports.org/ticket/52799
Closes: https://trac.macports.org/ticket/52800
Closes: https://trac.macports.org/ticket/52801
Closes: https://trac.macports.org/ticket/52802
Closes: https://trac.macports.org/ticket/52803
Closes: https://trac.macports.org/ticket/52804
Closes: https://trac.macports.org/ticket/52805