### PR TITLE
New port: clustershell @1.7.2

### DIFF
--- a/net/clustershell/Portfile
+++ b/net/clustershell/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+PortGroup               github 1.0
+
+github.setup            cea-hpc clustershell 1.7.2 v
+
+categories              net python
+platforms               darwin
+license                 LGPL-2+
+maintainers             kornel.us:karl openmaintainer
+
+description             Scalable cluster administration Python framework
+long_description        ClusterShell is an event-driven open source Python \
+                        library, designed to run local or distant commands in \
+                        parallel on server farms or on large Linux clusters. \
+                        It will take care of common issues encountered on HPC \
+                        clusters, such as operating on groups of nodes, \
+                        running distributed commands using optimized execution \
+                        algorithms, as well as gathering results and merging \
+                        identical outputs, or retrieving return codes. \
+                        ClusterShell takes advantage of existing remote shell \
+                        facilities already installed on your systems, like SSH.
+homepage                http://cea-hpc.github.com/clustershell
+
+checksums               rmd160 571e5e485ba5d11c11c458791b44b5c0abd7ec84 \
+                        sha256 ae83754a3f5e1bac109888d26d923820b3af060b0d5a6022c4f3f502b8e47c63
+
+# ClusterShell does not currently support Python 3.
+python.versions         27
+python.default_version  27
+
+# setuptools is used for build/install; YAML is used for configuration.
+depends_build-append    port:py${python.version}-setuptools
+depends_lib-append      port:py${python.version}-yaml
+
+# The code (in lib/ClusterShell/Defaults.py) has a hard-coded config file 
+# search path.  We need to change this before the compile phase.
+patchfiles              patch-lib-ClusterShell-Defaults.py
+post-patch {
+    reinplace "s|@MACPORTS_PREFIX@|${prefix}|g" ${worksrcpath}/lib/ClusterShell/Defaults.py
+}
+
+# The setup script creates some example config files, but does not respect 
+# $prefix when creating those files.  I think that's because, when setup.py is
+# run, it's given $destroot as the --root.  We deal with this my moving the 
+# files ourselves, after setup.py runs.
+post-destroot {
+    move [glob ${destroot}/etc/*] ${destroot}${prefix}/etc
+}

--- a/net/clustershell/files/patch-lib-ClusterShell-Defaults.py
+++ b/net/clustershell/files/patch-lib-ClusterShell-Defaults.py
@@ -1,0 +1,11 @@
+--- lib/ClusterShell/Defaults.py	2016-11-21 12:50:40.000000000 -0800
++++ lib/ClusterShell/Defaults.py	2016-11-21 12:51:42.000000000 -0800
+@@ -69,7 +69,7 @@
+ 
+ def config_paths(config_name):
+     """Return default path list for a ClusterShell config file name."""
+-    return ['/etc/clustershell/%s' % config_name, # system-wide config file
++    return ['@MACPORTS_PREFIX@/etc/clustershell/%s' % config_name, # system-wide config file
+             # default pip --user config file
+             os.path.expanduser('~/.local/etc/clustershell/%s' % config_name),
+             # per-user config (top override)


### PR DESCRIPTION
Clustershell is a Python 2 program that lets you run commands, and transfer files to/from, many servers at the same time.  It's meant for HPC environments, but works anywhere you have multiple machines (and can list them).

There is one patch, which is required because ClusterShell wants to look in /etc/clustershell for system-wide configuration.  The patch, plus a post-patch call to "reinpace", prepends ${prefix} before compilation.