### PR TITLE
afl: new port

### DIFF
--- a/devel/afl/Portfile
+++ b/devel/afl/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                afl
+version             2.41b
+categories          devel security
+platforms           darwin
+maintainers         {stevenmyint.com:git @myint} openmaintainer
+license             Apache-2
+
+description         Instrumentation-driven fuzzer
+
+long_description    American fuzzy lop is a security-oriented fuzzer that \
+                    employs a novel type of compile-time instrumentation and \
+                    genetic algorithms to automatically discover clean, \
+                    interesting test cases that trigger new internal states \
+                    in the targeted binary.
+
+homepage            http://lcamtuf.coredump.cx/afl
+master_sites        ${homepage}/releases
+extract.suffix      .tgz
+
+checksums           rmd160 170b4c304f698d6461fb9572962f8b58fc6649bd \
+                    sha256 0670b13235264e688a7ccfbeeee257e9c57dcc86ead676247d92d199c194968f
+
+use_configure       no
+
+build.env           CC=${configure.cc} \
+                    CXX="${configure.cxx}" \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]" \
+                    PREFIX=${prefix}
+
+destroot.env        PREFIX=${prefix}
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     afl-(\\d+(?:\\.\\d+)*b).tgz
+
+notes "
+WARNING: Fuzzing on MacOS X is slow because of the unusually high overhead of \
+fork() on this OS. Consider using Linux or *BSD. You can also use VirtualBox \
+(virtualbox.org) to put AFL inside a Linux or *BSD VM.
+"


### PR DESCRIPTION
###### Description
This adds a new port for [`afl`](http://lcamtuf.coredump.cx/afl/). It is one of the more popular fuzzers and has been available for several years.

This is my first time contributing a port so I may have missed something.

I had to add the `port:gnuplot` runtime requirement since the `afl-plot` script uses it. It might be nice to eventually add a variant that doesn't depend on `port:gnuplot` by not installing `afl-plot`. But that might require patching `Makefile` conditionally, which I don't know how to do. Or perhaps MacPorts supports excluding a file installed by the makefile?

```makefile
#
# american fuzzy lop - makefile
...
PROGS       = afl-gcc afl-fuzz afl-showmap afl-tmin afl-gotcpu afl-analyze
SH_PROGS    = afl-plot afl-cmin afl-whatsup
...
install: all
...
        install -m 755 $(PROGS) $(SH_PROGS) $${DESTDIR}$(BIN_PATH)
```

###### Tested on
macOS 10.12.4
Xcode 8.3.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?