### PR TITLE
py-astropy: Update to version 2.0

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             1.3.3
-maintainers         robitaille gmail.com:Deil.Christoph
+version             2.0
+maintainers         {gmail.com:Deil.Christoph @cdeil} robitaille openmaintainer
 
 dist_subdir         ${name}/${version}
 
@@ -19,11 +19,11 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     adeb46f1686417f897fc16dd5d8955ac \
-                    rmd160  fcb249af4e0beb482325f3e127440e21cd86242b \
-                    sha256  ed093e033fcbee5a3ec122420c3376f8a80f74663214560727d3defe82170a99
+checksums           md5     5b8d4191ea210423826d4a254e984e5d \
+                    rmd160  e42372cd7ae83063c52d2871b9d02e04fef49221 \
+                    sha256  cdd60fce57c2be5d93fdc39a8ddf3621c4099026f50617294875273321cd8f99
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 build.args-append   --use-system-cfitsio \
                     --use-system-expat \

--- a/science/erfa/Portfile
+++ b/science/erfa/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            liberfa erfa 1.4.0 v
 categories              science
-maintainers             robitaille openmaintainer
+maintainers             {gmail.com:Deil.Christoph @cdeil} robitaille openmaintainer
 license                 BSD
 platforms               darwin
 


### PR DESCRIPTION
This PR updates Astropy to version 2.0.

I see that @Schamschula already updated ERFA to 1.4 in https://github.com/macports/macports-ports/commit/2a9c28ec16ad8181b39bd7c2f3bbcde82c1076f7

When I run the tests with Python 3.5 locally, they pass, but there's a ton of warnings:
https://gist.github.com/cdeil/b34e9d3457279828be087037ddce542f

@astrofrog @Schamschula  - Are those warnings expected because the system WCSLib and CFITSIO is used and those aren't updated yet? (Some warnings seem plain incorrect) How to I proceed here? Can / should CFITSIO and WCSLib updates happen in separate PRs first or will this break Astropy in the meantime?

###### Tested on
macOS 10.12.5 (16F73)
Xcode 8.3.3
