### PR TITLE
Update Portfile

### DIFF
--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                nsis
 version             3.02.1
+revision            1
 set major           [lindex [split ${version} .] 0]
 categories          devel
 license             zlib CPL-1 MIT
@@ -57,7 +58,8 @@ build.args          APPEND_CCFLAGS="[get_canonical_archflags cc] -stdlib=${confi
                     SKIPPLUGINS=all \
                     SKIPSTUBS=all \
                     SKIPUTILS=all \
-                    STRIP=0
+                    STRIP=0 \
+                    VERSION=${version}
 
 use_parallel_build  no
 


### PR DESCRIPTION
When not specified, `makensis` will return the build-date as version. This probably makes sense for custom builds, but since we're compiling the upstream version, the version string should match.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
