### PR TITLE
sift: new port

### DIFF
--- a/sysutils/sift/Portfile
+++ b/sysutils/sift/Portfile
@@ -1,0 +1,92 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+# this doesn't work directly because files need to be fetched from multiple repositories
+#
+# PortGroup         github 1.0
+# github.setup      svent sift 0.9.0 v
+
+name                sift
+version             0.9.0
+platforms           darwin
+categories          sysutils
+license             GPL-3+
+installs_libs       no
+maintainers         {kahuna.com:esafak @esafak}
+description         A fast and powerful open source alternative to grep
+long_description    sift is an alternative that aims for both speed and flexibility, \
+                    adding features while trying to reach (or even surpass) the performance \
+                    of the original grep. The additional features include gitignore support, \
+                    conditions (e.g., match A only when preceded by B within X lines), \
+                    full multi-core support and multiline matching.
+homepage            http://sift-tool.org
+platforms           darwin
+use_zip             yes
+
+set crypto_hash     2faea14
+set nbreader_hash   7cef48da76dca6a496faa7fe63e39ed665cbd219
+set flags_version   1.3.0
+
+master_sites        https://github.com/svent/sift/archive:sift \
+                    https://github.com/jessevdk/go-flags/archive:flags \
+                    https://github.com/svent/go-nbreader/archive:nbreader \
+                    https://raw.githubusercontent.com/golang/crypto/${crypto_hash}/ssh/terminal:crypto
+
+distfiles           v${version}.zip:sift \
+                    v${flags_version}.zip:flags \
+                    ${nbreader_hash}.zip:nbreader \
+                    terminal.go:crypto \
+                    util_bsd.go:crypto \
+                    util.go:crypto
+
+extract.only        v${version}.zip \
+                    v${flags_version}.zip \
+                    ${nbreader_hash}.zip
+
+checksums           v${version}.zip \
+                    rmd160  e1b1eae2e314510b852ee86f0152fa541b5b4af9 \
+                    sha256  00f4a57cd4140999443833b6bbf446a21ec5660613af5ce101d651a265152051 \
+                    v${flags_version}.zip \
+                    rmd160  0797467ba23c4c28ff8b13aa40b52bc8bad852a0 \
+                    sha256  be1356988abd183851b754a66a4171e370b952bee2dd3de5fc33f0370e534703 \
+                    ${nbreader_hash}.zip \
+                    rmd160  6bd004bdca7944c9ff523e479bd7814bc87aff34 \
+                    sha256  2f9c0c3b45bf04cb5ebc92b146d022b6a6e437258fc4d9936dfcd1a115af3578 \
+                    terminal.go \
+                    rmd160  ad3f5da181a2fa618e104b1deb79a869a9164cb2 \
+                    sha256  b35ec763e014dcc944989ff5ddea401c754bcc27c011f71012a2454eaca1b11a \
+                    util_bsd.go \
+                    rmd160  9a75a1dc87ad32232627302e266215cba35766a4 \
+                    sha256  fc3b7bafbded5b824b3b9c5d4c4d6730958cbeb9ae9cd2dde2132d670d2cc3f4 \
+                    util.go \
+                    rmd160  6f17dbf32422a7e43d9182137c0ebc2bc9704ef5 \
+                    sha256  c0506e16f0f7ec105437f35f2a7fb6c3b71a28f95102f3b5dec0d22f040cb727
+
+depends_build       port:go
+universal_variant   no
+use_configure       no
+
+build.cmd           go
+build.target        build
+build.env           GOPATH=${worksrcpath}
+
+post-extract {
+    file mkdir ${worksrcpath}/src/github.com/svent/sift
+    file mkdir ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal
+
+    move ${worksrcpath}/gitignore                 ${worksrcpath}/src/github.com/svent/sift
+    move ${workpath}/go-nbreader-${nbreader_hash} ${worksrcpath}/src/github.com/svent/go-nbreader
+    move ${workpath}/go-flags-${flags_version}    ${worksrcpath}/src/github.com/svent/go-flags
+
+    ln -sf ${distpath}/terminal.go                ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal/terminal.go
+    ln -sf ${distpath}/util_bsd.go                ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal/util_bsd.go
+    ln -sf ${distpath}/util.go                    ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal/util.go
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name}-${version} ${destroot}${prefix}/bin/${name}
+}
+
+livecheck.url       https://github.com/svent/${name}/tags
+livecheck.regex     archive/v(\[^"\]+)${extract.suffix}


### PR DESCRIPTION
Addresses svent/sift/issues/5

I wanted to use the github PortGroup but I could not. I also failed to find a "go" PortGroup. The portfile works and passes the linter, but I'm not sure I handled versioning the right way.

I'm open to starting a new folder for all go submissions (like python), moving this there. Likewise, I could rename the port to go-sift.