### PR TITLE
bitbucket PG: fix default livecheck

### DIFF
--- a/_resources/port1.0/group/bitbucket-1.0.tcl
+++ b/_resources/port1.0/group/bitbucket-1.0.tcl
@@ -57,6 +57,7 @@ proc handle_tarball_from {option action args} {
     if {[string equal ${action} "set"] && ${args} eq "downloads"} {
         bitbucket.tarball_from ${args}
         bitbucket.master_sites https://bitbucket.org/${bitbucket.author}/${bitbucket.project}/downloads
+        default livecheck.url ${bitbucket.master_sites}
         default distname {${bitbucket.project}-${bitbucket.version}}
     }
 }

--- a/games/gdash/Portfile
+++ b/games/gdash/Portfile
@@ -39,3 +39,5 @@ configure.args      --disable-glibtest \
 app.name            GDash
 app.executable      gdash
 app.icon            gdash.png
+
+livecheck.regex     "downloads/gdash-(\[0-9\]+unstable)${extract.suffix}"


### PR DESCRIPTION
for ports using bitbucket.tarball_from downloads