### PR TITLE
unibilium: use MacPorts terminfo if installed

### DIFF
--- a/devel/unibilium/Portfile
+++ b/devel/unibilium/Portfile
@@ -22,6 +22,9 @@ checksums           rmd160  85817faa6df4d8afad85764020e7aec19ece9f9a \
 
 depends_build       port:libtool
 
+patchfiles          patch-Makefile.diff
+patch.pre_args      -p1
+
 use_configure no
 
 build.args          PREFIX=${prefix}

--- a/devel/unibilium/Portfile
+++ b/devel/unibilium/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup github 1.0
 
-github.setup        mauke unibilium 1.2.0 v
+github.setup        mauke unibilium 1.2.1 v
 categories          devel
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -17,8 +17,8 @@ long_description \
     any other library. It also doesn't use global variables, so it should be \
     thread-safe.
 
-checksums           rmd160  3b073256e54966b6cc5eac433aa092bb8b7e5e52 \
-                    sha256  c342ad643155bcef6a6bb38ef1e8c37e268658f06d19a173c64b9024be3b6b0c
+checksums           rmd160  85817faa6df4d8afad85764020e7aec19ece9f9a \
+                    sha256  006d2e6765fe3c6b508affc51ea11b7afb6622683a61a36ed9ef8be0b6ffb1ac
 
 depends_build       port:libtool
 

--- a/devel/unibilium/files/patch-Makefile.diff
+++ b/devel/unibilium/files/patch-Makefile.diff
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -33,7 +33,7 @@
+ MAN3DIR=$(MANDIR)/man3
+ 
+ ifneq ($(OS),Windows_NT)
+-  TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo"
++  TERMINFO_DIRS="/etc/terminfo:$(PREFIX)/share/terminfo:/usr/local/share/terminfo:/usr/share/terminfo"
+ else
+   TERMINFO_DIRS=""
+ endif


### PR DESCRIPTION
###### Description

The default TERMINFO_DIRS for unibilium is not optimal for MacPorts [1],
since it won't use the newer/better terminal database (if available)
installed by ncurses in $PREFIX/share/terminfo compared to the older
version shipped by Apple in /usr/share/terminfo.

This commit changes TERMINFO_DIRS to search for localy-installed terminal
definitions first (/etc and /usr/local), and then the MacPorts prefix,
before falling back to the system ones shipped by Apple.

[1] https://github.com/mauke/unibilium/blob/v1.2.0/Makefile#L35

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Pinging the maintainer @raimue