### PR TITLE
iperf3 and iperf3-devel: add dependency and Test phase

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -21,6 +21,9 @@ conflicts           ${name}-devel
 checksums           rmd160  eae80e399734d3e9e26222105ee1fbd6fb8d8e2f \
                     sha256  a1beff784aab49e5ccd6a13b1525be849fb9afce83d4c87693342492a6eea1c4
 
+test.run            yes
+test.target         check
+
 post-destroot {
     # install doc files
     xinstall -d ${destroot}${prefix}/share/doc/${name}

--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -8,7 +8,7 @@ name                iperf3
 categories          net
 platforms           darwin
 license             BSD
-maintainers         gmail.com:allan.que openmaintainer
+maintainers         {gmail.com:allan.que @aque} openmaintainer
 description         Measures the maximum achievable bandwidth on IP networks
 long_description    ${name} is a tool for active measurements of the maximum \
                     achievable bandwidth on IP networks. It supports tuning \

--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -31,9 +31,12 @@ post-destroot {
 subport ${name}-devel {
     github.setup        esnet iperf 4f3a7a5403b61f49ab277d0756e87c651a45bdfe
     version             20170620
+    revision            1
 
     checksums           rmd160  7a72ece6402ae52e2df464ad74af068bd00b4ea6 \
                         sha256  591867e864deb355b8d67d39afce34a963e9ca6d3a12a29b93fc336edc29c666
+
+    depends_lib-append  port:openssl
 
     conflicts           ${name}
 


### PR DESCRIPTION
###### Description
iperf3-devel: revbump to add openssl dependency
iperf3 and iperf3-devel: add Test phase

I am the maintainer listed for this port.
<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?