### PR TITLE
In ghc use llvm 3.9 instead of llvm 3.5 to support macOS Sierra

### DIFF
--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup                       xcodeversion 1.0
 
 name                            graphviz-devel
 set my_name                     graphviz
-version                         2.39.20161126.1803
+version                         2.39.20161129.2123
 set thisbranch                  [strsed ${name} "g/^${my_name}//"]
 set otherbranch                 [expr {${thisbranch} eq {} ? {-devel} : {}}]
 categories                      graphics
@@ -30,8 +30,8 @@ long_description                Graphviz is ${description}. Graph visualization 
                                 simple text language, and produce output in a \
                                 variety of visual and text formats.
 
-checksums                       rmd160  c3338080b802b6b9925331b2554f0aa41185f01a \
-                                sha256  3716f67eef572aa39c072187cc7c0f5530f75f547ffe53a479c7d739ba8ff53d
+checksums                       rmd160  ed35ec3f7c865bfc22687181950e36e27f8afb2b \
+                                sha256  a1b86ead97e3b0bc9582c7fa6e1bcbcb366366a2381ee5ef43ce00d683801ec9
 
 # graphviz needs Xcode 3.1+ to avoid the libGL error when building the smyrna variant
 # graphviz-gui needs Xcode 3.1.2+; see #18811


### PR DESCRIPTION
This is in regards to:
https://trac.macports.org/ticket/52582

llvm 3.5 won't compile on Sierra. This is an update to the port file to have ghc use llvm 3.9. 