### PR TITLE
openttd: fix build failure due to const char * rvalue

### DIFF
--- a/games/openttd/Portfile
+++ b/games/openttd/Portfile
@@ -49,7 +49,8 @@ if {${name} eq ${subport}} {
 
     patchfiles          patch-config.lib-remove-deployment-target.diff \
                         patch-src__music__cocoa_m.cpp-support-new-audio-api.diff \
-                        patch-src__video__cocoa__wnd_quartz.mm-avoid-removed-cmgetsystemprofile.diff
+                        patch-src__video__cocoa__wnd_quartz.mm-avoid-removed-cmgetsystemprofile.diff \
+                        patch-src-fileio-const-char.diff
 
     configure.env-append \
                         CFLAGS_BUILD="${configure.cflags}" \

--- a/games/openttd/files/patch-src-fileio-const-char.diff
+++ b/games/openttd/files/patch-src-fileio-const-char.diff
@@ -1,0 +1,11 @@
+--- src/fileio.cpp.orig	2017-06-16 21:51:32.000000000 -0700
++++ src/fileio.cpp	2017-06-16 21:51:46.000000000 -0700
+@@ -1034,7 +1034,7 @@
+ {
+ 	bool success = false;
+ #ifdef WITH_COCOA
+-	char *app_bundle = strchr(exe, '.');
++	char *app_bundle = (char *)strchr(exe, '.');
+ 	while (app_bundle != NULL && strncasecmp(app_bundle, ".app", 4) != 0) app_bundle = strchr(&app_bundle[1], '.');
+ 
+ 	if (app_bundle != NULL) app_bundle[0] = '\0';


### PR DESCRIPTION
newer compilers flag setting a char * to a const char * as an error

@neverpanic 

##### Description
```
/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_games_openttd/openttd/work/openttd-1.6.1/src/fileio.cpp:1037:8: error: cannot initialize a variable of type 'char *' with an rvalue of type 'const char *'
        char *app_bundle = strchr(exe, '.');
              ^            ~~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [fileio.o] Error 1
```

[also FYI game is now at 1.7.1 - not upgraded here to keep the commits separate]