### PR TITLE
libuv: update to 1.14.0

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -18,9 +18,9 @@ long_description \
 
 if {${subport} eq ${name}} {
 
-    github.setup    libuv libuv 1.13.1 v
-    checksums       rmd160 7e278950228c4c84d7c8f45d76142706c770eb0f \
-                    sha256 5038787b4f65b7e9c6d7ba9fbad156ff8459c12cfd5ec73c90286dc729a3f513
+    github.setup    libuv libuv 1.14.0 v
+    checksums       rmd160 4931ddc5d8467156b02d31e9fe96e84067a4498c \
+                    sha256 0a552ae730d88d83b883549f8b49b141163fcc81a9eee7f6febc84304a3b9c37
 
     conflicts       libuv-devel
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs upgrade`?
