### PR TITLE
botan: respect -stdlib settings when building with clang

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -35,6 +35,14 @@ if {[string match *clang* ${configure.compiler}]} {
   configure.args-append --cc=gcc
 }
 
+# add the selected -stdlib to clang builds
+# see https://trac.macports.org/ticket/53123
+set cxx_stdlibflags {}
+if {[string match *clang* ${configure.cxx}]} {
+    set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+}
+configure.cxx ${configure.cxx} ${cxx_stdlibflags}
+
 destroot.destdir    DESTDIR=${destroot}${prefix}
 
 platform darwin { configure.args-append --os=darwin }


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/53123

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.7
Xcode 4.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
