### PR TITLE
livecheck fixes

### DIFF
--- a/audio/sphinx3/Portfile
+++ b/audio/sphinx3/Portfile
@@ -46,5 +46,5 @@ post-destroot {
 }
 
 livecheck.type  regex
-livecheck.url   http://sourceforge.net/projects/cmusphinx/files
-livecheck.regex /${name}-(\[0-9.\]+)${extract.suffix}
+livecheck.url   https://sourceforge.net/projects/cmusphinx/files/sphinx3/
+livecheck.regex "/${name}/(\[0-9.\]+)/\""

--- a/audio/sphinxbase/Portfile
+++ b/audio/sphinxbase/Portfile
@@ -42,5 +42,5 @@ post-destroot {
 }
 
 livecheck.type  regex
-livecheck.url   http://sourceforge.net/projects/cmusphinx/files
-livecheck.regex /${name}-(\[0-9.\]+)${extract.suffix}
+livecheck.url   https://sourceforge.net/projects/cmusphinx/files/sphinxbase/
+livecheck.regex "/${name}/(\[0-9.\]+)/\""

--- a/audio/sphinxtrain/Portfile
+++ b/audio/sphinxtrain/Portfile
@@ -48,5 +48,5 @@ destroot {
 }
 
 livecheck.type  regex
-livecheck.url   http://sourceforge.net/projects/cmusphinx/files
-livecheck.regex /${real_name}-(\[0-9.\]+)${extract.suffix}
+livecheck.url   https://sourceforge.net/projects/cmusphinx/files/sphinxtrain/
+livecheck.regex "/${name}/(\[0-9.\]+)/\""

--- a/databases/percona-toolkit/Portfile
+++ b/databases/percona-toolkit/Portfile
@@ -73,4 +73,4 @@ post-destroot {
 }
 
 livecheck.url       http://www.percona.com/downloads/percona-toolkit/
-livecheck.regex     "<a href=\"/downloads/percona-toolkit/(\[^/\]+)/\""
+livecheck.regex     "<a href=\"/downloads/percona-toolkit/(\[^/\]+)/"

--- a/databases/tcl-sqlite3/Portfile
+++ b/databases/tcl-sqlite3/Portfile
@@ -44,7 +44,7 @@ build.type          gnu
 
 livecheck.type      regex
 livecheck.url       http://www.sqlite.org/download.html
-livecheck.regex     sqlite-(\[0-9\\.\]+\[0-9\])\\.
+livecheck.regex     for SQLite version (\\d+(?:\\.\\d+)*)\\.
 
 post-destroot {
     # Make sure the correct version is used, not sure why this is

--- a/devel/ocaml-uuidm/Portfile
+++ b/devel/ocaml-uuidm/Portfile
@@ -27,4 +27,4 @@ configure.args-append "--override bindir ${destroot}${prefix}/bin"
 
 livecheck.type      regex
 livecheck.url       http://erratique.ch/software/uuidm/releases
-livecheck.regex     {>uuidm-(.*)\.tbz}
+livecheck.regex     {> uuidm-(.*)\.tbz}

--- a/devel/treecc/Portfile
+++ b/devel/treecc/Portfile
@@ -34,6 +34,6 @@ test.run        yes
 test.target     check
 
 livecheck.type	regex
-livecheck.url	${homepage}
+livecheck.url	${homepage}pnet-packages.html
 livecheck.regex	treecc-(\[0-9\\.\]+)\\.
 

--- a/devel/trio/Portfile
+++ b/devel/trio/Portfile
@@ -28,5 +28,4 @@ post-configure {
 test.run         yes
 test.target      test
 
-livecheck.regex  trio (\[^ \]+) released
-livecheck.name   ctrio
+livecheck.regex  /trio-(\\d+(?:\\.\\d+)*).tar.gz

--- a/devel/uncrustify/Portfile
+++ b/devel/uncrustify/Portfile
@@ -22,5 +22,5 @@ checksums           rmd160  3dc2a87abbab255d5f9f7fb6bc7c9d35a79f2252 \
                     sha256  1df0e5a2716e256f0a4993db12f23d10195b3030326fdf2e07f8e6421e172df9
 
 livecheck.type      regex
-livecheck.url       http://sourceforge.net/projects/uncrustify/files/
-livecheck.regex     "${name}-(0\\.\\d+)\\.tar"
+livecheck.url       http://sourceforge.net/projects/uncrustify/files/uncrustify/
+livecheck.regex     "${name}-(0\\.\\d+)"

--- a/graphics/ogre/Portfile
+++ b/graphics/ogre/Portfile
@@ -96,6 +96,4 @@ post-destroot {
         ${destroot}${prefix}/share/doc/OGRE/Tutorials
 }
 
-livecheck.type      regex
-livecheck.url       ${homepage}download/source
-livecheck.regex     {>OGRE ([0-9.]+) Source}
+livecheck.regex     ogre_src_v(\\d+(?:-\\d+)*).tar.bz2

--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.0
 
-github.setup            davvil pdfpc 3.1.1 v
+github.setup            pdfpc pdfpc 3.1.1 v
 revision                1
 maintainers             nomaintainer
 
@@ -23,7 +23,7 @@ long_description    ${description}\
 platforms               darwin
 license                 GPL-2+
 
-homepage                http://${github.author}.github.com/${name}/
+homepage                https://${github.author}.github.io/
 
 fetch.type              git
 post-fetch {
@@ -41,4 +41,4 @@ cmake.out_of_source     yes
 
 livecheck.type          regex
 livecheck.url           ${homepage}
-livecheck.regex         "[quotemeta ${name}] (\\d+(?:\\.\\d+)*) released"
+livecheck.regex         "[quotemeta ${name}] (\\d+(?:\\.\\d+)*) release"

--- a/graphics/wxWidgets-python/Portfile
+++ b/graphics/wxWidgets-python/Portfile
@@ -134,5 +134,5 @@ post-destroot {
 }
 
 livecheck.type      regex
-livecheck.url       ${homepage}/downloads/
-livecheck.regex     Current Stable Release.*(2\\.\[0-9\]\\.\[0-9\]+)
+livecheck.url       ${homepage}downloads/
+livecheck.regex     Previous Stable Release.*(2\\.\[0-9\]\\.\[0-9\]+)

--- a/irc/silc-server/Portfile
+++ b/irc/silc-server/Portfile
@@ -36,5 +36,5 @@ configure.args          --with-etcdir=${prefix}/etc/${name} \
 universal_variant       no
 
 livecheck.type          regex
-livecheck.url           ${homepage}
+livecheck.url           ${homepage}server.html
 livecheck.regex         ${name}-(\[0-9.\]+)\\.tar

--- a/kde/prison/Portfile
+++ b/kde/prison/Portfile
@@ -27,4 +27,4 @@ checksums           rmd160  e3104f7b812176921f3e2ab0e4c3eb80b76d853e \
                     sha256  394f242c42a735689bfecef944093ca1b313e966df532cb96f579aa1daff1322
 
 livecheck.url       ${kde4.mirror}${name}/
-livecheck.regex     >(\\d+(\\.\\d+)+)/
+livecheck.regex     >(\\d+(?:\\.\\d+)+)</a>/

--- a/kde/skrooge/Portfile
+++ b/kde/skrooge/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  48b8779f6e7522a360709d12c16bf7325c8566ff \
 
 livecheck.type      regex
 livecheck.url       http://skrooge.org
-livecheck.regex     "Skrooge (\[\\d+.\]+) released"
+livecheck.regex     "release-(\\d+(?:\\.\\d+)*)-"
 
 depends_lib-append  port:kdelibs4 \
                     port:libofx \

--- a/lang/ocaml3-camlp5/Portfile
+++ b/lang/ocaml3-camlp5/Portfile
@@ -47,4 +47,4 @@ universal_variant   no
 
 livecheck.type  regex
 livecheck.url   [lindex ${master_sites} 0]
-livecheck.regex ${name}-(\[0-9.\]+)\\.tgz
+livecheck.regex camlp5-(\[0-9.\]+)\\.tgz

--- a/lang/python24-doc/Portfile
+++ b/lang/python24-doc/Portfile
@@ -89,5 +89,5 @@ platform linux {
 }
 
 livecheck.type  regex
-livecheck.url   http://www.python.org/download/releases/
+livecheck.url   http://www.python.org/downloads/
 livecheck.regex Python (2.4.\[0-9\]+)

--- a/lang/python24/Portfile
+++ b/lang/python24/Portfile
@@ -216,6 +216,6 @@ variant universal {
 }
 
 livecheck.type          regex
-livecheck.url           ${homepage}download/releases/
+livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}.\[0-9\]+)
 

--- a/lang/python25/Portfile
+++ b/lang/python25/Portfile
@@ -219,5 +219,5 @@ if {${os.platform} eq "darwin" && ${os.major} >= 14} {
 }
 
 livecheck.type          regex
-livecheck.url           ${homepage}download/releases/
+livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}.\[0-9\]+)

--- a/lang/python26/Portfile
+++ b/lang/python26/Portfile
@@ -195,5 +195,5 @@ variant ucs4 description {Enable support for UCS4} {
 }
 
 livecheck.type          regex
-livecheck.url           ${homepage}download/releases/
+livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}(?:\\.\\d+)*)

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -164,6 +164,6 @@ variant ucs4 description {Enable support for UCS4} {
 }
 
 livecheck.type          regex
-#livecheck.url           ${homepage}download/releases/
+#livecheck.url           ${homepage}downloads/
 livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}(?:\\.\\d+)*)

--- a/lang/python31/Portfile
+++ b/lang/python31/Portfile
@@ -166,5 +166,5 @@ variant ucs4 description {Use 4-byte Unicode characters} {
 }
 
 livecheck.type          regex
-livecheck.url           ${homepage}download/releases/
+livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}(?:\\.\\d+)*)

--- a/lang/python32/Portfile
+++ b/lang/python32/Portfile
@@ -153,5 +153,5 @@ variant ucs4 description {Use 4-byte Unicode characters} {
 }
 
 livecheck.type          regex
-livecheck.url           ${homepage}download/releases/
+livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}(?:\\.\\d+)*)

--- a/lang/python33/Portfile
+++ b/lang/python33/Portfile
@@ -172,6 +172,6 @@ variant universal {
 }
 
 livecheck.type      regex
-#livecheck.url       ${homepage}download/releases/
+#livecheck.url       ${homepage}downloads/
 livecheck.url       ${homepage}downloads/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)

--- a/lang/python34/Portfile
+++ b/lang/python34/Portfile
@@ -188,6 +188,6 @@ variant universal {
 }
 
 livecheck.type      regex
-#livecheck.url       ${homepage}download/releases/
+#livecheck.url       ${homepage}downloads/
 livecheck.url       ${homepage}downloads/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)

--- a/lang/python35/Portfile
+++ b/lang/python35/Portfile
@@ -188,7 +188,7 @@ variant universal {
 }
 
 livecheck.type      regex
-#livecheck.url       ${homepage}download/releases/
+#livecheck.url       ${homepage}downloads/
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)
 #regex below just for test releases, proper above

--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -190,7 +190,7 @@ variant universal {
 }
 
 livecheck.type      regex
-#livecheck.url       ${homepage}download/releases/
+#livecheck.url       ${homepage}downloads/
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)
 #regex below just for test releases, proper above

--- a/lang/see/Portfile
+++ b/lang/see/Portfile
@@ -13,7 +13,7 @@ long_description    The Simple ECMAScript Engine ('SEE') is a parser and \
 license             BSD
 homepage            http://www.adaptive-enterprises.com.au/~d/software/see/
 
-livecheck.regex     {'see-(.*)\.tar\.gz'}
+livecheck.regex     {see-(\d+(?:\.\d+)*)\.tar\.gz}
 livecheck.type      regex
 livecheck.url       ${homepage}
 

--- a/lang/squirrel/Portfile
+++ b/lang/squirrel/Portfile
@@ -58,4 +58,5 @@ destroot {
         ${destroot}${prefix}/include
 }
 
-livecheck.version       [string map {. _} $version]
+livecheck.type          regex
+livecheck.regex         The current stable release is (\\d+(?:\\.\\d+)*)

--- a/lang/tclxml/Portfile
+++ b/lang/tclxml/Portfile
@@ -24,6 +24,4 @@ checksums               md5  9d1605246c899eff7db591bca3c23200 \
                         rmd160  618d19c83159e85b1f95e4e8a173280d9ecb647c
 depends_run             port:tcl port:tcllib port:libxml2
 configure.args          --with-prefix=${prefix} --with-tcl=${prefix}/lib
-livecheck.type  regex
-livecheck.url   http://sourceforge.net/project/showfiles.php?group_id=13178&package_id=13686
 livecheck.regex tclxml-(\[0-9\\.\]+)\\.tar.gz

--- a/lang/xmlgen/Portfile
+++ b/lang/xmlgen/Portfile
@@ -38,6 +38,4 @@ destroot                {
                         $doc_dest_dir
 }
 
-livecheck.type  regex
-livecheck.url   http://sourceforge.net/project/showfiles.php?group_id=13178&package_id=48507
 livecheck.regex xmlgen-(\[0-9\\.\]+)\\.tar.gz

--- a/math/reduce/Portfile
+++ b/math/reduce/Portfile
@@ -100,7 +100,8 @@ if {${name} eq ${subport}} {
     }
 
     livecheck.version       ${version_dashes}
-    livecheck.regex         {reduce-src-(\d{4}-\d{2}-\d{2})}
+    livecheck.url           https://sourceforge.net/projects/reduce-algebra/files/
+    livecheck.regex         {snapshot_(\d{4}-\d{2}-\d{2})}
 } else {
     livecheck.type          none
 }

--- a/math/yacas/Portfile
+++ b/math/yacas/Portfile
@@ -8,7 +8,7 @@ revision            1
 categories          math
 platforms           darwin
 license             GPL-2
-homepage            http://yacas.sourceforge.net/
+homepage            http://www.yacas.org/
 maintainers         nomaintainer
 description         Yet Another Computer Algebra System
 long_description    YACAS is an easy to use, general purpose Computer Algebra\
@@ -48,5 +48,5 @@ variant server description {Add the ability to run as server} {
 
 test.run            yes
 
-livecheck.url       http://yacas.sourceforge.net/downloads.html
-livecheck.regex     "version (\\d(?:\\.\\d+)*)"
+livecheck.url       ${homepage}getting_started/downloads/
+livecheck.regex     "Current stable version \\((\\d+(?:\\.\\d+)*)\\)"

--- a/net/radmind/Portfile
+++ b/net/radmind/Portfile
@@ -78,4 +78,5 @@ platform darwin {
 	startupitem.stop			"/usr/bin/killall radmind"
 }
 
-livecheck.regex		<title>${name} ${name}-(.*) released.*</title>
+livecheck.type		regex
+livecheck.regex		<p>Radmind (\\d+(?:\\.\\d+)*) <a

--- a/office/topydo/Portfile
+++ b/office/topydo/Portfile
@@ -26,7 +26,3 @@ checksums           rmd160  ddac4980c437268f6513d8abfb67f2c2c1a365d2 \
 python.default_version  27
 
 depends_lib-append  port:py${python.default_version}-setuptools
-
-livecheck.type      regex
-livecheck.url       ${homepage}/releases
-livecheck.regex     /${github.author}/${github.project}/releases/tag/(${github.version})

--- a/php/pear-AWSSDKforPHP/Portfile
+++ b/php/pear-AWSSDKforPHP/Portfile
@@ -15,7 +15,7 @@ long_description    ${description}
 
 license             Apache-2
 livecheck.url       http://pear.amazonwebservices.com/feed.xml
-livecheck.regex     "<link href=\"http://pear.amazonwebservices.com/get/${pear.package}-((?!\.tgz).*)${extract.suffix}\"/>"
+livecheck.regex     "<id>http://pear.amazonwebservices.com/get/${pear.package}-((?!\.tgz).*)${extract.suffix}</id>"
 
 checksums           rmd160  c1ce8e011a584290669f85567a463e7be1b8c4e3 \
                     sha256  06de3e6cfae2e695a12b02d068010711bd6f998c7b272cdbebf3d04b52da5a82

--- a/python/py-astrolibcoords/Portfile
+++ b/python/py-astrolibcoords/Portfile
@@ -31,7 +31,6 @@ if {${name} ne ${subport}} {
 
     livecheck.type          none
 } else {
-    livecheck.type          regex
-    livecheck.url           [lindex ${master_sites} 0]
-    livecheck.regex         ${realname}-(\[0-9.\]+).tar.gz
+    # obsolete by py-astropy
+    livecheck.type          none
 }

--- a/python/py-cchardet/Portfile
+++ b/python/py-cchardet/Portfile
@@ -31,5 +31,5 @@ if {${name} ne ${subport}} {
     livecheck.type  none
 } else {
     livecheck.type  regex
-    livecheck.regex [format "%s-%s" ${realname} {(\d+(?:\.\d+)*)}]
+    livecheck.regex [format "%s/%s\"" ${realname} {(\d+(?:\.\d+)*)}]
 }

--- a/python/py-cx_Freeze/Portfile
+++ b/python/py-cx_Freeze/Portfile
@@ -16,7 +16,7 @@ long_description    cx_Freeze is a set of scripts and modules for freezing Pytho
                     scripts into executables in much the same way that py2exe and \
                     py2app do. Unlike these two tools, cx_Freeze is cross platform \
                     and should work on any platform that Python itself works on.
-homepage            http://cx-freeze.sourceforge.net/
+homepage            https://anthony-tuininga.github.io/cx_Freeze/
 
 master_sites        sourceforge:cx-freeze
 distname            cx_Freeze-${version}
@@ -30,5 +30,5 @@ if {${name} ne ${subport}} {
 } else {
     livecheck.type  regex
     livecheck.url   ${homepage}
-    livecheck.regex Download (\\d+\\.\\d+\\.\\d+) released
+    livecheck.regex <p>Version (\\d+\\.\\d+\\.\\d+), released
 }

--- a/python/py-demjson/Portfile
+++ b/python/py-demjson/Portfile
@@ -39,4 +39,4 @@ if {${name} ne ${subport}} {
 
 livecheck.type    regex
 livecheck.url     http://pypi.python.org/pypi/demjson/
-livecheck.regex   "demjson-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+livecheck.regex   "/demjson/(\\d+(?:\\.\\d+)*)\""

--- a/python/py-django-debug-toolbar/Portfile
+++ b/python/py-django-debug-toolbar/Portfile
@@ -30,5 +30,5 @@ if {${name} ne ${subport}} {
 } else {
     livecheck.type      regex
     livecheck.url       https://pypi.python.org/pypi/django-debug-toolbar
-    livecheck.regex     "django-debug-toolbar (0\.\[0-9\]+\.\[0-9\]+)"
+    livecheck.regex     "django-debug-toolbar-(\\d+(?:\\.\\d+)*)${extract.suffix}"
 }

--- a/python/py-formencode/Portfile
+++ b/python/py-formencode/Portfile
@@ -12,7 +12,7 @@ long_description        ${description}
 license                 PSF
 homepage                http://pypi.python.org/pypi/FormEncode/
 
-livecheck.regex         {>FormEncode (.+) :}
+livecheck.regex         {/FormEncode/(\d+(?:\.\d+)*)"}
 livecheck.type          regex
 livecheck.url           ${homepage}
 

--- a/ruby/rb-rbot/Portfile
+++ b/ruby/rb-rbot/Portfile
@@ -29,4 +29,4 @@ destroot.env        rake=rake
 set ruby.link_binaries_suffix ""
 
 livecheck.type      regex
-livecheck.regex     {Stable rbot: ([0-9.]+)}
+livecheck.regex     {<i class="page__subheading">(\d+(?:\.\d+)*)</i>}

--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -58,7 +58,7 @@ if {[string first "-devel" $subport] > 0} {
 
     livecheck.version   ${newrev}-${tag}
     livecheck.url       [lindex ${master_sites} 0]
-    livecheck.regex     <strong>dev-(\[0-9\]+-g\[0-9a-f\]+)
+    livecheck.regex     <strong>master-(\[0-9\]+-\[0-9a-f\]+)
 }
 
 # As OpenMPI creates compiler wrappers, there are lots of

--- a/science/root5/Portfile
+++ b/science/root5/Portfile
@@ -623,11 +623,6 @@ foreach ver ${gcc_versions} {
 }
 
 # ========================================================================================
-
-# default regex of github suggests version 6
-livecheck.regex     archive/v(5\[-0-9\]+)${extract.suffix}
-
-# ========================================================================================
 # The following have build issues, are obsolete or experimental.
 # ========================================================================================
 

--- a/science/udunits/Portfile
+++ b/science/udunits/Portfile
@@ -55,6 +55,4 @@ pre-destroot {
 #    configure.env-append    FC=${prefix}/bin/g95
 #    configure.env-append    FFLAGS="-O2 -fno-common"
 #}
-livecheck.type  regex
-livecheck.url   http://www.unidata.ucar.edu/downloads/udunits/index.jsp
-livecheck.regex {Deprecated, original version[ ]+\(([0-9]+\.[0-9]+\.[0-9]+)\)}
+livecheck.type  none

--- a/science/veriwell/Portfile
+++ b/science/veriwell/Portfile
@@ -42,4 +42,4 @@ post-destroot {
         ${docdir}
 }
 
-livecheck.regex "<title>VeriWell ${name} (.*) released.*</title>"
+livecheck.regex "/veriwell-(\\d+(?:\\.\\d+)*).tar.gz"

--- a/science/wcalc/Portfile
+++ b/science/wcalc/Portfile
@@ -55,5 +55,5 @@ post-destroot {
 }
 
 livecheck.type  regex
-livecheck.url   http://sourceforge.net/projects/${name}/files/
-livecheck.regex "${name}-(\\d+)${extract.suffix}"
+livecheck.url   http://sourceforge.net/projects/${name}/files/${name}/
+livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)"

--- a/shells/osh/Portfile
+++ b/shells/osh/Portfile
@@ -40,4 +40,4 @@ destroot.target     install install-doc install-exp
 
 livecheck.type      regex
 livecheck.url       ${master_sites}
-livecheck.regex     ${name}-(\\d{8})${extract.suffix}
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}

--- a/sysutils/wait_on/Portfile
+++ b/sysutils/wait_on/Portfile
@@ -40,4 +40,4 @@ destroot.args       PREFIX=${prefix} \
 
 livecheck.type      regex
 livecheck.url       ${homepage}
-livecheck.regex     ${name} (\[0-9.\]+)
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*).tar.gz

--- a/sysutils/zeroinstall-injector/Portfile
+++ b/sysutils/zeroinstall-injector/Portfile
@@ -84,5 +84,6 @@ test.dir	${worksrcpath}/tests
 test.target	testall.py
 }
 
-livecheck.name	zero-install
-livecheck.distname	injector
+livecheck.type  regex
+livecheck.url   https://sourceforge.net/projects/zero-install/files/injector/
+livecheck.regex /injector/(\\d+(?:\\.\\d+)*)/

--- a/tex/tex-beamerposter/Portfile
+++ b/tex/tex-beamerposter/Portfile
@@ -40,5 +40,5 @@ destroot {
 post-activate { system "mktexlsr" }
 
 livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "beamerposter\.sty\.(\\d+(?:\\.\\d+)*)"
+livecheck.url       http://www.ctan.org/pkg/beamerposter
+livecheck.regex     "<td>(\\d+(?:\\.\\d+)*) "

--- a/tex/xindy/Portfile
+++ b/tex/xindy/Portfile
@@ -54,5 +54,5 @@ default_variants +doc
 
 livecheck.type  regex
 livecheck.url   http://www.ctan.org/tex-archive/indexing/xindy/base/
-livecheck.regex "${name}-(\[0-9.\]+)${extract.suffix}"
+livecheck.regex "sion</td><td>(\\d+(?:\\.\\d+)*) </td>"
 

--- a/textproc/ocaml-xtmpl/Portfile
+++ b/textproc/ocaml-xtmpl/Portfile
@@ -27,6 +27,6 @@ configure {
 }
 
 livecheck.type      regex
-livecheck.url       ${master_sites}
+livecheck.url       ${master_sites}download.html
 livecheck.regex     xtmpl-(\[0-9\.]+)${extract.suffix}
 

--- a/textproc/pdftohtml/Portfile
+++ b/textproc/pdftohtml/Portfile
@@ -27,4 +27,4 @@ destroot {
 }
 
 livecheck.version   0.40
-livecheck.regex     "<title>.* pdftohtml (.*) released.*</title>"
+livecheck.regex     "pdftohtml-(\\d+(?:\\.\\d+)*).tar.gz"

--- a/textproc/saxon/Portfile
+++ b/textproc/saxon/Portfile
@@ -56,4 +56,4 @@ destroot {
 
 livecheck.type      regex
 livecheck.url       ${homepage}
-livecheck.regex     The current maintenance release is (\[0-9.\]\\.\[0-9.\]\\.\[0-9.\]\\.\[0-9.\]).
+livecheck.regex     release on the 9.6 branch is (\[0-9.\]\\.\[0-9.\]\\.\[0-9.\]\\.\[0-9.\]).

--- a/textproc/wv/Portfile
+++ b/textproc/wv/Portfile
@@ -35,4 +35,6 @@ configure.args	--mandir=${prefix}/share/man
 
 universal_variant no
 
-livecheck.regex "<title>${name} (.*) released.*</title>"
+livecheck.type  regex
+livecheck.url   https://sourceforge.net/projects/wvware/files/wv/
+livecheck.regex "wvware/files/wv/(\\d+(?:\\.\\d+)*)/"

--- a/www/phantomjs/Portfile
+++ b/www/phantomjs/Portfile
@@ -48,4 +48,4 @@ destroot    {
     move ${worksrcpath}/examples ${destroot}${docdir}/examples
 }
 
-livecheck.regex     {phantomjs-(\d+(?:\.\d+)*)-source\.[tz]}
+livecheck.regex     {phantomjs-(\d+(?:\.\d+)*)-source\.zip}

--- a/www/phpicalendar/Portfile
+++ b/www/phpicalendar/Portfile
@@ -46,4 +46,4 @@ post-activate {
 	}
 }
 
-livecheck.regex     ${name}(\\d+\\.\\d+(\\.\\d+)?) released
+livecheck.regex     ${name}(\\d+(?:\\.\\d+)*).tgz

--- a/www/tiki/Portfile
+++ b/www/tiki/Portfile
@@ -39,5 +39,4 @@ destroot    {
     system "cd ${destroot}${prefix}/www/${name} && sudo sh ./setup.sh www www && chown -R www:www *"
 }
 
-livecheck.url       http://sourceforge.net/api/file/index/project-id/64258/rss?path=%2FTikiWiki%203.x%20-Betelgeuse-
-livecheck.regex     tikiwiki-(\\d+\\.\\d+)${extract.suffix}
+livecheck.regex     tiki-(\\d+\\.\\d+)${extract.suffix}

--- a/www/wordpress/Portfile
+++ b/www/wordpress/Portfile
@@ -27,7 +27,7 @@ depends_lib             port:php5-web \
                         port:php5-gd
 
 livecheck.type          regex
-livecheck.url           ${homepage}
+livecheck.url           ${homepage}download/
 livecheck.regex         "Download&nbsp;WordPress&nbsp;(\\d+(?:\\.\\d+)*)"
 
 use_configure           no

--- a/x11/sawfish/Portfile
+++ b/x11/sawfish/Portfile
@@ -43,4 +43,4 @@ exec sawfish
 }
 
 livecheck.url   http://download.tuxfamily.org/${name}/
-livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)"
+livecheck.regex "${name}_(\\d+(?:\\.\\d+)*)"


### PR DESCRIPTION
This PR is used to detect merge conflicts and should be merged before any massive refactoring.

Notes:
extract.suffix changed (requires update): indi, john-jumbo, lbdb, libtommath, mod_gnutls, pngquant
Moved to GitHub: kaffe, minimumprofit, ocaml-pcre, ocaml-zip, php5-unit-db, php5-unit-selenium, PlasmaShop, shogun, tiled, tuareg-mode.el, xpa, py-ezodf
Moved to Bitbucket: volta
Moved to LaunchPad: sahana2