### PR TITLE
highlight: update to 3.39

### DIFF
--- a/textproc/highlight/Portfile
+++ b/textproc/highlight/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.0
+PortGroup           cxx11 1.1
 
 name                highlight
-version             3.38
+version             3.39
 categories          textproc devel
 platforms           darwin
 license             GPL-3
@@ -16,8 +16,8 @@ homepage            http://www.andre-simon.de
 master_sites        ${homepage}/zip/
 use_bzip2           yes
 
-checksums           rmd160  026d5752f5d5c7815717939f639196425e7bb262 \
-                    sha256  c017d817e397d2d98c9264f63af2613a011bcbdcac53a92d3d540ae0978807fb
+checksums           rmd160  9fb610686cba96c97a0443ba90f77ceed1e04cb1 \
+                    sha256  44f2cef6b5c0b89b5c0d76cf39ce4c2944eeff6b9c23ba27d1d153ac93d10f7d
 
 depends_build       port:boost \
                     port:cctools \
@@ -29,6 +29,14 @@ patchfiles          patch-makefile.diff
 use_configure       no
 
 build.target        cli lib
+
+# add the selected -stdlib to clang builds
+set cxx_stdlibflags {}
+if {[string match *clang* ${configure.cxx}]} {
+    set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+}
+configure.cxx ${configure.cxx} ${cxx_stdlibflags}
+
 
 # Yes, this project's makefile uses CFLAGS to compile its C++ code.
 build.args          CXX="${configure.cxx}" \


### PR DESCRIPTION
change to cxx11 1.1 portgroup
add -stdlib to clang builds
fixes: https://trac.macports.org/ticket/53994
fixes: https://trac.macports.org/ticket/53719

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7
Xcode 4.63

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
