### PR TITLE
(nodejs7): enabling node-inspector now that it is stable

### DIFF
--- a/devel/nodejs7/Portfile
+++ b/devel/nodejs7/Portfile
@@ -67,7 +67,6 @@ post-patch {
 
 configure.args-append   --without-npm
 configure.args-append   --with-intl=system-icu
-configure.args-append   --without-inspector
 configure.args-append   --shared-openssl
 configure.args-append   --shared-openssl-includes=${prefix}/include/openssl
 configure.args-append   --shared-openssl-libpath=${prefix}/lib


### PR DESCRIPTION
... `--debug` and `--debug-brk` are deprecated and have been removed completely from later versions of node, breaking tooling

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
