### PR TITLE
pure-ftpd: update to 1.0.45, fix destroot

### DIFF
--- a/net/pure-ftpd/Portfile
+++ b/net/pure-ftpd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                pure-ftpd
 set pretty_name     Pure-FTPd
-version             1.0.44
+version             1.0.45
 
 categories          net
 platforms           darwin
@@ -27,8 +27,8 @@ master_sites        https://download.pureftpd.org/pub/pure-ftpd/releases/ \
 
 use_bzip2           yes
 
-checksums           rmd160  b12624f1ded15639a59a34226f4454b24cec3b27 \
-                    sha256  30b65765cab64db04ebb983a8ff363a6d45fd1f99e9e5ec2fbdd40eba3c68b7a
+checksums           rmd160  c12402c776bfbf0f679f661f42b4fee17d22d37a \
+                    sha256  9256db7e59abdba712f84581a3ec47cd5b039034c78825d9dc24ea4eecda7d20
 
 livecheck.type      regex
 livecheck.url       https://download.pureftpd.org/pub/pure-ftpd/releases/
@@ -40,13 +40,15 @@ configure.args      --with-everything \
                     --with-paranoidmsg \
                     --with-bonjour \
                     --without-inetd \
+                    --prefix=${prefix} \
                     --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info \
                     --sysconfdir=${prefix}/etc/${name}/conf \
                     --localstatedir=${prefix}/var
 
 destroot.destdir    prefix=${destroot}${prefix} \
-                    mandir=${destroot}${prefix}/share/man
+                    mandir=${destroot}${prefix}/share/man \
+                    sysconfdir=${destroot}${prefix}/etc/${name}/conf
 
 destroot.keepdirs   ${destroot}${prefix}/etc/${name}/ssl \
                     ${destroot}${prefix}/etc/${name}/conf \


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files? (delete if not applicable)