### PR TITLE
New subport: gromacs-plumed

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -88,8 +88,8 @@ subport gromacs-plumed {
       THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED
     conflicts gromacs
 
-    depends_build-append   port:plumed
-    depends_lib-append     port:plumed
+    depends_build-append   path:${prefix}/bin/plumed:plumed
+    depends_lib-append     path:${prefix}/lib/libplumedKernel.dylib:plumed
     mpi.enforce_variant plumed
     pre-configure {
 # I need to execute with full path since PATH variable is not properly set here

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -84,8 +84,10 @@ post-test {
 ## ADDITION FOR PLUMED SUBPORT
 subport gromacs-plumed {
 
-    long_description    ${description}: \
-      THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED
+    description    ${description}: \
+      (THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED)
+    long_description    ${long_description}: \
+      (THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED)
     conflicts gromacs
 
     depends_build-append   path:${prefix}/bin/plumed:plumed

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -92,7 +92,6 @@ subport gromacs-plumed {
 
     depends_build-append   path:${prefix}/bin/plumed:plumed
     depends_lib-append     path:${prefix}/lib/libplumedKernel.dylib:plumed
-    mpi.enforce_variant plumed
     pre-configure {
 # I need to execute with full path since PATH variable is not properly set here
 # Also notice that I am patching with runtime. Notice that 

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -81,6 +81,29 @@ post-test {
 #For more information and tips for troubleshooting, please check the GROMACS
 #website at http://www.gromacs.org/Documentation/Errors
 
+## ADDITION FOR PLUMED SUBPORT
+subport gromacs-plumed {
+
+    long_description    ${description}: \
+      THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED
+    conflicts gromacs
+
+    depends_build-append   port:plumed
+    depends_lib-append     port:plumed
+    mpi.enforce_variant plumed
+    pre-configure {
+# I need to execute with full path since PATH variable is not properly set here
+# Also notice that I am patching with runtime. Notice that 
+# plumed compiled for MacPorts have the hardcoded path also in the runtime patch.
+# This allows the user to work with MacPorts plumed and possibly
+# override the choice setting the PLUMED_KERNEL environment variable.
+# Also notice that gromacs version is hardcoded here. Plumed patch is not always
+# updated when gromacs is.
+      exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-5.1.4 --runtime -p
+    }
+}
+## END ADDITION FOR PLUMED SUBPORT ONLY
+
 linalg.setup  noveclibfort
 pre-configure {
     if {[mpi_variant_isset]} {

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -90,6 +90,13 @@ subport gromacs-plumed {
       (THIS PORT INSTALLS A VERSION OF GROMACS PATCHED WITH PLUMED)
     conflicts gromacs
 
+# in case gromacs is compiled with MPI, also enforce that plumed is complied with the same MPI variant:
+    if {[mpi_variant_isset]} {
+      require_active_variants path:${prefix}/lib/libplumedKernel.dylib:plumed [mpi_variant_name]
+    }
+# make sure that thread MPI is disabled, since it does not work with plumed
+    configure.args-append -DGMX_THREAD_MPI=OFF
+
     depends_build-append   path:${prefix}/bin/plumed:plumed
     depends_lib-append     path:${prefix}/lib/libplumedKernel.dylib:plumed
     pre-configure {


### PR DESCRIPTION
This subport allows installing gromacs with plumed support.

###### Description

I enclose a pull request for a modified version of gromacs which includes the PLUMED library. Could anyone check it and, in case is ok, merge it? See also explanations below.

**How does GROMACS+PLUMED work.** [PLUMED](http://www.plumed.org) provides a library and a command line tool. It can be currently installed with MacPorts (`port install plumed`). The library is used already in some molecular dynamics code. However, for some other codes, including gromacs, a patch is necessary. The patch is contained in PLUMED itself and is applied with a command such as `plumed patch -p`.

**Variant vs subport**. I originally implemented a variant `gromacs +plumed`. However, based on the feedbacks I received during the review of #408, I now think it is better to have a subport `gromacs-plumed`. I make the subport conflict with `gromacs` so that either one or the other is installed. I am happy to change it back to a variant in case MacPorts developers think it is better in this case (it is a two lines change).

**Portfile changes**. The only changes are those required for the `gromacs-plumed` subport. In particular, before installing gromacs, the patch is applied using the `plumed patch` command.

Please let me know if this request is ready for merge or if I should make some change. Thanks!

Giovanni
 
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G1611
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
