### PR TITLE
qt5-qtcreator: add prefetch block for incompatible systems

### DIFF
--- a/devel/qt5-qtcreator/Portfile
+++ b/devel/qt5-qtcreator/Portfile
@@ -26,6 +26,15 @@ master_sites        https://download.qt.io/official_releases/qtcreator/[join [lr
 
 checksums           rmd160  200b302418f4e0387df1713326ff78be099668f2 \
                     sha256  db43c796adf11f02fd22d01820678cd118fc5bd9a7bb5d2d76ed0f86e0dd8a69
+                    
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    # last version that runs on lion is 3.6.1
+        ui_error "${name} only runs on Mac OS X 10.8 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
 
 # qtcreator does not depend directly on openssl
 # qtcreator links against QtNetwork.framework, and any OpenSSL functionality


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7
Xcode 4.63

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
