### PR TITLE
iterm2: Only build on 10.11 and 10.12 with Xcode 8+

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem  1.0
 PortGroup   github 1.0
+PortGroup   xcodeversion 1.0
 
 github.setup     gnachman iTerm2 3.0.13 v
 categories       aqua shells
@@ -32,9 +33,11 @@ build.target        prod
 
 destroot.destdir    APPS=${destroot}${applications_dir}
 
-if {${os.platform} eq "darwin" && ${os.major} < 12} {
+minimum_xcodeversions {15 8.0 16 8.0}
+
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
     pre-fetch {
-        ui_error "${subport} @${version} requires OS X 10.8 or newer"
+        ui_error "${subport} @${version} requires OS X 10.11 or newer"
         return -code error "unsupported Mac OS X version"
     }
 }


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/51983 