### PR TITLE
git: update to 2.11.1

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.11.0
-revision            1
+version             2.11.1
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -18,15 +17,16 @@ homepage            http://git-scm.com/
 master_sites        https://www.kernel.org/pub/software/scm/git/ \
                     https://cdn.kernel.org/pub/software/scm/git/
 distname            git-${version}
+use_xz              yes
 distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}${extract.suffix} \
-                    rmd160  3bfee730144e0bdde7a91b3c05c97afb6725ab22 \
-                    sha256  d3be9961c799562565f158ce5b836e2b90f38502d3992a115dfb653d7825fd7e \
+                    rmd160  b0250e6c09ee4aa5516bab2b355854c20673ebdc \
+                    sha256  c0a779cae325d48a1d5ba08b6ee1febcc31d0657a6da01fd1dec1c6e10976415 \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  a642417b9dce25e12c9281c6f6145d4eb9f4c595 \
-                    sha256  437a0128acd707edce24e1a310ab2f09f9a09ee42de58a8e7641362012dcfe22
+                    rmd160  a454ebedf160dab26cf00040bcd046e568455d73 \
+                    sha256  69486ed339ee0591001ae83d43c888aa26351b9680b6ceb59e06b593051bca31
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -129,7 +129,7 @@ post-destroot {
     copy ${worksrcpath}/contrib ${share_path}
 
     xinstall -m 755 -d ${destroot}${prefix}/share/emacs/site-lisp/
-    eval xinstall -m 644 [glob ${worksrcpath}/contrib/emacs/*.el] \
+    xinstall -m 644 {*}[glob ${worksrcpath}/contrib/emacs/*.el] \
         ${destroot}${prefix}/share/emacs/site-lisp/
 
 }
@@ -142,8 +142,8 @@ variant pcre {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}${extract.suffix} \
-                            rmd160  b0ddf6af383caaab9133f6c5663c89c7d0aa3050 \
-                            sha256  0e8cf71f53873eec6a5716e79122ff387fecaede8be78c9c39a4f395e90d32e7
+                            rmd160  262a1b4bbac016853c3c21db07e4550b9baa8361 \
+                            sha256  1a5f1e4a5eadad89b0783efa08bb1f7e3802d4a4d0a135bf5f61fd672ea3846e
 
     patchfiles-append       git-subtree.html.diff
 


### PR DESCRIPTION
###### Description
Switched to xz for smaller archive, replaced `eval` according to lint.

Note for myself: `port test` takes too long.

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (delete if not applicable)
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)