### PR TITLE
heimdal: 7.4.0, CVE-2017-11103

### DIFF
--- a/net/heimdal/Portfile
+++ b/net/heimdal/Portfile
@@ -1,38 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                heimdal
-version             1.5.3
-revision            1
-checksums           rmd160  834660b4c0fe81a3aac4ffd9d8d37d74add1fa70 \
-                    sha256  aac27bedb33c341b6aed202af07ccc816146a893148721f8123abbbf93bbfea5
+github.setup        heimdal heimdal 7.4.0 heimdal-
+github.tarball_from releases
+checksums           rmd160  3d25ebc96df785f4d6691b826f59c2584980ff6b \
+                    sha256  3de14ecd36ad21c1694a13da347512b047f4010d176fe412820664cb5d1429ad
 
 maintainers         nomaintainer
 categories          net security
 platforms           darwin
 
-license             BSD MIT Permissive
+license             BSD
 homepage            http://www.h5l.org/
-description         Kerberos is a network authentication protocol.
+description         Heimdal is a Kerberos 5 implementation.
 long_description    \
-    Kerberos provides a means of verifying the identities of principals, (e.g., \
-    a workstation user or a network server) on an open (unprotected) network. \
-    This is accomplished without relying on authentication by the host \
-    operating system, without basing trust on host addresses, without requiring \
-    physical security of all the hosts on the network, and under the assumption \
-    that packets traveling along the network can be read, modified, and \
-    inserted at will.
+    Heimdal is an implementation of Kerberos 5 (and some more stuff) largely \
+    written in Sweden (which was important when we started writing it, less so \
+    now). It is freely available under a three clause BSD style license.
 
-master_sites        ${homepage}dist/src/
+depends_build       port:pkgconfig
 
 depends_lib         port:readline \
-                    port:gettext
-
-# See https://trac.macports.org/ticket/44738, drop when integrated upstream
-# Patch from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=711221
-patch.pre_args      -p1
-patchfiles          heimdal-texi.diff
+                    port:gettext \
+                    port:libtasn1 \
+                    port:libcomerr
 
 # Use a separate prefix to avoid conflicts with the port kerberos5
 # (and openssl, if that variant is selected)
@@ -43,6 +36,7 @@ configure.args      \
     --enable-static            \
     --enable-pthread-support   \
     --with-readline=${prefix}  \
+    --without-libedit          \
     --with-libintl=${prefix}   \
     --without-x                \
     --without-openldap         \
@@ -50,9 +44,6 @@ configure.args      \
     --without-sqlite3
 
 build.env-append    LC_CTYPE=C
-
-# ./kadm5_locl.h:77:10: fatal error: 'kadm5_err.h' file not found
-use_parallel_build  no
 
 variant x11 description \
     {Enable X11 use in libraries, and build X11-related applications} {
@@ -73,13 +64,12 @@ variant openldap description \
     configure.args-append   --with-openldap=${prefix}
 }
 
-# heimdal fails with openssl-1.0.0a due to removal of md2
-#variant openssl description \
-#    {Use OpenSSL libraries instead of internal ones for crypto and ssl related functions} {
-#    depends_lib-append     path:lib/libssl.dylib:openssl
-#    configure.args-delete  --without-openssl
-#    configure.args-append  --with-openssl=${prefix}
-#}
+variant openssl description \
+    {Use OpenSSL libraries instead of internal ones for crypto and ssl related functions} {
+    depends_lib-append     path:lib/libssl.dylib:openssl
+    configure.args-delete  --without-openssl
+    configure.args-append  --with-openssl=${prefix}
+}
 
 variant sqlite3 description \
     {Enable SQlite3 database support for keeping track of Kerberos information} {


### PR DESCRIPTION
Fix license, switch to GitHub, update to 7.4.0 to fix CVE-2017-11103
"Orpheus' Lyre". Re-enable openssl variant, add dependencies on libtasn1
and libcomerr to prevent building of a local version.

Add pkg-config dependency since the build system uses pkg-config.

###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12.5
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
