### PR TITLE
zeitgeist: fix 'echo' command that generates Python script

### DIFF
--- a/devel/zeitgeist/Portfile
+++ b/devel/zeitgeist/Portfile
@@ -5,6 +5,7 @@ PortGroup           gobject_introspection 1.0
 
 name                zeitgeist
 version             1.0
+revision            1
 license             LGPL-2.1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Zeitgeist is a service which logs the users's activities and \
@@ -36,7 +37,8 @@ gobject_introspection yes
 
 configure.python    ${prefix}/bin/python2.7
 
-patchfiles          patch-configure.ac.diff
+patchfiles          patch-configure.ac.diff \
+                    patch-python_Makefile.am.diff
 
 post-patch {
     reinplace "s|^#\!.*|#!${configure.python}|" \

--- a/devel/zeitgeist/files/patch-python_Makefile.am.diff
+++ b/devel/zeitgeist/files/patch-python_Makefile.am.diff
@@ -1,0 +1,11 @@
+--- python/Makefile.am.orig
++++ python/Makefile.am
+@@ -15,7 +15,7 @@
+ 	$(NULL)
+ 
+ _ontology.py: $(ONTOLOGY) $(top_srcdir)/data/ontology2code
+-	@echo -e "#\n# Auto-generated from .trig files. Do not edit.\n#" > $@
++	@echo "#\n# Auto-generated from .trig files. Do not edit.\n#" > $@
+ 	$(AM_V_GEN)$(top_srcdir)/data/ontology2code --dump-python >> $@
+ 
+ CLEANFILES = \


### PR DESCRIPTION
MacOS X / macOS 'echo' command does not recognize the '-e' flag, which
instead gets added to the output file, resulting in invalid Python.
This simple patch removes the '-e'.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
