### PR TITLE
mapserver: update to 6.2.4 [security]

### DIFF
--- a/gis/mapserver/Portfile
+++ b/gis/mapserver/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                mapserver
-version             6.2.1
-revision            4
+version             6.2.4
 maintainers         hbaspecto.com:jea openmaintainer
 categories          gis
 license             permissive
@@ -17,9 +16,8 @@ long_description    MapServer is an Open Source development environment for \
 homepage            http://mapserver.org
 master_sites        http://download.osgeo.org/mapserver
 
-checksums           md5     8c48991dc54a307076b1fb670bc59ef9 \
-                    rmd160  4914dd5c5d400bc4f5d4cbdb40277b0b21967f24 \
-                    sha256  77087306246451df2cea3711e601f56ebf8a55f29ede4ca8e5f0433dfad743d5
+checksums           rmd160  690374d43a1b733c3b7acd73c37099d95554c599 \
+                    sha256  237d83f84042fef8a63c590256aaa3bc1400668a470b52252fae197d9689e41c
 
 depends_lib         port:gd2 \
                     port:jpeg \


### PR DESCRIPTION
###### Description
See https://lists.osgeo.org/pipermail/mapserver-dev/2017-January/015007.html.

Build NOT tested.

```
--->  Verifying Portfile for mapserver
Warning: Dependency port:gdal specified multiple times in depends_lib
Warning: Dependency port:libxml2 specified multiple times in depends_lib
Warning: Dependency port:curl specified multiple times in depends_lib
--->  0 errors and 3 warnings found.
```

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)