### PR TITLE
entr: update to version 3.7

### DIFF
--- a/sysutils/entr/Portfile
+++ b/sysutils/entr/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                entr
-version             3.6
+version             3.7
 categories          sysutils
 license             ISC
 platforms           darwin
@@ -19,10 +19,10 @@ long_description    a utility for running arbitrary commands when \
 homepage            http://entrproject.org
 master_sites        ${homepage}/code
 
-checksums           rmd160  7bc74e6d0177a049990ed2eb4994949df5d55bfd \
-                    sha256  a42746d81c548d7e557d500f93422b8ec9731d719309eb2601b8be69ae0dc8eb
+checksums           rmd160  15907ee7b88582ad731b915a7848c47f31bafc61 \
+                    sha256  94efd50c8f7e9d569060d5deebf366c3565e81e814ab332b973d7298fa8ea22f
 
-worksrcdir          eradman-entr-c15b0be493fc
+worksrcdir          eradman-entr-c5b62bde107d
 
 # ./configure is just a simple batch file
 configure.pre_args

--- a/sysutils/entr/Portfile
+++ b/sysutils/entr/Portfile
@@ -7,7 +7,7 @@ version             3.7
 categories          sysutils
 license             ISC
 platforms           darwin
-maintainers         darkcog.com:casr+macports openmaintainer
+maintainers         {darkcog.com:casr @casr} openmaintainer
 
 description         a utility for running arbitrary commands when files change.
 


### PR DESCRIPTION
###### Description
Update [entr](http://entrproject.org/) to new version 3.7 released on 2017-02-27.

###### Tested on
macOS 10.12.5
Xcode 8.1 (8B62)

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
