### PR TITLE
chromaprint: change to cxx11 1.1 PortGroup

### DIFF
--- a/audio/chromaprint/Portfile
+++ b/audio/chromaprint/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
-PortGroup           cxx11 1.0
+PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 # don't forget to revbump gstreamer1-gst-plugins-bad if


### PR DESCRIPTION
fixes build on older systems
closes: https://trac.macports.org/ticket/53072

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.5
Xcode 3.26

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
