### PR TITLE
mosh: Switch to protobuf3-cpp

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -5,6 +5,7 @@ PortGroup               perl5 1.0
 
 name                    mosh
 version                 1.3.2
+revision                1
 categories              net
 license                 {GPL-3+ OpenSSLException}
 platforms               darwin
@@ -28,7 +29,7 @@ perl5.create_variants   ${perl5.branches}
 depends_build           port:pkgconfig
 
 depends_lib             port:ncurses \
-                        port:protobuf-cpp \
+                        port:protobuf3-cpp \
                         port:zlib \
                         port:p${perl5.major}-getopt-long \
                         port:p${perl5.major}-io-socket-ip


### PR DESCRIPTION
###### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
