### PR TITLE
zstd: fix build on OS X < 10.7

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -18,6 +18,10 @@ long_description    Zstd, short for Zstandard, is a fast lossless compression \
 checksums           rmd160  7fa5acfb0fe7cce8ad5adfe355d5959a990085de \
                     sha256  a8f57a1f69a76ae3480fda0655bfe2201127d373236a9e9f359b0db406ab7306
 
+post-patch {
+    reinplace -W ${worksrcpath} "s/-Wvla //g" lib/Makefile programs/Makefile tests/Makefile tests/fuzz/Makefile
+}
+
 use_configure       no
 
 build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \


### PR DESCRIPTION
###### Description
Broke by facebook/zstd@83d0c764dcd940fc058e8649c6982c7512563344. Fix not verified.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
