### PR TITLE
tig: update to 2.2.1 and update homepage

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.2 tig-
-checksums           rmd160  11cbe17b2505e6b4e370f1cc5d3f45521ef17891 \
-                    sha256  0cb315ac31eb749eba4b700cec4c3c81934204487e04055cf76982f09b83b770
+github.setup        jonas tig 2.2.1 tig-
+github.tarball_from releases
+checksums           rmd160  b703931e634358db9d241fb0c4f64ba2acd47a54 \
+                    sha256  0b48080896de59179c45c980080b4b414bb235df65ad08d661a9c9e169c3fa71
 
 categories          devel
 maintainers         mk cal openmaintainer
 description         A text interface to git repositories
 long_description    ${description}
 
-homepage            http://jonas.nitro.dk/tig/
+homepage            https://jonas.github.io/tig/
 license             GPL-2+
 platforms           darwin
 


### PR DESCRIPTION
###### Description
Build NOT tested!

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -v -t install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)