### PR TITLE
refactored sysutils/salt startupitems into subports, v2016.11.2 upgrade

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -1,137 +1,84 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           python 1.0
-
-github.setup        saltstack salt 2016.11 v
 name                salt
+version             2016.11.2
 categories          sysutils
 platforms           darwin
 maintainers         gmail.com:jeremy.mcmillan
 license             Apache-2
 supported_archs     noarch
-
 description         Salt is a Python-based remote execution, automation, \
                     configuration, and orchestration engine.
-
 long_description    SaltStack is fast, scalable and flexible software for data \
                     center automation, from infrastructure and any cloud, \
                     to the entire application stack.
-
 homepage            http://saltstack.com/
 
-python.default_version 27
+if {$subport eq $name} {
+    PortGroup           github 1.0
 
-checksums           rmd160 ad958f0c1a1bb0656ce401e06533a5f60b43fe72 \
-                    sha256 d277570404bdd53bc883847f1ebdd2686d1b23f428ceb735006d2cddc5b15b79
+    PortGroup           python 1.0
 
-depends_build       port:py${python.version}-setuptools
+    github.setup        saltstack salt ${version} v
 
-depends_lib-append  port:py${python.version}-crypto \
-                    port:py${python.version}-jinja2 \
-                    port:py${python.version}-msgpack \
-                    port:py${python.version}-pip \
-                    port:py${python.version}-yaml \
-                    port:py${python.version}-tornado \
-                    port:py${python.version}-zmq \
-                    port:swig-python
+    python.default_version 27
 
-startupitem.create        yes
-startupitem.name          salt-minion
-startupitem.netchange     yes
-startupitem.logevents     yes
-startupitem.logfile       ${prefix}/var/log/salt/minion
-startupitem.executable    ${prefix}/bin/salt-minion
+    checksums           rmd160 f5b8518700fee08acf555f846e9d53b45c89be3f \
+                        sha256 cb0540cd03de28c59cc2fd372bb59dd5ca69624aefaa29f0748b856ac8ea8543
 
+    depends_build       port:py${python.version}-setuptools
 
+    depends_lib-append  port:py${python.version}-crypto \
+                        port:py${python.version}-jinja2 \
+                        port:py${python.version}-msgpack \
+                        port:py${python.version}-pip \
+                        port:py${python.version}-yaml \
+                        port:py${python.version}-tornado \
+                        port:py${python.version}-zmq \
+                        port:swig-python
 
-post-activate {
+    post-activate {
 
-    file mkdir ${prefix}/etc/salt
+        file mkdir ${prefix}/etc/salt
 
-    if ![file exists /etc/salt] {
-        ln -s ${prefix}/etc/salt /etc/salt
+        if ![file exists /etc/salt] {
+            ln -s ${prefix}/etc/salt /etc/salt
+        }
+
+        if ![file exists ${prefix}/etc/salt/minion] {
+            copy ${worksrcpath}/conf/minion ${prefix}/etc/salt
+        }
+
+        if ![file exists ${prefix}/etc/salt/master] {
+            copy ${worksrcpath}/conf/master ${prefix}/etc/salt
+        }
     }
 
-    if ![file exists ${prefix}/etc/salt/minion] {
-        copy ${worksrcpath}/conf/minion ${prefix}/etc/salt
+    pre-deactivate {
+
+        if { [file type /etc/salt] == "link" } {
+            file delete /etc/salt
+        }
+
     }
 
-    if ![file exists ${prefix}/etc/salt/master] {
-        copy ${worksrcpath}/conf/master ${prefix}/etc/salt
-    }
+    notes   "salt startupitems are now installed by subports salt-minion, salt-master, salt-syndic, salt-api"
 }
 
-post-destroot {
-
-    if ![file exists ${destroot}/Library/LaunchDaemons] {
-        file mkdir ${destroot}/Library/LaunchDaemons
+foreach daemon [list minion master syndic api] {
+    subport salt-${daemon} {
+        startupitem.create      yes
+        startupitem.name        salt-${daemon}
+        startupitem.netchange   yes
+        startupitem.logevents   yes
+        startupitem.logfile     ${prefix}/var/log/salt/${daemon}
+        startupitem.executable  ${prefix}/bin/salt-${daemon}
+        depends_run             port:salt
+        description             install startupitem for salt-${daemon}
+        distfiles
+        configure {}
+        build {}
+        destroot {}
     }
-    copy ${worksrcpath}/pkg/osx/scripts/com.saltstack.salt.master.plist \
-        ${destroot}/Library/LaunchDaemons/org.macports.salt-master.plist
-    reinplace -W ${destroot}/Library/LaunchDaemons \
-        "s|/opt/salt/bin/start-salt-master.sh|${prefix}/bin/salt-master|g" org.macports.salt-master.plist
-    reinplace -W ${destroot}/Library/LaunchDaemons \
-        "s|com.saltstack.salt.master|org.macports.salt-master|g" org.macports.salt-master.plist
-    copy ${worksrcpath}/pkg/osx/scripts/com.saltstack.salt.api.plist \
-        ${destroot}/Library/LaunchDaemons/org.macports.salt-api.plist
-    reinplace -W ${destroot}/Library/LaunchDaemons \
-        "s|/opt/salt/bin/start-salt-api.sh|${prefix}/bin/salt-api|g" org.macports.salt-api.plist
-    reinplace -W ${destroot}/Library/LaunchDaemons \
-        "s|com.saltstack.salt.api|org.macports.salt-api|g" org.macports.salt-api.plist
-    copy ${worksrcpath}/pkg/osx/scripts/com.saltstack.salt.syndic.plist \
-        ${destroot}/Library/LaunchDaemons/org.macports.salt-syndic.plist
-    reinplace -W ${destroot}/Library/LaunchDaemons \
-        "s|/opt/salt/bin/start-salt-syndic.sh|${prefix}/bin/salt-syndic|g" org.macports.salt-syndic.plist
-    reinplace -W ${destroot}/Library/LaunchDaemons \
-        "s|com.saltstack.salt.syndic|org.macports.salt-syndic|g" org.macports.salt-syndic.plist
-
 }
-
-pre-deactivate {
-
-    if { [file type /etc/salt] == "link" } {
-        file delete /etc/salt
-    }
-
-}
-
-notes "
-This port configures a LaunchItem for salt-minion.
-
-It also installs LaunchItems for the salt-master, api, and the salt-syndic.
-
-To start the salt-master, api, or syndic via launchd, run
-
-sudo launchctl load -w /Library/LaunchDaemons/org.macports.salt-master.plist
-sudo launchctl load -w /Library/LaunchDaemons/org.macports.salt-api.plist
-sudo launchctl load -w /Library/LaunchDaemons/org.macports.salt-syndic.plist
-
-or to start on El Capitan (10.11) or later system
-
-sudo launchctl enable system/org.macports.salt-master
-sudo launchctl bootstrap system /Library/LaunchDaemons/org.macports.salt-master.plist
-sudo launchctl enable system/org.macports.salt-api
-sudo launchctl bootstrap system /Library/LaunchDaemons/org.macports.salt-api.plist
-sudo launchctl enable system/org.macports.salt-syndic
-sudo launchctl bootstrap system /Library/LaunchDaemons/org.macports.salt-syndic.plist
-
-To disable launchd management for the master or syndic, run the appropriate
-unload command:
-
-sudo launchctl unload -w /Library/LaunchDaemons/org.macports.salt-master.plist
-sudo launchctl unload -w /Library/LaunchDaemons/org.macports.salt-api.plist
-sudo launchctl unload -w /Library/LaunchDaemons/org.macports.salt-syndic.plist
-
-or to disable on El Capitan (10.11) or later system
-
-sudo launchctl disable system/org.macports.salt-master
-sudo launchctl bootout system /Library/LaunchDaemons/org.macports.salt-master.plist
-sudo launchctl disable system/org.macports.salt-api
-sudo launchctl bootout system /Library/LaunchDaemons/org.macports.salt-api.plist
-sudo launchctl disable system/org.macports.salt-syndic
-sudo launchctl bootout system /Library/LaunchDaemons/org.macports.salt-syndic.plist
-
-"
-


### PR DESCRIPTION
Upgrade salt version 2016.11 --> 2016.11.2

Deleted notes about creating startupitems via plist files in upstream source.
Refactored Portfile to include subports to install MacPosrts startupitems
- salt-minion
- salt-master
- salt-syndic
- salt-api
