### PR TITLE
google-cloud-sdk: Fix gsutil and bq commands

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                google-cloud-sdk
 version             167.0.0
+revision            1
 categories          devel python
 license             Apache-2
 maintainers         nomaintainer
@@ -29,12 +30,14 @@ use_configure       no
 build               {}
 
 destroot {
-    foreach file {gcloud bq gsutil} {
-        copy ${worksrcpath}/bin/${file} ${destroot}${prefix}/bin
+    system -W ${worksrcpath} "CLOUDSDK_CONFIG=${worksrcpath}/.config ./install.sh --usage-reporting false --command-completion false --path-update false --quiet"
+    set sharedir ${destroot}${prefix}/share/${name}
+    xinstall -d ${sharedir}
+    copy ${worksrcpath}/bin ${worksrcpath}/lib ${worksrcpath}/platform ${sharedir}
+    foreach f {gcloud bq gsutil} {
+        ln -s ../share/${name}/bin/${f} ${destroot}${prefix}/bin/${f}
     }
-    copy ${worksrcpath}/bin/git-credential-gcloud.sh ${destroot}${prefix}/bin/git-credential-gcloud
-
-    copy {*}[glob -directory ${worksrcpath}/lib *] ${destroot}${prefix}/lib
+    ln -s ../share/${name}/bin/git-credential-gcloud.sh ${destroot}${prefix}/bin/git-credential-gcloud
 
     if {[variant_isset bash_completion]} {
         # set completions_path ${prefix}/share/bash-completion/completions


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/54658

###### Description

The gsutil and bq commands expect to find bootstrapping code in directories relative to the executables. Copy the google-cloud-sdk bin, lib, and platform directories to ${prefix}/share/google-cloud-sdk to preserve the original directory structure. Create symlinks in ${prefix}/bin to invoke commands in their original directory structure. Invoke the google-cloud-sdk install.sh script to generate *.pyc files. Set the CLOUDSDK_CONFIG environment variable for the duration of install.sh to prevent modifying the user's ~/.config as root.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
