### PR TITLE
Python 3.6 support for some ports

### DIFF
--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -19,14 +19,17 @@ homepage            http://mycli.net
 checksums           rmd160  1b10dc7c4c37a22505bb09c55e841e56a7f689b7 \
                     sha256  6d009ad91d65c4eb2d2afb55332c38b9b5f20d3b7b7c518ace1f2b2b238aed75
 
-variant python27 conflicts python34 python35 description "Use Python 2.7" {}
-variant python34 conflicts python27 python35 description "Use Python 3.4" {}
-variant python35 conflicts python27 python34 description "Use Python 3.5" {}
+variant python27 conflicts python34 python35 python36 description "Use Python 2.7" {}
+variant python34 conflicts python27 python35 python36 description "Use Python 3.4" {}
+variant python35 conflicts python27 python34 python36 description "Use Python 3.5" {}
+variant python36 conflicts python27 python34 python35 description "Use Python 3.6" {}
 
 if {[variant_isset python34]} {
     python.default_version 34
 } elseif {[variant_isset python35]} {
     python.default_version 35
+} elseif {[variant_isset python36]} {
+    python.default_version 36
 } else {
     default_variants +python27
     python.default_version 27

--- a/python/py-click/Portfile
+++ b/python/py-click/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-configobj/Portfile
+++ b/python/py-configobj/Portfile
@@ -1,5 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -18,7 +17,7 @@ long_description    ConfigObj is a simple but powerful config file \
                     with a straightforward programmer's interface and \
                     a simple syntax for config files.
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 homepage            https://pypi.python.org/pypi/configobj/
 master_sites        pypi:c/configobj/
@@ -31,7 +30,5 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     livecheck.type          none
 } else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     "configobj/(\\d+\\.\\d+(?:\\.\\d+))"
+    livecheck.type          pypi
 }

--- a/python/py-crypto/Portfile
+++ b/python/py-crypto/Portfile
@@ -1,5 +1,4 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -24,7 +23,7 @@ distname            pycrypto-${version}
 checksums           rmd160  ac0db079e5e4be9daf739e094c10e96291dbc009 \
                     sha256  f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:gmp

--- a/python/py-pip/Portfile
+++ b/python/py-pip/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-pip/files/pip36
+++ b/python/py-pip/files/pip36
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.6/bin/pip

--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -12,7 +12,7 @@ maintainers         gmail.com:xeron.oskom openmaintainer
 description         Library for building powerful interactive command lines in Python
 long_description    ${description}
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}

--- a/python/py-pygments/Portfile
+++ b/python/py-pygments/Portfile
@@ -1,5 +1,4 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -11,7 +10,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-pymysql/Portfile
+++ b/python/py-pymysql/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
@@ -10,7 +12,7 @@ maintainers         gmail.com:xeron.oskom openmaintainer
 description         Pure-Python MySQL client library
 long_description    ${description}
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}

--- a/python/py-six/Portfile
+++ b/python/py-six/Portfile
@@ -1,5 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -26,12 +25,10 @@ distname            six-${version}
 checksums           rmd160  9c5e84a8d2640fc98b33f62896a4f9a3f64167ee \
                     sha256  105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     livecheck.type      none
 } else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/six/json
-    livecheck.regex     {six-(\d+(?:\.\d+)*)\.[tz]}
+    livecheck.type      pypi
 }

--- a/python/py-sqlparse/Portfile
+++ b/python/py-sqlparse/Portfile
@@ -13,7 +13,7 @@ description         Non-validating SQL parser
 long_description    ${description} that provides support for parsing, splitting \
                     and formatting SQL statements.
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 categories-append   textproc
 

--- a/python/py-wcwidth/Portfile
+++ b/python/py-wcwidth/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -12,7 +12,7 @@ maintainers         gmail.com:xeron.oskom openmaintainer
 description         Library for building powerful interactive command lines in Python
 long_description    ${description}
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 homepage            https://pypi.python.org/pypi/wcwidth/
 master_sites        pypi:w/wcwidth
@@ -25,7 +25,5 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     livecheck.type          none
 } else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     "wcwidth (\\d+\\.\\d+(?:\\.\\d+))"
+    livecheck.type          pypi
 }


### PR DESCRIPTION
List of the ports updated:

* mycli
* py-click
* py-configobj (+ livecheck change to `pypi`)
* py-crypto
* py-pip
* py-prompt_toolkit
* py-pygments
* py-pymysql
* py-six (+ livecheck change to `pypi`)
* py-sqlparse
* py-wcwidth (+ livecheck change to `pypi`)

Also removed `$Id$` from the ports which still have it and made vim `coding` line to be the same for all these ports.