### PR TITLE
sysutils/fswatch: update to 1.10.0

### DIFF
--- a/sysutils/fswatch/Portfile
+++ b/sysutils/fswatch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        emcrisostomo fswatch 1.9.2
+github.setup        emcrisostomo fswatch 1.10.0
 github.tarball_from releases
 
 categories          sysutils
@@ -21,8 +21,8 @@ long_description    A cross-platform file change monitor with multiple \
 
 homepage            http://emcrisostomo.github.io/fswatch/
 
-checksums           rmd160 d35508efcd9ca802a4de88525a1fee04409d790c \
-                    sha256 e8bcb9018831c353cd85a8ce5fcc427e27bdff8bfc3cace1619f6cda3527d111
+checksums           rmd160 0719cff16901b5a6c537b6d14d5147034c7c6358 \
+                    sha256 f0b35bcc27e73dbeeb2e74567f978e11b239a2ea229f870ce27b39593ab0eb72
 
 # Blacklist compilers not supporting C++11.
 compiler.blacklist-append \


### PR DESCRIPTION
###### Description
Maintainer update of `sysutils/fswatch` to `1.10.0`.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
