### PR TITLE
py-unidecode: Upgrade to 0.04.20 and add support for py35, py36

### DIFF
--- a/python/py-unidecode/Portfile
+++ b/python/py-unidecode/Portfile
@@ -3,15 +3,15 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-name                py-unidecode
-set realName Unidecode
-version             0.04.17
-revision            1
+set realName        unidecode
+name                py-$realName
+version             0.04.20
+# revision            1
 categories-append   textproc
 platforms           darwin
 supported_archs     noarch
 license             GPL-2+
-maintainers         phas.ubc.ca:jfcaron openmaintainer
+maintainers         phas.ubc.ca:jfcaron @esafak openmaintainer
 
 description         ASCII transliterations of Unicode text
 long_description    Unidecode takes Unicode data and tries to \
@@ -24,13 +24,12 @@ long_description    Unidecode takes Unicode data and tries to \
                     Perl module by Sean M. Burke.
 homepage            https://pypi.python.org/pypi/$realName/
 
-master_sites        pypi:U/$realName/
+master_sites        pypi:u/$realName
 distname            $realName-${version}
-checksums           md5     5862c893d5aac49f5eefbd96e9e9e682 \
-                    rmd160  d2eb1039b8b77728784d8b1bebe1a5bd998d1dfa \
-                    sha256  f0f8d53d39877da4849293d548eecb5e79364b573643296869dbc7f5b86709ef
+checksums           rmd160  43424072a59c6cbb88e3915cc1942bed33eeb6d5 \
+                    sha256  ed4418b4b1b190487753f1cca6299e8076079258647284414e6d607d1f8a00e0
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 if {${subport} ne ${name}} {
     livecheck.type          none
@@ -39,5 +38,5 @@ if {${subport} ne ${name}} {
     # The usual URL to use here would be the master site, but for some
     # reason PyPi isn't serving anything at that URL.
     livecheck.url           ${homepage}
-    livecheck.regex         $realName-(\\d+(?:\\.\\d+)*)${extract.suffix}
+    livecheck.regex         $realName (\\d+(\\.\\d+)+)
 }


### PR DESCRIPTION
Upgrade in order to support py-awesome_slugify

Passes linter and installs.

https://trac.macports.org/ticket/53647