### PR TITLE
py-agate: update to 1.6

### DIFF
--- a/python/py-agate/Portfile
+++ b/python/py-agate/Portfile
@@ -5,8 +5,7 @@ PortGroup           python 1.0
 
 set base_name       agate
 name                py-$base_name
-version             1.5.5
-revision            1
+version             1.6.0
 python.versions     27 35 36
 platforms           darwin
 maintainers         @esafak
@@ -20,8 +19,8 @@ long_description    \
 homepage            https://pypi.python.org/pypi/$base_name
 master_sites        pypi:a/$base_name
 
-checksums           rmd160  987dd4a63607712e9a27fcb03d73b710e4d06b4c \
-                    sha256  2861da5ef44a442a2225f0945a8ddce67ba4653622bf55b22f793a7b7fd95265
+checksums           rmd160  2cfeb1813f109eb870cf2532a80b428f234c200d \
+                    sha256  1547eb66a4caaea08cc247077e5b3740629be6724a047c94be0ecbbfa52ceb0a
 
 distname            $base_name-${version}
 
@@ -39,6 +38,7 @@ if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-awesome_slugify \
                         port:py${python.version}-babel \
                         port:py${python.version}-cssselect \
+                        port:py${python.version}-parsedatetime \
                         port:py${python.version}-isodate \
                         port:py${python.version}-leather \
                         port:py${python.version}-lxml \


### PR DESCRIPTION
agate is a Python data analysis library that is optimized for humans instead of machines. It is an alternative to numpy and pandas that solves real-world problems with readable code.

Submission has passed the linter without warning and error, and installs.

https://trac.macports.org/ticket/53639

###### Description

Was originally submitted in PR #338 but closed with the merging on 1.5.5 in ea750b4. Resubmitted due to requirement errors in py-csvkit @mf2k 

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->