### PR TITLE
py-pyavm: add python 3.5 and update to version 0.9.2

### DIFF
--- a/python/py-pyavm/Portfile
+++ b/python/py-pyavm/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyavm
-version             0.9.1
+version             0.9.2
 maintainers         robitaille openmaintainer
 
 categories-append   science
@@ -19,8 +19,8 @@ homepage            https://github.com/astrofrog/pyavm
 master_sites        pypi:P/PyAVM/
 
 distname            PyAVM-${version}
-checksums           md5     db5eb5284c9d432d7aedb67ecbdf00b3 \
-                    sha1    e1bb60ef3d02a199c5998930061eb0713a4aa7b0 \
-                    rmd160  718460d7679bc6eedf5cfdb71ea9a72302152a16
+checksums           md5     da9b19ba6f4ccafcccb644fbd998bade \
+                    sha1    daf2b717912fddfde4e0614f8968b2e5741248fa \
+                    rmd160  86e77a3e85db8e77f5f7f792ecfac4fe59a15c2f
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36


### PR DESCRIPTION
This PR adds a python 3.5 version for py-pyavm and updates to version 0.9.2

Following #101, I just now tried
```
$ sudo port install py35-aplpy
Password:
--->  Computing dependencies for py35-aplpy
Error: Dependency 'py35-pyavm' not found.
To report a bug, follow the instructions in the guide:
    http://guide.macports.org/#project.tickets
Error: Processing of port py35-aplpy failed
```

cc port maintainer @astrofrog

I didn't do any local testing.