### PR TITLE
Faust update

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -1,11 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            grame-cncm faust 344fc7fe9c7f4f8e1ee7d33f3b975a7613871cd5
+version                 0.9.95-20170104
+
+checksums               rmd160  9238f09c1905871e1524b27845b4756cc7655405 \
+                        sha256  e022511459cd574cd3fe204fadf3ba03205c0080e2c5b88698ede95d37c1c2c5
 
 name                    faust-devel
 conflicts               faust faust2-devel
-version                 0.9.73-20160426
-git.branch              4941ac4e91fac5f65ac663a2cffee1fcda759d85
 categories              audio lang
 platforms               darwin
 maintainers             ryandesign gmail.com:aggraef
@@ -17,9 +22,6 @@ description             functional programming language for realtime audio
 long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
                         and plugins.
-
-fetch.type              git
-git.url                 git://git.code.sf.net/p/faudiostream/code
 
 depends_build           port:pkgconfig
 
@@ -60,7 +62,7 @@ post-destroot {
     xinstall -d ${docdir}
     xinstall -m 644 -W ${worksrcpath} \
         COPYING \
-        README \
+        README.md \
         WHATSNEW \
         ${docdir}
 }

--- a/audio/faust/Portfile
+++ b/audio/faust/Portfile
@@ -4,15 +4,14 @@ PortSystem              1.0
 
 name                    faust
 conflicts               faust-devel faust2-devel
-version                 0.9.67
-revision                1
+version                 0.9.85
 categories              audio lang
 platforms               darwin
 maintainers             ryandesign
 license                 GPL-2
 master_sites            sourceforge:project/faudiostream
 homepage                http://faust.grame.fr/
-use_zip                 yes
+extract.suffix          .tgz
 
 description             functional programming language for realtime audio
 
@@ -20,8 +19,8 @@ long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
                         and plugins.
 
-checksums               rmd160  faba6c82eb8c1a21e8f58cdd85de4cbabd8c88d3 \
-                        sha256  a176d435035c8c7f4c5b6c7162e62d3d83143f64cc713b2f91c07e334aa21b19
+checksums               rmd160  c9b1848201757890f37a4712be2b496171b5f22e \
+                        sha256  50e37744a7c7baef1f806a8824e0776e86e9125f45ead7422d569885a97c121c
 
 post-patch {
     reinplace "s|/usr/local|${prefix}|g" \

--- a/audio/faust2-devel/Portfile
+++ b/audio/faust2-devel/Portfile
@@ -1,13 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            grame-cncm faust 7406a909506e62537f30a1096da21e1940ddfc09
+# When updating faust2-devel to a new version, please rebuild faustlive-devel
+# simultaneously by increasing its revision or updating it to a new version.
+version                 2.0-20170105
+
+checksums               rmd160  27ccb091e6db29bc2be89d61ec4f9b041bd45332 \
+                        sha256  a497f90c8260577be384b38af0efcbc044a161b51c4c607734dc723d9dcd4798
 
 name                    faust2-devel
 conflicts               faust faust-devel
-# When updating faust2-devel to a new version, please rebuild faustlive-devel
-# simultaneously by increasing its revision or updating it to a new version.
-version                 2.0-20160426
-git.branch              b3c42db30145fee76d5eeac98a878e82cf3698e5
 categories              audio lang
 platforms               darwin
 maintainers             ryandesign gmail.com:aggraef
@@ -20,9 +25,6 @@ long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
                         and plugins. This is the Faust2 branch which offers \
                         additional backends for C, Java and LLVM bitcode.
-
-fetch.type              git
-git.url                 git://git.code.sf.net/p/faudiostream/code
 
 set llvm_version        3.4
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
@@ -69,7 +71,7 @@ post-destroot {
     xinstall -d ${docdir}
     xinstall -m 644 -W ${worksrcpath} \
         COPYING \
-        README \
+        README.md \
         WHATSNEW \
         ${docdir}
 }

--- a/audio/faustlive-devel/Portfile
+++ b/audio/faustlive-devel/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 
 name                    faustlive-devel
-version                 2.43-20160413
-git.branch              9d439cbdc0e8965bb9ec21e16fb69c44158f11ee
+version                 2.45-20170105
+git.branch              d2ee69d542b4e89872b01f5970a5635341d1983f
 categories              audio
 platforms               darwin
 maintainers             ryandesign gmail.com:aggraef


### PR DESCRIPTION
This updates all MP packages for Grame's Faust to the latest upstream source. It also updates the git repos of faust-devel and faust2-devel which are now maintained at github.

- faust is now at 0.9.85 (latest stable release)
- faust-devel is at 0.9.95-20170104 (rev. 344fc7fe)
- faust2-devel is at 2.0-20170105 (rev. 7406a909)
- faustlive-devel is at 2.45-20170105 (rev. d2ee69d5)