### PR TITLE
bitkeeper: move to libexec to obey standard layout

### DIFF
--- a/devel/bitkeeper/Portfile
+++ b/devel/bitkeeper/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                bitkeeper
 version             7.3.1ce
+revision            1
 categories          devel
 platforms           darwin
 supported_archs     x86_64
@@ -43,12 +44,12 @@ build.args-append   CC=${configure.cc} \
                     CXXFLAGS="${configure.cxxflags}" \
                     LDFLAGS="${configure.ldflags}"
 
-destroot.args       BINDIR=${prefix}/bitkeeper
+destroot.args       BINDIR=${prefix}/libexec/bitkeeper
 
 post-destroot {
-    ln -s ${prefix}/bitkeeper/bk ${destroot}${prefix}/bin/bk
-    foreach manpage [glob -tails -directory ${destroot}${prefix}/bitkeeper/man/man1 bk.1 bk-*] {
-        ln -s ${prefix}/bitkeeper/man/man1/${manpage} ${destroot}${prefix}/share/man/man1/${manpage}
+    ln -s ${prefix}/libexec/bitkeeper/bk ${destroot}${prefix}/bin/bk
+    foreach manpage [glob -tails -directory ${destroot}${prefix}/libexec/bitkeeper/man/man1 bk.1 bk-*] {
+        ln -s ${prefix}/libexec/bitkeeper/man/man1/${manpage} ${destroot}${prefix}/share/man/man1/${manpage}
     }
 }
 


### PR DESCRIPTION
###### Description
Fixes
```
Warning: violation by /opt/local/bitkeeper
Warning: bitkeeper violates the layout of the ports-filesystems!
Warning: Please fix or indicate this misbehavior (if it is intended), it will be an error in future releases!
```

Blocked by #592 to save a revision bump.

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
