### PR TITLE
texstudio: Major update and cleanup

### DIFF
--- a/editors/texstudio/Portfile
+++ b/editors/texstudio/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               qt4 1.0
+PortGroup               qt5 1.0
 
 name                    texstudio
-version                 2.5.1
+version                 2.12.6
 categories              editors
 platforms               darwin
 license                 GPL-2+
@@ -17,12 +17,14 @@ long_description        texstudio is a TeX editor forked off texmarker.
 
 homepage                http://texstudio.sourceforge.net/
 master_sites            sourceforge:project/texstudio/texstudio/TeXstudio%20${version}
-extract.suffix          .orig.tar.gz
+extract.suffix          .tar.gz
 
-checksums               rmd160  e2b90518a60b4c70771a4885e920a324d68ceb60 \
-                        sha256  7f7ae53818d74a06fffef81e1aa9552badd85045a9953b13f28d15b393962015
+worksrcdir              ${name}${version}
 
-depends_lib-append      port:poppler-qt4-mac
+checksums               rmd160  d184a71590c87610b4a8fb5540dd05f4d47b7df7 \
+                        sha256  cdae8c9f3fa84af2424cfef6d4a3abb2437cc71ecb24c1883e4ecca2f2693da3
+
+depends_lib-append      port:poppler-qt5 port:qt5-qtbase port:qt5-qtsvg port:qt5-qtscript
 
 pre-patch {
     # DOS to UNIX line endings so we can patch
@@ -35,15 +37,10 @@ post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/texstudio.pro
 }
 
-# error: unable to read PCH file: 'Is a directory'
-# https://bugreports.qt-project.org/browse/QTBUG-27018
-compiler.blacklist      *clang*
-
 universal_variant       no
 
 configure.cmd           ${qt_qmake_cmd}
 configure.pre_args      PREFIX=${prefix}
-configure.args-append   CONFIG+="${qt_arch_types}"
 
 build.args              CC="${configure.cc} [get_canonical_archflags cc]" \
                         CXX="${configure.cxx} [get_canonical_archflags cxx]" \

--- a/editors/texstudio/files/patch-texstudio.pro.diff
+++ b/editors/texstudio/files/patch-texstudio.pro.diff
@@ -1,32 +1,30 @@
---- texstudio.pro.orig	2012-11-30 15:18:01.000000000 -0600
-+++ texstudio.pro	2012-11-30 15:18:01.000000000 -0600
-@@ -2,6 +2,7 @@
- LANGUAGE = C++
- DESTDIR = ./
- CONFIG += qt precompile_header uitools
+--- texstudio.pro.orig	2017-08-05 17:42:45.000000000 +0800
++++ texstudio.pro	2017-08-05 17:42:45.000000000 +0800
+@@ -13,6 +13,8 @@
+     CONFIG -= precompile_header
+ }
+ 
 +CONFIG -= debug
- exists(texmakerx_my.pri):include(texmakerx_my.pri)
++
+ # allow loading extra config by file for automatic compilations (OBS)
+ exists(texstudio.pri):include(texstudio.pri)
  QT += network \
-     xml \
-@@ -262,8 +263,7 @@
+@@ -295,8 +297,7 @@
      config += unix
-     
+ 
      # #universal tiger
 -    CONFIG += link_prl \
 -        x86_64
 +    CONFIG += link_prl
-     
+ 
      # QMAKE_MAC_SDK = /Developer/SDKs/MacOSX10.4u.sdk
      # QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.4
-@@ -532,9 +532,8 @@
-             -lz
-     }
-     macx { 
--        INCLUDEPATH += /usr/local/include/poppler/qt4
--        LIBS += -L/usr/lib \
--            -L/usr/local/lib \
-+        INCLUDEPATH += @PREFIX@/include/poppler/qt4
-+        LIBS += -L@PREFIX@/lib \
-             -lpoppler-qt4 \
-             -lz
-     }
+@@ -572,7 +573,7 @@
+ macx:LIBS += -framework CoreFoundation
+ 
+ unix {
+-    LIBS += -L/usr/lib \
++    LIBS += -L@PREFIX@/lib \
+     -lz
+ }
+ 


### PR DESCRIPTION
###### Description

1. Switch to qt5
2. texstudio no longer uses precompile_header, so blacklisting clang is not necessary
3. <del>Use GNU tar to extract the source tarball. BSD tar can't handle 2.16.6 tarballs. 2.16.4 worked fine, so it may change in the future.</del> Fixed upstream

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
It builds yet with quite a few warnings:
```
Warning: The following files inside the MacPorts prefix not installed by a port were accessed:
  /opt/local/libexec/qt5/include/QtConcurrent/qtconcurrent_global.h
  /opt/local/libexec/qt5/include/QtConcurrent/qtconcurrentcompilertest.h
  /opt/local/libexec/qt5/include/QtConcurrent/qtconcurrentrunbase.h
  /opt/local/libexec/qt5/include/QtConcurrent/qtconcurrentstoredfunctioncall.h
```
/opt/local/libexec/qt5/include/QtConcurrent symlinks to ../lib/QtConcurrent.framework/Headers, and /opt/local/libexec/qt5/lib/QtConcurrent.framework/Headers is part of qt5-qtbase, so I guess those warnings are harmless.
- [x] tested basic functionality of all binary files?

By the way, may I become the maintainer of this package? I expect I'll use it for at least a few more years.
