### PR TITLE
smlnj: Update from 110.79 to 110.80, fixes Sierra break.

### DIFF
--- a/lang/smlnj/Portfile
+++ b/lang/smlnj/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                smlnj
-version             110.79
+version             110.80
 categories          lang ml
 license             BSD
 maintainers         bfulgham toby
@@ -24,27 +24,27 @@ checksums
 
 # Files needed for basic distribution.
 set srcs [list \
-    ckit.tgz bb39f5029531db138e408504259c16158884b782 \
-    cml.tgz 1ee263ca8da2147ebc3e6d318d8fa1cd26d59f06 \
-    cm.tgz 5779b26a500cf258ab5fc803f40ed41a9d177481 \
-    compiler.tgz 8e4ce5bd8f6605d4ef1d1b9db52dda68c6b3cc7d \
-    config.tgz 945a0ecd97365188f4c23d33c4d38e9bc073cb1a \
-    doc.tgz bf833b64029612d1c59864106894f78a0a4ba6aa \
-    eXene.tgz 53ea8dd1d930a1537a9a81c2d12032c2c98de501 \
-    heap2asm.tgz 0ba4d8c91dd8e1ed4f0543980757f29ab286241e \
-    ml-burg.tgz 0cfc5665b8b05e1249432330936357236f46cbb3 \
-    ml-lex.tgz f6e99b672be6bc689dbc24532ea8068a73c87fc2 \
-    ml-lpt.tgz 97e7d95718eec2d0fafc7dca9e3bd4c025171958 \
-    MLRISC.tgz 148b4256f6c7c6978355126cb38d6447c727a779 \
-    ml-yacc.tgz b28f3f06bf1494a9acabb2e8e463669b29693e54 \
-    nlffi.tgz 802e28b56fbb7d6dae039237144eb0a3286334b5 \
-    old-basis.tgz d79f72ad9b6e55c4df47fe73646700310d10b954 \
-    pgraph.tgz 0b9c1a9f08d3df618a4f374c493252c8b30d8c12 \
-    runtime.tgz f196e3b3568081e8666bc92ed5025f7738d9a6c5 \
-    smlnj-c.tgz d8fd5771f0c7d4baf6f4c25ebb17f0e4ccef0298 \
-    smlnj-lib.tgz 7cdeacf3fb2c45e7768efdcb716614261fff270f \
-    system.tgz 184ef6a6414e3b6f9bdc5ed5d523721d84dc3981 \
-    trace-debug-profile.tgz ab761a6480f00225e91dd40dd59d1f511e50d591 \
+    ckit.tgz ad6ee5f6f2c9dd6719cc43840f8d4b49b1bb964f \
+    cml.tgz 2777c3dc0ed84dfae6ea40f7bbe3670fcd65bdcf \
+    cm.tgz 289c39d1c149dca43aa8d8096e826f2c86b141a4 \
+    compiler.tgz 4dbc2d75abd2f9d6ae36993a570372e8075d3dae \
+    config.tgz 918df9e648bf19619e89c54114818e1d18a44bda \
+    doc.tgz 9b3a070506c3810213293837c8ef531c3a20400f \
+    eXene.tgz e7306683fa706a84a4fc5c05cbe1df12bb0984e1 \
+    heap2asm.tgz 72cacbaa4d335e0742bb9dc872e37db21a0e29f4 \
+    ml-burg.tgz b3978428c9d2147a3e4527cf1a8fdbb54da24d2f \
+    ml-lex.tgz b762e312b8c2a11d92f60269a3e65f99f2728061 \
+    ml-lpt.tgz 82c2a13c6e4c833c17335ebb48e4e89b15bdf580 \
+    MLRISC.tgz ca958d7f14ca7a103921e0c1bdde1a7097e74bed \
+    ml-yacc.tgz 9b90c774c951eb747b249a610467f86af7b9e64b \
+    nlffi.tgz 80e9854839232036b71786943170c58067a6a04d \
+    old-basis.tgz d05adf45d75d954763ce178b448f5d2d5aa9685c \
+    pgraph.tgz 90da4ce310f3c2d89d6d411110f53027fb985616 \
+    runtime.tgz 7a7cc05dcba481b47f50c7d87c4abcc85e51cce4 \
+    smlnj-c.tgz a69ff7cbe6821bb8d50f2d729992be80ab69e12f \
+    smlnj-lib.tgz b3fa8ac6531f737c6b96b2250a3f827ffa17408d \
+    system.tgz f4bd70f6cc5369def248f5632075290e881a9aac \
+    trace-debug-profile.tgz f0fdd25f38a311e67a29628f7a8bc5dad2256e87 \
 ]
 
 foreach {tarball checksum} $srcs {
@@ -56,11 +56,11 @@ foreach {tarball checksum} $srcs {
 # Platform-specific boot code (omitted: sparc-unix, x86-win32)
 platform powerpc {
     distfiles-append boot.ppc-unix.tgz
-    checksums-append boot.ppc-unix.tgz sha1 1f519ef4e31329cc1fe52e34fe927e54fe688815
+    checksums-append boot.ppc-unix.tgz sha1 ee32acfd97f7bcb4ec337565805f3d358ab299ba
 }
 platform i386 {
     distfiles-append boot.x86-unix.tgz
-    checksums-append boot.x86-unix.tgz sha1 c2ab5569be827afea10e8b8bb07a597845d3d201
+    checksums-append boot.x86-unix.tgz sha1 df24a467d68dd9259a7a3d00c5d37c51dbc7ed2a
 }
 
 ### extract ###


### PR DESCRIPTION
###### Description

Update SML-NJ to the 110.80 version, which fixes the break on Sierra.

Closes: https://trac.macports.org/ticket/52421
Closes: https://trac.macports.org/ticket/52972

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
