### PR TITLE
faust-devel: update to rev. c1b89ad9.

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 344fc7fe9c7f4f8e1ee7d33f3b975a7613871cd5
-version                 0.9.95-20170104
+github.setup            grame-cncm faust c1b89ad933bf97376d0ae714164aa54e7383fee8
+version                 0.9.96-20170305
 
-checksums               rmd160  9238f09c1905871e1524b27845b4756cc7655405 \
-                        sha256  e022511459cd574cd3fe204fadf3ba03205c0080e2c5b88698ede95d37c1c2c5
+checksums               rmd160  7fd375dd7b6cd44b974793390da507ef3c801bfd \
+                        sha256  c0248efcbb5b0b57c464018d2075d51f2f2198621b7a06811d7a75edb8441b69
 
 name                    faust-devel
 conflicts               faust faust2-devel


### PR DESCRIPTION
This updates faust-devel to the latest upstream revision.