### PR TITLE
gperftools: new port at 2.5

### DIFF
--- a/devel/gperftools/Portfile
+++ b/devel/gperftools/Portfile
@@ -1,0 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        gperftools gperftools 2.5 gperftools-
+categories          devel
+platforms           darwin
+license             BSD
+maintainers         nomaintainer
+description         high-performance multi-threaded malloc() and nifty performance analysis tools
+long_description    gperftools is a collection of a high-performance multi-threaded malloc() \
+                    implementation, plus some pretty nifty performance analysis tools.
+
+github.tarball_from releases
+checksums           rmd160  20506514b0f9d98190dca30da8a219aa67f5d0aa \
+                    sha256  6fa2748f1acdf44d750253e160cf6e2e72571329b42e563b455bde09e9e85173


### PR DESCRIPTION
###### Description
Replaces google-perftools.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
