### PR TITLE
py-csvkit: Update to 1.0.2, add ports for new dependencies

### DIFF
--- a/python/py-csvkit/Portfile
+++ b/python/py-csvkit/Portfile
@@ -4,45 +4,52 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-name                py-csvkit
-version             0.9.1
+set base_name       csvkit
+name                py-$base_name
+version             1.0.2
 python.versions     27 34 35 36
 categories-append   textproc
 platforms           darwin
-maintainers         nomaintainer
+maintainers         openmaintainer @esafak
 license             MIT
 supported_archs     noarch
 
-description         suite of utilities for converting to and working with CSV
-long_description    \
-    csvkit is a suite of utilities for converting to and working with CSV, the \
-    king of tabular file formats. csvkit is to tabular data what the standard \
-    Unix text processing suite (grep, sed, cut, sort) is to text. As such, csvkit \
-    adheres to the Unix philosophy.
+description         A suite of utilities for converting to and working with CSV, the king of tabular file formats
+long_description    csvkit is a suite of utilities for converting to and working with CSV, \
+                    the king of tabular file formats. csvkit is to tabular data what the \
+                    standard Unix text processing suite (grep, sed, cut, sort) is to text. \
+                    As such, csvkit adheres to the Unix philosophy.
 
-homepage            http://pypi.python.org/pypi/csvkit
-master_sites        pypi:c/csvkit
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:c/$base_name
 
-checksums           rmd160  e83e5968dbdd22a63bb50caf11ab0f73c62928c8 \
-                    sha256  92f8b8647becb5cb1dccb3af92a13a4e85702d42ba465ce8447881fb38c9f93a
+checksums           rmd160  8c275858eb178d0b66bf0424e37a02de48843a18 \
+                    sha256  35c8c7c699573bec47cbd3576240cc9b444d35f309386f8030340bc50315cdec
 
-distname            csvkit-${version}
+distname            $base_name-${version}
 
 if {${name} ne ${subport}} {
     livecheck.type      none
 
     depends_build-append \
-                        port:py${python.version}-setuptools
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-coverage \
+                        port:py${python.version}-sphinx \
+                        port:py${python.version}-sphinx_rtd_theme \
+                        port:py${python.version}-nose \
+                        port:py${python.version}-tox
 
-    depends_lib-append  port:csvkit_select \
-                        port:py${python.version}-dateutil \
-                        port:py${python.version}-openpyxl \
-                        port:py${python.version}-sqlalchemy \
-                        port:py${python.version}-xlrd
-    select.group        csvkit
-    select.file         ${filespath}/py${python.version}-csvkit
+    depends_lib-append  port:${base_name}_select \
+                        port:py${python.version}-agate \
+                        port:py${python.version}-agate-excel \
+                        port:py${python.version}-agate-dbf \
+                        port:py${python.version}-agate-sql \
+                        port:py${python.version}-six
+
+    select.group        $base_name
+    select.file         ${filespath}/py${python.version}-$base_name
 } else {
     livecheck.type      regex
     livecheck.url       ${homepage}
-    livecheck.regex     csvkit (\\d+(\\.\\d+)+)
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
 }


### PR DESCRIPTION
[Introduces new dependencies: py-agate, py-agate_sql, py-agate_dbf, py-agate_excel](https://github.com/wireservice/csvkit/blob/1.0.1/requirements-py3.txt)

Passes linter and installs.

https://trac.macports.org/ticket/53643