### PR TITLE
lout: fix to use MacPorts-selected compiler, and specify compatible compilers

### DIFF
--- a/textproc/lout/Portfile
+++ b/textproc/lout/Portfile
@@ -25,6 +25,7 @@ use_configure   no
 
 use_parallel_build  yes
 build.args          PREFIX=${prefix} \
+                    CC=${configure.cc} \
                     LOUTLIBDIR=${prefix}/share/lout \
                     PDF_COMPRESSION=1 \
                     ZLIB=${prefix}/lib/libz.a \

--- a/textproc/lout/Portfile
+++ b/textproc/lout/Portfile
@@ -1,4 +1,5 @@
 PortSystem 1.0
+PortGroup  compiler_blacklist_versions 1.0
 
 name            lout
 version         3.40
@@ -22,6 +23,10 @@ checksums           rmd160  d1da2583f1727abf4ccb74d2128c26deacca2ef9 \
 depends_build   port:zlib
 
 use_configure   no
+
+# see <https://github.com/macports/macports-ports/pull/662>
+compiler.blacklist-append   {macports-clang-3.[0-9]} {clang > 800}
+compiler.fallback-append    macports-clang-4.0 macports-clang-5.0
 
 use_parallel_build  yes
 build.args          PREFIX=${prefix} \


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
