### PR TITLE
Update to ncurses-6.0-20170520

### DIFF
--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            ncurses
-version         6.0-20170422
+version         6.0-20170520
 categories      devel
 platforms       darwin freebsd
 license         MIT
@@ -20,9 +20,8 @@ extract.suffix	.tgz
 
 # hex.diff from http://opensource.apple.com/source/ncurses/ncurses-44/patches.applied/
 patchfiles      hex.diff
-checksums       rmd160  b7cfcf4a6bbd518397fb347100e5eedd3206d03f \
-                sha256  3ef623a69cc7dc067a8e67c552aad49dda79ff28a8f8c7d67b2ef36ae901a71d
-
+checksums       rmd160  a859522a57f342ece5ed8f5bb6ab16bfc0e0687f \
+                sha256  34aa2525ec3514c1dff03c9cae0d880f77226b8ba12562f238ddc31d869ad5c3
 configure.cppflags
 configure.ldflags
 configure.args  --enable-widec \


### PR DESCRIPTION
###### Description
ncurses: Updating to ncurses-6.0-20170520

Updating Portfile to use most recent version which includes a fix affecting ncurses applications displaying weird colors. For an example see: https://github.com/vifm/vifm/issues/269

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.5
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
