### PR TITLE
py-iminuit: Python fitting package

### DIFF
--- a/python/py-iminuit/Portfile
+++ b/python/py-iminuit/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+name                py-iminuit
+version             1.2
+maintainers         gmail.com:Deil.Christoph openmaintainer
+
+dist_subdir         ${name}/${version}
+
+categories-append   science
+description         MINUIT from Python - Fitting like a boss
+long_description    ${description}
+
+platforms           darwin
+license             LGPL
+
+homepage            https://github.com/iminuit/iminuit
+master_sites        pypi:i/iminuit/
+distname            iminuit-${version}
+checksums           md5     4701ec472cae42015e26251703e6e984 \
+                    rmd160  333e937fb2400a9ee245610be5a909778c3da6ef \
+                    sha256  7651105fc3f186cfb5742f075ffebcc5088bf7797d8ed124c00977eebe0d1c64
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    depends_build-append  port:py${python.version}-setuptools \
+                          port:py${python.version}-cython
+
+    depends_run-append    port:py${python.version}-numpy
+
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   [lindex ${master_sites} 0]
+    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+}


### PR DESCRIPTION
This PR adds an initial version of `py-iminuit`, a Python fitting package.

References:
* https://github.com/iminuit/iminuit
* https://pypi.python.org/pypi/iminuit
* http://iminuit.readthedocs.io

`iminuit` uses Cython to interface to the MINUIT C++ library, which comes bundled with `iminuit` and is built via `setup.py`. I hope that's OK, I'd prefer to package it like this, instead of trying to separate MINUIT out into a separate C++ package. I've never done this for iminuit, not sure if it works at all.

This works for me locally:
```
cd python/py-iminuit
sudo port -d install subport=py34-iminuit
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages /opt/local/bin/python3.4
# execute the basic example from http://iminuit.readthedocs.io/en/latest/index.html#in-a-nutshell
```

port contents looks OK to me:
https://gist.github.com/cdeil/cde01eb48908fcc81398ee94542bc843

This is my first C++/Python package in Macports.
If anyone has time for review or testing, it would be very much appreciated.

