### PR TITLE
gss: fix error for missing getline()

### DIFF
--- a/security/gss/Portfile
+++ b/security/gss/Portfile
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           snowleopard_fixes 1.0
+
 name                gss
 version             1.0.3
 categories          security
@@ -20,9 +22,10 @@ master_sites        gnu
 checksums           rmd160  e20ee482f159f5ad9b6285f1302fa959e0139b79 \
                     sha256  ff919ddc731531d65e27d7ababdc361aae05ada5f1a6dd60703d153307dcdeeb
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    port:pkgconfig
 
-depends_lib         port:libiconv \
+depends_lib-append  port:libiconv \
                     port:gettext
 
 set docdir          ${prefix}/share/doc/${name}


### PR DESCRIPTION
add PortGroup snowleopard_fixes
closes: https://trac.macports.org/ticket/54060

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.4, 10.5
Xcode 2.5, 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
