### PR TITLE
ansifilter: update to 2.5

### DIFF
--- a/textproc/ansifilter/Portfile
+++ b/textproc/ansifilter/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       cxx11 1.1
 
 name            ansifilter
-version         2.4
+version         2.5
 categories      textproc
 maintainers     {evermeet.cx:tessarek @tessus} openmaintainer
 platforms       darwin
@@ -20,8 +20,8 @@ homepage        http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php
 master_sites    http://www.andre-simon.de/zip/
 use_bzip2       yes
 
-checksums       rmd160  bb1619fc5a734718a06e1e0e15a95ffed95cb686 \
-                sha256  c57cb878afa7191c7b7db3c086a344b4234df814aed632596619a4bda5941d48
+checksums       rmd160  680823bf9de1804be80ee28b6d1a995eff2302d3 \
+                sha256  30d05ccfa9be98b0328ee29fe39473e55047f1d32a9a2460d3d4d1ff2475f0e2
 
 patchfiles      patch-src-makefile.diff
 
@@ -29,7 +29,7 @@ use_configure   no
 
 build.args-append \
                 CC="${configure.cxx}" \
-                CFLAGS="${configure.cxxflags} -std=c++11" \
-                LDFLAGS="${configure.ldflags} -stdlib=${configure.cxx_stdlib}"
+                EXTRA_CXXFLAGS="${configure.cxxflags} -std=c++11" \
+                EXTRA_LDFLAGS="${configure.ldflags} -stdlib=${configure.cxx_stdlib}"
 
 destroot.args   PREFIX="${prefix}"

--- a/textproc/ansifilter/files/patch-src-makefile.diff
+++ b/textproc/ansifilter/files/patch-src-makefile.diff
@@ -1,11 +1,11 @@
---- src/makefile.orig
-+++ src/makefile
-@@ -23,7 +23,7 @@ $(EXECUTABLE): $(OBJECTS)
- 	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+--- src/makefile.orig	2017-06-21 04:11:20.000000000 -0400
++++ src/makefile	2017-07-05 14:27:19.000000000 -0400
+@@ -23,7 +23,7 @@
+ 	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(OBJECTS) -o $@
  
  .cpp.o:
--	$(CC) $(CFLAGS) $< -o $@
-+	$(CC) -c $(CFLAGS) $< -o $@
+-	$(CC) -c $(CXXFLAGS) $< -o $@
++	$(CC) -c $(CXXFLAGS) $(EXTRA_CXXFLAGS) $< -o $@
  
  clean:
  	@rm -f *.o


### PR DESCRIPTION
###### Description

update to 2.5

###### Tested on
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
