### PR TITLE
percona-toolkit: Fix master_sites URL to work with correct version

### DIFF
--- a/databases/percona-toolkit/Portfile
+++ b/databases/percona-toolkit/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                percona-toolkit
 version             2.2.20
+revision            1
 categories          databases
 platforms           darwin
 license             GPL
@@ -12,7 +13,7 @@ description         Collection of essential command-line utilities for MySQL
 long_description    ${description}
 
 homepage            https://www.percona.com/software/percona-toolkit
-master_sites        https://www.percona.com/downloads/percona-toolkit/LATEST/tarball
+master_sites        https://www.percona.com/downloads/percona-toolkit/${version}/tarball
 
 checksums           rmd160  03181ed37d2348a830acd93fab0b579631ab42e3 \
                     sha256  8439be616ee43b22ba7526135719ef6f40af6621327acc30b84be5f18cd426b1


### PR DESCRIPTION
This fixes the `master_sites` value to work with the version increment in #425 .

Using 'LATEST' only worked while the current version was the most up-to-date. Adding in the version token makes sure it's always the expected file.

I've tested this by running `port clean --all percona-toolkit` followed by `port upgrade --force -n -vst percona-toolkit` to make sure that it downloads the file correctly from the Percona site.

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.4
Xcode 8.3.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
