### PR TITLE
Add Portfile for Yarn 0.18.1

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        yarnpkg yarn 0.18.1 v
+
+categories          devel
+
+platforms           darwin
+supported_archs     noarch
+
+license             BSD
+
+maintainers         andrewsforge.com:code \
+                    gmail.com:isomacrte \
+                    openmaintainer
+
+description         JavaScript dependency manager
+long_description    Created by Facebook to replace NPM, yarn boasts about its \
+                    speed, security, and reliability. Most notably, yarn \
+                    dependencies are installed deterministically, whereas \
+                    NPM's dependencies are not.
+
+homepage            https://yarnpkg.com/
+
+github.tarball_from releases
+distname            ${name}-${git.branch}
+worksrcdir          dist
+checksums           rmd160 c806b890b1e348e35256191d52681d220e73a5b8 \
+                    Sha256 7d16699c8690ef145e1732004266fb82a32b0c06210a43c624986d100537b5a8
+
+depends_run         bin:node:nodejs6
+
+patchfiles          patch-0001-Allow-yarn-script-to-be-linked.patch
+
+use_configure       no
+build {}
+
+destroot {
+  copy ${worksrcpath} ${destroot}${prefix}/libexec/yarn
+  ln -s ${prefix}/libexec/yarn/bin/yarn ${destroot}${prefix}/bin/yarn
+}
+
+notes "
+${name} stores data in:
+
+    ~/.yarn
+    ~/.yarnrc
+    ~/.cache/yarn
+    ~/.config/yarn
+
+Should you choose to install packages globally with ${name} (yarn global\
+add), these files will not be removed if you deactivate or uninstall ${name}.\
+By default, these packages will be installed in ~/.config/yarn/global, and\
+soft-linked to ${prefix}/bin. To uninstall them all:
+
+$ ls -1 \$HOME/.config/yarn/global/node_modules/ \
+| xargs sudo yarn global remove
+
+You may then remove the directories listed above and uninstall ${name}.
+
+${name} is meant to replace NPM, and may cause conflicts if you use both.
+
+You may override the default global installation directory by setting the\
+PREFIX environment variable, e.g.
+
+mkdir -p \$HOME/.config/yarn/bin # Or wherever you want
+export PREFIX=\$HOME/.config/yarn/bin
+export PATH=\$PREFIX:\$PATH
+"

--- a/devel/yarn/files/patch-0001-Allow-yarn-script-to-be-linked.patch
+++ b/devel/yarn/files/patch-0001-Allow-yarn-script-to-be-linked.patch
@@ -1,0 +1,11 @@
+https://github.com/yarnpkg/yarn/pull/2217
+
+--- bin/yarn
++++ bin/yarn
+@@ -1,5 +1,5 @@
+ #!/bin/sh
+-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
++basedir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")
+
+ case `uname` in
+   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;


### PR DESCRIPTION
Hi,
This PR adds support for installation of [yarn](https://yarnpkg.com/), Facebook's Javascript dependency manager.

The Portfile follows the spirit of the [bash installer found on the yarn website](https://yarnpkg.com/install.sh), but instead of installing yarn in the users' home directory, yarn is placed in Macports' `libexec` directory. This installation is therefore **not global**.

The installation is independent of [NPM](https://www.npmjs.com/) (what yarn aims to replace).

Yarn requires [Node](http://nodejs.org/) to run. I've added Node 6 as default (as it's the current version with Long-Term Support), but have added installation variants to force Node6 via Macports (even if it's already installed), or else to use Node 4 or Node 7. As Node 5 is no longer supported or maintained, I have not included it.

The `reinplace` invocation in the patch phase changes the line of code in 1 into the line of code in 2.

1. `basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")`
2. `basedir=$(dirname "$(readlink "$0" || echo "$(echo "$0" | sed -e 's,\\,/,g')")")`

This enables the script to be soft-linked in `${prefix}/bin` and called from Macports' structure. This step is essential, as it's what allows yarn to be installed in `${prefix}/libexec` instead of globally.

I would prefer to use a regular expression capturing group, but I wasn't able to get that working. I was thinking of something like the code below (where the `\1` prints the code captured by `(.+)`).

```tcl
reinplace -E "s;basedir=\\$\\(dirname (.+)\\);basedir=\$(dirname \"\$(readlink \"\$0\" || echo \1)\");" ${worksrcpath}/bin/yarn
```

Following PR #43, I've not included the line `# $Id$`.

Thanks for reviewing! Feedback welcome.