### PR TITLE
New port: sqlite3-tools

### DIFF
--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -23,7 +23,8 @@ long_description    SQLite3 is an SQL database engine in a C library. \
 homepage            http://www.sqlite.org/
 master_sites        ${homepage}2017
 
-distname            sqlite-autoconf-[string range [subst [regsub -all {\.([0-9]+)} "${version}.0.0" {[format %02d \1]}]] 0 6]
+set padded_ver      [string range [subst [regsub -all {\.([0-9]+)} "${version}.0.0" {[format %02d \1]}]] 0 6]
+distname            sqlite-autoconf-${padded_ver}
 
 checksums           rmd160  86b351cfa4321a857fe6987694e188655226951f \
                     sha256  65cc0c3e9366f50c0679c5ccd31432cea894bc4a3e8947dabab88c8693263615
@@ -56,9 +57,44 @@ livecheck.url       http://www.sqlite.org/news.html
 livecheck.regex     (3(?:\\.\[0-9\]+)+)
 
 post-destroot {
-    xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1
+    if {${subport} eq ${name}} {
+        xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1
+    }
 }
 
 platform darwin 8 {
     configure.cppflags-append -DSQLITE_WITHOUT_ZONEMALLOC
+}
+
+subport ${name}-tools {
+    distname                  sqlite-src-${padded_ver}
+    description               A bundle of command-line tools for managing SQLite \
+                              database files
+
+    long_description          A bundle of command-line tools for managing SQLite \
+                              database files, including the sqldiff program and the \
+                              sqlite3_analyzer program.
+
+    checksums                 rmd160  0b704dbe2e26c3b6153ef2a8108d1b668fd419c0 \
+                              sha256  ee77c2cc5cc4a7b0a746a1d4496f7aee0d71c558a3bbfcf8e9e0b35416910337
+    use_zip                   yes
+    depends_lib               port:tcl
+    configure.args            --with-tcl=${prefix}/lib
+    build.target              sqldiff sqlite3_analyzer
+    destroot {
+        xinstall -m 755 ${worksrcpath}/sqldiff ${destroot}${prefix}/bin
+        xinstall -m 755 ${worksrcpath}/sqlite3_analyzer ${destroot}${prefix}/bin
+    }
+    pre-activate {
+        # tcl previously conflicted because it installed files now provided by sqlite3-tools
+        if {![catch {set installed [lindex [registry_active tcl] 0]}]} {
+            set _version [lindex $installed 1]
+            set _revision [lindex $installed 2]
+            set _cmp866 [vercmp $_version 8.6.6]
+            if {($_cmp866 < 0) || ($_cmp866 == 0 && $_revision < 1)} {
+                # tcl used to install some files now provided by sqlite3-tools in versions < 8.6.6_1
+                registry_deactivate_composite tcl "" [list ports_nodepcheck 1]
+            }
+        }
+    }
 }

--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name          tcl
 version       8.6.6
+revision      1
 # Tk (x11/tk) port depends on this version
 categories    lang
 license       Tcl/Tk
@@ -38,6 +39,8 @@ destroot.destdir  INSTALL_ROOT=${destroot}
 post-destroot {
     ln -s tclsh8.6 ${destroot}${prefix}/bin/tclsh
     ln -s libtcl8.6.dylib ${destroot}${prefix}/lib/libtcl.dylib
+    # sqlite3_analyzer is provided by sqlite3
+    delete ${destroot}${prefix}/bin/sqlite3_analyzer
 }
 
 # dont enable threads by default as Tcl uses thread-local storage which makes


### PR DESCRIPTION
This PR adds the `sqlite3-tools` port, a subport of `sqlite3`. This port provides the `sqldiff` and `sqlite3_analyzer` binaries that are provided in the full `sqlite3` source.

This bumps the revision of the `tcl` port to remove the outdated version of `sqlite3_analyzer` that it provides.

There was some discussion about this on [macports-dev](https://lists.macports.org/pipermail/macports-dev/2017-January/035131.html), where approval was given for removing `sqlite3_analyzer` from `tcl`.