### PR TITLE
py-typing: new port @3.5.2.2

### DIFF
--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-typing
+version             3.5.2.2
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             PSF
+maintainers         gmail.com:allan.que openmaintainer
+
+description         Type hints for Python
+long_description    Typing is a backport of the standard library \
+                    'typing' module to Python versions older than 3.5. \
+                    It defines a standard notation for Python function \
+                    and variable type annotations. The notation can be \
+                    used for documenting code in a concise, standard \
+                    format, and it has been designed to also be used \
+                    by static and runtime type checkers, static \
+                    analyzers, IDEs and other tools.
+homepage            http://pypi.python.org/pypi/${python.rootname}/
+
+master_sites        pypi:t/${python.rootname}
+distname            ${python.rootname}-${version}
+checksums           md5     61ffbe736df9f419563dbfffa64ebb7d \
+                    rmd160  8bd175ae415b89da4edc2d9ffc2dada1a2bb8a2a \
+                    sha256  2bce34292653af712963c877f3085250a336738e64f99048d1b8509bebc4772f
+
+python.versions     27 33 34
+
+if {${name} ne ${subport}} {
+    livecheck.type  none
+} else {
+    # Work around incorrect PyPI versioning (3.5.2 vs. 3.5.2.2).
+    livecheck.regex {typing-(\d+(?:\.\d+)*)}
+}


### PR DESCRIPTION
Backport of the standard library typing module to Python versions
older than 3.5. This package is a new dependency for py-m2crypto (https://github.com/macports/macports-ports/pull/34).