### PR TITLE
gdub: new port

### DIFF
--- a/devel/gdub/Portfile
+++ b/devel/gdub/Portfile
@@ -1,0 +1,37 @@
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        dougborg gdub 0.1.0 v
+categories          devel java groovy
+platforms           darwin
+supported_archs     noarch
+maintainers         @breun openmaintainer
+license             MIT
+
+description         A gradlew / gradle wrapper
+long_description    gdub (gw on the command line) is a gradle / gradlew wrapper. \
+                    Not to be confused with the Gradle Wrapper, gw invokes ./gradlew on \
+                    projects where one is configured, and falls back to use the gradle \
+                    from the \$PATH if a wrapper is not available. Also, gw is 66% shorter \
+                    to type than gradle and 78% shorter to type than ./gradlew.
+
+homepage            http://www.gdub.rocks/
+
+checksums           rmd160  fa612e31fd2f32e429225338ff5361184b82b318 \
+                    sha256  76d9a81ba295cf8a4024bde845cd8e36bb01e3465ed09221fb69d7627150afbc
+
+use_configure       no
+build {}
+
+pre-destroot {
+    delete ${worksrcpath}/install
+}
+
+destroot    {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}
+    copy ${worksrcpath}/bin \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/README.md \
+        ${destroot}${prefix}/share/java/${name}
+    ln -s ${prefix}/share/java/${name}/bin/gw ${destroot}${prefix}/bin
+}

--- a/devel/gdub/Portfile
+++ b/devel/gdub/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           github 1.0
 
@@ -23,11 +25,7 @@ checksums           rmd160  fa612e31fd2f32e429225338ff5361184b82b318 \
 use_configure       no
 build {}
 
-pre-destroot {
-    delete ${worksrcpath}/install
-}
-
-destroot    {
+destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}
     copy ${worksrcpath}/bin \
         ${worksrcpath}/LICENSE \


### PR DESCRIPTION
###### Description

Added a new port for gdub.

###### Tested on
macOS 10.12.5
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
