### PR TITLE
bro: Upgrade to 2.5

### DIFF
--- a/net/bro/Portfile
+++ b/net/bro/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 name                bro
 version             2.5
-revision            1
 categories          net security
 platforms           darwin
 maintainers         nomaintainer

--- a/net/bro/Portfile
+++ b/net/bro/Portfile
@@ -21,8 +21,8 @@ master_sites        ${homepage}downloads/ \
                     ${homepage}downloads/release/ \
                     ${homepage}downloads/archive/
 
-checksums           rmd160  df3758ab4710f9e4b515ded49bace9a92ca9dba7 \
-                    sha256  bb51e917cd8bb35dc2eae53e5ee59a94da28ffccf4e02412ee8247eeea32e260
+checksums           rmd160  85c28a9ab963c8e804bdac1f8fd88ba2526b9f89 \
+                    sha256  1502a290d3663fa67a44ff6c1c8e8e9434b8ae5e76be5c2a02b06a0e391dc080
 
 depends_build       port:cmake \
                     port:libgeoip \

--- a/net/bro/Portfile
+++ b/net/bro/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                bro
-version             2.4.1
+version             2.5
 revision            1
 categories          net security
 platforms           darwin
@@ -17,11 +17,12 @@ long_description    Bro is an open-source, Unix-based Network Intrusion \
                     traffic and looks for suspicious activity.
 
 homepage            http://www.bro.org/
-master_sites        ${homepage}downloads/release/ \
+master_sites        ${homepage}downloads/ \
+                    ${homepage}downloads/release/ \
                     ${homepage}downloads/archive/
 
-checksums           rmd160  d0de91e52d5ff4edd08dff3b913a4250ad43e03a \
-                    sha256  d8b99673a5024630f6bae820c4f8c3ca9029f1167f9e5729c914c66e1fc7c8f6
+checksums           rmd160  df3758ab4710f9e4b515ded49bace9a92ca9dba7 \
+                    sha256  bb51e917cd8bb35dc2eae53e5ee59a94da28ffccf4e02412ee8247eeea32e260
 
 depends_build       port:cmake \
                     port:libgeoip \


### PR DESCRIPTION
> $ port lint --nitpick
> --->  Verifying Portfile for bro
> --->  0 errors and 0 warnings found.

`port build` passes and after `sudo port install`:

> $ bro -v
> bro version 2.5

