### PR TITLE
libssh2: update to 1.8.0

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libssh2
-version             1.7.0
+version             1.8.0
 categories          devel net
 platforms           darwin
 maintainers         wohner.eu:normen
@@ -20,8 +20,8 @@ license             BSD
 homepage            http://www.libssh2.org/
 master_sites        ${homepage}download/
 
-checksums           rmd160  69dd061067e0512e5a08b2d8c4ca6166e22820ba \
-                    sha256  e4561fd43a50539a8c2ceb37841691baf03ecb7daf043766da1b112e4280d584
+checksums           rmd160  84c91d81503510673386714b30630fb3cb169725 \
+                    sha256  39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
 
 depends_lib         path:lib/libssl.dylib:openssl port:zlib
 


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?