### PR TITLE
pgcli: remove postgresql variants.

### DIFF
--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -35,47 +35,6 @@ if {[variant_isset python34]} {
     python.default_version 27
 }
 
-variant postgresql84 conflicts postgresql90 postgresql91 postgresql92 \
-        postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Build using postgresql v8.4" {}
-
-variant postgresql90 conflicts postgresql84 postgresql91 postgresql92 \
-        postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Build using postgresql v9.0" {}
-
-variant postgresql91 conflicts postgresql84 postgresql90 postgresql92 \
-        postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Build using postgresql v9.1" {}
-
-variant postgresql92 conflicts postgresql84 postgresql90 postgresql91 \
-        postgresql93 postgresql94 postgresql95 postgresql96 \
-        description "Build using postgresql v9.2" {}
-
-variant postgresql93 conflicts postgresql84 postgresql90 postgresql91 \
-        postgresql92 postgresql94 postgresql95 postgresql96 \
-        description "Build using postgresql v9.3" {}
-
-variant postgresql94 conflicts postgresql84 postgresql90 postgresql91 \
-        postgresql92 postgresql93 postgresql95 postgresql96 \
-        description "Build using postgresql v9.4" {}
-
-variant postgresql95 conflicts postgresql84 postgresql90 postgresql91 \
-        postgresql92 postgresql93 postgresql94 postgresql96 \
-        description "Build using postgresql v9.5" {}
-
-variant postgresql96 conflicts postgresql84 postgresql90 postgresql91 \
-        postgresql92 postgresql93 postgresql94 postgresql95 \
-        description "Build using postgresql v9.6" {}
-
-if {
-    ![variant_isset postgresql84] && ![variant_isset postgresql90] &&
-    ![variant_isset postgresql91] && ![variant_isset postgresql92] &&
-    ![variant_isset postgresql93] && ![variant_isset postgresql94] &&
-    ![variant_isset postgresql95] && ![variant_isset postgresql96]
-} {
-    default_variants    +postgresql96
-}
-
 depends_build       port:py${python.version}-setuptools
 depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-configobj \


### PR DESCRIPTION
`port install pgcli +postgresql96` propagates variant to `py-psycopg2` even without these empty variants.