### PR TITLE
MenuMeters: check for minimum macOS required

### DIFF
--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -35,3 +35,10 @@ destroot    {
     file copy ${worksrcpath}/build/UninstalledProducts/macosx/${name}.prefPane \
         ${destroot}/Library/PreferencePanes
 }
+
+pre-fetch {
+    if {${os.subplatform} eq "macosx" && [vercmp ${macosx_version} 10.10] < 0} {
+        ui_error "${name} ${version} requires OS X 10.10 or greater."
+        return -code error "incompatible macOS version"
+    }
+}


### PR DESCRIPTION
###### Description
The oldest version of macOS that works with MenuMeters is 10.10. Older versions of macOS produce various build errors as detected by Buildbot:

- https://build.macports.org/builders/ports-10.8_x86_64_legacy-builder/builds/30952/steps/install-port/logs/stdio
- https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/30273/steps/install-port/logs/stdio

###### Tested on
macOS 10.12.5
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?