### PR TITLE
blitzwave: update to 0.8.0, moved to GitHub

### DIFF
--- a/math/blitzwave/Portfile
+++ b/math/blitzwave/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                blitzwave
-version             0.7.1
+github.setup        oschulz blitzwave 0.8.0 v
 categories          math devel
 license             GPL-2+
 platforms           darwin
@@ -18,10 +18,13 @@ long_description    blitzwave is a ${description}. blitzwave is heavily \
                     You can define and use your own wavelets, a number of \
                     pre-defined, ready-to-use wavelets are available
 
-homepage            http://blitzwave.sourceforge.net/
-master_sites        sourceforge:project/blitzwave/blitzwave/${version}
+homepage            https://oschulz.github.io/blitzwave/
 
-checksums           sha1    2a53f1a9b7967897415afce256f02693a35f380e \
-                    rmd160  66f38a181e482eb14b0bb279fd7c967a3eaef554
+checksums           rmd160  4123a45ea934e11eb093e455660e0c6bc4f2509c \
+                    sha256  daacce4f65c9c569e83ff5312d0910f2b269a67883883d359ea017b6b7132cb8
 
 depends_lib         port:blitz
+
+patchfiles          patch-configure.ac.diff
+
+use_autoreconf      yes

--- a/math/blitzwave/files/patch-configure.ac.diff
+++ b/math/blitzwave/files/patch-configure.ac.diff
@@ -1,0 +1,10 @@
+--- configure.ac.orig	2014-02-19 15:47:17.000000000 +0000
++++ configure.ac	2017-08-24 11:30:00.000000000 +0000
+@@ -5,6 +5,7 @@
+ 
+ # Checks for programs:
+ 
++AM_PROG_AR
+ AC_PROG_CXX
+ AC_LIBTOOL_DLOPEN
+ AC_PROG_LIBTOOL


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
