### PR TITLE
neomutt: drop --disable-warnings

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -36,7 +36,6 @@ configure.args      --disable-debug \
                     --disable-gpgme \
                     --disable-notmuch \
                     --disable-silent-rules \
-                    --disable-warnings \
                     --mandir=${prefix}/share/man \
                     --with-docdir=${prefix}/share/doc/mutt \
                     --with-libiconv-prefix=${prefix} \


### PR DESCRIPTION
###### Description
`configure: WARNING: unrecognized options: --disable-warnings`

See neomutt/neomutt@2a463faedb373a9095e1ceec39632f57243839d1.

neomutt port was updated in 097f873cf6bcdea18441f85a85fceec5035b975a.

@lbschenkel

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
