### PR TITLE
py-tox: update to 2.7.0

### DIFF
--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -5,11 +5,11 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 PortGroup           github 1.0
 
-github.setup        tox-dev tox 2.6.0 v
+github.setup        tox-dev tox 2.7.0 v
 
 name                py-tox
 categories-append   devel
-maintainers         gmail.com:pedro.salgado openmaintainer
+maintainers         {gmail.com:pedro.salgado @steenzout} openmaintainer
 platforms           darwin
 supported_archs     noarch
 license             MIT
@@ -22,8 +22,8 @@ master_sites        pypi:t/tox/
 
 distname            tox-${version}
 
-checksums           rmd160  8a2eec89f7849666426650be2d060c244816b837 \
-                    sha256  916498d2971f44a76baf3773a700f775c2f51aa6cc20be1828309148fc412252
+checksums           rmd160  89a1a09d8e0631a217388a8f98b1e61f8e393b2c \
+                    sha256  9c3bdc06fe411d24015e8bbbab9d03dc5243a970154496aac13f9283682435f9
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
###### Description

Use [tox 2.7.0](https://github.com/tox-dev/tox).

###### Tested on

macOS 10.x
Xcode 8.x

###### Verification

Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?