### PR TITLE
tesseract: Fix URL for training data

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -453,7 +453,7 @@ foreach {lang_code lang_version lang_name lang_checksums} ${langs} {
 
             supported_archs     noarch
 
-            master_sites        https://github.com/tesseract-ocr/tessdata/raw/master/
+            master_sites        https://github.com/tesseract-ocr/tessdata/raw/3.04.00/
             distfiles           ${lang_code}.traineddata
 
             checksums           [string trim ${lang_checksums}]


### PR DESCRIPTION
The master branch contains training data for Tesseract 4.0
which does not work with Tesseract 3.04.

Signed-off-by: Stefan Weil <sw@weilnetz.de>