### PR TITLE
weechat: update to 1.9

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,10 +9,10 @@ name                weechat
 
 if {${name} eq ${subport}} {
     conflicts       weechat-devel
-    github.setup    weechat weechat 1.8 v
+    github.setup    weechat weechat 1.9 v
 
-    checksums       rmd160  57f0238e47b093f1df1f272880a8a6e27ee44ac2 \
-                    sha256  48c660b9a167be4e7011e44ef1f69d2f0bbc4ebf7c5f7ae340f2f92f7105f11f
+    checksums       rmd160  b8b91c5c81e86d3aea431b1a24f66d95117c1135 \
+                    sha256  75c5cafac02f9f30fdfa4d4060efe3960669d4f85e0656a800f866f21078516f
 }
 
 subport weechat-devel {


### PR DESCRIPTION
###### Description
Can I use https://weechat.org/files/src/weechat-1.9.tar.xz instead? xz archives are much smaller.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
