### PR TITLE
Updating location of gtest source. Google has moved it to GitHub.

### DIFF
--- a/devel/gtest/Portfile
+++ b/devel/gtest/Portfile
@@ -4,8 +4,9 @@ PortSystem      1.0
 PortGroup       cmake 1.0
 
 name            gtest
-set svn_revision 746
-version         1.7.0.${svn_revision}
+set rel_num 1.7.0
+set git_tag release-${rel_num}
+version         ${rel_num}
 categories      devel
 maintainers     blair
 license         BSD
@@ -20,13 +21,13 @@ long_description \
                 fatal and non-fatal failures, various options for \
                 running the tests, and XML test report generation.
 
-homepage        https://code.google.com/p/googletest/
+homepage        https://github.com/google/googletest
 
 platforms       darwin
 
-fetch.type      svn
-svn.url         http://googletest.googlecode.com/svn/trunk
-svn.revision    ${svn_revision}
+fetch.type      git
+git.url         git://github.com/google/googletest.git
+git.branch      ${git_tag}
 worksrcdir      trunk
 
 cmake.out_of_source     yes


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
