### PR TITLE
py-poppler-qt5: new port

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qt5 1.0
+PortGroup           python 1.0
+
+set _name           python-poppler-qt5
+set _n              [string index ${_name} 0]
+
+name                py-poppler-qt5
+version             0.24.2
+platforms           darwin
+license             LGPL-2.1+
+maintainers         gmail.com:davide.liessi openmaintainer
+
+description         Python binding for Poppler-Qt5
+long_description    ${_name} is a Python binding for Poppler-Qt5 \
+                    that aims for completeness \
+                    and for being actively maintained. \
+                    Using this module you can access \
+                    the contents of PDF files \
+                    inside PyQt5 applications.
+
+homepage            https://github.com/wbsoft/${_name}
+master_sites        pypi:${_n}/${_name}/
+distname            ${_name}-${version}
+
+checksums           md5     1f45ed0f7f3cacc1d0f9e626bd5fb5c8 \
+                    rmd160  baa134c6a9e466dddcb15a23f7238b88d1eed8af \
+                    sha256  3970c35ce1f0f1464a6c2746bea4c479b9780b4e17030c92479f7f1738a5c950
+
+python.versions     27 34 35
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    depends_lib-append      port:qt5 \
+                            port:poppler-qt5 \
+                            port:py${python.version}-sip \
+                            port:py${python.version}-pyqt5
+
+    patchfiles              patch-fix-qtxml.diff \
+                            patch-fix-qt-dirs.diff \
+                            patch-fix-demo.diff
+
+    post-patch {
+        reinplace "s|%%QMAKE%%|${qt_bins_dir}/qmake|g" ${worksrcpath}/setup.py
+        reinplace "s|%%PYQTSIPDIR%%|${python.prefix}/share/sip/PyQt5/|g" ${worksrcpath}/setup.py
+    }
+
+    post-destroot {
+        set doc_dir ${destroot}${prefix}/share/doc/${subport}
+        xinstall -d ${doc_dir}
+        xinstall -m 644 -W ${worksrcpath} \
+            ChangeLog \
+            LICENSE \
+            README.rst \
+            ${doc_dir}
+        set examples_dir ${destroot}${prefix}/share/examples/${subport}
+        xinstall -d ${examples_dir}
+        xinstall -m 644 -W ${worksrcpath} demo.py ${examples_dir}
+    }
+
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   https://pypi.python.org/pypi/${_name}
+    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+}

--- a/python/py-poppler-qt5/files/patch-fix-demo.diff
+++ b/python/py-poppler-qt5/files/patch-fix-demo.diff
@@ -1,0 +1,37 @@
+--- demo.py
++++ demo.py
+@@ -1,5 +1,5 @@
+ import sys
+-from PyQt5 import QtGui
++from PyQt5 import QtGui, QtWidgets
+ import popplerqt5
+ 
+ usage = """
+@@ -15,7 +15,7 @@ Usage:
+ def pdf_view(filename):
+     """Return a Scrollarea showing the first page of the specified PDF file."""
+     
+-    label = QtGui.QLabel()
++    label = QtWidgets.QLabel()
+     
+     doc = popplerqt5.Poppler.Document.load(filename)
+     doc.setRenderHint(popplerqt5.Poppler.Document.Antialiasing)
+@@ -26,15 +26,15 @@ def pdf_view(filename):
+     
+     label.setPixmap(QtGui.QPixmap.fromImage(image))
+     
+-    area = QtGui.QScrollArea()
++    area = QtWidgets.QScrollArea()
+     area.setWidget(label)
+     area.setWindowTitle(filename)
+     return area
+ 
+ 
+ def main():
+-    app = QtGui.QApplication(sys.argv)
+-    argv = QtGui.QApplication.arguments()
++    app = QtWidgets.QApplication(sys.argv)
++    argv = QtWidgets.QApplication.arguments()
+     if len(argv) < 2:
+         sys.stderr.write(usage)
+         sys.exit(2)

--- a/python/py-poppler-qt5/files/patch-fix-qt-dirs.diff
+++ b/python/py-poppler-qt5/files/patch-fix-qt-dirs.diff
@@ -1,0 +1,15 @@
+--- setup.py
++++ setup.py
+@@ -137,10 +137,10 @@ class build_ext(build_ext_base):
+         build_ext_base.initialize_options(self)
+         self.poppler_version = None
+ 
+-        self.qmake_bin = 'qmake'
++        self.qmake_bin = '%%QMAKE%%'
+ 
+         self.qt_include_dir = None
+-        self.pyqt_sip_dir = None
++        self.pyqt_sip_dir = '%%PYQTSIPDIR%%'
+         self.pyqt_sip_flags = None
+ 
+     def finalize_options (self):

--- a/python/py-poppler-qt5/files/patch-fix-qtxml.diff
+++ b/python/py-poppler-qt5/files/patch-fix-qtxml.diff
@@ -1,0 +1,18 @@
+--- poppler-qt5.sip
++++ poppler-qt5.sip
+@@ -5,11 +5,13 @@
+  * Maintained by Wilbert Berendsen <wbsoft@xs4all.nl>
+  */
+ 
++%Feature QTXML_AVAILABLE
+ 
+ %Import QtCore/QtCoremod.sip
+ %Import QtGui/QtGuimod.sip
+-
+-%Feature QTXML_AVAILABLE
++%If(QTXML_AVAILABLE)
++%Import QtXml/QtXmlmod.sip
++%End
+ 
+ %Timeline {
+     POPPLER_V0_20_0


### PR DESCRIPTION
Analogous to py-poppler-qt4, it will be a dependency of new versions of Frescobaldi.