### PR TITLE
spring-boot-cli: Update to 1.5.6

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.4
+version         1.5.6
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  fb1879a5c1a9776f3d29a32ec88a91b24ead3389 \
-                sha256  630bb7546fd0251ca8691193a2b70558ec41c12de4fa2e09e54bce31a4605b19
+checksums       rmd160  e8f1b35242a641eea6a56010060a04674dd1ee2f \
+                sha256  d129e7952f8cc687da436db1fff091991e8b85500894e3bc655ecbda7da6d8ae
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
###### Description

Update to Spring Boot CLI 1.5.6.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
