### PR TITLE
gnustep-make: Update to 2.7.0

### DIFF
--- a/gnustep/gnustep-make/Portfile
+++ b/gnustep/gnustep-make/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            gnustep-make
-version         2.6.1
+version         2.7.0
 categories      gnustep devel cross
 platforms       darwin
 license         GPL-3+
@@ -20,8 +20,8 @@ long_description \
 
 master_sites        gnustep:core
 
-checksums           rmd160  a72970e1bf0fa93622981e991717714795cdb7a5 \
-                    sha256  c48b0a4c85eee4799b12cceeb327c470b168100cbcda4f111b1edad71f8762eb
+checksums           rmd160  870c8e498d9e2618e443061c8524570af927a0b9 \
+                    sha256  90a01cbfb68aafe01c4cc4123121ebd2da0e1e2076795b5682f0833fddf311ce
 
 destroot.violate_mtree yes
 


### PR DESCRIPTION
update gnustep-make to 2.7.0

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
