### PR TITLE
py-mpi4py: Add py36-mpi4py subport

### DIFF
--- a/python/py-mpi4py/Portfile
+++ b/python/py-mpi4py/Portfile
@@ -30,7 +30,7 @@ checksums           rmd160  1f345e24ffeb1c07e7260ecf291c28c1d1e936ba \
 
 mpi.setup           require
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
New subport: py36-mpi4py. Builds and runs fine using Python 3.6.1_1 from macports.