### PR TITLE
py-dbfread: new port

### DIFF
--- a/python/py-dbfread/Portfile
+++ b/python/py-dbfread/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       dbfread
+name                py-$base_name
+version             2.0.7
+python.versions     27 33 34 35 36
+
+platforms           darwin
+maintainers         @esafak
+license             MIT
+
+description         Read DBF Files with Python
+long_description    ${description}
+
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:d/$base_name
+
+checksums           rmd160  6599d0c691b9047c46ec75842ed380880c595567 \
+                    sha256  07c8a9af06ffad3f6f03e8fe91ad7d2733e31a26d2b72c4dd4cfbae07ee3b73d
+
+distname            $base_name-${version}
+
+if {${name} ne ${subport}} {
+    livecheck.type      none
+
+    depends_build-append port:py${python.version}-setuptools
+
+} else {
+    livecheck.type      regex
+    livecheck.url       ${homepage}
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
+}


### PR DESCRIPTION
Added to support py-agate_dbf

Passes the linter and installs.

https://trac.macports.org/ticket/53646