### PR TITLE
gradle: update to 4.0.1

### DIFF
--- a/devel/gradle/Portfile
+++ b/devel/gradle/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gradle
-version             4.0
+version             4.0.1
 categories          devel java groovy
 license             Apache-2
 maintainers         madlon-kay.com:aaron+macports openmaintainer
@@ -15,13 +15,13 @@ long_description    Gradle is a build system which offers you ease, power and fr
                     integration for Ivy. It gives you always the choice between the flexibility \
                     of Ant and the convenience of a build-by-convention behavior.
 
-homepage            http://www.gradle.org/
+homepage            https://gradle.org/
 platforms           darwin
 distname            ${name}-${version}-bin
 master_sites        https://services.gradle.org/distributions
 
-checksums           rmd160  92a1b1ae0463ac505cd28e27628855a379b31070 \
-                    sha256  56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe
+checksums           rmd160  1e202205daac63dfb17c7ab1ecb55145787b613d \
+                    sha256  d717e46200d1359893f891dab047fdab98784143ac76861b53c50dbd03b44fd4
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
###### Description

Updated to Gradle 4.0.1 and changed website URL to HTTPS version.

###### Tested on
macOS 10.12.5
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
