### PR TITLE
gnupg21: update to 2.1.18

### DIFF
--- a/mail/gnupg21/Portfile
+++ b/mail/gnupg21/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnupg21
-version             2.1.17
+version             2.1.18
 categories          mail security
 maintainers         jann ionic openmaintainer
 license             GPL-3+
@@ -22,9 +22,9 @@ master_sites        gnupg:gnupg
 
 use_bzip2           yes
 
-checksums           rmd160  4b297b524d3952206fc48022a25695c355c0e835 \
-                    sha256  c5dc54db432209fa8f9bdb071c8fb60a765ff28e363150e30bdd4543160243cb \
-                    sha1    d83ab893faab35f37ace772ca29b939e6a5aa6a7
+checksums           rmd160  a11128b9228b5b990fd8fe52923ea348d6571ffd \
+                    sha256  d04c6fab7e5562ce4b915b22020e34d4c1a256847690cf149842264fc7cef994 \
+                    sha1    b698012cc2d77c2652afd168a15e679d1394fa89
 
 notes               "GPG 2.1 uses a new format for its key files. Therefore you cannot\
                     use it together with any earlier version of GPG. Neither can you easily go\


### PR DESCRIPTION
###### Description
gnupg21: 2.1.17 -> 2.1.18

###### System Info
macOS version: 10.12.2

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [x] Have you tested basic functionality of all binary files?