### PR TITLE
nodejs6: update to 6.9.5, use xz and https

### DIFF
--- a/devel/nodejs6/Portfile
+++ b/devel/nodejs6/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    nodejs6
-version                 6.9.4
+version                 6.9.5
 
 categories              devel net
 platforms               darwin
@@ -20,11 +20,12 @@ long_description        Node's goal is to provide an easy way to build scalable 
 
 conflicts               nodejs4 nodejs5 nodejs7
 
-homepage                http://nodejs.org/
+homepage                https://nodejs.org/
 master_sites            ${homepage}dist/v${version}
+use_xz                  yes
 
-checksums               rmd160  538d4813c76d27d55732dad0d381822bc10e577d \
-                        sha256  f0257c83eb5e8b0e7b09db7264dc1e93e1f024c6dfccb098363b4fb0c192cf7f
+checksums               rmd160  7a85ada15322d919e563a9a88456928572a6e09d \
+                        sha256  d7fed1a354b29503f3e176d7fdb90b1a9de248e0ce9b3eb56cc26bb1f3d5b6b3
 
 distname                node-v${version}
 


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)