### PR TITLE
mercurial: update to 4.1.1, use mercurial-scm.org

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     seanfarley mercurial 4.1
+name                mercurial
+version             4.1.1
 categories          devel python
 license             GPL-2+
 maintainers         sean openmaintainer
@@ -23,10 +24,11 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
                     CGI, SSH or a stream of patch emails. Mercurial supports \
                     Apples' FileMerge for merges.
 
-homepage            http://www.selenic.com/mercurial/
+homepage            https://www.mercurial-scm.org/
 platforms           darwin
-checksums           rmd160  3643126eacb0e1bede84072b6f368742e8f0fa32 \
-                    sha256  d9ecbec6b2e051ac369a588c6356b7eea20b4a4338d32008b50767d7313ad63f
+master_sites        https://www.mercurial-scm.org/release/
+checksums           rmd160  700d33187081d08ff02370489e77ebf508704394 \
+                    sha256  63571be1202f83c72041eb8ca2a2ebaeda284d2031fd708919fc610589d3359e
 
 depends_build       port:py27-docutils
 


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
