### PR TITLE
mandoc: update to 1.14.3

### DIFF
--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 
 name                mandoc
-version             1.14.1
+version             1.14.3
 description         UNIX manpage compiler
-homepage            http://mdocml.bsd.lv/
+homepage            http://mandoc.bsd.lv/
 categories          textproc
 conflicts           man
 license             ISC
@@ -17,12 +17,10 @@ long_description    mandoc is a suite of tools compiling mdoc, \
                     BSD manual pages, and man, the predominant \
                     historical language for UNIX manuals.
 
-master_sites        http://mdocml.bsd.lv/snapshots/
+master_sites        http://mandoc.bsd.lv/snapshots/
 
-livecheck.name	    mdocml
-distname            mdocml-${version}
-checksums           rmd160  2e2d593e3f6cfcde3bdf57b090947b355ce2b2e8 \
-                    sha256  356954f141ec6f5635e938c826f2e16e4619bb361c64d84a31f6775d030a615b
+checksums           rmd160 0155d0670421c37aa79c1887ecab3904236907cd \
+                    sha256 0b0c8f67958c1569ead4b690680c337984b879dfd2ad4648d96924332fd99528
 
 pre-configure {
     set filename "${worksrcpath}/configure.local"


### PR DESCRIPTION
This updates mandoc to the latest release.
The last remnants of the 'mdocml' name have been removed.

Tested on 10.6.8