### PR TITLE
fakeroot: update to 1.22

### DIFF
--- a/sysutils/fakeroot/Portfile
+++ b/sysutils/fakeroot/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                fakeroot
-version             1.20.2
+version             1.22
 categories          sysutils
 platforms           darwin
 license             GPL-3+
@@ -23,8 +23,8 @@ worksrcdir          ${name}-${version}
 
 use_bzip2           yes
 
-checksums           rmd160  9f193b56314b797d5c03447e86e7c63299f3c0aa \
-                    sha256  7c0a164d19db3efa9e802e0fc7cdfeff70ec6d26cdbdc4338c9c2823c5ea230c
+checksums           rmd160  685a45a61dcb64e996610fef6e482a3f1aa28cd8 \
+                    sha256  bd806a4a1e641203eb3d4571a10089e8a038c10ec7e492fa1e061b03ae3ec6fe
 
 patchfiles          patch-libfakeroot.c.diff \
                     patch-message.h.diff \


### PR DESCRIPTION
###### Description
Test failed and `fakeroot whoami` didn't print `root`. However 1.20.2 also failed.

```
========================================
   fakeroot 1.22: test/test-suite.log
========================================

# TOTAL: 11
# PASS:  6
# SKIP:  1
# XFAIL: 0
# FAIL:  4
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: t.chmod_dev
=================

FAIL t.chmod_dev (exit status: 1)

FAIL: t.mknod
=============

FAIL t.mknod (exit status: 1)

FAIL: t.tar
===========

FAIL t.tar (exit status: 1)

FAIL: t.touchinstall
====================

FAIL t.touchinstall (exit status: 1)

SKIP: t.xattr
=============

SKIP t.xattr (exit status: 77)
```

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
