### PR TITLE
apache-ant upgrade 1.10.0

### DIFF
--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant
-version                 1.9.7
+version                 1.10.0
 categories              devel java
 license                 Apache-2 W3C
 maintainers             openmaintainer blair
@@ -21,9 +21,8 @@ platforms               darwin freebsd
 distname                ${name}-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
-checksums               md5    99a86981333a0ff39bb56c963d1f492b \
-                        sha1   230c6a5c59dc08364f615deb240aa50c23ccfe2a \
-                        sha512 3954a6ad3f522c135f327ba0d376eb16ae42103849c8cc5cd6c8c6e87b8c5433c95a0f2d4dfa3e6c2705ee0b8996e5b27d0b2248f64a05fc8c902116cc45a7b2
+checksums               rmd160 5986951626e6601d349d3b13908eb86de3b7dfa0 \
+                        sha512 8e21144d9303e06747f5c121cb29f5d57540e32e70497c01f65b6a5ccc7d0a508576078c67c8abf14a4b710257d4deb8fa542858c5977e0291ee2393c0e40e1d
 
 worksrcdir              ${name}-${version}
 set workTarget          ""


### PR DESCRIPTION
new version of apache-ant
have dropped md5 and sha1 checksum