### PR TITLE
faust2-devel: update to rev. ff07c37b, bugfixes in Portfile

### DIFF
--- a/audio/faust2-devel/Portfile
+++ b/audio/faust2-devel/Portfile
@@ -3,13 +3,13 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 199b2a5e29921c0b21a3262c9ccd260d0475a4a4
+github.setup            grame-cncm faust ff07c37bfdd546e3fdd9cb95fd0e6be5d059c893
 # When updating faust2-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.0-20170303
+version                 2.0-20170306
 
-checksums               rmd160  2b08186db0321e1422db1c4e36ca018973032845 \
-                        sha256  9f5c115081485336d0afcfdb432a6eb55d0056e07a8159b71292ac429ca8ad5f
+checksums               rmd160  f5195d7544062cd6456716d06ae23af8b915a9b5 \
+                        sha256  9282da1cc145eddd61d05207f183e2c7eb0e04d54446c1faaa6231a506774053
 
 name                    faust2-devel
 conflicts               faust faust-devel
@@ -27,12 +27,18 @@ long_description        Faust is a functional programming language \
                         additional backends for C, Java and LLVM bitcode.
 
 set llvm_version        3.4
+if {${os.platform} eq "darwin" && ${os.major} > 14} {
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
+    set llvm_version    3.9
+}
+
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
 build.env               PATH=${llvm_prefix}/bin:$env(PATH)
 
 depends_build           port:pkgconfig
 
-depends_lib             port:libmicrohttpd \
+depends_lib             port:clang-${llvm_version} \
+                        port:libmicrohttpd \
                         port:libsndfile \
                         port:llvm-${llvm_version} \
                         path:lib/libssl.dylib:openssl


### PR DESCRIPTION
This also adds the clang dependency again which was removed in #367, to (hopefully) fix the compile problems on legacy systems introduced with PR #367. It also bumps the llvm/clang version to 3.9 on macOS 10.11+ (necessary because clang 3.5- is not supported there any more). Tested on Sierra, builds and runs fine there for me.

See: https://trac.macports.org/ticket/52424