### PR TITLE
kde-extra-cmake-modules: update to 5.29.0 + 3 new patches

### DIFF
--- a/kde/kde-extra-cmake-modules/Portfile
+++ b/kde/kde-extra-cmake-modules/Portfile
@@ -1,15 +1,36 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
-
+PortGroup           cmake   1.1
 cmake.out_of_source yes
 
 set ECM             extra-cmake-modules
 name                kde-${ECM}
-version             5.11.0
-set branch          [join [lrange [split ${version} .] 0 1] .]
+subport ${name}-devel {}
+
+set kf5.branch      5.29
+
+if {${subport} eq "${name}-devel"} {
+    fetch.type      git
+    git.url         git://anongit.kde.org/extra-cmake-modules
+#    v5.30.0-rc2-1-gf63f400
+    git.branch      f63f400787ac42f64fafe006ef19579238067f40
+    version         5.29.92
+    distname        ECM-5.1x.git
+} else {
+    version         ${kf5.branch}.0
+    set branch      [join [lrange [split ${version} .] 0 1] .]
+    master_sites    http://download.kde.org/stable/frameworks/${branch}/
+
+    distname        ${ECM}-${version}
+    use_xz          yes
+
+    checksums       rmd160  bdf712bed088fc497f14b625cd5dc48f4b8d7b3f \
+                    sha256  48f76e626e2235bd4b64aeea9bbbcb803eb8966a6d020d0ab8ddbe81930e98d8
+}
+
 supported_archs     noarch
+installs_libs       no
 categories          kde kf5 devel
 license             GPL-2+
 maintainers         gmail.com:rjvbertin mk openmaintainer
@@ -20,47 +41,64 @@ long_description    Extra CMake Modules, or ECM, aims to augment CMake with addi
                     whatever reason, are not a good fit for CMake itself.
 platforms           darwin
 homepage            http://projects.kde.org/projects/kdesupport/${ECM}
-master_sites        http://download.kde.org/stable/frameworks/${branch}/
 
-distname            ${ECM}-${version}
-use_xz              yes
-
-checksums           rmd160  f5df1f931934433cce0496630d7eca5e9efbe69c \
-                    sha256  9ee39c08ca4a6066e9c7061b740ed8b1d5f289e6b19a568d1704585d883cb718
-
-
-variant qt4 description {Use qt4-mac to build the Qt documentation} {
-    PortGroup               qt4 1.0
+patchfiles-append   patch-BUNDLEDIR.diff
+# https://commits.kde.org/extra-cmake-modules/f63f400787ac42f64fafe006ef19579238067f40
+if {${subport} eq "${name}"} {
+    patchfiles-append \
+                    patch-ecm-addappicon.diff
 }
-variant qt5 description {Use qt5-mac to build the Qt documentation} {
-    PortGroup               qt5 1.0
+if {${subport} eq "${name}"} {
+    # https://commits.kde.org/extra-cmake-modules/187d8881a6a0c33f50eb65689aa1dd74a8d107a4
+    patchfiles-append \
+                    patch-no-undefined.diff
 }
-variant docs description {Build documentation} {
-   if {![variant_isset qt4] && ![variant_isset qt5]} {
+
+# # Not used here, but these are used when configuring KF5 packages (cf KF5 PortGroup):
+# configure.args-append \
+#                     -DCMAKE_DISABLE_FIND_PACKAGE_X11=ON \
+#                     -DAPPLE_SUPPRESS_X11_WARNING=ON \
+#                     -DCMAKE_INSTALL_LIBEXECDIR=${prefix}/libexec \
+#                     -DKDE_INSTALL_LIBEXECDIR=${prefix}/libexec/kde5
+
+configure.args-append   -DBUILD_HTML_DOCS:BOOL=OFF
+
+variant qt4 conflicts qt5 description {Use Qt4 to build the Qt documentation} {}
+variant qt5 conflicts qt4 description {Use Qt5 to build the Qt documentation} {}
+
+variant docs description {Build documentation} {}
+if {[variant_isset docs]} {
+    if {![variant_isset qt4] && ![variant_isset qt5]} {
         # user didn't request a Qt variant to use for building the documentation
-        if {[file exists ${prefix}/libexec/qt5/bin/qcollectiongenerator] || [file exists ${prefix}/libexec/qt5-mac/bin/qcollectiongenerator]} {
-            # qcollectiongenerator is installed and provided by a concurrent qt5-mac port
+        if {[file exists ${prefix}/libexec/qt5/bin/qcollectiongenerator] \
+            || [file exists ${prefix}/libexec/qt5-mac/bin/qcollectiongenerator]} {
+            # qcollectiongenerator is installed and provided by a concurrent qt5 port
             default_variants    +qt5
-            PortGroup           qt5 1.0
         } elseif {[file exists ${prefix}/libexec/qt4/bin/qcollectiongenerator]} {
-            # qcollectiongenerator is installed and provided by a concurrent qt4-mac port
+            # qcollectiongenerator is installed and provided by a concurrent qt4 port
             default_variants    +qt4
-            PortGroup           qt4 1.0
         } else {
             # a qcollectiongenerator version cannot be found in a location indicating who provides it
-            # fall back to using the most Qt version most likely to be installed at this time
-            # (and which at this exact time won't need to be built from source)
-            default_variants    +qt4
-            PortGroup           qt4 1.0
+            # fall back to using the Qt version most likely to be required by ports
+            # that use ECM.
+            default_variants    +qt5
         }
     }
-    depends_build-append    port:py-sphinx
+    # no else here!
+    if {[variant_isset qt4]} {
+        PortGroup           qt4 1.0
+    } elseif {[variant_isset qt5]} {
+        set qt5.prefer_kde  1
+        PortGroup           qt5 1.0
+    }
     patchfiles-append       patch-doc-building.diff
-    configure.args-append   -DBUILD_HTML_DOCS:BOOL=OFF -DBUILD_QTHELP_DOCS:BOOL=ON
+    depends_build-append    port:py-sphinx
+    configure.args-append   -DBUILD_QTHELP_DOCS:BOOL=ON
     pre-destroot {
         system -W ${build.dir}/docs "${qt_bins_dir}/qcollectiongenerator qthelp/ExtraCMakeModules.qhcp"
     }
 }
 
-livecheck.type      none
-
+livecheck.type      regex
+livecheck.url       http://download.kde.org/stable/frameworks/${kf5.branch}
+livecheck.regex     (5+(\\.\\d+)+)

--- a/kde/kde-extra-cmake-modules/Portfile
+++ b/kde/kde-extra-cmake-modules/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake   1.1
-cmake.out_of_source yes
 
 set ECM             extra-cmake-modules
 name                kde-${ECM}
@@ -13,7 +12,7 @@ set kf5.branch      5.29
 if {${subport} eq "${name}-devel"} {
     fetch.type      git
     git.url         git://anongit.kde.org/extra-cmake-modules
-#    v5.30.0-rc2-1-gf63f400
+#     v5.30.0-rc2-1-gf63f400
     git.branch      f63f400787ac42f64fafe006ef19579238067f40
     version         5.29.92
     distname        ECM-5.1x.git
@@ -101,4 +100,4 @@ if {[variant_isset docs]} {
 
 livecheck.type      regex
 livecheck.url       http://download.kde.org/stable/frameworks/${kf5.branch}
-livecheck.regex     (5+(\\.\\d+)+)
+livecheck.regex     ${ECM}-(5+(\\.\\d+)+)

--- a/kde/kde-extra-cmake-modules/files/patch-BUNDLEDIR.diff
+++ b/kde/kde-extra-cmake-modules/files/patch-BUNDLEDIR.diff
@@ -1,0 +1,22 @@
+diff --git kde-modules/KDEInstallDirs.cmake kde-modules/KDEInstallDirs.cmake
+index b7cd34d..89b37b6 100644
+--- kde-modules/KDEInstallDirs.cmake
++++ kde-modules/KDEInstallDirs.cmake
+@@ -18,7 +18,7 @@
+ # deprecated variable name in square brackets):
+ #
+ # ``BUNDLEDIR``
+-#     application bundles (``/Applications/KDE``) [``BUNDLE_INSTALL_DIR``]
++#     application bundles (``/Applications/MacPorts/KF5``) [``BUNDLE_INSTALL_DIR``]
+ # ``EXECROOTDIR``
+ #     executables and libraries (``<empty>``) [``EXEC_INSTALL_PREFIX``]
+ # ``BINDIR``
+@@ -383,7 +383,7 @@ macro(_define_non_cache varname value)
+ endmacro()
+ 
+ if(APPLE)
+-    _define_absolute(BUNDLEDIR "/Applications/KDE"
++    _define_absolute(BUNDLEDIR "/Applications/MacPorts/KF5"
+         "application bundles"
+         BUNDLE_INSTALL_DIR)
+ endif(APPLE)

--- a/kde/kde-extra-cmake-modules/files/patch-doc-building.diff
+++ b/kde/kde-extra-cmake-modules/files/patch-doc-building.diff
@@ -1,34 +1,14 @@
 diff --git docs/CMakeLists.txt docs/CMakeLists.txt
 index f17400f..2dd6b8b 100644
---- docs/CMakeLists.txt
-+++ docs/CMakeLists.txt
-@@ -17,8 +17,9 @@ message(STATUS "Looking for Sphinx Documentation Builder...")
- find_program(SPHINX_EXECUTABLE
-     NAMES
+--- cmake/orig.FindSphinx.cmake 2015-12-06 15:09:22.000000000 +0100
++++ cmake/FindSphinx.cmake  2015-12-15 13:06:38.000000000 +0100
+@@ -56,6 +56,9 @@
          sphinx-build
--        sphinx-build2
--        sphinx-build3
-+        sphinx-build-3.4
-+        sphinx-build-3.3
+         sphinx-build2
+         sphinx-build3
 +        sphinx-build-2.7
++        sphinx-build-3.4
++        sphinx-build-3.5
      DOC "Sphinx Documentation Builder (http://sphinx-doc.org/)"
  )
- if(SPHINX_EXECUTABLE)
-@@ -67,7 +68,7 @@ if(BUILD_QTHELP_DOCS)
-     set(qthelp_extra_commands
-         COMMAND
-             qcollectiongenerator
--            ${CMAKE_CURRENT_BINARY_DIR}/qthelp/extra-cmake-modules.qhcp
-+            ${CMAKE_CURRENT_BINARY_DIR}/qthelp/ExtraCMakeModules.qhcp
-     )
- endif()
  
-@@ -122,7 +123,7 @@ if(BUILD_HTML_DOCS)
- endif()
- if(BUILD_QTHELP_DOCS)
-     install(
--        FILES ${CMAKE_CURRENT_BINARY_DIR}/qthelp/extra-cmake-modules.qch
-+        FILES ${CMAKE_CURRENT_BINARY_DIR}/qthelp/ExtraCMakeModules.qch
-         DESTINATION ${DOC_INSTALL_DIR}
-     )
- endif()

--- a/kde/kde-extra-cmake-modules/files/patch-ecm-addappicon.diff
+++ b/kde/kde-extra-cmake-modules/files/patch-ecm-addappicon.diff
@@ -1,0 +1,36 @@
+diff --git modules/ECMAddAppIcon.cmake modules/ECMAddAppIcon.cmake
+index ca64314..aec7e1c 100644
+--- modules/ECMAddAppIcon.cmake
++++ modules/ECMAddAppIcon.cmake
+@@ -77,6 +77,31 @@ function(ecm_add_app_icon appsources)
+         message(FATAL_ERROR "Unexpected arguments to ecm_add_app_icon: ${ARG_UNPARSED_ARGUMENTS}")
+     endif()
+ 
++    if(APPLE)
++        find_program(KSVG2ICNS NAMES ksvg2icns)
++        foreach(icon ${ARG_ICONS})
++            get_filename_component(icon_full ${icon} ABSOLUTE)
++            get_filename_component(icon_type ${icon_full} EXT)
++            # do we have ksvg2icns in the path and did we receive an svg (or compressed svg) icon?
++            if(KSVG2ICNS AND (${icon_type} STREQUAL ".svg" OR ${icon_type} STREQUAL ".svgz"))
++                # convert the svg icon to an icon resource
++                execute_process(COMMAND ${KSVG2ICNS} "${icon_full}"
++                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} RESULT_VARIABLE KSVG2ICNS_ERROR)
++                if(${KSVG2ICNS_ERROR})
++                    message(AUTHOR_WARNING "ksvg2icns could not generate an OS X application icon from ${icon}")
++                else()
++                    # install the icns file we just created
++                    get_filename_component(icon_name ${icon_full} NAME_WE)
++                    set(MACOSX_BUNDLE_ICON_FILE ${icon_name}.icns PARENT_SCOPE)
++                    set(${appsources} "${${appsources}};${CMAKE_CURRENT_BINARY_DIR}/${icon_name}.icns" PARENT_SCOPE)
++                    set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/${icon_name}.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
++                    # we're done now
++                    return()
++                endif()
++            endif()
++        endforeach()
++    endif()
++
+     set(known_sizes 16 32 48 64 128 256 512 1024)
+     foreach(size ${known_sizes})
+         set(icons_at_${size}px)

--- a/kde/kde-extra-cmake-modules/files/patch-no-undefined.diff
+++ b/kde/kde-extra-cmake-modules/files/patch-no-undefined.diff
@@ -1,0 +1,13 @@
+diff --git kde-modules/KDECompilerSettings.cmake kde-modules/KDECompilerSettings.cmake
+index f81b661..8b458f5 100644
+--- kde-modules/KDECompilerSettings.cmake
++++ kde-modules/KDECompilerSettings.cmake
+@@ -332,7 +332,7 @@ endfunction()
+ # Better diagnostics (warnings, errors)
+ ############################################################
+ 
+-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
++if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT APPLE) OR
+         (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT APPLE) OR
+         (CMAKE_CXX_COMPILER_ID STREQUAL "Intel" AND NOT WIN32))
+     # Linker warnings should be treated as errors


### PR DESCRIPTION
- upgrade to 5.30.0 rc2 (5.29.92)
- upstreamed app icon patch
- fixes an incompatibility with recent Qt5 PG changes