### PR TITLE
pdns-recursor: update to 4.0.6

### DIFF
--- a/net/pdns-recursor/Portfile
+++ b/net/pdns-recursor/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pdns-recursor
-version             4.0.5
+version             4.0.6
 categories          net
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -22,8 +22,8 @@ homepage            https://www.powerdns.com/recursor.html
 master_sites        https://downloads.powerdns.com/releases/
 use_bzip2           yes
 
-checksums           rmd160  3cf3594ab6ede39a1400cb21e2905217d735bc4e \
-                    sha256  ba43ce4280b3a06afebe58c5d63680f51dd525c63d1de7f3b229b380e6b1b7af
+checksums           rmd160  93aeaaa2b26834f0a2cbea7421b6fe01a82d048e \
+                    sha256  f2182ac644268bb08b865a71351f11d75c5015ac0608a1469eb4c1cd5494d60d
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3
