### PR TITLE
py-photutils: add initial version of Portfile

### DIFF
--- a/python/py-photutils/Portfile
+++ b/python/py-photutils/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set _name           photutils
+set _n              [string index ${_name} 0]
+
+name                py-${_name}
+version             0.3
+categories-append   science
+platforms           darwin
+maintainers         gmail.com:Deil.Christoph openmaintainer
+
+description         An Astropy package for photometry
+long_description    ${description}
+
+homepage            https://github.com/astropy/photutils
+master_sites        pypi:${_n}/${_name}/
+distname            ${_name}-${version}
+
+checksums           md5     51830cfa4f033883388055550901e5c8 \
+                    rmd160  c0ca9835792ee33e33b87185615c0f8c0719b61b \
+                    sha256  7a746229c1d538b671806c48f561fb7d85fabf460b23b828a8af8a66e0097872
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    # By default, astropy downloads an astropy-helpers package for setup.py.
+    # The --offline and --no-git flags prevent this and use a bundled version.
+    build.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+    destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+
+    depends_build-append  port:py${python.version}-setuptools
+
+    depends_run-append    port:py${python.version}-numpy \
+                          port:py${python.version}-astropy
+
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   [lindex ${master_sites} 0]
+    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+}


### PR DESCRIPTION
This pull request adds a new port py-photutils for https://pypi.python.org/pypi/photutils .
photutils is an Astropy affilated package for photometry.

---

This pull request is part of me proposing a few (5-10) new Astropy-affiliated packages to Macports.
As mentioned in #213, they are pretty much all the same in terms of build, and this should be OK.

Running the tests via
```
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages /opt/local/bin/python3.5 -c 'import photutils; photutils.test()'
```
results in a few fails because a few test data files have permissions to be only readable by ROOT:
```
$ ls -lh /opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/photutils/detection/tests/data/irafstarfind_test_thresh08.0_fwhm01.5.txt
-rw-------  1 root  wheel   2.5K Oct  9  2014 /opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/photutils/detection/tests/data/irafstarfind_test_thresh08.0_fwhm01.5.txt
```

Macports Python people and @astrofrog @larrybradley @bsipocz (maybe also CC @olebole as Debian astro packaging expert): Is this something you've encountered before with photutils or other Astropy-affiliated packages using astropy-helpers? Is it an issue with photutils or astropy-helpers? Or something that needs to be configured in the Macports Portfile?