### PR TITLE
fluidsynth: new variants & maintainers

### DIFF
--- a/multimedia/fluidsynth/Portfile
+++ b/multimedia/fluidsynth/Portfile
@@ -1,22 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
 
 name                fluidsynth
 version             1.1.6
-revision            2
-categories          multimedia
-maintainers         nomaintainer
+revision            3
+categories          multimedia audio
+maintainers         gmail.com:rjvbertin mojca openmaintainer
 license             LGPL
 
 description         FluidSynth is a real-time software synthesizer based on the SoundFont 2 specifications.
-long_description    FluidSynth is a real-time software synthesizer based on the SoundFont 2 specifications.
+long_description    FluidSynth is a cross-platform real-time software synthesizer with \
+                    support for SoundFont 2 and a built-in command line shell. \
+                    It may be used for playback of MIDI files, but also \
+                    provides a shared library which can be used in other programs.
 
 platforms           darwin
 
 homepage            http://fluidsynth.sourceforge.net/
-master_sites        sourceforge:project/${name}/${name}-${version}
+master_sites        sourceforge
 use_bzip2           yes
 
 checksums           rmd160  27b17e1e097004dd3cf8fb88d8e4499eeb339ea8 \
@@ -26,7 +28,6 @@ depends_build       port:pkgconfig
 depends_lib         port:flac \
                     port:gettext \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:jack \
                     port:libiconv \
                     port:libogg \
                     port:libsndfile \
@@ -35,7 +36,25 @@ depends_lib         port:flac \
                     port:portaudio \
                     port:readline
 
-configure.args      --disable-pulse-support
+configure.args-append \
+                    --disable-dependency-tracking \
+                    --disable-pulse-support \
+                    --disable-jack-support \
+                    --disable-dbus-support
 
-livecheck.type      sourceforge
+# support for JACK makes JACK output the default and requires the daemon to be running
+variant jack description {Enable JACK support (requires the deamon to be running)} {
+    depends_lib-append \
+                    port:jack
+    configure.args-replace \
+                    --disable-jack-support --enable-jack-support
+}
+
+variant dbus description {Enable D-Bus support} {
+    depends_lib-append \
+                    port:dbus
+    configure.args-replace \
+                    --disable-dbus-support --enable-dbus-support
+}
+
 livecheck.regex     /${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
This is an update (mostly written by René, I only did minor edits) to fluidsynth that:
* introduces a new variant `dbus` for D-Bus support
* introduces a new variant `jack` (support for JACK makes JACK output default and requires the daemon to be running)
* adds me and @RJVB as maintainers

If you install `generaluser-soundfont`, you may test
```
fluidsynth /opt/local/share/sounds/sf2/GeneralUser_GS_v1.47.sf2 /opt/local/share/examples/generaluser-soundfont/earthday.mid
```

This is what I get with jack support built-in (without doing anything else):
```
SoundFont(R) is a registered trademark of E-mu Systems, Inc.

connect(2) call to /tmp//jack-501/default/jack_0 failed (err=No such file or directory)
jackd 0.124.1
Copyright 2001-2009 Paul Davis, Stephane Letz, Jack O'Quinn, Torben Hohn and others.
jackd comes with ABSOLUTELY NO WARRANTY
This is free software, and you are welcome to redistribute it
under certain conditions; see the file COPYING for details

connect(2) call to /tmp//jack-501/default/jack_0 failed (err=No such file or directory)
JACK compiled with POSIX SHM support.
loading driver ..
all 32 bit float mono audio port buffers in use!
cannot assign buffer for port
cannot deliver port registration request
Type 'help' for help topics.

jack_client_resume: send error for (ipc/rcv) timed out

timeout waiting for client fluidsynth to handle a xrun event
```
without jack it works out of the box.

@ryandesign, @Ionic, @jmroot: your ports (`lmms`, `audacious-plugins`, `libsdl2_mixer`) use fluidsynth (ok, the last one explicitly disables support). I didn't test any of them, but I would be grateful if you could confirm whether the changes are not doing any harm to your ports.

Some other potentially affected ports include `denemo`, `VLC`, `gstreamer1-gst-plugins-bad`.


Shouldn't this port be in the `audio` folder?