### PR TITLE
shared-mime-info: add patch for Objective C++

### DIFF
--- a/devel/shared-mime-info/Portfile
+++ b/devel/shared-mime-info/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 
 name                shared-mime-info
 version             1.7
-revision            1
+revision            2
 maintainers         gmail.com:rjvbertin mk openmaintainer
 categories          devel
 license             GPL-2+
@@ -32,6 +32,10 @@ depends_build       port:pkgconfig \
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxml2
 
+# add an entry for Objective C++
+# (https://bugs.freedesktop.org/show_bug.cgi?id=98823)
+patchfiles-append   patch-add-objc++-def.diff
+
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 
 post-patch {
@@ -44,6 +48,11 @@ use_parallel_build  no
 
 configure.args      --disable-silent-rules \
                     --disable-update-mimedb
+
+post-destroot {
+    xinstall -m 644 ${filespath}/ObjCpp.xml \
+        ${destroot}${prefix}/share/mime/packages
+}
 
 post-activate {
     ui_debug "Updating MIME database..."

--- a/devel/shared-mime-info/files/ObjCpp.xml
+++ b/devel/shared-mime-info/files/ObjCpp.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+It comes with ABSOLUTELY NO WARRANTY, to the extent permitted by law. You may
+redistribute copies of update-mime-database under the terms of the GNU General
+Public License. For more information about these matters, see the file named
+COPYING.
+-->
+<!--
+Notes:
+- the mime types in this file are valid with the version 0.30 of the
+  shared-mime-info package.
+- the "fdo #xxxxx" are the wish in the freedesktop.org bug database to include
+  the mime type there.
+-->
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/x-objc++src">
+    <comment>Objective-C++ source code</comment>
+    <comment xml:lang="ar">شفرة مصدر الهدف-C</comment>
+    <comment xml:lang="ast">códigu fonte en Objective-C++</comment>
+    <comment xml:lang="be">Kryničny kod Objective-C++</comment>
+    <comment xml:lang="be@latin">Kryničny kod Objective-C++</comment>
+    <comment xml:lang="bg">Изходен код — Objective C++</comment>
+    <comment xml:lang="bo">Objective-C++ ཐོག་མའི་ཚབ་ཨང</comment>
+    <comment xml:lang="bs">Objektni-C izvorni kôd</comment>
+    <comment xml:lang="ca">codi font en Objective-C++</comment>
+    <comment xml:lang="cs">Zdrojový kód v Objective-C++</comment>
+    <comment xml:lang="da">Objektiv C-kildekode</comment>
+    <comment xml:lang="de">Objective-C++-Quelltext</comment>
+    <comment xml:lang="el">πηγαίος κώδικας Objective-C++</comment>
+    <comment xml:lang="en_AU">Objective-C++ source code</comment>
+    <comment xml:lang="en_GB">Objective-C++ source code</comment>
+    <comment xml:lang="eo">fontkodo en Objective-C++</comment>
+    <comment xml:lang="es">código fuente en Objective-C++</comment>
+    <comment xml:lang="eu">Objective-C++ iturburu-kodea</comment>
+    <comment xml:lang="fi">Objective-C++-lähdekoodi</comment>
+    <comment xml:lang="fo">Objective-C++ keldukota</comment>
+    <comment xml:lang="fr">code source Objective-C++</comment>
+    <comment xml:lang="ga">cód foinseach Objective-C++</comment>
+    <comment xml:lang="gl">código fonte de Objective-C++</comment>
+    <comment xml:lang="he">קוד מקור של Objective-C++</comment>
+    <comment xml:lang="hu">Objective-C++ forráskód</comment>
+    <comment xml:lang="id">Kode program Objective-C++</comment>
+    <comment xml:lang="it">Codice sorgente Objective-C++</comment>
+    <comment xml:lang="ja">Objective-C++ ソースコード</comment>
+    <comment xml:lang="ka">Objective-C++-ის საწყისი კოდი</comment>
+    <comment xml:lang="kk">Objective-C++ бастапқы коды</comment>
+    <comment xml:lang="ko">Objective-C++ 소스 코드</comment>
+    <comment xml:lang="lt">Objective-C++ pradinis kodas</comment>
+    <comment xml:lang="lv">Objective-C++ pirmkods</comment>
+    <comment xml:lang="ms">Kod sumber Objective-C++</comment>
+    <comment xml:lang="nb">Objective-C++-kildekode</comment>
+    <comment xml:lang="nl">Objective-C++-broncode</comment>
+    <comment xml:lang="nn">Objective-C++-kjeldekode</comment>
+    <comment xml:lang="no">Objective-C++-kildekode</comment>
+    <comment xml:lang="pl">Kod źródłowy Objective-C++</comment>
+    <comment xml:lang="pt">código fonte Objective-C++</comment>
+    <comment xml:lang="pt_BR">Código-fonte Objective-C++</comment>
+    <comment xml:lang="ro">Cod sursă Objective-C++</comment>
+    <comment xml:lang="ru">исходный код Objective-C++</comment>
+    <comment xml:lang="sk">Zdrojový kód Objective-C++</comment>
+    <comment xml:lang="sl">Datoteka izvorne kode Objective-C++</comment>
+    <comment xml:lang="sq">Kod burues C objekt</comment>
+    <comment xml:lang="sr">Објектни-C изворни ко̂д</comment>
+    <comment xml:lang="sv">Objective-C++-källkod</comment>
+    <comment xml:lang="tr">Objective-C++ kaynak kodu</comment>
+    <comment xml:lang="uk">вихідний код мовою Objective-C++</comment>
+    <comment xml:lang="vi">Mã nguồn Objective-C++</comment>
+    <comment xml:lang="zh_CN">Objective-C++ 源代码</comment>
+    <comment xml:lang="zh_TW">Objective-C++ 源碼</comment>
+    <sub-class-of type="text/x-c++src"/>
+    <magic priority="30">
+      <match value="#import" type="string" offset="0"/>
+    </magic>
+    <glob pattern="*.mm"/>
+  </mime-type>
+</mime-info>

--- a/devel/shared-mime-info/files/patch-add-objc++-def.diff
+++ b/devel/shared-mime-info/files/patch-add-objc++-def.diff
@@ -1,0 +1,68 @@
+Add entry for Objective-C++
+
+Upstream-Status: Submitted [https://bugs.freedesktop.org/show_bug.cgi?id=98823]
+
+--- orig.freedesktop.org.xml	2015-09-16 13:39:12.000000000 +0200
++++ freedesktop.org.xml	2015-10-16 18:08:42.000000000 +0200
+@@ -31982,6 +31982,61 @@
+     </magic>
+     <glob pattern="*.m"/>
+   </mime-type>
++  <mime-type type="text/x-objc++src">
++    <comment>Objective-C++ source code</comment>
++    <comment xml:lang="ar">شفرة مصدر الهدف-C </comment>
++    <comment xml:lang="be@latin">Kryničny kod Objective-C++</comment>
++    <comment xml:lang="bg">Изходен код — Objective C++</comment>
++    <comment xml:lang="ca">codi font en Objective-C++</comment>
++    <comment xml:lang="cs">zdrojový kód Objective-C++</comment>
++    <comment xml:lang="da">Objektiv C++-kildekode</comment>
++    <comment xml:lang="de">Objective-C++-Quelltext</comment>
++    <comment xml:lang="el">Πηγαίος κώδικας Objective-C++</comment>
++    <comment xml:lang="en_GB">Objective-C++ source code</comment>
++    <comment xml:lang="eo">fontkodo en Objective-C++</comment>
++    <comment xml:lang="es">código fuente en Objective-C++</comment>
++    <comment xml:lang="eu">Objective-C++ iturburu-kodea</comment>
++    <comment xml:lang="fi">Objective-C++-lähdekoodi</comment>
++    <comment xml:lang="fo">Objective-C++ keldukota</comment>
++    <comment xml:lang="fr">code source Objective-C++</comment>
++    <comment xml:lang="ga">cód foinseach Objective-C++</comment>
++    <comment xml:lang="gl">código fonte de Objective-C++</comment>
++    <comment xml:lang="he">קוד מקור של Objective-C++</comment>
++    <comment xml:lang="hu">Objective-C++ forráskód</comment>
++    <comment xml:lang="ia">Codice-fonte Objective-C++</comment>
++    <comment xml:lang="id">Kode program Objective-C++</comment>
++    <comment xml:lang="it">Codice sorgente Objective-C++</comment>
++    <comment xml:lang="ja">Objective-C++ ソースコード</comment>
++    <comment xml:lang="ka">Objective-C++-ის საწყისი კოდი</comment>
++    <comment xml:lang="kk">Objective-C++ бастапқы коды</comment>
++    <comment xml:lang="ko">Objective-C++ 소스 코드</comment>
++    <comment xml:lang="lt">Objective-C++ pradinis kodas</comment>
++    <comment xml:lang="lv">Objective-C++ pirmkods</comment>
++    <comment xml:lang="ms">Kod sumber Objective-C++</comment>
++    <comment xml:lang="nb">Objective-C++-kildekode</comment>
++    <comment xml:lang="nl">Objective-C++-broncode</comment>
++    <comment xml:lang="nn">Objective-C++-kjeldekode</comment>
++    <comment xml:lang="pl">Kod źródłowy Objective-C++</comment>
++    <comment xml:lang="pt">código fonte Objective-C++</comment>
++    <comment xml:lang="pt_BR">Código-fonte Objective-C++</comment>
++    <comment xml:lang="ro">Cod sursă Objective-C++</comment>
++    <comment xml:lang="ru">исходный код Objective-C++</comment>
++    <comment xml:lang="sk">Zdrojový kód Objective-C++</comment>
++    <comment xml:lang="sl">Datoteka izvorne kode Objective-C++</comment>
++    <comment xml:lang="sq">Kod burues C++ objekt</comment>
++    <comment xml:lang="sr">Објектни-Ц изворни ко̂д</comment>
++    <comment xml:lang="sv">Objective-C++-källkod</comment>
++    <comment xml:lang="tr">Objective-C++ kaynak kodu</comment>
++    <comment xml:lang="uk">вихідний код мовою Objective-C++</comment>
++    <comment xml:lang="vi">Mã nguồn Objective-C++</comment>
++    <comment xml:lang="zh_CN">Objective-C++ 源代码</comment>
++    <comment xml:lang="zh_TW">Objective-C++ 原始碼</comment>
++    <sub-class-of type="text/x-c++src"/>
++    <magic priority="30">
++      <match value="#import" type="string" offset="0"/>
++    </magic>
++    <glob pattern="*.mm"/>
++  </mime-type>
+   <mime-type type="text/x-ocaml">
+     <comment>OCaml source code</comment>
+     <comment xml:lang="ar">شفرة مصدر OCaml</comment>


### PR DESCRIPTION
- remove Id keyword
- take maintainership
- set env var XDG_DATA_DIRS when running update-mime-database for later