### PR TITLE
chordii: new port

### DIFF
--- a/textproc/chordii/Portfile
+++ b/textproc/chordii/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                chordii
+version             4.5.3
+
+categories          textproc
+maintainers         {breun.nl:nils breun} openmaintainer
+platforms           darwin
+license             GPL-2
+description         Produce a professional looking PostScript sheet-music from an ASCII file containing lyrics and chords information.
+long_description    chordii produces a PostScript document from a lyrics file \
+                    containing chord indications and chorus delimiters. The \
+                    document produced contains the lyrics of a song, with the \
+                    guitar chords appearing above the right words. A \
+                    representation of all chords used in the song is printed \
+                    at the bottom of the last page.
+
+set branch          [join [lrange [split ${version} .] 0 1] .]
+
+homepage            https://www.vromans.org/johan/projects/Chordii/
+master_sites        sourceforge:project/${name}/${name}/${branch}
+
+checksums           rmd160  a5abb489c0b59231cd4c7c7fd12c19961862211f \
+                    sha256  140d24a8bc8c298e8db1b9ca04cf02890951aa048a656adb7ee7212c42ce8d06


### PR DESCRIPTION
###### Description

Added a new port for chordii.

###### Tested on
macOS 10.12.4
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?