### PR TITLE
py-dpkt: update to 1.8.8

### DIFF
--- a/python/py-dpkt/Portfile
+++ b/python/py-dpkt/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem 1.0
 PortGroup python 1.0
 
 name                    py-dpkt
-version                 1.8
+version                 1.8.8
 categories-append       net
 license                 BSD
 maintainers             nomaintainer
@@ -16,11 +15,11 @@ long_description        dpkt provides fast, simple packet creation and \
 platforms               darwin
 supported_archs         noarch
 
-homepage                http://code.google.com/p/dpkt/
-master_sites            googlecode:dpkt
+homepage                https://github.com/kbandla/dpkt
+master_sites            pypi:d/dpkt
 
-checksums               rmd160  6c52dd753897ea10b15b9a67ef0303464bbfc7eb \
-                        sha256  c56de2f9dc2f4654a356de0f0d458bb7b1c86c374988e8b4f358556f7dbe0507
+checksums               rmd160  cb26e932fe407834370629f6857aab8295131e2b \
+                        sha256  d99525e534266818ecd122052f4086c684a88491c8073a848193bbf13ed69800
 
 python.versions         27
 


### PR DESCRIPTION
remove outdated Id line, update master_sites to pypi instead of Google Code, and set homepage to the project on Github.