### PR TITLE
py-gammapy: update to v0.6

### DIFF
--- a/python/py-gammapy/Portfile
+++ b/python/py-gammapy/Portfile
@@ -7,7 +7,7 @@ set _name           gammapy
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.5
+version             0.6
 categories-append   science
 platforms           darwin
 maintainers         gmail.com:Deil.Christoph openmaintainer
@@ -19,9 +19,9 @@ homepage            https://github.com/gammapy/gammapy
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     4966b7f47656cde5dfa9d3132f5f977a \
-                    rmd160  f5b57a7f8cf88a049ef82711b177cb2346671d16 \
-                    sha256  7d5711b2e74b887947bde74d982a50e19723f0e2bcba1dc93836855e48112042
+checksums           md5     68679182c52654aeb8e0ad97b9a28f81 \
+                    rmd160  2413dd10219ed9b679b088b3f4d2d3336c8d9f0d \
+                    sha256  50f816a1b13de0bd483b588fc5ca4799849cca65a74102f81b8d972d48903550
 
 python.versions     27 34 35 36
 
@@ -38,6 +38,7 @@ if {${name} ne ${subport}} {
                           port:py${python.version}-scipy \
                           port:py${python.version}-matplotlib \
                           port:py${python.version}-astropy \
+                          port:py${python.version}-regions \
                           port:py${python.version}-yaml \
                           port:py${python.version}-click
 


### PR DESCRIPTION
This PR updates `py-gammapy` to version 0.6:
https://pypi.python.org/pypi/gammapy/0.6

I've also added `py-regions` as a dependency.

I'm part of the Gammapy team, and am maintaining this port and I've tested this locally.

Can someone please merge this?