### PR TITLE
plumed: new port

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           mpi 1.0
+PortGroup           linear_algebra 1.0
+PortGroup           debug 1.0
+
+github.setup        plumed plumed2 2.3.2 v
+name                plumed
+
+categories          science
+
+# Most of the PLUMED code is L-GPL3. However, PLUMED containts
+# molfile plugins from VMD that are released with a BSD-like license
+# http://www.ks.uiuc.edu/Research/vmd/plugins/molfile/
+license             LGPL-3 BSD
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+description         PLUMED is a plugin for molecular dynamics
+long_description    PLUMED is a plugin for molecular dynamics that can be used \
+                    in combination with popular molecular dynamics codes to perform biased simulations. \
+                    Additionally, it can be used as a standalone tool to analyze trajectories.
+
+platforms           darwin
+
+homepage            http://www.plumed.org/
+
+checksums           rmd160  a9925428b2a5fa1d43a4ef677b216bcec0e2ac27 \
+                    sha256  6df6a31ec47da3ec81e3554224b0c66b49ca62dd9cac659d085e0b89c870d9f5
+
+# Disable additional features.
+# --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
+# --disable-libsearch:    Avoid searching libraries using their default names.
+#                         This forces the libraries names to be explicitly passed (e.g. "-lz").
+#                         It has the advantage that during compilation from source it does not
+#                         link packages that are not explicitely required.
+# --disable-static-patch: Avoid a number of tests that are only required when linking plumed
+#                         statically to an MD code.
+# --disable-mpi:          Do not search for MPI compiler (replaced when enabling mpi, see below)
+configure.args-append \
+               --disable-doc \
+               --disable-libsearch \
+               --disable-static-patch \
+               --disable-mpi 
+
+# Hardcode path for libplumedKernel.dylib.
+# This allows to patch MD codes using the --runtime option but using as
+# default kernel the installed one. In this way, MacPorts users
+# can just use patched MD codes with the installed plumed or replace it
+# by setting PLUMED_KERNEL at runtime
+configure.cppflags-append "-D__PLUMED_DEFAULT_KERNEL=${prefix}/lib/libplumedKernel.dylib"
+
+compilers.choose    cc cxx
+mpi.setup
+
+# To enable mpi, replace a configure flag
+if {[mpi_variant_isset]} {
+  configure.args-replace --disable-mpi --enable-mpi
+}
+
+# Libraries.
+# Library names are specified here to make sure that
+# only requested packages are linked.
+configure.ldflags-append -lmatheval -lxdrfile -lz -lgsl
+depends_lib-append port:libmatheval port:xdrfile port:zlib port:gsl
+
+# This variant enables optional modules in PLUMED.
+variant allmodules description {Enable all optional modules} {
+  configure.args-append --enable-modules=all
+}
+
+# Link lapack/blas libraries
+pre-configure {
+  # commands should be included in a pre-configure block to access tcl variables
+  configure.ldflags-append ${linalglib}
+}
+


### PR DESCRIPTION
Dear MacPorts developers,

I am opening a pull request for a new port submission related to the software [PLUMED](http://www.plumed.org), which I am co-developing. Before asking you to merge it, I would like some feedback about the way I structured this rather complex Portfile so that I could perhaps simplify it a bit.

**So, please do not merge yet!**

I list my questions here:

- Even though the PLUMED software resides on [github](http://github.com/plumed/plumed2), I preferred to use manually uploaded .tgz files. This allowed me to save checksums (thus avoiding new downloads when files have been fetched already) and to split the download in two separate .tgz files (plumed-src and plumed-doc). The latter is very big and is only downloaded when installing documentation (variant +doc). Is this ok?
- I defined several variants so as to switch on/off dependent libraries (+xdrfile, +matheval, +zlib, +gsl). Some of them (+xdrfile, +matheval, and +zlib) are active by default since they require small libraries that are fast to install. Should I remove these three variants completely and make the dependence hard coded? I would prefer to keep gsl optional since it needs time to compile.
- PLUMED itself contains modules that might have different authors. I am adding variants for each of the non-default modules (here +mod_manyrestraints, +mod_crystallization, +mod_adjmat). The number of modules will increase in the future. Is it bad practice to have a variant for each of them? Should I only keep the variant +allmodules which enables all of them?
- I have a variant +molfile which can be used to discard (with -molfile) an internal piece of code with a BSD license. I thought someone might want to have a pure LGPL3 license. Is there any advantage or I can also remove this variant to simplify the Portfile?
- I did not manage to setup tests. I could do it if necessary, since we have a wide spectrum regression test suite contained in an additional plumed-test tgz file. Is it possible to selectively download it when the user wants to run the test?

Finally, notice that this port is based on just released PLUMED 2.3.1 and requires a small patch to work smoothly with MacPorts (already included in files/). Patch is already included upstream and will be removed when we will release PLUMED 2.3.2.

Many thanks in advance for your help and sorry for the long post!

Giovanni

###### Description
Implement a Portfile for PLUMED software.

###### Tested on
macOS 10.11.6
Xcode 8.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
