### PR TITLE
byobu: new port at 5.119

### DIFF
--- a/sysutils/byobu/Portfile
+++ b/sysutils/byobu/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                byobu
+version             5.119
+categories          sysutils
+platforms           darwin
+license             GPL-3
+maintainers         {l2dy @l2dy} openmaintainer
+description         open source text-based window manager and terminal multiplexer
+long_description    Byobu is a GPLv3 open source text-based window manager and \
+                    terminal multiplexer. It was originally designed to provide \
+                    elegant enhancements to the otherwise functional, plain, \
+                    practical GNU Screen, for the Ubuntu server distribution. \
+                    Byobu now includes an enhanced profiles, convenient \
+                    keybindings, configuration utilities, and toggle-able system \
+                    status notifications for both the GNU Screen window manager \
+                    and the more modern Tmux terminal multiplexer, and works on \
+                    most Linux, BSD, and Mac distributions.
+homepage            http://byobu.co/
+master_sites        https://launchpad.net/byobu/trunk/${version}/+download/
+distname            ${name}_${version}.orig
+worksrcdir          ${name}-${version}
+
+checksums           rmd160  0fd0a3e66d2166370d8c3ed707ea26d29c4ec0e3 \
+                    sha256  4b092ca12d3a33e89d84cc90c4a41af2ba8697d48e26080a45d64d6b7800ca77
+
+depends_run         port:coreutils \
+                    port:tmux
+
+livecheck.type      regex
+livecheck.url       https://launchpad.net/byobu/+download
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*).orig${extract.suffix}


### PR DESCRIPTION
###### Description
I'm not sure if we need gsed as dependency.
`byobu-config` is broken, see https://trac.macports.org/ticket/44044.
`ERROR: Could not import the python snack module`

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
