### PR TITLE
nds2-client: Updated to version 0.14.2

### DIFF
--- a/science/nds2-client/Portfile
+++ b/science/nds2-client/Portfile
@@ -1,8 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem        1.0
+PortGroup         cmake 1.0
 
 name              nds2-client
-version           0.11.6
-revision          3
+version           0.14.2
+revision          0
 categories        science
 platforms         darwin
 license           GPL-2
@@ -13,117 +16,170 @@ long_description \
   Client tool for accessing streamed LIGO data using the Network \
   Data Server version 2.
 
-homepage          https://www.lsc-group.phys.uwm.edu/daswg/projects/nds-client.html
-master_sites      https://www.lsc-group.phys.uwm.edu/daswg/download/software/source/
+homepage          https://wiki.ligo.org/DASWG/NDSClient
+master_sites      http://software.ligo.org/lscsoft/source/
 
-checksums         rmd160  ca470079f3d908cb95b379d257374e3b91863034 \
-                  sha256  3abc8ec2ca58fc3184e46b14b81b1b87882b1abe4e739c7c0ae35e1ad77b5f20
+checksums         rmd160  b8b00f8de773d8149b0552b9369bde3c09dc6768 \
+                  sha256  a3cca2d5490cf22428120d4b5c7fbe8c5fd0dcc9c1abe6a64eef68c5029ab63e
 
 depends_build-append \
-                  port:pkgconfig
+                  port:pkgconfig \
+                  port:swig
+depends_lib-append port:sqlite3
 
-default_variants  +doc +gssapi +swig_python27 +swig_java
+default_variants  +gssapi
 
-configure.javac   /usr/bin/javac -source 1.5 -target 1.5
-configure.args    --disable-silent-rules \
-                  --disable-doc \
-                  --disable-swig-python \
-                  --disable-swig-octave \
-                  --disable-swig-java \
-                  --without-sasl \
-                  --without-gssapi
+cmake.out_of_source yes
 
-set pythons_suffixes {27 34}
-
-set pythons_ports {}
-foreach s ${pythons_suffixes} {
-    lappend pythons_ports swig_python${s}
-}
-
-variant doc description "Enable HTML documentation" {
-
-    depends_build-append            port:docbook-xsl \
-                                    port:libxslt
-    configure.args-strsed           s/--disable-doc/--enable-doc/
-
-}
-
-foreach s ${pythons_suffixes} {
-    set p python${s}
-    set v [string index ${s} 0].[string index ${s} 1]
-    set i [lsearch -exact ${pythons_ports} swig_${p}]
-    set c [lreplace ${pythons_ports} ${i} ${i}]
-    set d ${frameworks_dir}/Python.framework/Versions/${v}/lib/python${v}
-    eval [subst {
-        variant swig_${p} description "Enable SWIG Python interface for Python ${v}" conflicts ${c} {
-
-            depends_build-append    port:swig-python
-            depends_lib-append      port:${p} port:py${s}-numpy
-            configure.args-strsed   s/--disable-swig-python/--enable-swig-python/
-            destroot.args-append    pythondir="${d}" pyexecdir="${d}"
-
-        }
-    }]
-}
-
-variant swig_octave description "Enable SWIG Octave interface" {
-
-    depends_build-append            port:swig-octave
-    configure.args-strsed           s/--disable-swig-octave/--enable-swig-octave/
-
-}
-
-variant swig_java description "Enable SWIG Java interface" {
-
-    # Need GNU Classpath to get jni.h header
-    depends_build-append            bin:javac:gcc48 port:swig-java port:gnu-classpath
-    depends_lib-append              bin:java:kaffe
-    configure.args-strsed           s/--disable-swig-java/--enable-swig-java/
-
-}
+configure.args    -DPYTHON=false \
+                  -DPYTHON_EXECUTABLE=false \
+                  -DENABLE_SWIG_JAVA=no \
+                  -DENABLE_SWIG_MATLAB=no \
+                  -DENABLE_SWIG_OCTAVE=no \
+                  -DENABLE_SWIG_PYTHON=no \
+                  -DWITH_SASL=no \
+                  -DWITH_GSSAPI=no
 
 variant sasl description "Use cyrus-sasl2 for authentication" conflicts gssapi {
 
-    configure.args-replace          --without-sasl --with-sasl=${prefix}
+    configure.args-replace          -DWITH_SASL=no -DWITH_SASL=${prefix}
     depends_lib-append              port:cyrus-sasl2
-
 }
 
 variant gssapi description "Use kerberos5 gssapi for authentication" conflicts sasl {
 
-    configure.args-replace          --without-gssapi --with-gssapi=${prefix}
+    configure.args-replace          -DWITH_GSSAPI=no -DWITH_GSSAPI=${prefix}
     depends_lib-append              port:kerberos5
 
 }
 
-set need_octave 0
-if {[variant_isset swig_octave]} {
-    set need_octave 1
-}
-if ${need_octave} {
-    # The Octave dependency can be satisfied by either octave or octave-devel.
-    depends_lib-append              path:bin/octave:octave
-    destroot.args-append            pkgoctexecdir="${prefix}/share/octave/site/m"
-}
-
-set need_sqlite 0
-foreach s ${pythons_ports} {
-    if {[variant_isset ${s}]} {
-        set need_sqlite 1
-    }
-}
-if {[variant_isset swig_octave]} {
-    set need_sqlite 1
-}
-if {[variant_isset swig_java]} {
-    set need_sqlite 1
-}
-if ${need_sqlite} {
-    depends_lib-append port:sqlite3
-}
+test.run           yes
+test.cmd           ${prefix}/bin/ctest
+test.target        -R '.*'
 
 use_parallel_build yes
 
 livecheck.type    regex
 livecheck.url     ${master_sites}
 livecheck.regex   {nds2-client-(\d+(?:\.\d+)*).tar.gz}
+
+#========================================================================
+# Create subports for Java
+#========================================================================
+
+subport ${name}-java {
+  categories-append         java
+  description               Java bindings for ${description}
+  long_description          ${long_description} This package provides Java \
+                            bindings, modules, and scripts.
+
+  # Need GNU Classpath to get jni.h header
+  depends_build-append      port:swig-java port:gnu-classpath
+  depends_lib-append        bin:java:kaffe
+  depends_lib-append        port:${name}
+
+  configure.javac           /usr/bin/javac -source 1.5 -target 1.5
+  configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
+
+  destroot.target           install
+  destroot.args-append      -C ${worksrcpath}/../build/swig/java
+
+  livecheck.type            none
+}
+
+#========================================================================
+# Create subports for MATLAB
+#========================================================================
+
+subport ${name}-matlab {
+  categories-append         matlab
+  description               MATLAB bindings for ${description}
+  long_description          ${long_description} This package provides MATLAB \
+                            bindings, modules, and scripts.
+
+  # Need GNU Classpath to get jni.h header
+  depends_build-append      port:swig-java port:gnu-classpath
+  depends_lib-append        port:${name}-java
+
+  destroot.target           install
+
+  configure.args-replace    -DENABLE_SWIG_JAVA=no -DENABLE_SWIG_JAVA=yes
+  configure.args-replace    -DENABLE_SWIG_MATLAB=no -DENABLE_SWIG_MATLAB=yes
+
+  destroot.args-append      -C ${worksrcpath}/../build/swig/matlab
+
+  livecheck.type            none
+}
+
+#========================================================================
+# Create subports for Octave
+#========================================================================
+
+subport ${name}-octave {
+  categories-append         octave
+  description               Octave bindings for ${description}
+  long_description          ${long_description} This package provides Octave \
+                            bindings, modules, and scripts.
+
+  depends_build-append      port:swig-octave
+  depends_lib-append        path:bin/octave:octave
+  depends_lib-append        port:${name}
+
+  destroot.target           install
+  destroot.args-append      pkgoctexecdir="${prefix}/share/octave/site/m"
+
+  # At least as of Octave 3.2.4, the Octave C++ API does not work with clang.
+  # compiler.blacklist-append *clang*
+
+  configure.args-replace    -DENABLE_SWIG_OCTAVE=no -DENABLE_SWIG_OCTAVE=yes
+
+  destroot.args-append      -C ${worksrcpath}/../build/swig/octave
+
+  livecheck.type            none
+}
+
+#========================================================================
+# Create subports for each supported Python version
+#========================================================================
+foreach v {27} {
+  set python.version          ${v}
+  set python.branch           [string range ${python.version} 0 end-1].[string index ${python.version} end]
+  set python.bin              ${prefix}/bin/python${python.branch}
+  set python.prefix           ${frameworks_dir}/Python.framework/Versions/${python.branch}
+  set python.site_packages    "${python.prefix}/lib/python${python.branch}/site-packages"
+  set python.pkgname          ""
+
+  subport py${v}-${name} {
+    categories-append         python
+    description               Python ${python.version} bindings for ${description}
+    long_description          ${long_description} This package provides Python \
+                              ${python.version} bindings, modules, and scripts.
+
+    depends_build-append      port:swig-python
+    depends_lib-append        port:${name}
+    depends_lib-append        port:python${python.version}
+    depends_lib-append        port:py${python.version}-numpy
+
+    configure.python          ${python.bin}
+    configure.args-replace    -DPYTHON=false -DPYTHON=${python.prefix}/bin/python${python.branch}
+    configure.args-replace    -DPYTHON_EXECUTABLE=false -DPYTHON_EXECUTABLE=${python.prefix}/bin/python${python.branch}
+    configure.args-replace    -DENABLE_SWIG_PYTHON=no -DENABLE_SWIG_PYTHON=yes
+    configure.args-append     -DPYTHON_MODULE_INSTALL_DIR="${python.site_packages}" \
+                              -DPYTHON_EXTMODULE_INSTALL_DIR="${python.site_packages}" \
+                              -DSWIG_CPPFLAGS="-I${python.prefix}/include"
+
+    destroot.target           install
+    destroot.args-append      -C ${worksrcpath}/../build/swig/python
+
+    post-destroot {
+      if {${subport} eq "py27-${name}"} {
+        foreach script [glob -tails -nocomplain -directory ${destroot}${python.prefix}/bin *] {
+          file link -symbolic ${destroot}${prefix}/bin/${script} ../Library/Frameworks/Python.framework/Versions/${python.version}/bin/${script}
+        }
+      }
+    }
+
+    livecheck.type        none
+  }
+}
+


### PR DESCRIPTION
###### Description

This reflects a major change to the building of the NDS2 Client package as the package itself has switched from autotools to CMake
Also included in this change set is the use of subpackages to allow for better control of what portions are installed.

###### Tested on
macOS 10.11.6
Xcode 8.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
