### PR TITLE
gdal: upstream patch to to fix non-C++11 builds

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -113,6 +113,18 @@ patchfiles          patch-gdalwarpkernel_opencl_h.diff \
 # see https://github.com/mdadams/jasper/commit/d42b2388f7f8e0332c846675133acea151fc557a#diff-c9eea58015962f20fc7ba09e1388c3da
 patchfiles-append   patch-uchar.diff
 
+# for all platforms without C++11 support
+# this is just a suboptimal approximation (doesn't hold for gcc)
+if {${configure.cxx_stdlib} != "libc++"} {
+    configure.args-append \
+                    --without-cpp11
+    # backported from master and could be applied everywhere
+    patchfiles-append \
+                    patch-configure-isnan.diff \
+                    patch-port-cpl_config.h.in.patch \
+                    patch-port-cpl_port.h.diff
+}
+
 pre-configure {
     global worksrcpath_dirs
     if { ![variant_isset universal] } {

--- a/gis/gdal/files/patch-configure-isnan.diff
+++ b/gis/gdal/files/patch-configure-isnan.diff
@@ -1,0 +1,53 @@
+--- configure.orig
++++ configure
+@@ -17954,6 +17954,50 @@ if test "x$CXX" = x ; then
+   as_fn_error $? "\"You don't have a working C++ compiler.\"" "$LINENO" 5
+ fi
+ 
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for std::isnan" >&5
++$as_echo_n "checking for std::isnan... " >&6; }
++ac_ext=cpp
++ac_cpp='$CXXCPP $CPPFLAGS'
++ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
++ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
++
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <cmath>
++    int CPLIsNan(float f) { return std::isnan(f); }
++int
++main ()
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_cxx_try_compile "$LINENO"; then :
++
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_STD_IS_NAN 1
++_ACEOF
++
++
++else
++
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++ac_ext=c
++ac_cpp='$CPP $CPPFLAGS'
++ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
++ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_c_compiler_gnu
++
++
+ 
+ # Check whether --with-libtool was given.
+ if test "${with_libtool+set}" = set; then :

--- a/gis/gdal/files/patch-port-cpl_config.h.in.patch
+++ b/gis/gdal/files/patch-port-cpl_config.h.in.patch
@@ -1,0 +1,9 @@
+--- port/cpl_config.h.in.orig
++++ port/cpl_config.h.in
+@@ -258,3 +258,6 @@
+ 
+ /* Define to 1 if you have the `uselocale' function. */
+ #undef HAVE_USELOCALE
++
++/* Define to 1 if you have the `std::isnan' function. */
++#undef HAVE_STD_IS_NAN

--- a/gis/gdal/files/patch-port-cpl_port.h.diff
+++ b/gis/gdal/files/patch-port-cpl_port.h.diff
@@ -1,0 +1,16 @@
+--- port/cpl_port.h
++++ port/cpl_port.h
+@@ -653,10 +653,11 @@ static inline char* CPL_afl_friendly_strstr(const char* haystack, const char* ne
+ #  define CPLIsNan(x) _isnan(x)
+ #  define CPLIsInf(x) (!_isnan(x) && !_finite(x))
+ #  define CPLIsFinite(x) _finite(x)
+-#elif defined(__cplusplus) && defined(__MINGW32__) &&  __GNUC__ == 4 && __GNUC_MINOR__ == 2
+-/* Hack for compatibility with ancient i586-mingw32msvc toolchain */
++#elif defined(__cplusplus) && defined(HAVE_STD_IS_NAN) && HAVE_STD_IS_NAN
+ extern "C++" {
++#ifndef DOXYGEN_SKIP
+ #include <cmath>
++#endif
+ static inline int CPLIsNan(float f) { return std::isnan(f); }
+ static inline int CPLIsNan(double f) { return std::isnan(f); }
+ static inline int CPLIsInf(float f) { return std::isinf(f); }


### PR DESCRIPTION
The build of `gdal` was broken in 71a4f62c26c997dd7d7065f498026965f59e553c for < 10.9.

As long as C++03 support lasts ... this is a backport of an upstream fix (see https://github.com/OSGeo/gdal/commit/eb053282f34598d5c9f1c593ca6b1e56a0128ce2) for builds with non-C++11 compilers, combined with `--without-cpp11` configure flag that should only be used when non-C++11 compiler is used.

This still needs to be tested on 10.6, I guess that we might have to blacklist the default compiler.

Thanks to @rouault for guidance, I hope this will get backported to the 2.2 branch as well.

Closes: https://trac.macports.org/ticket/54203

###### Description

<!-- (delete all below for minor changes) -->

###### Tested on
OS X 10.7
Xcode 4.6.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
