### PR TITLE
openjade: fix overzealous .a -> .la translation

### DIFF
--- a/textproc/openjade/Portfile
+++ b/textproc/openjade/Portfile
@@ -5,7 +5,7 @@ PortGroup       xmlcatalog 1.0
 
 name            openjade
 version         1.3.2
-revision        10
+revision        11
 categories      textproc
 license         MIT
 maintainers     gmail.com:tlockhart1976 openmaintainer

--- a/textproc/openjade/files/patch-delete_la_files.diff
+++ b/textproc/openjade/files/patch-delete_la_files.diff
@@ -5,7 +5,7 @@
  ALL_LIBS = $(XLIBS) $(LIBS)
  Makefile.lt:
 -	echo 'LT_LIBS='`echo $(XLIBS)|sed 's/\.a/.la/g'` >Makefile.lt
-+	echo 'LT_LIBS='`echo $(XLIBS)|sed 's/\.a/.la/g'|sed 's|libosp\.la|libosp.dylib|'` >Makefile.lt
++	echo 'LT_LIBS='`echo $(XLIBS)|sed -E 's/\.a([[:space:]]|$$)/.la\1/g'|sed 's|libosp\.la|libosp.dylib|'` >Makefile.lt
  
  PROG:=$(shell echo "$(PROG)" | sed '@program_transform_name@')
  


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/46132