### PR TITLE
onioncat: delete gcat

### DIFF
--- a/net/onioncat/Portfile
+++ b/net/onioncat/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                onioncat
 version             0.2.2.r569
+revision            1
 categories          net
 platforms           darwin
 maintainers         icloud.com:l2dy openmaintainer
@@ -30,6 +31,15 @@ depends_run         port:tuntaposx \
                     port:tor
 
 configure.args      --disable-silent-rules
+
+post-destroot {
+    delete ${destroot}${prefix}/bin/gcat
+}
+
+notes "
+gcat is removed due to conflict with coreutils,
+please use ocat -I instead.
+"
 
 livecheck.type      regex
 livecheck.url       ${master_sites}?sort=date&order=desc


### PR DESCRIPTION
`gcat` conflicts with `coreutils`, deleting it. You can use `ocat -I` instead.