### PR TITLE
libopus: update to 1.1.4

### DIFF
--- a/audio/libopus/Portfile
+++ b/audio/libopus/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            libopus
-version         1.1.3
+version         1.1.4
 categories      audio
 license         BSD
 platforms       darwin
@@ -26,8 +26,8 @@ platform i386 {
     compiler.blacklist *gcc-4.* {clang < 500}
 }
 
-checksums       rmd160  d498f13d81f3337a2e0b6683c09280955ec3d705 \
-                sha256  58b6fe802e7e30182e95d0cde890c0ace40b6f125cffc50635f0ad2eef69b633
+checksums       rmd160  a5cb4400e6e41be23d522cfffb04f14e1ac555f1 \
+                sha256  9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1dbb27ad59d8692
 
 distname        opus-${version}
 


### PR DESCRIPTION
###### Description
> This Opus 1.1.4 release fixes a single bug. A specially-crafted Opus packet could cause an integer wrap-around in the SILK LSF stabilization code. This would cause an out-of-bounds read 256 bytes before a constant table. In most circumstances, the consequences are harmless and the result is simply noise in the audio.

> This was reported as CVE-2017-0381. Contrary to that report, our own analysis shows that no remote code execution is possible. However, we are making this release as a precaution.

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?