### PR TITLE
libsoundio: new port

### DIFF
--- a/audio/libsoundio/Portfile
+++ b/audio/libsoundio/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   cmake 1.0
+
+name                        libsoundio
+version                     1.1.0
+license                     MIT
+categories                  audio
+maintainers                 {darkcog.com:casr+macports @casr} \
+                            openmaintainer
+homepage                    http://libsound.io/
+platforms                   darwin
+
+description                 cross-platform audio input and output
+long_description            libsoundio is a lightweight abstraction over \
+                            various sound drivers. It provides a \
+                            well-documented API that operates consistently \
+                            regardless of the sound driver it connects to. \
+                            It performs no buffering or processing on your \
+                            behalf\; instead exposing the raw power of the \
+                            underlying backend.
+
+master_sites                http://libsound.io/release/
+
+checksums                   rmd160 61b8416e3feb9d6299b443c3e455cb2b0a2de350 \
+                            sha256 ba0b21397cb3e29dc8f51ed213ae27625f05398c01aefcfbaa860fab42a84281
+
+configure.args-append       -DBUILD_EXAMPLE_PROGRAMS=Off \
+                            -DBUILD_TESTS=Off \
+                            -DENABLE_JACK=Off \
+                            -DENABLE_PULSEAUDIO=Off \
+                            -DENABLE_ALSA=Off \
+                            -DENABLE_WASAPI=Off
+
+variant pulseaudio description {Enable PulseAudio support} {
+    depends_build-append        port:pulseaudio
+
+    configure.args-replace      -DENABLE_PULSEAUDIO=Off -DENABLE_PULSEAUDIO=On
+}
+
+# As PulseAudio is a build time only dependency we may as well let the
+# buildbot take care of this
+default_variants            +pulseaudio
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 14} {
+        ui_error "${name} ${version} requires macOS 10.10 or greater."
+        return -code error "incompatible macOS version"
+    }
+}
+
+
+livecheck.type              regex
+livecheck.regex             ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
###### Description

libsoundio: cross-platform audio input and output. It collates a bunch of audio backends on different platforms and presents them as a "consistent API".

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.3
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
