### PR TITLE
mosh: update to 1.3.2, use https

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               perl5 1.0
 
 name                    mosh
-version                 1.3.0
+version                 1.3.2
 categories              net
 license                 {GPL-3+ OpenSSLException}
 platforms               darwin
@@ -13,11 +13,11 @@ description             Mobile Shell
 long_description        Mosh is a replacement for ssh that better handles \
                         high-latency, high-packet-loss, dynamically-addressed \
                         network links
-homepage                http://mosh.org/
+homepage                https://mosh.org/
 master_sites            ${homepage}
 
-checksums               rmd160  83f737acdbd79a217d55bbb41631a7a8fb865b30 \
-                        sha256  320e12f461e55d71566597976bd9440ba6c5265fa68fbf614c6f1c8401f93376
+checksums               rmd160  09cec7da65f525c4a414c1506d153ac72ea38c8a \
+                        sha256  da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216
 
 perl5.require_variant   yes
 perl5.conflict_variants no


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
