### PR TITLE
get_iplayer: upgrade to 3.02

### DIFF
--- a/net/get_iplayer/Portfile
+++ b/net/get_iplayer/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 PortGroup           github 1.0
 
-github.setup        get-iplayer get_iplayer 3.00 v
+github.setup        get-iplayer get_iplayer 3.02 v
 categories          net multimedia
 platforms           darwin
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -15,14 +15,13 @@ description         A utility for downloading TV and radio from BBC iPlayer
 long_description    ${description}. \
                     \nThis port does not install the Web PVR Manager (get_iplayer.cgi).
 
-checksums           rmd160  3ab746ad297dfb37426b9b2015ddcd28698fc608 \
-                    sha256  eed4b401968056bdcd210489b1082b8244d57a20943f472db1749fe30e0f3d15
+checksums           rmd160  0d30990121dd2c9b49c241825c27c0e708b92ba2 \
+                    sha256  8a740bc5ecad0bba3bff828ffa5a07a0e07c628d45a78de27b39a3bd007a28c9
 
 perl5.branches      5.24
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-libwww-perl \
-                    port:p${perl5.major}-xml-simple \
                     port:p${perl5.major}-xml-libxml \
                     port:p${perl5.major}-mp3-tag \
                     port:p${perl5.major}-mp3-info \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/54680

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G1611
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
