### PR TITLE
neomutt: give up maintainership

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -7,7 +7,7 @@ github.setup        neomutt neomutt 20170602 neomutt-
 categories          mail
 platforms           darwin
 license             GPL-2+
-maintainers         schenkel.net:leonardo openmaintainer
+maintainers         nomaintainer
 
 description         The Mutt E-Mail Client (patched version with added features)
 long_description    Mutt is a small but very powerful text-based MIME \


### PR DESCRIPTION
Normal version bumps aside, this port has been frequently modified without me (the maintainer) being notified about the changes. Since I'm not able to participate on setting the future direction of the port nor I feel confident being able to troubleshoot new issues when I'm not aware of the current state of it, I feel that I cannot really function as the responsible person for the port and therefore I'm relinquishing the role. 