### PR TITLE
py-leather: new port

### DIFF
--- a/python/py-leather/Portfile
+++ b/python/py-leather/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       leather
+name                py-$base_name
+version             0.3.3
+python.versions     27 33 34 35 36
+
+platforms           darwin
+maintainers         @esafak
+license             MIT
+
+description         Python charting for 80% of humans
+long_description    \
+    Leather is the Python charting library for those who need charts now and don’t care if they’re perfect. \
+    \
+    Leather isn’t picky. It’s rough. It gets dirty. It looks sexy just hanging on the back of a chair. \
+    Leather doesn’t need your accessories. Leather is how Snake Plissken would make charts.
+
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:l/$base_name
+
+checksums           rmd160  5d9701a4ef7ac3e32bd9275e0dd2906aa0b6a624 \
+                    sha256  076d1603b5281488285718ce1a5ce78cf1027fe1e76adf9c548caf83c519b988
+
+distname            $base_name-${version}
+
+if {${name} ne ${subport}} {
+    livecheck.type      none
+
+    depends_build-append port:py${python.version}-setuptools
+
+    depends_lib-append  port:py${python.version}-nose \
+                        port:py${python.version}-sphinx \
+                        port:py${python.version}-coverage \
+                        port:py${python.version}-six \
+                        port:py${python.version}-sphinx_rtd_theme \
+                        port:py${python.version}-tz \
+                        port:py${python.version}-tox \
+                        port:py${python.version}-lxml \
+                        port:py${python.version}-cssselect
+                        # port:py${python.version}-unittest2 \
+} else {
+    livecheck.type      regex
+    livecheck.url       ${homepage}
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
+}


### PR DESCRIPTION
[A python charting library](https://github.com/wireservice/leather) [required for py-agate](https://github.com/wireservice/agate/blob/master/requirements-py2.txt)

Passes linter and installs.

https://trac.macports.org/ticket/53645