### PR TITLE
curl: update to 7.53.0 [security]

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -3,7 +3,7 @@
 PortSystem                      1.0
 
 name                            curl
-version                         7.52.1
+version                         7.53.0
 categories                      net www
 platforms                       darwin freebsd
 maintainers                     ryandesign
@@ -27,8 +27,8 @@ set curl_distfile               ${distfiles}
 distfiles                       ${curl_distfile}:curl
 
 checksums                       ${curl_distfile} \
-                                rmd160  fa55d67d8a075a49fa3d777bb6c692598886d1f1 \
-                                sha256  d16185a767cb2c1ba3d5b9096ec54e5ec198b213f45864a38b3bda4bbf87389b
+                                rmd160  1c865c3abc0a39f5ce326f0752820a7a1ae89ee4 \
+                                sha256  b2345a8bef87b4c229dedf637cb203b5e21db05e20277c8e1094f0d4da180801
 
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
@@ -207,7 +207,7 @@ if {${name} eq ${subport}} {
 }
 
 subport curl-ca-bundle {
-    revision                    2
+    revision                    0
     categories                  net
     license                     {MPL-2 LGPL-2.1+}
     supported_archs             noarch


### PR DESCRIPTION
###### Description
CVE-2017-2629. See https://curl.haxx.se/docs/adv_20170222.html.

`TESTDONE: 817 tests out of 817 reported OK: 100%`

*(delete all below for minor changes)*

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (Please don't open a new Trac ticket if you are submitting a pull request.)
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (delete if not applicable)
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files? (delete if not applicable)