### PR TITLE
net/teleport: new port

### DIFF
--- a/net/teleport/Portfile
+++ b/net/teleport/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        gravitational teleport 2.2.3 v
+
+homepage            http://gravitational.com/teleport/
+categories          net
+maintainers         { gmail.com:graemelawes @gclawes } openmaintainer
+description         Teleport SSH server and Certificate Authority
+long_description    Teleport is a modern SSH server and CA for managing clusters \
+                    that provides secure login with certificate-based access, \
+                    2-factor authentication, session logging and replay, \
+                    integration with Google Apps and other OAuth identity providers, \
+                    and a Web UI.  Built on the Golang SSH library, and compatible with OpenSSH
+license             Apache-2
+
+checksums           rmd160  db3e486459c21aa3c706cc66d289f8e39b8e11ca \
+                    sha256  b187b73d3d60750d6abbdfca5b694a29c4ad081e9ea33077e47ab7f219e0991b
+
+depends_lib         port:go port:zip
+platforms           darwin
+use_configure       no
+worksrcdir          src/github.com/${github.author}/${github.project}
+
+build.env-append    GOPATH=${workpath}
+build.target        release
+use_parallel_build  no
+
+post-extract {
+    xinstall -d ${workpath}/src/github.com/${github.author}
+    move ${workpath}/${name}-${github.version} \
+        ${worksrcpath}
+}
+
+destroot {
+    foreach i { tctl tsh teleport } {
+        xinstall ${worksrcpath}/build/${i} ${destroot}${prefix}/bin
+    }
+}
+


### PR DESCRIPTION
Teleport is a modern SSH server and CA written in Go that
is designed for managing clusters, developed by Gravitational.

Homepage: http://gravitational.com/teleport

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
