### PR TITLE
grib_api: Update to 1.19.0.

### DIFF
--- a/math/gnudatalanguage/Portfile
+++ b/math/gnudatalanguage/Portfile
@@ -8,7 +8,7 @@ PortGroup                   mpi 1.0
 
 name                        gnudatalanguage
 version                     0.9.6
-revision                    2
+revision                    3
 epoch                       2
 
 compilers.choose            cc cxx

--- a/python/py-pygrib/Portfile
+++ b/python/py-pygrib/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 name                py-pygrib
 version             2.0.1
-revision            0
+revision            1
 categories-append   science
 license             MIT
 platforms           darwin

--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 
 name                        cdo
 version                     1.7.2
-revision                    1
+revision                    2
 platforms                   darwin
 maintainers                 takeshi openmaintainer
 license                     GPL-2

--- a/science/gri/Portfile
+++ b/science/gri/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 
 name                gri
 version             2.12.23
-revision            1
+revision            2
 categories          science graphics
 platforms           darwin
 license             GPL-3

--- a/science/grib_api/Portfile
+++ b/science/grib_api/Portfile
@@ -6,8 +6,7 @@ PortGroup cmake     1.0
 PortGroup compilers 1.0
 
 name                grib_api
-version             1.18.0
-revision            1
+version             1.19.0
 platforms           darwin
 maintainers         takeshi
 license             Apache-2
@@ -16,8 +15,8 @@ description         GRIB decoder
 homepage            https://software.ecmwf.int/wiki/display/GRIB/Home
 master_sites        https://software.ecmwf.int/wiki/download/attachments/3473437
 distname            ${name}-${version}-Source
-checksums           rmd160  93846fae559958be1a1ff4f57eec192047baf66a \
-                    sha256  dfffeeb4df715b234907cb12d6729617bed0df0ff023337c2dd3cd20ab58199e
+checksums           rmd160  693270232ec5f22d6f736190eb8679627af0a659 \
+                    sha256  caec66c2d54331de9830dde853195262a1859bab36d5d03b4d44ac55784d921d
 long_description \
     The ECMWF GRIB API is an application program interface accessible \
     from C and FORTRAN programs developed for encoding and decoding   \

--- a/science/libemos/Portfile
+++ b/science/libemos/Portfile
@@ -6,6 +6,7 @@ PortGroup cmake     1.0
 
 name                libemos
 version             4.4.4
+revision            1
 platforms           darwin
 maintainers         takeshi
 license             Apache-2
@@ -21,7 +22,7 @@ long_description \
     The Interpolation library (EMOSLIB) includes Interpolation software \
     and BUFR & CREX encoding/decoding routines.
 
-compilers.choose    fc f77 f90 
+compilers.choose    fc f77 f90
 compilers.setup     -clang -dragonegg -g95 -llvm
 cmake.out_of_source yes
 

--- a/science/magicspp/Portfile
+++ b/science/magicspp/Portfile
@@ -10,7 +10,7 @@ perl5.branches      5.24
 
 name                magicspp
 version             2.29.4
-revision            3
+revision            4
 platforms           darwin
 maintainers         takeshi
 license             Apache-2

--- a/science/metview/Portfile
+++ b/science/metview/Portfile
@@ -7,7 +7,7 @@ PortGroup qt4       1.0
 
 name                metview
 version             4.7.0
-revision            3
+revision            4
 platforms           darwin
 maintainers         takeshi
 license             Apache-2


### PR DESCRIPTION
Updates the `grib_api` package to `1.19.0`.
