### PR TITLE
npm5: new port

### DIFF
--- a/devel/npm2/Portfile
+++ b/devel/npm2/Portfile
@@ -17,7 +17,7 @@ long_description    npm is a package manager for node. \
                     You can use it to install and publish your node programs. \
                     It manages dependencies and does other cool stuff.
 
-conflicts           npm3 npm4
+conflicts           npm3 npm4 npm5
 
 homepage            http://www.npmjs.org/
 

--- a/devel/npm3/Portfile
+++ b/devel/npm3/Portfile
@@ -18,7 +18,7 @@ long_description    npm is a package manager for node. \
                     You can use it to install and publish your node programs. \
                     It manages dependencies and does other cool stuff.
 
-conflicts           npm2 npm4
+conflicts           npm2 npm4 npm5
 
 homepage            http://www.npmjs.org/
 

--- a/devel/npm5/Portfile
+++ b/devel/npm5/Portfile
@@ -2,13 +2,13 @@
 
 PortSystem          1.0
 
-name                npm4
-version             4.6.1
+name                npm5
+version             5.3.0
 
 categories          devel
 platforms           darwin
 license             MIT
-maintainers         ciserlohn
+maintainers         { ether.org.za:light @dylanbr } openmaintainer
 
 supported_archs     noarch
 
@@ -17,7 +17,7 @@ long_description    npm is a package manager for node. \
                     You can use it to install and publish your node programs. \
                     It manages dependencies and does other cool stuff.
 
-conflicts           npm2 npm3 npm5
+conflicts           npm2 npm3 npm4
 
 homepage            http://www.npmjs.org/
 
@@ -27,8 +27,8 @@ distname            npm-${version}
 
 extract.suffix      .tgz
 
-checksums           rmd160  f78373f0de0e3466101a3b73a0fd3cf3e140661f \
-                    sha256  ba858e926aaaacb886a92861e6683607b2eb11809e994917e1db299604da50d2
+checksums           rmd160  17c00e7a94b939b438c62ec603b9574399c8c93e \
+                    sha256  dd96ece7cbd6186a51ca0a5ab7e1de0113333429603ec2ccb6259e0bef2e03eb
 
 worksrcdir          "package"
 
@@ -48,33 +48,40 @@ post-patch {
     regsub -all {/} "^${prefix}/lib" {\\\/} npm_path_jsregex
     reinplace "s|@@NPM_PATH_JSREGEX@@|${npm_path_jsregex}|g" ${worksrcpath}/lib/update.js
 
-    foreach f [concat ${worksrcpath}/cli.js \
-                   ${worksrcpath}/bin/npm-cli.js \
-                   ${worksrcpath}/node_modules/cmd-shim/test/00-setup.js \
+    foreach f [concat ${worksrcpath}/bin/npm-cli.js \
                    ${worksrcpath}/node_modules/mkdirp/bin/cmd.js \
                    ${worksrcpath}/node_modules/node-gyp/bin/node-gyp.js \
+                   ${worksrcpath}/node_modules/node-gyp/node_modules/nopt/bin/nopt.js \
+                   ${worksrcpath}/node_modules/node-gyp/node_modules/nopt/examples/my-program.js \
                    ${worksrcpath}/node_modules/nopt/bin/nopt.js \
                    ${worksrcpath}/node_modules/nopt/examples/my-program.js \
                    ${worksrcpath}/node_modules/opener/opener.js \
-                   ${worksrcpath}/node_modules/read-cmd-shim/test/integration.js \
-                   ${worksrcpath}/node_modules/uuid/bin/uuid \
+                   ${worksrcpath}/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info \
+                   ${worksrcpath}/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-conv \
+                   ${worksrcpath}/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-sign \
+                   ${worksrcpath}/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-verify \
                    ${worksrcpath}/node_modules/rimraf/bin.js \
                    ${worksrcpath}/node_modules/semver/bin/semver \
+                   ${worksrcpath}/node_modules/uuid/bin/uuid \
                    ${worksrcpath}/node_modules/which/bin/which \
-                   ${worksrcpath}/scripts/index-build.js \
+                   ${worksrcpath}/node_modules/worker-farm/node_modules/errno/build.js \
+                   ${worksrcpath}/node_modules/worker-farm/node_modules/errno/cli.js \
+                   ${worksrcpath}/node_modules/worker-farm/node_modules/errno/test.js \
                    ${worksrcpath}/scripts/relocate.sh \
+                   ${worksrcpath}/scripts/maketest \
                    ${worksrcpath}/test/tap/config-edit.js \
-                   ${worksrcpath}/test/tap/gently-rm-cmdshims.js \
                    ${worksrcpath}/test/tap/install-link-scripts.js \
                    ${worksrcpath}/test/tap/scripts-whitespace-windows.js] {
         reinplace "s|/usr/bin/env node|${prefix}/bin/node|" ${f}
     }
 }
 
-build {}
+build {
+    system -W ${worksrcpath} "NPM_CONFIG_UNSAFE_PERM=false ${prefix}/bin/node bin/npm-cli.js pack"
+}
 
-destroot.cmd        ${prefix}/bin/node ./cli.js
-destroot.args       --global .
+destroot.cmd        ${prefix}/bin/node ./bin/npm-cli.js
+destroot.args       --global ${distname}.tgz
 destroot.destdir    --prefix=${destroot}${prefix}
 
 post-destroot {
@@ -92,4 +99,4 @@ ${prefix}/lib/node_modules/ until you manually delete them.
 
 livecheck.type      regex
 livecheck.url       http://registry.npmjs.org/npm
-livecheck.regex     {"next-4":"(.*?)"}
+livecheck.regex     {"next-5":"(.*?)"}

--- a/devel/npm5/files/patch-lib-update.js.diff
+++ b/devel/npm5/files/patch-lib-update.js.diff
@@ -1,0 +1,16 @@
+--- lib/update.js.orig	2016-04-26 09:35:11.000000000 +0200
++++ lib/update.js	2016-04-26 09:34:24.000000000 +0200
+@@ -47,7 +47,12 @@
+       if (url.parse(ww.req).protocol) ww.what = ww.req
+ 
+       var where = ww.dep.parent && ww.dep.parent.path || ww.dep.path
+-      if (toInstall[where]) {
++      if (ww.what.match(/^npm@/) && where.match(/@@NPM_PATH_JSREGEX@@/)) {
++        log.error("Trying to update '" + what + "' in '" + where + "'")
++        log.error("which is part of the MacPorts npm base installation.")
++        log.error("To update npm please run:")
++        log.error("sudo port selfupdate && sudo port upgrade npm\n")
++      } else if (toInstall[where]) {
+         toInstall[where].push(ww.what)
+       } else {
+         toInstall[where] = [ww.what]


### PR DESCRIPTION
###### Description

Add a new port for npm5 and add conflicts to the earlier versions of npm

Closes: https://trac.macports.org/ticket/54298

###### Tested on
macOS 10.12.5
Xcode 8.3.3

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
