### PR TITLE
openjk: new port

### DIFF
--- a/games/openjk/Portfile
+++ b/games/openjk/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.0
+PortGroup           github 1.0
+PortGroup           cxx11 1.1
+
+github.setup        JACoders OpenJK 36b675920981d0e964cbc9c93cc7255eefdc4c3b
+name                openjk
+version             20170511
+categories          games
+platforms           darwin
+maintainers         {gmail.com:ken.cunningham.webuse @kencu} openmaintainer
+license             GPL-2
+
+description         Community effort to maintain and improve Jedi Academy + Jedi \
+                    Outcast released by Raven Software.
+long_description    ${description}
+
+checksums           rmd160  f5ad81f3ac10ec164c726accfe48733bece64b70 \
+                    sha256  712af602035bc896fb84b3a58a2b03ca2f835527a29b0aade1e0b3867e3219be
+
+cmake.out_of_source yes
+
+depends_lib         port:libsdl2 \
+                    port:libpng \
+                    port:zlib
+
+patchfiles          patch-code-rd-vanilla-gltext.diff \
+                    patch-codemp-rd-vanilla-gltext.diff \
+                    patch-cmakelists-archfix.diff
+                    
+post-destroot {
+    move ${destroot}${prefix}/JediAcademy ${destroot}${applications_dir}
+}
+
+notes "
+To run this game, place the game folder named base from your original
+Star Wars Jedi Knight Jedi Academy game into:
+~/Library/Application Support/OpenJK/
+"

--- a/games/openjk/files/patch-cmakelists-archfix.diff
+++ b/games/openjk/files/patch-cmakelists-archfix.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2017-06-13 19:34:11.000000000 -0700
++++ CMakeLists.txt	2017-06-13 19:34:19.000000000 -0700
+@@ -118,7 +118,7 @@
+ 	elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
+ 		set(X86 ON)
+ 		if(APPLE)
+-			set(Architecture "x86")
++			set(Architecture "x86_64")
+ 		else()
+ 			# e.g. Linux
+ 			set(Architecture "i386")

--- a/games/openjk/files/patch-code-rd-vanilla-gltext.diff
+++ b/games/openjk/files/patch-code-rd-vanilla-gltext.diff
@@ -1,0 +1,18 @@
+--- code/rd-vanilla/glext.h.orig	2017-05-27 21:37:23.000000000 -0700
++++ code/rd-vanilla/glext.h	2017-05-27 21:37:54.000000000 -0700
+@@ -65,6 +65,15 @@
+  * Extensions removed: _nomatch_^
+  */
+ 
++#if defined (__APPLE__)
++typedef long GLsizeiptrARB;
++typedef long GLintptrARB;
++#else
++typedef ptrdiff_t GLsizeiptrARB;
++typedef ptrdiff_t GLintptrARB;
++#endif
++
++
+ #ifndef GL_VERSION_1_2
+ #define GL_VERSION_1_2 1
+ #define GL_UNSIGNED_BYTE_3_3_2            0x8032

--- a/games/openjk/files/patch-codemp-rd-vanilla-gltext.diff
+++ b/games/openjk/files/patch-codemp-rd-vanilla-gltext.diff
@@ -1,0 +1,18 @@
+--- codemp/rd-vanilla/glext.h.orig	2017-05-27 21:37:36.000000000 -0700
++++ codemp/rd-vanilla/glext.h	2017-05-27 21:37:59.000000000 -0700
+@@ -65,6 +65,15 @@
+  * Extensions removed: _nomatch_^
+  */
+ 
++#if defined (__APPLE__)
++typedef long GLsizeiptrARB;
++typedef long GLintptrARB;
++#else
++typedef ptrdiff_t GLsizeiptrARB;
++typedef ptrdiff_t GLintptrARB;
++#endif
++
++
+ #ifndef GL_VERSION_1_2
+ #define GL_VERSION_1_2 1
+ #define GL_UNSIGNED_BYTE_3_3_2            0x8032


### PR DESCRIPTION
###### Description
A modern open-source runtime infrastructure to run the venerable and still-popular Star Wars Jedi Academy game. Supported by SDL2. Requires a copy of the original game for the content.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6, 10.12
Xcode 4.2, 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
