### PR TITLE
openjpeg: update to 2.1.2 [security]

### DIFF
--- a/graphics/openjpeg/Portfile
+++ b/graphics/openjpeg/Portfile
@@ -2,12 +2,12 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
+PortGroup           github 1.0
 
 # see #47197
 cmake.out_of_source yes
 
-name                openjpeg
-version             2.1.0
+github.setup        uclouvain openjpeg 2.1.2 v
 categories          graphics
 platforms           darwin
 license             BSD
@@ -21,11 +21,10 @@ long_description    The OpenJPEG library is an open-source JPEG 2000 codec. \
                     2000, the new still-image compression standard from the \
                     Joint Photographic Experts Group (JPEG).
 
-homepage            http://sourceforge.net/projects/openjpeg.mirror/
-master_sites        sourceforge:project/openjpeg.mirror/${version}/
+homepage            http://www.openjpeg.org/
 
-checksums           rmd160  dc6e77a2539ab4071cf1a1b62f653fea13707b54 \
-                    sha256  1232bb814fd88d8ed314c94f0bfebb03de8559583a33abbe8c64ef3fc0a8ff03
+checksums           rmd160  54f8a500ede8ded988dd5655a85215a5ce6d896a \
+                    sha256  fd2a136705d72e7bbf1a138d1e045fa41058aba20a459828978771e438ec2b4c
 
 depends_build-append \
                     port:pkgconfig
@@ -50,7 +49,3 @@ pre-activate {
         }
     }
 }
-
-livecheck.type      sourceforge
-livecheck.name      openjpeg.mirror
-livecheck.distname  ${livecheck.name}/files


### PR DESCRIPTION
###### Description
See https://github.com/uclouvain/openjpeg/blob/master/CHANGELOG.md#v212-2016-09-28.

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)