### PR TITLE
opus-tools: update to 0.1.10

### DIFF
--- a/audio/opus-tools/Portfile
+++ b/audio/opus-tools/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            opus-tools
-version         0.1.9
+version         0.1.10
 categories      audio
 license         BSD
 platforms       darwin
@@ -24,9 +24,8 @@ master_sites    http://downloads.xiph.org/releases/opus
 depends_lib     port:libopus port:libogg port:flac
 depends_build   port:pkgconfig
 
-checksums           sha1    03551ec3b206288e93a2f2bb18768a5a9e033206 \
-                    rmd160  dad0b21c6cdea8212643d8ffd48a58feb3dabd60 \
-                    sha256  b1873dd78c7fbc98cf65d6e10cfddb5c2c03b3af93f922139a2104baedb4643a
+checksums           rmd160  74eb1bbd31f1cc6a9ad706069f6341bc5d807762 \
+                    sha256  a2357532d19471b70666e0e0ec17d514246d8b3cb2eb168f68bb0f6fd372b28c
 
 compiler.blacklist  gcc-4.0 *gcc-4.2 {clang < 300}
 


### PR DESCRIPTION
###### Description


###### System Info
macOS 10.12.3
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you referenced relating tickets on [Trac](https://trac.macports.org/search) with full URL?
- [x] Have you checked your Portfile with `port lint --nitpick`?
- [x] Have you built your port locally with `port build`?
- [x] Have you tested basic functionality of all binary files?