### PR TITLE
py-rtmidi-python, py-sounddevice: new ports

### DIFF
--- a/python/py-rtmidi-python/Portfile
+++ b/python/py-rtmidi-python/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rtmidi-python
+version             0.2.2
+platforms           darwin
+license             MIT
+maintainers         mojca openmaintainer
+
+description         Python wrapper for RtMidi
+long_description    Python wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library
+
+homepage            https://github.com/superquadratic/rtmidi-python
+master_sites        pypi:r/rtmidi-python
+distname            rtmidi-python-${version}
+
+checksums           rmd160  246334f69cf21659926f61cb1c61894b050beae0 \
+                    sha256  a092ab3d9b45d43a342a602a60bfd94381dce39d8120f4d06152d7755d57ecf2
+
+python.versions     27 35 36
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}

--- a/python/py-sounddevice/Portfile
+++ b/python/py-sounddevice/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sounddevice
+version             0.3.8
+platforms           darwin
+license             MIT
+maintainers         mojca openmaintainer
+
+description         Play and Record Sound with Python
+long_description    This Python module provides bindings for the PortAudio library \
+                    and a few convenience functions to play and record NumPy arrays \
+                    containing audio signals
+
+homepage            http://python-sounddevice.readthedocs.io/
+master_sites        pypi:s/sounddevice
+distname            sounddevice-${version}
+
+checksums           rmd160  0c86cd2031f34bb63ea0b1fafbe578946e39db44 \
+                    sha256  dc5ec8534c3831ab133c497721f3aaeed4f5084b0eda842f0c0ada09f2f066dc
+
+python.versions     27 35 36
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+    depends_run-append  port:portaudio \
+                        port:py${python.version}-cffi \
+                        port:py${python.version}-numpy
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
###### Description

Two new ports for handling audio, dependencies of http://www.samplerbox.org.

I wanted to do a test build with Travis just in case.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
