### PR TITLE
uncrustify: update to 0.64, add doc

### DIFF
--- a/devel/uncrustify/Portfile
+++ b/devel/uncrustify/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.0
 
 name                uncrustify
-version             0.61
+version             0.64
 categories          devel
 platforms           darwin
 maintainers         nomaintainer
@@ -18,8 +19,18 @@ long_description    Banish crusty code with the Uncrustify \
 homepage            http://uncrustify.sourceforge.net/
 master_sites        sourceforge:project/uncrustify/uncrustify/uncrustify-${version}
 
-checksums           rmd160  3dc2a87abbab255d5f9f7fb6bc7c9d35a79f2252 \
-                    sha256  1df0e5a2716e256f0a4993db12f23d10195b3030326fdf2e07f8e6421e172df9
+checksums           rmd160  b643b8932a8e37b9c5d7c68c76f6e2173b948611 \
+                    sha256  0fca05fe8bac2cd80bf3ed77378c82ffe365f37a3f80b8e0ca2dbb3c6e25f3d7
+
+extract.mkdir       yes
+
+cmake.out_of_source yes
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    copy ${worksrcpath}/documentation ${destroot}${docdir}
+}
 
 livecheck.type      regex
 livecheck.url       http://sourceforge.net/projects/uncrustify/files/uncrustify/


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)