### PR TITLE
py-agate_excel 0.2.0: new port

### DIFF
--- a/python/py-agate_excel/Portfile
+++ b/python/py-agate_excel/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       agate-excel
+name                py-agate_excel
+version             0.2.0
+python.versions     27 34 35 36
+# categories-append   textproc
+platforms           darwin
+maintainers         @esafak
+license             MIT
+
+description         Adds read support for Excel files (xls and xlsx) to agate
+long_description    ${description}
+
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:a/$base_name
+
+checksums           rmd160  a595f227561d6a18318a9483023f3f7c46e3fd12 \
+                    sha256  5e75452fefe1ffe18fe695eeb08337c50eb3f0b74bfe108d5a85a2bb3ee806d2
+
+distname            $base_name-${version}
+
+if {${name} ne ${subport}} {
+    livecheck.type      none
+
+    depends_build-append port:py${python.version}-setuptools \
+                        port:py${python.version}-nose \
+                        port:py${python.version}-tox \
+                        port:py${python.version}-sphinx \
+                        port:py${python.version}-sphinx_rtd_theme
+
+    depends_lib-append  port:py${python.version}-openpyxl \
+                        port:py${python.version}-agate
+} else {
+    livecheck.type      regex
+    livecheck.url       ${homepage}
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
+}


### PR DESCRIPTION
[Adds read support for Excel files (xls and xlsx) to agate](https://github.com/wireservice/agate-excel).

Passes the linter and installs. Depends on new submission, py-agate, among other existing ports.

https://trac.macports.org/ticket/53642