### PR TITLE
new port: sfml 2.4.1

### DIFF
--- a/multimedia/sfml/Portfile
+++ b/multimedia/sfml/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+
+name                sfml
+version             2.4.1
+categories          multimedia devel
+platforms           darwin
+maintainers         gmail.com:rkitover openmaintainer
+license             zlib
+
+description         SFML is the Simple and Fast Multimedia Library
+
+long_description    ${description}. It provides a simple interface to the various \
+                    components of your computer, to ease the development of games and \
+                    multimedia applications. It is composed of five modules: system, \
+                    window, graphics, audio and network.
+
+homepage            http://www.sfml-dev.org/
+master_sites        http://www.sfml-dev.org/download/${name}/${version}/
+distname            SFML-${version}-sources
+use_zip             yes
+
+checksums           rmd160  fab652f52772e6f7d418e823dddebb6973020415 \
+                    sha256  f75096b2dc9cae67e10a28dbbefc9fe02e9dbe2e1ed50f2e208046bae9d3c9a4
+
+worksrcdir          ${name}-${version}
+
+depends_build-append port:doxygen
+
+# and we are not using mesa because it uses X11
+# (most users will not want this)
+
+depends_lib-append  port:freetype \
+                    port:jpeg \
+                    port:libsndfile \
+                    port:flac \
+                    port:libogg \
+                    port:libvorbis \
+                    port:openal-soft
+
+cmake.out_of_source yes
+
+configure.args-append \
+                    -DCMAKE_FRAMEWORK_PATH=${frameworks_dir} \
+                    -DCMAKE_INSTALL_FRAMEWORK_PREFIX=${frameworks_dir} \
+                    -DSFML_BUILD_DOC=TRUE
+
+# don't use the bundled libraries
+# except for stb_image headers, those aren't in macports yet
+post-extract {
+    delete {*}[glob ${worksrcpath}/extlibs/libs-*] \
+              ${worksrcpath}/extlibs/bin \
+           {*}[glob ${worksrcpath}/extlibs/headers/{AL,FLAC,freetype2,jpeg,ogg,vorbis}]
+}


### PR DESCRIPTION
C++ multimedia/network library popular with game developers and others.

Portfile based on the original submission here:

https://trac.macports.org/ticket/38987

but updated and improved.

The trac has been updated as well.

Happy to make any other improvements you would like to see to get this
merged.