### PR TITLE
sqsh: patch to fix builds with FreeTDS 1.0+

### DIFF
--- a/sysutils/sqsh/Portfile
+++ b/sysutils/sqsh/Portfile
@@ -22,7 +22,8 @@ checksums           md5     0ad6cc9452d3257866ccde5f14ffa013 \
 depends_lib         port:readline port:freetds
 extract.suffix      .tgz
 
-patchfiles          patch-sqsh_readline.c
+patchfiles          patch-sqsh_readline.c \
+                    patch-cmd_connect.diff
 
 post-patch {
     reinplace "s|malloc.h|stdlib.h|" ${worksrcpath}/src/sqsh_parser/tsql.c

--- a/sysutils/sqsh/files/patch-cmd_connect.diff
+++ b/sysutils/sqsh/files/patch-cmd_connect.diff
@@ -1,0 +1,25 @@
+--- src/cmd_connect.c.orig	2017-04-25 18:09:43.000000000 -0700
++++ src/cmd_connect.c	2017-04-25 18:10:44.000000000 -0700
+@@ -45,10 +45,22 @@
+ static char RCS_Id[] = "$Id: cmd_connect.c,v 1.34 2013/08/22 19:54:34 mwesdorp Exp $";
+ USE(RCS_Id)
+ #endif /* !defined(lint) */
+ 
+ /*
++ *  patch taken from sqsh-3.0 development branch
++ *  Define FreeTDS enumerated values to prevent compile errors
++ *  when using different versions of FreeTDS.
++ */
++#define CS_TDS_70 7365
++#define CS_TDS_71 7366
++#define CS_TDS_72 7367
++#define CS_TDS_73 7368
++#define CS_TDS_74 7369
++#define CS_TDS_80 CS_TDS_71
++
++/*
+  * sqsh-2.1.6 - Structure for Network Security Options
+ */
+ typedef struct _NetSecService {
+     CS_INT  service;
+     CS_CHAR optchar;


### PR DESCRIPTION
FreeTDS 1.0 removed some constants that SQSH depends upon, breaking
compatibility. This patch re-defines those constants the same way that
sqsh-3.0 (unreleased) does.

###### Description
See commit body. This will eventually be fixed with the release of SQSH 3.0 but the timeline on that release is unclear.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.4
Xcode 8.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
