### PR TITLE
py-agate: fix dependencies

### DIFF
--- a/python/py-agate/Portfile
+++ b/python/py-agate/Portfile
@@ -7,6 +7,7 @@ set base_name       agate
 name                py-$base_name
 version             1.6.0
 python.versions     27 35 36
+revision			1
 platforms           darwin
 maintainers         @esafak
 license             MIT
@@ -35,13 +36,13 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-sphinx_rtd_theme \
                         port:py${python.version}-tox
 
-    depends_lib-append  port:py${python.version}-awesome_slugify \
-                        port:py${python.version}-babel \
+    depends_lib-append  port:py${python.version}-babel \
                         port:py${python.version}-cssselect \
-                        port:py${python.version}-parsedatetime \
                         port:py${python.version}-isodate \
                         port:py${python.version}-leather \
                         port:py${python.version}-lxml \
+                        port:py${python.version}-parsedatetime \
+                        port:py${python.version}-slugify \
                         port:py${python.version}-pytimeparse \
                         port:py${python.version}-six \
                         port:py${python.version}-tz


### PR DESCRIPTION
awesome_slugify has been replaced with python-slugify in agate 1.6: wireservice/agate#660

The py-pyslugify PR has to be merged first.

Fixes https://trac.macports.org/ticket/51339

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
