### PR TITLE
tmux-mem-cpu-load: New port

### DIFF
--- a/sysutils/tmux-mem-cpu-load/Portfile
+++ b/sysutils/tmux-mem-cpu-load/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.0
+PortGroup           github 1.0
+
+github.setup        thewtex tmux-mem-cpu-load 3.4.0 v
+categories          sysutils
+platforms           darwin
+license             Apache-2.0
+
+maintainers         {gmail.com:justrafi @rafi} openmaintainer
+description         CPU, RAM, and load monitor for use with tmux
+long_description    A simple, lightweight program provided for system \
+                    monitoring in the status line of tmux.
+
+checksums           rmd160  0851ffe84f0c9767dcbe05c9662fbf8f3baabf50 \
+                    sha256  7b84807a02262b8162bb37de0cd43a0ec2b253758a92b0bd33b8bd9d17929692
+
+cmake.out_of_source yes


### PR DESCRIPTION
###### Description
[tmux-mem-cpu-load](https://github.com/thewtex/tmux-mem-cpu-load) shows a CPU, RAM, and load monitor for use with tmux.

###### Tested on
macOS 10.12.5
Xcode 8.1 (8B62)

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
