### PR TITLE
llvm-4.0: Update to 4.0.1

### DIFF
--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -10,7 +10,7 @@ PortGroup cmake         1.0
 set llvm_version        4.0
 set llvm_version_no_dot 40
 set clang_executable_version 4.0
-set lldb_executable_version 4.0.0
+set lldb_executable_version 4.0.1
 name                    llvm-${llvm_version}
 revision                0
 subport                 clang-${llvm_version} {}
@@ -24,7 +24,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} larryv
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -36,7 +36,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -97,7 +97,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 #default_variants-append +assertions
 #default_variants-append +debug
 
-version                 ${llvm_version}.0
+version                 ${llvm_version}.1
 epoch                   2
 master_sites            http://llvm.org/releases/${version}
 use_xz                  yes
@@ -117,27 +117,27 @@ if {${distfiles} ne ""} {
     }
 }
 
-checksums           llvm-4.0.0.src.tar.xz \
-                    rmd160  468ae2502ba523b35c5e8340724ddaa50b31ccb5 \
-                    sha256  8d10511df96e73b8ff9e7abbfb4d4d432edbdbe965f1f4f07afaf370b8a533be \
-                    cfe-4.0.0.src.tar.xz \
-                    rmd160  aae742d32a18cd8660b0eabecfcf14139f2f4d4a \
-                    sha256  cea5f88ebddb30e296ca89130c83b9d46c2d833685e2912303c828054c4dc98a \
-                    compiler-rt-4.0.0.src.tar.xz \
-                    rmd160  82af42752eb7cf9f90cc678263596b713e642067 \
-                    sha256  d3f25b23bef24c305137e6b44f7e81c51bbec764c119e01512a9bd2330be3115 \
-                    libcxx-4.0.0.src.tar.xz \
-                    rmd160  b1a870353076c9af77c16f182d5d6a987a0e3030 \
-                    sha256  4f4d33c4ad69bf9e360eebe6b29b7b19486948b1a41decf89d4adec12473cf96 \
-                    clang-tools-extra-4.0.0.src.tar.xz \
-                    rmd160  1fae1678b524ec44c3eaed9bbe8d1accd2c85ec0 \
-                    sha256  41b7d37eb128fd362ab3431be5244cf50325bb3bb153895735c5bacede647c99 \
-                    lldb-4.0.0.src.tar.xz \
-                    rmd160  a4f8d036901ae17ca0959dc4cd1064bbbbaa05af \
-                    sha256  2dbd8f05c662c1c9f11270fc9d0c63b419ddc988095e0ad107ed911cf882033d \
-                    polly-4.0.0.src.tar.xz \
-                    rmd160  5e37430f0bc80a9a1acfce1643c02815609b2504 \
-                    sha256  27a5dbf95e8aa9e0bbe3d6c5d1e83c92414d734357aa0d6c16020a65dc4dcd97
+checksums           llvm-4.0.1.src.tar.xz \
+                    rmd160  37387a5ca73ea270b2f541ecbd1cd641f7b09be2 \
+                    sha256  da783db1f82d516791179fe103c71706046561f7972b18f0049242dee6712b51 \
+                    cfe-4.0.1.src.tar.xz \
+                    rmd160  4f30f077c6c39489720ec43a748d04dab0fbff79 \
+                    sha256  61738a735852c23c3bdbe52d035488cdb2083013f384d67c1ba36fabebd8769b \
+                    compiler-rt-4.0.1.src.tar.xz \
+                    rmd160  5dc0cfa63a5b01595abdd718ba566439df56cbfc \
+                    sha256  a3c87794334887b93b7a766c507244a7cdcce1d48b2e9249fc9a94f2c3beb440 \
+                    libcxx-4.0.1.src.tar.xz \
+                    rmd160  0f97ba9597a0b93c545fa06ac45ae5106440ab8e \
+                    sha256  520a1171f272c9ff82f324d5d89accadcec9bc9f3c78de11f5575cdb99accc4c \
+                    clang-tools-extra-4.0.1.src.tar.xz \
+                    rmd160  e6e99d84ee314688e94bde8b2f9eec058236473f \
+                    sha256  35d1e64efc108076acbe7392566a52c35df9ec19778eb9eb12245fc7d8b915b6 \
+                    lldb-4.0.1.src.tar.xz \
+                    rmd160  b97f62bb00f2df15e7ba9f720c4981b3fac232d7 \
+                    sha256  8432d2dfd86044a0fc21713e0b5c1d98e1d8aad863cf67562879f47f841ac47b \
+                    polly-4.0.1.src.tar.xz \
+                    rmd160  473d2c41d30a1e504cf43ffd02f1ce11b0c3c54e \
+                    sha256  b443bb9617d776a7d05970e5818aa49aa2adfb2670047be8e9f242f58e84f01a
 
 patch.pre_args  -p1
 patchfiles \


### PR DESCRIPTION
###### Description

Update to the new upstream release. This helps with https://github.com/servo/rust-bindgen.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.5
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? _No tests_
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
