### PR TITLE
ldns: update to 1.7.0

### DIFF
--- a/net/ldns/Portfile
+++ b/net/ldns/Portfile
@@ -6,7 +6,7 @@ name                ldns
 subport             ldns-tools {}
 subport             drill {}
 
-version             1.6.17
+version             1.7.0
 categories          net devel
 platforms           darwin
 license             BSD
@@ -35,8 +35,8 @@ switch ${subport} {
 homepage            http://www.nlnetlabs.nl/projects/ldns/
 master_sites        http://www.nlnetlabs.nl/downloads/ldns/
 
-checksums           rmd160  5382cfaafa7ec1fadcf390f804fbf14e04d7c03a \
-                    sha256  8b88e059452118e8949a2752a55ce59bc71fa5bc414103e17f5b6b06f9bcc8cd
+checksums           rmd160  b0dfb70085258e69dda0fc343f0eece6df52e0a1 \
+                    sha256  c19f5b1b4fb374cfe34f4845ea11b1e0551ddc67803bd6ddd5d2a20f0997a6cc
 
 depends_build       bin:glibtool:libtool
 depends_lib         path:lib/libssl.dylib:openssl
@@ -66,6 +66,9 @@ if {${subport} eq "ldns"} {
 if {${subport} ne "drill"} {
     build.type          gnu
 }
+
+# OpenSSL 1.1.0 not available
+configure.args-append --disable-dane-ta-usage
 
 if {${subport} eq "ldns"} {
     pre-destroot {


### PR DESCRIPTION
###### Description
```
configure: error: OpenSSL does not support offline DANE verification (Needed for the DANE-TA usage type).
Please upgrade OpenSSL to version >= 1.1.0 or rerun with --disable-dane-verify or --disable-dane-ta-usage
```

###### System Info
macOS 10.12.3
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [x] Have you tested basic functionality of all binary files?