### PR TITLE
tmux-pasteboard: update to 2.6

### DIFF
--- a/sysutils/tmux-pasteboard/Portfile
+++ b/sysutils/tmux-pasteboard/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ChrisJohnsen tmux-MacOSX-pasteboard 2.5 v
+github.setup        ChrisJohnsen tmux-MacOSX-pasteboard 2.6 v
 name                tmux-pasteboard
 categories          sysutils
 platforms           darwin
@@ -15,8 +15,8 @@ long_description    ${description}
 
 depends_run         path:bin/tmux:tmux
 
-checksums           rmd160  4be706e4d7824ba8ccc3a239309ee4b3a1151fe7 \
-                    sha256  50a88af5d8ed9e0f37130e453a78fbeec3020e5e64c5f5a52b37084c89067bd2
+checksums           rmd160  647603906f23e3f1781c75b627c500d5f04b3391 \
+                    sha256  3472ff08a1250a20bfc955310bf5855175c60a109176bcefdd22ac517418af70
 
 use_configure       no
 variant universal {}


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
