### PR TITLE
py-typing: update to 3.6.1 and add python35 support

### DIFF
--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typing
-version             3.5.3.0
+version             3.6.1
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -24,9 +24,9 @@ homepage            http://pypi.python.org/pypi/${python.rootname}/
 
 master_sites        pypi:t/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           md5     3996a747158e5591abf689c1c5f8f9db \
-                    rmd160  23e668619f848f41b3470455407cb42889c491f0 \
-                    sha256  ca2daac7e393e8ee86e9140cd0cf0172ff6bb50ebdf0b06281770f98f31bff21
+checksums           md5     3fec97415bae6f742fb3c3013dedeb89 \
+                    rmd160  315f0d1236eb05035cadcba94f1e0b62b8e53c0d \
+                    sha256  c36dec260238e7464213dcd50d4b5ef63a507972f5780652e835d0228d0edace
 
 python.versions     27 33 34
 

--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -9,7 +9,7 @@ categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             PSF
-maintainers         gmail.com:allan.que openmaintainer
+maintainers         {gmail.com:allan.que @aque} openmaintainer
 
 description         Type hints for Python
 long_description    Typing is a backport of the standard library \

--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -13,7 +13,7 @@ maintainers         gmail.com:allan.que openmaintainer
 
 description         Type hints for Python
 long_description    Typing is a backport of the standard library \
-                    'typing' module to Python versions older than 3.5. \
+                    'typing' module to Python versions older than 3.6. \
                     It defines a standard notation for Python function \
                     and variable type annotations. The notation can be \
                     used for documenting code in a concise, standard \
@@ -28,7 +28,7 @@ checksums           md5     3fec97415bae6f742fb3c3013dedeb89 \
                     rmd160  315f0d1236eb05035cadcba94f1e0b62b8e53c0d \
                     sha256  c36dec260238e7464213dcd50d4b5ef63a507972f5780652e835d0228d0edace
 
-python.versions     27 33 34
+python.versions     27 33 34 35
 
 if {${name} ne ${subport}} {
     livecheck.type  none


### PR DESCRIPTION
###### Description

Edit: (I'm the maintainer listed for this port.)

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.4
Xcode 8.3.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
