### PR TITLE
botan: redo block to add selected -stdlib to configure.cxx

### DIFF
--- a/security/botan/Portfile
+++ b/security/botan/Portfile
@@ -36,11 +36,10 @@ if {[string match *clang* ${configure.compiler}]} {
 
 # add the selected -stdlib to clang builds
 # see https://trac.macports.org/ticket/53123
-set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}]} {
-    set cxx_stdlibflags -stdlib=${configure.cxx_stdlib}
+    configure.cxx ${configure.cxx} -stdlib=${configure.cxx_stdlib}
 }
-configure.cxx ${configure.cxx} ${cxx_stdlibflags}
+
 
 destroot.destdir    DESTDIR=${destroot}${prefix}
 


### PR DESCRIPTION
@l2dy 
This version is simpler, and more reliable.
confirmed directly to work with non-clang compilers