### PR TITLE
py-supervisor: update to 3.1.4

### DIFF
--- a/python/py-supervisor/Portfile
+++ b/python/py-supervisor/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 set real_name       supervisor
 
 name                py-supervisor
-version             3.1.3
+version             3.1.4
 platforms           darwin
 supported_archs     noarch
 license             BSD ZPL-2.1
@@ -23,8 +23,8 @@ homepage            http://supervisord.org
 master_sites        pypi:s/${real_name}
 distname            supervisor-${version}
 
-checksums           rmd160  9598b25640e72b0322cbb79a8f8f26712135efba \
-                    sha256  e32c546fe8d2a6e079ec4819c49fd24534d4075a58af39118d04367918b3c282
+checksums           rmd160  47f0fabb2f3298a28a9f49a8d09815a531d77c44 \
+                    sha256  82f75089f719a7a3ca87f35c89a03c20fd3c0912552c96eb6fa40274ced6604e
 
 python.versions     27
 


### PR DESCRIPTION
###### Description
Fixes CVE-2017-11610.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
