### PR TITLE
ansifilter: fix compiler incompatibility on OSX 10.8 and below

### DIFF
--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -25,3 +25,9 @@ checksums       rmd160  bb1619fc5a734718a06e1e0e15a95ffed95cb686 \
 use_configure   no
 
 destroot.args   PREFIX="${prefix}"
+
+# The OS provided compilers on Mac OSX 10.8 and below do not like C++11
+if {${os.platform} eq "darwin" && ${os.major} < 13} {
+	patchfiles  0001-make-it-work-with-old-compilers-main.cpp.patch \
+	            0001-make-it-work-with-old-compilers-makefile.patch
+}

--- a/textproc/ansifilter/files/0001-make-it-work-with-old-compilers-main.cpp.patch
+++ b/textproc/ansifilter/files/0001-make-it-work-with-old-compilers-main.cpp.patch
@@ -1,0 +1,11 @@
+--- ./src/main.cpp.orig	2017-04-12 15:45:45.000000000 -0400
++++ ./src/main.cpp	2017-04-12 15:48:21.000000000 -0400
+@@ -113,7 +113,7 @@
+     }
+ 
+     const  vector <string> inFileList=options.getInputFileNames();
+-    unique_ptr<ansifilter::CodeGenerator> generator(ansifilter::CodeGenerator::getInstance(options.getOutputType()));
++    auto_ptr<ansifilter::CodeGenerator> generator(ansifilter::CodeGenerator::getInstance(options.getOutputType()));
+ 
+     string outDirectory = options.getOutDirectory();
+ 

--- a/textproc/ansifilter/files/0001-make-it-work-with-old-compilers-makefile.patch
+++ b/textproc/ansifilter/files/0001-make-it-work-with-old-compilers-makefile.patch
@@ -1,0 +1,11 @@
+--- ./src/makefile.orig	2017-04-12 15:45:31.000000000 -0400
++++ ./src/makefile	2017-04-12 15:47:17.000000000 -0400
+@@ -6,7 +6,7 @@
+ CC=g++
+ 
+ # Added -std=c++11 because of auto_ptr to unique_ptr transition
+-CFLAGS= -c -Wall -O2 -DNDEBUG -std=c++11
++CFLAGS= -c -Wall -O2 -DNDEBUG 
+ 
+ LDFLAGS=
+ 


### PR DESCRIPTION
Older compilers do not have the C++11 standard included.
ansilfilter uses unique_ptr, which is only available in C++11.
This patch removes the C++11 flag from the compiler options and
replaces the unique_ptr with an auto_ptr type.