### PR TITLE
git: credential helper must be installed in libexec/git-core

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.11.0
+revision            1
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -209,7 +210,7 @@ variant credential_osxkeychain description {Install git credential-osxkeychain u
 
     pre-destroot {
         xinstall -m 755 "${worksrcpath}/contrib/credential/osxkeychain/git-credential-osxkeychain" \
-            "${destroot}${prefix}/bin/"
+            "${destroot}${prefix}/libexec/git-core/"
     }
 }
 


### PR DESCRIPTION
git expects to find credential helpers in libexec/git-core/ not bin.

The credential osxkeychain helper was being installed into bin/.