### PR TITLE
ldas-tools-framecpp: updated for version 2.5.5

### DIFF
--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -18,6 +18,12 @@ master_sites  http://software.ligo.org/lscsoft/source/
 checksums     rmd160 5a4eafe72975961707ab072d1c2df030e7a1f3bf \
               sha256 15130fe497ec7697de58d58258999d3773cdd1912115ce8e506d095fe6fac2fc
 
+depends_build  port:pkgconfig \
+               port:autoconf \
+               port:automake \
+               port:libtool \
+               port:libframe
+
 depends_lib    port:ldas-tools-al \
                port:openssl \
                port:zlib \

--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-framecpp
-version       2.5.4
+version       2.5.5
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -15,8 +15,8 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
-checksums     rmd160 53853b72a57db344437b8ab7b8d199c6cee91495 \
-              sha256 54783c5ae235b8016adbc02d95aedcbd5f1256ae3b74b27ae516d9dee3cbe11b
+checksums     rmd160 5a4eafe72975961707ab072d1c2df030e7a1f3bf \
+              sha256 15130fe497ec7697de58d58258999d3773cdd1912115ce8e506d095fe6fac2fc
 
 depends_lib    port:ldas-tools-al \
                port:openssl \


### PR DESCRIPTION
###### Description
These changes reflect modifications to update the build process for the 2.5.5 release of the software.

They have also reduced some of the warning messages by introducing depends_build dependencies.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
