### PR TITLE
tcpdump: update to 4.9.0 [security]

### DIFF
--- a/net/tcpdump/Portfile
+++ b/net/tcpdump/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                tcpdump
-version             4.8.1
+version             4.9.0
 categories          net
 maintainers         mww openmaintainer
 license             BSD
@@ -15,8 +15,8 @@ homepage            http://www.tcpdump.org/
 platforms           darwin
 master_sites        ${homepage}release/
 
-checksums           rmd160  ebfb5465cf8141faca23bf355c93db69cf17cc6b \
-                    sha256  20e4341ec48fcf72abcae312ea913e6ba6b958617b2f3fb496d51f0ae88d831c
+checksums           rmd160  fd558121691cacd4ea1412ef422792a1aca525e1 \
+                    sha256  eae98121cbb1c9adbedd9a777bf2eae9fa1c1c676424a54740311c8abcee5a5e
 
 depends_lib         port:libpcap \
                     port:libsmi \


### PR DESCRIPTION
###### Description
the-tcpdump-group/tcpdump#584

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)