### PR TITLE
parallel: update to 20170322

### DIFF
--- a/sysutils/parallel/Portfile
+++ b/sysutils/parallel/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                parallel
-version             20170222
+version             20170322
 categories          sysutils
 platforms           darwin
 license             GPL-3+
@@ -20,8 +20,8 @@ use_bzip2           yes
 
 depends_lib         port:perl5
 
-checksums           rmd160  edb67206b6f46aa70fc600333186520d4a36c955 \
-                    sha256  6248cae7e0da7702710bf082290054b0ca3d26225fe66f7b03df20f3550ac955
+checksums           rmd160  097041cd2259cdaa47d6ad8da8c62752d4677a3e \
+                    sha256  f8f810040088bf3c52897a2ee0c0c71bd8d097e755312364b946f107ae3553f6
 
 post-patch {
     set perl_bin ${prefix}/bin/perl


### PR DESCRIPTION
###### Description
Is this alright?
```
Executing:  cd "/opt/local/var/macports/build/_..._ports_sysutils_parallel/parallel/work/parallel-20170322" && /usr/bin/make -w install DESTDIR=/opt/local/var/macports/build/_..._ports_sysutils_parallel/parallel/work/destroot
make: Entering directory `/opt/local/var/macports/build/_..._ports_sysutils_parallel/parallel/work/parallel-20170322'
Making install in src
make[1]: Entering directory `/opt/local/var/macports/build/_..._ports_sysutils_parallel/parallel/work/parallel-20170322/src'
pod2texi --output=./parallel.texi ./parallel.pod \
	|| echo "Warning: pod2texi not found. Using old parallel.texi"
/bin/sh: pod2texi: command not found
Warning: pod2texi not found. Using old parallel.texi
...
```

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
