### PR TITLE
fzy: new port at 0.9

### DIFF
--- a/devel/fzy/Portfile
+++ b/devel/fzy/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        jhawthorn fzy 0.9
+categories          devel
+platforms           darwin
+license             MIT
+
+maintainers         {darkcog.com:casr @casr} openmaintainer
+description         A better fuzzy finder
+long_description    fzy tries to find the result the user intended. It does \
+                    this by favouring matches on consecutive letters and \
+                    starts of words. This allows matching using acronyms or \
+                    different parts of the path.
+
+checksums           sha256 f5e122251d41527007c0675276f414534337b5814d1bb6d23587f7a3dcc91de4 \
+                    rmd160 e278ef08985c476c7c70c6f870ea301abaecc6c9
+
+use_configure       no
+test.run            yes
+destroot.destdir    DESTDIR=${destroot} PREFIX=${prefix}


### PR DESCRIPTION
###### Description

A better fuzzy finder. `fzy` tries to find the result the user intended. It does this by favouring matches on consecutive letters and starts of words. This allows matching using acronyms or different parts of the path.

###### Tested on
macOS 10.12.4
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
