### PR TITLE
libquicktime-devel: update to 20170307

### DIFF
--- a/multimedia/libquicktime-devel/Portfile
+++ b/multimedia/libquicktime-devel/Portfile
@@ -4,7 +4,7 @@ name                libquicktime-devel
 set my_name         libquicktime
 conflicts           libquicktime
 version             1.2.4
-revision            20160423
+revision            20170307
 categories          multimedia
 platforms           darwin
 maintainers         {jeremyhu @jeremyhu}
@@ -30,15 +30,15 @@ configure.args      --without-gtk --without-alsa --without-libdv --without-openg
                     --enable-gpl
 
 post-patch {
-	system "cd ${worksrcpath} && ./make_potfiles"
+    system "cd ${worksrcpath} && ./make_potfiles"
 }
 
 use_autoreconf      yes
 autoreconf.args     -fvi
 
 fetch.type          cvs
-cvs.root            :pserver:anonymous@libquicktime.cvs.sourceforge.net:/cvsroot/libquicktime 
-cvs.date            2016-04-22
+cvs.root            :pserver:anonymous@libquicktime.cvs.sourceforge.net:/cvsroot/libquicktime
+cvs.date            2017-03-07
 cvs.module          libquicktime
 worksrcdir          libquicktime
 


### PR DESCRIPTION
###### Description
```
RCS file: /cvsroot/libquicktime/libquicktime/src/util.c,v
Working file: src/util.c
head: 1.47
branch:
locks: strict
access list:
symbolic names:
keyword substitution: kv
total revisions: 47;	selected revisions: 47
description:
----------------------------
revision 1.47
date: 2017/03/06 10:16:11;  author: gmerlin;  state: Exp;  lines: +8 -3
* Fix security hole
----------------------------
revision 1.46
date: 2016/04/26 18:04:01;  author: gmerlin;  state: Exp;  lines: +1 -1
* Security fix
----------------------------
```

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -v -t install`?
- [ ] tested basic functionality of all binary files?