### PR TITLE
For some reason, `remote-ext.h` is not installed.

### DIFF
--- a/net/libpcap/Portfile
+++ b/net/libpcap/Portfile
@@ -20,8 +20,6 @@ checksums           rmd160  295766ab2646c05c330aa04cabc30c5737200279 \
                     sha256  673dbc69fdc3f5a86fb5759ab19899039a8e5e6c631749e48dcd9c6f0c83541e
 
 configure.args      --disable-bluetooth \
-                    --disable-canusb \
-                    --disable-can \
                     --disable-universal \
                     --disable-dbus \
                     --enable-ipv6

--- a/net/libpcap/Portfile
+++ b/net/libpcap/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                libpcap
 version             1.8.1
+revision            1
 categories          net
 maintainers         mps openmaintainer
 license             BSD
@@ -37,6 +38,10 @@ post-destroot {
         README.macosx \
         TODO \
         ${docdir}
+
+    xinstall -m 644 -W ${worksrcpath} \
+        remote-ext.h \
+        ${destroot}${prefix}/include
 }
 
 livecheck.type      regex


### PR DESCRIPTION
I need that file for port:ostinato to build successfully. This patch manually
installs the header file.