### PR TITLE
rabbitmq-server: update to 3.6.11

### DIFF
--- a/net/rabbitmq-server/Portfile
+++ b/net/rabbitmq-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rabbitmq-server
-version             3.6.6
+version             3.6.11
 categories          net
 platforms           darwin
 maintainers         nomaintainer
@@ -24,8 +24,8 @@ use_xz              yes
 distfiles           ${name}-generic-unix-${version}${extract.suffix}
 worksrcdir          [string map {- _} $name]-$version
 
-checksums           rmd160  9c737acc0640a227a4c2f2ad48fbb9ae983cd183 \
-                    sha256  781d17a6c8bbfbcd749d23913218de38e692a5e3093cf47eecf499532ac25d61
+checksums           rmd160  a9dd4c0ec89b6754f8f896fcae687b3485428cda \
+                    sha256  8270c8aa1d6b29a4700287603793caacdc8120bf12b6e286e264f3560295d14e
 
 depends_lib         port:erlang
 depends_build       port:libxslt


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
