### PR TITLE
gptfdisk version upgrades to 1.0.3

### DIFF
--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    gptfdisk
-version                 1.0.1
+version                 1.0.3
 categories              sysutils
 platforms               darwin
 license                 GPL-2+
@@ -17,17 +17,24 @@ long_description        GPT fdisk (gdisk) is a disk partitioning tool loosely mo
 homepage                http://www.rodsbooks.com/gdisk/
 master_sites            sourceforge:project/gptfdisk/gptfdisk/${version}
 
-checksums               md5     d7f3d306b083123bcc6f5941efade586 \
-                        sha1    ad28c511c642235815b83fffddf728c117057cba \
-                        rmd160  21bef329361690a1a7d44e464eb9d682c6335137 \
-                        sha256  864c8aee2efdda50346804d7e6230407d5f42a8ae754df70404dd8b2fdfaeac7
+
+checksums               md5 07b625a583b66c8c5840be5923f3e3fe \
+                        sha1 9a74bbe7805d562316e92417f71e4b03155308e6 \
+                        sha256 89fd5aec35c409d610a36cb49c65b442058565ed84042f767bba614b8fc91b5c \
+                        rmd160 9bf949224cb5fa4fe7df4f332c22a7106a2cfa0c
+
+patchfiles              patch-Makefile.mac.diff
+
+post-patch {
+    reinplace "s|__PREFIX__|${prefix}|g" ${worksrcpath}/Makefile.mac
+}
 
 depends_lib             port:ncurses \
                         port:popt
 
 use_configure           no
 
-build.args              -f Makefile.mac CC="${configure.cc}" \
+build.args              -f Makefile.mac CC="${configure.cc} [get_canonical_archflags cc]" \
                         LN="${configure.cc}"
 
 destroot {

--- a/sysutils/gptfdisk/files/patch-Makefile.mac.diff
+++ b/sysutils/gptfdisk/files/patch-Makefile.mac.diff
@@ -1,0 +1,30 @@
+--- Makefile.mac.orig	2017-08-07 13:33:46.000000000 +0300
++++ Makefile.mac	2017-08-07 18:09:48.000000000 +0300
+@@ -1,9 +1,9 @@
++prefix=__PREFIX__
+ CC=gcc
+ CXX=clang++
+-FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.4
++FATBINFLAGS=
+ CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
+-#CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
+-CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -I /usr/local/include -I/opt/local/include -g
++CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I$(prefix)/include -I $(prefix)/include -I$(prefix)/include -g
+ LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
+ MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
+ #LIB_SRCS=$(NAMES:=.cc)
+@@ -19,12 +19,11 @@
+ #	$(CXX) $(LIB_OBJS) -L/usr/lib -licucore gpttext.o gdisk.o -o gdisk
+ 
+ cgdisk: $(LIB_OBJS) cgdisk.o gptcurses.o
+-	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /opt/local/lib/libncurses.a $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
++	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(prefix)/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
+ #	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(LDFLAGS) -licucore -lncurses -o cgdisk
+ 
+ sgdisk: $(LIB_OBJS) gptcl.o sgdisk.o
+-#	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o /opt/local/lib/libiconv.a /opt/local/lib/libintl.a /opt/local/lib/libpopt.a $(FATBINFLAGS) -o sgdisk
+-	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/opt/local/lib -lpopt $(FATBINFLAGS) -o sgdisk
++	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L$(prefix)/lib -lpopt $(FATBINFLAGS) -o sgdisk
+ #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/sw/lib -licucore -lpopt -o sgdisk
+ 
+ fixparts: $(MBR_LIB_OBJS) fixparts.o


### PR DESCRIPTION
version upgrades to 1.0.3
build flag removed to support mac os 10.10
fixed https://trac.macports.org/ticket/54575
link with dylib
fixed https://trac.macports.org/ticket/54577
fixed https://trac.macports.org/ticket/54576

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
