### PR TITLE
Use nodejs4 for yarn on pre-Lion mac os

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -13,7 +13,7 @@ supported_archs     noarch
 license             BSD
 
 maintainers         andrewsforge.com:code \
-                    gmail.com:isomacrte \
+                    gmail.com:isomarcte \
                     openmaintainer
 
 description         JavaScript dependency manager
@@ -31,6 +31,14 @@ checksums           rmd160 c806b890b1e348e35256191d52681d220e73a5b8 \
                     Sha256 7d16699c8690ef145e1732004266fb82a32b0c06210a43c624986d100537b5a8
 
 depends_run         bin:node:nodejs6
+
+platform darwin {
+    # Fix for https://trac.macports.org/ticket/53166
+    # Mac OS X 10.6 Snow Leopard and earlier cannot install Node JS v6
+    if {${os.major} < 11} {
+        depends_run-replace bin:node:nodejs6 bin:node:nodejs4
+    }
+}
 
 patchfiles          patch-0001-Allow-yarn-script-to-be-linked.patch
 


### PR DESCRIPTION
This PR is an attempt to fix for [Trac Bug 53166](https://trac.macports.org/ticket/53166). I'm still new to this, and would appreciate any help/guidance/feedback.

I'm using the Darwin versions based on the [macOS version table on Wikipedia.](https://en.wikipedia.org/wiki/MacOS#Release_history)

I've opted to use Node v4 instead of v5 based on the support table found [on the LTS Working group repo](https://github.com/nodejs/LTS)

Using Node v4 with yarn should be safe. While I could not find any documentation about expected Node version support, yarn is [actively tested against Node 4](https://github.com/yarnpkg/yarn/blob/0.18-stable/.travis.yml#L34) and [explicitly checks for Node v4](https://github.com/yarnpkg/yarn/blob/0.18-stable/bin/yarn.js#L19).

@isomarcte : I originally copied and pasted your email from [your branch](https://github.com/isomarcte/ports/blob/b4278b6618386f84e02715f073866ce35f43244e/devel/yarn/Portfile#L11) but the email pseudonym is not the same as your github username, and @mojca asked in the ticket if that was a typo. Could you confirm that my change is valid?