### PR TITLE
etsh: new port at 4.6.0

### DIFF
--- a/shells/etsh/Portfile
+++ b/shells/etsh/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                etsh
+version             4.6.0
+categories          shells
+license             BSD BSD-old
+maintainers         nomaintainer
+description         Ports of the Sixth Edition (V6) UNIX Thompson shell
+long_description    The Etsh Project provides two ports of the original /bin/sh \
+                    from Sixth Edition (V6) UNIX (circa 1975). Etsh is an enhanced port of \
+                    the shell. Tsh is an unenhanced port of the shell, and glob is a port \
+                    of its global command. This project also includes the following shell \
+                    utilities: if, goto, and fd2.
+platforms           darwin
+homepage            https://etsh.io/
+master_sites        ${homepage}src/
+
+checksums           rmd160  96e1a4b7d32ae9d8d18c3b4a31ba23c81c51e84a \
+                    sha256  2884a862a89c4ecaf66ff2bab8d0a3156f3e32477290e117d03ac94981d92659
+
+configure.pre_args
+
+build.args          PREFIX=${prefix}
+
+# Ensure use of the correct build utilities.
+build.args-append   CC=${configure.cc} CPP=${configure.cpp}
+
+# Ensure use of the correct build_arch.
+build.args-append   OSXCFLAGS="[get_canonical_archflags cc]" \
+                    OSXLDFLAGS="[get_canonical_archflags ld]"
+
+destroot.args       PREFIX=${prefix} MANDIR=${prefix}/share/man/man1
+destroot.target     install install-doc install-exp


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
