### PR TITLE
kotlin: update to 1.1.2-2

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.1.1 v
+github.setup        JetBrains kotlin 1.1.2-2 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  b06916dd934f80860233eaefd963935f8fe34de1 \
-                    sha256  aca2c91f6e10224df07bf523d34736c9a1f101bcf53b26104314503a57a026b1
+checksums           rmd160  07a5c7ec508cf2240086705a655e4364cd72ebcf \
+                    sha256  57e18528f665675206e88cdc0bd42d1550b10f2508e08035270974d7abec3f2f
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
###### Description

Update to Kotlin compiler 1.1.2-2.

###### Tested on
macOS 10.12.4
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
