### PR TITLE
liboping: update to 1.9.0, update homepage

### DIFF
--- a/net/liboping/Portfile
+++ b/net/liboping/Portfile
@@ -18,15 +18,15 @@ long_description    C library and ncurses-based frontend to generate ICMP \
 homepage            http://noping.cc/
 
 if {${subport} eq ${name}} {
-#   github.setup    octo liboping 1.8.0 liboping-
+#   github.setup    octo liboping 1.9.0 liboping-
     conflicts       liboping-devel
-    version         1.8.0
-    revision        2
+    version         1.9.0
 
     master_sites    ${homepage}files/
+    use_bzip2       yes
 
-    checksums       sha256  824792ae7fc5e9569bacc4167b89de31f6ba8476de44760f0bc272682e894b41 \
-                    rmd160  c17e66bcfe9e531746a850d0b68bbcd70b55d5bf
+    checksums       rmd160  aa948beef09854ddca2e4a8984b750cb9625822c \
+                    sha256  44bb1d88b56b88fda5533edb3aa005c69b3cd396f20453a157d7e31e536f3530
 
 } else {
     github.setup    octo liboping 74470ba


### PR DESCRIPTION
###### Description
Switching to github adds `use_autoreconf` and is not neccessary. Switched to bz2 to avoid conflicting checksums.

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)