### PR TITLE
py-agate_sql 0.5.0: new port

### DIFF
--- a/python/py-agate_sql/Portfile
+++ b/python/py-agate_sql/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       agate-sql
+name                py-agate_sql
+version             0.5.0
+python.versions     27 34 35 36
+# categories-append   textproc
+platforms           darwin
+maintainers         @esafak
+license             MIT
+
+description         Adds SQL read/write support to agate.
+long_description    ${description}
+
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:a/$base_name
+
+checksums           rmd160  095f3808fe6579ab4bcb79fb5d32347cf3fbe080 \
+                    sha256  e5fa728dd5c0d71d3c7653a794cd830330fa2cf8b2f02230db68ddea3ab32ffb
+
+distname            $base_name-${version}
+
+if {${name} ne ${subport}} {
+    livecheck.type      none
+
+    depends_build-append port:py${python.version}-setuptools \
+                        port:py${python.version}-nose \
+                        port:py${python.version}-tox \
+                        port:py${python.version}-sphinx \
+                        port:py${python.version}-sphinx_rtd_theme
+
+    depends_lib-append  port:py${python.version}-sqlalchemy \
+                        port:py${python.version}-agate
+} else {
+    livecheck.type      regex
+    livecheck.url       ${homepage}
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
+}


### PR DESCRIPTION
Adds SQL read/write support to agate.

Installs and passes the linter. Depends on py-agate, which is also a new submission, among other existing ports.

https://trac.macports.org/ticket/53640