### PR TITLE
perl5: update to 5.24.1, 5.22.3, 5.25.9

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                perl5
-version             5.24.0
+version             5.24.1
 categories          lang
 platforms           darwin freebsd linux
 license             {Artistic-1 GPL}
@@ -12,15 +12,6 @@ maintainers         mojca openmaintainer
 
 homepage            http://www.perl.org/
 master_sites        http://www.cpan.org/src/5.0/
-
-# obsolete Perl versions; remove after 2016-12-09
-foreach perl5.major {5.8 5.10 5.12 5.14} {
-    subport perl${perl5.major} {
-        version             5.22.0
-        replaced_by         perl5.22
-        PortGroup           obsolete 1.0
-    }
-}
 
 # current Perl versions
 #
@@ -33,15 +24,10 @@ set perl5.versions_info {
     5.16 3 4 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8
     5.18 4 3 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5
     5.20 3 2 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b
-    5.22 2 2 203afca8995ca426db0af48b78eb606b5d24011a  f2322b9b04fe0cdbca9fe755360da04892cb6483d44959457cfebc0bcddc8058
-    5.24 0 1 756bf07069e91eabe3dac3a47aec5097d48f8963  62328a53d157e8153b33e137594155f6f8b64418f7f9238210feb809585290e0
+    5.22 3 0 4a823625f60db7dd05c62ff73ff0ee0d66f07dfc  770dd077a67a382501ab195cc75eee0baa5efa3544892c9a713a5bdb2645449f
+    5.24 1 0 e824cb74998ebbbc3286fa353e64e75104d4c5b1  482ac5dca262b57d26c381382a3e057b22ede631fcce32523c004b8bf773f6f0
 }
-#   5.22 3-RC3 0 24f508e342cb824d96254e91ffd35b09ed740382  9074ac008f11aa5ea3df91a646fa8c23fec37923c729e06a8bc54be4fa710d07
-#   5.24 1-RC3 0 9d055aa3bc92b8cae2a1dd14fd29b7dde1345218  9be39db0b008d2c2d14ae4f6b92418260ce5eb7809a79d729686a0d461b96404
 #   5.25 3 0 268c9c45e4b4f296981be238c11332094fe559b9  0d406dc08717822cfc67937414cf38801ca7101b5a971465b88c0aee005fe823
-
-# NOTE: if you need to revbump perl, please consult with maintainer first
-#       to change the configure flags at the same time
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256} ${perl5.versions_info} {
     subport perl${perl5.v} {

--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -27,7 +27,7 @@ set perl5.versions_info {
     5.22 3 0 4a823625f60db7dd05c62ff73ff0ee0d66f07dfc  770dd077a67a382501ab195cc75eee0baa5efa3544892c9a713a5bdb2645449f
     5.24 1 0 e824cb74998ebbbc3286fa353e64e75104d4c5b1  482ac5dca262b57d26c381382a3e057b22ede631fcce32523c004b8bf773f6f0
 }
-#   5.25 3 0 268c9c45e4b4f296981be238c11332094fe559b9  0d406dc08717822cfc67937414cf38801ca7101b5a971465b88c0aee005fe823
+#   5.25 9 0 2b8c7b9708b7e817967f4757e2939943781efb8c  137af6bc72fdbc0c5f4aaf577a8aa04654443ad0539b2f0218b7b5af53a01ba8
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256} ${perl5.versions_info} {
     subport perl${perl5.v} {
@@ -74,7 +74,7 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256} ${pe
             patchfiles-append \
                             ${perl5.major}/fix-cxx-dNOOP-PR43150.patch
         }
-        if {${perl5.major} >= 5.22} {
+        if {${perl5.major} >= 5.22 && ${perl5.major} <= 5.24} {
             # failed test
             # https://trac.macports.org/ticket/51327
             patchfiles-append \
@@ -87,11 +87,15 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256} ${pe
                             ${perl5.major}/patch-dist-Time-HiRes-HiRes.xs.diff
             patchfiles-append \
                             ${perl5.major}/fix-ld-modification.patch
-        } else {
+        }
+        if {${perl5.major} < 5.24} {
             # Do not compile for 10.3/10.4
             # https://trac.macports.org/ticket/51980
             patchfiles-append \
                             ${perl5.major}/remove-10.3-target-PR126360.patch
+        }
+        if {${perl5.major} == 5.25} {
+            configure.args-append -Dusedevel
         }
 
         post-patch {

--- a/lang/perl5/files/5.25/avoid-bind9-linking.patch
+++ b/lang/perl5/files/5.25/avoid-bind9-linking.patch
@@ -1,0 +1,15 @@
+I guess the last line
+	loclibpth="$loclibpth /opt/local/lib/libgcc" ;;
+which is new in 5.22 needs some special "treatment".
+
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -487,7 +487,7 @@ i_dbm=undef;
+ # Configure doesn't detect ranlib on Tiger properly.
+ # NeilW says this should be acceptable on all darwin versions.
+ ranlib='ranlib'
+-
++libswanted="$(echo $libswanted | sed -e 's/bind //' -e 's/ bind//')"
+ # Catch MacPorts gcc/g++ extra libdir
+ case "$($cc -v 2>&1)" in
+ *"MacPorts gcc"*) loclibpth="$loclibpth /opt/local/lib/libgcc" ;;

--- a/lang/perl5/files/5.25/avoid-no-cpp-precomp-PR38913.patch
+++ b/lang/perl5/files/5.25/avoid-no-cpp-precomp-PR38913.patch
@@ -1,0 +1,11 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -130,7 +130,7 @@ esac
+ 
+ # Avoid Apple's cpp precompiler, better for extensions
+ if [ "X`echo | ${cc} -no-cpp-precomp -E - 2>&1 >/dev/null`" = "X" ]; then
+-    cppflags="${cppflags} -no-cpp-precomp"
++
+ 
+     # This is necessary because perl's build system doesn't
+     # apply cppflags to cc compile lines as it should.

--- a/lang/perl5/files/5.25/clean-up-paths.patch
+++ b/lang/perl5/files/5.25/clean-up-paths.patch
@@ -1,0 +1,37 @@
+--- Configure.orig
++++ Configure
+@@ -111,8 +111,8 @@ if test -d c:/. || ( uname -a | grep -i 
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
++paths='/bin /usr/bin /usr/ucb /usr/lbin'
++paths="$paths /opt/bin __PREFIX__/bin __PREFIX__ /opt/lbin"
+ paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+ paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+ paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+@@ -1443,7 +1443,7 @@ archobjs=''
+ i_whoami=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
++locincpth="__PREFIX__/include /usr/gnu/include"
+ locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
+ :
+ : no include file wanted by default
+@@ -1460,12 +1460,12 @@ libnames=''
+ : change the next line if compiling for Xenix/286 on Xenix/386
+ xlibpth='/usr/lib/386 /lib/386'
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
++loclibpth="__PREFIX__/lib /usr/gnu/lib"
+ loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
+ 
+ : general looking path for locating libraries
+ glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
++glibpth="$glibpth /usr/ccs/lib /usr/ucblib"
+ test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+ test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+ test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"

--- a/lang/perl5/files/5.25/config.h.ed
+++ b/lang/perl5/files/5.25/config.h.ed
@@ -1,0 +1,157 @@
+/define[ 	]PRINTF_FORMAT_NULL_OK/c
+#ifdef __LP64__
+/*#define PRINTF_FORMAT_NULL_OK	/ **/
+#else /* !__LP64__ */
+#define PRINTF_FORMAT_NULL_OK	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]LONGSIZE/c
+#ifdef __LP64__
+#define LONGSIZE 8		/**/
+#else /* !__LP64__ */
+#define LONGSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]CASTI32/c
+#ifdef __ppc__
+#define CASTI32		/**/
+#else /* !__ppc__ */
+/*#define CASTI32		/ **/
+#endif /* __ppc__ */
+.
+/define[ 	]CASTNEGFLOAT/a
+.
+.,.+1c
+#ifdef __i386__
+/*#define CASTNEGFLOAT		/ **/
+#define CASTFLAGS 1		/**/
+#else
+#define CASTNEGFLOAT		/**/
+#define CASTFLAGS 0		/**/
+#endif
+.
+/define[ 	]Quad_t/a
+.
+.,.+2c
+#ifdef __LP64__
+#   define Quad_t long	/**/
+#   define Uquad_t unsigned long	/**/
+#   define QUADKIND 2	/**/
+#else /* !__LP64__ */
+#   define Quad_t long long	/**/
+#   define Uquad_t unsigned long long	/**/
+#   define QUADKIND 3	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]PTRSIZE/c
+#ifdef __LP64__
+#define PTRSIZE 8		/**/
+#else /* !__LP64__ */
+#define PTRSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_BSD_SETPGRP/c
+#if __DARWIN_UNIX03
+/*#define USE_BSD_SETPGRP	/ **/
+#else /* !__DARWIN_UNIX03 */
+#define USE_BSD_SETPGRP	/**/
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]I32TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I32TYPE		int	/**/
+#define	U32TYPE		unsigned int	/**/
+#else /* !__LP64__ */
+#define	I32TYPE		long	/**/
+#define	U32TYPE		unsigned long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]I64TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I64TYPE		long	/**/
+#define	U64TYPE		unsigned long	/**/
+#else /* !__LP64__ */
+#define	I64TYPE		long long	/**/
+#define	U64TYPE		unsigned long long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]IVSIZE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	IVSIZE		8		/**/
+#define	UVSIZE		8		/**/
+#else /* !__LP64__ */
+#define	IVSIZE		4		/**/
+#define	UVSIZE		4		/**/
+#endif /* __LP64__ */
+.
+/NV_PRESERVES_UV$/a
+.
+.,.+1c
+#ifdef __LP64__
+#undef	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	53
+#else /* !__LP64__ */
+#define	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	32
+#endif /* __LP64__ */
+.
+/define[ 	]HAS_STDIO_STREAM_ARRAY/a
+.
+.,.+3c
+#if __DARWIN_UNIX03
+/*#define	HAS_STDIO_STREAM_ARRAY	/ **/
+#define STDIO_STREAM_ARRAY	
+#else /* !__DARWIN_UNIX03 */
+#define	HAS_STDIO_STREAM_ARRAY	/**/
+#define STDIO_STREAM_ARRAY	__sF
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]USE_64_BIT_INT/c
+#ifdef __LP64__
+#define	USE_64_BIT_INT		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_INT		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_64_BIT_ALL/c
+#ifdef __LP64__
+#define	USE_64_BIT_ALL		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_ALL		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]Gid_t_f/c
+#ifdef __LP64__
+#define	Gid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Gid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]Size_t_size/c
+#ifdef __LP64__
+#define Size_t_size 8		/* */
+#else /* !__LP64__ */
+#define Size_t_size 4		/* */
+#endif /* __LP64__ */
+.
+/define[ 	]Uid_t_f/c
+#ifdef __LP64__
+#define	Uid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Uid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]NEED_VA_COPY/c
+#ifdef __LP64__
+#define	NEED_VA_COPY		/**/
+#else /* !__LP64__ */
+/*#define	NEED_VA_COPY		/ **/
+#endif /* __LP64__ */
+.
+w

--- a/lang/perl5/files/5.25/fix-miniperl-linking-PR36438.patch
+++ b/lang/perl5/files/5.25/fix-miniperl-linking-PR36438.patch
@@ -1,0 +1,11 @@
+--- Makefile.SH.orig
++++ Makefile.SH
+@@ -998,7 +998,7 @@ NAMESPACEFLAGS = -force_flat_namespace
+ 		$spitshell >>$Makefile <<'!NO!SUBS!'
+ lib/buildcustomize.pl: $& $(miniperl_objs) write_buildcustomize.pl
+ 	-@rm -f miniperl.xok
+-	$(CC) $(CLDFLAGS) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
++	unset LIBRARY_PATH && $(CC) $(subst -L__PREFIX__/lib,,$(CLDFLAGS)) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
+ 	    $(miniperl_objs) $(libs)
+ 	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
+ 	$(MINIPERL) -f write_buildcustomize.pl

--- a/lang/perl5/files/5.25/install-under-short-version-PR43480.patch
+++ b/lang/perl5/files/5.25/install-under-short-version-PR43480.patch
@@ -1,0 +1,39 @@
+https://trac.macports.org/ticket/43480
+--- Configure.orig
++++ Configure
+@@ -4378,6 +4378,8 @@ dos|vms)
+ *)
+ 	version=`echo $revision $patchlevel $subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
++	version_short=`echo $revision $patchlevel | \
++		 $awk '{ printf "%d.%d\n", $1, $2 }'`
+ 	api_versionstring=`echo $api_revision $api_version $api_subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
+ 	;;
+@@ -7359,7 +7361,7 @@ esac
+ : /opt/perl/lib/perl5... would be redundant.
+ : The default "style" setting is made in installstyle.U
+ case "$installstyle" in
+-*lib/perl5*) set dflt privlib lib/$package/$version ;;
++*lib/perl5*) set dflt privlib lib/$package/$version_short ;;
+ *)	 set dflt privlib lib/$version ;;
+ esac
+ eval $prefixit
+@@ -7607,7 +7609,7 @@ siteprefixexp="$ansexp"
+ prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ case "$sitelib" in
+ '') case "$installstyle" in
+-	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version ;;
++	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version_short ;;
+ 	*)	 dflt=$siteprefix/lib/site_$prog/$version ;;
+ 	esac
+ 	;;
+@@ -8025,7 +8027,7 @@ case "$vendorprefix" in
+ 	'')
+ 		prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ 		case "$installstyle" in
+-		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version ;;
++		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version_short ;;
+ 		*)	     dflt=$vendorprefix/lib/vendor_$prog/$version ;;
+ 		esac
+ 		;;


### PR DESCRIPTION
This updates perl5 to the latest version, but:
* requires testing on 10.12 (including a full `port -v test perl5.24`)
* one of the tests fails (at least on 10.7) and might require fixing, see: https://trac.macports.org/ticket/53440
I submitted this pull request to simplify testing, but please don't merge it until the two points above have been addressed.

Any testing of 5.25 is also welcome (just uncomment the line for 5.25 and move it up a bit), in particular on the very old OSes and on 10.12.