### PR TITLE
py-pytimeparse: new port

### DIFF
--- a/python/py-pytimeparse/Portfile
+++ b/python/py-pytimeparse/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       pytimeparse
+name                py-$base_name
+version             1.1.6
+python.versions     27 35 36
+platforms           darwin
+maintainers         openmaintainer @esafak
+license             MIT
+
+description         A small Python module to parse various kinds of time expressions
+long_description    $description
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:p/$base_name
+
+checksums           rmd160  e6a4d1ecc57fd4b50f86fe7199ec8b393c4d4acd \
+                    sha256  74c52ae0db8a1d9055b9159bf09023ad5fba828b87ec47c0a9aed8129159ab46
+
+distname            $base_name-${version}
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     $base_name (\\d+(\\.\\d+)+)


### PR DESCRIPTION
A small Python module to parse various kinds of time expressions.

###### Description

Created to support py-agate https://trac.macports.org/ticket/53639
 
<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?