### PR TITLE
Updates to AWS-related Python ports; add Python 3.6 support

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-awscli
-version             1.11.28
+version             1.11.45
 platforms           darwin
 license             Apache-2
 maintainers         pixilla openmaintainer
@@ -16,10 +16,10 @@ homepage            http://aws.amazon.com/cli/
 master_sites        pypi:a/awscli
 distname            awscli-${version}
 
-checksums           rmd160  c2ced8f98c727692eaaa035a4872345dc4d898cf \
-                    sha256  4f56328e3bef6618821f87db0e1fa0f584d49fde23b013da28cc2dd0ab402cff
+checksums           rmd160  6f7b4dd11c3102606b803250e91fc8ffea506f25 \
+                    sha256  ca0b6c8b544a6badd0159f5204c927a370802085dcaed64e754865fd096f696b
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 
@@ -31,7 +31,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-botocore \
                         port:py${python.version}-colorama \
                         port:py${python.version}-docutils \
-                        port:py${python.version}-jmespath \
+                        port:py${python.version}-yaml \
                         port:py${python.version}-rsa \
                         port:py${python.version}-s3transfer \
                         port:py${python.version}-yaml

--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-boto3
-version             1.2.3
+version             1.4.4
 platforms           darwin
 license             Apache-2
 maintainers         nomaintainer
@@ -16,17 +16,18 @@ homepage            https://github.com/boto/boto3
 master_sites        pypi:b/boto3
 distname            boto3-${version}
 
-checksums           rmd160  adcc22281811c6722c35ab4808a65d0bea20834a \
-                    sha256  091206847d296520e5ec57706a5e4b428d017352eb3168c6bcb9a1ac9feab224
+checksums           rmd160  d2c86bd6fc4e25b6cf45fb8c5bf7159774c18a66 \
+                    sha256  518f724c4758e5a5bed114fbcbd1cf470a15306d416ff421a025b76f1d390939
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_run-append \
                         port:py${python.version}-botocore \
-                        port:py${python.version}-jmespath
+                        port:py${python.version}-jmespath \
+                        port:py${python.version}-s3transfer
 
     livecheck.type      none
 } else {

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-botocore
-version             1.4.85
+version             1.5.8
 platforms           darwin
 license             Apache-2
 maintainers         pixilla openmaintainer
@@ -16,10 +16,10 @@ homepage            https://github.com/boto/botocore
 master_sites        pypi:b/botocore
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  60ef2d1dbb70c2dafe7260f1563e2856b281bfea \
-                    sha256  329155bfe2f5efb1fb0421cbc2a9a2563698828136f91712fa9f4ccb5be9b3bb
+checksums           rmd160  228bcaaad914cb885d6502c5019a5295fd6f84d2 \
+                    sha256  7f536fd7c31e858e7b24d95524479a7a612588df10f397ed1b11ee99a8c019e2
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-jmespath/Portfile
+++ b/python/py-jmespath/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jmespath
-version             0.9.0
+version             0.9.1
 platforms           darwin
 license             Permissive
 maintainers         pixilla openmaintainer
@@ -16,11 +16,11 @@ homepage            https://github.com/boto/${python.rootname}
 master_sites        pypi:j/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     471b7d19bd153ac11a21d4fb7466800c \
-                    rmd160  edb0afdbc63737ee73af0c81449c6ed493b48280 \
-                    sha256  08dfaa06d4397f283a01e57089f3360e3b52b5b9da91a70e1fd91e9f0cdd3d3d
+checksums           md5     a602b76abb2c0001b47c1bff810cf44e \
+                    rmd160  85f33b5ecb77e0289b489725325256ee9f3d22fd \
+                    sha256  e72d02de23c1814322f7c0dcffb46716271f9b52b129aace0ab6f5a0450d5f02
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-rsa/Portfile
+++ b/python/py-rsa/Portfile
@@ -22,7 +22,7 @@ distname            rsa-${version}
 checksums           rmd160  ed031a093373ab3c1a6d27d2d9e58235c0058809 \
                     sha256  25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-s3transfer/Portfile
+++ b/python/py-s3transfer/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-s3transfer
-version             0.1.9
+version             0.1.10
 platforms           darwin
 license             Apache-2
 maintainers         pixilla openmaintainer
@@ -15,11 +15,11 @@ long_description    ${description}
 homepage            https://github.com/boto/${python.rootname}
 master_sites        pypi:s/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           md5     036d467e77e0d4dfa65448d63a9208bc \
-                    rmd160  cdbd57c8617cf6a3f38a3049540d18b7d42c435a \
-                    sha256  17ad7d672115f93a72ed7917209cb0bb02fc87f96f11886408ed8a6b1bb4c754
+checksums           md5     976734d3ec36b8fc2c1b505a907c3259 \
+                    rmd160  9cf24471739a668c152271d2aad9caa0874e4187 \
+                    sha256  ba1a9104939b7c0331dc4dd234d79afeed8b66edce77bbeeecd4f56de74a0fc1
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools


### PR DESCRIPTION
Hello!

As a MacPorts user, I'd like to use MacPorts' builds of boto3 and the AWS CLI.  I'd also like to use them with the latest Python (3.6), and have them be up-to-date.  So, I've gone through the AWS-related ports, and updated them!

This pull request contains one commit per port updated.  I followed the same pattern on each port:

1) Update the checksums based on the .tar.gz files downloaded from PyPi.
2) Unpack the .tar.gz file and check `setup.cfg`.  Update the dependencies as appropriate.
3) Build the py36 subport of each port.

Exception: For `py-rsa`, it was already the current version.  I just added python36 to the `python.versions` list.

All of my tests were done on a macOS 10.12.2 system.

Everything built & installed cleanly.  To test, I focused on the `aws s3` command.  I generated a 20 GB file of random data, checksummed it, uploaded it (which invoked an S3 multi-part upload), re-downloaded it, and compared the checksum.  The commands were:

    dd if=/dev/urandom of=randomfile.test bs=1m count=20480
    md5sum randomfile.test > randomfile.test.md5
    aws s3 mv randomfile.test s3://stanfordkarl/some_path/randomfile.test --content-type application/octet-string
    rm randomfile.test
    aws s3 cp s3://stanfordkarl/some_path/randomfile.test randomfile.test
    md5sum --check randomfile.test.md5
    aws s3 rm s3://stanfordkarl/some_path/randomfile.test

py-boto3 has no maintainer.  All of the other ports have pixilla set as maintainer, but are also openmaintainer.  That's the reason why I felt OK in updating multiple ports in a single pull request, because they all have the same maintainer.

One thing I wasn't sure about: Some ports have an md5 checksum specified.  When an md5 checksum was specified, I made sure to update it, but I was wondering: Would you like me to remove them, so that there are only sha256 and rmd160 checksums?  If yes, I'll do that, and re-push.