### PR TITLE
inkscape-app: fix crash when using nonstandard locale

### DIFF
--- a/aqua/inkscape-app/Portfile
+++ b/aqua/inkscape-app/Portfile
@@ -6,7 +6,9 @@ PortGroup           github 1.0
 github.setup        piksels-and-lines-orchestra inkscape 628ca88bdb258c0be08a5aa6337ed6df31190326
 name                inkscape-app
 version             0.92
+revision            1
 license             GPL-2+
+platforms           darwin
 maintainers         nomaintainer
 description         Inkscape.app application bundle
 long_description    ${description}

--- a/aqua/inkscape-app/files/Inkscape
+++ b/aqua/inkscape-app/files/Inkscape
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+export LANG=${LANG:-C}
+export LC_ALL=${LC_ALL:-C}
+
 PATH=@@PREFIX@@/bin:$PATH @@PREFIX@@/bin/inkscape


### PR DESCRIPTION
###### Description
Currently on my machine Inkscape.app crashes immediately after launch with a message like "Inkscape has encountered an error and will exit immediately", giving the stack trace included below.

I discovered the reason for this is that my system is set to a non-standard locale, namely `en-JP` (primary language English, region Japan). This is not a POSIX-supported locale, so with these settings the environment for GUI programs has its locale envars set as follows:

```
LANG=
LC_COLLATE="C"
LC_CTYPE="C"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
```

Inkscape doesn't like the empty `LANG` and `LC_ALL`; this patch sets them to `C` if they are not already set, thus avoiding the crash and allowing the app to launch in its default language (English).

In the Terminal you can set these variables in `.profile` and so on, but as I understand it there is no good way to set these dynamically for GUI programs. Thus I have modified the launch script to set them.

An argument can be made that a fix should be made upstream, but I think my patch is at least a reasonable stopgap as it should have no ill effects (it does nothing if the envars are already set).

Crash report stack trace:
```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_c.dylib             	0x00007fffe1f720f3 _UTF8_mbsnrtowcs + 287
1   libsystem_c.dylib             	0x00007fffe1f6cf02 __collate_mbstowcs + 123
2   libsystem_c.dylib             	0x00007fffe1f9679c strcoll_l + 76
3   libglib-2.0.0.dylib           	0x000000010909ff99 g_utf8_collate + 105
4   inkscape                      	0x00000001065b9d33 font_factory::GetUIStyles(_PangoFontFamily*) + 221
5   inkscape                      	0x00000001065bf488 Inkscape::FontLister::update_font_list(SPDocument*) + 1490
6   inkscape                      	0x00000001066e76cc sp_text_toolbox_prep(SPDesktop*, _GtkActionGroup*, _GObject*) + 156
7   inkscape                      	0x00000001066f0f25 setup_aux_toolbox(_GtkWidget*, SPDesktop*) + 435
8   inkscape                      	0x00000001066f0a44 Inkscape::UI::ToolboxFactory::setToolboxDesktop(_GtkWidget*, SPDesktop*) + 518
9   inkscape                      	0x000000010671e71f Inkscape::UI::UXManagerImpl::connectToDesktop(std::__1::vector<_GtkWidget*, std::__1::allocator<_GtkWidget*> > const&, SPDesktop*) + 201
10  inkscape                      	0x0000000106696ac8 SPDesktopWidget::createInstance(SPNamedView*) + 794
11  inkscape                      	0x0000000106696795 sp_desktop_widget_new(SPNamedView*) + 11
12  inkscape                      	0x000000010638097f sp_file_new(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 223
13  inkscape                      	0x0000000106380c89 sp_file_new_default() + 49
14  inkscape                      	0x0000000106342cba sp_main_gui(int, char const**) + 929
15  libdyld.dylib                 	0x00007fffe1f05255 start + 1
```

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
