### PR TITLE
Move KDE4 headers to specific location

### DIFF
--- a/_resources/port1.0/group/kde4-1.1.tcl
+++ b/_resources/port1.0/group/kde4-1.1.tcl
@@ -66,14 +66,24 @@ switch ${os.platform}_${os.major} {
     }
 }
 
+# Install the kdelibs headerfiles in their own directory to prevent clashes with KF5 headers
+set kde4.include_prefix KDE4
+set kde4.include_dirs   ${prefix}/include/${kde4.include_prefix}
+set kde4.cmake_module_dir \
+                        ${prefix}/lib/cmake/${kde4.include_prefix}
+
 # augment the CMake module lookup path, if necessary depending on
 # where Qt4 is installed.
 if {${qt_cmake_module_dir} ne ${cmake_share_module_dir}} {
-    set cmake_module_path ${cmake_share_module_dir}\;${qt_cmake_module_dir}
-    configure.args-delete -DCMAKE_MODULE_PATH=${cmake_share_module_dir}
-    configure.args-append -DCMAKE_MODULE_PATH="${cmake_module_path}"
-    unset cmake_module_path
+    set cmake_module_path ${kde4.cmake_module_dir}\;${cmake_share_module_dir}\;${qt_cmake_module_dir}
+} else {
+    # prepend our own (new) install location for cmake modules:
+    set cmake_module_path ${kde4.cmake_module_dir}\;${cmake_share_module_dir}
 }
+configure.args-delete -DCMAKE_MODULE_PATH=${cmake_share_module_dir}
+configure.args-append -DCMAKE_MODULE_PATH="${cmake_module_path}" \
+                        -DCMAKE_PREFIX_PATH="${cmake_module_path}"
+
 
 # standard configure args; virtually all KDE ports use CMake and Qt4.
 configure.args-append   -DBUILD_doc=OFF \

--- a/audio/taglib-extras/Portfile
+++ b/audio/taglib-extras/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4    1.1
 
 name                taglib-extras
 version             1.0.1
-revision            4
+revision            5
 categories          audio
 license             LGPL-2.1
 maintainers         nomaintainer

--- a/devel/akonadi/Portfile
+++ b/devel/akonadi/Portfile
@@ -12,7 +12,7 @@ git.branch          c733429f
 name                akonadi
 set akoversion      1.13.1
 version             ${akoversion}.20141210
-revision            1
+revision            2
 categories          devel kde kde4
 maintainers         nicos openmaintainer
 license             LGPL-2+

--- a/devel/automoc/Portfile
+++ b/devel/automoc/Portfile
@@ -9,7 +9,7 @@ depends_lib-delete  port:phonon
 
 name                automoc
 version             0.9.88
-revision            8
+revision            9
 categories          devel kde kde4
 license             BSD
 maintainers         nomaintainer

--- a/devel/dbusmenu-qt/Portfile
+++ b/devel/dbusmenu-qt/Portfile
@@ -21,7 +21,7 @@ subport dbusmenu-qt5 {
 if {${subport} eq "${name}"} {
     PortGroup       kde4 1.1
     version         0.9.2
-    revision        1
+    revision        2
     master_sites    ${homepage}/trunk/${version}/+download/
     use_bzip2       yes
     checksums       rmd160  e50cbffbf57329a26742ddf32d0f54248fe672cc \

--- a/devel/grantlee/Portfile
+++ b/devel/grantlee/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                grantlee
 version             0.3.0
-revision            1
+revision            2
 categories          devel kde kde4
 maintainers         nomaintainer
 description         string template engine based on the Django template system

--- a/devel/kdiff3/Portfile
+++ b/devel/kdiff3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                kdiff3
 version             0.9.98
-revision            2
+revision            3
 categories          devel
 platforms           darwin
 maintainers         khindenburg openmaintainer

--- a/devel/qjson/Portfile
+++ b/devel/qjson/Portfile
@@ -12,7 +12,7 @@ PortGroup           cmake 1.0
 
 name                qjson
 version             0.8.1
-revision            1
+revision            2
 categories          devel kde4 kde
 maintainers         nomaintainer
 license             LGPL-2.1

--- a/devel/soprano/Portfile
+++ b/devel/soprano/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                soprano
 version             2.9.4
-revision            1
+revision            2
 categories          devel
 maintainers         pixilla openmaintainer
 license             GPL-2+ LGPL-2+

--- a/devel/strigi/Portfile
+++ b/devel/strigi/Portfile
@@ -5,7 +5,7 @@ PortGroup       kde4 1.1
 
 name            strigi
 version         0.7.8
-revision        6
+revision        7
 categories      devel
 maintainers     nomaintainer
 license         LGPL-2+

--- a/graphics/qimageblitz/Portfile
+++ b/graphics/qimageblitz/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                qimageblitz
 version             0.0.6
-revision            1
+revision            2
 categories          graphics kde kde4
 maintainers         nomaintainer
 license             BSD

--- a/kde/amarok/Portfile
+++ b/kde/amarok/Portfile
@@ -6,7 +6,7 @@ PortGroup           kde4    1.1
 name                amarok
 conflicts           amarok-devel
 version             2.6.0
-revision            2
+revision            3
 categories          kde kde4
 maintainers         nomaintainer
 # Future GPL versions must be approved by KDE

--- a/kde/analitza/Portfile
+++ b/kde/analitza/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                analitza
 version             4.14.3
+revision            1
 categories          kde kde4
 maintainers         nicos
 license             GPL-2 GFDL-1.2

--- a/kde/ark/Portfile
+++ b/kde/ark/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ark
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/attica/Portfile
+++ b/kde/attica/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                attica
 version             0.4.2
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             LGPL-2.1

--- a/kde/baloo-widgets/Portfile
+++ b/kde/baloo-widgets/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                baloo-widgets
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             {LGPL-2 LGPL-2.1+}

--- a/kde/baloo/Portfile
+++ b/kde/baloo/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                baloo
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             {LGPL-2 LGPL-2.1+ GPL-2+}

--- a/kde/blinken/Portfile
+++ b/kde/blinken/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                blinken
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos

--- a/kde/bomber/Portfile
+++ b/kde/bomber/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                bomber
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/bovo/Portfile
+++ b/kde/bovo/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                bovo
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/cantor/Portfile
+++ b/kde/cantor/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                cantor
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos

--- a/kde/cervisia/Portfile
+++ b/kde/cervisia/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                cervisia
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/choqok/Portfile
+++ b/kde/choqok/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake   1.0
 
 name                choqok
 version             1.4
+revision            1
 categories          kde kde4
 maintainers         nomaintainer
 license             GPL-2+

--- a/kde/digikam/Portfile
+++ b/kde/digikam/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                digikam
 version             4.9.0
-revision            2
+revision            3
 categories          kde kde4
 license             GPL-2+
 maintainers         hyper-world.de:jan openmaintainer \

--- a/kde/dolphin-plugins/Portfile
+++ b/kde/dolphin-plugins/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                dolphin-plugins
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/dragon/Portfile
+++ b/kde/dragon/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                dragon
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+

--- a/kde/ffmpegthumbs/Portfile
+++ b/kde/ffmpegthumbs/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ffmpegthumbs
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+

--- a/kde/granatier/Portfile
+++ b/kde/granatier/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                granatier
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             LGPL-2+ GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/gwenview/Portfile
+++ b/kde/gwenview/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                gwenview
 version             4.14.3
-revision            3
+revision            4
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/juk/Portfile
+++ b/kde/juk/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                juk
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+

--- a/kde/kactivities/Portfile
+++ b/kde/kactivities/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kactivities
 version             4.13.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+ LGPL-2+ GFDL-1.2

--- a/kde/kalgebra/Portfile
+++ b/kde/kalgebra/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kalgebra
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+

--- a/kde/kalzium/Portfile
+++ b/kde/kalzium/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kalzium
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 chemistry
 license             GPL-2+ LGPL-2+
 maintainers         nicos

--- a/kde/kamera/Portfile
+++ b/kde/kamera/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kamera
 version             4.14.3
+revision            1
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kanagram/Portfile
+++ b/kde/kanagram/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kanagram
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2.1+ BSD
 maintainers         nicos

--- a/kde/kapman/Portfile
+++ b/kde/kapman/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kapman
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kapptemplate/Portfile
+++ b/kde/kapptemplate/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kapptemplate
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kate/Portfile
+++ b/kde/kate/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kate
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 license             LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/katomic/Portfile
+++ b/kde/katomic/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                katomic
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kblackbox/Portfile
+++ b/kde/kblackbox/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kblackbox
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kblocks/Portfile
+++ b/kde/kblocks/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kblocks
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kbounce/Portfile
+++ b/kde/kbounce/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kbounce
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kbreakout/Portfile
+++ b/kde/kbreakout/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kbreakout
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kbruch/Portfile
+++ b/kde/kbruch/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kbruch
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos

--- a/kde/kcachegrind4/Portfile
+++ b/kde/kcachegrind4/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kcachegrind4
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2.1+
 maintainers         nicos openmaintainer

--- a/kde/kcalc/Portfile
+++ b/kde/kcalc/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kcalc
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kcharselect/Portfile
+++ b/kde/kcharselect/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kcharselect
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kcm-baloo-advanced/Portfile
+++ b/kde/kcm-baloo-advanced/Portfile
@@ -9,7 +9,7 @@ git.branch          35991b9
 
 name                kcm-baloo-advanced
 version             20141008
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             {LGPL-2+ LGPL-2.1+}

--- a/kde/kcolorchooser/Portfile
+++ b/kde/kcolorchooser/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kcolorchooser
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             MIT
 maintainers         nicos openmaintainer

--- a/kde/kcron/Portfile
+++ b/kde/kcron/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kcron
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kde-dev-scripts/Portfile
+++ b/kde/kde-dev-scripts/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kde-dev-scripts
 version             4.14.3
+revision            1
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kde-dev-utils/Portfile
+++ b/kde/kde-dev-utils/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kde-dev-utils
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kde-wallpapers/Portfile
+++ b/kde/kde-wallpapers/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kde-wallpapers
 version             4.14.3
+revision            1
 categories			kde kde4
 license             LGPL-3
 maintainers         nicos

--- a/kde/kde4-baseapps/Portfile
+++ b/kde/kde4-baseapps/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kde4-baseapps
 version             4.14.3
-revision            3
+revision            4
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2+ GFDL-1.2

--- a/kde/kde4-filelight/Portfile
+++ b/kde/kde4-filelight/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kde4-filelight
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kde4-runtime/Portfile
+++ b/kde/kde4-runtime/Portfile
@@ -9,7 +9,7 @@ git.branch          e08a9f70
 
 name                kde4-runtime
 version             4.14.4.20150225
-revision            7
+revision            8
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2.1+

--- a/kde/kde4-workspace/Portfile
+++ b/kde/kde4-workspace/Portfile
@@ -9,7 +9,7 @@ git.branch          b904af16
 
 name                kde4-workspace
 version             4.14.4.20150324
-revision            1
+revision            2
 set plasmaversion   4.11.17
 categories          kde kde4
 maintainers         gmail.com:rjvbertin

--- a/kde/kdeadmin/Portfile
+++ b/kde/kdeadmin/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdeadmin
 version             4.14.3
+revision            1
 categories          kde kde4
 maintainers         nicos
 license             Permissive

--- a/kde/kdeartwork/Portfile
+++ b/kde/kdeartwork/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdeartwork
 version             4.14.3
+revision            1
 categories          kde kde4
 maintainers         nicos
 license             GFDL-1.2 GPL-2 LGPL-2.1

--- a/kde/kdegraphics-strigi-analyzer/Portfile
+++ b/kde/kdegraphics-strigi-analyzer/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdegraphics-strigi-analyzer
 version             4.14.3
+revision            1
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdegraphics-thumbnailers/Portfile
+++ b/kde/kdegraphics-thumbnailers/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdegraphics-thumbnailers
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdelibs4/Portfile
+++ b/kde/kdelibs4/Portfile
@@ -80,6 +80,9 @@ configure.args-append   -DWITH_ENCHANT=ON \
                         -DWITH_FAM=OFF \
                         -DKDE4_AUTH_BACKEND_NAME="OSX"
 
+# Install the kdelibs headerfiles in their own directory to prevent clashes with KF5 headers
+configure.args-append   -DINCLUDE_INSTALL_DIR=${kde4.include_dirs}
+
 if { [file exists ${destroot}${prefix}/lib/kde4/kspell_aspell.so] } {
     notes "
 Only the English dictionary has been installed.

--- a/kde/kdenetwork-filesharing/Portfile
+++ b/kde/kdenetwork-filesharing/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdenetwork-filesharing
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdenetwork-strigi-analyzers/Portfile
+++ b/kde/kdenetwork-strigi-analyzers/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdenetwork-strigi-analyzers
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdepim4-runtime/Portfile
+++ b/kde/kdepim4-runtime/Portfile
@@ -6,6 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                kdepim4-runtime
 version             4.14.3
+revision            1
 categories          kde kde4
 maintainers         intevation.de:bjoern.ricks nicos
 license             GPL-2+ LGPL-2+

--- a/kde/kdepim4/Portfile
+++ b/kde/kdepim4/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                kdepim4
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 maintainers         intevation.de:bjoern.ricks nicos
 license             GPL-2+ LGPL-2+

--- a/kde/kdepimlibs4/Portfile
+++ b/kde/kdepimlibs4/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4    1.1
 
 name                kdepimlibs4
 version             4.14.3
-revision            7
+revision            8
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2+ BSD

--- a/kde/kdepimlibs4/Portfile
+++ b/kde/kdepimlibs4/Portfile
@@ -59,16 +59,6 @@ pre-activate {
     }
 }
 
-post-destroot {
-    #Move headers only in case of main port
-    if {${subport} eq ${name}} {
-        #Move internal gpgme headers out of the way
-        file mkdir ${destroot}${prefix}/include/KDE4
-        move ${destroot}${prefix}/include/gpgme++ \
-            ${destroot}${prefix}/include/KDE4/gpgme++
-    }
-}
-
 subport kdepimlibs4-kioslaves {
 
 #kioslaves components conflict with openssl license

--- a/kde/kdesdk-kioslaves/Portfile
+++ b/kde/kdesdk-kioslaves/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdesdk-kioslaves
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdesdk-strigi-analyzers/Portfile
+++ b/kde/kdesdk-strigi-analyzers/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdesdk-strigi-analyzers
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdesdk-thumbnailers/Portfile
+++ b/kde/kdesdk-thumbnailers/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdesdk-thumbnailers
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdesvn/Portfile
+++ b/kde/kdesvn/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                kdesvn
 version             1.6.0
-revision            1
+revision            2
 categories          kde kde4
 license             {GPL-2+ OpenSSLException}
 maintainers         nomaintainer

--- a/kde/kdetoys4/Portfile
+++ b/kde/kdetoys4/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdetoys4
 version             4.10.5
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2 LGPL-2

--- a/kde/kdevelop/Portfile
+++ b/kde/kdevelop/Portfile
@@ -7,6 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                kdevelop
 version             4.7.3
+revision            1
 categories          kde kde4
 platforms           darwin
 license             GPL-2+

--- a/kde/kdevplatform/Portfile
+++ b/kde/kdevplatform/Portfile
@@ -7,6 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                kdevplatform
 version             1.7.3
+revision            1
 categories          kde kde4
 platforms           darwin
 license             GPL-2+

--- a/kde/kdewebdev/Portfile
+++ b/kde/kdewebdev/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdewebdev
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2+ GFDL-1.2

--- a/kde/kdiamond/Portfile
+++ b/kde/kdiamond/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdiamond
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdiskfree/Portfile
+++ b/kde/kdiskfree/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdiskfree
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kdnssd/Portfile
+++ b/kde/kdnssd/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdnssd
 version             4.12.2
-revision            1 
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kfilemetadata/Portfile
+++ b/kde/kfilemetadata/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kfilemetadata
 version             4.14.3
-revision            4
+revision            5
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             {LGPL-2+ LGPL-2.1+}

--- a/kde/kfloppy/Portfile
+++ b/kde/kfloppy/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kfloppy
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kfourinline/Portfile
+++ b/kde/kfourinline/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kfourinline
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kgeography/Portfile
+++ b/kde/kgeography/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kgeography
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/kget/Portfile
+++ b/kde/kget/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kget
 version             4.14.3
-revision            6
+revision            7
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kgoldrunner/Portfile
+++ b/kde/kgoldrunner/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kgoldrunner
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kgpg/Portfile
+++ b/kde/kgpg/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kgpg
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kgraphviewer/Portfile
+++ b/kde/kgraphviewer/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4 1.1
 
 name                kgraphviewer
 version             2.2.0
+revision            1
 categories          kde kde4
 maintainers         hep.phy.cam.ac.uk:jonesc openmaintainer
 

--- a/kde/khangman/Portfile
+++ b/kde/khangman/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                khangman
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2.1+ GFDL-1.2

--- a/kde/kig/Portfile
+++ b/kde/kig/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kig
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/kigo/Portfile
+++ b/kde/kigo/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kigo
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             {GPL-2 GPL-3}
 maintainers         nicos openmaintainer

--- a/kde/killbots/Portfile
+++ b/kde/killbots/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                killbots
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kimono/Portfile
+++ b/kde/kimono/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                kimono
 version             4.14.3
+revision            1
 categories          kde kde4 devel
 platforms           darwin
 license             GPL-2+ LGPL-2.1+

--- a/kde/kiriki/Portfile
+++ b/kde/kiriki/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kiriki
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kiten/Portfile
+++ b/kde/kiten/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kiten
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2+ GFDL-1.2

--- a/kde/kjumpingcube/Portfile
+++ b/kde/kjumpingcube/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kjumpingcube
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/klettres/Portfile
+++ b/kde/klettres/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                klettres
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/klickety/Portfile
+++ b/kde/klickety/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                klickety
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/klines/Portfile
+++ b/kde/klines/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                klines
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kmahjongg/Portfile
+++ b/kde/kmahjongg/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kmahjongg
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kmines/Portfile
+++ b/kde/kmines/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kmines
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kmix/Portfile
+++ b/kde/kmix/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kmix
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             LGPL-2+

--- a/kde/kmplot/Portfile
+++ b/kde/kmplot/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kmplot
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/kmymoney4-devel/Portfile
+++ b/kde/kmymoney4-devel/Portfile
@@ -11,6 +11,7 @@ git.branch          485aea8e20604cf79612f62d1393fde9872c0273
 
 name                kmymoney4-devel
 version             4.8-20161022
+revision            1
 
 categories          kde kde4 finance
 maintainers         mk pixilla openmaintainer

--- a/kde/kmymoney4/Portfile
+++ b/kde/kmymoney4/Portfile
@@ -7,7 +7,7 @@ PortGroup           kde4    1.1
 
 name                kmymoney4
 version             4.7.2
-revision            3
+revision            4
 
 categories          kde kde4 finance
 maintainers         mk pixilla openmaintainer

--- a/kde/knavalbattle/Portfile
+++ b/kde/knavalbattle/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                knavalbattle
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/knetwalk/Portfile
+++ b/kde/knetwalk/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                knetwalk
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/koffice2-devel/Portfile
+++ b/kde/koffice2-devel/Portfile
@@ -3,7 +3,7 @@ PortGroup           kde4    1.0
 
 name                koffice2-devel
 version             1.9.98.7
-revision            0
+revision            1
 categories          kde kde4
 license             GPL-2
 maintainers         nomaintainer

--- a/kde/kolf/Portfile
+++ b/kde/kolf/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kolf
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+ LGPL-2+ MIT
 maintainers         nicos openmaintainer

--- a/kde/kollision/Portfile
+++ b/kde/kollision/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kollision
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kolourpaint/Portfile
+++ b/kde/kolourpaint/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kolourpaint
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             LGPL-2 LGPL-2+ BSD
 maintainers         nicos openmaintainer

--- a/kde/kompare/Portfile
+++ b/kde/kompare/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kompare
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/konquest/Portfile
+++ b/kde/konquest/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                konquest
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/konsole/Portfile
+++ b/kde/konsole/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                konsole
 version             4.14.3
+revision            1
 categories          kde kde4
 platforms           darwin
 license             GPL-2+

--- a/kde/konversation/Portfile
+++ b/kde/konversation/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                konversation
 version             1.5.1
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+ GFDL-1.2

--- a/kde/kopete/Portfile
+++ b/kde/kopete/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kopete
 version             4.14.3
-revision            7
+revision            8
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/korundum/Portfile
+++ b/kde/korundum/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                korundum
 version             4.14.3
+revision            1
 categories          kde kde4 devel
 platforms           darwin
 license             GPL-2+ LGPL-2.1+

--- a/kde/kpat/Portfile
+++ b/kde/kpat/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kpat
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+ MIT
 maintainers         nicos openmaintainer

--- a/kde/kqtquickcharts/Portfile
+++ b/kde/kqtquickcharts/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kqtquickcharts
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/krdc/Portfile
+++ b/kde/krdc/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                krdc
 version             4.14.3
+revision            1
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kreversi/Portfile
+++ b/kde/kreversi/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kreversi
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kross-interpreters/Portfile
+++ b/kde/kross-interpreters/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kross-interpreters
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             LGPL-2.1+

--- a/kde/kruler/Portfile
+++ b/kde/kruler/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kruler
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/krusader/Portfile
+++ b/kde/krusader/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                krusader
 version             2.4.0-beta3
+revision            1
 categories          kde kde4
 maintainers         khindenburg openmaintainer
 license             GPL-2+

--- a/kde/ksaneplugin/Portfile
+++ b/kde/ksaneplugin/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ksaneplugin
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             {LGPL-2.1 LGPL-3}
 maintainers         nicos openmaintainer

--- a/kde/kscd/Portfile
+++ b/kde/kscd/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kscd
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+

--- a/kde/kshisen/Portfile
+++ b/kde/kshisen/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kshisen
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/ksirk/Portfile
+++ b/kde/ksirk/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ksirk
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4 games
 license             GPL-2+ LGPL-2.1+ MIT
 maintainers         nicos openmaintainer

--- a/kde/ksnakeduel/Portfile
+++ b/kde/ksnakeduel/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ksnakeduel
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kspaceduel/Portfile
+++ b/kde/kspaceduel/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kspaceduel
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/ksquares/Portfile
+++ b/kde/ksquares/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ksquares
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kstars/Portfile
+++ b/kde/kstars/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kstars
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 platforms           darwin
 license             GPL-2+

--- a/kde/ksudoku/Portfile
+++ b/kde/ksudoku/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ksudoku
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/ksystemlog/Portfile
+++ b/kde/ksystemlog/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ksystemlog
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/ktimer/Portfile
+++ b/kde/ktimer/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ktimer
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/ktorrent4/Portfile
+++ b/kde/ktorrent4/Portfile
@@ -7,6 +7,7 @@ name                ktorrent4
 conflicts           ktorrent
 # ktorrent4 and libktorrent usually need to be updated together
 version             4.3.1
+revision            1
 categories          kde kde4
 license             GPL-3+
 maintainers         nicos openmaintainer

--- a/kde/ktouch/Portfile
+++ b/kde/ktouch/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ktouch
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/ktuberling/Portfile
+++ b/kde/ktuberling/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                ktuberling
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kturtle/Portfile
+++ b/kde/kturtle/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kturtle
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/kubrick/Portfile
+++ b/kde/kubrick/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kubrick
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kuser/Portfile
+++ b/kde/kuser/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kuser
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kwallet/Portfile
+++ b/kde/kwallet/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kwallet
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/kwordquiz/Portfile
+++ b/kde/kwordquiz/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kwordquiz
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2 LGPL-2

--- a/kde/libalkimia/Portfile
+++ b/kde/libalkimia/Portfile
@@ -7,7 +7,7 @@ PortGroup           kde4    1.1
 
 name                libalkimia
 version             4.3.2
-revision            2
+revision            3
 
 categories          kde finance
 maintainers         mk pixilla openmaintainer

--- a/kde/libkcddb/Portfile
+++ b/kde/libkcddb/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkcddb
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+ LGPL-2+

--- a/kde/libkcompactdisc/Portfile
+++ b/kde/libkcompactdisc/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkcompactdisc
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+ LGPL-2+

--- a/kde/libkdcraw/Portfile
+++ b/kde/libkdcraw/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 
 name                libkdcraw
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libkdeedu/Portfile
+++ b/kde/libkdeedu/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkdeedu
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2+ BSD

--- a/kde/libkdegames/Portfile
+++ b/kde/libkdegames/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkdegames
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             LGPL-2+ GPL-2+ BSD MIT
 maintainers         nicos openmaintainer

--- a/kde/libkexiv2/Portfile
+++ b/kde/libkexiv2/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkexiv2
 version             4.14.3
-revision            3
+revision            4
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libkgapi/Portfile
+++ b/kde/libkgapi/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4    1.1
 
 name                libkgapi
 version             2.2.0
-revision            1
+revision            2
 categories          kde kde4 net
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libkipi/Portfile
+++ b/kde/libkipi/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkipi
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libkmahjongg/Portfile
+++ b/kde/libkmahjongg/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkmahjongg
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             LGPL-2+ GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libkomparediff2/Portfile
+++ b/kde/libkomparediff2/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libkomparediff2
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libksane/Portfile
+++ b/kde/libksane/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                libksane
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/libktorrent/Portfile
+++ b/kde/libktorrent/Portfile
@@ -6,7 +6,7 @@ PortGroup           kde4    1.1
 name                libktorrent
 # ktorrent4 and libktorrent usually need to be updated together
 version                 1.3.1
-revision            2
+revision            3
 set ktorrent_version    4.3.1
 categories          kde kde4
 license             GPL-2+

--- a/kde/lokalize/Portfile
+++ b/kde/lokalize/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                lokalize
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/lskat/Portfile
+++ b/kde/lskat/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                lskat
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/marble/Portfile
+++ b/kde/marble/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                marble
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             LGPL-2.1+ GFDL-1.2

--- a/kde/massif-visualizer/Portfile
+++ b/kde/massif-visualizer/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                massif-visualizer
 version             0.4.0
+revision            1
 categories          kde kde4
 maintainers         hep.phy.cam.ac.uk:jonesc openmaintainer
 

--- a/kde/mobipocket/Portfile
+++ b/kde/mobipocket/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                mobipocket
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/mplayerthumbs/Portfile
+++ b/kde/mplayerthumbs/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                mplayerthumbs
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             LGPL-2.1+

--- a/kde/nepomuk-core/Portfile
+++ b/kde/nepomuk-core/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                nepomuk-core
 version             4.14.3
-revision            4
+revision            5
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             GPL-2+ LGPL-2.1+

--- a/kde/nepomuk-widgets/Portfile
+++ b/kde/nepomuk-widgets/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                nepomuk-widgets
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             LGPL-2+

--- a/kde/okteta/Portfile
+++ b/kde/okteta/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                okteta
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4
 license             GPL-2+ LGPL-2.1+
 maintainers         nicos openmaintainer

--- a/kde/okular/Portfile
+++ b/kde/okular/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                okular
 version             4.14.3
-revision            4
+revision            5
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/pairs/Portfile
+++ b/kde/pairs/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                pairs
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos openmaintainer
 license             {GPL-2 GPL-3}

--- a/kde/palapeli/Portfile
+++ b/kde/palapeli/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                palapeli
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/kde/parley/Portfile
+++ b/kde/parley/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                parley
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/perlkde/Portfile
+++ b/kde/perlkde/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                perlkde
 version             4.14.3
+revision            1
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/perlqt/Portfile
+++ b/kde/perlqt/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                perlqt
 version             4.14.3
+revision            1
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/picmi/Portfile
+++ b/kde/picmi/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                picmi
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 games
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/poxml/Portfile
+++ b/kde/poxml/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                poxml
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/prison/Portfile
+++ b/kde/prison/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                prison
 version             1.0
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nomaintainer
 license             MIT

--- a/kde/py-pykde4/Portfile
+++ b/kde/py-pykde4/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                py-pykde4
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 devel
 license             LGPL-2+
 maintainers         gmail.com:rjvbertin openmaintainer

--- a/kde/qtcurve/Portfile
+++ b/kde/qtcurve/Portfile
@@ -7,6 +7,7 @@ git.url             git://anongit.kde.org/qtcurve.git
 
 name                qtcurve
 set qtc_version     1.8.18
+revision            1
 if {${subport} eq "${name}-gtk2"} {
     # the GTk2 branch barely evolves at all so qtcurve-gtk2 doesn't need to
     # be updated every time the Qt version is updated.

--- a/kde/qtruby/Portfile
+++ b/kde/qtruby/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                qtruby
 version             4.14.3
+revision            1
 categories          kde kde4 devel
 license             GPL-2+ LGPL-2.1+
 maintainers         nicos openmaintainer

--- a/kde/qyoto/Portfile
+++ b/kde/qyoto/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                qyoto
 version             4.14.3
+revision            1
 categories          kde kde4 devel
 platforms           darwin
 license             GPL-2+ LGPL-2.1+

--- a/kde/rkward/Portfile
+++ b/kde/rkward/Portfile
@@ -7,6 +7,7 @@ PortGroup           kde4    1.1
 
 name                rkward
 version             0.6.5
+revision            1
 
 conflicts           rkward-devel
 categories          kde kde4 math science

--- a/kde/rocs/Portfile
+++ b/kde/rocs/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                rocs
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2.1 GFDL-1.2

--- a/kde/shared-desktop-ontologies/Portfile
+++ b/kde/shared-desktop-ontologies/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4 1.1
 
 name                shared-desktop-ontologies
 version             0.11.0
+revision            1
 categories          kde kde4 devel
 maintainers         nomaintainer
 license             BSD

--- a/kde/skrooge/Portfile
+++ b/kde/skrooge/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4    1.1
 
 name                skrooge
 version             1.8.0
+revision            1
 
 categories          kde finance
 maintainers         mk pixilla openmaintainer

--- a/kde/smokegen/Portfile
+++ b/kde/smokegen/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                smokegen
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ LGPL-2.1+

--- a/kde/smokekde/Portfile
+++ b/kde/smokekde/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                smokekde
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4 devel
 platforms           darwin
 license             GPL-2+ LGPL-2

--- a/kde/smokeqt/Portfile
+++ b/kde/smokeqt/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                smokeqt
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4 devel
 platforms           darwin
 license             GPL-2+ LGPL-2.1+

--- a/kde/step/Portfile
+++ b/kde/step/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                step
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 maintainers         nicos
 license             GPL-2+ GFDL-1.2

--- a/kde/svgpart/Portfile
+++ b/kde/svgpart/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                svgpart
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/sweeper/Portfile
+++ b/kde/sweeper/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                sweeper
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+
 maintainers         nicos openmaintainer

--- a/kde/tellico/Portfile
+++ b/kde/tellico/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4 1.1
 
 name                tellico
 version             2.3.11
+revision            1
 categories          kde kde4
 platforms           darwin
 maintainers         nomaintainer

--- a/kde/umbrello/Portfile
+++ b/kde/umbrello/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                umbrello
 version             4.14.3
-revision            1
+revision            2
 categories          kde kde4
 license             GPL-2+ LGPL-2+
 maintainers         nicos openmaintainer

--- a/multimedia/kdenlive/Portfile
+++ b/multimedia/kdenlive/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                kdenlive
 version             0.9.10
-revision            1
+revision            2
 categories          multimedia
 maintainers         mk
 license             GPL-2+

--- a/science/libklustersshared/Portfile
+++ b/science/libklustersshared/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                libklustersshared
 version             2.0.0
+revision            1
 categories          science kde4
 platforms           darwin
 maintainers         nicos openmaintainer

--- a/science/ndmanager2/Portfile
+++ b/science/ndmanager2/Portfile
@@ -5,6 +5,7 @@ PortGroup           kde4   1.1
 
 name                ndmanager2
 version             2.0.0
+revision            1
 categories          science
 platforms           darwin
 maintainers         nicos openmaintainer

--- a/tex/kde4-kile/Portfile
+++ b/tex/kde4-kile/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4 1.1
 
 name                kde4-kile
 version             2.1.3
-revision            1
+revision            2
 categories          tex kde kde4
 platforms           darwin
 license             GPL-2+


### PR DESCRIPTION
These commits move the headers of KDE4 ports to a specific location, to avoid conflicts with potential ports from KF5, and enable simultaneous installs.

The PR is meant to allow feedback considering the large amount of ports involved before committing. 