### PR TITLE
tmux: update to 2.4

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,9 +3,8 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 2.3
+github.setup    tmux tmux 2.4
 if {${subport} eq ${name}} {
-    revision        1
     conflicts       tmux-devel
 }
 subport tmux-devel {
@@ -29,8 +28,8 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  57c282ae32dcaf5bcbab9a9f049630c3555b787c \
-                            sha256  55313e132f0f42de7e020bf6323a1939ee02ab79c48634aa07475db41573852b
+    checksums               rmd160  2f1f7e9a73155f7ad351c6067312e964ca514db1 \
+                            sha256  757d6b13231d0d9dd48404968fc114ac09e005d475705ad0cd4b7166f799b349
 }
 subport tmux-devel {
     checksums               rmd160  90229b0bcc7a7f734fcfadc9761e0fc4293892cb \


### PR DESCRIPTION
###### Description

update tmux to 2.4

###### Tested on
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
