### PR TITLE
dovecot2, dovecot2-sieve: update to 2.2.32 and 0.4.19

### DIFF
--- a/mail/dovecot2-antispam/Portfile
+++ b/mail/dovecot2-antispam/Portfile
@@ -9,7 +9,7 @@ version             0.0-${hg.tag}
 
 # Please revbump port:dovecot2-sieve and port:dovecot2-antispam
 # on port:dovecot2 version changes.
-revision            13
+revision            14
 
 categories          mail
 maintainers         pixilla openmaintainer

--- a/mail/dovecot2-antispam/Portfile
+++ b/mail/dovecot2-antispam/Portfile
@@ -4,12 +4,11 @@ PortSystem          1.0
 
 name                dovecot2-antispam
 set name_package    dovecot-antispam-plugin
-hg.tag              51
-version             0.0-${hg.tag}
+version             0.0-52
 
 # Please revbump port:dovecot2-sieve and port:dovecot2-antispam
 # on port:dovecot2 version changes.
-revision            14
+revision            0
 
 categories          mail
 maintainers         pixilla openmaintainer
@@ -18,26 +17,21 @@ license             GPL-2
 description         Anti-spam plugin for dovecot2
 long_description    ${description}
 
-homepage            http://hg.dovecot.org/${name_package}/
-master_sites        http://hg.dovecot.org/${name_package}/archive/
+homepage            https://hg.dovecot.org/
+master_sites        https://dovecot.org/tmp/
 use_bzip2           yes
-distfiles           ${hg.tag}${extract.suffix}
-worksrcdir          ${name_package}-${hg.tag}
+distfiles           dovecot-antispam-plugin-final.tbz2
+worksrcdir          ${name_package}
 
 # fetch.type          hg
 # hg.url              http://hg.dovecot.org/dovecot-antispam-plugin
 
 depends_lib         port:dovecot2
-depends_build       port:autoconf port:automake
+depends_build       port:autoconf port:automake port:gawk
 
-checksums           rmd160  08dd1cd6ae778f6d27aa5dfedb58750ca886c946 \
-                    sha256  0fe2ae5d0e42e96fd6c4b0d74cbab1fdc4c67378ab556ca7f455a315c69f4331
+checksums           rmd160  a8bf7d2ff075c9632f17d5722ff4da65ba8cc1dc \
+                    sha256  914a967a8e62b7b3dff9f02fe835fc1dc853079f6254038bc9b157ecc0fd3527
 
 pre-configure {
     system "cd ${worksrcpath} && ./autogen.sh"
 }
-
-livecheck.type      regex
-livecheck.url       http://hg.dovecot.org/dovecot-antispam-plugin/log/
-livecheck.version   ${hg.tag}
-livecheck.regex     " rev (\[0-9\]+)</i><br/>"

--- a/mail/dovecot2-sieve/Portfile
+++ b/mail/dovecot2-sieve/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dovecot2-sieve
-version             0.4.11
+version             0.4.19
 # set hg.tag to tag or rev.
 hg.tag              ${version}
 #hg.tag              2027
@@ -32,8 +32,8 @@ master_sites        http://pigeonhole.dovecot.org/releases/${dovecot2}
 
 distname            dovecot-${dovecot2}-pigeonhole-${version}
 
-checksums           rmd160  371561b97fb6da72304a144686959d1b153741c5 \
-                    sha256  5168b4ac4e173b563dd71f4024452da5a578aa8d5d047d98903489ab4d84ad72
+checksums           rmd160  45614b72ecce000410f9261c89ddca5258352ab1 \
+                    sha256  629204bfbdcd3480e1ebcdc246da438323c3ea5fea57480ab859e8b201ad8793
 
 depends_build       port:libtool port:autoconf port:automake
 depends_lib         port:dovecot2

--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -6,7 +6,7 @@ name                dovecot2
 set base_name       dovecot
 # Please revbump port:dovecot2-sieve and port:dovecot2-antispam
 # on port:dovecot2 version changes.
-version             2.2.22
+version             2.2.32
 # set hg.tag to tag or rev.
 hg.tag              ${version}
 #hg.tag              69630e6048fd
@@ -53,8 +53,8 @@ add_users ${default_login_user}    group=${default_login_user}    realname=Doven
 patch.pre_args      -p1
 patchfiles          patch-doc-example-config-conf.d-10-master.conf.diff
 
-checksums           rmd160  bf5e0e55bee720fed369676a331f523145a9eeed \
-                    sha256  c7a9db3c4ae9d9b4da920d2c82669700a0d407934501b405f37f89cc0b706ec7
+checksums           rmd160  ff583c903b774e1e691718088ec9ab305b342cdb \
+                    sha256  160b2151e2af359877f69cb2dcdfe1a3f4138ad3766e3b8562b96616e2f6bc2e
 
 post-patch {
     reinplace "s|@@default_internal_user@@|${default_internal_user}|g" \
@@ -78,7 +78,7 @@ configure.args      --sysconfdir=${prefix}/etc \
                     --with-bzlib \
                     --with-ssldir=${prefix}/etc/ssl \
                     --enable-shared \
-                    --disable-static \
+                    --enable-static \
                     --with-shared-libs
 
 # Do not build with kqueue or poll support prior to Darwin 10.7.0 (Mac OS X 10.6)


### PR DESCRIPTION
This pull request updates dovecot2 and dovecot2-sieve to the current
versions. It also updates dovecot2-antispam to the final version (the package
currently in macports did not build anymore).

This commit also changes one of the dovecot compile flags: it switches
from --disable-static to --enable-static. The reason for this change is
that 2.2.32 does not succesfully compile when --disable-static is set.

dovecot2-antispam is deprecated, no longer updated, and should probably
be removed from macports in the future.

###### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 8.3.1 8E1000a

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (no tickets)
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`? (no tests)
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
