### PR TITLE
py-gammapy: add new port

### DIFF
--- a/python/py-gammapy/Portfile
+++ b/python/py-gammapy/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set _name           gammapy
+set _n              [string index ${_name} 0]
+
+name                py-${_name}
+version             0.5
+categories-append   science
+platforms           darwin
+maintainers         gmail.com:Deil.Christoph openmaintainer
+
+description         A Python package for gamma-ray astronomy
+long_description    ${description}
+
+homepage            https://github.com/gammapy/gammapy
+master_sites        pypi:${_n}/${_name}/
+distname            ${_name}-${version}
+
+checksums           md5     4966b7f47656cde5dfa9d3132f5f977a \
+                    rmd160  f5b57a7f8cf88a049ef82711b177cb2346671d16 \
+                    sha256  7d5711b2e74b887947bde74d982a50e19723f0e2bcba1dc93836855e48112042
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    # By default, astropy downloads an astropy-helpers package for setup.py.
+    # The --offline and --no-git flags prevent this and use a bundled version.
+    build.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+    destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+
+    depends_build-append  port:py${python.version}-setuptools
+
+    depends_run-append    port:py${python.version}-numpy \
+                          port:py${python.version}-scipy \
+                          port:py${python.version}-matplotlib \
+                          port:py${python.version}-astropy \
+                          port:py${python.version}-yaml \
+                          port:py${python.version}-click
+
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   [lindex ${master_sites} 0]
+    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+}


### PR DESCRIPTION
This PR adds Gammapy as a new port: https://github.com/gammapy/gammapy

Gammapy is an in-development Astropy-affiliated package for gamma-ray astronomy.

I've looked at the `py-astropy`, `py-aplpy` and `py-pyregion` port files for guidance and this is what I came up with.

Can someone please review this and give feedback?

@astrofrog - Should Astropy-affiliated packages have
```
    depends_build-append \
                        port:pkgconfig \
                        port:py${python.version}-setuptools
```
like you put for `py-astropy`?