### PR TITLE
ansifilter: update to 2.4

### DIFF
--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            ansifilter
-version         1.16
+version         2.4
 categories      textproc
 maintainers     evermeet.cx:tessarek openmaintainer
 platforms       darwin
@@ -19,8 +19,8 @@ homepage        http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php
 master_sites    http://www.andre-simon.de/zip/
 use_bzip2       yes
 
-checksums       rmd160  0b242149b07c361f2d412c3251e7c9bc4dfd4c66 \
-                sha256  db8903bf1a73263feee942f350b8fcfb4a088a562e355825bccff20603d910bf
+checksums       rmd160  bb1619fc5a734718a06e1e0e15a95ffed95cb686 \
+                sha256  c57cb878afa7191c7b7db3c086a344b4234df814aed632596619a4bda5941d48
 
 use_configure   no
 


### PR DESCRIPTION
Maintainer fixed https://trac.macports.org/ticket/53947

###### Description

update ansifilter to 2.4

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
