### PR TITLE
nodejs6 and some npm updates

### DIFF
--- a/devel/nodejs4/Portfile
+++ b/devel/nodejs4/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    nodejs4
-version                 4.6.1
+version                 4.7.2
 
 categories              devel net
 platforms               darwin
@@ -23,8 +23,8 @@ conflicts               nodejs5 nodejs6 nodejs7
 homepage                http://nodejs.org/
 master_sites            ${homepage}dist/v${version}
 
-checksums               rmd160  b62e9420642f6f898f9be541eab9ca836baa6085 \
-                        sha256  b8ca4db42c5a1fed95baf6996ff776db3c95ad2bcf73c7aed2f1f921a1225de3
+checksums               rmd160  3891474d4d3f4817d245e0dfa8619446253f8ef5 \
+                        sha256  771e9f4ef946f8f13452039c5bd1eb3edb9e4a0937b7a5f328dbd8e529a09284
 
 distname                node-v${version}
 

--- a/devel/nodejs4/files/patch-common.gypi.diff
+++ b/devel/nodejs4/files/patch-common.gypi.diff
@@ -1,6 +1,6 @@
---- common.gypi.orig	2014-09-16 17:47:52.000000000 -0500
-+++ common.gypi	2014-10-13 22:42:11.000000000 -0500
-@@ -207,7 +207,6 @@
+--- common.gypi.orig
++++ common.gypi
+@@ -352,7 +352,6 @@
            'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
            'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
            'PREBINDING': 'NO',                       # No -Wl,-prebind

--- a/devel/nodejs4/files/patch-src-util.h.diff
+++ b/devel/nodejs4/files/patch-src-util.h.diff
@@ -1,5 +1,5 @@
---- src/util.h.orig	2016-10-06 23:29:01.000000000 +0200
-+++ src/util.h	2016-10-06 23:27:20.000000000 +0200
+--- src/util.h.orig
++++ src/util.h
 @@ -8,11 +8,7 @@
  #include <stddef.h>
  #include <stdlib.h>

--- a/devel/nodejs4/files/patch-tools-gyp-pylib-gyp-generator-make.py.diff
+++ b/devel/nodejs4/files/patch-tools-gyp-pylib-gyp-generator-make.py.diff
@@ -1,6 +1,6 @@
---- ./tools/gyp/pylib/gyp/generator/make.py	2016-01-20 19:08:27.000000000 -0600
-+++ ./tools/gyp/pylib/gyp/generator/make.new.py	2016-01-22 14:34:20.000000000 -0600
-@@ -1211,6 +1211,7 @@
+--- tools/gyp/pylib/gyp/generator/make.py
++++ tools/gyp/pylib/gyp/generator/make.new.py
+@@ -1216,6 +1216,7 @@
        includes = config.get('include_dirs')
        if includes:
          includes = map(Sourceify, map(self.Absolutify, includes))

--- a/devel/nodejs6/Portfile
+++ b/devel/nodejs6/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    nodejs6
-version                 6.9.1
+version                 6.9.4
 
 categories              devel net
 platforms               darwin
@@ -23,8 +23,8 @@ conflicts               nodejs4 nodejs5 nodejs7
 homepage                http://nodejs.org/
 master_sites            ${homepage}dist/v${version}
 
-checksums               rmd160  e722d24bb066d198d1905ecfd49e9ea8e48cacaa \
-                        sha256  a98997ca3a4d10751f0ebe97839b2308a31ae884b4203cda0c99cf36bc7fe3bf
+checksums               rmd160  538d4813c76d27d55732dad0d381822bc10e577d \
+                        sha256  f0257c83eb5e8b0e7b09db7264dc1e93e1f024c6dfccb098363b4fb0c192cf7f
 
 distname                node-v${version}
 

--- a/devel/npm3/Portfile
+++ b/devel/npm3/Portfile
@@ -90,4 +90,4 @@ ${prefix}/lib/node_modules/ until you manually delete them.
 
 livecheck.type      regex
 livecheck.url       http://registry.npmjs.org/npm
-livecheck.regex     {"latest":"(.*?)"}
+livecheck.regex     {"latest-3":"(.*?)"}

--- a/devel/npm3/Portfile
+++ b/devel/npm3/Portfile
@@ -36,6 +36,12 @@ worksrcdir          "package"
 
 depends_lib         path:bin/node:nodejs6
 
+platform darwin {
+    if {${os.major} < 11} {
+        depends_lib-replace bin:node:nodejs6 bin:node:nodejs4
+    }
+}
+
 use_configure       no
 
 patchfiles          patch-lib-update.js.diff

--- a/devel/npm3/Portfile
+++ b/devel/npm3/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm3
-version             3.10.9
+version             3.10.10
 
 categories          devel
 platforms           darwin
@@ -27,8 +27,8 @@ distname            npm-${version}
 
 extract.suffix      .tgz
 
-checksums           rmd160  8ffd8d88e10c40ccf79cdd61923200a4924e0d72 \
-                    sha256  fb0871b1aebf4b74717a72289fade356aedca83ee54e7386e38cb51874501dd6
+checksums           rmd160  b6a6049f561d9e5f54578ca897a51b3db79fad68 \
+                    sha256  1a7cd203ac30fd1417326d576ca5c66ae2ae6a2bf1ada151bee2fc0d6965f99a
 
 distname            npm-${version}
 

--- a/devel/npm3/files/patch-lib-update.js.diff
+++ b/devel/npm3/files/patch-lib-update.js.diff
@@ -1,6 +1,6 @@
---- lib/update.js.orig	2016-04-26 09:35:11.000000000 +0200
-+++ lib/update.js	2016-04-26 09:34:24.000000000 +0200
-@@ -47,7 +47,12 @@
+--- lib/update.js.orig
++++ lib/update.js
+@@ -51,7 +51,12 @@
        if (url.parse(ww.req).protocol) ww.what = ww.req
  
        var where = ww.dep.parent && ww.dep.parent.path || ww.dep.path

--- a/devel/npm4/Portfile
+++ b/devel/npm4/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm4
-version             4.0.2
+version             4.0.5
 
 categories          devel
 platforms           darwin
@@ -27,10 +27,8 @@ distname            npm-${version}
 
 extract.suffix      .tgz
 
-checksums           rmd160  09f4947995f778ab3302ed98ae94d633a7e1ce58 \
-                    sha256  b49cdd9831a911fdb0de242ffd5a8764e92e51f0c6d8f4182d17739d7dbcb602
-
-distname            npm-${version}
+checksums           rmd160  fbcfe70ebc6f10d1bc31a4ddeff2d6171749ad95 \
+                    sha256  195f654387867484a17826990fce2d46177a16f4911297c53b870597c037a27e
 
 worksrcdir          "package"
 
@@ -55,7 +53,7 @@ post-patch {
                    ${worksrcpath}/node_modules/read-cmd-shim/test/integration.js \
                    ${worksrcpath}/node_modules/request/node_modules/har-validator/bin/har-validator \
                    ${worksrcpath}/node_modules/request/node_modules/har-validator/node_modules/commander/Readme.md \
-                   ${worksrcpath}/node_modules/request/node_modules/node-uuid/bin/uuid \
+                   ${worksrcpath}/node_modules/request/node_modules/uuid/bin/uuid \
                    ${worksrcpath}/node_modules/rimraf/bin.js \
                    ${worksrcpath}/node_modules/semver/bin/semver \
                    ${worksrcpath}/node_modules/which/bin/which \

--- a/devel/npm4/Portfile
+++ b/devel/npm4/Portfile
@@ -15,7 +15,7 @@ supported_archs     noarch
 description         node package manager
 long_description    npm is a package manager for node. \
                     You can use it to install and publish your node programs. \
-		            It manages dependencies and does other cool stuff.
+                    It manages dependencies and does other cool stuff.
 
 conflicts           npm2 npm3
 

--- a/devel/npm4/Portfile
+++ b/devel/npm4/Portfile
@@ -34,6 +34,12 @@ worksrcdir          "package"
 
 depends_lib         path:bin/node:nodejs6
 
+platform darwin {
+    if {${os.major} < 11} {
+        depends_lib-replace bin:node:nodejs6 bin:node:nodejs4
+    }
+}
+
 use_configure       no
 
 patchfiles          patch-lib-update.js.diff


### PR DESCRIPTION
Following https://trac.macports.org/ticket/53026 I created some updates for `nodejs6` and `npm3`. I tried updating `npm4`, but that requires more works.

Apart from version and checksums update and probably
```patch
-livecheck.regex     {"next":"(.*?)"}
+livecheck.regex     {"latest":"(.*?)"}
```
the list of files for patching is completely different.

Changes need to be approved by maintainer (@ci42).

See also #127 for dependencies of `npm` ports.