### PR TITLE
spring-boot-cli: update to 1.4.4

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.4.3
+version         1.4.4
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    http://repo.spring.io/release/org/springframework/boot/${name}/$
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  2a009f6335a1731b1c008108873adc4289ea4ce5 \
-                sha256  b74e63f0c4f79f7d588ecff27556fb8f63a4bad14fe06471a831b19e70e1ccc8
+checksums       rmd160  6c7c08584b736b598db6e10164c2b84fb27fd353 \
+                sha256  f894c9726c48c6b4c9d65dc26e275533289684493e1d1efb288f5af21b52f3ad
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
Spring Boot 1.4.4 includes over 60 fixes, improvements and 3rd party dependency updates.

https://spring.io/blog/2017/01/26/spring-boot-1-4-4-available-now

https://github.com/spring-projects/spring-boot/milestone/77?closed=1