### PR TITLE
tcl: fix error on older compilers re: pragmas inside functions

### DIFF
--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -30,6 +30,9 @@ configure.args  --mandir=${prefix}/share/man \
 configure.cppflags-delete  -I${prefix}/include
 configure.ldflags-delete   -L${prefix}/lib
 
+# fix error on older compilers with pragma inside functions
+patchfiles-append patch-unix-tclunixsock-pragma.diff
+
 post-configure {
     reinplace -E {s|-arch [^ ]+||g} ${worksrcpath}/tclConfig.sh
 }

--- a/lang/tcl/files/patch-unix-tclunixsock-pragma.diff
+++ b/lang/tcl/files/patch-unix-tclunixsock-pragma.diff
@@ -1,0 +1,31 @@
+--- tclUnixSock.c.orig	2017-08-13 07:57:43.000000000 -0700
++++ tclUnixSock.c	2017-08-13 07:58:30.000000000 -0700
+@@ -700,6 +700,10 @@
+  */
+ 
+ #ifndef NEED_FAKE_RFC2553
++
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wstrict-aliasing"
++
+ static inline int
+ IPv6AddressNeedsNumericRendering(
+     struct in6_addr addr)
+@@ -713,16 +717,14 @@
+      * at least some versions of OSX.
+      */
+ 
+-#pragma GCC diagnostic push
+-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+     if (!IN6_IS_ADDR_V4MAPPED(&addr)) {
+-#pragma GCC diagnostic pop
+         return 0;
+     }
+ 
+     return (addr.s6_addr[12] == 0 && addr.s6_addr[13] == 0
+             && addr.s6_addr[14] == 0 && addr.s6_addr[15] == 0);
+ }
++#pragma GCC diagnostic pop
+ #endif /* NEED_FAKE_RFC2553 */
+ 
+ static void


### PR DESCRIPTION
move pragma just outside the function
fixes build on older gcc compilers
closes: https://trac.macports.org/ticket/54596

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.5, 10.12
Xcode 3.2.6, 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
