### PR TITLE
mosh: 1.3.0, switch to CommonCrypto

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -4,8 +4,7 @@ PortSystem              1.0
 PortGroup               perl5 1.0
 
 name                    mosh
-version                 1.2.6
-revision                2
+version                 1.3.0
 categories              net
 license                 {GPL-3+ OpenSSLException}
 platforms               darwin
@@ -17,8 +16,8 @@ long_description        Mosh is a replacement for ssh that better handles \
 homepage                http://mosh.org/
 master_sites            ${homepage}
 
-checksums               rmd160  4e06957083f9fcdd4c85b8f3b3b3407f734eed0d \
-                        sha256  7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85
+checksums               rmd160  83f737acdbd79a217d55bbb41631a7a8fb865b30 \
+                        sha256  320e12f461e55d71566597976bd9440ba6c5265fa68fbf614c6f1c8401f93376
 
 perl5.require_variant   yes
 perl5.conflict_variants no
@@ -28,19 +27,18 @@ perl5.create_variants   ${perl5.branches}
 
 depends_build           port:pkgconfig
 
-depends_lib             path:lib/libssl.dylib:openssl \
-                        port:ncurses \
-                        port:p${perl5.major}-getopt-long \
-                        port:p${perl5.major}-io-socket-ip \
+depends_lib             port:ncurses \
                         port:protobuf-cpp \
-                        port:zlib
+                        port:zlib \
+                        port:p${perl5.major}-getopt-long \
+                        port:p${perl5.major}-io-socket-ip
 
 post-patch {
     reinplace "s|#!/usr/bin/env perl|#!${prefix}/bin/perl${perl5.major}|" \
         ${worksrcpath}/scripts/mosh.pl
 }
 
-configure.args          --with-crypto-library=openssl
+configure.args          --with-crypto-library=apple-common-crypto
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/etc/bash_completion.d


### PR DESCRIPTION
Update to 1.3.0 and switch back to CommonCrypto, dropping the OpenSSL
dependency now that older systems should work with CommonCrypto with
  https://trac.macports.org/ticket/52222
fixed upstream.

This reverts commit fbcb8396fcf918f4fdf0da2519ed259e724d192f.

Closes: https://trac.macports.org/ticket/53870
See: https://trac.macports.org/ticket/52222

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
