### PR TITLE
grace: fixed bug

### DIFF
--- a/x11/grace/Portfile
+++ b/x11/grace/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                grace
 version             5.1.25
-revision            1
+revision            2
 categories          x11 math science print
 license             GPL-2+
 platforms           darwin
@@ -37,7 +37,7 @@ patchfiles          patch-configure.diff
 configure.optflags  -O1
 configure.pre_args  --prefix=${prefix}/lib
 configure.args      --with-helpviewer="${prefix}/bin/openbrowser ${prefix}/share/doc/${name}/`basename %s`" \
-                    --x-include=${prefix}/include --x-lib=${prefix}/lib
+                    --x-include=${prefix}/include --x-lib=${prefix}/lib --with-bundled-t1lib=yes
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc


### PR DESCRIPTION
Force configure to use bundled t1lib.
Without this fix, if t1lib is available, grace
links it and crashes as soon as it is launched.
With this fix, internal t1lib is used, which works correctly.

###### Description

I already proposed this tiny change sometime ago:
https://trac.macports.org/ticket/49893
I think the present pull request would allow to close once for this ticket:
https://trac.macports.org/ticket/45582

Notice that alternative fixes have been proposed as well, such as:
- temporarily uninstalling t1lib
- installing grace +universal

However, I think that avoiding to link against t1lib directly from the configure option
is a cleaner and more robust solution


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11.6
Xcode 8.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
