### PR TITLE
Small updates to ports related to pgcli

### DIFF
--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        dbcli pgcli 1.4.0 v
 
 categories          databases python
-maintainers         g5pw openmaintainer
+maintainers         g5pw gmail.com:xeron.oskom openmaintainer
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -35,10 +35,50 @@ if {[variant_isset python34]} {
     python.default_version 27
 }
 
+variant postgresql84 conflicts postgresql90 postgresql91 postgresql92 \
+        postgresql93 postgresql94 postgresql95 postgresql96 \
+        description "Build using postgresql v8.4" {}
+
+variant postgresql90 conflicts postgresql84 postgresql91 postgresql92 \
+        postgresql93 postgresql94 postgresql95 postgresql96 \
+        description "Build using postgresql v9.0" {}
+
+variant postgresql91 conflicts postgresql84 postgresql90 postgresql92 \
+        postgresql93 postgresql94 postgresql95 postgresql96 \
+        description "Build using postgresql v9.1" {}
+
+variant postgresql92 conflicts postgresql84 postgresql90 postgresql91 \
+        postgresql93 postgresql94 postgresql95 postgresql96 \
+        description "Build using postgresql v9.2" {}
+
+variant postgresql93 conflicts postgresql84 postgresql90 postgresql91 \
+        postgresql92 postgresql94 postgresql95 postgresql96 \
+        description "Build using postgresql v9.3" {}
+
+variant postgresql94 conflicts postgresql84 postgresql90 postgresql91 \
+        postgresql92 postgresql93 postgresql95 postgresql96 \
+        description "Build using postgresql v9.4" {}
+
+variant postgresql95 conflicts postgresql84 postgresql90 postgresql91 \
+        postgresql92 postgresql93 postgresql94 postgresql96 \
+        description "Build using postgresql v9.5" {}
+
+variant postgresql96 conflicts postgresql84 postgresql90 postgresql91 \
+        postgresql92 postgresql93 postgresql94 postgresql95 \
+        description "Build using postgresql v9.6" {}
+
+if {
+    ![variant_isset postgresql84] && ![variant_isset postgresql90] &&
+    ![variant_isset postgresql91] && ![variant_isset postgresql92] &&
+    ![variant_isset postgresql93] && ![variant_isset postgresql94] &&
+    ![variant_isset postgresql95] && ![variant_isset postgresql96]
+} {
+    default_variants    +postgresql96
+}
+
 depends_build       port:py${python.version}-setuptools
 depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-configobj \
-                    port:py${python.version}-crypto \
                     port:py${python.version}-humanize \
                     port:py${python.version}-pgspecial \
                     port:py${python.version}-prompt_toolkit \

--- a/python/py-humanize/Portfile
+++ b/python/py-humanize/Portfile
@@ -5,22 +5,22 @@ PortGroup           python 1.0
 
 name                py-humanize
 version             0.5.1
-platforms           darwin
 license             MIT
-maintainers         nomaintainer
-
-description         python humanize utilities
+platforms           darwin
+supported_archs     noarch
+maintainers         gmail.com:xeron.oskom openmaintainer
+description         Python humanize utilities
 long_description    ${description}
 
-homepage            http://github.com/jmoiron/humanize
-master_sites        https://pypi.python.org/packages/8c/e0/e512e4ac6d091fc990bbe13f9e0378f34cf6eecd1c6c268c9e598dcf5bb9
+python.versions     27 34 35 36
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            humanize-${version}
 
 checksums           md5     e8473d9dc1b220911cac2edd53b1d973 \
                     rmd160  7c5a7c9c5ac28eb29b04e80e83506e14bf46f811 \
                     sha256  a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19
-
-python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pgspecial/Portfile
+++ b/python/py-pgspecial/Portfile
@@ -5,22 +5,23 @@ PortGroup           python 1.0
 
 name                py-pgspecial
 version             1.7.0
+license             BSD
 platforms           darwin
-license             NULL
-maintainers         nomaintainer
+supported_archs     noarch
+maintainers         gmail.com:xeron.oskom openmaintainer
+description         Meta-commands handler for Postgres Database
+long_description    This package provides an API to execute meta-commands \
+                    (AKA “special”, or “backslash commands”) on PostgreSQL.
 
-description         Meta commands handler for Postgres Database.
-long_description    ${description}
+python.versions     27 34 35 36
 
-homepage            http://pgcli.com
-master_sites        https://pypi.python.org/packages/71/cc/93ee525a00e5ad6306945529d6f9c7ea0058d2f7a72ad25759c21e558780
-distname            pgspecial-${version}
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           md5     4997a3343cb332bb215e5a39cad29235 \
                     rmd160  b660547c0f0fa9e27cd6a256e2ac343945b3d037 \
                     sha256  297e231caf77e129c4d0b71f97ca022be8d32684928af5959050de727245db4a
-
-python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-psycopg2/Portfile
+++ b/python/py-psycopg2/Portfile
@@ -5,9 +5,7 @@ PortGroup           python 1.0
 
 name                py-psycopg2
 version             2.6.2
-# only port:trac requires py26-psyocopg2
-python.versions     26 27 34 35 36
-python.default_version  27
+
 categories-append   databases
 maintainers         snc openmaintainer
 license             LGPL-3+
@@ -20,11 +18,11 @@ long_description    Psycopg2 is a postgresql database adapter for python. \
                     designed for heavily multi-threaded applications \
                     featuring connection pooling.
 
-homepage            http://initd.org/psycopg/
+python.versions     27 34 35 36
 
-set branch          [join [lrange [split ${version} .] 0 1] -]
-master_sites        http://www.psycopg.org/psycopg/tarballs/PSYCOPG-${branch}/
-distname            psycopg2-${version}
+homepage            http://initd.org/psycopg/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           md5     4a392949ba31a378a18ed3e775a4693f \
                     rmd160  f9b73dd247d2caa97f08b8730798d9f6f4ae9dd1 \
@@ -74,36 +72,51 @@ if {${name} ne ${subport}} {
         }
     }
 
-    variant postgresql91 conflicts postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 description "Build using postgresql v9.1" {
-        depends_lib-append  port:postgresql91
+    variant postgresql91 conflicts postgresql92 postgresql93 postgresql94 \
+            postgresql95 postgresql96 \
+            description "Build using postgresql v9.1" {
+                depends_lib-append  port:postgresql91
     }
 
-    variant postgresql92 conflicts postgresql91 postgresql93 postgresql94 postgresql95 postgresql96 description "Build using postgresql v9.2" {
-        depends_lib-append  port:postgresql92
+    variant postgresql92 conflicts postgresql91 postgresql93 postgresql94 \
+            postgresql95 postgresql96 \
+            description "Build using postgresql v9.2" {
+                depends_lib-append  port:postgresql92
     }
 
-    variant postgresql93 conflicts postgresql91 postgresql92 postgresql94 postgresql95 postgresql96 description "Build using postgresql v9.3" {
-        depends_lib-append  port:postgresql93
+    variant postgresql93 conflicts postgresql91 postgresql92 postgresql94 \
+            postgresql95 postgresql96 \
+            description "Build using postgresql v9.3" {
+                depends_lib-append  port:postgresql93
     }
 
-    variant postgresql94 conflicts postgresql91 postgresql92 postgresql93 postgresql95 postgresql96 description "Build using postgresql v9.4" {
-        depends_lib-append  port:postgresql94
+    variant postgresql94 conflicts postgresql91 postgresql92 postgresql93 \
+            postgresql95 postgresql96 \
+            description "Build using postgresql v9.4" {
+                depends_lib-append  port:postgresql94
     }
 
-    variant postgresql95 conflicts postgresql91 postgresql92 postgresql93 postgresql94 postgresql96 description "Build using postgresql v9.5" {
-        depends_lib-append  port:postgresql95
+    variant postgresql95 conflicts postgresql91 postgresql92 postgresql93 \
+            postgresql94 postgresql96 \
+            description "Build using postgresql v9.5" {
+                depends_lib-append  port:postgresql95
     }
 
-    variant postgresql96 conflicts postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 description "Build using postgresql v9.6" {
-        depends_lib-append  port:postgresql96
+    variant postgresql96 conflicts postgresql91 postgresql92 postgresql93 \
+            postgresql94 postgresql95 \
+            description "Build using postgresql v9.6" {
+                depends_lib-append  port:postgresql96
     }
 
-    if {![variant_isset postgresql91] && ![variant_isset postgresql92] && ![variant_isset postgresql93] && ![variant_isset postgresql94] && ![variant_isset postgresql95] && ![variant_isset postgresql96]} {
+    if {
+        ![variant_isset postgresql91] && ![variant_isset postgresql92] &&
+        ![variant_isset postgresql93] && ![variant_isset postgresql94] &&
+        ![variant_isset postgresql95] && ![variant_isset postgresql96]
+    } {
         default_variants    +postgresql95
     }
 
     livecheck.type      none
 } else {
-    livecheck.url       ${master_sites}
-    livecheck.regex     psycopg2-(\\d+(\\.\\d+)+)${extract.suffix}
+    livecheck.type      pypi
 }

--- a/python/py-setproctitle/Portfile
+++ b/python/py-setproctitle/Portfile
@@ -5,22 +5,23 @@ PortGroup           python 1.0
 
 name                py-setproctitle
 version             1.1.10
-platforms           darwin
 license             BSD
-maintainers         nomaintainer
-
+platforms           darwin
+supported_archs     noarch
+maintainers         gmail.com:xeron.oskom openmaintainer
 description         A Python module to customize the process title
-long_description    ${description}
+long_description    The setproctitle module allows a process to change \
+                    its title (as displayed by system tools such as ps and top).
 
-homepage            https://github.com/dvarrazzo/py-setproctitle
-master_sites        https://pypi.python.org/packages/5a/0d/dc0d2234aacba6cf1a729964383e3452c52096dc695581248b548786f2b3
-distname            setproctitle-${version}
+python.versions     27 34 35 36
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           md5     2dcdd1b761700a5a13252fea3dfd1977 \
                     rmd160  c2a6c024fcd7d30f6d2f3ead2b021821a5ecaa34 \
                     sha256  6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398
-
-python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-wcwidth/Portfile
+++ b/python/py-wcwidth/Portfile
@@ -14,9 +14,9 @@ long_description    ${description}
 
 python.versions     27 34 35 36
 
-homepage            https://pypi.python.org/pypi/wcwidth/
-master_sites        pypi:w/wcwidth
-distname            wcwidth-${version}
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           rmd160  11891327c61ce243072d1bfc1fdd589037d4c113 \
                     sha256  3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e


### PR DESCRIPTION
I was using my local version of `pgcli` for a very long time and finally wanted to add it to macports and  realized that @g5pw did the same recently.

This PR is to refresh `pgcli` port dependencies, mostly removing `md5` checksums, adding myself as maintainer and standardizing usage of `pypi` `livecheck` / `master_sites`.

Also adds `postgresql` variants to `pgcli` port. This is required to get correct `postgresql` variant on `py-psycopg2`.

Related tickets which could be closed now:

https://trac.macports.org/ticket/47403
https://trac.macports.org/ticket/49554
https://trac.macports.org/ticket/49555