### PR TITLE
qjackctl: fix configuration error with qt4-mac

### DIFF
--- a/audio/qjackctl/Portfile
+++ b/audio/qjackctl/Portfile
@@ -42,9 +42,14 @@ variant qt4 description "Enable qt4 instead of qt5 interface" {}
 
 if {[variant_isset qt4]} {
     PortGroup             qt4 1.0
+    PortGroup             active_variants 1.1
     depends_lib-append    port:qt4-mac
+    
+    # https://trac.macports.org/ticket/54151
+    require_active_variants qt4-mac universal
+    
     configure.args-append --enable-qt4
-    configure.args-append --with-qt4=${qt_dir} \
+    configure.args-append --with-qt4=${qt_dir}
 } else {
     PortGroup             qt5 1.0
     depends_lib-append    port:qt5


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/54151
qt4-mac configures builds differently depending on whether it is
installed as +universal. This breaks several ports when qt4 is
not installed +universal. The most direct solution to this is to
require qt4-mac to be installed as +universal which should fix this issue
for all such ports

###### Description

This works around a somewhat cryptic configuration issue that involves qt4-mac when it is not installed as universal, which involves some ports. This issue goes back many years. See <https://trac.macports.org/changeset/73290> for an old example.