### PR TITLE
Update opencore-amr to 0.1.5

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 curl -fsSLO "https://raw.githubusercontent.com/Homebrew/install/master/uninstall"
 chmod 0755 uninstall && ./uninstall -fq && rm -f uninstall
 /usr/bin/sudo /usr/bin/find /usr/local -mindepth 2 -delete && hash -r
@@ -15,6 +16,7 @@ git remote add macports https://github.com/macports/macports-ports.git
 git fetch macports master
 git checkout -qf macports/master
 git checkout -qf -
+sudo patch /opt/local/bin/portindex _ci/patch-portindex.diff
 portindex
 sudo /opt/local/postflight && sudo rm -f /opt/local/postflight
 git clone --depth 1 https://github.com/macports/mpbb.git ../mpbb

--- a/_ci/patch-portindex.diff
+++ b/_ci/patch-portindex.diff
@@ -1,0 +1,10 @@
+--- portindex.orig
++++ portindex
+@@ -299,3 +299,7 @@
+       \nPorts successfully parsed:\t[expr {$stats(total) - $stats(failed)}]\
+       \nPorts failed:\t\t\t$stats(failed)\
+       \nUp-to-date ports skipped:\t$stats(skipped)\n"
++
++if {$stats(failed) > 0} {
++    exit 1
++}

--- a/audio/opencore-amr/Portfile
+++ b/audio/opencore-amr/Portfile
@@ -6,7 +6,7 @@ name                opencore-amr
 version             0.1.5
 categories          audio
 platforms           darwin
-maintainers         stare.cz:hans
+maintainers         {stare.cz:hans @janstary}
 license             Apache-2
 
 description         implementation of the Adaptive Multi Rate speech codec

--- a/audio/opencore-amr/Portfile
+++ b/audio/opencore-amr/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                opencore-amr
-version             0.1.3
+version             0.1.5
 categories          audio
 platforms           darwin
 maintainers         stare.cz:hans
@@ -25,6 +25,6 @@ livecheck.url       ${homepage}/files/opencore-amr/
 livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)"
 
 checksums \
-	rmd160 5631ee1e2a99800a3d276e94fe679ac4eeaece0c \
-	sha256 106bf811c1f36444d7671d8fd2589f8b2e0cca58a2c764da62ffc4a070595385
+	rmd160 02c092bf631345fe4d53787739e30722f5989a7c \
+	sha256 2c006cb9d5f651bfb5e60156dbff6af3c9d35c7bbcc9015308c0aff1e14cd341
 


### PR DESCRIPTION
###### Description

This updates opencore-amr to the lates version 0.1.5

###### Tested on
macOS 10.6.8
Xcode 3.2.6
