### PR TITLE
git: install credential-osxkeychain during post-destroot.

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -208,7 +208,7 @@ variant credential_osxkeychain description {Install git credential-osxkeychain u
         system -W "${worksrcpath}/contrib/credential/osxkeychain" "make [join ${build.args}]"
     }
 
-    pre-destroot {
+    post-destroot {
         xinstall -m 755 "${worksrcpath}/contrib/credential/osxkeychain/git-credential-osxkeychain" \
             "${destroot}${prefix}/libexec/git-core/"
     }


### PR DESCRIPTION
See PR https://github.com/macports/macports-ports/pull/282

It broke `git` installation:

```
:debug:destroot Executing proc-pre-org.macports.destroot-destroot-0
:info:destroot xinstall: /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_git/git/work/git-2.11.0/contrib/subtree/git-subtree.1 -> /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_git/git/work/man1/git-subtree.1
:debug:destroot Executing proc-pre-org.macports.destroot-destroot-1
:info:destroot xinstall: /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_git/git/work/git-2.11.0/contrib/subtree/git-subtree.html -> /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_git/git/work/htmldocs/git-subtree.html
:debug:destroot Executing proc-pre-org.macports.destroot-destroot-2
:error:destroot Failed to destroot git: xinstall: Unable to create new file for: /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_git/git/work/destroot/opt/local/libexec/git-core/, No such file or directory
:debug:destroot Error code: NONE
:debug:destroot Backtrace: xinstall: Unable to create new file for: /opt/local/var/macports/build/_Users_xeron_workspace_devel_macports-ports_devel_git/git/work/destroot/opt/local/libexec/git-core/, No such file or directory
:debug:destroot     while executing
:debug:destroot "$pre $targetname"
:error:destroot See /opt/local/var/macports/logs/_Users_xeron_workspace_devel_macports-ports_devel_git/git/main.log for details.
```