### PR TITLE
spring-boot-cli: update to 1.5.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.4.4
+version         1.5.1
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    http://repo.spring.io/release/org/springframework/boot/${name}/$
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  6c7c08584b736b598db6e10164c2b84fb27fd353 \
-                sha256  f894c9726c48c6b4c9d65dc26e275533289684493e1d1efb288f5af21b52f3ad
+checksums       rmd160  b2bcd49aa916339a10d68326c3a34e9ec1f2103c \
+                sha256  6a5e871e63743683687a56829d947a54e84e19a8da1c84e13a8de40c1a93a9ca
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
Release notes: https://spring.io/blog/2017/01/30/spring-boot-1-5-1-released