### PR TITLE
darwinbuild-legacy: convert to github portgroup

### DIFF
--- a/devel/darwinbuild-legacy/Portfile
+++ b/devel/darwinbuild-legacy/Portfile
@@ -1,53 +1,57 @@
-PortSystem      1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            darwinbuild-legacy
-version         0.8.0
-revision	655
-categories      devel
-platforms       darwin
-maintainers     wms
-description     Darwinbuild is a set of tools that facilitate building the sources \
-		released by Apple.
+PortSystem          1.0
 
-long_description \
-		The Darwin Build Scripts are a collection of tools that assist compilation of \
-		the many projects contained in Darwin, the open source base of Apple's \
-		Mac OS X operating system.  Apple publishes the sources of these projects \
-		in an archive format (.tar.gz).  An archive is published for each project \
-		version on Apple's site. These tools will provide the proper build environment as well as help to \
-		resolve any necessary dependencies prior to building.
+name                darwinbuild-legacy
+version             0.8.0
+revision            655
+categories          devel
+platforms           darwin
+maintainers         wms
+description         Darwinbuild is a set of tools that facilitate building the sources \
+                    released by Apple.
 
-homepage        http://darwinbuild.macosforge.org/
-master_sites    http://svn.macosforge.org/repository/darwinbuild/
+long_description    The Darwin Build Scripts are a collection of tools that assist compilation of \
+                    the many projects contained in Darwin, the open source base of Apple's \
+                    Mac OS X operating system.  Apple publishes the sources of these projects \
+                    in an archive format (.tar.gz).  An archive is published for each project \
+                    version on Apple's site. These tools will provide the proper build environment as well as help to \
+                    resolve any necessary dependencies prior to building.
+
+homepage            http://darwinbuild.macosforge.org/
+master_sites        http://svn.macosforge.org/repository/darwinbuild/
 
 pre-fetch {
     if {${os.major} > 9} {
         return -code error "The ${name} port is only for Darwin 8 and 9. For Darwin\
-			    10 and later, install the darwinbuild port." 
+                    10 and later, install the darwinbuild port."
     }
 }
 
 platform darwin 9 {
-	worksrcdir	Darwin9
-	svn.url         ${master_sites}/releases/${worksrcdir}
+    worksrcdir      Darwin9
+    svn.url         ${master_sites}/releases/${worksrcdir}
 }
 
 platform darwin 8 {
-	set worksrcdir	Darwin8
-	svn.url         ${master_sites}/releases/${worksrcdir}
+    set worksrcdir  Darwin8
+    svn.url         ${master_sites}/releases/${worksrcdir}
 }
 
-fetch.type	svn
-svn.revision	${revision}
+fetch.type          svn
+svn.revision        ${revision}
 
-build.post_args-append		PREFIX=${prefix}
+
+build.post_args-append \
+                    PREFIX=${prefix}
 if {[info exists build_arch]} {
-	build.env-append		RC_CFLAGS="-arch ${build_arch}"
+    build.env-append \
+                    RC_CFLAGS="-arch ${build_arch}"
 }
-destroot.post_args-append	PREFIX=${prefix}
+destroot.post_args-append \
+                    PREFIX=${prefix}
 
-depends_lib-append	port:sqlite3 \
-			path:lib/libssl.dylib:openssl
+depends_lib-append  port:sqlite3 \
+                    path:lib/libssl.dylib:openssl
 
-use_configure 	no
-
+use_configure       no

--- a/devel/darwinbuild-legacy/Portfile
+++ b/devel/darwinbuild-legacy/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
 name                darwinbuild-legacy
-version             0.8.0
-revision            655
 categories          devel
 platforms           darwin
+license             BSD
 maintainers         wms
 description         Darwinbuild is a set of tools that facilitate building the sources \
                     released by Apple.
@@ -18,8 +18,7 @@ long_description    The Darwin Build Scripts are a collection of tools that assi
                     version on Apple's site. These tools will provide the proper build environment as well as help to \
                     resolve any necessary dependencies prior to building.
 
-homepage            http://darwinbuild.macosforge.org/
-master_sites        http://svn.macosforge.org/repository/darwinbuild/
+homepage            https://macosforge.github.io/darwinbuild/
 
 pre-fetch {
     if {${os.major} > 9} {
@@ -29,17 +28,20 @@ pre-fetch {
 }
 
 platform darwin 9 {
-    worksrcdir      Darwin9
-    svn.url         ${master_sites}/releases/${worksrcdir}
+    github.setup    macosforge darwinbuild 4848b7f5b223e094a26c413b451d27b938b0f2bd
+    checksums       rmd160  501aeec0ee10cd4018c423f067fe1a3db98ab5cc \
+                    sha256  5462ea6f1031c8521a8c1dd8c4bf609d7d54c090f65a2dcf29add03701285e25
 }
 
 platform darwin 8 {
-    set worksrcdir  Darwin8
-    svn.url         ${master_sites}/releases/${worksrcdir}
+    github.setup    macosforge darwinbuild e67e529a642fe7f361af6662bfddcf2e4376cdce
+    checksums       rmd160  9758ef38fbc192e276f1a5899961c540e6907fec \
+                    sha256  3bf86a7c51deaa49ccddeadbc35ec337f43a57b31dfd3d998a61f82d2f6f2fa2
 }
 
-fetch.type          svn
-svn.revision        ${revision}
+# pick up the old revision number to continue the proper flow
+version             0.8.0
+revision            655
 
 
 build.post_args-append \


### PR DESCRIPTION
Darwin8 and Darwin9 only

###### Tested on
10.4 PPC and 10.5 PPC