### PR TITLE
curl: fix darwinssl variant description

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -132,7 +132,7 @@ if {${name} eq ${subport}} {
         configure.args-replace  --disable-ares --enable-ares
     }
 
-    variant darwinssl conflicts ssl gnutls wolfssl description {Allow secure connections using GNU TLS} {
+    variant darwinssl conflicts ssl gnutls wolfssl description {Allow secure connections using Apple OS native TLS} {
         configure.args-replace  --without-darwinssl --with-darwinssl
     }
 


### PR DESCRIPTION
###### Description
```
  --with-darwinssl        enable Apple OS native SSL/TLS
  --without-darwinssl     disable Apple OS native SSL/TLS
```