### PR TITLE
Add py-reproject: Astro Python image reprojection package

### DIFF
--- a/python/py-reproject/Portfile
+++ b/python/py-reproject/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set _name           reproject
+set _n              [string index ${_name} 0]
+
+name                py-${_name}
+version             0.3.1
+categories-append   science
+platforms           darwin
+maintainers         gmail.com:Deil.Christoph openmaintainer
+
+description         Astropy affiliated package for image reprojection
+long_description    ${description}
+
+homepage            https://github.com/astrofrog/reproject
+master_sites        pypi:${_n}/${_name}/
+distname            ${_name}-${version}
+
+checksums           md5     075e174f9cbe8e853f1be4dbbb93d585 \
+                    rmd160  c75a239c0ce56db265c005e1fb4f12fb91523945 \
+                    sha256  4a5d9b290361d3804cd7a1bbbfe8af1a96a451faaa33be80e8e7b6a5f5add998
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    # By default, astropy downloads an astropy-helpers package for setup.py.
+    # The --offline and --no-git flags prevent this and use a bundled version.
+    build.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+    destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
+
+    depends_build-append  port:py${python.version}-setuptools
+
+    depends_run-append    port:py${python.version}-numpy \
+                          port:py${python.version}-scipy \
+                          port:py${python.version}-astropy \
+                          port:py${python.version}-healpy
+
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   [lindex ${master_sites} 0]
+    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+}


### PR DESCRIPTION
This PR adds an initial version of a Portfile for `py-reproject`, an Astropy affiliated package for image reprojection.

References:
* https://pypi.python.org/pypi/reproject
* http://reproject.readthedocs.io
* https://github.com/astrofrog/reproject

I did this locally on latest macOS, and didn't see any issues with install / tests:
```
cd python/py-reproject
sudo port -d install subport=py35-reproject
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages /opt/local/bin/python3.5 -c 'import reproject; reproject.test()'
```

As stated [here](http://reproject.readthedocs.io/en/stable/#requirements), `healpy` is an optional dependency. I guess it could be turned into a Macports variant, but I think it should be on by default. I think this would be mainly useful for people where HEALPIX or py-healpy install fails. As long as that works, I think it's OK to just always install the full functionality.
I've never written a Portfile with variants, so my suggestion would be to merge as-is, or someone more knowledgeable please add it if you think it's better to have optional dependencies in variants.