### PR TITLE
botan: update to 1.10.16, update master_sites

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -2,8 +2,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                botan
-version             1.10.9
-revision            1
+version             1.10.16
 categories          security devel
 platforms           darwin
 maintainers         nomaintainer
@@ -15,11 +14,11 @@ long_description    Botan is a C++ library implementing a variety of \
                     programs.
 
 homepage            http://botan.randombit.net/
-master_sites        http://files.randombit.net/botan/
+master_sites        https://botan.randombit.net/releases/
 distfiles           Botan-${version}.tgz
 worksrcdir          Botan-${version}
-checksums           rmd160  2412c33938442ffff6eca67c2db4c7a2a55b2a41 \
-                    sha256  487d27d3a081ae403cf87c0fc78c2a64183f001b48f9feb87e8de1e16fba8df2
+checksums           rmd160  72f02a2817109f90cb99045107f8385825d6fc1a \
+                    sha256  6c5472401d06527e87adcb53dd270f3c9b1fb688703b04dd7a7cfb86289efe52
 
 depends_build       port:python27
 depends_lib         path:lib/libssl.dylib:openssl port:zlib port:bzip2


### PR DESCRIPTION
###### Description
Fixes CVE-2017-2801

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
