### PR TITLE
Add Python 3.6 version for Sphinx

### DIFF
--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -17,7 +17,7 @@ long_description    ${description}
 checksums           rmd160  33d9ddb282a79f1d14cbf48f1eda52f51422e303 \
                     sha256  765b9609fedf1abbb9541bfc47272f9a07d1c67c4ff39a2320729b1bc5e89cb2
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-imagesize/Portfile
+++ b/python/py-imagesize/Portfile
@@ -23,7 +23,7 @@ checksums           md5 976148283286a6ba5f69b0f81aef8052 \
                     sha256 0ab2c62b87987e3252f89d30b7cedbec12a01af9274af9ffa48108f2c13c6062
 distname            ${python.rootname}-${version}
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {$subport ne $name} {
     depends_build    port:py${python.version}-setuptools

--- a/python/py-snowballstemmer/Portfile
+++ b/python/py-snowballstemmer/Portfile
@@ -21,7 +21,7 @@ distname            snowballstemmer-${version}
 checksums           rmd160 fe80dd91bf4d1c5c6df947959a117c5e918d7cfc \
                     sha256 6d54f350e7a0e48903a4e3b6b2cabd1b43e23765fbc975065402893692954191
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {$subport ne $name} {
     livecheck.type      none

--- a/python/py-sphinx/Portfile
+++ b/python/py-sphinx/Portfile
@@ -28,7 +28,7 @@ checksums           md5 1abb725861037e13cbc49eb84cd8cef3 \
                     rmd160 a938285fc310e86ded124fce309222b9423e2a7f \
                     sha256 8e6a77a20b2df950de322fc32f3b508697d9d654fe984e3cc88f446a5b4c17c5
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-docutils \

--- a/python/py-sphinx/files/py36-sphinx
+++ b/python/py-sphinx/files/py36-sphinx
@@ -1,0 +1,4 @@
+${frameworks_dir}/Python.framework/Versions/3.6/bin/sphinx-apidoc
+${frameworks_dir}/Python.framework/Versions/3.6/bin/sphinx-quickstart
+${frameworks_dir}/Python.framework/Versions/3.6/bin/sphinx-autogen
+${frameworks_dir}/Python.framework/Versions/3.6/bin/sphinx-build

--- a/python/py-sphinx_rtd_theme/Portfile
+++ b/python/py-sphinx_rtd_theme/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  4fd81f7ac50fcf507b6c1996c7194d9b769e30dd \
 # version 0.1.9 used to fetch from github, whose file has different checksums as current file from pypi
 dist_subdir          ${name}/${version}_1
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
This PR adds the Python 3.6 version for all Sphinx-related packages:
* `py-alabaster` - dependency of `py-sphinx`
* `py-babel` - dependency of `py-sphinx`
* `py-imagesize` - dependency of `py-sphinx`
* `py-snowballstemmer` - dependency of `py-sphinx`
* `py-sphinx`
* `py-sphinx_rtd_theme`

@g5pw - Please review.