### PR TITLE
pop3proxy: fix livecheck.regex

### DIFF
--- a/mail/pop3proxy/Portfile
+++ b/mail/pop3proxy/Portfile
@@ -49,4 +49,4 @@ post-destroot {
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     ${name}-(\[0-9a-z.- \]+)${extract.suffix}
+livecheck.regex     ${name}-(\[0-9a-z.-\]+)${extract.suffix}


### PR DESCRIPTION
###### Description
```
Error: org.macports.livecheck for port pop3proxy returned: couldn't compile regular expression pattern: invalid character range
To report a bug, follow the instructions in the guide:
    http://guide.macports.org/#project.tickets
Error: Processing of port pop3proxy failed
```

###### System Info
macOS 10.12.3
Xcode 8.2.1

###### Verification
- [x] Have you checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] Have you referenced relating tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] Have you checked your Portfile with `port lint`?
- [ ] Have you tried a full install with `sudo port install`?
- [ ] Have you tested basic functionality of all binary files?