### PR TITLE
jsoncpp: add cxx11 1.1 PortGroup

### DIFF
--- a/devel/jsoncpp/Portfile
+++ b/devel/jsoncpp/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.0
+PortGroup           cxx11 1.1
 
 name                jsoncpp
 categories          devel
@@ -48,31 +49,3 @@ configure.args-append \
                     -DBUILD_SHARED_LIBS=ON \
                     -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF
 
-# require c++11
-
-if {${configure.cxx_stdlib} eq "libstdc++"} {
-
-    # *clang* when using libstdc++ do not seem to support C++11;
-    # C++11 support seems to need GCC 4.7+ when using libstdc++;
-    # could use C++0x support on GCC4.[56], but just ignore it since
-    # there are newer compilers already in place as defaults.
-
-    # Blacklist GCC compilers not supporting C++11 and all CLANG.
-    # This is probably not necessary, but it's good practice.
-
-    compiler.blacklist-append *clang* {*gcc-3*} {*gcc-4.[0-6]}
-
-    # and whitelist those we do want to use. wish there were a better way.
-    # these will be used in the order provided.
-
-    compiler.whitelist macports-gcc-4.9 macports-gcc-4.8 macports-gcc-4.7
-
-} else {
-
-    # using libc++;
-    # Blacklist Clang not supporting C++11 in some form and all GCC.
-    # Just use the cxx11 PortGroup for this specific case.
-
-    PortGroup cxx11 1.0
-
-}


### PR DESCRIPTION
remove other c++11-related blacklisting in Portfile
closed https://trac.macports.org/ticket/52045

###### Description
Fixes build on older systems

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.4, 10.5
Xcode 2.5, 3.26

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
