### PR TITLE
tinc: add OpenSSLException in license

### DIFF
--- a/net/tinc/Portfile
+++ b/net/tinc/Portfile
@@ -4,7 +4,7 @@ name                tinc
 version             1.0.30
 categories          net
 maintainers         bentzen.com.au:mike
-license             GPL-2+
+license             {GPL-2+ OpenSSLException}
 platforms           darwin
 
 conflicts           tinc-devel


### PR DESCRIPTION
In COPYING.README:
```
The following applies to tinc:

This program is released under the GPL with the additional exemption that
compiling, linking, and/or using OpenSSL is allowed.  You may provide binary
packages linked to the OpenSSL libraries, provided that all other requirements
of the GPL are met.
```