### PR TITLE
ruby24: fix multiple vulnerabilities in RubyGems

### DIFF
--- a/lang/ruby24/Portfile
+++ b/lang/ruby24/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                ruby24
 version             2.4.1
-revision            1
+revision            2
 
 categories          lang ruby
 maintainers         kimuraw openmaintainer
@@ -29,6 +29,9 @@ dist_subdir         ruby24
 # 10.7 or earlier cannot compile ruby-2.4.0, upstream ruby-trunk's r57180 fixes this error
 patchfiles          patch-legacy_mac.diff \
                     patch-leopard.diff
+
+patchfiles-append   rubygems-2612-ruby24.patch \
+                    rubygems-2613-ruby24.patch
 
 checksums           md5 07b2ae5d2f46321c95b37066c8415900 \
                     rmd160 02f0be92b3fb3fbb4bd1f945359c0d45297cefc6 \

--- a/lang/ruby24/files/rubygems-2612-ruby24.patch
+++ b/lang/ruby24/files/rubygems-2612-ruby24.patch
@@ -1,0 +1,437 @@
+diff --git lib/rubygems.rb lib/rubygems.rb
+index 5cd1a4c47a..bc5bf9b4c2 100644
+--- lib/rubygems.rb
++++ lib/rubygems.rb
+@@ -10,7 +10,7 @@
+ require 'thread'
+ 
+ module Gem
+-  VERSION = "2.6.11"
++  VERSION = "2.6.12"
+ end
+ 
+ # Must be first since it unloads the prelude from 1.9.2
+@@ -234,6 +234,7 @@ def self.needs
+ 
+   def self.finish_resolve(request_set=Gem::RequestSet.new)
+     request_set.import Gem::Specification.unresolved_deps.values
++    request_set.import Gem.loaded_specs.values.map {|s| Gem::Dependency.new(s.name, s.version) }
+ 
+     request_set.resolve_current.each do |s|
+       s.full_spec.activate
+diff --git lib/rubygems/commands/open_command.rb lib/rubygems/commands/open_command.rb
+index a89b7421e3..059635e835 100644
+--- lib/rubygems/commands/open_command.rb
++++ lib/rubygems/commands/open_command.rb
+@@ -72,7 +72,7 @@ def open_editor path
+   end
+ 
+   def spec_for name
+-    spec = Gem::Specification.find_all_by_name(name, @version).last
++    spec = Gem::Specification.find_all_by_name(name, @version).first
+ 
+     return spec if spec
+ 
+diff --git lib/rubygems/commands/query_command.rb lib/rubygems/commands/query_command.rb
+index f25d120b88..70f8127292 100644
+--- lib/rubygems/commands/query_command.rb
++++ lib/rubygems/commands/query_command.rb
+@@ -86,7 +86,7 @@ def execute
+       name = Array(options[:name])
+     else
+       args = options[:args].to_a
+-      name = options[:exact] ? args : args.map{|arg| /#{arg}/i }
++      name = options[:exact] ? args.map{|arg| /\A#{Regexp.escape(arg)}\Z/ } : args.map{|arg| /#{arg}/i }
+     end
+ 
+     prerelease = options[:prerelease]
+diff --git lib/rubygems/commands/sources_command.rb lib/rubygems/commands/sources_command.rb
+index 9832afd214..7e46963a4c 100644
+--- lib/rubygems/commands/sources_command.rb
++++ lib/rubygems/commands/sources_command.rb
+@@ -44,7 +44,7 @@ def add_source source_uri # :nodoc:
+     source = Gem::Source.new source_uri
+ 
+     begin
+-      if Gem.sources.include? source_uri then
++      if Gem.sources.include? source then
+         say "source #{source_uri} already present in the cache"
+       else
+         source.load_specs :released
+diff --git lib/rubygems/dependency_list.rb lib/rubygems/dependency_list.rb
+index 35fe7c4c1a..d8314eaf60 100644
+--- lib/rubygems/dependency_list.rb
++++ lib/rubygems/dependency_list.rb
+@@ -104,7 +104,7 @@ def find_name(full_name)
+   end
+ 
+   def inspect # :nodoc:
+-    "#<%s:0x%x %p>" % [self.class, object_id, map { |s| s.full_name }]
++    "%s %p>" % [super[0..-2], map { |s| s.full_name }]
+   end
+ 
+   ##
+diff --git lib/rubygems/installer.rb lib/rubygems/installer.rb
+index f4d3e728de..967543c2d1 100644
+--- lib/rubygems/installer.rb
++++ lib/rubygems/installer.rb
+@@ -214,7 +214,7 @@ def check_executable_overwrite filename # :nodoc:
+ 
+       ruby_executable = true
+       existing = io.read.slice(%r{
+-          ^(
++          ^\s*(
+             gem \s |
+             load \s Gem\.bin_path\( |
+             load \s Gem\.activate_bin_path\(
+@@ -701,6 +701,8 @@ def verify_gem_home(unpack = false) # :nodoc:
+   # Return the text for an application file.
+ 
+   def app_script_text(bin_file_name)
++    # note that the `load` lines cannot be indented, as old RG versions match
++    # against the beginning of the line
+     return <<-TEXT
+ #{shebang bin_file_name}
+ #
+@@ -723,7 +725,12 @@ def app_script_text(bin_file_name)
+   end
+ end
+ 
++if Gem.respond_to?(:activate_bin_path)
+ load Gem.activate_bin_path('#{spec.name}', '#{bin_file_name}', version)
++else
++gem #{spec.name.dump}, version
++load Gem.bin_path(#{spec.name.dump}, #{bin_file_name.dump}, version)
++end
+ TEXT
+   end
+ 
+diff --git lib/rubygems/platform.rb lib/rubygems/platform.rb
+index d22d91ae54..2dd9ed5782 100644
+--- lib/rubygems/platform.rb
++++ lib/rubygems/platform.rb
+@@ -112,7 +112,7 @@ def initialize(arch)
+   end
+ 
+   def inspect
+-    "#<%s:0x%x @cpu=%p, @os=%p, @version=%p>" % [self.class, object_id, *to_a]
++    "%s @cpu=%p, @os=%p, @version=%p>" % [super[0..-2], *to_a]
+   end
+ 
+   def to_a
+diff --git lib/rubygems/security.rb lib/rubygems/security.rb
+index 119d6d56f7..6963ca156f 100644
+--- lib/rubygems/security.rb
++++ lib/rubygems/security.rb
+@@ -455,7 +455,7 @@ def self.create_cert_self_signed subject, key, age = ONE_YEAR,
+ 
+   ##
+   # Creates a new key pair of the specified +length+ and +algorithm+.  The
+-  # default is a 2048 bit RSA key.
++  # default is a 3072 bit RSA key.
+ 
+   def self.create_key length = KEY_LENGTH, algorithm = KEY_ALGORITHM
+     algorithm.new length
+diff --git lib/rubygems/server.rb lib/rubygems/server.rb
+index 81df0e608e..df4eb566d3 100644
+--- lib/rubygems/server.rb
++++ lib/rubygems/server.rb
+@@ -657,7 +657,7 @@ def root(req, res)
+       "only_one_executable" => true,
+       "full_name" => "rubygems-#{Gem::VERSION}",
+       "has_deps" => false,
+-      "homepage" => "http://docs.rubygems.org/",
++      "homepage" => "http://guides.rubygems.org/",
+       "name" => 'rubygems',
+       "ri_installed" => true,
+       "summary" => "RubyGems itself",
+diff --git lib/rubygems/specification.rb lib/rubygems/specification.rb
+index a2f289d162..500f0af768 100644
+--- lib/rubygems/specification.rb
++++ lib/rubygems/specification.rb
+@@ -2105,7 +2105,7 @@ def inspect # :nodoc:
+     if $DEBUG
+       super
+     else
+-      "#<#{self.class}:0x#{__id__.to_s(16)} #{full_name}>"
++      "#{super[0..-2]} #{full_name}>"
+     end
+   end
+ 
+diff --git lib/rubygems/test_case.rb lib/rubygems/test_case.rb
+index 86b68e1efb..4e48f1eb4c 100644
+--- lib/rubygems/test_case.rb
++++ lib/rubygems/test_case.rb
+@@ -484,7 +484,7 @@ def git_gem name = 'a', version = 1
+ 
+       system @git, 'add', gemspec
+       system @git, 'commit', '-a', '-m', 'a non-empty commit message', '--quiet'
+-      head = Gem::Util.popen('git', 'rev-parse', 'master').strip
++      head = Gem::Util.popen(@git, 'rev-parse', 'master').strip
+     end
+ 
+     return name, git_spec.version, directory, head
+@@ -1498,6 +1498,8 @@ def self.key_path key_name
+ begin
+   gem 'rdoc'
+   require 'rdoc'
++
++  require 'rubygems/rdoc'
+ rescue LoadError, Gem::LoadError
+ end
+ 
+@@ -1514,3 +1516,4 @@ def self.key_path key_name
+ pid = $$
+ END {tmpdirs.each {|dir| Dir.rmdir(dir)} if $$ == pid}
+ Gem.clear_paths
++Gem.loaded_specs.clear
+diff --git test/rubygems/test_gem.rb test/rubygems/test_gem.rb
+index a605f9cdfe..62b36dfd41 100644
+--- test/rubygems/test_gem.rb
++++ test/rubygems/test_gem.rb
+@@ -75,6 +75,29 @@ def test_self_finish_resolve_wtf
+     end
+   end
+ 
++  def test_self_finish_resolve_respects_loaded_specs
++    save_loaded_features do
++      a1 = new_spec "a", "1", "b" => "> 0"
++      b1 = new_spec "b", "1", "c" => ">= 1"
++      b2 = new_spec "b", "2", "c" => ">= 2"
++      c1 = new_spec "c", "1"
++      c2 = new_spec "c", "2"
++
++      install_specs c1, c2, b1, b2, a1
++
++      a1.activate
++      c1.activate
++
++      assert_equal %w(a-1 c-1), loaded_spec_names
++      assert_equal ["b (> 0)"], unresolved_names
++
++      Gem.finish_resolve
++
++      assert_equal %w(a-1 b-1 c-1), loaded_spec_names
++      assert_equal [], unresolved_names
++    end
++  end
++
+   def test_self_install
+     spec_fetcher do |f|
+       f.gem  'a', 1
+@@ -492,7 +515,7 @@ def test_self_find_files_with_gemfile
+     skip if RUBY_VERSION <= "1.8.7"
+ 
+     cwd = File.expand_path("test/rubygems", @@project_dir)
+-    $LOAD_PATH.unshift cwd
++    actual_load_path = $LOAD_PATH.unshift(cwd).dup
+ 
+     discover_path = File.join 'lib', 'sff', 'discover.rb'
+ 
+@@ -518,12 +541,12 @@ def test_self_find_files_with_gemfile
+     expected = [
+       File.expand_path('test/rubygems/sff/discover.rb', @@project_dir),
+       File.join(foo1.full_gem_path, discover_path)
+-    ]
++    ].sort
+ 
+-    assert_equal expected, Gem.find_files('sff/discover')
+-    assert_equal expected, Gem.find_files('sff/**.rb'), '[ruby-core:31730]'
++    assert_equal expected, Gem.find_files('sff/discover').sort
++    assert_equal expected, Gem.find_files('sff/**.rb').sort, '[ruby-core:31730]'
+   ensure
+-    assert_equal cwd, $LOAD_PATH.shift unless RUBY_VERSION <= "1.8.7"
++    assert_equal cwd, actual_load_path.shift unless RUBY_VERSION <= "1.8.7"
+   end
+ 
+   def test_self_find_latest_files
+diff --git test/rubygems/test_gem_commands_open_command.rb test/rubygems/test_gem_commands_open_command.rb
+index 3ec38972e6..a96fa6ea23 100644
+--- test/rubygems/test_gem_commands_open_command.rb
++++ test/rubygems/test_gem_commands_open_command.rb
+@@ -24,7 +24,8 @@ def test_execute
+     @cmd.options[:args] = %w[foo]
+     @cmd.options[:editor] = "#{Gem.ruby} -e0 --"
+ 
+-    spec = gem 'foo'
++    gem 'foo', '1.0.0'
++    spec = gem 'foo', '1.0.1'
+     mock = MiniTest::Mock.new
+     mock.expect(:call, true, [spec.full_gem_path])
+ 
+diff --git test/rubygems/test_gem_commands_query_command.rb test/rubygems/test_gem_commands_query_command.rb
+index 223f205b2d..d8d682b136 100644
+--- test/rubygems/test_gem_commands_query_command.rb
++++ test/rubygems/test_gem_commands_query_command.rb
+@@ -642,7 +642,7 @@ def test_execute_local_details
+     assert_equal expected, @ui.output
+   end
+ 
+-  def test_execute_exact
++  def test_execute_exact_remote
+     spec_fetcher do |fetcher|
+       fetcher.spec 'coolgem-omg', 3
+       fetcher.spec 'coolgem', '4.2.1'
+@@ -665,6 +665,60 @@ def test_execute_exact
+     assert_equal expected, @ui.output
+   end
+ 
++  def test_execute_exact_local
++    spec_fetcher do |fetcher|
++      fetcher.spec 'coolgem-omg', 3
++      fetcher.spec 'coolgem', '4.2.1'
++      fetcher.spec 'wow_coolgem', 1
++    end
++
++    @cmd.handle_options %w[--exact coolgem]
++
++    use_ui @ui do
++      @cmd.execute
++    end
++
++    expected = <<-EOF
++
++*** LOCAL GEMS ***
++
++coolgem (4.2.1)
++    EOF
++
++    assert_equal expected, @ui.output
++  end
++
++  def test_execute_exact_multiple
++    spec_fetcher do |fetcher|
++      fetcher.spec 'coolgem-omg', 3
++      fetcher.spec 'coolgem', '4.2.1'
++      fetcher.spec 'wow_coolgem', 1
++
++      fetcher.spec 'othergem-omg', 3
++      fetcher.spec 'othergem', '1.2.3'
++      fetcher.spec 'wow_othergem', 1
++    end
++
++    @cmd.handle_options %w[--exact coolgem othergem]
++
++    use_ui @ui do
++      @cmd.execute
++    end
++
++    expected = <<-EOF
++
++*** LOCAL GEMS ***
++
++coolgem (4.2.1)
++
++*** LOCAL GEMS ***
++
++othergem (1.2.3)
++    EOF
++
++    assert_equal expected, @ui.output
++  end
++
+   private
+ 
+   def add_gems_to_fetcher
+diff --git test/rubygems/test_gem_commands_sources_command.rb test/rubygems/test_gem_commands_sources_command.rb
+index 014b4b4c12..d5b6d99419 100644
+--- test/rubygems/test_gem_commands_sources_command.rb
++++ test/rubygems/test_gem_commands_sources_command.rb
+@@ -108,6 +108,58 @@ def test_execute_add_redundant_source
+     assert_equal '', @ui.error
+   end
+ 
++  def test_execute_add_redundant_source_trailing_slash
++    # Remove pre-existing gem source (w/ slash)
++    repo_with_slash = "http://gems.example.com/"
++    @cmd.handle_options %W[--remove #{repo_with_slash}]
++    use_ui @ui do
++      @cmd.execute
++    end
++    source = Gem::Source.new repo_with_slash
++    assert_equal false, Gem.sources.include?(source)
++
++    expected = <<-EOF
++#{repo_with_slash} removed from sources
++    EOF
++
++    assert_equal expected, @ui.output
++    assert_equal '', @ui.error
++
++    # Re-add pre-existing gem source (w/o slash)
++    repo_without_slash = "http://gems.example.com"
++    @cmd.handle_options %W[--add #{repo_without_slash}]
++    use_ui @ui do
++      @cmd.execute
++    end
++    source = Gem::Source.new repo_without_slash
++    assert_equal true, Gem.sources.include?(source)
++
++    expected = <<-EOF
++http://gems.example.com/ removed from sources
++http://gems.example.com added to sources
++    EOF
++
++    assert_equal expected, @ui.output
++    assert_equal '', @ui.error
++
++    # Re-add original gem source (w/ slash)
++    @cmd.handle_options %W[--add #{repo_with_slash}]
++    use_ui @ui do
++      @cmd.execute
++    end
++    source = Gem::Source.new repo_with_slash
++    assert_equal true, Gem.sources.include?(source)
++
++    expected = <<-EOF
++http://gems.example.com/ removed from sources
++http://gems.example.com added to sources
++source http://gems.example.com/ already present in the cache
++    EOF
++
++    assert_equal expected, @ui.output
++    assert_equal '', @ui.error 
++  end
++
+   def test_execute_add_http_rubygems_org
+     http_rubygems_org = 'http://rubygems.org'
+ 
+diff --git test/rubygems/test_gem_installer.rb test/rubygems/test_gem_installer.rb
+index 6ceb2c6dfc..882981d344 100644
+--- test/rubygems/test_gem_installer.rb
++++ test/rubygems/test_gem_installer.rb
+@@ -62,7 +62,12 @@ def test_app_script_text
+   end
+ end
+ 
++if Gem.respond_to?(:activate_bin_path)
+ load Gem.activate_bin_path('a', 'executable', version)
++else
++gem "a", version
++load Gem.bin_path("a", "executable", version)
++end
+     EOF
+ 
+     wrapper = @installer.app_script_text 'executable'
+diff --git test/rubygems/test_require.rb test/rubygems/test_require.rb
+index dd606e44d4..936f78fb2a 100644
+--- test/rubygems/test_require.rb
++++ test/rubygems/test_require.rb
+@@ -301,6 +301,17 @@ def test_default_gem_only
+     assert_equal %w(default-2.0.0.0), loaded_spec_names
+   end
+ 
++  def test_realworld_default_gem
++    skip "no default gems on ruby < 2.0" unless RUBY_VERSION >= "2"
++    cmd = <<-RUBY
++      $stderr = $stdout
++      require "json"
++      puts Gem.loaded_specs["json"].default_gem?
++    RUBY
++    output = Gem::Util.popen(Gem.ruby, "-e", cmd).strip
++    assert_equal "true", output
++  end
++
+   def test_default_gem_and_normal_gem
+     default_gem_spec = new_default_spec("default", "2.0.0.0",
+                                         nil, "default/gem.rb")

--- a/lang/ruby24/files/rubygems-2613-ruby24.patch
+++ b/lang/ruby24/files/rubygems-2613-ruby24.patch
@@ -1,0 +1,355 @@
+diff --git lib/rubygems.rb lib/rubygems.rb
+index bc5bf9b4c2..55aa85b8b2 100644
+--- lib/rubygems.rb
++++ lib/rubygems.rb
+@@ -10,7 +10,7 @@
+ require 'thread'
+ 
+ module Gem
+-  VERSION = "2.6.12"
++  VERSION = "2.6.13"
+ end
+ 
+ # Must be first since it unloads the prelude from 1.9.2
+diff --git lib/rubygems/commands/query_command.rb lib/rubygems/commands/query_command.rb
+index 70f8127292..44144203e0 100644
+--- lib/rubygems/commands/query_command.rb
++++ lib/rubygems/commands/query_command.rb
+@@ -226,7 +226,7 @@ def output_versions output, versions
+         end
+       end
+ 
+-      output << make_entry(matching_tuples, platforms)
++      output << clean_text(make_entry(matching_tuples, platforms))
+     end
+   end
+ 
+@@ -353,7 +353,8 @@ def spec_platforms entry, platforms
+   end
+ 
+   def spec_summary entry, spec
+-    entry << "\n\n" << format_text(spec.summary, 68, 4)
++    summary = truncate_text(spec.summary, "the summary for #{spec.full_name}")
++    entry << "\n\n" << format_text(summary, 68, 4)
+   end
+ 
+ end
+diff --git lib/rubygems/installer.rb lib/rubygems/installer.rb
+index 967543c2d1..6fd3399dd4 100644
+--- lib/rubygems/installer.rb
++++ lib/rubygems/installer.rb
+@@ -697,6 +697,11 @@ def verify_gem_home(unpack = false) # :nodoc:
+       unpack or File.writable?(gem_home)
+   end
+ 
++  def verify_spec_name
++    return if spec.name =~ Gem::Specification::VALID_NAME_PATTERN
++    raise Gem::InstallError, "#{spec} has an invalid name"
++  end
++
+   ##
+   # Return the text for an application file.
+ 
+@@ -823,6 +828,8 @@ def pre_install_checks
+ 
+     ensure_loadable_spec
+ 
++    verify_spec_name
++
+     if options[:install_as_default]
+       Gem.ensure_default_gem_subdirectories gem_home
+     else
+diff --git lib/rubygems/remote_fetcher.rb lib/rubygems/remote_fetcher.rb
+index e6a13d4b8c..8f0cf0b402 100644
+--- lib/rubygems/remote_fetcher.rb
++++ lib/rubygems/remote_fetcher.rb
+@@ -110,7 +110,7 @@ def api_endpoint(uri)
+     else
+       target = res.target.to_s.strip
+ 
+-      if /\.#{Regexp.quote(host)}\z/ =~ target
++      if URI("http://" + target).host.end_with?(".#{host}")
+         return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
+       end
+ 
+diff --git lib/rubygems/specification.rb lib/rubygems/specification.rb
+index 500f0af768..88e320c05a 100644
+--- lib/rubygems/specification.rb
++++ lib/rubygems/specification.rb
+@@ -108,6 +108,8 @@ class Gem::Specification < Gem::BasicSpecification
+ 
+   private_constant :LOAD_CACHE if defined? private_constant
+ 
++  VALID_NAME_PATTERN = /\A[a-zA-Z0-9\.\-\_]+\z/ # :nodoc:
++
+   # :startdoc:
+ 
+   ##
+@@ -2671,9 +2673,15 @@ def validate packaging = true
+       end
+     end
+ 
+-    unless String === name then
++    if !name.is_a?(String) then
+       raise Gem::InvalidSpecificationException,
+-            "invalid value for attribute name: \"#{name.inspect}\""
++            "invalid value for attribute name: \"#{name.inspect}\" must be a string"
++    elsif name !~ /[a-zA-Z]/ then
++      raise Gem::InvalidSpecificationException,
++            "invalid value for attribute name: #{name.dump} must include at least one letter"
++    elsif name !~ VALID_NAME_PATTERN then
++      raise Gem::InvalidSpecificationException,
++            "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
+     end
+ 
+     if raw_require_paths.empty? then
+diff --git lib/rubygems/text.rb lib/rubygems/text.rb
+index 732f1b99f2..b944b62c27 100644
+--- lib/rubygems/text.rb
++++ lib/rubygems/text.rb
+@@ -6,13 +6,26 @@
+ 
+ module Gem::Text
+ 
++  ##
++  # Remove any non-printable characters and make the text suitable for
++  # printing.
++  def clean_text(text)
++    text.gsub(/[\000-\b\v-\f\016-\037\177]/, ".".freeze)
++  end
++
++  def truncate_text(text, description, max_length = 100_000)
++    raise ArgumentError, "max_length must be positive" unless max_length > 0
++    return text if text.size <= max_length
++    "Truncating #{description} to #{max_length.to_s.reverse.gsub(/...(?=.)/,'\&,').reverse} characters:\n" + text[0, max_length]
++  end
++
+   ##
+   # Wraps +text+ to +wrap+ characters and optionally indents by +indent+
+   # characters
+ 
+   def format_text(text, wrap, indent=0)
+     result = []
+-    work = text.dup
++    work = clean_text(text)
+ 
+     while work.length > wrap do
+       if work =~ /^(.{0,#{wrap}})[ \n]/ then
+diff --git test/rubygems/test_gem_commands_query_command.rb test/rubygems/test_gem_commands_query_command.rb
+index d8d682b136..469223c6c0 100644
+--- test/rubygems/test_gem_commands_query_command.rb
++++ test/rubygems/test_gem_commands_query_command.rb
+@@ -116,6 +116,86 @@ def test_execute_details
+     This is a lot of text. This is a lot of text. This is a lot of text.
+     This is a lot of text.
+ 
++pl (1)
++    Platform: i386-linux
++    Author: A User
++    Homepage: http://example.com
++
++    this is a summary
++    EOF
++
++    assert_equal expected, @ui.output
++    assert_equal '', @ui.error
++  end
++
++  def test_execute_details_cleans_text
++    spec_fetcher do |fetcher|
++      fetcher.spec 'a', 2 do |s|
++        s.summary = 'This is a lot of text. ' * 4
++        s.authors = ["Abraham Lincoln \x01", "\x02 Hirohito"]
++        s.homepage = "http://a.example.com/\x03"
++      end
++
++      fetcher.legacy_platform
++    end
++
++    @cmd.handle_options %w[-r -d]
++
++    use_ui @ui do
++      @cmd.execute
++    end
++
++    expected = <<-EOF
++
++*** REMOTE GEMS ***
++
++a (2)
++    Authors: Abraham Lincoln ., . Hirohito
++    Homepage: http://a.example.com/.
++
++    This is a lot of text. This is a lot of text. This is a lot of text.
++    This is a lot of text.
++
++pl (1)
++    Platform: i386-linux
++    Author: A User
++    Homepage: http://example.com
++
++    this is a summary
++    EOF
++
++    assert_equal expected, @ui.output
++    assert_equal '', @ui.error
++  end
++
++  def test_execute_details_truncates_summary
++    spec_fetcher do |fetcher|
++      fetcher.spec 'a', 2 do |s|
++        s.summary = 'This is a lot of text. ' * 10_000
++        s.authors = ["Abraham Lincoln \x01", "\x02 Hirohito"]
++        s.homepage = "http://a.example.com/\x03"
++      end
++
++      fetcher.legacy_platform
++    end
++
++    @cmd.handle_options %w[-r -d]
++
++    use_ui @ui do
++      @cmd.execute
++    end
++
++    expected = <<-EOF
++
++*** REMOTE GEMS ***
++
++a (2)
++    Authors: Abraham Lincoln ., . Hirohito
++    Homepage: http://a.example.com/.
++
++    Truncating the summary for a-2 to 100,000 characters:
++#{"    This is a lot of text. This is a lot of text. This is a lot of text.\n" * 1449}    This is a lot of te
++
+ pl (1)
+     Platform: i386-linux
+     Author: A User
+diff --git test/rubygems/test_gem_installer.rb test/rubygems/test_gem_installer.rb
+index 882981d344..dd049214fb 100644
+--- test/rubygems/test_gem_installer.rb
++++ test/rubygems/test_gem_installer.rb
+@@ -1448,6 +1448,26 @@ def test_pre_install_checks_wrong_rubygems_version
+     end
+   end
+ 
++  def test_pre_install_checks_malicious_name
++    spec = util_spec '../malicious', '1'
++    def spec.full_name # so the spec is buildable
++      "malicious-1"
++    end
++    def spec.validate; end
++
++    util_build_gem spec
++
++    gem = File.join(@gemhome, 'cache', spec.file_name)
++
++    use_ui @ui do
++      @installer = Gem::Installer.at gem
++      e = assert_raises Gem::InstallError do
++        @installer.pre_install_checks
++      end
++      assert_equal '#<Gem::Specification name=../malicious version=1> has an invalid name', e.message
++    end
++  end
++
+   def test_shebang
+     util_make_exec @spec, "#!/usr/bin/ruby"
+ 
+diff --git test/rubygems/test_gem_remote_fetcher.rb test/rubygems/test_gem_remote_fetcher.rb
+index cb994462cd..fbb7d89019 100644
+--- test/rubygems/test_gem_remote_fetcher.rb
++++ test/rubygems/test_gem_remote_fetcher.rb
+@@ -241,6 +241,21 @@ def test_api_endpoint_ignores_trans_domain_values_that_end_with_original
+     dns.verify
+   end
+ 
++  def test_api_endpoint_ignores_trans_domain_values_that_end_with_original_in_path
++    uri = URI.parse "http://example.com/foo"
++    target = MiniTest::Mock.new
++    target.expect :target, "evil.com/a.example.com"
++
++    dns = MiniTest::Mock.new
++    dns.expect :getresource, target, [String, Object]
++
++    fetch = Gem::RemoteFetcher.new nil, dns
++    assert_equal URI.parse("http://example.com/foo"), fetch.api_endpoint(uri)
++
++    target.verify
++    dns.verify
++  end
++
+   def test_api_endpoint_timeout_warning
+     uri = URI.parse "http://gems.example.com/foo"
+ 
+diff --git test/rubygems/test_gem_specification.rb test/rubygems/test_gem_specification.rb
+index d43289d745..0fcc11e78f 100644
+--- test/rubygems/test_gem_specification.rb
++++ test/rubygems/test_gem_specification.rb
+@@ -2985,7 +2985,37 @@ def test_validate_name
+       @a1.validate
+     end
+ 
+-    assert_equal 'invalid value for attribute name: ":json"', e.message
++    assert_equal 'invalid value for attribute name: ":json" must be a string', e.message
++
++    @a1.name = []
++    e = assert_raises Gem::InvalidSpecificationException do
++      @a1.validate
++    end
++    assert_equal "invalid value for attribute name: \"[]\" must be a string", e.message
++
++    @a1.name = ""
++    e = assert_raises Gem::InvalidSpecificationException do
++      @a1.validate
++    end
++    assert_equal "invalid value for attribute name: \"\" must include at least one letter", e.message
++
++    @a1.name = "12345"
++    e = assert_raises Gem::InvalidSpecificationException do
++      @a1.validate
++    end
++    assert_equal "invalid value for attribute name: \"12345\" must include at least one letter", e.message
++
++    @a1.name = "../malicious"
++    e = assert_raises Gem::InvalidSpecificationException do
++      @a1.validate
++    end
++    assert_equal "invalid value for attribute name: \"../malicious\" can only include letters, numbers, dashes, and underscores", e.message
++
++    @a1.name = "\ba\t"
++    e = assert_raises Gem::InvalidSpecificationException do
++      @a1.validate
++    end
++    assert_equal "invalid value for attribute name: \"\\ba\\t\" can only include letters, numbers, dashes, and underscores", e.message
+   end
+ 
+   def test_validate_non_nil
+diff --git test/rubygems/test_gem_text.rb test/rubygems/test_gem_text.rb
+index a6e22e04da..04f3f605e8 100644
+--- test/rubygems/test_gem_text.rb
++++ test/rubygems/test_gem_text.rb
+@@ -36,6 +36,10 @@ def test_format_text_trailing # for two spaces after .
+     assert_equal expected, format_text(text, 78)
+   end
+ 
++  def test_format_removes_nonprintable_characters
++    assert_equal "text with weird .. stuff .", format_text("text with weird \x1b\x02 stuff \x7f", 40)
++  end
++
+   def test_min3
+     assert_equal 1, min3(1, 1, 1)
+     assert_equal 1, min3(1, 1, 2)
+@@ -74,4 +78,11 @@ def test_levenshtein_distance_replace
+     assert_equal 7, levenshtein_distance("xxxxxxx", "ZenTest")
+     assert_equal 7, levenshtein_distance("zentest", "xxxxxxx")
+   end
++
++  def test_truncate_text
++    assert_equal "abc", truncate_text("abc", "desc")
++    assert_equal "Truncating desc to 2 characters:\nab", truncate_text("abc", "desc", 2)
++    s = "ab" * 500_001
++    assert_equal "Truncating desc to 1,000,000 characters:\n#{s[0, 1_000_000]}", truncate_text(s, "desc", 1_000_000)
++  end
+ end


### PR DESCRIPTION
###### Description
See: https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/
> At this moment, there are no Ruby releases including the fix for RubyGems.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
