### PR TITLE
cmake-1.1 portgroup: generator support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# macfork-ports
+The MacPorts ports tree
+
+This is a fork of the official MacPorts (development) port tree in git, created on November 9th 2016.
+It is currently used only for pull requests of select content from my MacStrop repository.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-# macfork-ports
-The MacPorts ports tree
-
-This is a fork of the official MacPorts (development) port tree in git, created on November 9th 2016.
-It is currently used only for pull requests of select content from my MacStrop repository.


### PR DESCRIPTION
This revision adds support for one more of CMake's generators, and
allows ports to use the more efficient ninja tool. This is supposed to
make a significant difference for large projects like llvm and clang,
even for once-off builds.
As an additional improvement the default destroot target for the Makefile
generator is set to install/fast. This skips the implicit "make" step
that is otherwise always part of "make install", and this can reduce
the destroot time significantly.

Sorry for the added and then deleted README.md .