### PR TITLE
iperf3: update to 3.2

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           snowleopard_fixes 1.0
 
-github.setup        esnet iperf 3.1.7
+github.setup        esnet iperf 3.2
 name                iperf3
 categories          net
 platforms           darwin
@@ -18,8 +19,10 @@ long_description    ${name} is a tool for active measurements of the maximum \
 
 conflicts           ${name}-devel
 
-checksums           rmd160  eae80e399734d3e9e26222105ee1fbd6fb8d8e2f \
-                    sha256  a1beff784aab49e5ccd6a13b1525be849fb9afce83d4c87693342492a6eea1c4
+checksums           rmd160  3cec3959b047dace2ba9598db2d236316cfa2593 \
+                    sha256  9b5b6709ae294217c573fe8e9d88f59ddedf599f9b44af22355e57e38997acc2
+
+depends_lib-append  port:openssl
 
 test.run            yes
 test.target         check
@@ -32,15 +35,12 @@ post-destroot {
 }
 
 subport ${name}-devel {
-    PortGroup           snowleopard_fixes 1.0
     github.setup        esnet iperf 88d907f7fb58bfab5d086c5da60c922e1c582c92
     version             20170626
     revision            1
 
     checksums           rmd160  3793eefb303ffebadbbe6ba2055683c1eca15374 \
                         sha256  3098ae6787da9ba08dad6cb6329d3b6282f058711033ff7edbb6ad145cd6d088
-
-    depends_lib-append  port:openssl
 
     conflicts           ${name}
 


### PR DESCRIPTION
###### Description
Is openssl needed as depends_lib in iperf3 too?

@aque 

<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
