### PR TITLE
terminus-font: update to version 4.46

### DIFF
--- a/x11/terminus-font/Portfile
+++ b/x11/terminus-font/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            terminus-font
-version         4.40
+version         4.46
 license         OFL-1.1 GPL-2+
 categories      x11
 maintainers     pobox.com:rlonstein
@@ -17,17 +17,22 @@ platforms       darwin
 homepage        http://terminus-font.sourceforge.net/
 master_sites    sourceforge:project/terminus-font/terminus-font-${version}
 
-checksums       rmd160  e63701657d348de6caadbd825fb00b1e241a621f \
-                sha256  64f52c24d3f1c1e39f21e6c43077a9be3e21d4384f176f5766c00558ba670711
+checksums       rmd160  29aa4c3d3a8b4a84dfcaa4e8fc17c76493876ca5 \
+                sha256  4e29433e5699b76df1f5c9a96f1228cccf8ea8a16791cfef063f2b8506c75bcd
 
-depends_build   path:bin/perl:perl5 \
+depends_build   port:python35 \
                 port:bdftopcf
 depends_lib     port:mkfontdir
 
-configure.args  --x11dir=${prefix}/share/fonts
+configure.args  --x11dir=${prefix}/share/fonts/misc
+build.args      INT=python3.5
 
 post-activate {
-    system "mkfontdir ${prefix}/share/fonts"
+    system "mkfontdir ${prefix}/share/fonts/misc"
+}
+
+post-deactivate {
+    system "mkfontdir ${prefix}/share/fonts/misc"
 }
 
 livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
The fonts are now installed in the "misc" font directory, which is
included in the default font path.
