### PR TITLE
curl-ca-bundle: update to be884de5820a / NSS 3.32

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -207,7 +207,7 @@ if {${name} eq ${subport}} {
 }
 
 subport curl-ca-bundle {
-    revision                    0
+    revision                    1
     categories                  net
     license                     {MPL-2 LGPL-2.1+}
     supported_archs             noarch
@@ -225,8 +225,8 @@ subport curl-ca-bundle {
     set certdata_file           certdata.txt
     # The output of the Tcl command "clock seconds" (you can run it in tclsh) when
     # the certdata.txt file in the port was last updated.
-    set certdata_updated        1491974200
-    set certdata_version        53be95383c09
+    set certdata_updated        1500995000
+    set certdata_version        be884de5820a
     set certdata_distfile       certdata-${certdata_version}${extract.suffix}
     set certdata_path           security/nss/lib/ckfw/builtins/${certdata_file}
 
@@ -240,8 +240,8 @@ subport curl-ca-bundle {
     distfiles-append            ${certdata_distfile}:certdata
 
     checksums-append            ${certdata_distfile} \
-                                rmd160  edd4628c626930bf182ccd023d99116679b2d6a8 \
-                                sha256  7fc7748de4376c581731de3c02c7fd01c94a9f0e6f4afe4c7110d76b9ae32a5b
+                                rmd160  f923926b7c5537cd04e27f1be4c1538f099eb4bf \
+                                sha256  94f67c4c88e8655d720d7c5f9332391899fe0a96ca1d2d1370f476e718ffb760
 
     extract.only                ${certdata_distfile}
 

--- a/net/curl/files/patch-no-autodownload.diff
+++ b/net/curl/files/patch-no-autodownload.diff
@@ -1,6 +1,6 @@
---- Makefile.orig	2016-11-02 01:55:09.000000000 -0500
-+++ Makefile	2016-11-03 01:06:30.000000000 -0500
-@@ -579,7 +579,7 @@
+--- Makefile.orig	2017-06-14 06:13:06.000000000 +0000
++++ Makefile	2017-07-25 15:30:42.000000000 +0000
+@@ -144,7 +144,7 @@
  
  ca-bundle: lib/mk-ca-bundle.pl
  	@echo "generate a fresh ca-bundle.crt"


### PR DESCRIPTION
###### Description


<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
