### PR TITLE
Httrack 3.48.22 update

### DIFF
--- a/net/httrack/Portfile
+++ b/net/httrack/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 name                httrack
 version             3.48.22
-revision            1
 categories          net
 platforms           darwin
 maintainers         ross-williams.net:ross

--- a/net/httrack/Portfile
+++ b/net/httrack/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                httrack
-version             3.48.3
+version             3.48.22
 revision            1
 categories          net
 platforms           darwin
@@ -18,8 +18,8 @@ long_description    HTTrack is an offline browser utility that allows you to \
 homepage            http://www.httrack.com/
 master_sites        http://mirror.httrack.com/
 
-checksums           rmd160  f69d27a0dedda3ab3e2d7170285b908f0c888257 \
-                    sha256  19d84efb14c6952ed503c84fc6f5daa40b9189b94546c6ddf903074071cee5d1
+checksums           rmd160  ddd7b570bd4d9cedf16ad2211e09d189b171899a \
+                    sha256  b2831ad7b48e933959f83a9de8a72bcaa0f8eb87e9453ad85debd50d33a9c48f
 
 depends_lib         port:zlib \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
Httrack 3.48.22 update. No major changes since 3.48.3 (mostly bugfixs) : https://www.httrack.com/history.txt