### PR TITLE
spice-gtk: Add x11 variant to gtk3 dependency

### DIFF
--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 
 name                spice-gtk
 version             0.33
@@ -40,6 +41,8 @@ depends_lib         port:spice-protocol \
                     port:pulseaudio \
                     port:libepoxy \
                     port:libusb
+
+require_active_variants gtk3 x11
 
 # for ucontext
 configure.cppflags-append \


### PR DESCRIPTION
gtk3 +quartz doesn't come with gdk/gdkx.h.