### PR TITLE
libevent: make it buildable against LibreSSL

### DIFF
--- a/devel/libevent/Portfile
+++ b/devel/libevent/Portfile
@@ -25,6 +25,9 @@ checksums           rmd160  f23ad93d555089535085c99f3f8cbb9ebae4fd53 \
 
 depends_lib         path:lib/libssl.dylib:openssl
 
+patchfiles          patch-libressl.diff
+patch.pre_args      -p1
+
 use_autoreconf      yes
 
 test.run            yes

--- a/devel/libevent/files/patch-libressl.diff
+++ b/devel/libevent/files/patch-libressl.diff
@@ -1,0 +1,91 @@
+diff --git a/openssl-compat.h b/openssl-compat.h
+index 69afc71..0f2dcb7 100644
+--- a/openssl-compat.h
++++ b/openssl-compat.h
+@@ -1,7 +1,7 @@
+ #ifndef OPENSSL_COMPAT_H
+ #define OPENSSL_COMPAT_H
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ 
+ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+ {
+@@ -30,6 +30,6 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+ 
+ #define TLS_method SSLv23_method
+ 
+-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
++#endif /* (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER) */
+ 
+ #endif /* OPENSSL_COMPAT_H */
+diff --git a/sample/https-client.c b/sample/https-client.c
+index 7483956..7566683 100644
+--- a/sample/https-client.c
++++ b/sample/https-client.c
+@@ -312,7 +312,7 @@ main(int argc, char **argv)
+ 	}
+ 	uri[sizeof(uri) - 1] = '\0';
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ 	// Initialize OpenSSL
+ 	SSL_library_init();
+ 	ERR_load_crypto_strings();
+@@ -480,7 +480,7 @@ main(int argc, char **argv)
+ 		SSL_CTX_free(ssl_ctx);
+ 	if (type == HTTP && ssl)
+ 		SSL_free(ssl);
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ 	EVP_cleanup();
+ 	ERR_free_strings();
+ 
+@@ -492,7 +492,7 @@ main(int argc, char **argv)
+ 	CRYPTO_cleanup_all_ex_data();
+ 
+ 	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
+-#endif /*OPENSSL_VERSION_NUMBER < 0x10100000L */
++#endif /* (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER) */
+ 
+ #ifdef _WIN32
+ 	WSACleanup();
+diff --git a/sample/le-proxy.c b/sample/le-proxy.c
+index 8d9b529..e2fbf45 100644
+--- a/sample/le-proxy.c
++++ b/sample/le-proxy.c
+@@ -259,7 +259,7 @@ main(int argc, char **argv)
+ 
+ 	if (use_ssl) {
+ 		int r;
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ 		SSL_library_init();
+ 		ERR_load_crypto_strings();
+ 		SSL_load_error_strings();
+diff --git a/sample/openssl_hostname_validation.c b/sample/openssl_hostname_validation.c
+index 40312f2..a60e38c 100644
+--- a/sample/openssl_hostname_validation.c
++++ b/sample/openssl_hostname_validation.c
+@@ -48,7 +48,7 @@ SOFTWARE.
+ 
+ #define HOSTNAME_MAX_SIZE 255
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ #define ASN1_STRING_get0_data ASN1_STRING_data
+ #endif
+ 
+diff --git a/test/regress_ssl.c b/test/regress_ssl.c
+index 681705f..490853f 100644
+--- a/test/regress_ssl.c
++++ b/test/regress_ssl.c
+@@ -186,7 +186,7 @@ get_ssl_ctx(void)
+ void
+ init_ssl(void)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ 	SSL_library_init();
+ 	ERR_load_crypto_strings();
+ 	SSL_load_error_strings();


### PR DESCRIPTION
Incorporates the following patch:
https://github.com/libevent/libevent/pull/445