### PR TITLE
py-agate_dbf 0.2.0: submission

### DIFF
--- a/python/py-agate_dbf/Portfile
+++ b/python/py-agate_dbf/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       agate-dbf
+name                py-agate_dbf
+version             0.2.0
+python.versions     27 34 35 36
+# categories-append   textproc
+platforms           darwin
+maintainers         @esafak
+license             MIT
+
+description         Adds read support for DBF files to agate.
+long_description    ${description}
+
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:a/$base_name
+
+checksums           rmd160  ea79069dd546f7b26291980fc7e214a3c35d660b \
+                    sha256  0666c1ad06cd4b2860351cebbd88bd4b05b2d1abd41b25cf91f8f6715035735e
+
+distname            $base_name-${version}
+
+if {${name} ne ${subport}} {
+    livecheck.type      none
+
+    depends_build-append port:py${python.version}-setuptools \
+                        port:py${python.version}-nose \
+                        port:py${python.version}-tox \
+                        port:py${python.version}-sphinx \
+                        port:py${python.version}-sphinx_rtd_theme
+
+    depends_lib-append  port:py${python.version}-dbfread \
+                        port:py${python.version}-agate
+} else {
+    livecheck.type      regex
+    livecheck.url       ${homepage}
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
+}


### PR DESCRIPTION
Adds read support for DBF files to agate (which depends on it).

Passes the linter and installs. [Depends on py-dbfread, and py-agate](https://github.com/wireservice/agate-dbf/blob/master/requirements-py2.txt).

https://trac.macports.org/ticket/53641