### PR TITLE
offlineimap: fix build

### DIFF
--- a/mail/offlineimap/Portfile
+++ b/mail/offlineimap/Portfile
@@ -43,7 +43,8 @@ python.default_version 27
 
 depends_build       port:py${python.version}-docutils \
                     port:py${python.version}-sphinx \
-                    port:asciidoc
+                    port:asciidoc \
+                    port:docbook-xsl
 
 depends_lib         port:py${python.version}-six
 


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
