### PR TITLE
tmux-devel: update devel port to the latest commit [5f662d]

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -14,7 +14,7 @@ subport tmux-devel {
     conflicts       tmux
 }
 categories      sysutils
-maintainers     evermeet.cx:tessarek
+maintainers     {evermeet.cx:tessarek @tessus}
 description     terminal multiplexer
 long_description \
     tmux is a \"terminal multiplexer\", it enables a number of terminals \

--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -9,9 +9,8 @@ if {${subport} eq ${name}} {
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux 52869ed182482c26163799a7215139f4d81b6fca
-    version         20160929-[string range ${github.version} 0 6]
-    revision        1
+    github.setup    tmux tmux 5f662d91db658abbcd46d7a678c0250754be35e3
+    version         20170406-[string range ${github.version} 0 6]
     conflicts       tmux
 }
 categories      sysutils
@@ -34,8 +33,8 @@ if {${subport} eq ${name}} {
                             sha256  55313e132f0f42de7e020bf6323a1939ee02ab79c48634aa07475db41573852b
 }
 subport tmux-devel {
-    checksums               rmd160  6cb5463c9604022ee8ddf30fc2393c812293e737 \
-                            sha256  eb8f101711f47244669ef71012a81cc7fe90680f27c82a32913de303a707e361
+    checksums               rmd160  90229b0bcc7a7f734fcfadc9761e0fc4293892cb \
+                            sha256  1c660596931cb177f917b3e16eb77b002a658a15ce6336a523e37bf807cba917
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh

--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -6,7 +6,7 @@ PortGroup       cxx11 1.1
 name            ansifilter
 version         2.4
 categories      textproc
-maintainers     evermeet.cx:tessarek openmaintainer
+maintainers     {evermeet.cx:tessarek @tessus} openmaintainer
 platforms       darwin
 license         GPL-3
 


### PR DESCRIPTION
###### Description
update devel port to the latest commit [5f662d]

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
