### PR TITLE
gmt5: Fix hdf5 library search path problem in building

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -112,6 +112,8 @@ variant nonfree conflicts lgpl description {enable nonfree code, libraries and b
     configure.args-append   -DLICENSE_RESTRICTED=no
 }
 
+patchfiles          patch-cmake-modules-FindNETCDF.cmake.diff
+
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     {(?i)gmt-(5\.[0-9]+\.[0-9a-z]+)<\/a>}

--- a/science/gmt5/files/patch-cmake-modules-FindNETCDF.cmake.diff
+++ b/science/gmt5/files/patch-cmake-modules-FindNETCDF.cmake.diff
@@ -1,0 +1,14 @@
+--- cmake/modules/FindNETCDF.cmake.orig	2017-07-12 19:28:09.000000000 +0900
++++ cmake/modules/FindNETCDF.cmake	2017-07-12 19:30:42.000000000 +0900
+@@ -114,7 +114,10 @@
+ foreach (_extralib ${_netcdf_lib})
+ 	find_library (_found_lib_${_extralib}
+ 		NAMES ${_extralib}
+-		PATHS ${_netcdf_libpath})
++		PATHS
++    ${_netcdf_libpath}
++	  ${NETCDF_ROOT}/lib/hdf5-18
++  )
+ 	list (APPEND NETCDF_LIBRARY ${_found_lib_${_extralib}})
+ endforeach (_extralib)
+ 


### PR DESCRIPTION
Indirect dependency library hdf5-18 is installed to
irregular location. Therefore, configuring of this ports fails.
This commit resolves this problem.

fix: https://trac.macports.org/ticket/54467#ticket

You don't face to this problem. If you had already installed hdf5.