### PR TITLE
cmus: simple edit to allow building on Tiger

### DIFF
--- a/audio/cmus/Portfile
+++ b/audio/cmus/Portfile
@@ -1,4 +1,4 @@
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
 PortGroup           github 1.0
@@ -44,6 +44,11 @@ configure.args      prefix=${prefix} CONFIG_FLAC=n CONFIG_MIKMOD=n \
                     HOSTCC="${configure.cc}" \
                     HOST_CFLAGS="${configure.cflags}" \
                     HOST_LDFLAGS="${configure.ldflags}"
+
+# add missing non-POSIX SIGWINCH definition for Darwin signal.h
+platform darwin 8 {
+    patchfiles-append   patch-cmus-uicurses-sigwinch-tiger.diff
+}
 
 post-configure {
     reinplace -W ${worksrcpath} "s|-R${prefix}/lib|-rpath ${prefix}/lib|g" config.mk

--- a/audio/cmus/files/patch-cmus-uicurses-sigwinch-tiger.diff
+++ b/audio/cmus/files/patch-cmus-uicurses-sigwinch-tiger.diff
@@ -1,0 +1,10 @@
+--- ui_curses.h.orig	2016-11-21 14:19:00.000000000 -0800
++++ ui_curses.h	2016-11-21 14:19:23.000000000 -0800
+@@ -30,6 +30,7 @@
+ };
+ 
+ #include <signal.h>
++#define SIGWINCH 28
+ 
+ extern sig_atomic_t cmus_running;
+ extern int ui_initialized;


### PR DESCRIPTION
SIGWINCH is non-POSIX, so by default is not included by Tiger.
This patch adds the missing definition to uicurses.h to allow building on Tiger.