### PR TITLE
libmatheval: depend on flex

### DIFF
--- a/math/libmatheval/Portfile
+++ b/math/libmatheval/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		libmatheval
 version		1.1.11
-revision        1
+revision        2
 categories	math devel
 platforms	darwin
 license		GPL-3
@@ -32,7 +32,8 @@ post-patch {
     reinplace "s/libguile.h/libguile18.h/g" ${worksrcpath}/configure ${worksrcpath}/tests/matheval.c
 }
 
-depends_build	port:guile18 port:flex
+depends_build	port:guile18
+depends_lib	port:flex
 
 configure.args	--infodir=${prefix}/share/info
 configure.env-append	GUILE=${prefix}/bin/guile18 GUILE_CONFIG=${prefix}/bin/guile18-config GUILE_TOOLS=${prefix}/bin/guile18-tools


### PR DESCRIPTION
Before this fix, libmatheval was correctly building but
the resulting dylib was not usable unless port flex
was not explicitly installed. The reason is that libmatheval
links flex:
/opt/local/lib/libmatheval.dylib:
	/opt/local/lib/libmatheval.1.dylib (compatibility version 2.0.0, current version 2.0.0)
	/opt/local/lib/libfl.2.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
but flex was only listed as a build dependence.

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11.7
Xcode 7

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
