### PR TITLE
php-xdebug: Update to 2.5.5

### DIFF
--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -26,10 +26,10 @@ if {[vercmp ${php.branch} 5.3] <= 0} {
     checksums           rmd160  01ce20a7b785b5eb04fd90f5be516b89e6898f80 \
                         sha256  23c8786e0f5aae67b1e5035972bfff282710fb84c483887cebceb8ef5bbdf8ef
 } else {
-    version             2.5.4
+    version             2.5.5
     revision            0
-    checksums           rmd160  d20b18b9af437a645105977ea44f625e4c01f084 \
-                        sha256  300ca6fc3d95025148b0b5d0c96e14e54299e536a93a5d68c67b2cf32c9432b8
+    checksums           rmd160  ad7939d2d2f453c0f2ccb12ce8f745db7163ad9d \
+                        sha256  72108bf2bc514ee7198e10466a0fedcac3df9bbc5bd26ce2ec2dafab990bf1a4
 }
 
 description             php5 extension for php debugging


### PR DESCRIPTION
Fixed bugs (https://xdebug.org/updates.php#x_2_5_5):
Fixed bug #1439: TYPE_CHECK needs overloading due to smart branches
Fixed bug #1444: Code Coverage misses a variable in a multi-line function call
Fixed bug #1446: Code Coverage misses elseif if it uses an isset with a property

###### Description


