### PR TITLE
py-fastavro: update to 0.14.3

### DIFF
--- a/python/py-fastavro/Portfile
+++ b/python/py-fastavro/Portfile
@@ -7,8 +7,8 @@ set _name           fastavro
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.9.8
-categories-append   net parallel science
+version             0.14.3
+categories-append   net parallel sciences
 platforms           darwin
 license             MIT
 
@@ -22,11 +22,11 @@ homepage            https://fastavro.readthedocs.org/
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-checksums           md5     af74d03d1fd3a2384ca655e08650ce76 \
-                    rmd160  546f374c2e10a4f189c925dacca5525c89104f62 \
-                    sha256  d6404f006e5b734021baed993c957ba12e98ef330a07ad9075c221738567f0cb
+checksums           md5 	966cb09c8be20c6e1a6c8f5e54548e63 \
+					rmd160  cf11ecc0877685863f3555277d8c6c2052aebea8 \
+                    sha256  2acb475a1391ff1aa635c51c52420264368fcca2994408a88b0a1cc13fdad3bb
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
###### Description
Updated and added py36 support

###### Tested on
macOS 10.x

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?