### PR TITLE
libsoup: update to 2.58.2

### DIFF
--- a/gnome/libsoup/Portfile
+++ b/gnome/libsoup/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           gobject_introspection 1.0
 
 name                libsoup
-version             2.58.1
+version             2.58.2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome net
 platforms           darwin
@@ -23,8 +23,8 @@ homepage            https://wiki.gnome.org/Projects/libsoup
 master_sites        gnome:sources/${name}/${branch}/
 use_xz              yes
 
-checksums           rmd160  ff874c01515ea6f18e95fa0561dfbcb35f41cb42 \
-                    sha256  62c669f557de745b7b20ba9d5b74d839c95e4c9cea1a5ab7f3da5531a1aeefb9
+checksums           rmd160  ecc17632960fc7760e449daaba27a5cfeebbd820 \
+                    sha256  442300ca1b1bf8a3bbf2f788203287ff862542d4fc048f19a92a068a27d17b72
 
 depends_build       port:pkgconfig \
                     port:intltool \


### PR DESCRIPTION
###### Description
Fixes CVE-2017-2885

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
