### PR TITLE
groovy: update to 2.4.8 [CVE-2016-6814]

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.4.7
+version         2.4.8
 
 categories      lang java
 maintainers     breun.nl:nils openmaintainer
@@ -37,8 +37,8 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  ba09b24ee7bd07b51724a48684ce4f3c7d0cba62 \
-                sha256  438dd6098252647e88ff12ac5737d0d0f7e16a8e4e42e8be3e05a4c43abefbd5
+checksums       rmd160  d350c004f8a3361206e7c2dcab8c2f0f63b0994c \
+                sha256  668a65ea17037371a1952cca5f42ebc03329e15d3619aacb4c7dd5f4b39a8dfd
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
###### Description
See http://groovy-lang.org/security.html.

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [ ] Have you tested basic functionality of all binary files?