### PR TITLE
iperf3-devel: getline() workaround for OSX <= 10.6

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -34,12 +34,13 @@ post-destroot {
 subport ${name}-devel {
     github.setup        esnet iperf 4f3a7a5403b61f49ab277d0756e87c651a45bdfe
     version             20170620
-    revision            1
+    revision            2
 
     checksums           rmd160  7a72ece6402ae52e2df464ad74af068bd00b4ea6 \
                         sha256  591867e864deb355b8d67d39afce34a963e9ca6d3a12a29b93fc336edc29c666
 
     depends_lib-append  port:openssl
+    patchfiles          patch-iperf_util.diff
 
     conflicts           ${name}
 

--- a/net/iperf3/files/patch-iperf_util.diff
+++ b/net/iperf3/files/patch-iperf_util.diff
@@ -1,0 +1,78 @@
+--- src/iperf_util.c	2017-06-20 17:04:30.000000000 -0500
++++ src/iperf_util.c	2017-06-26 13:30:16.000000000 -0500
+@@ -338,6 +338,75 @@
+     return features;
+ }
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED <= 1060
++
++static const int line_size = 128;
++
++static ssize_t
++getdelim (char **lineptr, size_t *n, int delim, FILE *stream);
++
++static ssize_t
++getline (char **lineptr, size_t *n, FILE *stream);
++
++static ssize_t
++getdelim (char **lineptr, size_t *n, int delim, FILE *stream)
++{
++    int indx = 0;
++    int c;
++
++    /* Sanity checks.  */
++    if (lineptr == NULL || n == NULL || stream == NULL)
++        return -1;
++
++    /* Allocate the line the first time.  */
++    if (*lineptr == NULL)
++    {
++        *lineptr = malloc (line_size);
++        if (*lineptr == NULL)
++            return -1;
++        *n = line_size;
++    }
++
++    /* Clear the line.  */
++    memset (*lineptr, '\0', *n);
++
++    while ((c = getc (stream)) != EOF)
++    {
++        /* Check if more memory is needed.  */
++        if (indx >= *n)
++        {
++            *lineptr = realloc (*lineptr, *n + line_size);
++            if (*lineptr == NULL)
++            {
++              return -1;
++            }
++            /* Clear the rest of the line.  */
++            memset(*lineptr + *n, '\0', line_size);
++            *n += line_size;
++        }
++
++        /* Push the result in the line.  */
++        (*lineptr)[indx++] = c;
++
++        /* Bail out.  */
++        if (c == delim)
++        {
++            break;
++        }
++    }
++    return (c == EOF) ? -1 : indx;
++}
++
++static ssize_t
++getline (char **lineptr, size_t *n, FILE *stream)
++{
++    return getdelim (lineptr, n, '\n', stream);
++}
++#endif
++#endif
++
+ /* Helper routine for building cJSON objects in a printf-like manner.
+ **
+ ** Sample call:


### PR DESCRIPTION
###### Description
Current iperf3-devel port does not build on OSX <= 10.6 due to a missing getline(). This attempts a work around and was taken from the [libgss patch in trac](https://trac.macports.org/attachment/ticket/54060/patch-src-gss.diff). I am [working with upstream](https://github.com/esnet/iperf/issues/607) and I will submit this workaround for inclusion once buildbot confirms it successfully builds.

###### Tested on
macOS 10.12
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?