### PR TITLE
Restore apache-ant 1.9 port

### DIFF
--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -1,0 +1,89 @@
+PortSystem 1.0
+PortGroup               java 1.0
+
+name                    apache-ant-1.9
+version                 1.9.9
+categories              devel java
+license                 Apache-2 W3C
+maintainers             openmaintainer blair
+supported_archs         noarch
+
+description             Java opensource build system
+long_description        Ant is a Java based build tool.  In theory it is \
+                        kind of like make without make's wrinkles.  Ant \
+                        uses XML build files that define a set of targets.  \
+                        Each target has dependencies (other targets) and \
+                        contains a set of tasks to perform.
+homepage                http://ant.apache.org/
+
+platforms               darwin freebsd
+
+distname                apache-ant-${version}-bin
+master_sites            apache:ant/
+master_sites.mirror_subdir        binaries
+checksums               md5    565ffd791def7f22936311e9aa3f8058 \
+                        sha1   570005afd7c080436742e128b07eb97d50178d53 \
+                        sha512 3c0cc564c27483eb526e004b31b211dd689aa24a2aa7097fc11bc5304771e49124a657203eeec748a70a6bfa6f2c050d5647b37a69e5eb02843fff7a0f7646ea
+
+worksrcdir              apache-ant-${version}
+set workTarget          ""
+
+use_bzip2               yes
+use_configure           no
+
+build.cmd               true
+
+# Ant is installed from the binary (jar) distribution by default. Due to
+# bootstrapping issues, the source variant generally doesn't build a very
+# usable ant: the ant tasks (such as junit) are non-functional as their
+# dependent support isn't available when ant is built, due to circular
+# dependencies back to ant.
+variant source description "build from source; not recommended" {
+        distname                        apache-ant-${version}-src
+        master_sites.mirror_subdir      source
+        checksums                       md5    c988158e101e7700b45c14b9804fd554 \
+                                        sha1   4c815a6f560cde94fc2b3d15e34393ebf6dbca52 \
+                                        sha512 27fe030f134e34d4e06ef32baf1e8cf392490745fa7a7f47cf3e123f1141499c059e317154c923a8d7dcb7af163eb0cc87636f5d6150e0ce54b6c0abc2d0a112
+        set workTarget                  /apache-ant
+
+        build.cmd                       ./build.sh
+        build.args                      -Dchmod.fail=false -Ddist.name=apache-ant
+        build.target                    dist
+}
+
+pre-destroot {
+        delete \
+                ${worksrcpath}${workTarget}/bin/ant.bat \
+                ${worksrcpath}${workTarget}/bin/ant.cmd \
+                ${worksrcpath}${workTarget}/bin/antRun.bat \
+                ${worksrcpath}${workTarget}/bin/antenv.cmd \
+                ${worksrcpath}${workTarget}/bin/envset.cmd \
+                ${worksrcpath}${workTarget}/bin/lcp.bat \
+                ${worksrcpath}${workTarget}/bin/runrc.cmd
+}
+
+destroot        {
+        xinstall -m 755 -d ${destroot}${prefix}/share/java
+        file copy ${worksrcpath}${workTarget} \
+                ${destroot}${prefix}/share/java/apache-ant
+
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/apache-ant
+        foreach f {INSTALL
+                   KEYS
+                   LICENSE
+                   NOTICE
+                   README
+                   WHATSNEW
+                   manual} {
+            file rename ${destroot}${prefix}/share/java/apache-ant/${f} \
+                ${destroot}${prefix}/share/doc/apache-ant/${f}
+        }
+
+        ln -s ../share/java/apache-ant/bin/ant ${destroot}${prefix}/bin/ant
+}
+
+universal_variant       no
+
+livecheck.type          regex
+livecheck.url           http://www.apache.org/dist/ant/binaries/
+livecheck.regex         {apache-ant-(\d+(?:\.\d+)*)-bin.tar.bz2}


### PR DESCRIPTION
Restored apache-ant 1.9 port for older versions of Mac OS X that don't have Java 8.

See also: https://trac.macports.org/ticket/53555