### PR TITLE
salt: upgrade Portfile to v2017.5

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -1,8 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+
 name                salt
-version             2016.11.2
+version             2017.5
 categories          sysutils
 platforms           darwin
 maintainers         gmail.com:jeremy.mcmillan
@@ -17,15 +18,14 @@ homepage            http://saltstack.com/
 
 if {$subport eq $name} {
     PortGroup           github 1.0
-
     PortGroup           python 1.0
 
     github.setup        saltstack salt ${version} v
 
     python.default_version 27
 
-    checksums           rmd160 f5b8518700fee08acf555f846e9d53b45c89be3f \
-                        sha256 cb0540cd03de28c59cc2fd372bb59dd5ca69624aefaa29f0748b856ac8ea8543
+    checksums           rmd160  0a1472ead01e543d0a39007f65406030943e5cf2 \
+                        sha256  90a27911216be7485c36182e6953b19a857ecd560a138f49b3b40c802e976ffe
 
     depends_build       port:py${python.version}-setuptools
 


### PR DESCRIPTION
###### Description
salt: upgrade Portfile to v2017.5

minor change, version bump only

###### Tested on
macOS 10.12.4

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
