### PR TITLE
fzy: pass on universal build flags

### DIFF
--- a/devel/fzy/Portfile
+++ b/devel/fzy/Portfile
@@ -18,5 +18,6 @@ checksums           sha256 f5e122251d41527007c0675276f414534337b5814d1bb6d23587f
                     rmd160 e278ef08985c476c7c70c6f870ea301abaecc6c9
 
 use_configure       no
-test.run            yes
+build.args-append   CC="${configure.cc} [get_canonical_archflags cc]"
 destroot.destdir    DESTDIR=${destroot} PREFIX=${prefix}
+test.run            yes


### PR DESCRIPTION
###### Tested on
macOS 10.12.4
Xcode 8.3.3

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
