### PR TITLE
gradle: update to 4.1

### DIFF
--- a/devel/gradle/Portfile
+++ b/devel/gradle/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gradle
-version             4.0.2
+version             4.1
 categories          devel java groovy
 license             Apache-2
 maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
@@ -20,8 +20,8 @@ platforms           darwin
 distname            ${name}-${version}-bin
 master_sites        https://services.gradle.org/distributions
 
-checksums           rmd160  f3254252f9061f44018cb46f7c7d08ed4910918d \
-                    sha256  79ac421342bd11f6a4f404e0988baa9c1f5fabf07e3c6fa65b0c15c1c31dda22
+checksums           rmd160  e1fbcd72201bae8b181980f923ad320229541044 \
+                    sha256  d55dfa9cfb5a3da86a1c9e75bb0b9507f9a8c8c100793ccec7beb6e259f9ed43
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
###### Description

Update to Gradle 4.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
