### PR TITLE
faust2-devel, faust-devel: update to latest revision

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 80b4b0856b7c9a1429bb187c1ddffcd4dd98923d
-version                 0.9.96-20170330
+github.setup            grame-cncm faust 10523e3c2f16444e188e4feb9e2e8399f6a39838
+version                 0.9.96-20170331
 
-checksums               rmd160  5edd157d0a532b2f118ea2ded67b704cc13d64bd \
-                        sha256  5588185d811cc4b8ba05a65b72daba4f47fe6ded5d8faf3c02d370889870045b
+checksums               rmd160  a257e307d38e3957f0b53b5b761769d7656d25cc \
+                        sha256  974326434347c0c0a39b2516b392ca0e699b5ac84ac875ae0e6feeafd1a63989
 
 name                    faust-devel
 conflicts               faust faust2-devel

--- a/audio/faust2-devel/Portfile
+++ b/audio/faust2-devel/Portfile
@@ -3,13 +3,13 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust d353536f673dafdb1c78a26569cfc4950a4c37e6
+github.setup            grame-cncm faust fda4ac1ee139558ce805dbdb394992bd0b1b89a8
 # When updating faust2-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.0-20170313
+version                 2.0-20170331
 
-checksums               rmd160  0f14e70aca6bb9e3c3234e1d3daf95109567f695 \
-                        sha256  2f84462c6a32105c3bc52a4d74c4352a60d63fb4ddf6e13350edb6d703393b56
+checksums               rmd160  b9e6ef758b57fcb4ac63b0956bf190db87a2c727 \
+                        sha256  001136f31baddfe208279cfed69446ea4fbbe1be23b5482e20699f48b5e6b1c6
 
 name                    faust2-devel
 conflicts               faust faust-devel


### PR DESCRIPTION
This brings faust2-devel and faust-devel in sync again, so that they both have all the latest bugfixes as of today.

Tested on Sierra, both ports build, install and run fine.