### PR TITLE
py-tox + py-pluggy: upgrade to 2.6.0 and 0.4.0

### DIFF
--- a/python/py-pluggy/Portfile
+++ b/python/py-pluggy/Portfile
@@ -2,9 +2,11 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        pytest-dev pluggy 0.4.0 v
 
 name                py-pluggy
-version             0.3.1
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -14,12 +16,13 @@ maintainers         gmail.com:pedro.salgado openmaintainer
 description         Plugin and hook calling mechanisms for Python
 long_description    This is the plugin manager as used by pytest but \
                     stripped of pytest specific details.
-homepage            https://github.com/hpk42/pluggy/
 
 master_sites        pypi:p/pluggy
 distname            pluggy-${version}
-checksums           rmd160  7735da5072ccb9873e757572a08d5cb663ce487f \
-                    sha256  159cc783e056c07da6552aa5aef6b1e6c0064b4f18bd49c531fd2d40aafb0ea3
+use_zip             yes
+
+checksums           rmd160  678774b6f5d45f6e2bd5c4cb9693fb334f6c4c50 \
+                    sha256  dd841b5d290b252cf645f75f3bd37ceecfa0f36394ab313e4f785fe68a4081a4
 
 python.versions     27 34 35 36
 

--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -3,9 +3,11 @@
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
+PortGroup           github 1.0
+
+github.setup        tox-dev tox 2.6.0 v
 
 name                py-tox
-version             2.3.1
 categories-append   devel
 maintainers         gmail.com:pedro.salgado openmaintainer
 platforms           darwin
@@ -20,8 +22,8 @@ master_sites        pypi:t/tox/
 
 distname            tox-${version}
 
-checksums           rmd160  dddc14678033bacc58a54b05f007b0dcefa50d93 \
-                    sha256  bf7fcc140863820700d3ccd65b33820ba747b61c5fe4e2b91bb8c64cb21a47ee
+checksums           rmd160  8a2eec89f7849666426650be2d060c244816b837 \
+                    sha256  916498d2971f44a76baf3773a700f775c2f51aa6cc20be1828309148fc412252
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
###### Description

Upgrade:
- [py-tox](https://github.com/tox-dev/tox) [2.6.0](https://github.com/tox-dev/tox/releases/tag/2.6.0)
- [py-pluggy](https://github.com/pytest-dev/pluggy) [0.4.0](https://github.com/pytest-dev/pluggy/releases/tag/0.4.0)

###### Tested on

- macOS 10.12.3

###### Verification

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
