### PR TITLE
python27: fix path to framework in LINKFORSHARED

### DIFF
--- a/lang/python24/Portfile
+++ b/lang/python24/Portfile
@@ -3,7 +3,7 @@ PortGroup select 1.0
 
 name                    python24
 version                 2.4.6
-revision                11
+revision                12
 set major               [lindex [split $version .] 0]
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              lang
@@ -125,10 +125,10 @@ platform macosx {
             # Without this, LINKFORSHARED is set to
             # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
             # (this becomes Python.framework/Versions/2.4/Python) which doesn't
-            # quite work (see ticket #15099); instead specifically list the
-            # full path to the proper Python framework file (which becomes
-            # ${prefix}/Library/Frameworks/Python.framework/Versions/2.4/Python)
-            reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${prefix}/lib/python${branch}/config/Makefile
+            # quite work (see ticket #15099); instead we mirror the behavior of
+            # `python-config --ldflags` here.
+            reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION) $(LIBS) $(SYSLIBS)|} \
+                ${destroot}${framewdir}/lib/python${branch}/config/Makefile
         }
     } else {
         # 64-bit, can't build mac-specific stuff

--- a/lang/python25/Portfile
+++ b/lang/python25/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 
 name                    python25
 version                 2.5.6
-revision                6
+revision                7
 
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              lang
@@ -111,10 +111,10 @@ post-destroot {
         # Without this, LINKFORSHARED is set to
         # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
         # (this becomes Python.framework/Versions/2.5/Python) which doesn't
-        # quite work (see ticket #15099); instead specifically list the
-        # full path to the proper Python framework file (which becomes
-        # ${prefix}/Library/Frameworks/Python.framework/Versions/2.5/Python)
-        reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/config/Makefile
+        # quite work (see ticket #15099); instead we mirror the behavior of
+        # `python-config --ldflags` here.
+        reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION) $(LIBS) $(SYSLIBS)|} \
+            ${destroot}${framewdir}/lib/python${branch}/config/Makefile
 
         foreach dir { lib include } {
             file rename ${destroot}${framewdir}/${dir}/python${branch} ${destroot}${prefix}/${dir}

--- a/lang/python26/Portfile
+++ b/lang/python26/Portfile
@@ -6,7 +6,7 @@ PortGroup select 1.0
 name                    python26
 # Remember to keep py26-tkinter and py26-gdbm's versions sync'd with this
 version                 2.6.9
-revision                5
+revision                6
 set major               [lindex [split $version .] 0]
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              lang
@@ -119,13 +119,13 @@ post-destroot {
    ln -s ${framewdir}/Python ${destroot}${prefix}/lib/libpython${branch}.dylib
    ln -s ${framewdir}/bin/2to3 ${destroot}${prefix}/bin/2to3-${branch}
 
-   # Without this, LINKFORSHARED is set to 
+   # Without this, LINKFORSHARED is set to
    # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
    # (this becomes Python.framework/Versions/2.6/Python) which doesn't
-   # quite work (see ticket #15099); instead specifically list the
-   # full path to the proper Python framework file (which becomes
-   # ${prefix}/Library/Frameworks/Python.framework/Versions/2.6/Python)
-   reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/config/Makefile
+   # quite work (see ticket #15099); instead we mirror the behavior of
+   # `python-config --ldflags` here.
+   reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION) $(LIBS) $(SYSLIBS)|} \
+      ${destroot}${framewdir}/lib/python${branch}/config/Makefile
 
    foreach unversionedFile {idle pydoc python python-config pythonw smtpd.py} {
       delete ${destroot}${prefix}/bin/${unversionedFile}

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -7,7 +7,7 @@ name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
 version             2.7.13
-revision            1
+revision            2
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -108,6 +108,14 @@ post-destroot {
 
     ln -s ${framewdir}/share/man/man1/python${branch}.1 ${destroot}${prefix}/share/man/man1/
     ln -s ${framewdir}/Python ${destroot}${prefix}/lib/libpython${branch}.dylib
+
+    # Without this, LINKFORSHARED is set to
+    # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
+    # (this becomes Python.framework/Versions/2.7/Python) which doesn't
+    # quite work (see ticket #15099); instead we mirror the behavior of
+    # `python-config --ldflags` here.
+    reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION) $(LIBS) $(SYSLIBS)|} \
+        ${destroot}${framewdir}/lib/python${branch}/config/Makefile
 
     foreach unversionedFile {2to3 2to3-2 idle idle2 pydoc pydoc2 python python2 python-config python2-config pythonw pythonw2 smtpd.py smtpd2.py} {
         delete ${destroot}${prefix}/bin/${unversionedFile}

--- a/lang/python31/Portfile
+++ b/lang/python31/Portfile
@@ -7,7 +7,7 @@ name                    python31
 epoch                   1
 # Remember to keep py31-tkinter and py31-gdbm's versions sync'd with this
 version                 3.1.5
-revision                5
+revision                6
 set major               [lindex [split $version .] 0]
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              lang
@@ -110,10 +110,10 @@ post-destroot {
    # Without this, LINKFORSHARED is set to
    # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
    # (this becomes Python.framework/Versions/3.1/Python) which doesn't
-   # quite work (see ticket #15099); instead specifically list the
-   # full path to the proper Python framework file (which becomes
-   # ${prefix}/Library/Frameworks/Python.framework/Versions/3.1/Python)
-   reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/config/Makefile
+   # quite work (see ticket #15099); instead we mirror the behavior of
+   # `python-config --ldflags` here.
+   reinplace {s|^\(LINKFORSHARED=\)$|\1 -L$(LIBPL) -lpython$(VERSION) $(LIBS) $(SYSLIBS)|} \
+      ${destroot}${framewdir}/lib/python${branch}/config/Makefile
 
    # remove -arch flags from the config
    reinplace -E {s|-arch [a-z0-9_]+||g} \

--- a/lang/python32/Portfile
+++ b/lang/python32/Portfile
@@ -7,7 +7,7 @@ name                    python32
 epoch                   20120412
 # Remember to keep py32-tkinter and py32-gdbm's versions sync'd with this
 version                 3.2.6
-revision                5
+revision                6
 
 set major               [lindex [split $version .] 0]
 set branch              [join [lrange [split ${version} .] 0 1] .]
@@ -108,10 +108,10 @@ post-destroot {
    # Without this, LINKFORSHARED is set to
    # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
    # (this becomes Python.framework/Versions/3.2/Python) which doesn't
-   # quite work (see ticket #15099); instead specifically list the
-   # full path to the proper Python framework file (which becomes
-   # ${prefix}/Library/Frameworks/Python.framework/Versions/3.2/Python)
-    reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/$confdir/Makefile
+   # quite work (see ticket #15099); instead we mirror the behavior of
+   # `python-config --ldflags` here.
+   reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION)$(ABIFLAGS) $(LIBS) $(SYSLIBS)|} \
+       ${destroot}${framewdir}/lib/python${branch}/config-3.2m/Makefile
 
    # remove -arch flags from the config
     reinplace -E {s|-arch [a-z0-9_]+||g} \

--- a/lang/python33/Portfile
+++ b/lang/python33/Portfile
@@ -7,7 +7,7 @@ name                python33
 
 # Remember to keep py33-tkinter and py33-gdbm's versions sync'd with this
 version             3.3.6
-revision            8
+revision            9
 
 epoch               20141012
 
@@ -118,11 +118,11 @@ post-destroot {
 
     # Without this, LINKFORSHARED is set to
     # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
-    # (this becomes Python.framework/Versions/3.2/Python) which doesn't
-    # quite work (see ticket #15099); instead specifically list the
-    # full path to the proper Python framework file (which becomes
-    # ${prefix}/Library/Frameworks/Python.framework/Versions/3.2/Python)
-    reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/$confdir/Makefile
+    # (this becomes Python.framework/Versions/3.3/Python) which doesn't
+    # quite work (see ticket #15099); instead we mirror the behavior of
+    # `python-config --ldflags` here.
+    reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION)$(ABIFLAGS) $(LIBS) $(SYSLIBS)|} \
+        ${destroot}${framewdir}/lib/python${branch}/config-3.3m/Makefile
 
     # remove -arch flags from the config
     reinplace -E {s|-arch [a-z0-9_]+||g} \

--- a/lang/python34/Portfile
+++ b/lang/python34/Portfile
@@ -7,6 +7,7 @@ name                python34
 
 # Remember to keep py34-tkinter and py34-gdbm's versions sync'd with this
 version             3.4.7
+revision            1
 
 epoch               20170810
 
@@ -113,11 +114,11 @@ post-destroot {
 
     # Without this, LINKFORSHARED is set to
     # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
-    # (this becomes Python.framework/Versions/3.2/Python) which doesn't
-    # quite work (see ticket #15099); instead specifically list the
-    # full path to the proper Python framework file (which becomes
-    # ${prefix}/Library/Frameworks/Python.framework/Versions/3.2/Python)
-    reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/$confdir/Makefile
+    # (this becomes Python.framework/Versions/3.4/Python) which doesn't
+    # quite work (see ticket #15099); instead we mirror the behavior of
+    # `python-config --ldflags` here.
+    reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION)$(ABIFLAGS) $(LIBS) $(SYSLIBS)|} \
+        ${destroot}${framewdir}/lib/python${branch}/config-3.4m/Makefile
 
     # remove -arch flags from the config
     reinplace -E {s|-arch [a-z0-9_]+||g} \

--- a/lang/python35/Portfile
+++ b/lang/python35/Portfile
@@ -7,6 +7,7 @@ name                python35
 
 # Remember to keep py35-tkinter and py35-gdbm's versions sync'd with this
 version             3.5.4
+revision            1
 
 epoch               20170810
 
@@ -114,11 +115,11 @@ post-destroot {
 
     # Without this, LINKFORSHARED is set to
     # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
-    # (this becomes Python.framework/Versions/3.2/Python) which doesn't
-    # quite work (see ticket #15099); instead specifically list the
-    # full path to the proper Python framework file (which becomes
-    # ${prefix}/Library/Frameworks/Python.framework/Versions/3.2/Python)
-    reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/$confdir/Makefile
+    # (this becomes Python.framework/Versions/3.5/Python) which doesn't
+    # quite work (see ticket #15099); instead we mirror the behavior of
+    # `python-config --ldflags` here.
+    reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION)$(ABIFLAGS) $(LIBS) $(SYSLIBS)|} \
+        ${destroot}${framewdir}/lib/python${branch}/config-3.5m/Makefile
 
     # remove -arch flags from the config
     reinplace -E {s|-arch [a-z0-9_]+||g} \

--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -7,6 +7,7 @@ name                python36
 
 # Remember to keep py36-tkinter and py36-gdbm's versions sync'd with this
 version             3.6.2
+revision            1
 
 epoch               20170717
 
@@ -123,11 +124,11 @@ post-destroot {
 
     # Without this, LINKFORSHARED is set to
     # ... $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)
-    # (this becomes Python.framework/Versions/3.2/Python) which doesn't
-    # quite work (see ticket #15099); instead specifically list the
-    # full path to the proper Python framework file (which becomes
-    # ${prefix}/Library/Frameworks/Python.framework/Versions/3.2/Python)
-    reinplace {s|^\(LINKFORSHARED=.*\)$(PYTHONFRAMEWORKDIR).*$|\1 $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)|} ${destroot}${framewdir}/lib/python${branch}/$confdir/Makefile
+    # (this becomes Python.framework/Versions/3.6/Python) which doesn't
+    # quite work (see ticket #15099); instead we mirror the behavior of
+    # `python-config --ldflags` here.
+    reinplace {s|^\(LINKFORSHARED=\).*$|\1 -L$(LIBPL) -lpython$(VERSION)$(ABIFLAGS) $(LIBS) $(SYSLIBS)|} \
+        ${destroot}${framewdir}/lib/python${branch}/config-3.6m-darwin/Makefile
 
     # remove -arch flags from the config
     reinplace -E {s|-arch [a-z0-9_]+||g} \


### PR DESCRIPTION
Other ports are unable to use python27 if this value is not fixed. All
other pythonXY ports bu python27 apply this reinplace.

This was previously part of this Portfile but was removed in commit
46d23fd7abaccb17c87381352582babcf789aaa4.

See: https://lists.macosforge.org/pipermail/macports-dev/2016-September/033712.html
See: https://trac.macports.org/ticket/39223

Review-Request: @jyrkiwahlstedt