### PR TITLE
emacs-mac-app: update to 6.3 (emacs 25.2)

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -3,13 +3,12 @@
 PortSystem          1.0
 PortGroup           bitbucket 1.0
 
-set emacs_version   25.1
-set emacs_mac_ver   6.1
+set emacs_version   25.2
+set emacs_mac_ver   6.3
 
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
 version             ${emacs_mac_ver}
-revision            2
 categories          aqua editors
 maintainers         nomaintainer
 
@@ -21,8 +20,8 @@ long_description    ${name} is "Mac port" addition to GNU Emacs 25. This provide
 platforms           darwin
 license             GPL-3+
 
-checksums           rmd160  2a351013bd32ac29e97fc6a14d5e7701ab6e1d8a \
-                    sha256  3ede57b06a20b361d5ed66d040e3b0adb1a84cbccabb6eaf21e2d8e8398de3b6
+checksums           rmd160  de431515144cd0c41a0be25781ccfe23cbf022b4 \
+                    sha256  6eb8ddc7155edac3fe46a97196b53192dfb742874fbe7754dd35197dd7d9459d
 
 depends_lib         port:ncurses \
                     port:libxml2 \


### PR DESCRIPTION
###### Description
Update the emacs-mac-app port to 6.3 (emacs 25.2).