### PR TITLE
libuv: update to 1.10.2

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -16,9 +16,9 @@ long_description \
 
 if {${subport} eq ${name}} {
 
-    github.setup    libuv libuv 1.10.1 v
-    checksums       rmd160 f24bec531b6f1735670e6ac1abae7de70c65bc82 \
-                    sha256 cba13fd6ac9729b0ae8fcec2d4920d1dfbb72ac56aedddd3e6aa7ef41affd10d
+    github.setup    libuv libuv 1.10.2 v
+    checksums       rmd160 2b132ca4858c15f6f49ab336f459cf595d1ed3c5 \
+                    sha256 4d16de46c5cdc6f0a44ba1793b43663ba6fd63be8602de4ee4f38b4f3b6870c3
 
     conflicts       libuv-devel
 


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?