### PR TITLE
nanopass-scheme: new port

### DIFF
--- a/scheme/nanopass-scheme/Portfile
+++ b/scheme/nanopass-scheme/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        nanopass nanopass-framework-scheme 1.9 v
+
+name                nanopass-scheme
+categories          scheme
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Nanopass Compiler Library
+
+long_description    An R6RS version of the Nanopass Compiler Infrastructure.
+
+checksums           rmd160  8b2ce43f9b1d44f24c38585dbdd7d354306415b1 \
+                    sha256  a37ef8c6f5909cc09d2ad4d4ec49cce7e3dc926f45344e95af98aa70df799a04
+
+use_configure       no
+
+build {}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/share/scheme/r6rs/nanopass
+    xinstall ${worksrcpath}/nanopass.ss ${destroot}${prefix}/share/scheme/r6rs
+    xinstall {*}[glob ${worksrcpath}/nanopass/*] ${destroot}${prefix}/share/scheme/r6rs/nanopass
+}


### PR DESCRIPTION
###### Description

Scheme library required for building ChezScheme (https://trac.macports.org/ticket/51863).

###### Tested on
macOS 10.12.4

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
