### PR TITLE
py-gnupg: New port

### DIFF
--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem           1.0
+PortGroup            python 1.0
+
+name                 py-gnupg
+version              0.4.1
+
+description          A Python wrapper for GnuPG
+long_description     The gnupg module allows Python programs to make use of \
+                     the functionality provided by the GNU Privacy Guard \
+                     (abbreviated GPG or GnuPG). Using this module, Python \
+                     programs can encrypt and decrypt data, digitally sign \
+                     documents and verify digital signatures, manage \
+                     (generate, list and delete) encryption keys, using \
+                     proven Public Key Infrastructure (PKI) encryption \
+                     technology based on OpenPGP.
+license              BSD
+homepage             https://pythonhosted.org/python-gnupg/
+
+categories-append    crypto security
+platforms            darwin
+maintainers          {@F30 f30.me:f30} openmaintainer
+
+python.versions      27 34 35 36
+depends_run          bin:gpg:gnupg
+
+master_sites         pypi:p/python-gnupg
+distname             python-gnupg-${version}
+checksums            rmd160  fe08a67d68e1c828e6f587d8aef1dc3b2c0a9432 \
+                     sha256  ef47b02eaf41dee3cf4b02ddf83130827318de9fe3eae89d01a3f05859e20e1a
+
+# See https://bitbucket.org/vinay.sajip/python-gnupg/pull-requests/19
+patchfiles           patch-gnupg.py.diff
+
+# Only enable tests for individual subports as otherwise `${python.bin}` is not
+# available
+if {${subport} ne ${name}} {
+    test.run         yes
+    test.cmd         ${python.bin} test_gnupg.py
+}

--- a/python/py-gnupg/files/patch-gnupg.py.diff
+++ b/python/py-gnupg/files/patch-gnupg.py.diff
@@ -1,0 +1,11 @@
+--- gnupg.py.orig	2017-07-06 16:09:20.000000000 +0200
++++ gnupg.py	2017-07-23 23:38:23.000000000 +0200
+@@ -687,7 +687,7 @@
+         else:  # pragma: no cover
+             logger.debug('message ignored: %s, %s', key, value)
+ 
+-VERSION_RE = re.compile(r'gpg \(GnuPG\) (\d+(\.\d+)*)'.encode('ascii'), re.I)
++VERSION_RE = re.compile(r'gpg \(GnuPG(?:/MacGPG2)?\) (\d+(\.\d+)*)'.encode('ascii'), re.I)
+ HEX_DIGITS_RE = re.compile(r'[0-9a-f]+$', re.I)
+ 
+ class GPG(object):


### PR DESCRIPTION
###### Description
This adds a port for [vsajip/python-gnupg](https://github.com/vsajip/python-gnupg), which is called "python-gnupg" on PyPI and also packaged in Debian. It appears to be the more popular version in general.

Alternatively, there is the rewrite [isislovecruft/python-gnupg](https://github.com/isislovecruft/python-gnupg) called "gnupg" on PyPI. To avoid name conflicts, this port could be called "py-python-gnupg", but that would still mean a clash for Python module "gnupg".

###### Tested on
macOS 10.12.6
Xcode 8.3.2

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?