### PR TITLE
libepoxy: python is just a build-time dependency

### DIFF
--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -45,22 +45,22 @@ configure.args      --disable-silent-rules \
                     --enable-glx
 
 variant python27 conflicts python34 python35 python36 description {build with python 2.7} {
-    depends_lib-append      port:python27
+    depends_build-append    port:python27
     configure.python        ${prefix}/bin/python2.7
 }
 
 variant python34 conflicts python27 python35 python36 description {build with python 3.4} {
-    depends_lib-append      port:python34
+    depends_build-append    port:python34
     configure.python        ${prefix}/bin/python3.4
 }
 
 variant python35 conflicts python27 python34 python36 description {build with python 3.5} {
-    depends_lib-append      port:python35
+    depends_build-append    port:python35
     configure.python        ${prefix}/bin/python3.5
 }
 
 variant python36 conflicts python27 python34 python35 description {build with python 3.6} {
-    depends_lib-append      port:python36
+    depends_build-append    port:python36
     configure.python        ${prefix}/bin/python3.6
 }
 

--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -44,26 +44,15 @@ configure.cmd       ./autogen.sh
 configure.args      --disable-silent-rules \
                     --enable-glx
 
-variant python27 conflicts python34 python35 python36 description {build with python 2.7} {
+variant python27 conflicts python36 description {build with python 2.7} {
     depends_build-append    port:python27
     configure.python        ${prefix}/bin/python2.7
 }
-
-variant python34 conflicts python27 python35 python36 description {build with python 3.4} {
-    depends_build-append    port:python34
-    configure.python        ${prefix}/bin/python3.4
-}
-
-variant python35 conflicts python27 python34 python36 description {build with python 3.5} {
-    depends_build-append    port:python35
-    configure.python        ${prefix}/bin/python3.5
-}
-
-variant python36 conflicts python27 python34 python35 description {build with python 3.6} {
+variant python36 conflicts python27 description {build with python 3.6} {
     depends_build-append    port:python36
     configure.python        ${prefix}/bin/python3.6
 }
 
-if {![variant_isset python27] && ![variant_isset python34] && ![variant_isset python35]} {
+if {![variant_isset python27]} {
     default_variants-append +python36
 }


### PR DESCRIPTION
###### Description

As title, python is just a build-time dependency for libepoxy. Installed files of libepoxy:
```
  /opt/local/include/epoxy/common.h
  /opt/local/include/epoxy/gl.h
  /opt/local/include/epoxy/gl_generated.h
  /opt/local/include/epoxy/glx.h
  /opt/local/include/epoxy/glx_generated.h
  /opt/local/lib/libepoxy.0.dylib
  /opt/local/lib/libepoxy.dylib
  /opt/local/lib/pkgconfig/epoxy.pc
```
There are no Python scripts or packages. Headers don't have Python.h inclusions, and libraries does not link to libpython.
<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.2.5
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. --> there are no tickets
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? There are no tests
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? GTK+3 OpenGL demo runs, so I guess libepoxy is working
