### PR TITLE
py35-spyder-devel: upgrade to 3.0.2

### DIFF
--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        spyder-ide spyder 3.0.1 v
+github.setup        spyder-ide spyder 3.0.2 v
 name                py-spyder-devel
 revision            0
 # Preference on mailing list is to use small numbers for epoch.
@@ -38,9 +38,8 @@ supported_archs     noarch
 universal_variant   no 
 
 if {${name} ne ${subport}} {
-    checksums \
-        rmd160  b82361a0f4c05d3bd0548d422b062a1af333d6f8 \
-        sha256  3830c6131ef1ef0a0088c78acdd3f99d95d018dcb66ad8334c7379b17f33d316
+    checksums           rmd160  5ee594ac07ea96e3f8b106fea5bddec21479db3f \
+                        sha256  ab9e39f22263e6d95d4aeddd96ab01cf48a9f6c24e2c460bb5745667956e463c
 
     conflicts           py${python.version}-spyder
 


### PR DESCRIPTION
- ATTENTION: spyder doesn't start from the console

See:    https://trac.macports.org/ticket/53084
Closes: https://trac.macports.org/ticket/51454