### PR TITLE
rpcgen: new port

### DIFF
--- a/lang/rpcgen-mt/Portfile
+++ b/lang/rpcgen-mt/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                rpcgen-mt
+# The version of rpcgen from developer_cmds doesn't support the `-M` flag
+categories          lang devel
+platforms           darwin
+# no idea what to put here: permissive, restrictive?
+license             restrictive
+maintainers         mojca openmaintainer
+
+description         RPC protocol compiler
+long_description    The rpcgen utility is a tool that generates C code \
+                    to implement an RPC protocol. \
+                    The input to rpcgen is a language similar to C known as \
+                    RPC Language (Remote Procedure Call Language). \
+                    This port installs a FreeBSD fork with multithreading support.
+
+fetch.type          svn
+svn.pre_args-append --ignore-keywords
+#                   https://svnweb.freebsd.org/base/head/usr.bin/rpcgen/
+svn.url             https://svn.FreeBSD.org/base/head/usr.bin/rpcgen/
+svn.revision        327266
+# no idea what to put here
+version             ${svn.revision}
+
+# no idea what to put here
+homepage            https://en.wikipedia.org/wiki/RPCGEN
+
+worksrcdir          rpcgen
+
+depends_fetch-append\
+                    port:subversion
+
+patchfiles          patch-Makefile.diff \
+                    patch-nofreebsd.diff \
+                    patch-rpc_main.c.diff \
+
+post-patch {
+    reinplace       "s|@@PREFIX@@|${prefix}|g"   ${worksrcpath}/Makefile
+    reinplace       "s|@@CC@@|${configure.cc}|g" ${worksrcpath}/Makefile
+    reinplace       "s|@@CFLAGS@@|${configure.cflags} [get_canonical_archflags]|g" ${worksrcpath}/Makefile
+}
+
+use_configure       no
+
+# Do we need to put the copyright statement into a separate file?
+# Do we need to rename the binary?
+
+variant universal {}
+
+# I'm sure there must be a better way to find the latest modification in the folder
+livecheck.url       https://svnweb.freebsd.org/base/head/usr.bin/rpcgen/
+livecheck.type      regex
+livecheck.regex     "title=\"Revision (\\d*)\">\\d*</a> \\(of"

--- a/lang/rpcgen-mt/files/patch-Makefile.diff
+++ b/lang/rpcgen-mt/files/patch-Makefile.diff
@@ -1,0 +1,25 @@
+--- Makefile.orig
++++ Makefile
+@@ -1,7 +1,21 @@
+ # $FreeBSD$
+ 
++prefix=@@PREFIX@@
++CC=@@CC@@
++CFLAGS=@@CFLAGS@@
++INSTALL=install
++
+ PROG=	rpcgen
+ SRCS=	rpc_main.c  rpc_clntout.c rpc_cout.c rpc_hout.c rpc_parse.c \
+ 	rpc_sample.c rpc_scan.c rpc_svcout.c rpc_tblout.c rpc_util.c
+ 
+-.include <bsd.prog.mk>
++$(PROG):
++	$(CC) $(CFLAGS) $(SRCS) -o $(PROG)
++
++all: $(PROG)
++
++install: $(PROG)
++	mkdir -p $(DESTDIR)$(prefix)/bin/
++	mkdir -p $(DESTDIR)$(prefix)/share/man/man1
++	$(INSTALL) $(PROG) $(DESTDIR)$(prefix)/bin/$(PROG)-mt
++	$(INSTALL) $(PROG).1 $(DESTDIR)$(prefix)/share/man/man1/$(PROG)-mt.1

--- a/lang/rpcgen-mt/files/patch-nofreebsd.diff
+++ b/lang/rpcgen-mt/files/patch-nofreebsd.diff
@@ -1,0 +1,110 @@
+--- rpc_clntout.c.orig
++++ rpc_clntout.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_clntout.c 1.11 89/02/22 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_clntout.c, Client-stub outputter for the RPC protocol compiler
+--- rpc_cout.c.orig
++++ rpc_cout.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_cout.c 1.13 89/02/22 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_cout.c, XDR routine outputter for the RPC protocol compiler
+--- rpc_hout.c.orig
++++ rpc_hout.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_hout.c 1.12 89/02/22 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_hout.c, Header file outputter for the RPC protocol compiler
+--- rpc_main.c.orig
++++ rpc_main.c
+@@ -36,7 +36,7 @@ static char sccsid[] = "@(#)rpc_main.c 1.30 89/03/30 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_main.c, Top level of the RPC protocol compiler.
+--- rpc_parse.c.orig
++++ rpc_parse.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_parse.c 1.8 89/02/22 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_parse.c, Parser for the RPC protocol compiler
+--- rpc_sample.c.orig
++++ rpc_sample.c
+@@ -30,7 +30,7 @@
+ /* #pragma ident	"@(#)rpc_sample.c	1.9	94/04/25 SMI" */
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_sample.c, Sample client-server code outputter for the RPC protocol compiler
+--- rpc_scan.c.orig
++++ rpc_scan.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_scan.c 1.11 89/02/22 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_scan.c, Scanner for the RPC protocol compiler
+--- rpc_svcout.c.orig
++++ rpc_svcout.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_svcout.c 1.29 89/03/30 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_svcout.c, Server-skeleton outputter for the RPC protocol compiler
+--- rpc_tblout.c.orig
++++ rpc_tblout.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_tblout.c 1.4 89/02/22 (C) 1988 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_tblout.c, Dispatch table outputter for the RPC protocol compiler
+--- rpc_util.c.orig
++++ rpc_util.c
+@@ -35,7 +35,7 @@ static char sccsid[] = "@(#)rpc_util.c 1.11 89/02/22 (C) 1987 SMI";
+ #endif
+ 
+ #include <sys/cdefs.h>
+-__FBSDID("$FreeBSD$");
++/*__FBSDID("$FreeBSD$");*/
+ 
+ /*
+  * rpc_util.c, Utility routines for the RPC protocol compiler

--- a/lang/rpcgen-mt/files/patch-rpc_main.c.diff
+++ b/lang/rpcgen-mt/files/patch-rpc_main.c.diff
@@ -1,0 +1,16 @@
+--- rpc_main.c.orig
++++ rpc_main.c
+@@ -82,11 +82,13 @@ static char pathbuf[MAXPATHLEN + 1];
+ static const char *allv[] = {
+ 	"rpcgen", "-s", "udp", "-s", "tcp",
+ };
++#define nitems(a) (sizeof(a)/sizeof(a[0]))
+ static int allc = nitems(allv);
+ static const char *allnv[] = {
+ 	"rpcgen", "-s", "netpath",
+ };
+ static int allnc = nitems(allnv);
++#undef nitems
+ 
+ /*
+  * machinations for handling expanding argument list


### PR DESCRIPTION
Mac ships its own `rpcgen`, but without support for the `-M` flag (thread-safe).

See for example:
https://lists.apple.com/archives/unix-porting/2005/Nov/msg00003.html

I took the ideas for writing the Portfile from the ticket
* https://trac.macports.org/ticket/47801

thanks to "pmusumeci" and @kurthindenburg.

I would like to ask for a careful review (not compiling, but for improving the details of the Portfile itself) before committing.

(I need `rpcgen` to package http://optics.eee.nottingham.ac.uk/vxi11/.)

This is the licence:
```
/*
 * Sun RPC is a product of Sun Microsystems, Inc. and is provided for
 * unrestricted use provided that this legend is included on all tape
 * media and as a part of the software program in whole or part.  Users
 * may copy or modify Sun RPC without charge, but are not authorized
 * to license or distribute it to anyone else except as part of a product or
 * program developed by the user.
 *
 * SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
 * WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
 * PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
 *
 * Sun RPC is provided with no support and without any obligation on the
 * part of Sun Microsystems, Inc. to assist in its use, correction,
 * modification or enhancement.
 *
 * SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
 * INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
 * OR ANY PART THEREOF.
 *
 * In no event will Sun Microsystems, Inc. be liable for any lost revenue
 * or profits or other special, indirect and consequential damages, even if
 * Sun has been advised of the possibility of such damages.
 *
 * Sun Microsystems, Inc.
 * 2550 Garcia Avenue
 * Mountain View, California  94043
 */
```