### PR TITLE
haproxy: update to 1.7.2

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                haproxy
-version             1.6.9
+version             1.7.2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          net
 platforms           darwin
@@ -21,11 +21,11 @@ long_description    HAproxy is a high-performance and highly-robust TCP/HTTP \
                     to achieve up to ten thousands hits per second on modern \
                     hardware, even with thousands simultaneous connections.
 
-homepage            http://haproxy.1wt.eu/
+homepage            http://www.haproxy.org/
 master_sites        ${homepage}download/${branch}/src/
 
-checksums           rmd160  f2c1c2ec78bf72246ad70298712229b05a5e6035 \
-                    sha256  cf7d2fa891d2ae4aa6489fc43a9cadf68c42f9cb0de4801afad45d32e7dda133
+checksums           rmd160  a0e54e8d5a1aa224c814bc3af1cb368576ef6e8d \
+                    sha256  f95b40f52a4d61feaae363c9b15bf411c16fe8f61fddb297c7afcca0072e4b2f
 
 depends_lib         port:pcre
 


### PR DESCRIPTION
###### Description


###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v -t install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)