### PR TITLE
salt: rm /etc/salt symlink to /opt/local/etc/salt

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                salt
 version             2017.5
+revision            1
 categories          sysutils
 platforms           darwin
 maintainers         gmail.com:jeremy.mcmillan
@@ -38,31 +39,6 @@ if {$subport eq $name} {
                         port:py${python.version}-zmq \
                         port:swig-python
 
-    post-activate {
-
-        file mkdir ${prefix}/etc/salt
-
-        if ![file exists /etc/salt] {
-            ln -s ${prefix}/etc/salt /etc/salt
-        }
-
-        if ![file exists ${prefix}/etc/salt/minion] {
-            copy ${worksrcpath}/conf/minion ${prefix}/etc/salt
-        }
-
-        if ![file exists ${prefix}/etc/salt/master] {
-            copy ${worksrcpath}/conf/master ${prefix}/etc/salt
-        }
-    }
-
-    pre-deactivate {
-
-        if { [file type /etc/salt] == "link" } {
-            file delete /etc/salt
-        }
-
-    }
-
     notes   "salt startupitems are now installed by subports salt-minion, salt-master, salt-syndic, salt-api"
 }
 
@@ -73,7 +49,7 @@ foreach daemon [list minion master syndic api] {
         startupitem.netchange   yes
         startupitem.logevents   yes
         startupitem.logfile     ${prefix}/var/log/salt/${daemon}
-        startupitem.executable  ${prefix}/bin/salt-${daemon}
+        startupitem.executable  ${prefix}/bin/salt-${daemon} --config-dir=${prefix}/etc/salt --pid-file=${prefix}/var/run/salt-${daemon}.pid
         depends_run             port:salt
         description             install startupitem for salt-${daemon}
         distfiles


### PR DESCRIPTION
###### Description
[minor revision]
rm /etc/salt symlink to /opt/local/etc/salt
     and startupitem dependency
     and preactivate/postactivate steps
Closes: https://trac.macports.org/ticket/48398

LaunchDaemon items now use CLI args pointing to /opt/local/etc/salt configs.
