### PR TITLE
Update dvisvgm port to v. 2.1.

### DIFF
--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name                dvisvgm
-version             1.5.2
+version             2.1
 revision            1
 categories          graphics textproc
 platforms           darwin
@@ -12,12 +12,13 @@ long_description    \
     The command-line utility dvisvgm is a tool for TeX/LaTeX users. It \
     converts DVI files to the XML-based scalable vector graphics format SVG.
 
-homepage            http://dvisvgm.sourceforge.net/
-master_sites        sourceforge
-checksums           rmd160  fe7ab360a8267661b1e1e4c1a3497df3a9ef330d \
-                    sha256  cd79aa6b1b37aac6cbb56c94e4e8bc65efbf61000d590877275719c6638803ea
+homepage            http://dvisvgm.bplaced.net/
+master_sites        https://github.com/mgieseki/dvisvgm/releases/download/${version}/dvisvgm-${version}.tar.gz
+checksums           rmd160  fda73317c3c5be38be09855b4d262e05bf394b36 \
+                    sha256  4ae8f128cd1f1f1018623255e7160187ac24929bb1f940ba9cf993a2a3115bae
 
 depends_lib         port:freetype port:zlib port:potrace port:texlive-bin port:pkgconfig
 
 test.run            no
 
+configure.args	    --disable-woff

--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name                dvisvgm
-version             2.1
+version             2.1.1
 revision            1
 categories          graphics textproc
 platforms           darwin
@@ -14,11 +14,9 @@ long_description    \
 
 homepage            http://dvisvgm.bplaced.net/
 master_sites        https://github.com/mgieseki/dvisvgm/releases/download/${version}/dvisvgm-${version}.tar.gz
-checksums           rmd160  fda73317c3c5be38be09855b4d262e05bf394b36 \
-                    sha256  4ae8f128cd1f1f1018623255e7160187ac24929bb1f940ba9cf993a2a3115bae
+checksums           rmd160  56dc3805ab683322a9c20733c6f5f6792c695b60 \
+                    sha256  90f7a276a3fd2e0585faa356164145b936e69463317c4255a994b56b3ea00c33
 
 depends_lib         port:freetype port:zlib port:potrace port:texlive-bin port:pkgconfig
 
 test.run            no
-
-configure.args	    --disable-woff

--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -13,7 +13,7 @@ long_description    \
     converts DVI files to the XML-based scalable vector graphics format SVG.
 
 homepage            http://dvisvgm.bplaced.net/
-master_sites        https://github.com/mgieseki/dvisvgm/releases/download/${version}/dvisvgm-${version}.tar.gz
+master_sites        https://github.com/mgieseki/dvisvgm/releases/download/${version}/
 checksums           rmd160  56dc3805ab683322a9c20733c6f5f6792c695b60 \
                     sha256  90f7a276a3fd2e0585faa356164145b936e69463317c4255a994b56b3ea00c33
 


### PR DESCRIPTION
This is an update of the dvisvgm portfile to build 2.1.

Also this disables WOFF support, since this doesn't seem to compile on OSX currently.

I'll be looking to getting the WOFF support working in any case, but the current state should still be an improvement to the current version.

Trac ticket: https://trac.macports.org/ticket/53235