### PR TITLE
cargo: update to 0.23.0

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -3,56 +3,83 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rust-lang cargo 0.18.0
+github.setup        rust-lang cargo 0.23.0
 categories          devel
 platforms           darwin
-
-universal_variant   no
+supported_archs     i386 x86_64
 license             {MIT Apache-2}
 maintainers         sean openmaintainer
 
 description         The Rust package manager
-long_description    Cargo downloads your Rust project’s dependencies and compiles your project.
-homepage            http://crates.io
 
-# Fetch from git instead of distfile because it needs submodules
-fetch.type          git
+long_description    Cargo downloads your Rust project’s dependencies and \
+                    compiles your project.
 
-depends_lib         port:rust \
-                    port:pkgconfig
-depends_build       bin:python2.6:python27 \
-                    bin:cmake:cmake \
-                    port:cctools \
-                    port:gawk
+homepage            https://crates.io
 
-depends_skip_archcheck  python27
+depends_build       port:cmake \
+                    bin:curl:curl \
+                    bin:python:python27
 
-build.type          gnu
+depends_lib         port:openssl \
+                    port:rust
 
-# the DYLD_FALLBACK_LIBRARY_PATH is ugly but currently the only way to have
-# rust find the libraries installed via rpath; using install_name_tool wouldn't
-# help in this situation because rust and cargo both download binaries to
-# bootstrap themselves. Since this is just a build argument, I think it's fine
-# for now.
-build.args          VERBOSE=1 \
-                    CC=${configure.cc} \
-                    CXX=${configure.cxx} \
-                    CPP="${configure.cc} -E" \
-                    DYLD_FALLBACK_LIBRARY_PATH="${prefix}/lib"
+# Use an older version of cargo to build itself
+set stage0(version)  0.22.0
+set stage0(platform) ${build_arch}-apple-darwin
 
-destroot.args       VERBOSE=1
-
-post-fetch {
-    system -W ${worksrcpath} "git submodule update --init"
+if {${build_arch} eq "i386"} {
+    set stage0(platform) i686-apple-darwin
 }
 
-post-destroot {
-    move ${destroot}${prefix}/lib/rustlib/components ${destroot}${prefix}/lib/rustlib/components-cargo
-    file delete ${destroot}${prefix}/lib/rustlib/install.log
-    file delete ${destroot}${prefix}/lib/rustlib/uninstall.sh
-    file delete ${destroot}${prefix}/lib/rustlib/rust-installer-version
+set stage0(distname) ${name}-${stage0(version)}-${stage0(platform)}
+set stage0(distfile) ${stage0(distname)}${extract.suffix}
 
-    # move bash-completion file to new location for on-demand loading
-    xinstall -d -m 0755 ${destroot}${prefix}/share/bash-completion/completions
-    move ${destroot}${prefix}/etc/bash_completion.d/cargo ${destroot}${prefix}/share/bash-completion/completions/cargo
+master_sites-append https://static.rust-lang.org/dist/:stage0
+distfiles-append    ${stage0(distfile)}:stage0
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  41b60b68def4cb450304e8c97c6b33d13d2be20a \
+                    sha256  ed88b54b4cccf4ce61bc5033316ac5eeedd9fb436d5a22b7cf9444678a338988 \
+
+if {${build_arch} eq "i386"} {
+    checksums-append \
+                    ${stage0(distfile)} \
+                    rmd160  a3e5641d43fdce80a5414ba15c394d211d256f45 \
+                    sha256  ca1149714d3c537c6ac82e8161387df317f69fb2b386c95dc046d3d37af87edd
+} else {
+    checksums-append \
+                    ${stage0(distfile)} \
+                    rmd160  5c5ef6d93c61c95c786ca5f067236537e45712ab \
+                    sha256  8968697ae6eef3b178438a6d5563f531e499308dcea7f4915665dbcec54c851a
+}
+
+# github.setup sets this to yes, breaking the stage0 fetch
+fetch.ignore_sslcert no
+
+use_configure       no
+
+build.cmd           ${workpath}/${stage0(distname)}/${name}/bin/cargo
+build.target        build
+build.args          --release -j${build.jobs}
+build.env           OPENSSL_DIR=${prefix}
+
+destroot {
+    xinstall ${worksrcpath}/target/release/cargo ${destroot}${prefix}/bin
+
+    xinstall {*}[glob ${worksrcpath}/src/etc/man/*] \
+        ${destroot}${prefix}/share/man/man1
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -W ${worksrcpath} \
+        LICENSE-APACHE LICENSE-MIT LICENSE-THIRD-PARTY README.md \
+        ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d ${destroot}${prefix}/etc/bash_completion.d
+    xinstall ${worksrcpath}/src/etc/cargo.bashcomp.sh \
+        ${destroot}${prefix}/etc/bash_completion.d/${name}
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall ${worksrcpath}/src/etc/_cargo \
+        ${destroot}${prefix}/share/zsh/site-functions
 }


### PR DESCRIPTION
###### Description
Update cargo to 0.23.0. This uses an older version of cargo to build itself.

Relevant tickets: https://trac.macports.org/ticket/53804, https://trac.macports.org/ticket/54308

###### Tested on
macOS 10.12.5
Xcode 8.3.3

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
