### PR TITLE
MenuMeters: support newer macOS versions

### DIFF
--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+
+PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-name                MenuMeters
-version             1.5
+github.setup        yujitach MenuMeters 1.9.5
 categories          aqua sysutils
-maintainers         nomaintainer
+maintainers         {stevenmyint.com:git @myint} openmaintainer
 license             GPL-2
 
 # bundled MenuCracker is only compiled for these archs
@@ -17,18 +18,9 @@ long_description    The MenuMeters monitors are true SystemUIServer plugins     
                     (also known as Menu Extras). This means they can be reordered   \
                     using command-drag and remember their positions in the menubar  \
                     across logins and restarts.
-homepage            http://www.ragingmenace.com/software/menumeters
-master_sites        http://www.ragingmenace.com/software/download
-distname            ${name}
-dist_subdir         ${name}/${version}
 
-checksums           rmd160  460af2fb40974d429389195fe49db1c7773ab472 \
-                    sha256  9e201177391fc0dcf86065c8f275829a45246f1a86322d2534c7aed63a82ecc4
-
-post-extract    {
-    file rename "${workpath}/${name} ${version} Source" ${worksrcpath}
-}
-worksrcdir          ${name}-${version}
+checksums           rmd160  214299100e47c576ccb4c6c702afef8380b79f59 \
+                    sha256  fc1da6bd44df522b787c90ccded23e700429e18ffc287cb64a59e209c1203f24
 
 patchfiles          patch-MenuMeters.xcodeproj-project.pbxproj.diff
 
@@ -40,10 +32,6 @@ destroot.violate_mtree \
 
 destroot    {
     xinstall -m 755 -d ${destroot}/Library/PreferencePanes
-    file copy ${worksrcpath}/build/Release/${name}.prefPane \
+    file copy ${worksrcpath}/build/UninstalledProducts/macosx/${name}.prefPane \
         ${destroot}/Library/PreferencePanes
 }
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     ${distfiles}">MenuMeters (\[0-9.\]+) source

--- a/aqua/MenuMeters/files/patch-MenuMeters.xcodeproj-project.pbxproj.diff
+++ b/aqua/MenuMeters/files/patch-MenuMeters.xcodeproj-project.pbxproj.diff
@@ -1,18 +1,10 @@
---- MenuMeters.xcodeproj/project.pbxproj.orig	2011-07-02 23:27:50.000000000 -0500
-+++ MenuMeters.xcodeproj/project.pbxproj	2011-11-13 01:18:18.000000000 -0600
-@@ -1643,7 +1643,6 @@
- 				SEPARATE_STRIP = YES;
- 				WARNING_CFLAGS = (
- 					"-Wall",
--					"-Werror",
- 					"-Wshorten-64-to-32",
- 				);
+--- MenuMeters.xcodeproj/project.pbxproj.orig
++++ MenuMeters.xcodeproj/project.pbxproj
+@@ -1380,6 +1380,7 @@
+ 				PRODUCT_NAME = MenuMeters;
+ 				SDKROOT = macosx;
+ 				WRAPPER_EXTENSION = prefPane;
++				SKIP_INSTALL = YES;
  			};
-@@ -1674,7 +1673,6 @@
- 				SEPARATE_STRIP = YES;
- 				WARNING_CFLAGS = (
- 					"-Wall",
--					"-Werror",
- 					"-Wshorten-64-to-32",
- 				);
- 			};
+ 			name = Release;
+ 		};


### PR DESCRIPTION
###### Description

MenuMeters has stopped building properly as of OS X 10.11. The original MenuMeters has not been updated since 2015. This instead uses the popular [fork of MenuMeters](https://github.com/yujitach/MenuMeters) that supports newer macOS versions.

Closes: https://trac.macports.org/ticket/51820

###### Tested on
macOS 10.12
Xcode 8.3.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?