### PR TITLE
py-isodate: Update to 0.5.4, support py35, py36

### DIFF
--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -1,32 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup python    1.0
+PortGroup           python 1.0
 
-name                py-isodate
-version             0.5.0
+set base_name       isodate
+name                py-$base_name
+version             0.5.4
+python.versions     26 27 33 34 35 36
 
 license             BSD
 platforms           darwin
-maintainers         nomaintainer
+maintainers         @esafak
 
 description         An ISO 8601 date/time/duration parser and formatter
-
 long_description    This module implements ISO 8601 date, time and duration \
                     parsing. The implementation follows ISO8601:2004 standard, \
                     and implements only date/time representations mentioned in \
                     the standard. If something is not mentioned there, then it \
                     is treated as non existent, and not as an allowed option.
 
-homepage            https://pypi.python.org/pypi/isodate
-master_sites        pypi:i/isodate
-distname            isodate-${version}
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:i/$base_name
 
-checksums           md5     9a267e9327feb3d021cae26002ba6e0e \
-                    rmd160  4154ab9e03a9a35649569d4dc65bae1d40f58d88 \
-                    sha256  f3e436a9c321882942a6c62e9d8ea49787b4c0ea7f7bb3cbd047bcf76bd0dfbe
+checksums           rmd160  8b483cedd72d92c3d0182a0d409672e1e21dc893 \
+                    sha256  42105c41d037246dc1987e36d96f3752ffd5c0c24834dd12e4fdbe1e79544e31
 
-python.versions     26 27 33 34
+distname            $base_name-${version}
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -43,5 +42,5 @@ if {${name} ne ${subport}} {
 } else {
     livecheck.type  regex
     livecheck.url   ${homepage}
-    livecheck.regex {isodate-([0-9\.]+)\.tar\.gz}
+    livecheck.regex $base_name (\\d+(\\.\\d+)+)
 }


### PR DESCRIPTION
Passes linter and installs.

https://trac.macports.org/ticket/53643