### PR TITLE
putty: update to 0.67 [security]

### DIFF
--- a/security/putty/Portfile
+++ b/security/putty/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                putty
-version             0.66
-revision            1
+version             0.67
 categories          security net
 platforms           darwin
 maintainers         nomaintainer
@@ -21,8 +20,8 @@ master_sites        ftp://ftp.chiark.greenend.org.uk/users/sgtatham/putty-${vers
                     http://the.earth.li/~sgtatham/putty/${version}/
 
 
-checksums           rmd160  2121860be81416f96a93963e4771a1edfca279dc \
-                    sha256  fe7312f66c54865868b362f4b79bd1fbe7ce9e8b1fd504b04034182db1f32993
+checksums           rmd160  910dc2257337eefcbe656d2d05bbf4ecc4fda22c \
+                    sha256  80192458e8a46229de512afeca5c757dd8fce09606b3c992fbaeeee29b994a47
 
 worksrcdir          ${worksrcdir}/unix
 


### PR DESCRIPTION
###### Description
0.66_1 -> 0.67, gui varient not tested.

CVE-2016-2563, see http://www.chiark.greenend.org.uk/~sgtatham/putty/wishlist/vuln-pscp-sink-sscanf.html.

###### System Info
macOS 10.12.3
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [x] Have you tested basic functionality of all binary files?