### PR TITLE
erfa: update to version 1.3.0

### DIFF
--- a/science/erfa/Portfile
+++ b/science/erfa/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            liberfa erfa 1.2.0 v
+github.setup            liberfa erfa 1.3.0 v
 categories              science
 maintainers             robitaille openmaintainer
 license                 BSD
@@ -15,6 +15,6 @@ long_description        Essential Routines for Fundamental Astronomy
 
 github.tarball_from     releases
 
-checksums               md5 63e8e694d53add33c16f3f494d2b65f4 \
-                        rmd160  889ac72a5585aa086afe10b82fa6328dd4261cff \
-                        sha256  361bc9c5f783140aa337eba8379476ec45ec13627a8c839ccc1aaec104ad3316
+checksums               md5 62347926625ecefbe5911446baed6676 \
+                        rmd160  19d8c9c3b9f5308be0f31c35a4ae9455b684f6ef \
+                        sha256  b3e709206fbd65aa32de06fd690c5a886b97274eecc84ba9711a5a50efba7c92


### PR DESCRIPTION
This PR updates `erfa` to version 1.3.0

This is a follow-up to #131 which left `py-astropy` in a broken state (see https://trac.macports.org/ticket/53162#comment:1).

This PR should fix the issue.

cc port maintainer @astrofrog