### PR TITLE
gnupg21: update to 2.1.23

### DIFF
--- a/mail/gnupg21/Portfile
+++ b/mail/gnupg21/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnupg21
-version             2.1.22
+version             2.1.23
 categories          mail security
 maintainers         jann ionic openmaintainer
 license             GPL-3+
@@ -22,9 +22,9 @@ master_sites        gnupg:gnupg
 
 use_bzip2           yes
 
-checksums           rmd160  3318d4963ac8ed315fa7e5b46dd4f00b172f4d0d \
-                    sha256  46716faf9e1b92cfca86609f3bfffbf5bb4b6804df90dc853ff7061cfcfb4ad7 \
-                    sha1    706b806f7d8d328b4ffa67954c613fdd3dfed1b9
+checksums           rmd160  622eef6554d77c2e0a2c04bd16dcebfbee2265ad \
+                    sha256  a94476391595e9351f219188767a9d6ea128e83be5ed3226a7890f49aa2d0d77 \
+                    sha1    c470777eaa9657ef3258068507065c9a7caef9eb
 
 notes               "GPG 2.1 uses a new format for its key files. Therefore you cannot\
                     use it together with any earlier version of GPG. Neither can you easily go\


### PR DESCRIPTION
###### Description
  * gpg: "gpg" is now installed as "gpg" and not anymore as "gpg2".
    If needed, the new configure option --enable-gpg-is-gpg2 can be
    used to revert this.


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
