### PR TITLE
hedgewars: new port

### DIFF
--- a/games/hedgewars/Portfile
+++ b/games/hedgewars/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.0
+
+name                    hedgewars
+version                 0.9.22
+categories              games
+platforms               darwin
+license                 GPL-2
+maintainers             {gmail:ken.cunningham.webuse @kencu} openmaintainer
+
+description             Funny turn-based artillery game, featuring fighting Hedgehogs!
+long_description        ${description}
+homepage                https://www.hedgewars.org/
+
+master_sites            https://www.hedgewars.org/download/releases/
+use_bzip2               yes
+distname                ${name}-src-${version}
+
+checksums               rmd160  359fd026643e69446121b94ba301646812353c19 \
+                        sha256  b699c8971ff420c3edd6533527ae2e99040f1e79207c9140826945bcf0e62192
+
+cmake.out_of_source     yes
+
+depends_build-append    port:pkgconfig \
+                        port:ghc \
+                        port:hs-vector \
+                        port:hs-bytestring-show \
+                        port:hs-network \
+                        port:hs-dataenc \
+                        port:hs-hslogger \
+                        port:hs-utf8-string \
+                        port:hs-sha \
+                        port:hs-entropy \
+                        port:hs-zlib \
+                        port:hs-random
+                    
+depends_lib-append      path:bin/ffmpeg:ffmpeg \
+                        port:libogg \
+                        port:libsdl \
+                        port:libsdl_image \
+                        port:libsdl_ttf \
+                        port:libsdl_mixer \
+                        port:libsdl_net \
+                        port:zlib \
+                        port:libpng \
+                        port:glew \
+                        port:qt4-mac
+
+# don't use the sparkle selfupdate mechanism; use macports update process instead
+configure.args-append   -DNOAUTOUPDATE=1
+
+# don't add all of the macports support libraries into the app bundle
+configure.args-append   -DSKIPBUNDLE:BOOL=ON
+
+configure.args-append   -DQT_QMAKE_EXECUTABLE:FILEPATH=${prefix}/libexec/qt4/bin/qmake
+
+# use the pas2c converter to compile the pascal portions rather than fpc
+configure.args-append   -DBUILD_ENGINE_C:BOOL=ON
+
+# update two source files to enable building against the current ffmpeg variable and procedure names
+patchfiles-append       patch-0001-avwrapper-avframealloc-fix.diff
+patchfiles-append       patch-0002-LibavInteraction-fix.diff
+
+# the authours of this game have hardcoded the c++ library in several places and this needs
+# to be deleted for proper linking to the supporting dependencies on macports
+
+# replace the hard-coded link to libstdc++ in the hwc engine build script with proper link flags
+patchfiles-append       patch-0003-proj-hwc-CMakeLists-proper-link-flags.diff
+
+# remove the hard-coded link to libstdc++ in QTfrontend build script with proper link flags
+patchfiles-append       patch-0004-remove-hardcoded-stdlib-and-iokit-QTfrontend.diff
+
+# lan server build fails unless this haskell optimization flag is disabled
+# probably due to excessive recursion
+patchfiles-append       patch-0005-remove-haskell-spec-constr.diff
+
+# remove clang search and compiler ID override which overrides cmake's compiler declarations
+patchfiles-append       patch-0006-CMakeLists-delete-clang-search.diff
+
+post-destroot {
+    move ${destroot}${workpath}/build/Hedgewars.app ${destroot}${applications_dir}/Hedgewars.app
+    move ${worksrcpath}/man/hedgewars.6 ${destroot}${prefix}/share/man/man6/hedgewars.6
+ }

--- a/games/hedgewars/files/patch-0001-avwrapper-avframealloc-fix.diff
+++ b/games/hedgewars/files/patch-0001-avwrapper-avframealloc-fix.diff
@@ -1,0 +1,29 @@
+--- ./hedgewars/avwrapper/avwrapper.c.orig	2017-01-09 19:45:35.000000000 -0800
++++ ./hedgewars/avwrapper/avwrapper.c	2017-01-09 19:53:26.000000000 -0800
+@@ -158,7 +158,7 @@
+     else
+         g_NumSamples = g_pAudio->frame_size;
+     g_pSamples = (int16_t*)av_malloc(g_NumSamples*g_Channels*sizeof(int16_t));
+-    g_pAFrame = avcodec_alloc_frame();
++    g_pAFrame = av_frame_alloc();
+     if (!g_pAFrame)
+     {
+         Log("Could not allocate frame\n");
+@@ -241,7 +241,7 @@
+     g_pVideo->time_base.den = g_Framerate.num;
+     g_pVideo->time_base.num = g_Framerate.den;
+     //g_pVideo->gop_size = 12; /* emit one intra frame every twelve frames at most */
+-    g_pVideo->pix_fmt = PIX_FMT_YUV420P;
++    g_pVideo->pix_fmt = AV_PIX_FMT_YUV420P;
+ 
+     // set quality
+     if (g_VQuality > 100)
+@@ -299,7 +299,7 @@
+ #endif
+         return FatalError("Could not open video codec %s", g_pVCodec->long_name);
+ 
+-    g_pVFrame = avcodec_alloc_frame();
++    g_pVFrame = av_frame_alloc();
+     if (!g_pVFrame)
+         return FatalError("Could not allocate frame");
+ 

--- a/games/hedgewars/files/patch-0002-LibavInteraction-fix.diff
+++ b/games/hedgewars/files/patch-0002-LibavInteraction-fix.diff
@@ -1,0 +1,13 @@
+--- ./QTfrontend/util/LibavInteraction.cpp.orig	2015-10-31 13:36:07.000000000 -0700
++++ ./QTfrontend/util/LibavInteraction.cpp	2017-01-09 19:54:54.000000000 -0800
+@@ -106,8 +106,8 @@
+             if (!pCodec->pix_fmts)
+                 continue;
+             bool yuv420Supported = false;
+-            for (const PixelFormat* pfmt = pCodec->pix_fmts; *pfmt != -1; pfmt++)
+-                if (*pfmt == PIX_FMT_YUV420P)
++            for (const AVPixelFormat* pfmt = pCodec->pix_fmts; *pfmt != -1; pfmt++)
++                if (*pfmt == AV_PIX_FMT_YUV420P)
+                 {
+                     yuv420Supported = true;
+                     break;

--- a/games/hedgewars/files/patch-0003-proj-hwc-CMakeLists-proper-link-flags.diff
+++ b/games/hedgewars/files/patch-0003-proj-hwc-CMakeLists-proper-link-flags.diff
@@ -1,0 +1,11 @@
+--- ./project_files/hwc/CMakeLists.txt.orig	2017-01-12 10:18:31.000000000 -0800
++++ ./project_files/hwc/CMakeLists.txt	2017-01-12 10:18:39.000000000 -0800
+@@ -95,7 +95,7 @@
+                                 #TODO: add other libraries
+                             )
+ if(APPLE)
+-    target_link_libraries(hwengine IOKit SDLmain)
++    target_link_libraries(hwengine ${CMAKE_CXX_FLAGS})
+ endif()
+ 
+ install(PROGRAMS "${EXECUTABLE_OUTPUT_PATH}/hwengine${CMAKE_EXECUTABLE_SUFFIX}" DESTINATION ${target_binary_install_dir})

--- a/games/hedgewars/files/patch-0004-remove-hardcoded-stdlib-and-iokit-QTfrontend.diff
+++ b/games/hedgewars/files/patch-0004-remove-hardcoded-stdlib-and-iokit-QTfrontend.diff
@@ -1,0 +1,21 @@
+--- ./QTfrontend/CMakeLists.txt.orig	2017-01-12 08:51:40.000000000 -0800
++++ ./QTfrontend/CMakeLists.txt	2017-01-12 08:52:31.000000000 -0800
+@@ -171,7 +171,6 @@
+ 
+ if(APPLE)
+     find_library(iokit_framework NAMES IOKit)
+-    list(APPEND HW_LINK_LIBS ${iokit_framework})
+     list(APPEND hwfr_src util/platform/CocoaInitializer.mm
+                          util/platform/InstallController.cpp
+                          util/platform/M3Panel.mm
+@@ -221,10 +220,6 @@
+         )
+ endif()
+ 
+-if(CMAKE_CXX_COMPILER MATCHES "clang*")
+-    list(APPEND HW_LINK_LIBS stdc++ m)
+-endif()
+-
+ target_link_libraries(hedgewars ${HW_LINK_LIBS})
+ 
+ 

--- a/games/hedgewars/files/patch-0005-remove-haskell-spec-constr.diff
+++ b/games/hedgewars/files/patch-0005-remove-haskell-spec-constr.diff
@@ -1,0 +1,12 @@
+--- ./gameServer/CMakeLists.txt.orig	2017-01-14 18:02:03.000000000 -0800
++++ ./gameServer/CMakeLists.txt	2017-01-14 18:03:02.000000000 -0800
+@@ -61,7 +61,8 @@
+     -o ${EXECUTABLE_OUTPUT_PATH}/hedgewars-server${CMAKE_EXECUTABLE_SUFFIX}
+     -odir ${CMAKE_CURRENT_BINARY_DIR}
+     -hidir ${CMAKE_CURRENT_BINARY_DIR}
+-    ${haskell_flags})
++    ${haskell_flags}
++    -fno-spec-constr)
+ 
+ add_custom_command(OUTPUT "${EXECUTABLE_OUTPUT_PATH}/hedgewars-server${CMAKE_EXECUTABLE_SUFFIX}"
+         COMMAND "${GHC_EXECUTABLE}"

--- a/games/hedgewars/files/patch-0006-CMakeLists-delete-clang-search.diff
+++ b/games/hedgewars/files/patch-0006-CMakeLists-delete-clang-search.diff
@@ -1,0 +1,22 @@
+--- CMakeLists.txt.orig	2017-06-20 19:46:55.000000000 -0700
++++ CMakeLists.txt	2017-06-20 19:47:56.000000000 -0700
+@@ -126,19 +126,6 @@
+ endif()
+ 
+ 
+-#build engine without freepascal
+-if(BUILD_ENGINE_C)
+-    find_package(Clang REQUIRED)
+-
+-    if(${CLANG_VERSION} VERSION_LESS "3.0")
+-        message(FATAL_ERROR "LLVM/Clang compiler required version is 3.0 but version ${CLANG_VERSION} was found!")
+-    endif()
+-
+-    set(CMAKE_C_COMPILER ${CLANG_EXECUTABLE})
+-    set(CMAKE_CXX_COMPILER ${CLANG_EXECUTABLE})
+-endif()
+-
+-
+ #server
+ if(NOT NOSERVER)
+     add_subdirectory(gameServer)


### PR DESCRIPTION
popular open-source game
fixed all mentioned issues with previous submit on trac
have updated to new download site
debugged and repaired a hard-coded standard library linkage issue
closes: https://trac.macports.org/ticket/53325

###### Description

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6, 10.7, 10.11, 10.12
Xcode 4.2 to 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
