### PR TITLE
ghc: Fix broken ghc port, and add a patch to make it work on Sierra.

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -8,7 +8,7 @@ name                ghc
 # When updating GHC, make sure to revbump all Haskell ports.
 # Also make sure to update the version in the Haskell PortGroup.
 version             7.8.3
-revision            4
+revision            5
 categories          lang haskell
 maintainers         cal openmaintainer
 license             BSD
@@ -51,12 +51,16 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-3.9       \
+                port:llvm-3.5       \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \
                 patch-configure-disable-docs.diff \
                 patch-unix_lib_osx_sandbox_compatibility.diff
+
+platform darwin 16 {
+    patchfiles-append   patch-sierra-compatibility.diff
+}
 
 livecheck.type  none
 test.run        yes
@@ -77,7 +81,7 @@ compiler.blacklist-append \
                 macports-clang-3.3
 
 set bootstraproot ${prefix}/share/ghc-bootstrap
-set llvmPrefix  ${prefix}/libexec/llvm-3.9
+set llvmPrefix  ${prefix}/libexec/llvm-3.5
 configure.args  --with-ghc=${bootstraproot}/bin/ghc \
                 --with-iconv-includes=${prefix}/include \
                 --with-iconv-libraries=${prefix}/lib \

--- a/lang/ghc/files/patch-sierra-compatibility.diff
+++ b/lang/ghc/files/patch-sierra-compatibility.diff
@@ -1,0 +1,13 @@
+--- rts/posix/GetTime.c.orig	2017-02-15 08:41:47.000000000 +0100
++++ rts/posix/GetTime.c	2017-02-15 08:43:42.000000000 +0100
+@@ -25,6 +25,10 @@
+ # include <papi.h>
+ #endif
+ 
++#ifdef darwin_HOST_OS
++#include <mach/mach_time.h>
++#endif
++
+ #if ! ((defined(HAVE_GETRUSAGE) && !irix_HOST_OS) || defined(HAVE_TIMES))
+ #error No implementation for getProcessCPUTime() available.
+ #endif


### PR DESCRIPTION
This fixes the fallout from #70 which in an attempt to make ghc compile on Sierra, broke the ghc port.

- It reverts the port to using LLVM 3.5 which is the LLVM version required by the ghc version in MP (7.8.3). Cf. https://trac.macports.org/ticket/52424#comment:27.

- It also adds a trivial patch required to make the compilation work on Sierra. Cf. https://trac.macports.org/ticket/48899#comment:25. The patch is only applied on Sierra (platform darwin 16) in order not to break the build on older macOS versions (although the chance is minimal anyway, I'd say, given the nature of the change).

Please check my comment at the end of #70 for more details.