### PR TITLE
py-astropy: update to version 1.3.1

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             1.3
-maintainers         robitaille
+version             1.3.1
+maintainers         robitaille gmail.com:Deil.Christoph
 
 dist_subdir         ${name}/${version}
 
@@ -19,9 +19,9 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     bf4c8a033a7085fbc9ec604eebbdbdc5 \
-                    rmd160  2ca2d3b7c36f9152eca808d81667d192ef7eee30 \
-                    sha256  49de3e86482abe24e3cd02c4a30a469ee4b928d5b46ea5f70fa605ff6f9c6d38
+checksums           md5     f7cb71c4802f0b262d0cfffbc0098cce \
+                    rmd160  698f7e6a9ebaf7d82e50093dfef22611c77eff9c \
+                    sha256  b76050354cfaf0f5f56dd6874dc760c0c7ddb708ed0ac251efeb714a6229a4f9
 
 python.versions     27 33 34 35 36
 


### PR DESCRIPTION
* Update Astropy to the recently released version 1.3.1:
https://pypi.python.org/pypi/astropy/1.3.1
* Add me as co-maintainer with @astrofrog (this was discussed within the Astropy team, see http://www.astropy.org/team.html).