### PR TITLE
devel/direnv: fix stable build for 2.12.0

### DIFF
--- a/devel/direnv/Portfile
+++ b/devel/direnv/Portfile
@@ -28,18 +28,6 @@ subport direnv-devel {
     checksums           rmd160 0b3f301e7eb8d255effede4da7f9f0ec67df1cc8 \
                         sha256 4acaae496ad176b2502f3856e152e38f026aaf4060d7d1a6de2a0ff13999ac48
     conflicts           direnv
-
-    # fix importing of dotenv
-    patchfiles-append       patch-cmd_dotenv.go.diff
-
-    post-patch {
-        # move 'dotenv' into 'src/dotenv' to make GOPATH happy
-        file mkdir ${worksrcpath}/src
-        move ${worksrcpath}/dotenv ${worksrcpath}/src
-    }
-
-    build.env-append        GOPATH=${worksrcpath}
-
 }
 
 # override github information
@@ -52,6 +40,16 @@ depends_lib-append      port:go
 
 # fix PREFIX and DESTDIR variables to match what 'port' needs
 patchfiles-append       patch-Makefile.diff
+# fix importing of dotenv
+patchfiles-append       patch-cmd_dotenv.go.diff
+
+post-patch {
+    # move 'dotenv' into 'src/dotenv' to make GOPATH happy
+    file mkdir ${worksrcpath}/src
+    move ${worksrcpath}/dotenv ${worksrcpath}/src
+}
+
+build.env-append        GOPATH=${worksrcpath}
 
 use_configure           no
 


### PR DESCRIPTION
###### Description

The latest stable release needs the patch previously only needed by devel.