### PR TITLE
gnupg: update to 1.4.22, remove idea variant

### DIFF
--- a/mail/gnupg/Portfile
+++ b/mail/gnupg/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                gnupg
-version             1.4.21
-revision            1
+version             1.4.22
 categories          mail security
 license             GPL-3+
 installs_libs       no
@@ -21,8 +20,9 @@ conflicts           gnupg21
 
 use_bzip2           yes
 
-checksums           ${distname}${extract.suffix}    rmd160  082b2759497ea470093bf856d72d5430711b6db9 \
-                                                    sha256  6b47a3100c857dcab3c60e6152e56a997f2c7862c1b8b2b25adf3884a1ae2276
+checksums           rmd160  570106363beacbb2bb514dcf869aa335c292dffd \
+                    sha256  9594a24bec63a21568424242e3f198b9d9828dea5ff0c335e47b06f835f930b4 \
+                    sha1    4bad84fba712626cbbd5adf20988788028c5a5a6
 
 configure.args      --infodir=${prefix}/share/info \
                     --disable-asm \
@@ -50,22 +50,6 @@ test.target         check
 # clang defaults to c99, and gnupg doesn't play nicely
 if {[string match *clang* ${configure.compiler}]} {
     configure.cflags-append -std=gnu89
-}
-
-variant idea description {Add support for the patented IDEA algorithm} {
-    depends_extract-append  bin:gunzip:gzip
-    master_sites-append     https://gnupg.dk/pub/contrib-dk/:ideasource
-    distfiles-append        idea.c.gz:ideasource
-    checksums-append \
-        idea.c.gz md5    9dc3bc086824a8c7a331f35e09a3e57f \
-                  sha1   82fded4ec31b97b3b2dd22741880b67cfee40f84 \
-                  rmd160 e35be5a031d10d52341ac5f029d28f811edd908d
-    extract.only            ${distname}${extract.suffix}
-
-    post-extract {
-        move ${worksrcpath}/cipher/idea.c ${worksrcpath}/cipher/idea.c.orig
-        system -W "${worksrcpath}/cipher" "gunzip -c < ${distpath}/idea.c.gz > idea.c"
-    }
 }
 
 platform darwin {


### PR DESCRIPTION
###### Description
https://dev.gnupg.org/T3268

IDEA is directly supported since GnuPG 1.4.13. https://www.gnupg.org/faq/why-not-idea.html
```
$ gpg --version
gpg (GnuPG) 1.4.22
Copyright (C) 2015 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: ~/.gnupg
Supported algorithms:
Pubkey: RSA, RSA-E, RSA-S, ELG-E, DSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: MD5, SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2
```
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
