### PR TITLE
py-unidecode: Add missing setuptools build dependency

### DIFF
--- a/python/py-unidecode/Portfile
+++ b/python/py-unidecode/Portfile
@@ -32,6 +32,8 @@ python.versions     27 35 36
 
 if {${subport} ne ${name}} {
     livecheck.type          none
+    depends_build-append	\
+    				port:py${python.version}-setuptools
 } else {
     livecheck.type          regex
     # The usual URL to use here would be the master site, but for some


### PR DESCRIPTION
###### Description

Add setuptools to address https://trac.macports.org/ticket/54248

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.11.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] <s> tried existing tests with `sudo port test`? </s>
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?