### PR TITLE
spring-boot-cli: update to 1.5.2

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.1
+version         1.5.2
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    http://repo.spring.io/release/org/springframework/boot/${name}/$
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  b2bcd49aa916339a10d68326c3a34e9ec1f2103c \
-                sha256  6a5e871e63743683687a56829d947a54e84e19a8da1c84e13a8de40c1a93a9ca
+checksums       rmd160  4e4d15b078593bdaeb8892b5f6390f7c05f0df24 \
+                sha256  a18dcfec67b2facc64b2b90e1baef2c4dc748480ea05b0e4deaba800dde7ed99
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
https://spring.io/blog/2017/03/03/spring-boot-1-4-5-and-1-5-2-available-now
https://github.com/spring-projects/spring-boot/milestone/83?closed=1