### PR TITLE
tmux: update to 2.5 / tmux-devel: update to latest commit

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,13 +3,13 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 2.4
+github.setup    tmux tmux 2.5
 if {${subport} eq ${name}} {
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux b853054e711c37a1f2c086311c1781ba44d66ef4
-    version         20170422-[string range ${github.version} 0 6]
+    github.setup    tmux tmux bfd7209053669f58cf2ddfa86bb3ed2f9340acd8
+    version         20170529-[string range ${github.version} 0 6]
     conflicts       tmux
 }
 categories      sysutils
@@ -28,12 +28,12 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  2f1f7e9a73155f7ad351c6067312e964ca514db1 \
-                            sha256  757d6b13231d0d9dd48404968fc114ac09e005d475705ad0cd4b7166f799b349
+    checksums               rmd160  c4b10cb03326fffece5dcb76b94938b5a7a2a645 \
+                            sha256  ae135ec37c1bf6b7750a84e3a35e93d91033a806943e034521c8af51b12d95df
 }
 subport tmux-devel {
-    checksums               rmd160  80b3e1583cf35e562a597fc77b4669d8a505cf41 \
-                            sha256  50348f7702f21b87cf957d74b0cf65f08db89944114afad76cb845039daa8b72
+    checksums               rmd160  1ce3cbbe09c9cbbd2965a4eec31dde79e204b996 \
+                            sha256  ae5005670e75ecee52b53737e52d0e2a74df5dd1d3c565c532d18033956fc073
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
###### Description

tmux: update to 2.5
tmux-devel: update to latest commit point

###### Tested on
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
