### PR TITLE
py-m2crypto: update to 0.25.1

### DIFF
--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -1,5 +1,3 @@
-# $Id$
-
 PortSystem         1.0
 PortGroup          python 1.0
 

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -10,7 +10,7 @@ categories-append  crypto devel
 platforms          darwin
 # demos include some Apache-2 and ZPL-2 files but are not installed
 license            MIT
-maintainers        nomaintainer
+maintainers        gmail.com:allan.que openmaintainer
 
 description        Crypto and SSL toolkit for Python
 long_description   M2Crypto is the most complete Python wrapper for OpenSSL.

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -12,8 +12,8 @@ platforms          darwin
 license            MIT
 maintainers        nomaintainer
 
-description        M2Crypto is a crypto and SSL toolkit for Python.
-long_description   ${description}
+description        Crypto and SSL toolkit for Python
+long_description   M2Crypto is the most complete Python wrapper for OpenSSL.
 homepage           https://pypi.python.org/pypi/M2Crypto
 
 master_sites       pypi:M/M2Crypto/

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -33,13 +33,7 @@ if {${name} ne ${subport}} {
     reinplace "s|self.openssl = '/usr'|self.openssl = '${prefix}'|g" \
         ${worksrcpath}/setup.py
   }
-}
 
-if {${name} eq ${subport}} {
-  livecheck.type     regex
-  livecheck.url      ${homepage}
-  livecheck.regex    M2Crypto-(\[0-9\\.\]+)\.tar\.gz
-} else {
   test.run           yes
 
   livecheck.type     none

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem         1.0
 PortGroup          python 1.0
 
@@ -5,22 +7,21 @@ name               py-m2crypto
 version            0.23.0
 revision           2
 categories-append  crypto devel
+platforms          darwin
 # demos include some Apache-2 and ZPL-2 files but are not installed
 license            MIT
 maintainers        nomaintainer
+
 description        M2Crypto is a crypto and SSL toolkit for Python.
 long_description   ${description}
-
-platforms          darwin
-
 homepage           https://pypi.python.org/pypi/M2Crypto
+
 master_sites       pypi:M/M2Crypto/
 distname           M2Crypto-${version}
+checksums          rmd160  f2d65c95c72b9ba9bd732768509be27f7d2c608e \
+                   sha256  1ac3b6eafa5ff7e2a0796675316d7569b28aada45a7ab74042ad089d15a9567f
 
 python.versions    26 27
-
-checksums           rmd160  f2d65c95c72b9ba9bd732768509be27f7d2c608e \
-                    sha256  1ac3b6eafa5ff7e2a0796675316d7569b28aada45a7ab74042ad089d15a9567f
 
 if {${name} ne ${subport}} {
   depends_build      port:py${python.version}-setuptools
@@ -30,7 +31,7 @@ if {${name} ne ${subport}} {
   post-patch {
     reinplace "s|#extra_link_args|extra_link_args|g" ${worksrcpath}/setup.py
     reinplace "s|self.openssl = '/usr'|self.openssl = '${prefix}'|g" \
-      ${worksrcpath}/setup.py
+        ${worksrcpath}/setup.py
   }
 }
 

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -4,8 +4,7 @@ PortSystem         1.0
 PortGroup          python 1.0
 
 name               py-m2crypto
-version            0.23.0
-revision           2
+version            0.25.1
 categories-append  crypto devel
 platforms          darwin
 # demos include some Apache-2 and ZPL-2 files but are not installed
@@ -18,14 +17,16 @@ homepage           https://pypi.python.org/pypi/${python.rootname}
 
 master_sites       pypi:m/${python.rootname}/
 distname           M2Crypto-${version}
-checksums          rmd160  f2d65c95c72b9ba9bd732768509be27f7d2c608e \
-                   sha256  1ac3b6eafa5ff7e2a0796675316d7569b28aada45a7ab74042ad089d15a9567f
+checksums          md5     040234289fbef5bed4029f0f7d1dae35 \
+                   rmd160  6dcb90c12a030b7c575efc310e6abd503be7e0a0 \
+                   sha256  ac303a1881307a51c85ee8b1d87844d9866ee823b4fdbc52f7e79187c2d9acef
 
 python.versions    26 27
 
 if {${name} ne ${subport}} {
   depends_build      port:py${python.version}-setuptools
   depends_lib-append port:swig-python \
+                     port:py${python.version}-typing \
                      path:lib/libssl.dylib:openssl
 
   post-patch {

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -14,9 +14,9 @@ maintainers        nomaintainer
 
 description        Crypto and SSL toolkit for Python
 long_description   M2Crypto is the most complete Python wrapper for OpenSSL.
-homepage           https://pypi.python.org/pypi/M2Crypto
+homepage           https://pypi.python.org/pypi/${python.rootname}
 
-master_sites       pypi:M/M2Crypto/
+master_sites       pypi:m/${python.rootname}/
 distname           M2Crypto-${version}
 checksums          rmd160  f2d65c95c72b9ba9bd732768509be27f7d2c608e \
                    sha256  1ac3b6eafa5ff7e2a0796675316d7569b28aada45a7ab74042ad089d15a9567f


### PR DESCRIPTION
add dependency to py-typing and replace the outdated Id line with the editor
modeline.

I seemed to have botched PR https://github.com/macports/macports-ports/pull/34 by doing a `git push -f` before reopening the PR. 😕 