### PR TITLE
Add +zts variant for PHP

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -249,6 +249,10 @@ if {[is_sapi_subport]} {
         configure.args-append   --enable-debug
     }
     
+    variant zts description {Enable zend thread safety} {
+        configure.args-append   --enable-maintainer-zts
+    }
+    
     if {[vercmp ${branch} 5.3] <= 0} {
     variant suhosin description {Add Suhosin patch} {
         pre-fetch {


### PR DESCRIPTION
Add zend thread safety variant (+zts) for PHP

###### Description

This variant enable thread safety for PHP. Аs `+debug` new variant `+zts` - global variant (for PHP and extensions).

Reasons:
Travis-CI use PHP7 with thread safety. 
For a extension developer this option is required
PHP has extensions that requires ZTS ([php-pthreads](http://php.net/manual/en/book.pthreads.php) e.g.)

###### Tested on
macOS 10.12
Xcode 8.3