### PR TITLE
gmt5: Add hdf5 dependency

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -35,6 +35,7 @@ depends_lib         port:dcw-gmt \
                     port:ghostscript \
                     port:gshhg-gmt \
                     port:netcdf \
+                    port:hdf5 \
 
 default_variants    +gdal +pcre
 if {![variant_isset lgpl]} {


### PR DESCRIPTION
I got following error in installation time. So I added hdf5 as dependency.

> :info:configure -- Searching dependent libraries. This may take a few minutes...
:info:configure -- Looking for nc_def_var_deflate
:info:configure CMake Error: The following variables are used in this project, b
ut they are set to NOTFOUND.
:info:configure Please set them or make sure they are set and tested correctly i
n the CMake files:
:info:configure _found_lib_hdf5
:info:configure     linked by target "cmTC_25994" in directory /opt/local/var/ma
cports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_
science_gmt5/gmt5/work/build/CMakeFiles/CMakeTmp
:info:configure _found_lib_hdf5_hl
:info:configure     linked by target "cmTC_25994" in directory /opt/local/var/ma
cports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_
science_gmt5/gmt5/work/build/CMakeFiles/CMakeTmp
:info:configure CMake Error at /opt/local/share/cmake-3.8/Modules/CheckSymbolExi
sts.cmake:76 (try_compile):
:info:configure   Failed to configure test project build system.


