### PR TITLE
tigervnc: update to 1.7.1 and destroot fix [security]

### DIFF
--- a/x11/tigervnc/Portfile
+++ b/x11/tigervnc/Portfile
@@ -6,7 +6,7 @@ PortGroup               conflicts_build 1.0
 PortGroup               github 1.0
 PortGroup               muniversal 1.0
 
-github.setup            TigerVNC tigervnc 1.7.0 v
+github.setup            TigerVNC tigervnc 1.7.1 v
 conflicts               vnc tightvnc
 categories              x11 vnc
 maintainers             ryandesign openmaintainer
@@ -23,8 +23,8 @@ long_description        TigerVNC is an advanced VNC implementation. \
 
 homepage                http://www.tigervnc.com/
 
-checksums               rmd160  c0bbf134574122b62b2ff0566a77a7509404d3f5 \
-                        sha256  27b3b5d08ea80636e6d023d33a87eb02f8c7e03e6064a99631511aa32cf1b9ad
+checksums               rmd160  837aac1c72218cc7717cb9f0cfebdab8c5360ec5 \
+                        sha256  fc9c7617c1500b815708912e78455c13d0c68e10a377cf6c83a05ca2cd951245
 
 depends_lib             port:gettext \
                         port:gnutls \
@@ -43,7 +43,7 @@ if {[file exists ${prefix}/include/os/os.h]} {
 
 cmake.out_of_source     yes
 
-build.target            dmg
+build.target            translations dmg
 
 if {[variant_isset universal]} {
     merger-post-destroot {


### PR DESCRIPTION

###### Description
Patch from https://trac.macports.org/ticket/53426.

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)