### PR TITLE
Updated coinor-liblemon to 1.3.1, which compiles using clang++.

### DIFF
--- a/science/coinor-liblemon/Portfile
+++ b/science/coinor-liblemon/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 
 name                coinor-liblemon
-version             1.3
+version             1.3.1
 categories          science
 platforms           darwin
 universal_variant   no
@@ -22,14 +22,9 @@ homepage            http://lemon.cs.elte.hu
 
 master_sites        http://lemon.cs.elte.hu/pub/sources/
 distname            lemon-${version}
-checksums           rmd160  25a19a53166531f5794b5f6aa85e78e491e9d9bc \
-                    sha256  6c190dbb1e17bdb71597e79c409b2e798ffcbdb7d764ea45d6299339b12d3e05
+checksums           rmd160  2877b2fe0f02b356c0510ff327e53573d3801f99 \
+                    sha256  71b7c725f4c0b4a8ccb92eb87b208701586cf7a96156ebd821ca3ed855bad3c8
 
-# The latest 1.3 release of LEMON won't compile with clang++ due to
-# some flaws in the sources.
-# seqan-apps port depends on this port and it depends on g++ as it
-# relies on OpenMP for multithreading.
-compiler.blacklist  *clang*
 configure.args-append   -DLEMON_ENABLE_GLPK=NO \
                         -DLEMON_ENABLE_COIN=NO \
                         -DLEMON_ENABLE_ILOG=NO


### PR DESCRIPTION
###### Description
The older version (1.3) didn't (at all) compile using the default settings of MacPorts, which use the clang compiler kit shipped with XCode. The current version 1.3.1 didn't show these problems for me.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
