### PR TITLE
py-regions: update to v0.2

### DIFF
--- a/python/py-regions/Portfile
+++ b/python/py-regions/Portfile
@@ -7,7 +7,7 @@ set _name           regions
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.1
+version             0.2
 categories-append   science
 platforms           darwin
 maintainers         gmail.com:Deil.Christoph openmaintainer
@@ -19,9 +19,9 @@ homepage            https://github.com/astropy/regions
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     772834a3c5fd7ca0b644ca17dd5ae62e \
-                    rmd160  3cd4af41627eab31890e4c8b61b82173c36cf8b4 \
-                    sha256  1a2d25abecb95b953b168d335d3b3dab30b9018937333a6d4d70c97650ccad2e
+checksums           md5     48597dc17906e478292040dae2df5596 \
+                    rmd160  06d84c11af473fee0e6816c8fb2b692df8e811fa \
+                    sha256  980b8091d935484dde5907ff1631f624c5c0b99f5c1790c6c7879bb1f4d51009
 
 
 python.versions     27 34 35 36
@@ -35,7 +35,8 @@ if {${name} ne ${subport}} {
 
     depends_build-append  port:py${python.version}-setuptools
 
-    depends_run-append    port:py${python.version}-astropy
+    depends_run-append    port:py${python.version}-numpy \
+                          port:py${python.version}-astropy
 
     livecheck.type  none
 } else {


### PR DESCRIPTION
This pull request updates the `py-regions` port to v0.2.

* See https://pypi.python.org/pypi/regions/0.2
* Add Numpy to `depends_run-append`

I did this test locally and all tests pass:
```
cd python/py-regions
sudo port -d install subport=py34-regions
pip-3.4 install pytest-arraydiff --user
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages /opt/local/bin/python3.4 -c 'import regions; regions.test()'
```

I'm the port maintainer. Someone - please merge.