### PR TITLE
glpk: disable reentrancy support for <=10.6

### DIFF
--- a/math/glpk/Portfile
+++ b/math/glpk/Portfile
@@ -33,6 +33,10 @@ if { [variant_isset odbc] || [variant_isset iodbc] || [variant_isset mysql5] || 
     patchfiles-append patch-configure.diff
 }
 
+if { ${os.major} <= 10 } {
+    configure.args-append --disable-reentrant
+}
+
 use_parallel_build  yes
 
 test.run        yes

--- a/math/glpk/Portfile
+++ b/math/glpk/Portfile
@@ -1,48 +1,48 @@
-PortSystem      1.0
-PortGroup       muniversal 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            glpk
-epoch           1
-version         4.61
-license         GPL-3+
-categories      math lang
-platforms       darwin
-maintainers     nomaintainer
-description     GNU Linear Programming Kit
+PortSystem          1.0
+PortGroup           muniversal 1.0
 
-long_description \
-    The GLPK (GNU Linear Programming Kit) package is intended for \
-    solving large-scale linear programming (LP), mixed integer \
-    programming (MIP), and other related problems. It is a set of \
-    routines written in ANSI C and organized in the form of a \
-    callable library.
+name                glpk
+epoch               1
+version             4.61
+license             GPL-3+
+categories          math lang
+platforms           darwin
+maintainers         nomaintainer
+description         GNU Linear Programming Kit
 
-homepage        http://www.gnu.org/software/${name}/
-master_sites    gnu
+long_description    The GLPK (GNU Linear Programming Kit) package is intended for \
+                    solving large-scale linear programming (LP), mixed integer \
+                    programming (MIP), and other related problems. It is a set of \
+                    routines written in ANSI C and organized in the form of a \
+                    callable library.
 
-checksums       rmd160  763b558b32b91fbf36a52cf539e11b7897bf7507 \
-                sha256  9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9
+homepage            http://www.gnu.org/software/${name}/
+master_sites        gnu
 
-depends_lib     port:gmp
+checksums           rmd160  763b558b32b91fbf36a52cf539e11b7897bf7507 \
+                    sha256  9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9
 
-configure.args  --with-gmp
+depends_lib         port:gmp
+configure.args      --with-gmp
 
 if { [variant_isset odbc] || [variant_isset iodbc] || [variant_isset mysql5] || [variant_isset mysql56] } {
-    depends_lib-append port:libtool
-    configure.args-append --enable-dl
-    patchfiles-append patch-configure.diff
+    depends_lib-append      port:libtool
+    configure.args-append   --enable-dl
+    patchfiles-append       patch-configure.diff
 }
 
 if { ${os.major} <= 10 } {
-    configure.args-append --disable-reentrant
+    configure.args-append   --disable-reentrant
 }
 
 use_parallel_build  yes
 
-test.run        yes
-test.target     check
+test.run            yes
+test.target         check
 
-set docdir ${prefix}/share/doc/${name}
+set docdir          ${prefix}/share/doc/${name}
 
 post-destroot {
     xinstall -d ${destroot}${docdir}
@@ -63,9 +63,9 @@ post-destroot {
 }
 
 variant odbc conflicts iodbc description {enable MathProg ODBC support using unixODBC} {
-    depends_lib-append port:unixODBC
+    depends_lib-append      port:unixODBC
+    configure.args-append   --enable-odbc=unix
 
-    configure.args-append --enable-odbc=unix
     post-patch {
         reinplace \
             "s|__MACPORTS__ODBC__LIB__|${prefix}/lib|g" \
@@ -74,11 +74,11 @@ variant odbc conflicts iodbc description {enable MathProg ODBC support using uni
 }
 
 variant iodbc description {enable MathProg ODBC support using iODBC} {
-    depends_lib-append port:libiodbc
+    depends_lib-append      port:libiodbc
+    configure.args-append   --enable-odbc
 
-    configure.args-append --enable-odbc
     post-patch {
-	reinplace \
+        reinplace \
             "s|__MACPORTS__IODBC__LIB__|${prefix}/lib|g" \
             ${worksrcpath}/configure
     }
@@ -87,23 +87,23 @@ variant iodbc description {enable MathProg ODBC support using iODBC} {
 variant mysql requires mysql5 description {legacy variant, use +mysql5 instead} {}
 
 variant mysql5 conflicts mysql56 description {enable MathProg MySQL support using MySQL 5.1} {
-    depends_lib-append path:bin/mysql_config5:mysql5
+    depends_lib-append      path:bin/mysql_config5:mysql5
+    configure.args-append   --enable-mysql
 
-    configure.args-append --enable-mysql
     post-patch {
         reinplace \
             "s|__MACPORTS__MYSQL__INCLUDE__|${prefix}/include/mysql5/mysql|g" \
             ${worksrcpath}/configure
-	reinplace \
+        reinplace \
             "s|__MACPORTS__MYSQL__LIB__|${prefix}/lib/mysql5/mysql|g" \
             ${worksrcpath}/configure
     }
 }
 
 variant mysql56 conflicts mysql5 description {enable MathProg MySQL support using MySQL 5.6} {
-    depends_lib-append port:mysql56
+    depends_lib-append      port:mysql56
+    configure.args-append   --enable-mysql
 
-    configure.args-append --enable-mysql
     post-patch {
         reinplace \
             "s|__MACPORTS__MYSQL__INCLUDE__|${prefix}/include/mysql56/mysql|g" \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/53415

I am unsure whether the revision needs to be increased: as far as I know the error prevented the port from building, so it should not be necessary.

###### Tested on
Mac OS X 10.6.8
Xcode 3.2.6

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?