### PR TITLE
postgresql96: update to 9.6.2

### DIFF
--- a/databases/postgresql96-doc/Portfile
+++ b/databases/postgresql96-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql96-doc
 conflicts           postgresql90-doc postgresql91-doc postgresql92-doc \
     postgresql93-doc postgresql94-doc postgresql95-doc
-version             9.6.1
+version             9.6.2
 categories          databases
 platforms           darwin
 maintainers         jwa
@@ -22,8 +22,8 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql96
 
-checksums           rmd160  5981c45f58ac5b2d3f2b7c21103b2a5ffc950224 \
-                    sha256  e5101e0a49141fc12a7018c6dad594694d3a3325f5ab71e93e0e51bd94e51fcd
+checksums           rmd160  b066967d367e15b88a1f6854dfe4f8324084098a \
+                    sha256  0187b5184be1c09034e74e44761505e52357248451b0c854dddec6c231fe50c9
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql96-server/Portfile
+++ b/databases/postgresql96-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql96-server
-version             9.6.1
+version             9.6.2
 categories          databases
 platforms           darwin
 maintainers         jwa

--- a/databases/postgresql96/Portfile
+++ b/databases/postgresql96/Portfile
@@ -6,7 +6,7 @@ PortGroup compiler_blacklist_versions 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql96
-version             9.6.1
+version             9.6.2
 
 categories          databases
 platforms           darwin
@@ -24,8 +24,8 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  5981c45f58ac5b2d3f2b7c21103b2a5ffc950224 \
-                    sha256  e5101e0a49141fc12a7018c6dad594694d3a3325f5ab71e93e0e51bd94e51fcd
+checksums           rmd160  b066967d367e15b88a1f6854dfe4f8324084098a \
+                    sha256  0187b5184be1c09034e74e44761505e52357248451b0c854dddec6c231fe50c9
 
 use_bzip2           yes
 


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)