### PR TITLE
graphics/dvisvgm: Update version to 2.1.2.

### DIFF
--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.0
 
 name                dvisvgm
-version             2.1.1
-revision            1
+version             2.1.2
 conflicts           texlive-bin-extra
 categories          graphics textproc
 platforms           darwin
@@ -19,8 +18,8 @@ long_description    The command-line utility dvisvgm is a tool for TeX/LaTeX use
 homepage            http://dvisvgm.bplaced.net/
 master_sites        https://github.com/mgieseki/dvisvgm/releases/download/${version}/
 
-checksums           rmd160  56dc3805ab683322a9c20733c6f5f6792c695b60 \
-                    sha256  90f7a276a3fd2e0585faa356164145b936e69463317c4255a994b56b3ea00c33
+checksums           rmd160  abfc81689d9093ef76883e959ae885751e992911 \
+                    sha256  e17146e06474eb9bd932c164c92c16bdadb60320123ccba04c4bb2db0d3eb788
 
 depends_build       port:pkgconfig
 
@@ -38,5 +37,5 @@ if { ${configure.cxx_stdlib} ne "libc++" } {
     depends_lib-append      port:libcxx
 }
 
-# requires googletest
-test.run            no
+test.run            yes
+test.target         check

--- a/graphics/dvisvgm/files/patch-doc-Makefile.in.diff
+++ b/graphics/dvisvgm/files/patch-doc-Makefile.in.diff
@@ -1,6 +1,6 @@
 --- doc/Makefile.in.orig
 +++ doc/Makefile.in
-@@ -544,7 +544,6 @@ dvisvgm.epub: dvisvgm-article.xml
+@@ -573,7 +573,6 @@ dvisvgm.epub: dvisvgm-article.xml
  dvisvgm-man.xml: dvisvgm.txt
  	if [ `type -p asciidoc` ]; then \
  		asciidoc -a icons -a 'iconsdir=.' -a badges -a 'revnumber=@VERSION@' --unsafe -bdocbook -dmanpage -o $@ $<; \


### PR DESCRIPTION
This includes a critical fix for libc++ compatibility, that makes dvisvgm work correctly on libc++ based OSX releases (10.9+ I believe).

@mojca has been heavily involved in this one, so should probably take a look before it's merged.