### PR TITLE
nginx: Add http2 to default variants

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -118,7 +118,7 @@ notes "\
     Additionally, the files [join ${auto_activate_confs} ", "] have been copied to ${nginx_confdir} if they didn't exist yet.\n\
     Adjust these files to your needs before starting nginx."
 
-default_variants +mp4 +flv +secure_link +ssl
+default_variants +mp4 +flv +secure_link +ssl +http2
 
 variant auth_request description {Add client authorization based on the result of a subrequest} {
     configure.args-append   --with-http_auth_request_module


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/54509

###### Description

Change the default variants to include HTTP/2.