### PR TITLE
afl: check for minimum macOS required

### DIFF
--- a/devel/afl/Portfile
+++ b/devel/afl/Portfile
@@ -35,6 +35,13 @@ build.env           CC=${configure.cc} \
 
 destroot.env        PREFIX=${prefix}
 
+pre-fetch {
+    if {${os.subplatform} eq "macosx" && [vercmp ${macosx_version} 10.7] < 0} {
+        ui_error "${name} ${version} requires memmem(3), only available on OS X 10.7 or greater."
+        return -code error "incompatible macOS version"
+    }
+}
+
 livecheck.type      regex
 livecheck.url       ${master_sites}
 livecheck.regex     afl-(\\d+(?:\\.\\d+)*b).tgz


### PR DESCRIPTION
###### Description

`afl` requires `memmem(3)`, which is only available on OS X 10.7 or greater. This patch makes the requirement explicit.

See https://github.com/macports/macports-ports/pull/481#issuecomment-306072058.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.5
Xcode 8.3.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?