### PR TITLE
cxx11 1.1 PortGroup: add support for PowerPC using gcc6

### DIFF
--- a/_resources/port1.0/group/cxx11-1.1.tcl
+++ b/_resources/port1.0/group/cxx11-1.1.tcl
@@ -56,6 +56,13 @@ if {${cxx_stdlib} eq "libstdc++" } {
 
     # see https://trac.macports.org/ticket/53194
     configure.cxx_stdlib macports-libstdc++
+    
+    platform darwin powerpc {
+        # ports will build on powerpc with gcc6, gcc4ABI-compatible
+        puts "PowerPC c++11 ports are compiling with gcc6. EXPERIMENTAL."
+        compiler.whitelist-delete macports-clang-4.0
+        universal_variant no
+    }
 
     if { ${os.major} < 13 } {
         # prior to OS X Mavericks, libstdc++ was the default C++ runtime, so


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/54374

###### Description
@mojca @MarcusCalhoun-Lopez 

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.4 PPC and 10.5 PPC
Xcode 2.5 and 3.14

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
