### PR TITLE
sfml: fix install name of dylibs

### DIFF
--- a/multimedia/sfml/Portfile
+++ b/multimedia/sfml/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.1
 
 name                sfml
 version             2.4.1
+revision            1
 categories          multimedia devel
 platforms           darwin
 maintainers         gmail.com:rkitover openmaintainer
@@ -27,6 +28,9 @@ checksums           rmd160  fab652f52772e6f7d418e823dddebb6973020415 \
 
 worksrcdir          SFML-${version}
 
+patchfiles          patch-src-cmake-Macros.cmake.diff \
+                    patch-src-CMakeLists.txt.diff
+
 depends_build-append port:doxygen
 
 # and we are not using mesa because it uses X11
@@ -45,7 +49,8 @@ cmake.out_of_source yes
 configure.args-append \
                     -DCMAKE_FRAMEWORK_PATH=${frameworks_dir} \
                     -DCMAKE_INSTALL_FRAMEWORK_PREFIX=${frameworks_dir} \
-                    -DSFML_BUILD_DOC=TRUE
+                    -DSFML_BUILD_DOC=TRUE \
+                    -DSFML_INSTALL_PKGCONFIG_FILES=TRUE
 
 # don't use the bundled libraries
 # except for stb_image headers, those aren't in macports yet

--- a/multimedia/sfml/files/patch-src-CMakeLists.txt.diff
+++ b/multimedia/sfml/files/patch-src-CMakeLists.txt.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2016-11-28 06:38:46.000000000 -0800
++++ CMakeLists.txt	2016-11-28 06:39:21.000000000 -0800
+@@ -202,7 +202,7 @@
+     set(XCODE_TEMPLATES_ARCH "\$(NATIVE_ARCH_ACTUAL)")
+ endif()
+ 
+-if(SFML_OS_LINUX OR SFML_OS_FREEBSD)
++if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_MACOSX)
+     set(PKGCONFIG_DIR lib${LIB_SUFFIX}/pkgconfig)
+     if(SFML_OS_FREEBSD)
+         set(PKGCONFIG_DIR libdata/pkgconfig)

--- a/multimedia/sfml/files/patch-src-cmake-Macros.cmake.diff
+++ b/multimedia/sfml/files/patch-src-cmake-Macros.cmake.diff
@@ -1,0 +1,14 @@
+--- cmake/Macros.cmake.orig	2016-11-28 01:35:55.000000000 -0800
++++ cmake/Macros.cmake	2016-11-28 01:36:45.000000000 -0800
+@@ -103,11 +103,6 @@
+                                   MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+                                   MACOSX_FRAMEWORK_BUNDLE_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+         endif()
+-
+-        # adapt install directory to allow distributing dylibs/frameworks in user's frameworks/application bundle
+-        set_target_properties(${target} PROPERTIES
+-                              BUILD_WITH_INSTALL_RPATH 1
+-                              INSTALL_NAME_DIR "@rpath")
+     endif()
+ 
+     # enable automatic reference counting on iOS


### PR DESCRIPTION
Remove cmake code that sets the install name of the dylibs to @rpath, so
that linking to them works.

Will send a patch upstream to allow disabling this with an option.