### PR TITLE
miredo: update to 1.2.6

### DIFF
--- a/net/miredo/Portfile
+++ b/net/miredo/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 
 name                miredo
-version             1.2.2
-revision            1
-maintainers         nomaintainer
+version             1.2.6
+maintainers         icloud.com:l2dy openmaintainer
 
 categories          net
 description         Miredo is an open-source Teredo IPv6 tunneling software
@@ -17,14 +16,13 @@ long_description    ${description}. \
 platforms           darwin
 license             GPL-2
 
-homepage            http://www.remlab.net/miredo/
-master_sites        http://www.remlab.net/files/miredo/
+homepage            https://www.remlab.net/miredo/
+master_sites        https://www.remlab.net/files/miredo/
 
-use_bzip2           yes
+use_xz              yes
 
-checksums           md5     a04a40c4b42869968e00495636ff6d82 \
-                    sha1    9facd2ef23ae7a9969dfbe179a6c3ebddd87a2cc \
-                    rmd160  16c9ec08d5ae935027a49153dc44745e2cc916c7
+checksums           rmd160  b02b96f233df2211f45c0dad981f0a5ab6aa1789 \
+                    sha256  fa26d2f4a405415833669e2e2e22677b225d8f83600844645d5683535ea43149
 
 patchfiles          patch-nosignal.diff
 use_parallel_build  no
@@ -40,13 +38,11 @@ startupitem.create      yes
 startupitem.executable  ${prefix}/sbin/miredo -c ${prefix}/etc/miredo/miredo.conf \
                             -p ${prefix}/var/run/${name}.pid --foreground
 
+add_users ${miredo_user} group=${miredo_group}
+
 post-destroot {
     # Renaming of interface isn't supported
     reinplace "s|^InterfaceName|#InterfaceName|" ${destroot}${prefix}/etc/miredo/miredo.conf
-
-    # Create user and group
-    addgroup ${miredo_group}
-    adduser ${miredo_user} gid=[existsgroup ${miredo_group}]
 }
 
 livecheck.type  regex


### PR DESCRIPTION
###### Description
1.2.2_1 -> 1.2.6

###### System Info
macOS 10.12.2
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [x] Have you tested basic functionality of all binary files?