### PR TITLE
libpng: update to 1.6.32

### DIFF
--- a/graphics/libpng/Portfile
+++ b/graphics/libpng/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    libpng
-version                 1.6.30
+version                 1.6.32
 set branch              [join [lrange [split ${version} .] 0 1] ""]
 categories              graphics
 maintainers             {ryandesign @ryandesign}
@@ -28,8 +28,8 @@ long_description        Libpng was written as a companion to the PNG \
 master_sites            sourceforge:project/${name}/${name}${branch}/${version} \
                         ftp://ftp.simplesystems.org/pub/libpng/png/src/${name}${branch}/
 
-checksums               rmd160  581e0d22c4ec839d05d895646dfeb45f214f6722 \
-                        sha256  267c332ffff70cc599d3929207869f698798f1df143aa5f9597b007c14353666
+checksums               rmd160  e0998ca79f73457c086b248ab06b31fad414e061 \
+                        sha256  c918c3113de74a692f0a1526ce881dc26067763eb3915c57ef3a0f7b6886f59b
 
 depends_lib             port:zlib
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
