### PR TITLE
Certbot fixes and plugin ports

### DIFF
--- a/python/py-acme/Portfile
+++ b/python/py-acme/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 set real_name       acme
 name                py-${real_name}
 version             0.10.1
+revision            1
 worksrcdir          ${real_name}-${version}
 distfiles           ${real_name}-${version}${extract.suffix}
 categories-append   security
@@ -35,7 +36,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-idna \
                     port:py${python.version}-openssl \
                     port:py${python.version}-requests \
-                    port:py${python.version}-rfc3339 \
+                    port:py${python.version}-pyrfc3339 \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-six \
                     port:py${python.version}-tz \

--- a/python/py-parsedatetime/Portfile
+++ b/python/py-parsedatetime/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        bear parsedatetime 1.2 v
+github.setup        bear parsedatetime 1.5 v
 name                py-${name}
 python.versions     27 34 35 36
 platforms           darwin
@@ -12,8 +12,8 @@ maintainers         nomaintainer
 description         Parse human-readable date/time text
 long_description    ${description}
 
-checksums           rmd160  1b33b4d16914979de88da52f69bb543d7abed1b4 \
-                    sha256  9592ed312d4ce745987ed63bf2eb55b452657914c2d5bd3f04eb0b26fceb3f51
+checksums           rmd160  6b28de8af13367e210a713481b3c92a6e0217a35 \
+                    sha256  3e910981ca058e85bb6de90605e4e6cf9e3d121f3188e8e7d67f6022d5ddfb66
 
 if {${name} ne ${subport}} {
     livecheck.type      none

--- a/python/py-pyrfc3339/Portfile
+++ b/python/py-pyrfc3339/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyrfc3339
+set real_name       pyRFC3339
+version             1.0
+python.versions     27
+maintainers         nomaintainer
+license             MIT
+description         pyRFC3339 parses and generates RFC 3339-compliant timestamps \
+                    using Python datetime.datetime objects.
+long_description    ${description}
+
+platforms           darwin
+
+homepage            http://pypi.python.org/pypi/${real_name}/
+master_sites        pypi:p/${real_name}
+distname            ${real_name}-${version}
+
+checksums           rmd160  cb2c3fbe046b22209c101b99455199459aae3ad5 \
+                    sha256  8dfbc6c458b8daba1c0f3620a8c78008b323a268b27b7359e92a4ae41325f535
+
+if {${name} ne ${subport}} {
+    depends_lib-append  \
+                    port:py${python.version}-tz
+}

--- a/python/py-python-augeas/Portfile
+++ b/python/py-python-augeas/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-python-augeas
+set real_name       python-augeas
+version             0.5.0
+python.versions     27 34 35
+maintainers         nomaintainer
+license             LGPL-2.1+
+description         Python bindings for Augeas
+long_description    ${description}
+
+platforms           darwin
+
+homepage            http://pypi.python.org/pypi/${real_name}/
+master_sites        pypi:p/${real_name}
+distname            ${real_name}-${version}
+
+checksums           rmd160  909056aeef54735a398581b7a30acb5eff190279 \
+                    sha256  67d59d66cdba8d624e0389b87b2a83a176f21f16a87553b50f5703b23f29bac2
+
+if {${name} ne ${subport}} {
+    depends_lib-append  \
+                    port:augeas
+}

--- a/security/certbot-apache/Portfile
+++ b/security/certbot-apache/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                certbot-apache
+version             0.10.1
+categories          security
+license             Apache-2
+maintainers         nomaintainer
+description         Apache plugin for Certbot
+long_description    ${description}
+platforms           darwin
+homepage            https://pypi.python.org/pypi/certbot-apache
+master_sites        pypi:c/certbot-apache
+
+python.versions     27
+
+checksums           rmd160  4374fd15f59368e3dccc1b4d1d08fa596d0ac63c \
+                    sha256  134f46690da55262125defa58aa74472eb4a1555c9ed83edb3c8667df5a561b5
+
+depends_lib-append  port:certbot \
+                    port:py${python.version}-acme \
+                    port:py${python.version}-python-augeas \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-zopecomponent \
+                    port:py${python.version}-zopeinterface \
+                    port:py${python.version}-mock

--- a/security/certbot-nginx/Portfile
+++ b/security/certbot-nginx/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                certbot-nginx
+version             0.10.1
+categories          security
+license             Apache-2
+maintainers         nomaintainer
+description         Nginx plugin for Certbot
+long_description    ${description}
+platforms           darwin
+homepage            https://pypi.python.org/pypi/certbot-nginx
+master_sites        pypi:c/certbot-nginx
+
+python.versions     27
+
+checksums           rmd160  d56da581495b8f1a22a93295ec9e5b97673549ca \
+                    sha256  da1b7ea4831ead3f9eb526ee11bf1bf197da0fea4defeeb7b1ce24c5d3f45b51
+
+depends_lib-append  port:certbot \
+                    port:py${python.version}-acme \
+                    port:py${python.version}-openssl \
+                    port:py${python.version}-parsing \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-zopeinterface \
+                    port:py${python.version}-mock

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        certbot certbot 0.10.1 v
-revision            1
+revision            2
 categories          security
 license             Apache-2
 maintainers         mps openmaintainer
@@ -29,7 +29,7 @@ depends_lib         port:py${python.version}-acme \
                     port:py${python.version}-parsedatetime \
                     port:py${python.version}-psutil \
                     port:py${python.version}-python2-pythondialog \
-                    port:py${python.version}-rfc3339 \
+                    port:py${python.version}-pyrfc3339 \
                     port:py${python.version}-six \
                     port:py${python.version}-tz \
                     port:py${python.version}-zopecomponent


### PR DESCRIPTION
I installed the certbot port and found the following issues (addressed in this PR):
- The dependency on rfc3339 is incorrect; the correct dependency is pyRFC3339 which is a different package altogether. We don't have a port for this, so I have added it.
  - The py-acme port (part of the certbot codebase) also had this problem.
- The required version of parsedatetime was newer than what was available in MacPorts.

In addition there are some plugins available for certbot; I added ports for certbot-apache and certbot-nginx. The former depends on python-augeas so I have added a port for that as well.