### PR TITLE
gildas: update to 201611b.

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -1,12 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           active_variants 1.1 
 
 name                gildas
-version             201609b
+version             201611b
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -31,8 +30,8 @@ master_sites        http://www.iram.fr/~gildas/dist/ \
                     http://www.iram.fr/~gildas/dist/archive/gildas/
 distname            ${name}-src-${my_version}
 
-checksums           rmd160  16eaa2862d3e762915d7a0a11e9512242603effa \
-                    sha256  81ad4d2fb524875954a509141dbad8b65620e839512cfc18cf757c5443e8775f
+checksums           rmd160  68e88a02747db994184c03903ac6b5bd21ab0974 \
+                    sha256  48a6e00c70dc71b51baf67b849cf206795fb37eb896003ddea59f8cc05fef2e9
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \


### PR DESCRIPTION
This PR update the gildas package to version 201611b. I've tested it on MacOS Sierra.

Note that I'm the maintainer of this port (`smaret@macport.org`).