### PR TITLE
neomutt: update to 20170421

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        neomutt neomutt 20170306 neomutt-
+github.setup        neomutt neomutt 20170421 neomutt-
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -24,10 +24,11 @@ depends_lib         port:gettext \
                     port:libiconv \
                     port:ncurses
 
+depends_build       port:gpgme
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
-checksums           rmd160  8021485996256136ad1b2c2476e392c9ea960151 \
-                    sha256  c10d2126dbdf01a89f40a493efecfd66f9ba726879a2934424f2333917444083
+checksums           rmd160  561c524c5571add84c463306e1d9b5d6f093268d \
+                    sha256  0477eafb3f36fb0cb563130b5754672181338aad9eaa8639451fbdf8dd9b7d23
 
 # Build from tags because upstream keeps omitting files from the release
 # tarballs (https://trac.macports.org/ticket/52485).


### PR DESCRIPTION
# Do Not Merge

###### Description
- [ ] Lua variant

Neomutt can't autoreconf without port:gpgme. Reported to neomutt/neomutt#542.
```
autoreconf: running: /opt/local/bin/aclocal -I m4
configure.ac:253: warning: macro 'AM_PATH_GPGME' not found in library
configure.ac:259: warning: macro 'AM_PATH_GPGME' not found in library
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /opt/local/bin/autoconf
configure.ac:253: error: possibly undefined macro: AM_PATH_GPGME
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /opt/local/bin/autoconf failed with exit status: 1
```

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
