### PR TITLE
py-emcee: add 35 to python.versions

### DIFF
--- a/python/py-emcee/Portfile
+++ b/python/py-emcee/Portfile
@@ -28,7 +28,7 @@ license             MIT
 checksums           rmd160  9d877a80ce5a19b8c442d225a27a57fe548a14f0 \
                     sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00
 
-python.versions     27 34
+python.versions     27 34 35
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
This PR adds Python 3.5 to the versions available for py-emcee.
