### PR TITLE
cdecl: add new port for cdecl

### DIFF
--- a/devel/cdecl/Portfile
+++ b/devel/cdecl/Portfile
@@ -1,0 +1,16 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+name                cdecl
+version             3.1.3
+categories          devel
+platforms           darwin
+maintainers         joelburton.com:joel
+description         Tool to compose or decipher C/C++ type declarations and casts.
+long_description    This is a command-line tool to compose or decipher C and C++ \
+                    type declarations and casts.
+homepage            https://github.com/paul-j-lucas/cdecl
+master_sites        https://github.com/paul-j-lucas/cdecl/releases/download/cdecl-3.1.3/
+checksums           sha256  dfd7a96d31c71226596910cecf13280cee76fe3d007f4a6d306abed66f2c14ca \
+                    rmd160  63a0046db3a49cb264787840085b192e4b7a19c8
+depends_lib         port:readline

--- a/devel/cdecl/Portfile
+++ b/devel/cdecl/Portfile
@@ -1,16 +1,18 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-name                cdecl
-version             3.1.3
+PortGroup           github 1.0
+github.setup        paul-j-lucas cdecl 3.1.3
+github.tarball_from releases
+
 categories          devel
 platforms           darwin
-maintainers         joelburton.com:joel
+
+maintainers         {joelburton.com:joel @joelburton} openmaintainer
 description         Tool to compose or decipher C/C++ type declarations and casts.
 long_description    This is a command-line tool to compose or decipher C and C++ \
                     type declarations and casts.
 homepage            https://github.com/paul-j-lucas/cdecl
-master_sites        https://github.com/paul-j-lucas/cdecl/releases/download/cdecl-3.1.3/
 checksums           sha256  dfd7a96d31c71226596910cecf13280cee76fe3d007f4a6d306abed66f2c14ca \
                     rmd160  63a0046db3a49cb264787840085b192e4b7a19c8
 depends_lib         port:readline


### PR DESCRIPTION
Add new port for cdecl, a console tool for C/C++ declaration/cast interpretation.

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [n/a] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [n/a] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
