### PR TITLE
Python 3.6 support for some ports

### DIFF
--- a/python/py-aplpy/Portfile
+++ b/python/py-aplpy/Portfile
@@ -30,7 +30,7 @@ checksums           md5     634422c006dcd366d5504af3349e9d10 \
                     rmd160  99edddf30cd7635edd8ffe9d1466c2ead1584525 \
                     sha256  1c3bc9972da5f738435449e5e8483824129f2a18e7426f0a8c2c06a1ef3b4b4b
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-emcee/Portfile
+++ b/python/py-emcee/Portfile
@@ -27,7 +27,7 @@ license             MIT
 checksums           rmd160  9d877a80ce5a19b8c442d225a27a57fe548a14f0 \
                     sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pyregion/Portfile
+++ b/python/py-pyregion/Portfile
@@ -23,7 +23,7 @@ checksums           md5     b776fc3ac848e17270508023ea1c94a0 \
                     rmd160  3e13a8c532b4ec34f23046578bdd11bf59eb4dc9 \
                     sha256  4f57070564526974661bbbf96cd1d509a708909002dd34f0354ac80c391b5e61
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-numpy

--- a/python/py-pytest-runner/Portfile
+++ b/python/py-pytest-runner/Portfile
@@ -27,7 +27,7 @@ checksums           md5     360a09bb80b505a7a093c20aeb4d1994 \
                     rmd160  174e6fdaf68daa8ee69401d40bbc07ef513c4b72 \
                     sha256  7b7682a5b4c00ed249cb72e0ffa06eec088a5fe9078e84c76517c90f1b3ce3f8
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-pytest-xdist/Portfile
+++ b/python/py-pytest-xdist/Portfile
@@ -24,7 +24,7 @@ distname            ${python.rootname}-${version}
 checksums           rmd160  adabee9f8df156188837348ab042f246daedbbf3 \
                     sha256  4a5e1199122fa29e3017d8d189f59ccc5d82e841474ba2a1eec0e89606153623
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -10,7 +10,7 @@ categories-append   science
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-scikit-learn/Portfile
+++ b/python/py-scikit-learn/Portfile
@@ -10,7 +10,7 @@ categories-append   science
 platforms           darwin
 license             BSD
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-yaml/Portfile
+++ b/python/py-yaml/Portfile
@@ -22,7 +22,7 @@ distname            PyYAML-${version}
 checksums           rmd160  8134421eb1b091ca3ee66ddf8d385f92069e7b73 \
                     sha256  592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-cython


### PR DESCRIPTION
This PR adds Python 3.6 support for the following ports:

* `py-aplpy`
* `py-emcee`
* `py-pyregion`
* `py-pytest`
* `py-pytest-runner`
* `py-pytest-xdist`
* `py-yaml`
* `py-scikit-image`
* `py-scikit-learn`

@g5pw - you've merged #126, maybe you could have a look at this PR as well?

cc @astrofrog as maintainer of `py-aplpy` and `py-pyregion`

(I don't know the Github usernames of the other maintainers.)