### PR TITLE
upx: add back universal variant and cleanup

### DIFF
--- a/archivers/upx/Portfile
+++ b/archivers/upx/Portfile
@@ -6,7 +6,6 @@ PortGroup        github 1.0
 github.setup     upx upx 3.92 v
 github.tarball_from releases
 
-name             upx
 categories       archivers
 maintainers      gmail.com:cedric.luthi icloud.com:l2dy openmaintainer
 license          GPL-2+
@@ -25,6 +24,12 @@ checksums        rmd160  fa68e21ae88fc0fe2f4d70f7c93ff571fb165729 \
                  sha256  0378169c342a0f98dc93236deae42f72fda07d0b02d7f51e6147448ee7e77794
 
 use_configure    no
+
+variant universal {}
+
+build.env        CPPFLAGS="${configure.cppflags}" \
+                 CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                 LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
 
 depends_lib      port:ucl port:zlib
 


### PR DESCRIPTION
###### Description


###### System Info
macOS 10.12.3
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you referenced relating tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] Have you checked your Portfile with `port lint`?
- [ ] Have you tried a full install with `sudo port install`?
- [ ] Have you tested basic functionality of all binary files?