### PR TITLE
gindent: Fix build failure due to type mismatch vs. gperf 3.1

### DIFF
--- a/devel/gindent/Portfile
+++ b/devel/gindent/Portfile
@@ -37,7 +37,8 @@ post-extract {
 }
 
 patchfiles          no-html.patch \
-                    respect-docdir.patch
+                    respect-docdir.patch \
+                    gperf.patch
 
 configure.args      --docdir=${prefix}/share/doc/${name} \
                     --program-prefix=g

--- a/devel/gindent/files/gperf.patch
+++ b/devel/gindent/files/gperf.patch
@@ -1,0 +1,32 @@
+gindent: Fix type incompatibility introduced with gperf 3.1
+
+The patch is based on the idea proposed by gnw3. I tried this on a clean
+build with macports 2.4.1 on El Capitan 10.11.6
+The problem was introduced with gperf 3.1 resulting in a build
+failure for gindent.
+see: https://trac.macports.org/ticket/54466
+
+Fixes bug #54466
+
+Index: src/lexi.c
+===============================================================================
+--- src/lexi.c.orig	2017-08-27 18:33:16.000000000 +0200
++++ src/lexi.c	2017-08-27 18:35:22.000000000 +0200
+@@ -201,7 +201,7 @@
+ #ifdef __GNUC__
+ __inline
+ #endif
+-templ_ty *is_reserved (const char *str, unsigned int len);
++templ_ty *is_reserved (const char *str, size_t len);
+ 
+ #include "gperf.c"
+ 
+@@ -215,7 +215,7 @@
+ #ifdef __GNUC__
+ __inline
+ #endif
+-templ_ty *is_reserved_cc (register const char *str, register unsigned int len);
++templ_ty *is_reserved_cc (register const char *str, register size_t len);
+ 
+ #include "gperf-cc.c"
+ 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/54466

gindent failed to build with new type definitions in gperf 3.1.
This patch changes the type information in gindent such that
it compiles also versus gperf 3.1.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G1611
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
