### PR TITLE
python: py-pymc3 update to 3.0

### DIFF
--- a/python/py-pymc3/Portfile
+++ b/python/py-pymc3/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pymc-devs pymc3 aca6086e385a5125fdc09f2df24c09baabe23436
+github.setup        pymc-devs pymc3 3.0 v
+# github.tarball_from releases
 name                py-pymc3
-version             20150703
 platforms           darwin
 maintainers         nomaintainer
 license             Apache-2
@@ -14,23 +14,25 @@ license             Apache-2
 description         Bayesian statistical models and fitting algorithms for python
 long_description    PyMC is a python module that implements Bayesian statistical models \
                     and fitting algorithms, including Markov chain Monte Carlo. \
-                    Its flexibility makes it applicable to a large suite of problems as well \
-                    as easily extensible. Along with core sampling functionality, \
-                    PyMC includes methods for summarizing output, plotting, goodness-of-fit and \
-                    convergence diagnostics.
+                    Its flexibility makes it applicable to a large suite of problems \
+                    as well as easily extensible. Along with core sampling functionality, \
+                    PyMC includes methods for summarizing output, plotting, \
+                    goodness-of-fit and convergence diagnostics.
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
-    checksums           rmd160  7c6d5eb8b9f45aa4776201d3b0ce1af96d4cfaec \
-                        sha256  53d6d1339c1ea0d5ee70228bc28cce62b302312dde9dfb337b310560f6a10684
+    checksums           rmd160  3a1fa7f584cb8d2427ad0b2947c9b2f9a7d7e5d2 \
+                        sha256  454d13ba4037235212af2f2437a1b3f349321ff268e228a99c355a07442b3261
 
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-scipy \
                         port:py${python.version}-matplotlib \
                         port:py${python.version}-theano \
                         port:py${python.version}-pandas \
-                        port:py${python.version}-patsy
+                        port:py${python.version}-patsy \
+                        port:py${python.version}-joblib \
+                        port:py${python.version}-tqdm
 
     livecheck.type      none
 }


### PR DESCRIPTION
###### Description

Replace python 3.3 support with 3.5 + 3.6, add tqdm and joblib dependencies. py-pymc unaffected.

###### Tested on
macOS 10.11.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?