### PR TITLE
py-awscli, py-boto3, py-botocore: update to current versions

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-awscli
-version             1.11.45
+version             1.11.129
 platforms           darwin
 license             Apache-2
 maintainers         pixilla openmaintainer
@@ -16,8 +16,8 @@ homepage            http://aws.amazon.com/cli/
 master_sites        pypi:a/awscli
 distname            awscli-${version}
 
-checksums           rmd160  6f7b4dd11c3102606b803250e91fc8ffea506f25 \
-                    sha256  ca0b6c8b544a6badd0159f5204c927a370802085dcaed64e754865fd096f696b
+checksums           rmd160  89195692142e1eabe6859a2644d6c2fce18f4f39 \
+                    sha256  a3084448d273391c5a1715e8564eb76f4feff4a7314091a0b81fc16755b06a3d
 
 python.versions     27 34 35 36
 

--- a/python/py-boto3/Portfile
+++ b/python/py-boto3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-boto3
-version             1.4.4
+version             1.4.5
 platforms           darwin
 license             Apache-2
 maintainers         nomaintainer
@@ -16,8 +16,8 @@ homepage            https://github.com/boto/boto3
 master_sites        pypi:b/boto3
 distname            boto3-${version}
 
-checksums           rmd160  d2c86bd6fc4e25b6cf45fb8c5bf7159774c18a66 \
-                    sha256  518f724c4758e5a5bed114fbcbd1cf470a15306d416ff421a025b76f1d390939
+checksums           rmd160  a45d8d533081b41ed26b3b24242a03deb35172b1 \
+                    sha256  6d570df0f692e82b35e9abafbb4584b899b2803e8cfcb70d1f371ca08919831d
 
 python.versions     27 34 35 36
 

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-botocore
-version             1.5.8
+version             1.5.92
 platforms           darwin
 license             Apache-2
 maintainers         pixilla openmaintainer
@@ -16,8 +16,8 @@ homepage            https://github.com/boto/botocore
 master_sites        pypi:b/botocore
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  228bcaaad914cb885d6502c5019a5295fd6f84d2 \
-                    sha256  7f536fd7c31e858e7b24d95524479a7a612588df10f397ed1b11ee99a8c019e2
+checksums           rmd160  3e4f3f5631247a4c99b9a4b139c029b961209765 \
+                    sha256  5a14eec600f5595dabe3949819d30e2c13c49b0efe224a9051ee3ef0689246a4
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
###### Description
Updated to awscli 1.11.129, boto3 1.4.5, and their dependency botocore 1.5.92. I did a pip download of awscli into a virtualenv first, and didn't see any changes to the requirements.

I am not the maintainer.

###### Tested on
macOS 10.12.6
Xcode 8.3.3
Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
