### PR TITLE
samtools: add missing xz dependency

### DIFF
--- a/science/samtools/Portfile
+++ b/science/samtools/Portfile
@@ -23,7 +23,9 @@ homepage                http://www.htslib.org/
 github.tarball_from     releases
 use_bzip2               yes
 
-depends_lib             port:zlib port:ncurses
+depends_lib             port:zlib \
+                        port:ncurses \
+                        port:xz
 
 use_configure           no
 


### PR DESCRIPTION
###### Description

samtools didn't build in trace mode because of the undeclared dependency. Installed files should not change, hence I don't increase the revision number.


###### Tested on
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
