### PR TITLE
mycli: add patch to support newer sqlparse.

### DIFF
--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        dbcli mycli 1.8.1 v
+revision            1
 
 categories          databases python
 maintainers         gmail.com:xeron.oskom openmaintainer
@@ -18,6 +19,9 @@ homepage            http://mycli.net
 
 checksums           rmd160  1b10dc7c4c37a22505bb09c55e841e56a7f689b7 \
                     sha256  6d009ad91d65c4eb2d2afb55332c38b9b5f20d3b7b7c518ace1f2b2b238aed75
+
+patchfiles-append   newer_sqlparse.patch
+patch.pre_args      -p1
 
 variant python27 conflicts python34 python35 python36 description "Use Python 2.7" {}
 variant python34 conflicts python27 python35 python36 description "Use Python 3.4" {}

--- a/databases/mycli/files/newer_sqlparse.patch
+++ b/databases/mycli/files/newer_sqlparse.patch
@@ -1,0 +1,61 @@
+From 71f503afb699b2a8365f9e8fddcdddb1960a1e79 Mon Sep 17 00:00:00 2001
+From: Darik Gamble <darik.gamble.spam@gmail.com>
+Date: Fri, 4 Nov 2016 19:54:34 -0400
+Subject: [PATCH 1/2] Bump sqlparse version
+
+---
+ mycli/packages/parseutils.py | 2 +-
+ setup.py                     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mycli/packages/parseutils.py b/mycli/packages/parseutils.py
+index 3cbf4a0..7f848ad 100644
+--- a/mycli/packages/parseutils.py
++++ b/mycli/packages/parseutils.py
+@@ -64,7 +64,7 @@ def last_word(text, include='alphanum_underscore'):
+ # This code is borrowed from sqlparse example script.
+ # <url>
+ def is_subselect(parsed):
+-    if not parsed.is_group():
++    if not parsed.is_group:
+         return False
+     for item in parsed.tokens:
+         if item.ttype is DML and item.value.upper() in ('SELECT', 'INSERT',
+diff --git a/setup.py b/setup.py
+index 3d80c96..c369357 100644
+--- a/setup.py
++++ b/setup.py
+@@ -16,7 +16,7 @@
+     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
+     'prompt_toolkit>=1.0.0,<1.1.0',
+     'PyMySQL >= 0.6.2',
+-    'sqlparse>=0.2.0,<0.2.2',
++    'sqlparse>=0.2.2,<0.3.0',
+     'configobj >= 5.0.6',
+ ]
+ 
+
+From 54a8206c5187347a6a6f6ae4db994e0d7864cbcc Mon Sep 17 00:00:00 2001
+From: Darik Gamble <darik.gamble.spam@gmail.com>
+Date: Sat, 5 Nov 2016 08:06:15 -0400
+Subject: [PATCH 2/2] Dangling `as` doesn't get grouped into identifiers in
+ this version of sqlparse, so we need to handle them explicitly
+
+---
+ mycli/packages/completion_engine.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mycli/packages/completion_engine.py b/mycli/packages/completion_engine.py
+index 31ef874..6e2165d 100644
+--- a/mycli/packages/completion_engine.py
++++ b/mycli/packages/completion_engine.py
+@@ -197,6 +197,9 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
+         return [{'type': 'column', 'tables': extract_tables(full_text)}]
+     elif token_v in ('set', 'by', 'distinct'):
+         return [{'type': 'column', 'tables': extract_tables(full_text)}]
++    elif token_v == 'as':
++        # Don't suggest anything for an alias
++        return []
+     elif token_v in ('show'):
+         return [{'type': 'show'}]
+     elif token_v in ('to',):


### PR DESCRIPTION
Patch is from this PR: https://github.com/dbcli/mycli/pull/324

Will be removed when they release new `mycli` version.