### PR TITLE
pcre2: update to 10.30

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                pcre
 version             8.41
 subport pcre2 {
-    version         10.23
+    version         10.30
 }
 categories          devel
 license             BSD
@@ -34,8 +34,8 @@ use_bzip2           yes
 
 set rmd160(pcre)    29342fea75514f96553149b18c44eae0abe86b9d
 set sha256(pcre)    e62c7eac5ae7c0e7286db61ff82912e1c0b7a0c13706616e94a7dd729321b530
-set rmd160(pcre2)   aa2207c04403f4dc53d5d29688bf8d639b4247c8
-set sha256(pcre2)   dfc79b918771f02d33968bd34a749ad7487fa1014aeb787fad29dd392b78c56e
+set rmd160(pcre2)   558de9a06531ff6b690abc5b6f587ce2c207f3b5
+set sha256(pcre2)   90bd41c605d30e3745771eb81928d779f158081a51b2f314bbcc1f73de5773db
 checksums           rmd160  $rmd160(${subport}) \
                     sha256  $sha256(${subport})
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
