### PR TITLE
py-astropy: update to version 1.3.2

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             1.3.1
+version             1.3.2
 maintainers         robitaille gmail.com:Deil.Christoph
 
 dist_subdir         ${name}/${version}
@@ -19,9 +19,9 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     f7cb71c4802f0b262d0cfffbc0098cce \
-                    rmd160  698f7e6a9ebaf7d82e50093dfef22611c77eff9c \
-                    sha256  b76050354cfaf0f5f56dd6874dc760c0c7ddb708ed0ac251efeb714a6229a4f9
+checksums           md5     c597c68e4392a82f90a9cb22c3b28628 \
+                    rmd160  6f2d493654ee75e80402ab8cc21ad16986bbddb5 \
+                    sha256  2f1de9d239b76a7d940a7bd66408e370874c84476566a3ae693fd06653836ad0
 
 python.versions     27 33 34 35 36
 


### PR DESCRIPTION
This pull request updates Astropy to version 1.3.2 .

This release fixes the issue reported in https://trac.macports.org/ticket/53865
and upstream in https://github.com/astropy/astropy/issues/5912 .

I've run tests locally via:
```
cd python/py-astropy
sudo port install subport=py35-astropy
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages /opt/local/bin/python3.5 -c 'import astropy; astropy.test()'
```

Please merge this ASAP -- at the moment `py-astropy` in Macports is completely broken.