### PR TITLE
py-regions: initial commit of new Portfile

### DIFF
--- a/python/py-regions/Portfile
+++ b/python/py-regions/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set _name           regions
+set _n              [string index ${_name} 0]
+
+name                py-${_name}
+version             0.1
+categories-append   science
+platforms           darwin
+maintainers         gmail.com:Deil.Christoph openmaintainer
+
+description         Astropy affilated package for region handling
+long_description    ${description}
+
+homepage            https://github.com/astropy/regions
+master_sites        pypi:${_n}/${_name}/
+distname            ${_name}-${version}
+
+checksums           md5     772834a3c5fd7ca0b644ca17dd5ae62e \
+                    rmd160  3cd4af41627eab31890e4c8b61b82173c36cf8b4 \
+                    sha256  1a2d25abecb95b953b168d335d3b3dab30b9018937333a6d4d70c97650ccad2e
+
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    # By default, astropy downloads an astropy-helpers package for setup.py.
+    # The --offline and --no-git flags prevent this and use a bundled version.
+    build.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+    destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+
+    depends_build-append  port:py${python.version}-setuptools
+
+    depends_run-append    port:py${python.version}-astropy
+
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   [lindex ${master_sites} 0]
+    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+}


### PR DESCRIPTION
This  pull request adds a new port `py-regions` for https://pypi.python.org/pypi/regions .
`regions` is a new Astropy affilated package for region handling.

---

This pull request is part of me proposing a few (5-10) new Astropy-affiliated packages to Macports (http://www.astropy.org/affiliated/). I have volunteered to be the Astropy distribution coordinator for Macports (see http://www.astropy.org/team.html), and I'll focus on the most base and popular packages and the ones that have Cython / C extensions, i.e. where `pip install` possibly isn't trivial. In this case there's no C extension yet, but in the upcoming regions 0.2 release there will be.

I hope these additions to Macports are welcome!
Most of the packages I'm adding were also added to e.g. Debian in the past year or two.

---

The build and install of Astropy-affiliated packages is very uniform, and the Portfile here follows the structure of the one that was already reviewed and is working fine from `py-gammapy` (see #141).

I did locally test that this works:
```
cd python/py-regions
sudo port install subport=py35-regions
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages /opt/local/bin/python3.5 -c 'import regions; regions.test()'
```
except for a very minor issue that has been fixed in the development version of regions already (to be released in the coming weeks).