### PR TITLE
pari: update to 2.9.1

### DIFF
--- a/math/pari/Portfile
+++ b/math/pari/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                pari
-version             2.9.0
+version             2.9.1
 categories          math
 platforms           darwin
 license             GPL-2+
@@ -19,8 +19,8 @@ long_description    PARI/GP is a widely used computer algebra system designed \
 homepage            http://pari.math.u-bordeaux.fr/
 master_sites        ${homepage}pub/pari/unix/
 
-checksums           rmd160  38f14940c69bf81264838d8ee058a30848bd282a \
-                    sha256  4aa4f737ad41e856001b13194fab281d07ef030dfd5d0a890dc73fb9b3fd9266
+checksums           rmd160  34d44f73eb1a47aecaf0d780a875551b19654a0a \
+                    sha256  dc510f96686463c1ade7c2a6e16fa9466fd4af6a65fddf9822ba07d7d2e70767
 
 depends_lib         port:gmp \
                     port:ncurses \


### PR DESCRIPTION
###### Description
From lint: `Warning: Variant x11 overrides global description`

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)