### PR TITLE
pidgin-sipe: new port

### DIFF
--- a/net/pidgin-sipe/Portfile
+++ b/net/pidgin-sipe/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                pidgin-sipe
+version             1.22.0
+categories          net
+platforms           darwin
+license             GPL-2
+maintainers         {puffin.lb.shuttle.de:michael.klein @mklein-de} openmaintainer
+description         Pidgin protocol plugin for Office 365/Lync/OCS
+long_description    ${description}
+
+homepage            http://sipe.sourceforge.net/
+master_sites        sourceforge:project/sipe/sipe/${name}-${version}
+
+use_bzip2           yes
+
+checksums           rmd160  007f3f5ba2b104a601b2437c0722f9dcaa784f26 \
+                    sha256  d392f9b474114b8a05fd6cbb997cabf4487398d0ccbd8375a03feb66c5b6280f
+
+depends_lib         port:pidgin
+depends_build       port:intltool \
+                    port:pkgconfig
+
+livecheck.url       http://sourceforge.net/projects/sipe/files/sipe/
+livecheck.regex     /pidgin-sipe-(\[a-zA-Z0-9.\]+\.\[a-zA-Z0-9.\]+)/download


### PR DESCRIPTION
###### Tested on
macOS 10.12
Xcode 8.3.2


Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
