### PR TITLE
tortoisehg: Update to 4.0

### DIFF
--- a/devel/tortoisehg/Portfile
+++ b/devel/tortoisehg/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 PortGroup           app 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     tortoisehg thg 3.9.2
+bitbucket.setup     tortoisehg thg 4.0
 name                tortoisehg
 categories          devel python
 platforms           darwin
@@ -19,8 +19,8 @@ description         A set of graphical tools for Mercurial
 long_description    A set of graphical tools for the Mercurial distributed \
                     source control management system.
 
-checksums           rmd160  223d8fb251d6bf47bdfed17e038a4d26893297c0 \
-                    sha256  67d42ef865519bd6675a34aa3750e5df3a48611da907108508bdbb8fd94dfbff
+checksums           rmd160  8080946f3198b0ecf109b336c97f31aefc8c98d5 \
+                    sha256  b4ee4969ee752c7fafb6c0b889386811a8ff14856961faa2fc274be553c61c94
 
 python.default_version 27
 
@@ -35,6 +35,7 @@ depends_build       port:py${python.version}-sphinx
 
 post-extract {
     copy ${filespath}/config.py ${worksrcpath}/tortoisehg/util/
+    delete file ${worksrcpath}/hgext3rd/__init__.py
     reinplace -W ${worksrcpath} "s,pyrcc4,pyrcc4-2.7," setup.py
 }
 


### PR DESCRIPTION
Updates TortoiseHg to 4.0
I had to remove `hgext3rd/__init__.py` since that file is already owned by the `mercurial` port. Is there a more elegant way of dealing with conflicting files?