### PR TITLE
uchardet: new port

### DIFF
--- a/textproc/uchardet/Portfile
+++ b/textproc/uchardet/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        BYVoid uchardet 0.0.5 v
+categories          textproc
+platforms           darwin
+maintainers         madlon-kay.com:aaron+macports openmaintainer
+license             {MPL-1.1 GPL-2+ LGPL-2.1+}
+
+description         A text encoding detector library and tool
+
+long_description    uchardet is an encoding detector library and \
+                    command-line tool which takes a sequence of bytes \
+                    in an unknown character encoding without any \
+                    additional information, and attempts to determine \
+                    the encoding of the text. Returned encoding names \
+                    are iconv-compatible.
+
+checksums           rmd160  44d3ee430f77de334ae81e3b9d8fd9c7d5e769e6 \
+                    sha256  823ad9b365eb38d697052403c58efd6859ade45da11f41f849a493018b1c1eff


### PR DESCRIPTION
###### Description
This adds a new port: uchardet, a library and tool for detecting text encodings.

###### Tested on
macOS 10.12.4
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
