### PR TITLE
xinit: fix font path initialization.

### DIFF
--- a/x11/xinit/Portfile
+++ b/x11/xinit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xinit
 version             1.3.4
-revision            3
+revision            4
 categories          x11
 platforms           darwin
 maintainers         {jeremyhu @jeremyhu} openmaintainer

--- a/x11/xinit/files/xinitrc.d/10-fontdir.sh
+++ b/x11/xinit/files/xinitrc.d/10-fontdir.sh
@@ -1,6 +1,8 @@
 if [ -x __PREFIX__/bin/xset ] ; then
-        fontpath="__PREFIX__/share/fonts/misc/,__PREFIX__/share/fonts/TTF/,__PREFIX__/share/fonts/OTF,__PREFIX__/share/fonts/Type1/,__PREFIX__/share/fonts/75dpi/:unscaled,__PREFIX__/share/fonts/100dpi/:unscaled,__PREFIX__/share/fonts/75dpi/,__PREFIX__/share/fonts/100dpi/,__PREFIX__/share/fonts/libwmf,__PREFIX__/share/fonts/urw-fonts"
+        fontpath="__PREFIX__/share/fonts/misc/,__PREFIX__/share/fonts/TTF/,__PREFIX__/share/fonts/OTF,__PREFIX__/share/fonts/Type1/,__PREFIX__/share/fonts/75dpi/:unscaled,__PREFIX__/share/fonts/100dpi/:unscaled,__PREFIX__/share/fonts/75dpi/,__PREFIX__/share/fonts/100dpi/"
 
+        [ -e __PREFIX__/share/fonts/libwmf/fonts.dir ] && fontpath="$fontpath,__PREFIX__/share/fonts/libwmf"
+        [ -e __PREFIX__/share/fonts/urw-fonts/fonts.dir ] && fontpath="$fontpath,__PREFIX__/share/fonts/urw-fonts"
         [ -e "$HOME"/.fonts/fonts.dir ] && fontpath="$fontpath,$HOME/.fonts"
         [ -e "$HOME"/Library/Fonts/fonts.dir ] && fontpath="$fontpath,$HOME/Library/Fonts"
         [ -e /Library/Fonts/fonts.dir ] && fontpath="$fontpath,/Library/Fonts"


### PR DESCRIPTION
The script 10-fontdir.sh fails to set the font path if libwmf or
urw-fonts is not installed.