### PR TITLE
binutils: update to 2.28

### DIFF
--- a/cross/arm-aout-binutils/Portfile
+++ b/cross/arm-aout-binutils/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-aout 2.27
+crossbinutils.setup arm-aout 2.28
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append --disable-werror

--- a/cross/arm-elf-binutils/Portfile
+++ b/cross/arm-elf-binutils/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-elf 2.27
+crossbinutils.setup arm-elf 2.28
 maintainers         gmail.com:stuartwesterman openmaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 # Fix build problems on powerpc, #29925
 configure.args-append --disable-werror

--- a/cross/arm-none-eabi-binutils/Portfile
+++ b/cross/arm-none-eabi-binutils/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-none-eabi 2.27
+crossbinutils.setup arm-none-eabi 2.28
 maintainers         gmail.com:stuartwesterman openmaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append --disable-werror
 

--- a/cross/arm-none-linux-gnueabi-binutils/Portfile
+++ b/cross/arm-none-linux-gnueabi-binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup arm-none-linux-gnueabi 2.27
+crossbinutils.setup arm-none-linux-gnueabi 2.28
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 maintainers         gmail.com:stuartwesterman openmaintainer
 

--- a/cross/avr-binutils/Portfile
+++ b/cross/avr-binutils/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup avr 2.27
+crossbinutils.setup avr 2.28
 revision            1
 maintainers         g5pw openmaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 # configure.args-append --disable-werror

--- a/cross/i386-elf-binutils/Portfile
+++ b/cross/i386-elf-binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup i386-elf 2.27
+crossbinutils.setup i386-elf 2.28
 maintainers         gmail.com:jinksys
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append --disable-werror

--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -7,12 +7,12 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.27
+crossbinutils.setup ${mingw_target} 2.28
 
 maintainers         mojca openmaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/m68k-elf-binutils/Portfile
+++ b/cross/m68k-elf-binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup m68k-elf 2.27
+crossbinutils.setup m68k-elf 2.28
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append \
                     --disable-werror

--- a/cross/mips-elf-binutils/Portfile
+++ b/cross/mips-elf-binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup mips-elf 2.27
+crossbinutils.setup mips-elf 2.28
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append \
                     --disable-werror

--- a/cross/ppc-linux-binutils/Portfile
+++ b/cross/ppc-linux-binutils/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup ppc-linux 2.27
+crossbinutils.setup ppc-linux 2.28
 maintainers         nomaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72

--- a/cross/spu-binutils/Portfile
+++ b/cross/spu-binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup spu 2.27
+crossbinutils.setup spu 2.28
 maintainers         nomaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append   --disable-werror

--- a/cross/x86_64-elf-binutils/Portfile
+++ b/cross/x86_64-elf-binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup x86_64-elf 2.27
+crossbinutils.setup x86_64-elf 2.28
 maintainers         gmail.com:nategriswold
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append --disable-werror

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -7,12 +7,12 @@ PortGroup           crossbinutils 1.0
 set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
-crossbinutils.setup ${mingw_target} 2.27
+crossbinutils.setup ${mingw_target} 2.28
 
 maintainers         mojca openmaintainer
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 configure.args-append \
                     --disable-multilib \

--- a/devel/binutils/Portfile
+++ b/devel/binutils/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                binutils
-version             2.27
+version             2.28
 
-checksums           rmd160  e6623d3a90578169790417b8dd83e850c0a81910 \
-                    sha256  369737ce51587f92466041a97ab7d2358c6d9e1b6490b3940eb09fb0a9a6ac88
+checksums           rmd160  2d697b066cf764ba5f4a5cb3c7cbb45c26c6dc5b \
+                    sha256  6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 
 description         FSF Binutils for native development.
 long_description    Free Software Foundation development toolchain ("binutils") \


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?