### PR TITLE
pidgin-sipe: add missing depenceny, add kerberos5 variant

### DIFF
--- a/net/pidgin-sipe/Portfile
+++ b/net/pidgin-sipe/Portfile
@@ -19,9 +19,16 @@ use_bzip2           yes
 checksums           rmd160  007f3f5ba2b104a601b2437c0722f9dcaa784f26 \
                     sha256  d392f9b474114b8a05fd6cbb997cabf4487398d0ccbd8375a03feb66c5b6280f
 
-depends_lib         port:pidgin
+depends_lib         port:pidgin \
+                    port:gmime \
+                    port:kerberos5 \
+                    port:telepathy-glib
+
 depends_build       port:intltool \
                     port:pkgconfig
+
+# disable -Werror
+configure.args-append --disable-quality-check
 
 livecheck.url       http://sourceforge.net/projects/sipe/files/sipe/
 livecheck.regex     /pidgin-sipe-(\[a-zA-Z0-9.\]+\.\[a-zA-Z0-9.\]+)/download


### PR DESCRIPTION
closes https://trac.macports.org/ticket/54229

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
