### PR TITLE
curl-ca-bundle: update to 6d5a6e5b4716 / NSS 3.30

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -207,7 +207,7 @@ if {${name} eq ${subport}} {
 }
 
 subport curl-ca-bundle {
-    revision                    1
+    revision                    2
     categories                  net
     license                     {MPL-2 LGPL-2.1+}
     supported_archs             noarch
@@ -225,8 +225,8 @@ subport curl-ca-bundle {
     set certdata_file           certdata.txt
     # The output of the Tcl command "clock seconds" (you can run it in tclsh) when
     # the certdata.txt file in the port was last updated.
-    set certdata_updated        1485749897
-    set certdata_version        052b90b5414f
+    set certdata_updated        1487309700
+    set certdata_version        6d5a6e5b4716
     set certdata_distfile       certdata-${certdata_version}${extract.suffix}
     set certdata_path           security/nss/lib/ckfw/builtins/${certdata_file}
 
@@ -240,8 +240,8 @@ subport curl-ca-bundle {
     distfiles-append            ${certdata_distfile}:certdata
 
     checksums-append            ${certdata_distfile} \
-                                rmd160  2ebc985eb5da2f8b7bb406548ce9ae4db7f915d6 \
-                                sha256  c91baf53af5138aed7a9b9c2be5abf5e486629f23d320f3b08e88f3a2f11d32a
+                                rmd160  a6eb7a2d21d0876042ea0403eaec28753e7ac711 \
+                                sha256  f5efca59a058228c30d2368eb8649fa3b060034889d8b2abc1d042e57a06308f
 
     extract.only                ${certdata_distfile}
 


### PR DESCRIPTION
###### Description


*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)