### PR TITLE
py-m2crypto: update to 0.26.0 and remove python26 subport

### DIFF
--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -21,7 +21,7 @@ checksums          md5     9f02f0b88fbe225cc6ea8680945cafa0 \
                    rmd160  8ffd4ccd0f040cc2d23d05397a883ab45fec45e7 \
                    sha256  05d94fd9b2dae2fb8e072819a795f0e05d3611b09ea185f68e1630530ec09ae8
 
-python.versions    26 27
+python.versions    27
 
 if {${name} ne ${subport}} {
   depends_build      port:py${python.version}-setuptools

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -4,7 +4,7 @@ PortSystem         1.0
 PortGroup          python 1.0
 
 name               py-m2crypto
-version            0.25.1
+version            0.26.0
 categories-append  crypto devel
 platforms          darwin
 # demos include some Apache-2 and ZPL-2 files but are not installed
@@ -17,9 +17,9 @@ homepage           https://pypi.python.org/pypi/${python.rootname}
 
 master_sites       pypi:m/${python.rootname}/
 distname           M2Crypto-${version}
-checksums          md5     040234289fbef5bed4029f0f7d1dae35 \
-                   rmd160  6dcb90c12a030b7c575efc310e6abd503be7e0a0 \
-                   sha256  ac303a1881307a51c85ee8b1d87844d9866ee823b4fdbc52f7e79187c2d9acef
+checksums          md5     9f02f0b88fbe225cc6ea8680945cafa0 \
+                   rmd160  8ffd4ccd0f040cc2d23d05397a883ab45fec45e7 \
+                   sha256  05d94fd9b2dae2fb8e072819a795f0e05d3611b09ea185f68e1630530ec09ae8
 
 python.versions    26 27
 

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -9,7 +9,7 @@ categories-append  crypto devel
 platforms          darwin
 # demos include some Apache-2 and ZPL-2 files but are not installed
 license            MIT
-maintainers        gmail.com:allan.que openmaintainer
+maintainers        {gmail.com:allan.que @aque} openmaintainer
 
 description        Crypto and SSL toolkit for Python
 long_description   M2Crypto is the most complete Python wrapper for OpenSSL.


### PR DESCRIPTION
###### Description
Remove py26-m2crypto since the required py-typing library does not support python26. This change breaks py-euca2ools and [ticket #52920 was created](https://trac.macports.org/ticket/52920) to notify that maintainer. As far as I can tell, it is the only remaining port that depends on py26-m2crypto.

(I'm the maintainer listed for this port.)

closes: https://trac.macports.org/ticket/53924
closes: https://trac.macports.org/ticket/43240

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.4
Xcode 8.3.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?