### PR TITLE
upx-devel: attempt to fix build on older compilers

### DIFF
--- a/archivers/upx-devel/Portfile
+++ b/archivers/upx-devel/Portfile
@@ -30,6 +30,7 @@ post-fetch {
 
 post-configure {
     reinplace "s|CXXFLAGS += -fno-delete-null-pointer-checks||" ${worksrcpath}/src/Makefile
+    reinplace "s| -Wvla||" ${worksrcpath}/src/Makefile
 }
 
 destroot {


### PR DESCRIPTION
`cc1plus: error: unrecognized command line option "-Wvla"`