### PR TITLE
HexFiend: Update to 2.8.0

### DIFF
--- a/editors/HexFiend/Portfile
+++ b/editors/HexFiend/Portfile
@@ -2,11 +2,12 @@
 
 PortSystem      1.0
 PortGroup       xcode 1.0
+PortGroup       xcodeversion 1.0
 PortGroup       github 1.0
 
-github.setup    ridiculousfish HexFiend 2.4.0 v
-checksums       rmd160  bc1b3dc44bbd9ab723a54241792c4ceccc67f5fd \
-                sha256  efea3f3cea6eed01bb35bb62ab43d0e01132abcd3c50f50ac6bec65221029d93
+github.setup    ridiculousfish HexFiend 2.8.0 v
+checksums       rmd160  24e73c3f4f4b6a9c6b672c1e36c8e13900105e52 \
+                sha256  2745472970e81e390d250374fcfb0a1e96544f549c8b1edad9145aa42dfab858
 
 epoch           1
 categories      editors aqua
@@ -26,8 +27,13 @@ long_description \n\
     * Smooth scrolling. No separate pages - scroll like any text document.
 
 supported_archs x86_64
+macosx_deployment_target 10.7
+
+# The project only works with Xcode >= 8
+minimum_xcodeversions {11 8.0}
+
 patch.pre_args  -p1
-patchfiles      disable-sparkle.patch
+patchfiles      0001-xcode-Disable-Sparkle.patch
 
 if {${subport} eq ${name}} {
     description     HexFiend is a fast and clever hex editor

--- a/editors/HexFiend/files/0001-xcode-Disable-Sparkle.patch
+++ b/editors/HexFiend/files/0001-xcode-Disable-Sparkle.patch
@@ -1,15 +1,30 @@
---- a/HexFiend_2.xcodeproj/project.pbxproj.orig	2017-01-27 00:29:05.000000000 +0100
-+++ b/HexFiend_2.xcodeproj/project.pbxproj	2017-01-27 00:30:30.000000000 +0100
-@@ -33,8 +33,6 @@
+From 06f14db92845806d64eade57cac354748e434700 Mon Sep 17 00:00:00 2001
+From: Clemens Lang <cal@macports.org>
+Date: Mon, 31 Jul 2017 22:30:35 +0200
+Subject: [PATCH] xcode: Disable Sparkle
+
+For use in packaging, we don't want Sparkle.framework to self-update the
+application and overwriting the files installed by the package manager.
+
+Upstream-Status: Inapropriate [configuration]
+---
+ HexFiend_2.xcodeproj/project.pbxproj | 111 -----------------------------------
+ 1 file changed, 111 deletions(-)
+
+diff --git a/HexFiend_2.xcodeproj/project.pbxproj b/HexFiend_2.xcodeproj/project.pbxproj
+index 455d525..3f3c203 100755
+--- a/HexFiend_2.xcodeproj/project.pbxproj
++++ b/HexFiend_2.xcodeproj/project.pbxproj
+@@ -32,8 +32,6 @@
  		9408FC0E19DD7C87004F800E /* HexFiend.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01E7BB80CDC530C00943F9E /* HexFiend.framework */; };
  		9408FC1019DD8669004F800E /* HFPrivilegedHelperConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9408FC0F19DD8669004F800E /* HFPrivilegedHelperConnection.h */; };
  		940C4E6A183C11E20009AFDA /* HexFiend.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01E7BB80CDC530C00943F9E /* HexFiend.framework */; };
 -		94548A4D19DC5218006EFA29 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94548A4219DC51FF006EFA29 /* Sparkle.framework */; };
 -		94548A4E19DC5218006EFA29 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 94548A4219DC51FF006EFA29 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
- 		9483479019DE188E0086A732 /* HFTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 9483478F19DE188E0086A732 /* HFTest.h */; };
  		9483479319DE1C8E0086A732 /* NaiveArray.m in Sources */ = {isa = PBXBuildFile; fileRef = D06D60A40FA7E980002376EE /* NaiveArray.m */; };
  		9483479419DE1C920086A732 /* TreeEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = D06D60BC0FA7EA23002376EE /* TreeEntry.m */; };
-@@ -205,62 +203,6 @@
+ 		9483479519DE1C950086A732 /* BTree_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = D06D60A50FA7E980002376EE /* BTree_Test.m */; };
+@@ -202,76 +200,6 @@
  /* End PBXBuildFile section */
  
  /* Begin PBXContainerItemProxy section */
@@ -69,10 +84,24 @@
 -			remoteGlobalIDString = 726B2B5D1C645FC900388755;
 -			remoteInfo = "UI Tests";
 -		};
+-		A5688D511E908B2100C3CED6 /* PBXContainerItemProxy */ = {
+-			isa = PBXContainerItemProxy;
+-			containerPortal = 94548A3619DC51FE006EFA29 /* Sparkle.xcodeproj */;
+-			proxyType = 2;
+-			remoteGlobalIDString = 722954B41D04ADAF00ECF9CA;
+-			remoteInfo = fileop;
+-		};
+-		A5688D531E908B2100C3CED6 /* PBXContainerItemProxy */ = {
+-			isa = PBXContainerItemProxy;
+-			containerPortal = 94548A3619DC51FE006EFA29 /* Sparkle.xcodeproj */;
+-			proxyType = 2;
+-			remoteGlobalIDString = 5AE13FB31E0D9E07000D2C2C;
+-			remoteInfo = generate_appcast;
+-		};
  		D039DBFF1481C17C00364FA6 /* PBXContainerItemProxy */ = {
  			isa = PBXContainerItemProxy;
  			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
-@@ -299,7 +241,6 @@
+@@ -310,7 +238,6 @@
  			dstSubfolderSpec = 10;
  			files = (
  				D047E4CA1022E1CA00EF307B /* HexFiend.framework in CopyFiles */,
@@ -80,15 +109,15 @@
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -342,7 +283,6 @@
+@@ -352,7 +279,6 @@
  		9408FBFD19DD72DE004F800E /* Framework_Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Framework_Tests-Info.plist"; sourceTree = "<group>"; };
  		9408FBFE19DD72DF004F800E /* Framework_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Framework_Tests.m; sourceTree = "<group>"; };
  		9408FC0F19DD8669004F800E /* HFPrivilegedHelperConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HFPrivilegedHelperConnection.h; path = sources/HFPrivilegedHelperConnection.h; sourceTree = "<group>"; };
 -		94548A3619DC51FE006EFA29 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = third_party/Sparkle/Sparkle.xcodeproj; sourceTree = SOURCE_ROOT; };
  		9483478F19DE188E0086A732 /* HFTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HFTest.h; sourceTree = "<group>"; };
- 		D00122E10D48A8D400540B10 /* HFFindReplaceBackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HFFindReplaceBackgroundView.h; path = app/sources/HFFindReplaceBackgroundView.h; sourceTree = "<group>"; };
- 		D00122E20D48A8D400540B10 /* HFFindReplaceBackgroundView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HFFindReplaceBackgroundView.m; path = app/sources/HFFindReplaceBackgroundView.m; sourceTree = "<group>"; };
-@@ -551,7 +491,6 @@
+ 		A56D78141E7EF088001D1892 /* CLIController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLIController.h; path = app/sources/CLIController.h; sourceTree = "<group>"; };
+ 		A56D78151E7EF088001D1892 /* CLIController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLIController.m; path = app/sources/CLIController.m; sourceTree = "<group>"; };
+@@ -559,7 +485,6 @@
  				795F46C314BAADB600EB2F7D /* DiskArbitration.framework in Frameworks */,
  				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
  				94ECCBC01BDF7DD2007FF44E /* HexFiend.framework in Frameworks */,
@@ -96,7 +125,7 @@
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -651,7 +590,6 @@
+@@ -660,7 +585,6 @@
  		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
  			isa = PBXGroup;
  			children = (
@@ -104,7 +133,7 @@
  				795F46C214BAADB600EB2F7D /* DiskArbitration.framework */,
  				D0D4BE84146F43A1001B0A71 /* ServiceManagement.framework */,
  				D05984CB1032C6D900059E72 /* Security.framework */,
-@@ -691,9 +629,6 @@
+@@ -703,9 +627,6 @@
  		94548A3719DC51FE006EFA29 /* Products */ = {
  			isa = PBXGroup;
  			children = (
@@ -114,7 +143,7 @@
  				94548A4819DC51FF006EFA29 /* BinaryDelta */,
  				94548A4A19DC51FF006EFA29 /* Autoupdate.app */,
  				A5056D5E1DDA6F6200DA325F /* UI Tests.xctest */,
-@@ -1273,7 +1208,6 @@
+@@ -1278,7 +1199,6 @@
  			projectReferences = (
  				{
  					ProductGroup = 94548A3719DC51FE006EFA29 /* Products */;
@@ -122,7 +151,7 @@
  				},
  			);
  			projectRoot = ../..;
-@@ -1289,27 +1223,6 @@
+@@ -1294,27 +1214,6 @@
  /* End PBXProject section */
  
  /* Begin PBXReferenceProxy section */
@@ -150,7 +179,7 @@
  		94548A4819DC51FF006EFA29 /* BinaryDelta */ = {
  			isa = PBXReferenceProxy;
  			fileType = "compiled.mach-o.executable";
-@@ -1525,16 +1438,6 @@
+@@ -1558,16 +1457,6 @@
  /* End PBXSourcesBuildPhase section */
  
  /* Begin PBXTargetDependency section */
@@ -167,3 +196,6 @@
  		D039DC001481C17C00364FA6 /* PBXTargetDependency */ = {
  			isa = PBXTargetDependency;
  			target = D047E3141022CEFE00EF307B /* FortunateSon (PrivilegedHelper) */;
+-- 
+2.13.3
+


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/54549
Closes: https://trac.macports.org/ticket/53486

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
