### PR TITLE
csu: update to 85, lint fix

### DIFF
--- a/devel/csu/Portfile
+++ b/devel/csu/Portfile
@@ -1,7 +1,7 @@
 PortSystem              1.0
+
 name                    csu
-version                 79
-revision                4
+version                 85
 categories              devel
 platforms               darwin
 maintainers             mfeiri
@@ -12,8 +12,8 @@ homepage                http://opensource.apple.com/source/Csu/
 master_sites            http://opensource.apple.com/tarballs/Csu/
 
 distname                Csu-${version}
-checksums               rmd160  2ab6404116ff40c0e5a3c1cf6f4afc592db33fe2 \
-                        sha256  d052e1daa1f5de7fc02e7e7cb8b79ee2eeaad0f321c0a70bea4fc7217e232ec2
+checksums               rmd160  5196472e25fbe87566646d3cfba55f8c20c6d482 \
+                        sha256  f2291d7548da854322acf194a875609bfae96c2481738cf6fd1d89eea9ae057a
 
 use_configure           no
 default_variants        +universal


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
