### PR TITLE
spring-boot-cli @1.4.2_0: Update to 1.4.3

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.4.2
+version         1.4.3
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    http://repo.spring.io/release/org/springframework/boot/${name}/$
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  8876637c6143d00de06a4f8f2efe79a855a3bdeb \
-                sha256  785955a4368c26fbb1eb5685508ebf1fec0e22808ddf3c06fef1b16ea55ab438
+checksums       rmd160  2a009f6335a1731b1c008108873adc4289ea4ce5 \
+                sha256  b74e63f0c4f79f7d588ecff27556fb8f63a4bad14fe06471a831b19e70e1ccc8
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
Release notes: https://spring.io/blog/2016/12/23/spring-boot-1-4-3-available-now

List of closed issues: https://github.com/spring-projects/spring-boot/milestone/75?closed=1