### PR TITLE
Widelands update

### DIFF
--- a/games/widelands/Portfile
+++ b/games/widelands/Portfile
@@ -7,7 +7,7 @@ name                widelands
 version             build19
 categories          games
 platforms           darwin
-maintainers         gmail.com:ken.cunningham.webuse openmaintainer
+maintainers         {gmail.com:ken.cunningham.webuse @kencu} openmaintainer
 license             GPL-2+
 
 description         open-source real-time strategy game inspired by Settlers

--- a/games/widelands/Portfile
+++ b/games/widelands/Portfile
@@ -5,39 +5,63 @@ PortGroup           cmake 1.0
 PortGroup           cxx11 1.0
 
 name                widelands
-version             build19
 categories          games
 platforms           darwin
 maintainers         {gmail.com:ken.cunningham.webuse @kencu} openmaintainer
 license             GPL-2+
-
-description         open-source real-time strategy game inspired by Settlers
-long_description    Widelands is an open-source real-time strategy game. It \
-                    is built upon the SDL and other open source libraries and \
-                    is (and will always be) under heavy development. If you \
-                    knew Settlers I & II™ (© Bluebyte), then you already have \
-                    a rough idea what Widelands is all about because \
-                    widelands is heavily inspired by those two games.
-
 homepage            https://wl.widelands.org/
-master_sites        https://launchpad.net/${name}/${version}/${version}/+download/
-
-use_bzip2           yes
-distfiles           ${distname}-src${extract.suffix}
-worksrcdir          ${distname}-src/
-checksums           rmd160  5fd3e33dd0e9014811936a125d8f1b64607b2914 \
-                    sha256  e511f9d26828a2b71b64cdfc6674e6e847543b2da73961ab882acca36c7c01a6
+description         open-source real-time strategy game inspired by Settlers
 
 depends_lib         port:libsdl2 \
                     port:libsdl2_image \
                     port:libsdl2_mixer \
-                    port:libsdl2_net \
                     port:libsdl2_ttf \
                     port:boost \
                     port:doxygen \
                     port:libpng \
                     port:glew \
                     port:lua
+
+subport             ${name}-devel {}
+
+if {${subport} eq ${name}} {
+
+    # release
+    version             build19
+    master_sites        https://launchpad.net/${name}/${version}/${version}/+download/
+    use_bzip2           yes
+    distfiles           ${distname}-src${extract.suffix}
+    worksrcdir          ${distname}-src/
+    checksums           rmd160  5fd3e33dd0e9014811936a125d8f1b64607b2914 \
+                        sha256  e511f9d26828a2b71b64cdfc6674e6e847543b2da73961ab882acca36c7c01a6
+
+    conflicts           ${name}-devel
+    
+    # builds before 8377 required this
+    # to be deleted when release version is build20 or more
+    depends_lib-append  port:libsdl2_net
+
+    long_description ${description}: \
+        This port follows the release version of ${name}, which is typically updated every 6 months. If for some reason this port does not build or function as desired, try the ${name}-devel port.
+
+} else {
+
+    # devel
+    pre-fetch {
+        ui_msg "--->  Fetching source from bzr repository: this may take a while"
+    }
+
+    fetch.type          bzr
+    bzr.url             lp:widelands
+
+    version             20170612
+    bzr.revision        8378
+        
+    conflicts           ${name}
+
+    long_description ${description}: \
+        This port follows the master version of ${name}, which is typically updated every few weeks.
+}
 
 cmake.out_of_source yes
 configure.args      -DCMAKE_INSTALL_PREFIX:PATH="${applications_dir}/Widelands.app/Contents/MacOS"

--- a/games/widelands/Portfile
+++ b/games/widelands/Portfile
@@ -56,7 +56,11 @@ if {${subport} eq ${name}} {
 
     version             20170612
     bzr.revision        8378
-        
+    
+    variant HEAD description "build tip of bzr commit tree" {
+        bzr.revision    -1
+    }
+
     conflicts           ${name}
 
     long_description ${description}: \

--- a/games/widelands/Portfile
+++ b/games/widelands/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           cxx11 1.0
+
 name                widelands
 version             build19
 categories          games


### PR DESCRIPTION
A series of four commits to widelands. The main thrust of this is to add a devel subport, and also add a HEAD variant for the devel version.  I know floating tip builds are frowned upon, but I thought perhaps a HEAD variant might be allowed. Otherwise the devs and beta testers have to edit the Portfile themselves to enable this.

Slight adjustment in dependencies, and shortened the description.

I posted a widelands-devel Portfile a few months ago in the widelands forums for people to use, and that forum post has > 2500 hits so far, so looks to be a demand for this.

I have one more addition to make, a glbinding variant, once glbinding makes it into MacPorts.