### PR TITLE
clang-4.0:  fix float.h for #include_next error <= 10.6

### DIFF
--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -161,7 +161,8 @@ if {${subport} eq "clang-${llvm_version}"} {
         3003-Fix-local-and-iterator-when-building-with-Lion-and-n.patch \
         3004-Fix-missing-long-long-math-prototypes-when-using-the.patch \
         3005-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch \
-        openmp-locations.patch
+        openmp-locations.patch \
+        3006-patch-tools-clang-lib-headers-float-next-SnowLeopard.diff
 
     # https://llvm.org/bugs/show_bug.cgi?id=25681
     if {${worksrcdir} eq "trunk" || ${worksrcdir} eq "release_${llvm_version_no_dot}"} {

--- a/lang/llvm-4.0/files/3006-patch-tools-clang-lib-headers-float-next-SnowLeopard.diff
+++ b/lang/llvm-4.0/files/3006-patch-tools-clang-lib-headers-float-next-SnowLeopard.diff
@@ -1,0 +1,15 @@
+--- ./tools/clang/lib/Headers/float.h.orig	2017-05-06 10:27:32.000000000 -0700
++++ ./tools/clang/lib/Headers/float.h	2017-05-06 10:28:08.000000000 -0700
+@@ -31,7 +31,12 @@
+  * Also fall back on Darwin to allow additional definitions and
+  * implementation-defined values.
+  */
+-#if (defined(__APPLE__) || (defined(__MINGW32__) || defined(_MSC_VER))) && \
++
++#if defined(__APPLE__) && __has_include(<Availability.h>)
++#include <Availability.h>
++#endif
++
++#if ((defined(__APPLE__) && __has_include(<Availability.h>) && (!defined(__MAC_OS_X_VERSION_MAX_ALLOWED) || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300)) || (defined(__MINGW32__) || defined(_MSC_VER))) && \
+     __STDC_HOSTED__ && __has_include_next(<float.h>)
+ #  include_next <float.h>


### PR DESCRIPTION
closes https://trac.macports.org/ticket/54135

###### Description
@jeremyhu 

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
