### PR TITLE
biblatex-biber: hardcode Perl instead of using env

### DIFF
--- a/tex/biblatex-biber/Portfile
+++ b/tex/biblatex-biber/Portfile
@@ -18,7 +18,7 @@ perl5.default_branch    5.24
 
 perl5.setup     Biber 2.7
 version         ${perl5.moduleversion}
-revision        1
+revision        2
 
 categories      tex
 license         {Artistic-2 GPL}
@@ -90,6 +90,11 @@ depends_lib-append      port:p${perl5.major}-autovivification \
 
 perl5.use_module_build
 perl5.link_binaries_suffix
+
+post-patch {
+    reinplace -W ${worksrcpath}/bin \
+        "s|#!/usr/bin/env perl|#!${perl5.bin}|g" biber
+}
 
 # post-destroot {
 #     xinstall -d ${destroot}${texlive_texmfports}/doc/bibtex/biber


### PR DESCRIPTION
###### Description

The biber Perl script had `#!/usr/bin/env perl` as its first line, but it depends on Perl 5.24 and on the modules installed by the port in `${prefix}/lib/perl5/vendor_perl/5.24/`.
This resulted in being unable to run biber when a different Perl was found in the path before the one provided by MacPorts, e.g., when running biber from TeXShop, which hard-codes `/usr/bin:/bin:/usr/sbin:/sbin` before the user-specified paths.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
OS X 10.11.6 15G1611
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
