### PR TITLE
py-geoip: update to 1.3.2

### DIFF
--- a/python/py-geoip/Portfile
+++ b/python/py-geoip/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
 PortGroup python    1.0
 
 name                py-geoip
-version             1.2.8
+version             1.3.2
 categories-append   net
 license             LGPL-2.1+
 platforms           darwin
@@ -14,31 +13,26 @@ maintainers         nomaintainer
 description         Python module for accessing the GeoIP C library
 long_description    ${description}
 
-homepage            http://www.maxmind.com/app/python
-master_sites        http://www.maxmind.com/download/geoip/api/python/
-distname            GeoIP-Python-${version}
+homepage            http://dev.maxmind.com/geoip/legacy/downloadable/
+master_sites        pypi:g/geoip
+distname            GeoIP-${version}
 
-checksums           rmd160  5311cb3553943a71e7335732c06d070a4bf2768f \
-                    sha256  8b946307355b60cb0f2b0be8ac90c1231286e0e79917509763267fce01a50e73
+checksums           rmd160  f5cf7a7f767d748827f432ab892bfa0b4d1272f4 \
+                    sha256  a890da6a21574050692198f14b07aa4268a01371278dfc24f71cd9bc87ebf0e6
 
-python.versions     27
+python.versions     27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:libgeoip
 
-    post-patch {
-        reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/setup.py
-    }
-
     post-destroot   {
-        xinstall -m 644 -W ${worksrcpath} ChangeLog LICENSE README \
+        xinstall -m 644 -W ${worksrcpath} LICENSE README.rst \
             ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath} test.py test_city.py test_org.py \
-            ${destroot}${prefix}/share/doc/${subport}/examples
+        foreach f [glob -type f -dir ${worksrcpath}/examples *] {
+            reinplace "s+/usr/bin/python$+/usr/bin/env python${python.branch}+g" ${f}
+            reinplace "s+/usr/local+${prefix}+g" ${f}
+            xinstall -m 755 ${f} ${destroot}${prefix}/share/doc/${subport}/examples
+        }
     }
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   ${master_sites}
-    livecheck.regex "GeoIP-Python-(\\d+(\\.\\d+)+)${extract.suffix}"
 }


### PR DESCRIPTION
add support for python3, change master_sites to use pypi, remove obsolete Id tag, and reinplace the correct paths in example files.