### PR TITLE
Salt: update to 2017.7.1

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -1,16 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
+PortSystem        1.0
 
-name                salt
-version             2017.5
-revision            1
-categories          sysutils
-platforms           darwin
-maintainers         gmail.com:jeremy.mcmillan
-license             Apache-2
-supported_archs     noarch
-description         Salt is a Python-based remote execution, automation, \
+name               salt
+version            2017.7.1
+categories         sysutils python
+platforms          darwin
+maintainers        {@aphor gmail.com:jeremy.mcmillan}
+license            Apache-2
+supported_archs    noarch
+description        Salt is a Python-based remote execution, automation, \
                     configuration, and orchestration engine.
 long_description    SaltStack is fast, scalable and flexible software for data \
                     center automation, from infrastructure and any cloud, \
@@ -18,42 +17,94 @@ long_description    SaltStack is fast, scalable and flexible software for data \
 homepage            http://saltstack.com/
 
 if {$subport eq $name} {
-    PortGroup           github 1.0
-    PortGroup           python 1.0
+    PortGroup               github 1.0
+    PortGroup               python 1.0
 
-    github.setup        saltstack salt ${version} v
+    github.setup            saltstack salt ${version} v
 
-    python.default_version 27
+    python.versions         27 34 35 36
+    categories              sysutils python
 
-    checksums           rmd160  0a1472ead01e543d0a39007f65406030943e5cf2 \
-                        sha256  90a27911216be7485c36182e6953b19a857ecd560a138f49b3b40c802e976ffe
+    checksums           rmd160  fe86b7cb73d1836301796f62e8a5fc4e200d43ad \
+                        sha256  ea256ee31f7fd9057f843fa1f496a535cf0a41a02d190319d6fb66ea202fe4ee
 
-    depends_build       port:py${python.version}-setuptools
+    notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
+    
+    default_variants    +python27
+    
+    variant python27 conflicts python34 python35 python36 description {experimental python-2.7 support} {
+        python.default_version 27
+        depends_build       port:py${python.version}-setuptools
+    
+        depends_lib-append  port:py${python.version}-yaml \
+                            port:py${python.version}-jinja2 \
+                            port:py${python.version}-msgpack \
+              port:py${python.version}-tornado \
+              port:py${python.version}-zmq
+                            
+        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
+    }
+    
+    variant python34 conflicts python27 python35 python36 description {experimental python-3.4 support} {
+        python.default_version 34
+        depends_build       port:py${python.version}-setuptools
+    
+        depends_lib-append  port:py${python.version}-yaml \
+                            port:py${python.version}-jinja2 \
+                            port:py${python.version}-msgpack \
+              port:py${python.version}-tornado \
+              port:py${python.version}-zmq
+                            
+        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
+                "Support for Python 3 versions is experimental."
+    }
+    
+    variant python35 conflicts python27 python34 python36 description {experimental python-3.5 support} {
+        python.default_version 35
+        depends_build       port:py${python.version}-setuptools
+    
+        depends_lib-append  port:py${python.version}-yaml \
+                            port:py${python.version}-jinja2 \
+                            port:py${python.version}-msgpack \
+              port:py${python.version}-tornado \
+              port:py${python.version}-zmq
+                            
+        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
+                "Support for Python 3 versions is experimental."
+    }
+    
+    variant python36 conflicts python27 python34 python35 description {experimental python-3.6 support} {
+        python.default_version 36
+        depends_build       port:py${python.version}-setuptools
+    
+        depends_lib-append  port:py${python.version}-yaml \
+                            port:py${python.version}-jinja2 \
+                            port:py${python.version}-msgpack \
+              port:py${python.version}-tornado \
+              port:py${python.version}-zmq
+                            
+        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
+                "Support for Python 3 versions is experimental."
+    }
+}
 
-    depends_lib-append  port:py${python.version}-crypto \
-                        port:py${python.version}-jinja2 \
-                        port:py${python.version}-msgpack \
-                        port:py${python.version}-pip \
-                        port:py${python.version}-yaml \
-                        port:py${python.version}-tornado \
-                        port:py${python.version}-zmq \
-                        port:swig-python
-
-    notes   "salt startupitems are now installed by subports salt-minion, salt-master, salt-syndic, salt-api"
+test {
+    system -W ${worksrcpath}/build \
+        "PYTHONPATH=${worksrcpath}/build/lib ${python.bin} scripts-${python.branch}/salt-call --log-file=${worksrcpath}/build/minion.log --config-dir=${worksrcpath}/conf --local test.versions_information"
 }
 
 foreach daemon [list minion master syndic api] {
     subport salt-${daemon} {
-        startupitem.create      yes
-        startupitem.name        salt-${daemon}
-        startupitem.netchange   yes
-        startupitem.logevents   yes
-        startupitem.logfile     ${prefix}/var/log/salt/${daemon}
-        startupitem.executable  ${prefix}/bin/salt-${daemon} --config-dir=${prefix}/etc/salt --pid-file=${prefix}/var/run/salt-${daemon}.pid
-        depends_run             port:salt
-        description             install startupitem for salt-${daemon}
+        startupitem.create       yes
+        startupitem.name         salt-${daemon}
+        startupitem.netchange    yes
+        startupitem.logevents    yes
+        startupitem.logfile      ${prefix}/var/log/salt/${daemon}
+        startupitem.executable   ${prefix}/bin/salt-${daemon} --config-dir=${prefix}/etc/salt --pid-file=${prefix}/var/run/salt-${daemon}.pid
+        depends_run              port:salt
+        description              install startupitem for salt-${daemon}
+        use_configure            no
         distfiles
-        configure {}
         build {}
         destroot {}
     }


### PR DESCRIPTION
###### Description
Rev salt to 2017.7.1 (Nitrogen) release #54665 CVE-2017-12791
https://trac.macports.org/ticket/54665

changes:
* variants for python versions updated to include zmq, tornado deps
* variants for zmq, tornado transports, gitfs using pygit2 or gitpython removed to ease build test server load

[skip notification]
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [X] bugfix
- [] enhancement
- [X] security fix

###### Tested on
macOS 10.12
Xcode 8.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
