### PR TITLE
KeePassXC: new port, version 2.2.0

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               qt5 1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.0
+
+github.setup            keepassxreboot keepassxc 2.2.0
+name                    KeePassXC
+categories              security aqua
+maintainers             nomaintainer
+
+description             KeePassXC is a cross-platform community-driven port \
+                        of the Windows application “Keepass Password Safe”.
+long_description        KeePassXC is a community fork of KeePassX with the \
+                        goal to extend and improve it with new features and \
+                        bugfixes to provide a feature-rich, fully \
+                        cross-platform and modern open-source password manager.
+
+platforms               darwin
+license                 GPL-2+
+license_noconflict      openssl
+
+homepage                https://www.keepassxc.org
+
+checksums               rmd160  2f97889600ed82f6cd8c7667f3e9858c89ef122c \
+                        sha256  48d67b7cac621621d37a076166ecb1031289c072546c06383c4224e610333224
+
+depends_lib-append      port:libgcrypt \
+                        port:zlib
+
+cmake.out_of_source     yes
+configure.pre_args-append \
+    -DCMAKE_INSTALL_PREFIX=${applications_dir} \
+    -DWITH_XC_HTTP=ON \
+    -DQT_BINARY_DIR=${prefix}/libexec/qt5/bin
+
+if {${configure.cxx_stdlib} eq "libstdc++"} {
+    configure.pre_args-append   -DWITH_CXX11=OFF
+}
+
+variant yubikey description {Enable YubiKey challenge-response support} {
+    configure.pre_args-append \
+        -DWITH_XC_YUBIKEY=ON
+    depends_lib-append port:ykpers
+}
+
+pre-configure {
+    reinplace "s#/usr/local/bin#${prefix}/bin#" \
+        ${worksrcpath}/CMakeLists.txt
+}
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -W ${worksrcpath} COPYING LICENSE.BOOST-1.0 LICENSE.BSD \
+             LICENSE.CC0 LICENSE.GPL-2 LICENSE.GPL-3 LICENSE.LGPL-2.1 \
+             LICENSE.LGPL-3 LICENSE.NOKIA-LGPL-EXCEPTION \
+             ${destroot}${prefix}/share/doc/${name}
+}
+
+test.run        yes
+test.target     test

--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -28,6 +28,7 @@ checksums               rmd160  2f97889600ed82f6cd8c7667f3e9858c89ef122c \
 
 depends_lib-append      port:libgcrypt \
                         port:zlib
+depends_build-append    port:qt5-qttools
 
 cmake.out_of_source     yes
 configure.pre_args-append \


### PR DESCRIPTION
###### Description

Apparently security/KeePassX is no longer maintained. KeePassXC is a
continuation of the original project.


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.5 (Sierra)
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (no relevant trac ticket)
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
Currently it says:
```
Error: invalid license CC0-1: missing hyphen before version.
```
However, CC0 is the exact name of the license. The number 0 indicates the author of relevant files keep NO rights, not its version number. The version KeePassXC uses is CC0 1.0, which can be seen from https://github.com/keepassxreboot/keepassxc/blob/develop/LICENSE.CC0
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
