### PR TITLE
py-mitmproxy: add variant to unblock firewall on activation

### DIFF
--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -76,5 +76,20 @@ if {${name} ne ${subport}} {
         }
     }
 
+    variant fw_unblock description {Unblocks firewall on activation} {
+
+        post-activate {
+            system "/usr/libexec/ApplicationFirewall/socketfilterfw --add ${prefix}/bin/mitmdump"
+            system "/usr/libexec/ApplicationFirewall/socketfilterfw --add ${prefix}/bin/mitmproxy"
+            system "/usr/libexec/ApplicationFirewall/socketfilterfw --unblockapp ${prefix}/bin/mitmdump"
+            system "/usr/libexec/ApplicationFirewall/socketfilterfw --unblockapp ${prefix}/bin/mitmproxy"
+        }
+
+        pre-deactivate {
+            system "/usr/libexec/ApplicationFirewall/socketfilterfw --remove ${prefix}/bin/mitmdump"
+            system "/usr/libexec/ApplicationFirewall/socketfilterfw --remove ${prefix}/bin/mitmproxy"
+        }
+    }
+
     livecheck.type  none
 }


### PR DESCRIPTION
This commit adds a variant which automatically unblocks the firewall
on activation. Take from ticket https://trac.macports.org/ticket/51825
where it was proposed.

###### Description

I am submitting this as PR in order to get feedback whether it is a good idea to provide a variant of this kind. This was first appeared in the cited ticket. 

Thanks for you review!

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.10
Xcode 6.4

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
