### PR TITLE
wine*: add 64-bit support

### DIFF
--- a/x11/wine-crossover/Portfile
+++ b/x11/wine-crossover/Portfile
@@ -1,14 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   muniversal 1.0
 PortGroup                   compiler_blacklist_versions 1.0
 PortGroup                   snowleopard_fixes 1.0
 
 # Please keep the wine, wine-devel and wine-crossover ports as similar as possible.
 
-# When updating the version of wine, update wine_gecko to a compatible version
-# per the table at http://wiki.winehq.org/Gecko and update wine-mono as well;
-# see http://wiki.winehq.org/Mono and http://sourceforge.net/projects/wine/files/Wine%20Mono/
+# When updating the version of wine, update wine_gecko and wine_mono to compatible versions
+# as referenced in the source code. Check here by replacing X.Y with the version:
+# https://source.winehq.org/git/wine.git/blob/refs/tags/wine-X.Y:/dlls/appwiz.cpl/addons.c
+# see also http://wiki.winehq.org/Gecko and http://wiki.winehq.org/Mono
 
 # Crossover-specific bug reports are accepted at info@codeweavers.com
 
@@ -16,6 +18,7 @@ name                        wine-crossover
 conflicts                   wine wine-devel
 set my_name                 wine
 version                     17.1.0
+revision                    1
 license                     LGPL-2.1+
 categories                  x11
 maintainers                 {ryandesign @ryandesign} {jeremyhu @jeremyhu} openmaintainer
@@ -26,6 +29,7 @@ dist_subdir                 ${my_name}
 set wine_distfile           ${distname}${extract.suffix}
 set wine_gecko_version      2.47
 set wine_gecko_distfile     wine_gecko-${wine_gecko_version}-x86.msi
+set wine_gecko64_distfile   wine_gecko-${wine_gecko_version}-x86_64.msi
 set wine_mono_version       4.7.0
 set wine_mono_distfile      wine-mono-${wine_mono_version}.msi
 worksrcdir                  sources/wine
@@ -53,6 +57,7 @@ extract.only                ${wine_distfile}
 
 distfiles                   ${wine_distfile}:winesource \
                             ${wine_gecko_distfile}:winegecko \
+                            ${wine_gecko64_distfile}:winegecko \
                             ${wine_mono_distfile}:winemono
 
 checksums                   ${wine_distfile} \
@@ -63,6 +68,10 @@ checksums                   ${wine_distfile} \
                             rmd160  abf7cc78b49dd0623bc8fe87ae0e32bb8694e13d \
                             sha256  3b8a361f5d63952d21caafd74e849a774994822fb96c5922b01d554f1677643a \
                             size    49266176 \
+                            ${wine_gecko64_distfile} \
+                            rmd160  254da21cb2503f20d065167b385b3e83ea3ab327 \
+                            sha256  c565ea25e50ea953937d4ab01299e4306da4a556946327d253ea9b28357e4a7d \
+                            size    50806272 \
                             ${wine_mono_distfile} \
                             rmd160  6158dce54355c4174ff30544db3a0fd2b9c488b5 \
                             sha256  7698474dd9cb9eb80796b5812dff37386ba97b78b21ca23b20079ca5ad6ca5a1 \
@@ -91,10 +100,21 @@ depends_build               port:bison \
                             port:pkgconfig
 
 patchfiles                  BOOL.patch \
+                            patch-configure.diff \
                             cups_headers.patch \
                             mach_machine.patch \
                             patch-include-distversion.h.diff \
                             QWORD.patch
+
+pre-configure {
+    if {[variant_isset universal]} {
+        foreach arch ${universal_archs_to_use} {
+            file mkdir ${worksrcpath}-${arch}
+        }
+
+        configure.cmd ${worksrcpath}/configure
+    }
+}
 
 # Wine requires the program specified in INSTALL to create intermediate
 # directories; /usr/bin/install doesn't.
@@ -193,9 +213,14 @@ variant x11 {
 
 default_variants            +x11
 
-# 64-bit Wine exists for Linux, but does not work on OS X.
-# http://www.winehq.org/pipermail/wine-devel/2014-February/103074.html
-supported_archs             i386
+configure.universal_args
+
+set merger_configure_args(x86_64) "--enable-win64 --libdir=${prefix}/lib"
+set merger_configure_args(i386)   --with-wine64=${workpath}/${worksrcdir}-x86_64
+
+if {${build_arch} eq "x86_64"} {
+    default_variants            +universal
+}
 
 # error: Xcode 3.x cannot build 16-bit code correctly
 compiler.blacklist-append   {gcc-4.2 < 5600}
@@ -264,6 +289,9 @@ post-destroot {
 
     xinstall -d ${destroot}${prefix}/share/wine/gecko
     xinstall -m 644 ${distpath}/${wine_gecko_distfile} ${destroot}${prefix}/share/wine/gecko
+
+    xinstall -d ${destroot}${prefix}/share/wine/gecko
+    xinstall -m 644 ${distpath}/${wine_gecko64_distfile} ${destroot}${prefix}/share/wine/gecko
 
     xinstall -d ${destroot}${prefix}/share/wine/mono
     xinstall -m 644 ${distpath}/${wine_mono_distfile} ${destroot}${prefix}/share/wine/mono

--- a/x11/wine-crossover/Portfile
+++ b/x11/wine-crossover/Portfile
@@ -307,6 +307,21 @@ post-destroot {
         ${destroot}${docdir}
 }
 
+if {[variant_isset universal]} {
+    notes-append "
+        \n
+        Wine supports both 32-bit and 64-bit now. It is compatible with your\
+        existing 32-bit wine prefix, but it will now default to 64-bit when you\
+        create a new wine prefix. The architecture can be selected using the\
+        WINEARCH environment variable which can be set to either \"win32\" or
+        \"win64\".
+
+        To create a new pure 32-bit prefix, you can run:
+            \$ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+
+        See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
+    "
+}
 livecheck.type              regex
 livecheck.url               http://ftp.codeweavers.com/pub/crossover/source/
 livecheck.regex             crossover-sources-(\[0-9.\]+)\\.tar

--- a/x11/wine-crossover/files/patch-configure.diff
+++ b/x11/wine-crossover/files/patch-configure.diff
@@ -1,0 +1,19 @@
+# Output DLLs to different directories so that we don't have a clash when
+# they're merged back together
+
+--- configure.orig
++++ configure
+@@ -7320,7 +7320,12 @@
+ 
+ 
+ 
+-dlldir="\${libdir}/wine"
++if test "x$enable_win64" = "xyes"
++then
++  dlldir="\${libdir}/wine64"
++else
++  dlldir="\${libdir}/wine"
++fi
+ 
+ DLLFLAGS="-D_REENTRANT"
+ 

--- a/x11/wine-devel/Portfile
+++ b/x11/wine-devel/Portfile
@@ -1,30 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   muniversal 1.0
 PortGroup                   compiler_blacklist_versions 1.0
 
 # Please keep the wine, wine-devel and wine-crossover ports as similar as possible.
 
-# When updating the version of wine, update wine_gecko to a compatible version
-# per the table at http://wiki.winehq.org/Gecko and update wine-mono as well;
-# see http://wiki.winehq.org/Mono and http://sourceforge.net/projects/wine/files/Wine%20Mono/
+# When updating the version of wine, update wine_gecko and wine_mono to compatible versions
+# as referenced in the source code. Check here by replacing X.Y with the version:
+# https://source.winehq.org/git/wine.git/blob/refs/tags/wine-X.Y:/dlls/appwiz.cpl/addons.c
+# see also http://wiki.winehq.org/Gecko and http://wiki.winehq.org/Mono
 
 name                        wine-devel
 conflicts                   wine wine-crossover
 set my_name                 wine
 version                     3.4
 set branch                  [lindex [split ${version} .] 0].x
+revision                    1
 license                     LGPL-2.1+
 categories                  x11
 maintainers                 {ryandesign @ryandesign} openmaintainer
 homepage                    https://www.winehq.org
 platforms                   darwin
+supported_archs             i386 x86_64
 use_xz                      yes
 distname                    ${my_name}-${version}
 dist_subdir                 ${my_name}
 set wine_distfile           ${distname}${extract.suffix}
 set wine_gecko_version      2.47
 set wine_gecko_distfile     wine_gecko-${wine_gecko_version}-x86.msi
+set wine_gecko64_distfile   wine_gecko-${wine_gecko_version}-x86_64.msi
 set wine_mono_version       4.7.1
 set wine_mono_distfile      wine-mono-${wine_mono_version}.msi
 use_parallel_build          yes
@@ -52,6 +57,7 @@ extract.only                ${wine_distfile}
 
 distfiles                   ${wine_distfile}:winesource \
                             ${wine_gecko_distfile}:winegecko \
+                            ${wine_gecko64_distfile}:winegecko \
                             ${wine_mono_distfile}:winemono
 
 checksums                   ${wine_distfile} \
@@ -62,6 +68,10 @@ checksums                   ${wine_distfile} \
                             rmd160  abf7cc78b49dd0623bc8fe87ae0e32bb8694e13d \
                             sha256  3b8a361f5d63952d21caafd74e849a774994822fb96c5922b01d554f1677643a \
                             size    49266176 \
+                            ${wine_gecko64_distfile} \
+                            rmd160  254da21cb2503f20d065167b385b3e83ea3ab327 \
+                            sha256  c565ea25e50ea953937d4ab01299e4306da4a556946327d253ea9b28357e4a7d \
+                            size    50806272 \
                             ${wine_mono_distfile} \
                             rmd160  3e2932960dabff8283f02b32dc573b0dda6adfac \
                             sha256  2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa \
@@ -93,6 +103,16 @@ patchfiles                  BOOL.patch \
                             cups_headers.patch \
                             fix-flicker.patch \
                             mach_machine.patch
+
+pre-configure {
+    if {[variant_isset universal]} {
+        foreach arch ${universal_archs_to_use} {
+            file mkdir ${worksrcpath}-${arch}
+        }
+
+        configure.cmd ${worksrcpath}/configure
+    }
+}
 
 # Wine requires the program specified in INSTALL to create intermediate
 # directories; /usr/bin/install doesn't.
@@ -191,9 +211,16 @@ variant x11 {
 
 default_variants            +x11
 
-# 64-bit Wine exists for Linux, but does not work on OS X.
-# http://www.winehq.org/pipermail/wine-devel/2014-February/103074.html
-supported_archs             i386
+configure.universal_args
+
+set merger_build_args(x86_64)     "dlldir=\\\\\${libdir}/wine64"
+set merger_destroot_args(x86_64)  "dlldir=\\\\\${libdir}/wine64"
+set merger_configure_args(x86_64) "--enable-win64 --libdir=${prefix}/lib"
+set merger_configure_args(i386)   --with-wine64=${workpath}/${worksrcdir}-x86_64
+
+if {${build_arch} eq "x86_64"} {
+    default_variants            +universal
+}
 
 # error: Xcode 3.x cannot build 16-bit code correctly
 compiler.blacklist-append   {gcc-4.2 < 5600}
@@ -262,6 +289,9 @@ post-destroot {
 
     xinstall -d ${destroot}${prefix}/share/wine/gecko
     xinstall -m 644 ${distpath}/${wine_gecko_distfile} ${destroot}${prefix}/share/wine/gecko
+
+    xinstall -d ${destroot}${prefix}/share/wine/gecko
+    xinstall -m 644 ${distpath}/${wine_gecko64_distfile} ${destroot}${prefix}/share/wine/gecko
 
     xinstall -d ${destroot}${prefix}/share/wine/mono
     xinstall -m 644 ${distpath}/${wine_mono_distfile} ${destroot}${prefix}/share/wine/mono

--- a/x11/wine-devel/Portfile
+++ b/x11/wine-devel/Portfile
@@ -307,5 +307,20 @@ post-destroot {
         ${destroot}${docdir}
 }
 
+if {[variant_isset universal]} {
+    notes-append "
+        \n
+        Wine supports both 32-bit and 64-bit now. It is compatible with your\
+        existing 32-bit wine prefix, but it will now default to 64-bit when you\
+        create a new wine prefix. The architecture can be selected using the\
+        WINEARCH environment variable which can be set to either \"win32\" or
+        \"win64\".
+
+        To create a new pure 32-bit prefix, you can run:
+            \$ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+
+        See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
+    "
+}
 livecheck.type              regex
 livecheck.regex             {"/announce/([^"]+)"}

--- a/x11/wine/Portfile
+++ b/x11/wine/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   muniversal 1.0
 PortGroup                   compiler_blacklist_versions 1.0
 
 # Please keep the wine, wine-devel and wine-crossover ports as similar as possible.
@@ -19,6 +20,7 @@ categories                  x11
 maintainers                 {ryandesign @ryandesign} openmaintainer
 homepage                    https://www.winehq.org
 platforms                   darwin
+supported_archs             i386 x86_64
 use_xz                      yes
 distname                    ${my_name}-${version}
 dist_subdir                 ${my_name}
@@ -90,9 +92,20 @@ depends_build               port:bison \
                             port:pkgconfig
 
 patchfiles                  BOOL.patch \
+                            patch-configure.diff \
                             cups_headers.patch \
                             fix-flicker.patch \
                             mach_machine.patch
+
+pre-configure {
+    if {[variant_isset universal]} {
+        foreach arch ${universal_archs_to_use} {
+            file mkdir ${worksrcpath}-${arch}
+        }
+
+        configure.cmd ${worksrcpath}/configure
+    }
+}
 
 # Wine requires the program specified in INSTALL to create intermediate
 # directories; /usr/bin/install doesn't.
@@ -191,9 +204,14 @@ variant x11 {
 
 default_variants            +x11
 
-# 64-bit Wine exists for Linux, but does not work on OS X.
-# http://www.winehq.org/pipermail/wine-devel/2014-February/103074.html
-supported_archs             i386
+configure.universal_args
+
+set merger_configure_args(x86_64) "--enable-win64 --libdir=${prefix}/lib"
+set merger_configure_args(i386)   --with-wine64=${workpath}/${worksrcdir}-x86_64
+
+if {${build_arch} eq "x86_64"} {
+    default_variants            +universal
+}
 
 # error: Xcode 3.x cannot build 16-bit code correctly
 compiler.blacklist-append   {gcc-4.2 < 5600}

--- a/x11/wine/Portfile
+++ b/x11/wine/Portfile
@@ -306,5 +306,21 @@ post-destroot {
         ${destroot}${docdir}
 }
 
+if {[variant_isset universal]} {
+    notes-append "
+        \n
+        Wine supports both 32-bit and 64-bit now. It is compatible with your\
+        existing 32-bit wine prefix, but it will now default to 64-bit when you\
+        create a new wine prefix. The architecture can be selected using the\
+        WINEARCH environment variable which can be set to either \"win32\" or
+        \"win64\".
+
+        To create a new pure 32-bit prefix, you can run:
+            \$ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+
+        See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
+    "
+}
+
 livecheck.type              regex
 livecheck.regex             {"/announce/([0-9]+\.0(\.[0-9]+)*)"}

--- a/x11/wine/Portfile
+++ b/x11/wine/Portfile
@@ -6,15 +6,17 @@ PortGroup                   compiler_blacklist_versions 1.0
 
 # Please keep the wine, wine-devel and wine-crossover ports as similar as possible.
 
-# When updating the version of wine, update wine_gecko to a compatible version
-# per the table at http://wiki.winehq.org/Gecko and update wine-mono as well;
-# see http://wiki.winehq.org/Mono and http://sourceforge.net/projects/wine/files/Wine%20Mono/
+# When updating the version of wine, update wine_gecko and wine_mono to compatible versions
+# as referenced in the source code. Check here by replacing X.Y with the version:
+# https://source.winehq.org/git/wine.git/blob/refs/tags/wine-X.Y:/dlls/appwiz.cpl/addons.c
+# see also http://wiki.winehq.org/Gecko and http://wiki.winehq.org/Mono
 
 name                        wine
 conflicts                   wine-devel wine-crossover
 set my_name                 wine
 version                     3.0
 set branch                  [lindex [split ${version} .] 0].0
+revision                    1
 license                     LGPL-2.1+
 categories                  x11
 maintainers                 {ryandesign @ryandesign} openmaintainer
@@ -27,6 +29,7 @@ dist_subdir                 ${my_name}
 set wine_distfile           ${distname}${extract.suffix}
 set wine_gecko_version      2.47
 set wine_gecko_distfile     wine_gecko-${wine_gecko_version}-x86.msi
+set wine_gecko64_distfile   wine_gecko-${wine_gecko_version}-x86_64.msi
 set wine_mono_version       4.7.1
 set wine_mono_distfile      wine-mono-${wine_mono_version}.msi
 use_parallel_build          yes
@@ -54,6 +57,7 @@ extract.only                ${wine_distfile}
 
 distfiles                   ${wine_distfile}:winesource \
                             ${wine_gecko_distfile}:winegecko \
+                            ${wine_gecko64_distfile}:winegecko \
                             ${wine_mono_distfile}:winemono
 
 checksums                   ${wine_distfile} \
@@ -64,6 +68,10 @@ checksums                   ${wine_distfile} \
                             rmd160  abf7cc78b49dd0623bc8fe87ae0e32bb8694e13d \
                             sha256  3b8a361f5d63952d21caafd74e849a774994822fb96c5922b01d554f1677643a \
                             size    49266176 \
+                            ${wine_gecko64_distfile} \
+                            rmd160  254da21cb2503f20d065167b385b3e83ea3ab327 \
+                            sha256  c565ea25e50ea953937d4ab01299e4306da4a556946327d253ea9b28357e4a7d \
+                            size    50806272 \
                             ${wine_mono_distfile} \
                             rmd160  3e2932960dabff8283f02b32dc573b0dda6adfac \
                             sha256  2c8d5db7f833c3413b2519991f5af1f433d59a927564ec6f38a3f1f8b2c629aa \
@@ -280,6 +288,9 @@ post-destroot {
 
     xinstall -d ${destroot}${prefix}/share/wine/gecko
     xinstall -m 644 ${distpath}/${wine_gecko_distfile} ${destroot}${prefix}/share/wine/gecko
+
+    xinstall -d ${destroot}${prefix}/share/wine/gecko
+    xinstall -m 644 ${distpath}/${wine_gecko64_distfile} ${destroot}${prefix}/share/wine/gecko
 
     xinstall -d ${destroot}${prefix}/share/wine/mono
     xinstall -m 644 ${distpath}/${wine_mono_distfile} ${destroot}${prefix}/share/wine/mono

--- a/x11/wine/files/patch-configure.diff
+++ b/x11/wine/files/patch-configure.diff
@@ -1,0 +1,19 @@
+# Output DLLs to different directories so that we don't have a clash when
+# they're merged back together
+
+--- configure.orig
++++ configure
+@@ -7320,7 +7320,12 @@
+ 
+ 
+ 
+-dlldir="\${libdir}/wine"
++if test "x$enable_win64" = "xyes"
++then
++  dlldir="\${libdir}/wine64"
++else
++  dlldir="\${libdir}/wine"
++fi
+ 
+ DLLFLAGS="-D_REENTRANT"
+ 


### PR DESCRIPTION
###### Description

I thought it would be easier to manage a patch in Git for enabling Wine 64. This just adds support for the Wine’s `Portfile` at the moment but before this changeset is committed it should add support for `wine-devel` and `wine-crossover`, if appropriate.

Note, that it does not automatically install Gecko or Mono for Wine 64.

Also be aware of this remark from Wine HQ:
> Current Wine includes support for 64 bit Wine on Mac OS X; however, this has not been tested very much, and some applications may never work due to an ABI incompatibility between Win64 and OS X.

Please see https://trac.macports.org/ticket/53651 for further information.

###### Tested on
macOS 10.12.4
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?