### PR TITLE
texlive-bin: add cxx11 1.1 PortGroup

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -3,10 +3,15 @@
 PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       texlive 1.0
+PortGroup       cxx11 1.1
+
+# The C++ code in 20170604 doesn't play well with clang-425.0.28
+compiler.blacklist-append {clang < 500}
 
 # luajittex requires muniversal (and some patches to configure
 # scripts) to build universal
 PortGroup       muniversal 1.0
+
 
 name            texlive-bin
 version         2017
@@ -70,7 +75,8 @@ depends_lib     port:fontconfig \
 
 depends_run     port:ghostscript
 
-depends_build   path:bin/perl:perl5 \
+depends_build-append \
+                path:bin/perl:perl5 \
                 path:bin/pkg-config:pkgconfig
 
 # patches related to changes in install paths
@@ -115,15 +121,6 @@ post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|" ${worksrcpath}/texk/kpathsea/paths.h
     reinplace "s|@@TEXMFSYSCONFIG@@|${texlive_texmfsysconfig}|" ${worksrcpath}/texk/kpathsea/paths.h
 }
-
-# llvm-gcc apparently fails on Xcode 4.0.x (#30758)
-compiler.blacklist {llvm-gcc-4.2 < 2335.15}
-
-# Fix build failure on Tiger due to use of -isystem
-compiler.blacklist-append gcc-4.0 gcc-3.3
-
-# The C++ code in 20170604 doesn't play well with clang-425.0.28
-compiler.blacklist-append {clang < 500}
 
 # We use MacPorts-provided libraries instead of the ones included in
 # texlive whenever possible, to avoid redundancy and to better keep


### PR DESCRIPTION
fixes build on older systems
still need to specify clang > 500 for libc++ systems
other compiler blacklisting now handled by cxx11 1.1 PortGroup
closes: https://trac.macports.org/ticket/54358
closes: https://trac.macports.org/ticket/54374
closes: https://trac.macports.org/ticket/54475

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
