### PR TITLE
gnome/dia: fix colors with quartz variant

### DIFF
--- a/gnome/dia/Portfile
+++ b/gnome/dia/Portfile
@@ -75,7 +75,9 @@ post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
 }
 
-variant quartz {}
+variant quartz description {Enable Quartz color bugfix} {
+    patchfiles-append       patch-lib-color.c.diff
+}
 
 if {[variant_isset quartz]} {
     require_active_variants gtk2 quartz

--- a/gnome/dia/files/patch-lib-color.c.diff
+++ b/gnome/dia/files/patch-lib-color.c.diff
@@ -1,0 +1,12 @@
+--- lib/color.c	2014-08-24 17:46:01.000000000 +0200
++++ lib/color.c	2015-11-06 14:52:12.000000000 +0100
+@@ -43,8 +43,7 @@
+ color_init(void)
+ {
+   if (!_color_initialized) {
+-    GdkVisual *visual = gtk_widget_get_default_visual();
+-    colormap = gdk_colormap_new (visual, FALSE); 
++    colormap = gdk_screen_get_system_colormap(gdk_screen_get_default());
+ 
+     _color_initialized = TRUE;
+ 


### PR DESCRIPTION
Needs some testing.
Closes: https://trac.macports.org/ticket/50873