### PR TITLE
groovy: update to 2.4.9

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.4.8
+version         2.4.9
 
 categories      lang java
 maintainers     breun.nl:nils openmaintainer
@@ -37,8 +37,8 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  d350c004f8a3361206e7c2dcab8c2f0f63b0994c \
-                sha256  668a65ea17037371a1952cca5f42ebc03329e15d3619aacb4c7dd5f4b39a8dfd
+checksums       rmd160  c06e3dc7439f6ec093f2de464264b087794e99c9 \
+                sha256  3f8fc6855b85b3575583744c7113ce182b133f5d84972515317a0625c35799fe
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
###### Description

Updated to latest release version.

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
