### PR TITLE
opencv: Add OpenCV 3.2.0 support for Python3.6 as a build variant.

### DIFF
--- a/graphics/opencv/Portfile
+++ b/graphics/opencv/Portfile
@@ -288,7 +288,7 @@ variant python27 description {Add Python 2.7 bindings.} {
 }
 
 
-set pythonversions {3.4 3.5}
+set pythonversions {3.4 3.5 3.6}
 foreach pdv ${pythonversions} {
     set pv [join [lrange [split ${pdv} .] 0 1] ""]
     set conflist ""


### PR DESCRIPTION
This commit adds OpenCV 3.2.0 support for Python3.6 as a build variant.

An example usage for installing OpenCV with support for both Python2.7
and Python3.6 is as follows:

sudo port -vv install opencv +python36 +python27 +readline

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
