### PR TITLE
py-m2crypto: update to 0.25.1

### DIFF
--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -1,11 +1,10 @@
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem         1.0
 PortGroup          python 1.0
 
 name               py-m2crypto
-version            0.23.0
-revision           2
+version            0.25.1
 categories-append  crypto devel
 # demos include some Apache-2 and ZPL-2 files but are not installed
 license            MIT
@@ -21,8 +20,8 @@ distname           M2Crypto-${version}
 
 python.versions    26 27
 
-checksums           rmd160  f2d65c95c72b9ba9bd732768509be27f7d2c608e \
-                    sha256  1ac3b6eafa5ff7e2a0796675316d7569b28aada45a7ab74042ad089d15a9567f
+checksums           rmd160  6dcb90c12a030b7c575efc310e6abd503be7e0a0 \
+                    sha256  ac303a1881307a51c85ee8b1d87844d9866ee823b4fdbc52f7e79187c2d9acef
 
 if {${name} ne ${subport}} {
   depends_build      port:py${python.version}-setuptools


### PR DESCRIPTION
replace the outdated Id line with the editor modeline.