### PR TITLE
pdnsd: update to 1.2.9a, fix livecheck

### DIFF
--- a/net/pdnsd/Portfile
+++ b/net/pdnsd/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name                pdnsd
-version             1.2.9
+version             1.2.9a
 categories          net
 platforms           darwin
 license             GPL-3
@@ -15,9 +15,8 @@ long_description    \
 homepage            http://members.home.nl/p.a.rombouts/pdnsd/
 master_sites        http://members.home.nl/p.a.rombouts/pdnsd/releases/
 distname            pdnsd-${version}-par
-checksums           md5     037f79d191b98974ffc2c9649727bf66 \
-                    sha256  772d50e8ab45e11a541a263f086ead18a795a0f97745c2215a5d8e7c0c4f92da \
-                    rmd160  0a584e03f6db8037ff6ef7289e279ff5ec71c34e
+checksums           rmd160  3ca151bac64c1d5ea3c4d400ab8a3993e6370145 \
+                    sha256  bb5835d0caa8c4b31679d6fd6a1a090b71bdf70950db3b1d0cea9cf9cb7e2a7b
 
 worksrcdir          ${name}-${version}
 
@@ -27,5 +26,6 @@ configure.args      --mandir=${prefix}/share/man \
                     --with-cachedir=${prefix}/var/cache/pdnsd \
                     --with-random-device=arc4random
 
-livecheck.type      freecode
-livecheck.version   ${version}-par
+livecheck.type      regex
+livecheck.url       "http://members.home.nl/p.a.rombouts/pdnsd/releases/?C=M;O=D"
+livecheck.regex     pdnsd-(\\d+(?:\\.\\d+)*\[a-z\]?)-par.tar.gz


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)