### PR TITLE
py-scikit-image: add missing dependency for pywavelets

### DIFF
--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -41,6 +41,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-networkx \
                         port:py${python.version}-dask \
                         port:py${python.version}-toolz \
+                        port:py${python.version}-pywavelets \
                         path:${python.pkgd}/PIL:py${python.version}-Pillow
 
     livecheck.type      none


### PR DESCRIPTION
With the update to scikit-image 0.13 I'm now getting this error:
```
$ python -c 'import skimage.restauration'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named 'skimage.restauration'
localhost:py-photutils deil$ python -c 'import skimage.restoration'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/skimage/restoration/__init__.py", line 23, in <module>
    from ._denoise import denoise_tv_chambolle, denoise_tv_bregman, \
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/skimage/restoration/_denoise.py", line 8, in <module>
    import pywt
ImportError: No module named 'pywt'
```

It looks like scikit-image added a runtime dependency on pywavelets:
http://scikit-image.org/docs/stable/release_notes_and_installation.html#runtime-requirements

This PR adds this dependency.

I didn't do any local testing, and I don't know if I should have incremented a revision number here.
Feel free to just do the right edits in master, or let me know what to change.
