### PR TITLE
hs-bytestring-show: new port

### DIFF
--- a/devel/hs-bytestring-show/Portfile
+++ b/devel/hs-bytestring-show/Portfile
@@ -1,0 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       bytestring-show 0.3.5.6
+checksums           rmd160  751da0fd03aee5775ac7d58883e697aa866f64b8 \
+                    sha256  29242efd16951ebba888218c469a99ff25b19ab74ee1e0d7b4db09b8800a0812
+
+
+maintainers         nomaintainer
+description         Efficient conversion of values into readable byte strings.
+long_description    ${description}
+
+platforms           darwin
+license             BSD
+


### PR DESCRIPTION
seems to be missing from the current hs* selections
needed for hedgewars
closes: https://trac.macports.org/ticket/53324

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6, 10.7, 10.11, 10.12
Xcode 4.2, 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
