### PR TITLE
py-lxml: update to 3.7.3

### DIFF
--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -7,7 +7,7 @@ set _name           lxml
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             3.6.0
+version             3.7.3
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -29,9 +29,9 @@ homepage            http://lxml.de/
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     5957cc384bd6e83934be35c057ec03b6 \
-                    rmd160  c9b12725206623b6c052a86641fe920b6d7bd56c \
-                    sha256  9c74ca28a7f0c30dca8872281b3c47705e21217c8bc63912d95c9e2a7cac6bdf
+checksums           md5     075692ce442e69bbd604d44e21c02753 \
+                    rmd160  b2f1c34f90ef8aae9916e3c710dfb3675024a734 \
+                    sha256  aa502d78a51ee7d127b4824ff96500f0181d3c7826e6ee7b800d068be79361c7
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
###### Description

Update py-lxml to version 3.7.3.  Smoketested on python 2.7 and 3.6.