### PR TITLE
snowleopardfixes: new port

### DIFF
--- a/sysutils/snowleopardfixes/Portfile
+++ b/sysutils/snowleopardfixes/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           muniversal 1.0
+
+github.setup        kencu snowleopardfixes 72c90d36d20023eab306b1f9be077c5e11c3fc58
+version             20170702
+categories          sysutils
+platforms           darwin
+maintainers         {gmail.com:ken.cunningham.webuse @kencu} openmaintainer
+license             GPL-2
+
+description         A library to replace common libc functions missing from SnowLeopard and earlier
+long_description    ${description}
+
+checksums           rmd160  43303d2c290455488a806b05fe22647b8b070e63 \
+                    sha256  b73fdaed13fb50a437cd5cbe530096f9afb921820ce1dcd292bc367470888b46
+                    
+use_configure       no
+
+build.env           CXX="${configure.cxx}" \
+                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    CC="${configure.cc}" \
+                    CFLAGS="${configure.cflags}" \
+                    LDFLAGS="${configure.ldflags}  [get_canonical_archflags ld]" \
+                    PREFIX=${prefix}
+
+destroot.env        PREFIX=${prefix}


### PR DESCRIPTION
replaces most missing libc functions in SnowLeopard and earlier

can be used like so for most ports with missing symbols on <=10.6
```
if {${os.platform} eq "darwin" && ${os.major} < 11} {
	depends_lib-append          port:snowleopardfixes
	configure.ldflags-append   -lsnowleopardfixes
}
```

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.6
Xcode 3.2.6 and 4.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
