### PR TITLE
pure-ftpd: update to 1.0.44

### DIFF
--- a/net/pure-ftpd/Portfile
+++ b/net/pure-ftpd/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 
 name                pure-ftpd
 set pretty_name     Pure-FTPd
-version             1.0.42
+version             1.0.44
 
 categories          net
 platforms           darwin
 maintainers         pixilla openmaintainer
 license             BSD
 
-homepage            http://pureftpd.org/
+homepage            https://www.pureftpd.org/
 description         ${pretty_name} is a fast, production-quality, standard-conformant FTP (SSL/TLS) \
                     server, based upon Troll-FTPd.
 
@@ -22,17 +22,16 @@ long_description    ${pretty_name} has been designed to be secure in default con
                     fortune files, Apache-like log files, text / HTML / XML real-time status report,\
                     virtual users, virtual quotas, privilege separation, SSL/TLS and more.
 
-master_sites        ftp://ftp.pureftpd.org/pure-ftpd/releases/ \
-                    ftp://ftp.fr.pureftpd.org/pure-ftpd/releases/ \
-                    http://download.pureftpd.org/pub/pure-ftpd/releases/
+master_sites        https://download.pureftpd.org/pub/pure-ftpd/releases/ \
+                    ftp://ftp.pureftpd.org/pure-ftpd/releases/
 
 use_bzip2           yes
 
-checksums           rmd160  9e169a59846be32006842f5fb575f98657ffa26f \
-                    sha256  efd11295998453e31dbeef9159624beabbac2643a338134ae8c2ef529aa2ec10
+checksums           rmd160  b12624f1ded15639a59a34226f4454b24cec3b27 \
+                    sha256  30b65765cab64db04ebb983a8ff363a6d45fd1f99e9e5ec2fbdd40eba3c68b7a
 
 livecheck.type      regex
-livecheck.url       http://download.pureftpd.org/pub/${name}/releases/
+livecheck.url       https://download.pureftpd.org/pub/pure-ftpd/releases/
 livecheck.regex     ${name}-(\[0-9.\]+)\\.tar
 
 configure.args      --with-everything \


### PR DESCRIPTION
###### Description
1.0.42 -> 1.0.44

###### System Info
macOS 10.12.3
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [ ] Have you tested basic functionality of all binary files?