### PR TITLE
faust-devel: update to latest revision

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 09e9836eb7398c9af327619c0ca0279c9f0d75ca
-version                 0.9.96-20170313
+github.setup            grame-cncm faust 80b4b0856b7c9a1429bb187c1ddffcd4dd98923d
+version                 0.9.96-20170330
 
-checksums               rmd160  9246cae79dadfeb7f2d679e1507f9f45e9a0ae88 \
-                        sha256  401e99714545c4f40550d72cffe6d2cf0939d0db88527bdc4aaf665f7b845cfb
+checksums               rmd160  5edd157d0a532b2f118ea2ded67b704cc13d64bd \
+                        sha256  5588185d811cc4b8ba05a65b72daba4f47fe6ded5d8faf3c02d370889870045b
 
 name                    faust-devel
 conflicts               faust faust2-devel


### PR DESCRIPTION
Latest revision with some bugfixes, in particular faust's -i option works again in the MP install.

Tested on macOS 10.12. Builds, installs and runs without any hitches there.
