### PR TITLE
ncurses: update to 6.0-20170708

### DIFF
--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            ncurses
-version         6.0-20170610
+version         6.0-20170708
 categories      devel
 platforms       darwin freebsd
 license         MIT
@@ -17,8 +17,8 @@ long_description \
 homepage        http://invisible-island.net/ncurses/
 master_sites    http://invisible-mirror.net/archives/ncurses/current/
 extract.suffix	.tgz
-checksums       rmd160  dfc8ed3b5bb27c15ca7c08c91ae00b0329a76f8a \
-                sha256  4c196bd0f1bf0ce643c1547cc7fc25cee713d21299a660eeb9b5dfa8becacb45
+checksums       rmd160  93ca7b05db0ec1f4fb7e6f55d3aa2ad4603b2c47 \
+                sha256  92f7024b9fabd0cc58fb5c25bbc6b64035750a8fb980c65b34032ec8f94209a4
 
 # hex.diff from http://opensource.apple.com/source/ncurses/ncurses-44/patches.applied/
 patchfiles      hex.diff


### PR DESCRIPTION
Fixes a regression that causes infocmp and tic -c to hang when TERM is
rxvt-unicode or xterm-88color:

http://lists.gnu.org/archive/html/bug-ncurses/2017-06/msg00023.html