### PR TITLE
taskjuggler: don't suffix binaries with Ruby version

### DIFF
--- a/_resources/port1.0/group/ruby-1.0.tcl
+++ b/_resources/port1.0/group/ruby-1.0.tcl
@@ -53,6 +53,8 @@
 #   ruby.branch: select ruby version. 2.3, 2.2, 2.1, 2.0, 1.9 or 1.8.
 #   ruby.link_binaries: whether generate suffixed symlink under ${prefix}/bin
 #        or not.
+#   ruby.link_binaries_suffix: suffix of commands from rb-foo under
+#        ${prefix}/bin. such as "-2.2" or "-2.1".
 # values:
 #   ruby.bin, ruby.rdoc, ruby.gem ruby.rake: fullpath to commands for ${ruby.branch}.
 #   ruby.suffix: suffix of portname. port:ruby${ruby.suffix} or
@@ -60,8 +62,6 @@
 #   ruby.bindir: install location of commands without suffix from rb-foo.
 #   ruby.gemdir: install location of rubygems.
 #        such as "${prefix}/lib/ruby2.2/gems/2.2.0".
-#   ruby.link_binaries_suffix: suffix of commands from rb-foo under
-#        ${prefix}/bin. such as "-2.2" or "-2.1".
 #   (obsoleted values)
 #   ruby.prog_suffix: use ruby.branch.
 #   ruby.version: use ruby.api_version.
@@ -89,8 +89,8 @@ proc ruby_set_branch {option action args} {
     }
     global prefix ruby.branch \
            ruby.bin ruby.rdoc ruby.gem ruby.rake ruby.bindir ruby.gemdir \
-           ruby.suffix ruby.link_binaries_suffix ruby.prog_suffix \
-           ruby.api_version ruby.lib ruby.archlib ruby.arch
+           ruby.suffix ruby.prog_suffix ruby.api_version ruby.lib \
+           ruby.archlib ruby.arch
     set ruby.bin            ${prefix}/bin/ruby${ruby.branch}
     set ruby.rdoc           ${prefix}/bin/rdoc${ruby.branch}
     set ruby.gem            ${prefix}/bin/gem${ruby.branch}
@@ -105,7 +105,6 @@ proc ruby_set_branch {option action args} {
     if {${ruby.branch} eq "1.8"} {
         set ruby.suffix     ""
     }
-    set ruby.link_binaries_suffix -${ruby.branch}
     set ruby.prog_suffix    ${ruby.branch}
     if {${ruby.branch} eq "1.8"} {
         set ruby.prog_suffix     ""
@@ -141,9 +140,6 @@ set ruby.docs           {}
 set ruby.srcdir         ""
 set ruby.prog_suffix    ""
 
-options ruby.link_binaries
-default ruby.link_binaries yes
-
 # detect setup.rb config option name of --rubyprog.
 # some setup.rb accepts this option by other name, such as --ruby-prog.
 # NOTE: set the value *before ruby.setup* to use ohter name.
@@ -151,6 +147,10 @@ options ruby.config_rubyprog_name
 default ruby.config_rubyprog_name --rubyprog
 
 default ruby.branch         ${ruby.default_branch}
+
+options ruby.link_binaries ruby.link_binaries_suffix
+default ruby.link_binaries yes
+default ruby.link_binaries_suffix {-${ruby.branch}}
 
 # ruby group setup procedure; optional for ruby 1.8 if you want only
 # basic variables, like ruby.lib and ruby.archlib.
@@ -160,7 +160,6 @@ proc ruby.setup {module vers {type "install.rb"} {docs {}} {source "custom"} {im
     global ruby.bin ruby.rdoc ruby.gem ruby.rake ruby.branch
     global ruby.api_version ruby.lib ruby.suffix ruby.bindir ruby.gemdir
     global ruby.module ruby.filename ruby.project ruby.docs ruby.srcdir
-    global ruby.link_binaries_suffix
     # ruby.version is obsoleted. use ruby.gemdir.
     global ruby.prog_suffix
     # from muniversal

--- a/net/nicinfo/Portfile
+++ b/net/nicinfo/Portfile
@@ -21,4 +21,4 @@ checksums           rmd160  55e107bac2582cc80f2d20c315477d1038c25fa8 \
                     sha256  ebeab769215c65519ba5be73c2e462f2ef6c1fcd5d3942763507044d7ff0782e
 
 #- want nicinfo installed without suffix
-set ruby.link_binaries_suffix ""
+ruby.link_binaries_suffix

--- a/office/taskjuggler/Portfile
+++ b/office/taskjuggler/Portfile
@@ -4,6 +4,8 @@ PortSystem          1.0
 PortGroup           ruby 1.0
 
 ruby.setup          taskjuggler 3.5.0 gem {} rubygems ruby19
+ruby.link_binaries_suffix
+revision            1
 name                taskjuggler
 homepage            http://www.taskjuggler.org/
 categories          office pim

--- a/ruby/rb-rbot/Portfile
+++ b/ruby/rb-rbot/Portfile
@@ -26,7 +26,7 @@ checksums           md5 9ff6fc4afcc62f3a264d5ccf4df3c9ff \
 depends_run         port:rb-bdb
 
 destroot.env        rake=rake
-set ruby.link_binaries_suffix ""
+ruby.link_binaries_suffix
 
 livecheck.type      regex
 livecheck.regex     {<i class="page__subheading">(\d+(?:\.\d+)*)</i>}

--- a/textproc/asciidoctor/Portfile
+++ b/textproc/asciidoctor/Portfile
@@ -7,7 +7,7 @@ ruby.setup          asciidoctor 1.5.5 gem {} rubygems ruby22
 name                asciidoctor
 
 # Prevent addition of the ruby interpreter version number as suffix to command line tools
-set ruby.link_binaries_suffix ""
+ruby.link_binaries_suffix
 
 categories          textproc
 platforms           darwin


### PR DESCRIPTION
###### Description
The `taskjuggler` port installs its binaries with a `-1.9` suffix as a side-effect of using the `ruby` group with implementation value `ruby19`. However this suffix is undesirable:
- TaskJuggler is a standalone tool that happens to be implemented in Ruby; it is not a Ruby gem or otherwise tied to the Ruby ecosystem
- There is various tooling (emacs org-mode packages, etc.) surrounding TaskJuggler that expects its binaries to be `tj3` and similar; the suffix makes these tools hard to use

This PR removes the suffix.