### PR TITLE
bash-completion: update to 2.5

### DIFF
--- a/sysutils/bash-completion/Portfile
+++ b/sysutils/bash-completion/Portfile
@@ -1,7 +1,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    scop bash-completion 2.4
+github.setup    scop bash-completion 2.5
 epoch           1
 conflicts       bash-completion-devel
 categories      sysutils
@@ -15,10 +15,10 @@ long_description \
     is meant to be used together with the bash port.
 
 github.tarball_from releases
-use_xz yes
+use_xz          yes
 
-checksums       rmd160  a560b9b7242d09b775843990c42d34dcd2473e48 \
-                sha256  c0f76b5202fec9ef8ffba82f5605025ca003f27cfd7a85115f838ba5136890f6
+checksums       rmd160  5bfef559490ba6b2c41567fb4839bc3e5145c162 \
+                sha256  b0b9540c65532825eca030f1241731383f89b2b65e80f3492c5dd2f0438c95cf
 
 depends_run     port:bash
 


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)