### PR TITLE
python/py-aplpy: update to 1.1.1 and add 35 to python.versions

### DIFF
--- a/python/py-aplpy/Portfile
+++ b/python/py-aplpy/Portfile
@@ -8,7 +8,7 @@ set _name           APLpy
 set _n              [string index ${_name} 0]
 
 name                py-aplpy
-version             1.0
+version             1.1.1
 categories-append   science
 platforms           darwin
 supported_archs     noarch
@@ -27,11 +27,11 @@ homepage            http://aplpy.github.com/
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     a660dc5a5e62536e32bf61e44a5eb6c8 \
-                    rmd160  7d98decf230c0ba9303aca8cc2b40c72a7a3cdef \
-                    sha256  09a8a24b46b93a1eacdbc0e6fd480fa38e4dd890a24963136d76185924602ff0
+checksums           md5     634422c006dcd366d5504af3349e9d10 \
+                    rmd160  99edddf30cd7635edd8ffe9d1466c2ead1584525 \
+                    sha256  1c3bc9972da5f738435449e5e8483824129f2a18e7426f0a8c2c06a1ef3b4b4b
 
-python.versions     27 34
+python.versions     27 34 35
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
This PR updates APLPy to 1.1.1 and adds 35 to python.versions.

I took the tarball from https://pypi.org/project/APLpy/#files and computed the checksums locally.

I did not do any local checks if this builds or works correctly within Macports.

cc port maintainer @astrofrog