### PR TITLE
gcc48: fix build

### DIFF
--- a/lang/gcc48/Portfile
+++ b/lang/gcc48/Portfile
@@ -33,9 +33,7 @@ checksums           rmd160  98e84aa59bd668c4ab58afea9c7a2d1cc0c6ef7e \
                     sha256  22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23
 
 depends_lib         port:cctools \
-                    path:lib/pkgconfig/cloog-isl.pc:cloog \
                     port:gmp \
-                    path:lib/pkgconfig/isl.pc:isl \
                     port:ld64 \
                     path:lib/libgcc/libgcc_s.1.dylib:libgcc \
                     port:libiconv \
@@ -54,11 +52,19 @@ patchfiles-append   macosx-version-min.patch
 # later (#45483).
 patchfiles-append   yosemite-libtool.patch
 
+# fix old texi file
+patchfiles-append   patch-gcc48-texi.diff
+
 set major           [join [lrange [split ${version} .-] 0 1] .]
 
 platform darwin {
     configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
 }
+
+# delete system isl and cloog because as of 20170304 these are too new (isl) to
+# be used by gcc48 to build. Might be able to restore GRAPHITE LOOP OPIMIZATION
+# by using an in-build isl 0.14 and cloog 0.14 decompressed into the gcc48 source
+# directory and named isl and cloog respectively
 
 configure.dir       ${workpath}/build
 configure.cmd       ${worksrcpath}/configure
@@ -76,8 +82,6 @@ configure.args      --enable-languages=c,c++,objc,obj-c++,lto,fortran,java \
                     --with-gmp=${prefix} \
                     --with-mpfr=${prefix} \
                     --with-mpc=${prefix} \
-                    --with-isl=${prefix} --disable-isl-version-check \
-                    --with-cloog=${prefix} --disable-cloog-version-check \
                     --enable-stage1-checking \
                     --disable-multilib \
                     --enable-lto \
@@ -102,7 +106,7 @@ configure.env-append \
 pre-configure {
     configure.args-append --with-pkgversion="MacPorts ${name} ${version}_${revision}${portvariants}"
 
-    if {${configure.sdkroot} ne "/"} {
+    if {${configure.sdkroot} ne ""} {
         # We should be using --with-build-sysroot here.  Using --with-sysroot
         # changes the behavior of the installed gcc to look in that sysroot
         # by default instead of /.  Using --with-build-sysroot is supposed

--- a/lang/gcc48/files/patch-gcc48-texi.diff
+++ b/lang/gcc48/files/patch-gcc48-texi.diff
@@ -1,0 +1,20 @@
+--- ./gcc/doc/gcc.texi.orig	2017-03-01 19:54:49.000000000 -0800
++++ ./gcc/doc/gcc.texi	2017-03-01 19:55:23.000000000 -0800
+@@ -85,9 +85,15 @@
+ @item GNU Press
+ @tab Website: www.gnupress.org
+ @item a division of the
+-@tab General: @tex press@@gnu.org @end tex
++@tab General: 
++@tex 
++press@@gnu.org 
++@end tex
+ @item Free Software Foundation
+-@tab Orders:  @tex sales@@gnu.org @end tex
++@tab Orders:  
++@tex 
++sales@@gnu.org 
++@end tex
+ @item 51 Franklin Street, Fifth Floor
+ @tab Tel 617-542-5942
+ @item Boston, MA 02110-1301 USA


### PR DESCRIPTION
add texinfo fix for newer versions of texinfo
delete isl and cloog requirements (disables GRAPHITE LOOP OPTIMIZATIONS)
GRAPHITE LOOP OPTIMIZATIONS may be restorable later with separate in-build isl and cloog
partially fixes https://trac.macports.org/ticket/53076. (gcc46 and gcc47 still need fixes)
partially fixes https://trac.macports.org/ticket/53662 (gcc46 and gcc47 still need fixes)

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6.8 and 10.12.3
Xcode 8.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
