### PR TITLE
ntpsec: new port

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           waf 1.0
+PortGroup           python 1.0
+
+name                ntpsec
+version             0.9.6
+categories          sysutils net
+maintainers         {schenkel.net:leonardo @lbschenkel} openmaintainer
+description         A secure, hardened, and improved implementation of NTP
+license             BSD-2-Clause BSD-3-Clause CC-BY-4.0 NTP MIT
+platforms           darwin
+long_description    A secure, hardened, and improved implementation of Network \
+                    Time Protocol derived from NTP Classic, Dave Mills’s original.
+homepage            https://www.ntpsec.org/
+
+conflicts           ntp openntpd
+
+master_sites        ftp://ftp.ntpsec.org/pub/releases/
+checksums           rmd160  9527cc6bc78f1a02c868fbb6a1fb583461b8fa81 \
+                    sha256  9d15ac59b67911eb1b42fe5916e8d00ded8b71ba34f1ab4fc0f251fc0d90d5e5
+
+depends_build       port:bison
+depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}
+
+patchfiles          patch-macros.diff patch-smear.diff
+patch.pre_args      -p1
+
+use_configure       yes
+configure.args      --alltests \
+                    --define=CONFIG_FILE=${prefix}/etc/ntp.conf \
+                    --disable-manpage \
+                    --pythondir=${python.pkgd}
+destroot.cmd        ${build.cmd}
+
+default_variants    +crypto +doc
+
+variant classic description {Enable classic mode} {
+    configure.args-append   --enable-classic-mode
+}
+variant crypto description {Enable crypto support (depends on OpenSSL)} {
+    depends_build-append    path:lib/libssl.dylib:openssl
+    configure.args-append   --enable-crypto
+}
+variant doc description {Build manpages and HTML documentation} {
+    depends_build-append    port:asciidoc port:docbook-xsl
+    configure.args-append   --enable-doc --htmldir=${prefix}/share/doc/${name}
+    configure.args-delete   --disable-manpage
+}
+variant refclock description {Enable all reference clocks} {
+    configure.args-append   --refclock=all
+}
+variant smear description {Enable smearing of leap seconds} {
+    configure.args-append   --enable-leap-smear
+}
+
+post-patch {
+    # build is not respecting --mandir
+    reinplace -W ${worksrcpath}/wafhelpers \
+        "s|\${PREFIX}/man/|\${PREFIX}/share/man/|g" \
+        asciidoc.py
+}
+post-destroot {
+    xinstall -o root -m 644 ${filespath}/ntp.conf \
+        ${destroot}${prefix}/etc/ntp.conf.dist
+    
+    xinstall -m 755 -d \
+        ${destroot}${prefix}/var/db \
+        ${destroot}${prefix}/var/run
+    destroot.keepdirs \
+        ${destroot}${prefix}/var/db \
+        ${destroot}${prefix}/var/run
+}
+post-activate {
+    if {![file exists ${prefix}/etc/ntp.conf]} {
+        file copy ${prefix}/etc/ntp.conf.dist ${prefix}/etc/ntp.conf
+    }
+}
+
+startupitem.create      yes
+startupitem.netchange   yes
+startupitem.executable  ${prefix}/sbin/ntpd -n -g -p ${prefix}/var/run/ntpd.pid -f ${prefix}/var/db/ntp.drift -c ${prefix}/etc/ntp.conf
+

--- a/sysutils/ntpsec/files/ntp.conf
+++ b/sysutils/ntpsec/files/ntp.conf
@@ -1,0 +1,9 @@
+# Limit network machines to time queries only
+restrict default kod limited nomodify nopeer noquery
+restrict -6 default kod limited nomodify nopeer noquery
+
+# localhost is unrestricted
+restrict 127.0.0.1
+restrict -6 ::1
+
+server time.apple.com

--- a/sysutils/ntpsec/files/patch-macros.diff
+++ b/sysutils/ntpsec/files/patch-macros.diff
@@ -1,0 +1,370 @@
+diff --git a/include/ntp_fp.h b/include/ntp_fp.h
+index 82d88a9..5098508 100644
+--- a/include/ntp_fp.h
++++ b/include/ntp_fp.h
+@@ -188,72 +188,79 @@ typedef uint32_t u_fp;
+ 
+ #include <math.h>	/* ldexp() */
+ 
+-#define M_DTOLFP(d, r_ui, r_uf)		/* double to l_fp */	\
+-	do {							\
+-		double	d_tmp;					\
+-		uint64_t	q_tmp;					\
+-		int	M_isneg;					\
+-								\
+-		d_tmp = (d);					\
+-		M_isneg = (d_tmp < 0.);				\
+-		if (M_isneg) {					\
+-			d_tmp = -d_tmp;				\
+-		}						\
+-		q_tmp = (uint64_t)ldexp(d_tmp, 32);		\
+-		if (M_isneg) {					\
+-			q_tmp = ~q_tmp + 1;			\
+-		}						\
+-		(r_uf) = (uint32_t)q_tmp;			\
+-		(r_ui) = (uint32_t)(q_tmp >> 32);		\
+-	} while (false)
++static inline l_fp dtolfp(double d)
++/* double to l_fp */
++{
++	double	d_tmp;
++	uint64_t	q_tmp;
++	int	M_isneg;
++	l_fp	r;
++
++	d_tmp = (d);
++	M_isneg = (d_tmp < 0.);
++	if (M_isneg) {
++		d_tmp = -d_tmp;
++	}
++	q_tmp = (uint64_t)ldexp(d_tmp, 32);
++	if (M_isneg) {
++		q_tmp = ~q_tmp + 1;
++	}
++	setlfpfrac(r, (uint32_t)q_tmp);
++	setlfpuint(r, (uint32_t)(q_tmp >> 32));
++	return r;
++}
+ 
+-#define M_LFPTOD(r_ui, r_uf, d) 	/* l_fp to double */	\
+-	do {							\
+-		double	d_tmp;					\
+-		uint64_t	q_tmp;					\
+-		int	M_isneg;				\
+-								\
+-		q_tmp = ((uint64_t)(r_ui) << 32) + (r_uf);	\
+-		M_isneg = M_ISNEG(r_ui);			\
+-		if (M_isneg) {					\
+-			q_tmp = ~q_tmp + 1;			\
+-		}						\
+-		d_tmp = ldexp((double)q_tmp, -32);		\
+-		if (M_isneg) {					\
+-			d_tmp = -d_tmp;				\
+-		}						\
+-		(d) = d_tmp;					\
+-	} while (false)
++static inline double lfptod(l_fp r)
++/* l_fp to double */
++{
++	double	d;
++	uint64_t	q_tmp;
++	int	M_isneg;
++
++	q_tmp = ((uint64_t)lfpuint(r) << 32) + lfpfrac(r);
++	M_isneg = M_ISNEG(lfpuint(r));
++	if (M_isneg) {
++		q_tmp = ~q_tmp + 1;
++	}
++	d = ldexp((double)q_tmp, -32);
++	if (M_isneg) {
++		d = -d;
++	}
++	return d;
++}
+ 
+ #else /* use only 32 bit unsigned values */
+ 
+-#define M_DTOLFP(d, r_ui, r_uf) 		/* double to l_fp */ \
+-	do { \
+-		double d_tmp; \
+-		if ((d_tmp = (d)) < 0) { \
+-			(r_ui) = (uint32_t)(-d_tmp); \
+-			(r_uf) = (uint32_t)(-(d_tmp + (double)(r_ui)) * FRAC); \
+-			M_NEG((r_ui), (r_uf)); \
+-		} else { \
+-			(r_ui) = (uint32_t)d_tmp; \
+-			(r_uf) = (uint32_t)((d_tmp - (double)(r_ui)) * FRAC); \
+-		} \
+-	} while (0)
+-#define M_LFPTOD(r_ui, r_uf, d) 		/* l_fp to double */ \
+-	do { \
+-		uint32_t l_thi, l_tlo; \
+-		l_thi = (r_ui); l_tlo = (r_uf); \
+-		if (M_ISNEG(l_thi)) { \
+-			M_NEG(l_thi, l_tlo); \
+-			(d) = -((double)l_thi + (double)l_tlo / FRAC); \
+-		} else { \
+-			(d) = (double)l_thi + (double)l_tlo / FRAC; \
+-		} \
+-	} while (0)
+-#endif
++static inline l_fp dtolfp(double d)
++/* double to l_fp */
++{
++	double d_tmp;
++	l_fp r;
++	if ((d_tmp = (d)) < 0) {
++		setlfpuint(r, (uint32_t)(-d_tmp));
++		setlfpfrac(r, (uint32_t)(-(d_tmp + (double)lfpuint(r)) * FRAC));
++		M_NEG((r_ui), (r_uf));
++	} else { \
++		setlfpuint(r, (uint32_t)d_tmp);
++		setlfpfrac(r, (uint32_t)((d_tmp - (double)lfpuint(r)) * FRAC));
++	}
++	return r;
++}
+ 
+-#define DTOLFP(d, v) 	M_DTOLFP((d), lfpuint(*v), lfpfrac(*v))
+-#define LFPTOD(v, d) 	M_LFPTOD(lfpuint(*v), lfpfrac(*v), (d))
++static inline double lfptod(l_fp r)
++/* l_fp to double */
++{
++	uint32_t l_thi, l_tlo;
++	l_thi = lfpuint(r); l_tlo = lfpfrac(r);
++	if (M_ISNEG(l_thi)) {
++		M_NEG(l_thi, l_tlo);
++		(d) = -((double)l_thi + (double)l_tlo / FRAC);
++	} else {
++		(d) = (double)l_thi + (double)l_tlo / FRAC;
++	}
++	return d;
++}
++#endif
+ 
+ /*
+  * Prototypes
+diff --git a/libntp/systime.c b/libntp/systime.c
+index 24a1c5c..6179d77 100644
+--- a/libntp/systime.c
++++ b/libntp/systime.c
+@@ -187,7 +187,7 @@ normalize_time(
+ 	 * Add in the fuzz.
+ 	 */
+ 	dfuzz = rand * 2. / FRAC * sys_fuzz;
+-	DTOLFP(dfuzz, &lfpfuzz);
++	lfpfuzz = dtolfp(dfuzz);
+ 	L_ADD(&result, &lfpfuzz);
+ 
+ 	/*
+@@ -208,7 +208,7 @@ normalize_time(
+ 				dfuzz);
+ 			lfpdelta = lfp_prev;
+ 			L_SUB(&lfpdelta, &result);
+-			LFPTOD(&lfpdelta, ddelta);
++			ddelta = lfptod(lfpdelta);
+ 			msyslog(LOG_ERR,
+ 				"prev get_systime 0x%x.%08x is %.9f later than 0x%x.%08x",
+ 				lfpuint(lfp_prev), lfpfrac(lfp_prev),
+@@ -362,8 +362,8 @@ step_systime(
+ #endif
+ 
+ 	/* get the complete jump distance as l_fp */
+-	DTOLFP(sys_residual, &fp_sys);
+-	DTOLFP(step,         &fp_ofs);
++	fp_sys = dtolfp(sys_residual);
++	fp_ofs = dtolfp(step);
+ 	L_ADD(&fp_ofs, &fp_sys);
+ 
+ 	/* ---> time-critical path starts ---> */
+diff --git a/ntpd/ntp_control.c b/ntpd/ntp_control.c
+index adca6c3..439c727 100644
+--- a/ntpd/ntp_control.c
++++ b/ntpd/ntp_control.c
+@@ -1757,7 +1757,7 @@ ctl_putsys(
+ 		break;
+ 
+ 	case CS_AUTHDELAY:
+-		LFPTOD(&sys_authdelay, dtemp);
++		dtemp = lfptod(sys_authdelay);
+ 		ctl_putdbl(sys_var[varid].text, dtemp * 1e3);
+ 		break;
+ 
+diff --git a/ntpd/ntp_packetstamp.c b/ntpd/ntp_packetstamp.c
+index fc1948c..e176348 100644
+--- a/ntpd/ntp_packetstamp.c
++++ b/ntpd/ntp_packetstamp.c
+@@ -190,7 +190,7 @@ fetch_packetstamp(
+ #endif  /* USE_SCM_TIMESTAMP */
+ 			}
+ 			fuzz = ntp_random() * 2. / FRAC * sys_fuzz;
+-			DTOLFP(fuzz, &lfpfuzz);
++			lfpfuzz = dtolfp(fuzz);
+ 			L_ADD(&nts, &lfpfuzz);
+ #ifdef ENABLE_DEBUG_TIMING
+ 			dts = ts;
+diff --git a/ntpd/ntp_proto.c b/ntpd/ntp_proto.c
+index 0782fe7..a925da8 100644
+--- a/ntpd/ntp_proto.c
++++ b/ntpd/ntp_proto.c
+@@ -2670,7 +2670,7 @@ measure_tick_fuzz(void)
+ 	max_repeats = 0;
+ 	repeats = 0;
+ 	changes = 0;
+-	DTOLFP(MINSTEP, &minstep);
++	minstep = dtolfp(MINSTEP);
+ 	get_systime(&last);
+ 	for (i = 0; i < MAXLOOPS && changes < MINCHANGES; i++) {
+ 		get_systime(&val);
+@@ -2681,7 +2681,7 @@ measure_tick_fuzz(void)
+ 			max_repeats = max(repeats, max_repeats);
+ 			repeats = 0;
+ 			changes++;
+-			LFPTOD(&ldiff, diff);
++			diff = lfptod(ldiff);
+ 			tick = min(diff, tick);
+ 		} else {
+ 			repeats++;
+diff --git a/ntpd/ntp_refclock.c b/ntpd/ntp_refclock.c
+index 82c6827..eb426b7 100644
+--- a/ntpd/ntp_refclock.c
++++ b/ntpd/ntp_refclock.c
+@@ -364,7 +364,7 @@ refclock_process_offset(
+ 	pp->lastrec = lastrec;
+ 	lftemp = lasttim;
+ 	L_SUB(&lftemp, &lastrec);
+-	LFPTOD(&lftemp, doffset);
++	doffset = lfptod(lftemp);
+ 	SAMPLE(doffset + fudge);
+ }
+ 
+@@ -408,7 +408,7 @@ refclock_process_f(
+ 
+ 	setlfpuint(offset, sec);
+ 	setlfpfrac(offset, 0);
+-	DTOLFP(pp->nsec / 1e9, &ltemp);
++	ltemp = dtolfp(pp->nsec / 1e9);
+ 	L_ADD(&offset, &ltemp);
+ 	refclock_process_offset(pp, offset, pp->lastrec, fudge);
+ 	return true;
+diff --git a/ntpd/refclock_gpsd.c b/ntpd/refclock_gpsd.c
+index 09e3229..5afa6fc 100644
+--- a/ntpd/refclock_gpsd.c
++++ b/ntpd/refclock_gpsd.c
+@@ -772,13 +772,13 @@ gpsd_control(
+ 	UNUSED_ARG(out_st);
+ 
+ 	if (peer == up->pps_peer) {
+-		DTOLFP(pp->fudgetime1, &up->pps_fudge2);
++		up->pps_fudge2 = dtolfp(pp->fudgetime1);
+ 		if ( ! (pp->sloppyclockflag & CLK_FLAG1))
+ 			peer->flags &= ~FLAG_PPS;
+ 	} else {
+ 		/* save preprocessed fudge times */
+-		DTOLFP(pp->fudgetime1, &up->pps_fudge);
+-		DTOLFP(pp->fudgetime2, &up->ibt_fudge);
++		up->pps_fudge = dtolfp(pp->fudgetime1);
++		up->ibt_fudge = dtolfp(pp->fudgetime2);
+ 
+ 		if (MODE_OP_MODE(up->mode ^ peer->ttl)) {
+ 			leave_opmode(peer, up->mode);
+diff --git a/ntpd/refclock_jupiter.c b/ntpd/refclock_jupiter.c
+index c6f79ab..ce3cb60 100644
+--- a/ntpd/refclock_jupiter.c
++++ b/ntpd/refclock_jupiter.c
+@@ -714,7 +714,7 @@ jupiter_control(
+ 	pp = peer->procptr;
+ 	instance = pp->unitptr;
+ 
+-	DTOLFP(pp->fudgetime2, &instance->limit);
++	instance->limit = dtolfp(pp->fudgetime2);
+ 	/* Force positive value. */
+ 	if (L_ISNEG(&instance->limit))
+ 		L_NEG(&instance->limit);
+diff --git a/ntpd/refclock_nmea.c b/ntpd/refclock_nmea.c
+index 74e5f8e..cc93831 100644
+--- a/ntpd/refclock_nmea.c
++++ b/ntpd/refclock_nmea.c
+@@ -721,7 +721,7 @@ refclock_ppsrelate(
+ 	pp_stamp = tspec_stamp_to_lfp(timeout);
+ 	pp_delta = *rd_stamp;
+ 	L_SUB(&pp_delta, &pp_stamp);
+-	LFPTOD(&pp_delta, delta);
++	delta = lfptod(pp_delta);
+ 	delta += pp_fudge - *rd_fudge;
+ 	if (fabs(delta) > 1.5)
+ 		return PPS_RELATE_NONE; /* PPS timeout control */
+@@ -744,7 +744,7 @@ refclock_ppsrelate(
+ 	/* check against reftime if PPS PLL can be used */
+ 	pp_delta = *reftime;
+ 	L_SUB(&pp_delta, &pp_stamp);
+-	LFPTOD(&pp_delta, delta);
++	delta = lfptod(pp_delta);
+ 	delta += pp_fudge;
+ 	if (fabs(delta) > 0.45)
+ 		return PPS_RELATE_EDGE; /* cannot PLL with PPS code */
+diff --git a/ntpd/refclock_oncore.c b/ntpd/refclock_oncore.c
+index 6dceab8..46c79a7 100644
+--- a/ntpd/refclock_oncore.c
++++ b/ntpd/refclock_oncore.c
+@@ -1765,7 +1765,7 @@ oncore_get_timestamp(
+ 
+ 	ts_tmp = ts;
+ 	setlfpuint(ts_tmp, 0);	/* zero integer part */
+-	LFPTOD(&ts_tmp, dmy);	/* convert fractional part to a double */
++	dmy = lfptod(ts_tmp);	/* convert fractional part to a double */
+ 	j = 1.0e9*dmy;		/* then to integer ns */
+ 
+ 	Rsm = 0;
+diff --git a/ntpfrob/jitter.c b/ntpfrob/jitter.c
+index b48656d..2d93505 100644
+--- a/ntpfrob/jitter.c
++++ b/ntpfrob/jitter.c
+@@ -84,7 +84,7 @@ void jitter(const iomode mode)
+ 	 */
+ 	for (i = 0; i < NBUF; i ++) {
+ 		get_clocktime(&tr);
+-		LFPTOD(&tr, gtod[i]);
++		gtod[i] = lfptod(tr);
+ 	}
+ 
+ 	/*
+diff --git a/tests/libntp/lfpfunc.c b/tests/libntp/lfpfunc.c
+index c768663..3266c91 100644
+--- a/tests/libntp/lfpfunc.c
++++ b/tests/libntp/lfpfunc.c
+@@ -131,20 +131,6 @@ static int l_fp_signum(const l_fp first)
+ 	return (lfpuint(first) || lfpfrac(first));
+ }
+ 
+-static double l_fp_convert_to_double(const l_fp first)
+-{
+-	double res;
+-	LFPTOD(&first, res);
+-	return res;
+-}
+-
+-static l_fp l_fp_init_from_double( double rhs)
+-{
+-	l_fp temp;
+-	DTOLFP(rhs, &temp);
+-	return temp;
+-}
+-
+ static void l_fp_swap(l_fp * first, l_fp *second)
+ {
+ 	l_fp temp = *second;
+@@ -372,11 +358,11 @@ TEST(lfpfunc, FDF_RoundTrip) {
+ 
+ 	for (idx = 0; idx < addsub_cnt; ++idx) {
+ 		l_fp op1 = l_fp_init(addsub_tab[idx][0].h, addsub_tab[idx][0].l);
+-		double op2 = l_fp_convert_to_double(op1);
+-		l_fp op3 = l_fp_init_from_double(op2); 
++		double op2 = lfptod(op1);
++		l_fp op3 = dtolfp(op2);
+ 
+ 		l_fp temp = l_fp_subtract(op1, op3);
+-		double d = l_fp_convert_to_double(temp);
++		double d = lfptod(temp);
+ 		TEST_ASSERT_DOUBLE_WITHIN(eps(op2), 0.0, fabs(d));
+ 	}
+ 

--- a/sysutils/ntpsec/files/patch-smear.diff
+++ b/sysutils/ntpsec/files/patch-smear.diff
@@ -1,0 +1,27 @@
+diff --git a/ntpd/ntp_proto.c b/ntpd/ntp_proto.c
+index f753534..3ab6b0e 100644
+--- a/ntpd/ntp_proto.c
++++ b/ntpd/ntp_proto.c
+@@ -2298,7 +2298,7 @@ fast_xmit(
+ 			xpkt.refid = convertLFPToRefID(leap_smear.offset);
+ 			DPRINTF(2, ("fast_xmit: leap_smear.in_progress: refid %8x, smear %s\n",
+ 				ntohl(xpkt.refid),
+-				lfptoa(&leap_smear.offset, 8)
++				lfptoa(leap_smear.offset, 8)
+ 				));
+ 		}
+ 		xpkt.reftime = htonl_fp(this_ref_time);
+diff --git a/ntpd/ntp_timer.c b/ntpd/ntp_timer.c
+index 05f2a00..2b9a302 100644
+--- a/ntpd/ntp_timer.c
++++ b/ntpd/ntp_timer.c
+@@ -479,7 +479,7 @@ check_leapsec(
+ 		/*
+ 		 * Update the current leap smear offset, eventually 0.0 if outside smear interval.
+ 		 */
+-		DTOLFP(leap_smear.doffset, &leap_smear.offset);
++		leap_smear.offset = dtolfp(leap_smear.doffset);
+ #endif	/* ENABLE_LEAP_SMEAR */
+ 
+ 		/* Full hit. Eventually step the clock, but always
+


### PR DESCRIPTION
From the homepage <https://www.ntpsec.org>:
> NTPsec project - a secure, hardened, and improved implementation of Network
> Time Protocol derived from NTP Classic, Dave Mills’s original.
>
> NTPsec, as its name implies, is a more secure NTP. Our goal is to deliver
> code that can be used with confidence in deployments with the most stringent
> security, availability, and assurance requirements.

This port is a drop-in replacement for ntp, with hardened internals. It should
behave identically in most circumstances, except that obsolete and/or insecure
features have been removed.

The current version of this port incorporates two newer patches from upstream
to fix a compilation error when leap second smearing is enabled.

The example file included in this port is the same example file included in
the ntp port, but with small adaptations for changes in ntpsec.