### PR TITLE
nsis: update to 3.02.1

### DIFF
--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                nsis
-version             3.02
+version             3.02.1
 set major           [lindex [split ${version} .] 0]
 categories          devel
 license             zlib CPL-1 MIT
@@ -26,11 +26,11 @@ distfiles-append    nsis-${version}.zip
 extract.only-delete nsis-${version}.zip
 
 checksums           nsis-${version}-src.tar.bz2 \
-                    rmd160  fda75f98f8c0dbb719c60493bc2d80f4c074889f \
-                    sha256  c44ad18462c56ada4b4303513997076b960f7a991993c5c43ae0edb4936dd83d \
+                    rmd160  209f4234ba4199cbcce6843a6c8c5d06030e84d3 \
+                    sha256  5f6d135362c70f6305317b3af6d8398184ac1a22d3f23b9c4164543c13fb8d60 \
                     nsis-${version}.zip \
-                    rmd160  f9caa343e1bf5cdbde6c6bf45555b1454290d145 \
-                    sha256  b63bf7cb1e2522754ccb5628e54277f553bc6810d6229d0fe7eb1d78b3457206
+                    rmd160  61fef3ba08ab0ee726b194148899a67da0502220 \
+                    sha256  deef3e3d90ab1a9e0ef294fff85eead25edbcb429344ad42fc9bc42b5c3b1fb5
 
 depends_build       port:scons
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
