### PR TITLE
chordii: new port

### DIFF
--- a/textproc/chordii/Portfile
+++ b/textproc/chordii/Portfile
@@ -1,0 +1,52 @@
+PortSystem          1.0
+
+name                chordii
+version             4.5.1
+revision            0
+categories          textproc
+maintainers         breun.nl:nils openmaintainer
+platforms           darwin
+license             GPL-2
+description         Chordii takes input files containing the lyrics and chords of one or more songs and produces a print (PostScript) version of these songs.
+long_description    Chordii, pronounced chord-ee-ee, is a utility that was \
+                    first created by lazy guitarists who got tired of turning \
+                    pages in the middle of the songs they liked. \
+                    \
+                    Chordii takes one or more input files containing the \
+                    lyrics and chords of one or more songs and produces a \
+                    print (PostScript) version of these songs. \
+                    \
+                    The output has the following characteristics: \
+                    * titles and sub-titles have been centered, \
+                    * the lyrics appear in the font and size of your choice, \
+                    * all chords names appear right above the right lyrics, \
+                    * all chords used in a song appear as grids at the bottom of the page. \
+                    \
+                    Optionally, you can also: \
+                    * generate an index of your songs, \
+                    * have the pages numbered, \
+                    * have chords transposed up or down, \
+                    * print in 2-up or 4-up modes (multiple pages per printed sheet) and, \
+                    * insert tablature and comments. \
+                    \
+                    You have a great many options on the final appearance of your songs.
+
+homepage            https://www.vromans.org/johan/projects/Chordii/
+master_sites        https://sourceforge.net/projects/chordii/files/chordii/4.5/
+distname            ${name}-${version}-mac
+worksrcdir          ${workpath}
+
+use_zip             yes
+checksums           rmd160  f2f836a7273d1301a24dc1311002e4752356f14f \
+                    sha256  16e3c63dc5a45112de3fe7d59f0a6a0fc8e66ec99d835e06a214d551f9414965
+
+use_configure       no
+
+build {}
+
+destroot {
+    # Copy over the binaries
+    foreach f { a2crd chordii } {
+        copy ${worksrcpath}/${f} ${destroot}${prefix}/bin
+    }
+}

--- a/textproc/chordii/Portfile
+++ b/textproc/chordii/Portfile
@@ -1,52 +1,22 @@
 PortSystem          1.0
 
 name                chordii
-version             4.5.1
-revision            0
+version             4.5.3
+
 categories          textproc
 maintainers         breun.nl:nils openmaintainer
 platforms           darwin
 license             GPL-2
-description         Chordii takes input files containing the lyrics and chords of one or more songs and produces a print (PostScript) version of these songs.
-long_description    Chordii, pronounced chord-ee-ee, is a utility that was \
-                    first created by lazy guitarists who got tired of turning \
-                    pages in the middle of the songs they liked. \
-                    \
-                    Chordii takes one or more input files containing the \
-                    lyrics and chords of one or more songs and produces a \
-                    print (PostScript) version of these songs. \
-                    \
-                    The output has the following characteristics: \
-                    * titles and sub-titles have been centered, \
-                    * the lyrics appear in the font and size of your choice, \
-                    * all chords names appear right above the right lyrics, \
-                    * all chords used in a song appear as grids at the bottom of the page. \
-                    \
-                    Optionally, you can also: \
-                    * generate an index of your songs, \
-                    * have the pages numbered, \
-                    * have chords transposed up or down, \
-                    * print in 2-up or 4-up modes (multiple pages per printed sheet) and, \
-                    * insert tablature and comments. \
-                    \
-                    You have a great many options on the final appearance of your songs.
+description         Produce a professional looking PostScript sheet-music from an ASCII file containing lyrics and chords information.
+long_description    chordii produces a PostScript document from a lyrics file \
+                    containing chord indications and chorus delimiters. The \
+                    document produced contains the lyrics of a song, with the \
+                    guitar chords appearing above the right words. A \
+                    representation of all chords used in the song is printed \
+                    at the bottom of the last page.
 
 homepage            https://www.vromans.org/johan/projects/Chordii/
 master_sites        https://sourceforge.net/projects/chordii/files/chordii/4.5/
-distname            ${name}-${version}-mac
-worksrcdir          ${workpath}
 
-use_zip             yes
-checksums           rmd160  f2f836a7273d1301a24dc1311002e4752356f14f \
-                    sha256  16e3c63dc5a45112de3fe7d59f0a6a0fc8e66ec99d835e06a214d551f9414965
-
-use_configure       no
-
-build {}
-
-destroot {
-    # Copy over the binaries
-    foreach f { a2crd chordii } {
-        copy ${worksrcpath}/${f} ${destroot}${prefix}/bin
-    }
-}
+checksums           rmd160  a5abb489c0b59231cd4c7c7fd12c19961862211f \
+                    sha256  140d24a8bc8c298e8db1b9ca04cf02890951aa048a656adb7ee7212c42ce8d06


### PR DESCRIPTION
###### Description

Added a new port for chordii.

###### Tested on
macOS 10.12.4
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
