### PR TITLE
Update redis to 3.2.7

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                redis
-version             3.2.6
+version             3.2.7
 categories          databases
 platforms           darwin
 license             BSD
@@ -16,8 +16,8 @@ long_description    ${description}
 homepage            http://redis.io/
 master_sites        http://download.redis.io/releases/
 
-checksums           rmd160  742ed3ac4273c01ce70cd44c4d8d73825bfb7b2c \
-                    sha256  2e1831c5a315e400d72bda4beaa98c0cfbe3f4eb8b20c269371634390cf729fa
+checksums           rmd160  57d828f86a8f75089dd537a428938f2d12b72ef4 \
+                    sha256  bf9df3e5374bfe7bfc3386380f9df13d94990011504ef07632b3609bb2836fa9
 
 patchfiles          patch-redis.conf.diff
 


### PR DESCRIPTION
Version 3.2.7 has a patch for a security vulnerability so all developers running redis locally should upgrade. See https://www.reddit.com/r/redis/comments/5r8wxn/redis_327_is_out_important_security_fixes_inside/

This is my first time trying to update a Portfile, so please let me know if there is anything else I need to do.