### PR TITLE
minicom: update to 2.7.1 [security]

### DIFF
--- a/comms/minicom/Portfile
+++ b/comms/minicom/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 
 name                minicom
-version             2.7
-revision            1
-set download_id     3977
+version             2.7.1
+set download_id     4215
 categories          comms
 maintainers         nomaintainer
 platforms           darwin
@@ -20,8 +19,8 @@ long_description    Minicom is a menu driven communications program. It \
 homepage            https://alioth.debian.org/projects/minicom
 master_sites        https://alioth.debian.org/frs/download.php/file/${download_id}
 
-checksums           rmd160  a7947e2e45cc6655b55b70cb65f8784a606248ce \
-                    sha256  9ac3a663b82f4f5df64114b4792b9926b536c85f59de0f2d2b321c7626a904f4
+checksums           rmd160  cc538b69d3bbc0de13691ac6394f03e97c5dfb5d \
+                    sha256  532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
Adds fix for CVE-2017-7467, see https://lists.alioth.debian.org/pipermail/minicom-devel/2017/001329.html

Tested on macOS 10.12.4 + XCode 8.3.2--seems to work just like 2.7.