### PR TITLE
mhash: Do not clutter PACKAGE_* in config header

### DIFF
--- a/devel/mhash/Portfile
+++ b/devel/mhash/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 
 name                    mhash
 version                 0.9.9.9
+revision                1
 categories              devel security
 maintainers             ryandesign openmaintainer
 license                 LGPL-2+
@@ -24,6 +25,10 @@ checksums \
     md5     f91c74f9ccab2b574a98be5bc31eb280 \
     sha1    d6f324e70a42a8bbf7a5458521257225afcf0caf \
     rmd160  4b3e8f601687e791aed62c90cbf5850ea714129b
+
+patchfiles \
+    patch-autotools-namespace-stomping.diff
+patch.pre_args -p1
 
 configure.args \
     --mandir=${prefix}/share/man

--- a/devel/mhash/files/patch-autotools-namespace-stomping.diff
+++ b/devel/mhash/files/patch-autotools-namespace-stomping.diff
@@ -1,0 +1,95 @@
+Upstream: https://anonscm.debian.org/cgit/collab-maint/mhash.git/tree/debian/patches/0007-autotools-namespace-stomping.patch?id=0a8a6cc7cd11d4f1a7dea8e45f5bb353f9ff5f09
+
+From: "Barak A. Pearlmutter" <bap@debian.org>
+Date: Mon, 24 Jun 2013 18:05:04 +0100
+Subject: autotools-namespace-stomping
+
+Via: git://pkgs.fedoraproject.org/mhash.git
+Taken from Gentoo:
+http://mirror.its.uidaho.edu/pub/gentoo-portage/app-crypt/mhash/files/mhash-0.9.9-autotools-namespace-stomping.patch
+---
+ configure.in                     |  1 +
+ include/mutils/config.h.in       | 22 ++++++++++++++++++++++
+ include/mutils/mhash_config.h.in | 21 ---------------------
+ 3 files changed, 23 insertions(+), 21 deletions(-)
+ create mode 100644 include/mutils/config.h.in
+
+diff --git a/configure.in b/configure.in
+index 17836f9..a667d94 100644
+--- a/configure.in
++++ b/configure.in
+@@ -6,6 +6,7 @@ AC_CONFIG_SRCDIR([lib/mhash.c])
+ AM_INIT_AUTOMAKE
+ 
+ AC_DEFINE([MHASH_VERSION], PROGRAM_VERSION, "MHash Version")
++AC_CONFIG_HEADER([include/mutils/config.h])
+ AC_CONFIG_HEADER([include/mutils/mhash_config.h])
+ 
+ 
+diff --git a/include/mutils/config.h.in b/include/mutils/config.h.in
+new file mode 100644
+index 0000000..a8db4ac
+--- /dev/null
++++ b/include/mutils/config.h.in
+@@ -0,0 +1,22 @@
++/* Name of package */
++#undef PACKAGE
++
++/* Define to the address where bug reports for this package should be sent. */
++#undef PACKAGE_BUGREPORT
++
++/* Define to the full name of this package. */
++#undef PACKAGE_NAME
++
++/* Define to the full name and version of this package. */
++#undef PACKAGE_STRING
++
++/* Define to the one symbol short name of this package. */
++#undef PACKAGE_TARNAME
++
++/* Define to the version of this package. */
++#undef PACKAGE_VERSION
++
++/* Version number of package */
++#undef VERSION
++
++
+diff --git a/include/mutils/mhash_config.h.in b/include/mutils/mhash_config.h.in
+index ed22aa5..9e039e6 100644
+--- a/include/mutils/mhash_config.h.in
++++ b/include/mutils/mhash_config.h.in
+@@ -181,24 +181,6 @@
+ /* Define to 1 if your C compiler doesn't accept -c and -o together. */
+ #undef NO_MINUS_C_MINUS_O
+ 
+-/* Name of package */
+-#undef PACKAGE
+-
+-/* Define to the address where bug reports for this package should be sent. */
+-#undef PACKAGE_BUGREPORT
+-
+-/* Define to the full name of this package. */
+-#undef PACKAGE_NAME
+-
+-/* Define to the full name and version of this package. */
+-#undef PACKAGE_STRING
+-
+-/* Define to the one symbol short name of this package. */
+-#undef PACKAGE_TARNAME
+-
+-/* Define to the version of this package. */
+-#undef PACKAGE_VERSION
+-
+ /* Define to 1 if the C compiler supports function prototypes. */
+ #undef PROTOTYPES
+ 
+@@ -208,9 +190,6 @@
+ /* dmalloc */
+ #undef USE_DMALLOC
+ 
+-/* Version number of package */
+-#undef VERSION
+-
+ /* Define if using the dmalloc debugging malloc package */
+ #undef WITH_DMALLOC
+ 

--- a/sysutils/mcrypt/Portfile
+++ b/sysutils/mcrypt/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                mcrypt
 version             2.6.8
+revision            1
 categories          sysutils security
 maintainers         snc openmaintainer
 license             GPL-3+


### PR DESCRIPTION
By defining PACKAGE_* macros, the mhash header cluttered the autotools
namespace, causing dependents to use the wrong name and version number.

This problem was discovered against mcrypt(1), which subsequently gets
a rev-bump with this commit.

    $ port -q installed \( mhash mcrypt \) and active
      mcrypt @2.6.8_0 (active)
      mhash @0.9.9.9_0 (active)
    $ mcrypt --version |& head -n1
    Mcrypt v.0.9.9 (i386-apple-darwin16.0.0)

With this patch, the output after rebuilding mcrypt will be correct:

    $ port -q installed \( mhash mcrypt \) and active
      mcrypt @2.6.8_1 (active)
      mhash @0.9.9.9_1 (active)
    $ mcrypt --version |& head -n1
    Mcrypt v.2.6.8 (i386-apple-darwin16.7.0)

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
