### PR TITLE
percona-toolkit: update to 2.2.20

### DIFF
--- a/databases/percona-toolkit/Portfile
+++ b/databases/percona-toolkit/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                percona-toolkit
-version             2.2.10
-revision            2
+version             2.2.20
 categories          databases
 platforms           darwin
 license             GPL
@@ -12,11 +11,11 @@ maintainers         pixilla openmaintainer
 description         Collection of essential command-line utilities for MySQL
 long_description    ${description}
 
-homepage            http://www.percona.com/software/percona-toolkit
-master_sites        http://www.percona.com/downloads/percona-toolkit/LATEST/tarball
+homepage            https://www.percona.com/software/percona-toolkit
+master_sites        https://www.percona.com/downloads/percona-toolkit/LATEST/tarball
 
-checksums           rmd160  d3ed201db8824902540e42b5a9ca5d9dca11f96e \
-                    sha256  0f0efc0c775fc1491a0f7cc520a511dd89634fab64888d92318b7cbae6a8606b
+checksums           rmd160  03181ed37d2348a830acd93fab0b579631ab42e3 \
+                    sha256  8439be616ee43b22ba7526135719ef6f40af6621327acc30b84be5f18cd426b1
 
 set mp.perl.versions {
     5.24
@@ -72,5 +71,5 @@ post-destroot {
     }        
 }
 
-livecheck.url       http://www.percona.com/downloads/percona-toolkit/
-livecheck.regex     "<a href=\"/downloads/percona-toolkit/(\[^/\]+)/"
+livecheck.url       https://www.percona.com/downloads/percona-toolkit/
+livecheck.regex     "<option value=\"percona-toolkit/(\[\\d.\]+)"


### PR DESCRIPTION
###### Description
This appears to be the last version in the 2.x branch, as they've already released 3.0.1 and 3.0.2.

Also update livecheck to match changes in their website.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.4
Xcode 8.3.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
