### PR TITLE
Python 3.6 support for some ports

### DIFF
--- a/python/py-networkx/Portfile
+++ b/python/py-networkx/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-py/Portfile
+++ b/python/py-py/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -19,7 +19,7 @@ platforms               darwin
 checksums               rmd160  a8805a0554d7ca6417775f4863e7277f81094a30 \
                         sha256  2a769626f977b7a76a44292d5fce8e938ba082e7d1f3325199762d5f671a35af
 
-python.versions         27 34 35
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append       port:py${python.version}-setuptools


### PR DESCRIPTION
This PR is a follow-up to #140 which adds Python 3.6 support for:
* `py36-networkx` (needed by `py36-scikit-image`, which was added in #140 earlier today)
* `py36-py` (needed by `py36-pytest` which was added in #140 earlier today)
* `py36-uncertainties` - a new package

I'll be more careful to check all dependencies in the future to make sure they are present for Python 3.6 already.

@g5pw - Merge?