### PR TITLE
faustlive-devel: update to latest revision

### DIFF
--- a/audio/faustlive-devel/Portfile
+++ b/audio/faustlive-devel/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faustlive 284ddb0229f9427f0bd916de9982073ce238c677
-version                 2.46-20170313
+github.setup            grame-cncm faustlive c0334c926b1604a2c2f1f1a57aa9ed9a6227a75b
+version                 2.46-20170330
 
-checksums               rmd160  2fdf8ed2dd739db2ba89ec0aa30b47d798ec9b01 \
-                        sha256  f3f8aac223d9d45472948034d053a69c21d14e2fffcc4d20aba064d2f9769a6b
+checksums               rmd160  8c7150848a930eb1ecbb9c0d0b411d544b837227 \
+                        sha256  bb6dd8fe3fe783d91d5dd8d96c1326197106d5cf32e708f4416b24996cacb6f4
 
 name                    faustlive-devel
 categories              audio


### PR DESCRIPTION
To go along with the recent update of faust2-devel (#403). Tested on Sierra, all looking good.

I tested both the qt4 and qt5 variants. Couldn't test the jack variant, as it requires the jack port which is broken (doesn't compile) and unmaintained at present. I'm keeping that variant for now, though, as someone -- not me 😉 -- will hopefully get the jack port going again some time.