### PR TITLE
py-astropy: update to 1.3, add Python 3.6

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             1.2
-revision            4
+version             1.3
 maintainers         robitaille
 
 dist_subdir         ${name}/${version}
@@ -20,11 +19,11 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     3a215762e1688c7d53bd32c78e7fa67a \
-                    sha1    2fd4410b51d1e8b657ad9c101f8612fa505284f6 \
-                    rmd160  ea9dad7b5124e6a577979f6e2c1a5f9fcbf0eeed
+checksums           md5     bf4c8a033a7085fbc9ec604eebbdbdc5 \
+                    rmd160  2ca2d3b7c36f9152eca808d81667d192ef7eee30 \
+                    sha256  49de3e86482abe24e3cd02c4a30a469ee4b928d5b46ea5f70fa605ff6f9c6d38
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 build.args-append   --use-system-cfitsio \
                     --use-system-expat \


### PR DESCRIPTION
This pull request for `py-astropy` updates to version 1.3 and adds Python version 3.6.

@astrofrog as port maintainer - OK?
