### PR TITLE
py-slugify: new port

### DIFF
--- a/python/py-slugify/Portfile
+++ b/python/py-slugify/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+set base_name       python-slugify
+name                py-slugify
+version             1.2.4
+
+python.versions     27 35 36
+
+categories-append   textproc
+platforms           darwin
+maintainers         openmaintainer @esafak
+license             MIT
+
+description         Returns unicode slugs
+long_description    $description
+
+homepage            https://pypi.python.org/pypi/$base_name
+master_sites        pypi:p/$base_name
+distname            $base_name-$version
+
+if {${name} ne ${subport}} {
+    checksums           rmd160  d60674c7bc950fa0665735de3ac0a85ef4c3a1c4 \
+                    	sha256  57a385df7a1c6dbd15f7666eaff0ff29d3f60363b228b1197c5308ed3ba5f824
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-unidecode
+    livecheck.type      none
+} else {
+    livecheck.type      regex
+    livecheck.url       $homepage
+    livecheck.regex     $base_name (\\d+(\\.\\d+)+)
+}


### PR DESCRIPTION
Provides python-slugify: https://github.com/un33k/python-slugify

###### Description

Returns unicode slugs.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
