### PR TITLE
tk: allow building +quartz on non-Retina systems

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -42,7 +42,8 @@ depends_lib \
 worksrcdir      ${name}${version}/unix
 
 patch.dir           ${workpath}/${name}${version}
-patchfiles          patch-unix-Makefile.in.diff
+patchfiles          patch-unix-Makefile.in.diff \
+                    patch-macosx-tkMacOSXXStubs.c.diff
 
 post-patch {
     reinplace s|@TCL_SRC_DIR@|${workpath}/tcl${version}/|g ${worksrcpath}/Makefile.in

--- a/x11/tk/files/patch-macosx-tkMacOSXXStubs.c.diff
+++ b/x11/tk/files/patch-macosx-tkMacOSXXStubs.c.diff
@@ -1,0 +1,21 @@
+--- macosx/tkMacOSXXStubs.c.orig
++++ macosx/tkMacOSXXStubs.c
+@@ -891,15 +891,17 @@ XGetImage(
+     int	        bytes_per_row = 4*width;
+     int                size;
+     MacDrawable *macDraw = (MacDrawable *) d;
++    int scalefactor = 1;
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+     NSWindow *win = TkMacOSXDrawableWindow(d);
+     /* This code assumes that backing scale factors are integers.  Currently
+      * Retina displays use a scale factor of 2.0 and normal displays use 1.0.
+      * We do not support any other values here.
+      */
+-    int scalefactor = 1;
+     if (win && [win respondsToSelector:@selector(backingScaleFactor)]) { 
+ 	scalefactor = ([win backingScaleFactor] == 2.0) ? 2 : 1;
+     }
++#endif
+     int scaled_height = height * scalefactor;
+     int scaled_width = width * scalefactor;
+ 


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/52090

I didn't increase the revision, since `tk +quartz` didn't build on systems <= 10.6 and the installed files without `+quartz` or on newer systems should not change.

###### Tested on
Mac OS X 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? Tested only via Perl/Tk
