### PR TITLE
openvpn2: update to 2.4.0

### DIFF
--- a/net/openvpn2/Portfile
+++ b/net/openvpn2/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                openvpn2
-version             2.3.12
+version             2.4.0
 distname            openvpn-${version}
 categories          net security
 platforms           darwin
@@ -21,8 +21,8 @@ master_sites        https://swupdate.openvpn.net/community/releases/
 
 use_xz              yes
 
-checksums           rmd160  b4bf63fdd5debeaaa1958953ca8f1de86a91fcb8 \
-                    sha256  13b963414e2430215981868c77b9795d93653ee535a2d73576f7bb2c28200abc
+checksums           rmd160  d74c5aa854a65d97034023fe8daba1d765e39234 \
+                    sha256  6f23ba49a1dbeb658f49c7ae17d9ea979de6d92c7357de3d55cd4525e1b2f87e
 
 depends_build       port:pkgconfig
 depends_lib         port:lzo2 \


### PR DESCRIPTION
###### Description
openvpn2: 2.3.12 -> 2.4.0

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [ ] Have you tested basic functionality of all binary files?
```
OpenVPN 2.4.0 x86_64-apple-darwin16.3.0 [SSL (OpenSSL)] [LZO] [LZ4] [MH/RECVDA] [AEAD] built on Jan 13 2017
library versions: OpenSSL 1.0.2j  26 Sep 2016, LZO 2.09
Originally developed by James Yonan
Copyright (C) 2002-2017 OpenVPN Technologies, Inc. <sales@openvpn.net>
Compile time defines: enable_async_push=no enable_comp_stub=no enable_crypto=yes enable_crypto_ofb_cfb=yes enable_debug=yes enable_def_auth=yes enable_dlopen=unknown enable_dlopen_self=unknown enable_dlopen_self_static=unknown enable_fast_install=needless enable_fragment=yes enable_iproute2=no enable_libtool_lock=yes enable_lz4=yes enable_lzo=yes enable_management=yes enable_multi=yes enable_multihome=yes enable_pam_dlopen=no enable_pedantic=no enable_pf=yes enable_pkcs11=no enable_plugin_auth_pam=yes enable_plugin_down_root=yes enable_plugins=yes enable_port_share=yes enable_selinux=no enable_server=yes enable_shared=yes enable_shared_with_static_runtimes=no enable_small=no enable_static=yes enable_strict=no enable_strict_options=no enable_systemd=no enable_werror=no enable_win32_dll=yes enable_x509_alt_username=no with_crypto_library=openssl with_gnu_ld=no with_mem_check=no with_plugindir='$(libdir)/openvpn/plugins' with_sysroot=no
```