### PR TITLE
py-photutils: update to version 0.3.2

### DIFF
--- a/python/py-photutils/Portfile
+++ b/python/py-photutils/Portfile
@@ -7,7 +7,7 @@ set _name           photutils
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.3
+version             0.3.2
 categories-append   science
 platforms           darwin
 maintainers         gmail.com:Deil.Christoph openmaintainer
@@ -19,9 +19,9 @@ homepage            https://github.com/astropy/photutils
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     51830cfa4f033883388055550901e5c8 \
-                    rmd160  c0ca9835792ee33e33b87185615c0f8c0719b61b \
-                    sha256  7a746229c1d538b671806c48f561fb7d85fabf460b23b828a8af8a66e0097872
+checksums           md5     7811873224b22c6ff8fef732e1d93daa \
+                    rmd160  5472fad52b375f736b177187c0a33e8ef9d56fe9 \
+                    sha256  a02a0b205c058467f10d1605acfcef8b56695a81005ee2136c64914e55c1b42d
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
This pull request updates photutils to version 0.3.2.

https://pypi.python.org/pypi/photutils/0.3.2

This release fixes the file permission issue discussed for version 0.3 in #214 (see https://photutils.readthedocs.io/en/stable/changelog.html).

I've locally verified that all is good using:
```
cd python/py-photutils
sudo port install subport=py35-photutils
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages /opt/local/bin/python3.5 -c 'import photutils; photutils.test()'
```
There's only one fail that's unrelated to photutils: https://gist.github.com/cdeil/fb9953495c15cb294529eef779f90186 (`skimage` missing a dependency on `pywt`).

Please merge.