### PR TITLE
irssi: update to 1.0.0 [security]

### DIFF
--- a/irc/irssi/Portfile
+++ b/irc/irssi/Portfile
@@ -1,7 +1,7 @@
-PortSystem 1.0
+PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    irssi irssi 0.8.20
+github.setup    irssi irssi 1.0.0
 github.tarball_from releases
 
 categories      irc
@@ -21,8 +21,8 @@ platforms       darwin
 use_xz          yes
 conflicts       irssi-devel
 
-checksums       rmd160  84b03909188a8fb1de0589bb55cf2e0717b525b7 \
-                sha256  7882c4e821f5aac469c5e69e69d7e235f4986101285c675e81a9a95bfb20505a
+checksums       rmd160  c3cdb21acdc1b3b9d2a2f200a956af97f4370152 \
+                sha256  6a8a3c1fc6a021a2c02a693877b2e19cbceb3eccd78fce49e44f596f4bae4fb8
 
 depends_build   port:pkgconfig
 depends_lib     port:gettext path:lib/pkgconfig/glib-2.0.pc:glib2 port:libiconv port:ncurses \


### PR DESCRIPTION
###### Description
four remote crash issues: https://irssi.org/2017/01/05/irssi-0.8.21-released/.

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)