### PR TITLE
iperf3-devel: update to release 3.2

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -32,15 +32,16 @@ post-destroot {
 }
 
 subport ${name}-devel {
-    github.setup        esnet iperf 4f3a7a5403b61f49ab277d0756e87c651a45bdfe
-    version             20170620
-    revision            2
+    github.setup        esnet iperf 88d907f7fb58bfab5d086c5da60c922e1c582c92
+    version             20170626
 
-    checksums           rmd160  7a72ece6402ae52e2df464ad74af068bd00b4ea6 \
-                        sha256  591867e864deb355b8d67d39afce34a963e9ca6d3a12a29b93fc336edc29c666
+    checksums           rmd160  3793eefb303ffebadbbe6ba2055683c1eca15374 \
+                        sha256  3098ae6787da9ba08dad6cb6329d3b6282f058711033ff7edbb6ad145cd6d088
 
     depends_lib-append  port:openssl
-    patchfiles          patch-iperf_util.diff
+    patchfiles          patch-iperf_auth.c.diff \
+                        patch-iperf_util.h.diff \
+                        patch-iperf_util.c.diff
 
     conflicts           ${name}
 

--- a/net/iperf3/files/patch-iperf_auth.c.diff
+++ b/net/iperf3/files/patch-iperf_auth.c.diff
@@ -1,0 +1,11 @@
+--- src/iperf_auth.c	2017-07-01 12:29:07.000000000 -0500
++++ src/iperf_auth.c	2017-07-01 14:22:54.000000000 -0500
+@@ -34,6 +34,8 @@
+ #include <stdio.h>
+ #include <termios.h>
+ 
++#include "iperf_util.h"
++
+ #if defined(HAVE_SSL)
+ 
+ #include <openssl/bio.h>

--- a/net/iperf3/files/patch-iperf_util.c.diff
+++ b/net/iperf3/files/patch-iperf_util.c.diff
@@ -1,20 +1,18 @@
---- src/iperf_util.c	2017-06-20 17:04:30.000000000 -0500
-+++ src/iperf_util.c	2017-06-26 13:30:16.000000000 -0500
-@@ -338,6 +338,75 @@
-     return features;
+--- src/iperf_util.c	2017-07-01 12:28:58.000000000 -0500
++++ src/iperf_util.c	2017-07-01 13:23:49.000000000 -0500
+@@ -432,3 +432,69 @@
+     }
+     fprintf(fp, "]\n");
  }
- 
++
++/* Fallback getline() for OSX <= 10.6
++** https://lists.gnu.org/archive/html/bug-mailutils/2002-10/msg00038.html
++**
++** First implementation by Alain Magloire.
++*/
 +#ifdef __APPLE__
 +#include <Availability.h>
 +#if __MAC_OS_X_VERSION_MIN_REQUIRED <= 1060
-+
-+static const int line_size = 128;
-+
-+static ssize_t
-+getdelim (char **lineptr, size_t *n, int delim, FILE *stream);
-+
-+static ssize_t
-+getline (char **lineptr, size_t *n, FILE *stream);
 +
 +static ssize_t
 +getdelim (char **lineptr, size_t *n, int delim, FILE *stream)
@@ -72,7 +70,3 @@
 +}
 +#endif
 +#endif
-+
- /* Helper routine for building cJSON objects in a printf-like manner.
- **
- ** Sample call:

--- a/net/iperf3/files/patch-iperf_util.h.diff
+++ b/net/iperf3/files/patch-iperf_util.h.diff
@@ -1,0 +1,25 @@
+--- src/iperf_util.h	2017-07-01 12:28:58.000000000 -0500
++++ src/iperf_util.h	2017-07-01 13:25:18.000000000 -0500
+@@ -56,3 +56,22 @@
+ void iperf_dump_fdset(FILE *fp, char *str, int nfds, fd_set *fds);
+ 
+ #endif
++
++/* Fallback getline() for OSX <= 10.6
++** https://lists.gnu.org/archive/html/bug-mailutils/2002-10/msg00038.html
++**
++** First implementation by Alain Magloire.
++*/
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED <= 1060
++
++static const int line_size = 128;
++
++static ssize_t
++getdelim (char **lineptr, size_t *n, int delim, FILE *stream);
++
++static ssize_t
++getline (char **lineptr, size_t *n, FILE *stream);
++#endif
++#endif


### PR DESCRIPTION
###### Description
New upstream release.

(I am the maintainer listed for this port.)

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?