### PR TITLE
weechat: fix homepage

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -7,7 +7,24 @@ PortGroup           github 1.0
 
 name                weechat
 
-homepage            http://weechat.org/
+if {${name} eq ${subport}} {
+    conflicts       weechat-devel
+    github.setup    weechat weechat 1.5 v
+
+    checksums       rmd160  3eba0f051cc158798a9810a83ff950faeaa48e49 \
+                    sha256  fe8cc22db690ed62b10514acf1142fa3669e50aff35e3bce41e478104fa56446
+}
+
+subport weechat-devel {
+    github.setup    weechat weechat 290b40af8905152e82f83a6f521ee420f7631c7a
+    version         1.6-dev-20160715
+
+    conflicts       weechat
+    checksums       rmd160  6473a48520503ca8941aa5f53f604a83515e2b84 \
+                    sha256  285803b61ab62a7e1e83b494a246b9eb300105a705f1687fd68443720ac9dbef
+}
+
+homepage            https://weechat.org/
 license             GPL-3
 description         Fast, light & extensible IRC client
 long_description    \
@@ -26,23 +43,6 @@ categories          irc
 maintainers         gmail.com:starkhalo \
                     openmaintainer
 platforms           darwin
-
-if {${name} eq ${subport}} {
-    conflicts       weechat-devel
-    github.setup    weechat weechat 1.5 v
-
-    checksums       rmd160  3eba0f051cc158798a9810a83ff950faeaa48e49 \
-                    sha256  fe8cc22db690ed62b10514acf1142fa3669e50aff35e3bce41e478104fa56446
-}
-
-subport weechat-devel {
-    github.setup    weechat weechat 290b40af8905152e82f83a6f521ee420f7631c7a
-    version         1.6-dev-20160715
-
-    conflicts       weechat
-    checksums       rmd160  6473a48520503ca8941aa5f53f604a83515e2b84 \
-                    sha256  285803b61ab62a7e1e83b494a246b9eb300105a705f1687fd68443720ac9dbef
-}
 
 depends_build-append \
                     port:asciidoc \


### PR DESCRIPTION
###### Description
`homepage` was overwritten by `github.setup`.
