### PR TITLE
Faust update

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust c1b89ad933bf97376d0ae714164aa54e7383fee8
-version                 0.9.96-20170305
+github.setup            grame-cncm faust 09e9836eb7398c9af327619c0ca0279c9f0d75ca
+version                 0.9.96-20170313
 
-checksums               rmd160  7fd375dd7b6cd44b974793390da507ef3c801bfd \
-                        sha256  c0248efcbb5b0b57c464018d2075d51f2f2198621b7a06811d7a75edb8441b69
+checksums               rmd160  9246cae79dadfeb7f2d679e1507f9f45e9a0ae88 \
+                        sha256  401e99714545c4f40550d72cffe6d2cf0939d0db88527bdc4aaf665f7b845cfb
 
 name                    faust-devel
 conflicts               faust faust2-devel

--- a/audio/faust2-devel/Portfile
+++ b/audio/faust2-devel/Portfile
@@ -3,13 +3,13 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust ff07c37bfdd546e3fdd9cb95fd0e6be5d059c893
+github.setup            grame-cncm faust d353536f673dafdb1c78a26569cfc4950a4c37e6
 # When updating faust2-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.0-20170306
+version                 2.0-20170313
 
-checksums               rmd160  f5195d7544062cd6456716d06ae23af8b915a9b5 \
-                        sha256  9282da1cc145eddd61d05207f183e2c7eb0e04d54446c1faaa6231a506774053
+checksums               rmd160  0f14e70aca6bb9e3c3234e1d3daf95109567f695 \
+                        sha256  2f84462c6a32105c3bc52a4d74c4352a60d63fb4ddf6e13350edb6d703393b56
 
 name                    faust2-devel
 conflicts               faust faust-devel

--- a/audio/faustlive-devel/Portfile
+++ b/audio/faustlive-devel/Portfile
@@ -1,10 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            grame-cncm faustlive 284ddb0229f9427f0bd916de9982073ce238c677
+version                 2.46-20170313
+
+checksums               rmd160  2fdf8ed2dd739db2ba89ec0aa30b47d798ec9b01 \
+                        sha256  f3f8aac223d9d45472948034d053a69c21d14e2fffcc4d20aba064d2f9769a6b
 
 name                    faustlive-devel
-version                 2.45-20170105
-git.branch              d2ee69d542b4e89872b01f5970a5635341d1983f
 categories              audio
 platforms               darwin
 maintainers             ryandesign gmail.com:aggraef
@@ -25,10 +30,13 @@ long_description        FaustLive is ${description}. \
                         sound or disconnecting the Jack audio server.
 
 homepage                http://faust.grame.fr/
-fetch.type              git
-git.url                 git://git.code.sf.net/p/faudiostream/faustlive
 
 set llvm_version        3.4
+if {${os.platform} eq "darwin" && ${os.major} > 14} {
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
+    set llvm_version    3.9
+}
+
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
 build.env               PATH=${llvm_prefix}/bin:$env(PATH)
 


### PR DESCRIPTION
Update of all Faust -devel ports to the latest revision from upstream. In particular, this adds support for the [JUCE architecture](http://faust.grame.fr/news/2017/02/21/Faust-meets-JUCE.html). Also, FaustLive has a new upstream repository at github now, so the faustlive-devel Portfile was updated accordingly.

Tested on macOS 10.12. Builds, installs and runs without hitches there.