### PR TITLE
leptonica: Update to version 1.74.1

### DIFF
--- a/graphics/leptonica/Portfile
+++ b/graphics/leptonica/Portfile
@@ -1,24 +1,30 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
+github.setup        DanBloomberg leptonica 1.74.1
 name                leptonica
-version             1.73
-revision            0
+version             1.74.1
 categories          graphics science devel
 platforms           darwin
 license             BSD
 
 maintainers         stromnov openmaintainer
 
-description         Leptonica is a image processing and image analysis library.
+description         Leptonica is an image processing and image analysis library.
 long_description    ${description}
 
 homepage            http://www.leptonica.com/
-master_sites        http://www.leptonica.com/source/
 
-checksums           rmd160  a95b69ca0ea40203519b2cf59ea71f037179fb46 \
-                    sha256  19e4335c674e7b78af9338d5382cc5266f34a62d4ce533d860af48eaa859afc1
+checksums           rmd160  40dc2ae1fcb94cc32680aa65a588a86c93f1d3d0 \
+                    sha256  65d5ed5a5ea8e6d29327f20882a4c84fc4f49536647872d0c0dae1fd34d6addd
+
+use_autoreconf      yes
+# Calling glibtoolize here is a hack and can be removed after Leptonica 1.74.1.
+autoreconf.cmd      glibtoolize && ./autobuild
+
+depends_build       port:autoconf port:automake port:libtool port:m4
 
 depends_lib         port:tiff \
                     port:zlib \
@@ -30,7 +36,3 @@ depends_lib         port:tiff \
 
 # ${prefix}/bin/fileinfo
 conflicts-append    osxutils
-
-livecheck.type      regex
-livecheck.url       http://www.leptonica.com/download.html
-livecheck.regex     {leptonica-(\d+(?:\.\d+)*)\.[tz]}


### PR DESCRIPTION
This also involves switching to releases from GitHub.
Fix also a typo in the description.

Signed-off-by: Stefan Weil <sw@weilnetz.de>