### PR TITLE
Update to Shellcheck 0.4.6

### DIFF
--- a/devel/haskell-platform/Portfile
+++ b/devel/haskell-platform/Portfile
@@ -264,9 +264,11 @@ haskell_platform_port HUnit 1.2.5.2 3 {
         tool for Java, see: http://www.junit.org.
 }
 
-haskell_platform_port mtl 2.1.3.1 1 {
-    checksums               rmd160  f6432fb7e64d66eff69f02ccca9fc30ac5dce502 \
-                            sha256  77af766957fb49361fe63446f272a698bddb13398669edc363022e5c2517f6f6
+haskell_platform_port mtl 2.2.1 1 {
+    checksums               rmd160  61f2af56029c85c40a66a04cbd8ff1b97e0f90d9 \
+        sha256  cae59d79f3a16f8e9f3c9adc1010c7c6cdddc73e8a97ff4305f6439d855c8dc5
+
+    depends_lib-append      port:hs-transformers
 
     description             Monad classes, using functional dependencies
     long_description        \

--- a/devel/hs-transformers/Portfile
+++ b/devel/hs-transformers/Portfile
@@ -6,8 +6,8 @@ name                hs-transformers
 checksums           rmd160  17d83a518f96280f35b8f9c0928fcf1235f45d85 \
                     sha256  b3d0a797e815ca50d411e20c02f781efe7751308007d880af7f0b5c4365c3a9d
 
-license             GPL-3+
-maintainers         favadi openmaintainer
+license             BSD
+maintainers         @favadi openmaintainer
 platforms           darwin
 homepage            http://hub.darcs.net/ross/transformers
 

--- a/devel/hs-transformers/Portfile
+++ b/devel/hs-transformers/Portfile
@@ -1,0 +1,20 @@
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       transformers 0.4.3.0
+name                hs-transformers
+checksums           rmd160  17d83a518f96280f35b8f9c0928fcf1235f45d85 \
+                    sha256  b3d0a797e815ca50d411e20c02f781efe7751308007d880af7f0b5c4365c3a9d
+
+license             GPL-3+
+maintainers         favadi openmaintainer
+platforms           darwin
+homepage            http://hub.darcs.net/ross/transformers
+
+
+description         A portable library of functor and monad transformers
+
+long_description    \
+    This package contains: \
+    \n - the monad transformer class (in Control.Monad.Trans.Class). \
+    \n - concrete functor and monad transformers, each with associated operations and functions to lift operations associated with other transformers.

--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -1,10 +1,10 @@
 PortSystem          1.0
 PortGroup           haskell 1.0
 
-haskell.setup       ShellCheck 0.3.8
+haskell.setup       ShellCheck 0.4.6
 name                shellcheck
-checksums           rmd160  18780082aa13e56f84fdd3bd0ddbcb98ccefb117 \
-                    sha256  c185b77166724c06531b3e07b7a8353c0451809a1f60e9f6756d29247853651a
+checksums           rmd160  bda350fbf061e68256ebf415580704b7799b0163 \
+                    sha256  11eb9b2794363fbccc6fbd18601db49680e2c439440a9b103eebfda1aa86b1bc
 
 license             GPL-3+
 maintainers         cal openmaintainer


### PR DESCRIPTION
###### Description

Update ShellCheck to 0.4.6. This PR also updates hs-mtl and adds hs-transformers as ShellCheck 0.4.6 requires them.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification 
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?


Trac: https://trac.macports.org/ticket/51568