### PR TITLE
libarchive: 3.2.1 -> 3.2.2

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -1,4 +1,4 @@
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
 name             libarchive

--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 name             libarchive
 homepage         http://libarchive.org/
 master_sites     ${homepage}downloads/
-version          3.2.1
+version          3.2.2
 categories       archivers
 license          BSD
 maintainers      toby
@@ -16,8 +16,8 @@ long_description \
 	also write shar archives.
 platforms        darwin
 
-checksums        rmd160  4779f14e2ccf8135908720786c2fa5c3ffe0cc1d \
-                 sha256  72ee1a4e3fd534525f13a0ba1aa7b05b203d186e0c6072a8a4738649d0b3cfd2
+checksums        rmd160  3fedae2b71685d3003e71acd4189c5f3de80a2db \
+                 sha256  691c194ee132d1f0f7a42541f091db811bc2e56f7107e9121be2bc8c04f1060f
 
 depends_lib      port:bzip2 port:zlib path:lib/libssl.dylib:openssl port:libxml2 port:xz \
                  port:lzo2 port:libiconv

--- a/archivers/libarchive/files/patch-libarchive__archive_read_support_format_lha.c.diff
+++ b/archivers/libarchive/files/patch-libarchive__archive_read_support_format_lha.c.diff
@@ -1,17 +1,20 @@
---- libarchive/archive_read_support_format_lha.c.orig	2016-06-28 22:40:09.000000000 -0700
-+++ libarchive/archive_read_support_format_lha.c	2016-06-28 22:40:33.000000000 -0700
-@@ -1712,10 +1712,13 @@
- 	for (;len >= 8; len -= 8) {
+--- libarchive/archive_read_support_format_lha.c.orig	2016-12-02 00:55:30.000000000 +0000
++++ libarchive/archive_read_support_format_lha.c	2016-12-02 00:59:09.000000000 +0000
+@@ -1713,13 +1713,15 @@
  		/* This if statement expects compiler optimization will
  		 * remove the stament which will not be executed. */
+ #undef bswap16
 +#ifndef __has_builtin
 +#define __has_builtin(x) 0
 +#endif
  #if defined(_MSC_VER) && _MSC_VER >= 1400  /* Visual Studio */
  #  define bswap16(x) _byteswap_ushort(x)
- #elif (defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8) \
--      || defined(__clang__)
-+      || (defined(__clang__) && __has_builtin(__builtin_bswap16))
+ #elif defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4)
+ /* GCC 4.8 and later has __builtin_bswap16() */
+ #  define bswap16(x) __builtin_bswap16(x)
+-#elif defined(__clang__)
+-/* All clang versions have __builtin_bswap16() */
++#elif defined(__clang__) && __has_builtin(__builtin_bswap16)
  #  define bswap16(x) __builtin_bswap16(x)
  #else
  #  define bswap16(x) ((((x) >> 8) & 0xff) | ((x) << 8))


### PR DESCRIPTION
I can put the patch back but is it still needed? (`/* All clang versions have __builtin_bswap16() */`) 

Two relevant upstream commits:

https://github.com/libarchive/libarchive/commit/43d23948f5fd86226fc47e78ce718283ead4f16a

https://github.com/libarchive/libarchive/commit/d2e8111b3a3468102737f7d414ea1bb6f6904bfe