### PR TITLE
scummvm: update to 1.90, add devel subport

### DIFF
--- a/emulators/scummvm/Portfile
+++ b/emulators/scummvm/Portfile
@@ -1,44 +1,132 @@
 PortSystem          1.0
 
 name                scummvm
-version             1.7.0
 platforms           darwin
 categories          emulators games
-maintainers         nomaintainer
+maintainers         {gmail.com:ken.cunningham.webuse @kencu} openmaintainer
 license             {GPL-2 BSD}
 description         cross-platform interpreter for several adventure engines
 long_description    \
     ScummVM is a cross-platform interpreter for several point-and-click \
-    adventure engines. This includes all SCUMM-based adventures by LucasArts, \
-    Simon the Sorcerer by AdventureSoft, and Beneath a Steel Sky and Broken \
-    Sword 2 by Revolution.
+    adventure engines. A current list of playable games is available at \
+    <https://www.scummvm.org/compatibility/>.
 
-homepage            http://scummvm.org/
-master_sites        sourceforge:project/${name}/${name}/${version}
-use_bzip2           yes
-checksums           sha256  d9ff0e8cf911afa466d5456d28fef692a17d47ddecfd428bf2fef591237c2e66 \
-                    rmd160  9c70db2cdc6631d6d8d6ac108c0cd58f1387e030
+homepage            https://scummvm.org/
 
-depends_lib         port:libsdl \
+subport             ${name}-devel {}
+
+if {${subport} eq ${name}} {
+
+    # release
+    conflicts           ${name}-devel
+    long_description ${description}: \
+        This port follows the release version of ${name}, which is typically updated every \
+        6 months. If for some reason this port does not build or function as desired, try \
+        the ${name}-devel port.
+
+    version             1.9.0
+    master_sites        http://scummvm.org/frs/${name}/${version}
+    use_bzip2           yes
+    checksums           sha256  813d7d8a76e3d05b45001d37451368711dadc32899ecf907df1cc7abfb1754d2 \
+                        rmd160  464a5039b7e1391141c223825f166d74f2bef3aa
+
+} else {
+
+    # devel
+    conflicts           ${name}
+    long_description ${description}: \
+        This port follows the master version of ${name}, which is typically updated every few weeks.
+
+    PortGroup           github 1.0
+    github.setup        scummvm scummvm 9bb9c0d58eea71292d05b4e5515c48ba53d1f194
+    version             20170612
+    checksums           rmd160  3c52f92a5e3b2c91cc0257cc3964ad64af2239fa \
+                        sha256  263984780c5e4ba5cad671198dda8fa3b7f0a04beaea2dbe0b7640a4c7e0fa10
+}
+
+patchfiles-append   patch-scummvm-sdl2indet.diff
+
+depends_lib-append  port:libsdl2 \
+                    port:libsdl2_net \
                     port:libmad \
                     port:libogg \
                     port:libvorbis \
                     port:libpng \
-                    port:flac
+                    port:flac \
+                    port:libtheora \
+                    port:fluidsynth \
+                    port:faad2 \
+                    port:jpeg \
+                    port:freetype \
+                    port:bzip2 \
+                    port:curl \
+                    port:expat \
+                    port:gettext \
+                    port:glib2 \
+                    port:libedit \
+                    port:libffi \
+                    port:libiconv \
+                    port:libsndfile \
+                    port:ncurses \
+                    port:pcre \
+                    port:portaudio \
+                    port:readline \
+                    port:zlib
 
-configure.args      --with-sdl-prefix=${prefix} \
-                    --with-mad-prefix=${prefix} \
-                    --with-ogg-prefix=${prefix} \
-                    --with-vorbis-prefix=${prefix} \
-                    --with-flac-prefix=${prefix} \
-                    --with-zlib-prefix=${prefix} \
-                    --with-png-prefix=${prefix} \
+configure.args-append  \
                     --enable-release \
+                    --enable-plugins \
+                    --default-dynamic \
+                    --enable-sdlnet \
+                    --enable-libcurl \
+                    --enable-theoradec \
+                    --enable-jpeg \
+                    --enable-readline \
+                    --enable-all-engines \
                     --enable-verbose-build
 
-configure.universal_args-delete --disable-dependency-tracking
-
-platform darwin {
-    destroot.args   INSTALL=/usr/bin/install
+variant cxx11 description {build with c++11} {
+     # scummvm builds fine without c++11
+     # I'm not sure if there is any advantage to enabling c++11 support at present
+     # but keep it here as a variant in case someone finds there is
+     PortGroup cxx11 1.1
+     configure.args-append \
+                    --enable-c++11
 }
 
+variant mpeg2 description {add mpeg2 support - has many dependencies} {
+     # this builds fine, but libmpeg2 is old (2008) and pulls in a lot of deps
+     # and I'm not sure if any games actually use this - make it optional
+     configure.args-append \
+                    --enable-mpeg2
+     depends_lib-append    \
+                    port:libmpeg2 \
+                    port:db48 \
+                    port:libsdl \
+                    port:libxml2 \
+                    port:openssl \
+                    port:python27 \
+                    port:python2_select \
+                    port:python_select \
+                    port:sqlite3 \
+                    port:xorg-kbproto \
+                    port:xorg-libX11 \
+                    port:xorg-libXau \
+                    port:xorg-libXdmcp \
+                    port:xorg-libXext \
+                    port:xorg-libXrandr \
+                    port:xorg-libXv \
+                    port:xorg-libice \
+                    port:xorg-libpthread-stubs \
+                    port:xorg-libsm \
+                    port:xorg-libxcb \
+                    port:xorg-randrproto \
+                    port:xorg-renderproto \
+                    port:xorg-videoproto \
+                    port:xorg-xcb-proto \
+                    port:xorg-xextproto \
+                    port:xorg-xproto \
+                    port:xrender \
+                    port:xz
+
+}

--- a/emulators/scummvm/files/patch-scummvm-sdl2indet.diff
+++ b/emulators/scummvm/files/patch-scummvm-sdl2indet.diff
@@ -1,0 +1,11 @@
+--- configure.old	2017-03-22 17:12:25.000000000 -0700
++++ configure	2017-03-22 17:13:00.000000000 -0700
+@@ -1254,7 +1254,7 @@
+ 		;;
+ 	--with-sdlnet-prefix=*)
+ 		arg=`echo $ac_option | cut -d '=' -f 2`
+-		SDL_NET_CFLAGS="-I$arg/include"
++		SDL_NET_CFLAGS="-I$arg/include/SDL2"
+ 		SDL_NET_LIBS="-L$arg/lib"
+ 		;;
+ 	--backend=*)


### PR DESCRIPTION
enables all possible features
assume maintainership
move to sdl2
makes mpeg2 an optional variant (old, probably not useful)
makes c++11 a variant (simpler for older systems)
closes: https://trac.macports.org/ticket/53847

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6, 10.12
Xcode 4.2, 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
