### PR TITLE
Texlive bin fix build with cxx11 1.1 PortGroup

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -218,6 +218,14 @@ if {[string match *clang* ${configure.cxx}]} {
     build.env-append        OBJCXXFLAGS="${configure.objcxxflags} [get_canonical_archflags objcxx]"
 }
 
+# work around differences between libc++ and libstdc++ headers building with clang
+# https://trac.macports.org/ticket/54358#comment:26
+if {[string match *clang* ${configure.cxx}]} {
+    configure.cxxflags-append -std=c++11
+    configure.cxxflags-append -Wno-reserved-user-defined-literal
+}
+
+
 post-destroot   {
     # Anything that gets installed into texmf-dist will be installed
     # by one of the texmf ports

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -5,9 +5,6 @@ PortGroup       compiler_blacklist_versions 1.0
 PortGroup       texlive 1.0
 PortGroup       cxx11 1.1
 
-# The C++ code in 20170604 doesn't play well with clang-425.0.28
-compiler.blacklist-append {clang < 500}
-
 # luajittex requires muniversal (and some patches to configure
 # scripts) to build universal
 PortGroup       muniversal 1.0


### PR DESCRIPTION
see https://trac.macports.org/ticket/54358#comment:26
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5 PPC, 10.6/libc++, 10.7/stock libstdc++, 10.12/stock libc++
Xcode 3.2, 4.2, 4.6, 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
