### PR TITLE
caffe: update to 1de4ceb (20170817)

### DIFF
--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        BVLC caffe 6d92d8fcfe0eea9495ffbc326256ec5b70c3eed1
-version             20150717
-revision            6
+name                caffe
+github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
+version             20170817
 categories          math science
 maintainers         nomaintainer
 
@@ -16,8 +16,8 @@ homepage            http://caffe.berkeleyvision.org/
 platforms           darwin
 license             BSD
 
-checksums           rmd160  12d7cddfe2b38f5b1a1b1675c457a7a958bff127 \
-                    sha256  07caf1bf1bfebe1a331e2ee61b4b3cccd415b3bd7da641ab8cb5373aabd5d612
+checksums           rmd160  fbf514385ccfb2e7c0ef3ccd85c15ffbbd52ec88 \
+                    sha256  3fae039f041bc024c966c3f6e99395602cbcd5a29a540f6f4336b6007f8d79b6
 
 depends_lib-append  port:google-glog \
                     port:gflags \
@@ -43,11 +43,15 @@ use_configure       no
 
 variant universal {}
 
-set defs "-DGTEST_HAS_TR1_TUPLE=0"
+set defs "-DGTEST_HAS_TR1_TUPLE=0 -Wno-deprecated -Wunused-local-typedef"
 build.args          CXX="${configure.cxx}" \
                     _CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx] ${defs}" \
                     _PREFIX=${prefix}
-                    
+
+test.run            yes
+test.args           ${build.args}
+test.target         test runtest
+
 set caffe_root ${prefix}/libexec/${name}
 
 destroot {
@@ -63,6 +67,10 @@ destroot {
     foreach dir {data examples models python scripts tools} {
         copy ${worksrcpath}/${dir} ${destroot}${caffe_root}
     }
+
+    # copy binary data of examples
+    file mkdir ${destroot}${caffe_root}/build
+    copy ${worksrcpath}/.build_release/examples ${destroot}${caffe_root}/build/
 
     # install additional documents
     set docdir ${prefix}/share/doc/${name}
@@ -117,18 +125,18 @@ variant python27 description {Install Python 2.7 interface} {
                     port:py27-protobuf \
                     port:py27-gflags \
                     port:py27-leveldb \
-                    port:py27-dateutil
+                    port:py27-dateutil \
+                    port:py27-pydot
 
     build.target-append  pycaffe
+    test.target-append   pytest
 
     post-destroot {
         set packages_dir \
             ${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
         xinstall -m 755 -d ${destroot}${packages_dir}
-        copy ${worksrcpath}/python/caffe ${destroot}${packages_dir}
-        system "install_name_tool -id ${packages_dir}/caffe/_caffe.so \
-                ${destroot}${packages_dir}/caffe/_caffe.so"
-        system "install_name_tool -change @rpath/libcaffe.so ${prefix}/lib/libcaffe.so \
-                ${destroot}${packages_dir}/caffe/_caffe.so"
+        system "install_name_tool -change @rpath/libcaffe.so.1.0.0 ${prefix}/lib/libcaffe.so \
+                ${destroot}${caffe_root}/python/caffe/_caffe.so"
+        copy ${destroot}${caffe_root}/python/caffe ${destroot}${packages_dir}
     }
 }

--- a/math/caffe/files/patch-Makefile.config.diff
+++ b/math/caffe/files/patch-Makefile.config.diff
@@ -1,6 +1,15 @@
---- Makefile.config.orig	2015-06-05 04:14:43.000000000 +0900
-+++ Makefile.config	2015-06-10 01:05:10.000000000 +0900
-@@ -48,8 +48,9 @@
+--- Makefile.config.orig	2017-08-24 10:43:43.000000000 +0900
++++ Makefile.config	2017-08-24 10:43:54.000000000 +0900
+@@ -18,7 +18,7 @@
+ # ALLOW_LMDB_NOLOCK := 1
+ 
+ # Uncomment if you're using OpenCV 3
+-# OPENCV_VERSION := 3
++OPENCV_VERSION := 3
+ 
+ # To customize your choice of compiler, uncomment and set the following.
+ # N.B. the default for Linux is g++ and the default for OSX is clang++
+@@ -65,8 +65,9 @@
  
  # NOTE: this is required only if you will compile the python interface.
  # We need to be able to find Python.h and numpy/arrayobject.h.
@@ -12,8 +21,8 @@
  # Anaconda Python distribution is quite popular. Include path:
  # Verify anaconda location, sometimes it's in root.
  # ANACONDA_HOME := $(HOME)/anaconda
-@@ -58,7 +59,7 @@
- 		# $(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include \
+@@ -80,7 +81,7 @@
+ #                 /usr/lib/python3.5/dist-packages/numpy/core/include
  
  # We need to be able to find libpythonX.X.so or .dylib.
 -PYTHON_LIB := /usr/lib
@@ -21,7 +30,7 @@
  # PYTHON_LIB := $(ANACONDA_HOME)/lib
  
  # Homebrew installs numpy in a non standard path (keg only)
-@@ -69,8 +70,8 @@
+@@ -91,8 +92,8 @@
  # WITH_PYTHON_LAYER := 1
  
  # Whatever else you find you need goes here.

--- a/math/caffe/files/patch-Makefile.diff
+++ b/math/caffe/files/patch-Makefile.diff
@@ -1,28 +1,33 @@
---- Makefile.orig	2015-06-24 06:48:24.000000000 +0900
-+++ Makefile	2015-06-27 18:51:14.000000000 +0900
-@@ -170,9 +170,9 @@
+--- Makefile.orig	2017-08-24 10:09:06.000000000 +0900
++++ Makefile	2017-08-24 10:09:18.000000000 +0900
+@@ -178,7 +178,7 @@
  	LIBRARIES := cudart cublas curand
  endif
- LIBRARIES += glog gflags protobuf leveldb snappy \
--	lmdb boost_system hdf5_hl hdf5 m \
--	opencv_core opencv_highgui opencv_imgproc
--PYTHON_LIBRARIES := boost_python python2.7
-+	lmdb boost_system-mt hdf5_hl hdf5 m \
-+	opencv_core opencv_highgui opencv_imgproc opencv_imgcodecs
-+PYTHON_LIBRARIES := boost_python-mt python2.7
+ 
+-LIBRARIES += glog gflags protobuf boost_system boost_filesystem m hdf5_hl hdf5
++LIBRARIES += glog gflags protobuf boost_system-mt boost_filesystem-mt m hdf5_hl hdf5
+ 
+ # handle IO dependencies
+ USE_LEVELDB ?= 1
+@@ -199,7 +199,7 @@
+ 	endif
+ 
+ endif
+-PYTHON_LIBRARIES ?= boost_python python2.7
++PYTHON_LIBRARIES ?= boost_python-mt python2.7
  WARNINGS := -Wall -Wno-sign-compare
  
  ##############################
-@@ -240,7 +240,7 @@
+@@ -270,7 +270,7 @@
  # clang++ instead of g++
  # libstdc++ for NVCC compatibility on OS X >= 10.9 with CUDA < 7.0
  ifeq ($(OSX), 1)
 -	CXX := /usr/bin/clang++
 +	CXX ?= /usr/bin/clang++
  	ifneq ($(CPU_ONLY), 1)
- 		CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release \d' | grep -o '\d')
- 		ifeq ($(shell echo $(CUDA_VERSION) \< 7.0 | bc), 1)
-@@ -349,7 +349,7 @@
+ 		CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release [0-9.]*' | tr -d '[a-z ]')
+ 		ifeq ($(shell echo | awk '{exit $(CUDA_VERSION) < 7.0;}'), 1)
+@@ -411,7 +411,7 @@
  
  # Complete build flags.
  COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
@@ -31,11 +36,11 @@
  NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
  # mex may invoke an older gcc that is too liberal with -Wuninitalized
  MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
-@@ -554,7 +554,7 @@
+@@ -619,7 +619,7 @@
  # Target for extension-less symlinks to tool binaries with extension '*.bin'.
  $(TOOL_BUILD_DIR)/%: $(TOOL_BUILD_DIR)/%.bin | $(TOOL_BUILD_DIR)
  	@ $(RM) $@
--	@ ln -s $(abspath $<) $@
+-	@ ln -s $(notdir $<) $@
 +	@ cd $(TOOL_BUILD_DIR); ln -s $(notdir $<) $(notdir $@)
  
  $(TOOL_BINS): %.bin : %.o | $(DYNAMIC_NAME)

--- a/math/caffe/files/patch-cpu-only.diff
+++ b/math/caffe/files/patch-cpu-only.diff
@@ -1,14 +1,15 @@
---- Makefile.config.orig	2014-12-18 01:12:23.000000000 +0900
-+++ Makefile.config	2014-12-20 16:03:45.000000000 +0900
-@@ -5,26 +5,26 @@
+--- Makefile.config.orig	2017-08-24 10:43:43.000000000 +0900
++++ Makefile.config	2017-08-24 10:43:54.000000000 +0900
+@@ -5,7 +5,7 @@
  # USE_CUDNN := 1
  
  # CPU-only switch (uncomment to build without GPU support).
 -# CPU_ONLY := 1
 +CPU_ONLY := 1
  
- # To customize your choice of compiler, uncomment and set the following.
- # N.B. the default for Linux is g++ and the default for OSX is clang++
+ # uncomment to disable IO dependencies and corresponding data layers
+ # USE_OPENCV := 0
+@@ -25,7 +25,7 @@
  # CUSTOM_CXX := g++
  
  # CUDA directory contains bin/ and lib/ directories that we need.
@@ -17,21 +18,28 @@
  # On Ubuntu 14.04, if cuda tools are installed via
  # "sudo apt-get install nvidia-cuda-toolkit" then use this instead:
  # CUDA_DIR := /usr
- 
+@@ -33,15 +33,15 @@
  # CUDA architecture setting: going with all of them.
- # For CUDA < 6.0, comment the *_50 lines for compatibility.
+ # For CUDA < 6.0, comment the *_50 through *_61 lines for compatibility.
+ # For CUDA < 8.0, comment the *_60 and *_61 lines for compatibility.
 -CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
 -		-gencode arch=compute_20,code=sm_21 \
 -		-gencode arch=compute_30,code=sm_30 \
 -		-gencode arch=compute_35,code=sm_35 \
 -		-gencode arch=compute_50,code=sm_50 \
--		-gencode arch=compute_50,code=compute_50
-+# CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
-+# 		-gencode arch=compute_20,code=sm_21 \
-+# 		-gencode arch=compute_30,code=sm_30 \
-+# 		-gencode arch=compute_35,code=sm_35 \
-+# 		-gencode arch=compute_50,code=sm_50 \
-+# 		-gencode arch=compute_50,code=compute_50
+-		-gencode arch=compute_52,code=sm_52 \
+-		-gencode arch=compute_60,code=sm_60 \
+-		-gencode arch=compute_61,code=sm_61 \
+-		-gencode arch=compute_61,code=compute_61
++#CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
++#		-gencode arch=compute_20,code=sm_21 \
++#		-gencode arch=compute_30,code=sm_30 \
++#		-gencode arch=compute_35,code=sm_35 \
++#		-gencode arch=compute_50,code=sm_50 \
++#		-gencode arch=compute_52,code=sm_52 \
++#		-gencode arch=compute_60,code=sm_60 \
++#		-gencode arch=compute_61,code=sm_61 \
++#		-gencode arch=compute_61,code=compute_61
  
  # BLAS choice:
  # atlas for ATLAS (default)

--- a/math/caffe/files/patch-cudnn.diff
+++ b/math/caffe/files/patch-cudnn.diff
@@ -1,5 +1,5 @@
---- Makefile.config.orig	2015-02-22 14:13:41.000000000 +0900
-+++ Makefile.config	2015-02-22 14:15:21.000000000 +0900
+--- Makefile.config.orig	2017-08-24 10:43:43.000000000 +0900
++++ Makefile.config	2017-08-24 10:43:54.000000000 +0900
 @@ -2,7 +2,7 @@
  # Contributions simplifying and improving our build system are welcome!
  

--- a/math/caffe/files/patch-openblas.diff
+++ b/math/caffe/files/patch-openblas.diff
@@ -1,6 +1,6 @@
---- Makefile.config.orig	2014-12-20 01:46:25.000000000 +0900
-+++ Makefile.config	2014-12-21 19:00:59.000000000 +0900
-@@ -30,7 +30,7 @@
+--- Makefile.config.orig	2017-08-24 10:43:43.000000000 +0900
++++ Makefile.config	2017-08-24 10:43:54.000000000 +0900
+@@ -47,7 +47,7 @@
  # atlas for ATLAS (default)
  # mkl for MKL
  # open for OpenBlas
@@ -10,13 +10,12 @@
  # Leave commented to accept the defaults for your choice of BLAS
  # (which should work)!
 --- include/caffe/util/mkl_alternate.hpp.orig	2014-12-18 01:12:23.000000000 +0900
-+++ include/caffe/util/mkl_alternate.hpp	2014-12-21 18:59:58.000000000 +0900
-@@ -8,7 +8,7 @@
- #else  // If use MKL, simply include the MKL header
- 
++++ include/caffe/util/mkl_alternate.hpp	2017-08-24 10:43:54.000000000 +0900
+@@ -11,7 +11,7 @@
+ #include <Accelerate/Accelerate.h>
+ #else
  extern "C" {
 -#include <cblas.h>
 +#include <cblas_openblas.h>
  }
- #include <math.h>
- 
+ #endif  // USE_ACCELERATE


### PR DESCRIPTION
#### **Caffe**: Update to master stable version: 1de4ceb
###### Description
Port for caffe was old (2015), so this commit upgrades its source to
current master stable. It updates required patches so library will
install successfuly.
Dynamic libraries are amended, so they will point to the correct
libcaffe. Current Port, has an issue with python and caffe, that
requires manual recolocation of affected library.
Also, tests are added for both library and python module.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.5 16F73
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?


- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
