### PR TITLE
mongo-tools: update to 3.5.10, use the right compiler

### DIFF
--- a/devel/mongo-tools/Portfile
+++ b/devel/mongo-tools/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        mongodb mongo-tools 3.4.6 r
+github.setup        mongodb mongo-tools 3.5.10 r
 categories          devel
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -27,14 +27,15 @@ long_description    mongo-tools is a collection of utilities for working with \
                     \n* mongotop: Monitor read/write activity on a mongo server \
                     \n* mongoreplay: Inspect and record commands sent to a MongoDB instance, and then replay the commands back onto another host at a later time
 
-checksums           rmd160  d5ffafcb450acc088cd17141112501ee8a9ef3eb \
-                    sha256  3dd91a69ae3592c9def9760af3e8d0eb871406ec3471fd7f87e8da1ad6fc1bdd
+checksums           rmd160  0ba364cca4ffdf81521036410f51d6024fc9ee7e \
+                    sha256  66d0f4bb49aa4e0675dde61985a185fc37ab27f67a3e6fe15c070291917b94fb
 
 depends_build       port:go
 
 use_configure       no
 
 build.cmd           ./build.sh
+build.env           CC=${configure.cc}
 
 destroot {
     copy {*}[glob ${worksrcpath}/bin/*] ${destroot}${prefix}/bin/


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
