### PR TITLE
gource: update to version 0.44

### DIFF
--- a/devel/gource/Portfile
+++ b/devel/gource/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.0
 PortGroup           github 1.0
 
-github.setup        acaudwell Gource 0.43 gource-
+github.setup        acaudwell Gource 0.44 gource-
 name                gource
 categories          devel
 platforms           darwin
@@ -21,15 +21,15 @@ homepage            http://gource.io/
 github.tarball_from releases
 distname            gource-${version}
 
-checksums           rmd160  5011a7f2a931c106a872e7d9bc8042233b7322e5 \
-                    sha256  85a40ac8e4f5c277764216465c248d6b76589ceac012541c4cc03883a24abde4
+checksums           rmd160  8b5511a7574bf36c45964fa8cc34b5b8712b35ca \
+                    sha256  2604ca4442305ffdc5bb1a7bac07e223d59c846f93567be067e8dfe2f42f097c
 
 depends_build       port:glm \
                     port:pkgconfig
 
 depends_lib         port:ftgl \
-                    port:libsdl \
-                    port:libsdl_image \
+                    port:libsdl2 \
+                    port:libsdl2_image \
                     port:pcre \
                     port:libpng \
                     port:jpeg \


### PR DESCRIPTION
###### Description
The switch to port:libsdl2 from port:libsdl is necessary to avoid a crash when entering full screen mode.

###### Tested on
macOS 10.12.5
Xcode 8.3.3

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?