### PR TITLE
faust2-devel: update to rev. 199b2a5e, fix Sierra compile problems.

### DIFF
--- a/audio/faust2-devel/Portfile
+++ b/audio/faust2-devel/Portfile
@@ -3,13 +3,13 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 7406a909506e62537f30a1096da21e1940ddfc09
+github.setup            grame-cncm faust 199b2a5e29921c0b21a3262c9ccd260d0475a4a4
 # When updating faust2-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.0-20170105
+version                 2.0-20170303
 
-checksums               rmd160  27ccb091e6db29bc2be89d61ec4f9b041bd45332 \
-                        sha256  a497f90c8260577be384b38af0efcbc044a161b51c4c607734dc723d9dcd4798
+checksums               rmd160  2b08186db0321e1422db1c4e36ca018973032845 \
+                        sha256  9f5c115081485336d0afcfdb432a6eb55d0056e07a8159b71292ac429ca8ad5f
 
 name                    faust2-devel
 conflicts               faust faust-devel
@@ -32,8 +32,7 @@ build.env               PATH=${llvm_prefix}/bin:$env(PATH)
 
 depends_build           port:pkgconfig
 
-depends_lib             port:clang-${llvm_version} \
-                        port:libmicrohttpd \
+depends_lib             port:libmicrohttpd \
                         port:libsndfile \
                         port:llvm-${llvm_version} \
                         path:lib/libssl.dylib:openssl


### PR DESCRIPTION
This port previously wouldn't build on Sierra because of the clang-3.4 dependency. Turns out that faust2 compiles just fine without that dependency now, so I removed it, making the port build fine on Sierra again, and updated to the latest upstream revision.

See: https://trac.macports.org/ticket/52424