### PR TITLE
hunspell-dict-pt_BR: New port

### DIFF
--- a/textproc/hunspell-dict-pt_BR/Portfile
+++ b/textproc/hunspell-dict-pt_BR/Portfile
@@ -1,0 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           hunspelldict 1.0
+
+hunspelldict.setup  pt_BR 3.2 {Portuguese (Brazilian)} ooo
+maintainers         {schenkel.net:leonardo @lbschenkel}
+homepage            https://pt-br.libreoffice.org/projetos/vero/
+
+license             LGPL-3 MPL-2
+
+master_sites        https://pt-br.libreoffice.org/assets/Uploads/PT-BR-Documents/VERO/
+distfiles           VeroptBRV320AOC.oxt
+checksums           rmd160  6f2346d3919b072f87e32c9028231a9ce098417c \
+                    sha256  78bac9ed27bf1b23666e240bc3809b9520004f14885423580a029771032bff54
+
+livecheck.regex     VERO (\\d+\\.\\d+)


### PR DESCRIPTION
Installs the official pt_BR dictionary from LibreOffice (VERO project).

###### Tested on
macOS 10.12.15
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

I'm volunteering to be the maintainer for this port.