### PR TITLE
pure-gen: Bump the default gcc variant/dependency to gcc6 on macOS 10.5+

### DIFF
--- a/pure/pure-gen/Portfile
+++ b/pure/pure-gen/Portfile
@@ -23,47 +23,53 @@ depends_lib-append              port:gmp
 
 # pure-gen uses gcc at runtime to parse C headers but the
 # -fdirectives-only option it needs is only available in gcc 4.3 and up.
-variant gcc43 conflicts gcc44 gcc45 gcc46 gcc47 gcc48 gcc49 description {Use gcc43 for runtime C header parsing} {
+variant gcc43 conflicts gcc44 gcc45 gcc46 gcc47 gcc48 gcc49 gcc6 description {Use gcc43 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.3:gcc43
     global gcc_version
     set gcc_version             4.3
 }
-variant gcc44 conflicts gcc43 gcc45 gcc46 gcc47 gcc48 gcc49 description {Use gcc44 for runtime C header parsing} {
+variant gcc44 conflicts gcc43 gcc45 gcc46 gcc47 gcc48 gcc49 gcc6 description {Use gcc44 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.4:gcc44
     global gcc_version
     set gcc_version             4.4
 }
-variant gcc45 conflicts gcc43 gcc44 gcc46 gcc47 gcc48 gcc49 description {Use gcc45 for runtime C header parsing} {
+variant gcc45 conflicts gcc43 gcc44 gcc46 gcc47 gcc48 gcc49 gcc6 description {Use gcc45 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.5:gcc45
     global gcc_version
     set gcc_version             4.5
 }
-variant gcc46 conflicts gcc43 gcc44 gcc45 gcc47 gcc48 gcc49 description {Use gcc46 for runtime C header parsing} {
+variant gcc46 conflicts gcc43 gcc44 gcc45 gcc47 gcc48 gcc49 gcc6 description {Use gcc46 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.6:gcc46
     global gcc_version
     set gcc_version             4.6
 }
-variant gcc47 conflicts gcc43 gcc44 gcc45 gcc46 gcc48 gcc49 description {Use gcc47 for runtime C header parsing} {
+variant gcc47 conflicts gcc43 gcc44 gcc45 gcc46 gcc48 gcc49 gcc6 description {Use gcc47 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.7:gcc47
     global gcc_version
     set gcc_version             4.7
 }
-variant gcc48 conflicts gcc43 gcc44 gcc45 gcc46 gcc47 gcc49 description {Use gcc48 for runtime C header parsing} {
+variant gcc48 conflicts gcc43 gcc44 gcc45 gcc46 gcc47 gcc49 gcc6 description {Use gcc48 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.8:gcc48
     global gcc_version
     set gcc_version             4.8
 }
-variant gcc49 conflicts gcc43 gcc44 gcc45 gcc46 gcc47 gcc48 description {Use gcc49 for runtime C header parsing} {
+variant gcc49 conflicts gcc43 gcc44 gcc45 gcc46 gcc47 gcc48 gcc6 description {Use gcc49 for runtime C header parsing} {
     depends_run-append          path:bin/gcc-mp-4.9:gcc49
     global gcc_version
     set gcc_version             4.9
+}
+variant gcc6 conflicts gcc43 gcc44 gcc45 gcc46 gcc47 gcc48 gcc49 description {Use gcc6 for runtime C header parsing} {
+    depends_run-append          path:bin/gcc-mp-6:gcc6
+    global gcc_version
+    set gcc_version             6
 }
 if {![variant_isset gcc43] && ![variant_isset gcc44] && ![variant_isset gcc45] && ![variant_isset gcc46] && ![variant_isset gcc47] && ![variant_isset gcc48] && ![variant_isset gcc49]} {
     if {${os.platform} eq "darwin" && ${os.major} < 9} {
         # gcc44 doesn't build for me on Tiger
         default_variants +gcc43
     } else {
-        default_variants +gcc48
+        # gcc6 should work fine on all recent macOS versions.
+        default_variants +gcc6
     }
 }
 


### PR DESCRIPTION
The default gcc dependency in this port is really ancient (gcc48), which doesn't even build on Sierra any more. pure-gen works just fine with the latest gcc versions, so this pull request updates the default to gcc6 on 10.5 and later. Tested on Sierra, works fine for me.