### PR TITLE
cjdns: new port at 18

### DIFF
--- a/net/cjdns/Portfile
+++ b/net/cjdns/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        cjdelisle cjdns 18 cjdns-v
+
+name                cjdns
+categories          net
+platforms           darwin
+maintainers         icloud.com:l2dy openmaintainer
+license             BSD
+
+description         Cjdns implements an encrypted IPv6 network.
+
+long_description    Cjdns implements an encrypted IPv6 network using public-key \
+                    cryptography for address allocation and a distributed hash table \
+                    for routing. This provides near-zero-configuration networking, and \
+                    prevents many of the security and scalability issues that plague existing networks.
+
+checksums           rmd160  d309f51122cc88b0d1aa4b621451122ecabea716 \
+                    sha256  5d7b6ed9ff1eab33823e26f8ff04716bba8e6454936341828405e09f56420af4
+
+depends_build       bin:node:nodejs6
+
+use_configure       no
+
+build.cmd           "./do"
+
+destroot {
+        xinstall -m 755 -d ${destroot}${prefix}/bin
+        xinstall -m 755 -s ${worksrcpath}/cjdroute ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
###### Description
Cjdns implements an encrypted IPv6 network.

###### System Info
macOS version: 10.12.2

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [x] Have you tested basic functionality of all binary files?