### PR TITLE
notmuch: update to 0.25

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           conflicts_build 1.0
 
 name                notmuch
-version             0.24.2
+version             0.25
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -19,8 +19,8 @@ long_description    \"Not much mail\" is what Notmuch thinks about your email \
 homepage            http://notmuchmail.org/
 master_sites        ${homepage}releases/
 
-checksums           rmd160  fe851236764b3d933446d65b8facb45c58c54cef \
-                    sha256  aa76a96684d5c5918d940182b6fe40f7d6745f144476fdda57388479d586cc51
+checksums           rmd160  75a3c6e42a89c9f575799f4319f485377a659901 \
+                    sha256  65d28d1f783d02629039f7d15d9a2bada147a7d3809f86fe8d13861b0f6ae60b
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
###### Description
Should I revbump `notmuch-addrlookup` and `alot`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
