### PR TITLE
jython: exec in launch script to avoid unnecessary process

### DIFF
--- a/lang/jython/Portfile
+++ b/lang/jython/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                jython
 version             2.7.0
-revision            1
+revision            2
 categories          lang python java
 platforms           darwin
 maintainers         nomaintainer
@@ -48,7 +48,7 @@ destroot {
 post-destroot {
     set fp [open ${destroot}${prefix}/bin/${name} w]
     puts $fp "#!/bin/sh"
-    puts $fp "${prefix}/share/java/${name}/bin/${bin_name} \\"
+    puts $fp "exec ${prefix}/share/java/${name}/bin/${bin_name} \\"
     puts $fp "  -Dpython.cachedir=\"\$HOME/.jython_cachedir\" \"\$@\""
     close $fp
     system "chmod +x ${destroot}${prefix}/bin/${name}"


### PR DESCRIPTION
###### Description
This PR uses `exec` to launch the jython process so as to remove an unnecessary shell layer.