### PR TITLE
Obsolete packages that were moved to py-astropy

### DIFF
--- a/python/py-asciitable/Portfile
+++ b/python/py-asciitable/Portfile
@@ -1,28 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+replaced_by         py-astropy
+PortGroup           obsolete 1.0
 PortGroup           python 1.0
-
 name                py-asciitable
 version             0.8.0
-revision            1
-maintainers         robitaille stsci.edu:mperrin
+revision            2
 
-categories-append   science
-description         An extensible ASCII table reader and writer
-long_description    ${description}
-
-platforms           darwin
-
-homepage            http://cxc.harvard.edu/contrib/asciitable/
-master_sites        pypi:a/asciitable/
-distname            asciitable-${version}
-checksums           md5     913dac05fbf69ae76504f955b77659e5 \
-                    sha1    b10ec19b930e7cd758ac4748c50c25f1285f256a \
-                    rmd160  3423ebb18d24bee4073209a6e073feeb99982f61
-
-python.versions     26 27 34
+python.versions     27 34
 
 if {${name} ne ${subport}} {
-    depends_run-append  port:py${python.version}-numpy
+    replaced_by     py${python.version}-astropy
+}
+
+subport py26-asciitable {
+    replaced_by     py27-astropy
 }

--- a/python/py-pyfits/Portfile
+++ b/python/py-pyfits/Portfile
@@ -1,54 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+replaced_by         py-astropy
+PortGroup           obsolete 1.0
 PortGroup           python 1.0
-PortGroup           select 1.0
 
-set realname        pyfits
-
-name                py-${realname}
+name                py-pyfits
 version             3.3
-revision            4
-categories-append   science
-license             BSD
-platforms           darwin
-maintainers         aronnax openmaintainer
+revision            5
 
-python.versions     26 27 33 34 35
-
-description         Python interface to FITS formatted files
-
-long_description    PyFITS provides an interface to FITS formatted files \
-                    under Python. It is useful both for interactive data \
-                    analysis and for writing analysis scripts in Python \
-                    using FITS files as either input or output. PyFITS is \
-                    a development project of the Science Software Branch \
-                    at the Space Telescope Science Institute.
-
-homepage            http://www.stsci.edu/resources/software_hardware/${realname}
-master_sites        pypi:[string index ${realname} 0]/${realname}
-distname            ${realname}-${version}
-
-checksums           md5     0d4f3515bc714f48093578e96ca7219d \
-                    sha1    7cae2cd16695c094b82e067defd627e2da619b7d \
-                    rmd160  eb213cac6b26661cb563e0da3733d1d6592c8ab8
-
-# As suggested in README.txt, to build against an external cfitsio package,
-# delete cextern/cfitsio directory and comment out cextern/cfitsio/* lines
-# in setup.cfg.
-patch {
-    delete file ${worksrcpath}/cextern/cfitsio
-    reinplace -E -W ${worksrcpath} {s|\s*(cextern/cfitsio).*||} setup.cfg
-}
+python.versions     27 33 34 35
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:cfitsio \
-                        port:py${python.version}-numpy \
-                        port:py${python.version}-setuptools
+    replaced_by     py${python.version}-astropy
+}
 
-    livecheck.type  none
-} else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}/Download
-    livecheck.regex     ${realname}-(\[0-9.\]+)\\.
+subport py26-pyfits {
+    replaced_by     py27-astropy
 }

--- a/python/py-pywcs/Portfile
+++ b/python/py-pywcs/Portfile
@@ -1,31 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+replaced_by         py-astropy
+PortGroup           obsolete 1.0
 PortGroup           python 1.0
-
 name                py-pywcs
 version             1.11-4.8.2
-revision            1
-maintainers         robitaille stsci.edu:mperrin
+revision            2
 
-categories-append   science
-description         pywcs is a set of routines for handling the FITS WCS standard
-long_description    pywcs is a set of routines for handling the FITS World \
-                    Coordinate System (WCS) standard. It is a thin wrapper \
-                    around the high- and mid-level interfaces of WCSLIB.
-
-platforms           darwin
-
-homepage            https://trac6.assembla.com/astrolib
-master_sites        http://stsdas.stsci.edu/astrolib/
-distname            pywcs-${version}
-checksums           md5  0721ceb7d8270868dd5d688ba60e4089 \
-                    sha1  670746ef477cef43cefe488b95f05c70891f1ae0 \
-                    rmd160  ca76fa03cf77a25613ad1aab86723b469e653924
-
-python.versions     26 27 34
+python.versions     27 34
 
 if {${name} ne ${subport}} {
-    depends_run-append  port:py${python.version}-numpy \
-                        port:py${python.version}-pyfits
+    replaced_by     py${python.version}-astropy
+}
+
+subport py26-pywcs {
+    replaced_by     py27-astropy
 }

--- a/python/py-vo/Portfile
+++ b/python/py-vo/Portfile
@@ -1,28 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+replaced_by         py-astropy
+PortGroup           obsolete 1.0
 PortGroup           python 1.0
-
 name                py-vo
 version             0.8
-revision            1
-maintainers         robitaille
+revision            2
 
-categories-append   science
-description         A Python library to parse, validate and generate VOTable XML files.
-long_description    ${description}
-
-platforms           darwin
-
-homepage            https://trac6.assembla.com/astrolib
-master_sites        http://stsdas.stsci.edu/astrolib/
-distname            vo-${version}
-checksums           md5  af67d56c102bfffd975c8180bb656de2 \
-                    sha1  ca8aa70ebb1a04ba6818bca6e1268fc5f8b8fd62 \
-                    rmd160  4d8a7d39a9e867939dd9214bd48fb519765cd581
-
-python.versions     26 27 34
+python.versions     27 34
 
 if {${name} ne ${subport}} {
-    depends_run-append  port:py${python.version}-numpy
+    replaced_by     py${python.version}-astropy
+}
+
+subport py26-vo {
+    replaced_by     py27-astropy
 }


### PR DESCRIPTION
About 5 years ago a few Python astronomy packages were moved to Astropy (http://www.astropy.org/).

This pull requests moves the following packages to the "obsolete" PortGroup in Macports:
* `py-pyfits`
* `py-pywcs`
* `py-asciitable`
* `py-vo`

This was discussed via email with Port maintainer @astrofrog and he agrees to this change.

---

Could someone familiar with obsolete in Macports please have a look?
There's https://guide.macports.org/chunked/development.practices.html#development.obsolete-portgroup , but it's still based on SVN.

What I did here is to keep the current version number, and increase the revision by one.