### PR TITLE
nsis: adapt to upstream

### DIFF
--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 name                nsis
 version             3.02.1
 set major           [lindex [split ${version} .] 0]
+revision            1
 categories          devel
 license             zlib CPL-1 MIT
 platforms           darwin
@@ -57,7 +58,8 @@ build.args          APPEND_CCFLAGS="[get_canonical_archflags cc] -stdlib=${confi
                     SKIPPLUGINS=all \
                     SKIPSTUBS=all \
                     SKIPUTILS=all \
-                    STRIP=0
+                    STRIP=0 \
+                    VERSION=${version}
 
 use_parallel_build  no
 
@@ -73,4 +75,12 @@ post-destroot {
         file copy ${workpath}/nsis-${version}/${dir} ${destroot}${prefix}/share/nsis
     }
     system "chmod -R go-w '${destroot}${prefix}/share/nsis'"
+}
+
+variant advanced_logging description {Builds makensis with advanced logging support} {
+    build.args-append    NSIS_CONFIG_LOG=yes
+}
+
+variant large_strings description {Builds makensis with support for large strings} {
+    build.args-append    NSIS_MAX_STRLEN=8192
 }


### PR DESCRIPTION
###### Description

The changes in this PR will decrease the differences between upstream and the port:

1. Rather than using the build-date, `makensis` will use the actual version (e.g. `makensis -VERSION`)

2. Upstream ships two [Special Builds](http://nsis.sourceforge.net/Special_Builds): Advanced Logging and Large Strings. I've added variants to build either, as well as a combination of both.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12
Xcode 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
