### PR TITLE
surf @ 2.0 : new port

### DIFF
--- a/www/surf/Portfile
+++ b/www/surf/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+
+name                surf
+version             2.0
+license             MIT
+
+categories          www
+maintainers         {gmail.com:ken.cunningham.webuse @kencu} openmaintainer
+description         simple webkit2-gtk-based browser
+long_description    surf is a simple Web browser based on WebKit2/GTK+. It is able to display \
+    websites and follow links. It supports the  XEmbed protocol which makes it possible to embed \
+    it in another application. Furthermore, one can point surf to another URI by setting its XProperties.
+
+
+homepage            http://surf.suckless.org/
+platforms           darwin
+
+master_sites        http://dl.suckless.org/${name}/
+
+checksums           rmd160  02c94f3009e9fe69b12087d5884186b07bf89790 \
+                    sha256  faee4c7a62c38fc9791eff1ad06787c3c9b2b79f338806827f5152a7bc54951d
+                    
+depends_build-append \
+                    port:pkgconfig
+
+depends_lib-append  path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk \
+                    port:gtk3 \
+                    port:dmenu
+
+# uses X11 specific code in UI
+require_active_variants \
+                    port:gtk3 x11
+
+use_configure       no
+
+patchfiles-append   patch-config-mk.diff \
+                    patch-surf-Style-namecollision.diff \
+                    patch-downloader.diff
+
+post-patch {
+    reinplace "s|@@MACPORTS_PREFIX@@|${prefix}|g" ${worksrcpath}/config.mk
+}
+
+build.args          CC=${configure.cc} CXX=${configure.cxx}
+destroot.args       CC=${configure.cc} CXX=${configure.cxx}
+                    
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/www/surf/files/patch-config-mk.diff
+++ b/www/surf/files/patch-config-mk.diff
@@ -1,0 +1,22 @@
+--- config.mk.orig	2017-08-26 10:41:22.000000000 -0700
++++ config.mk	2017-08-26 10:44:05.000000000 -0700
+@@ -4,7 +4,7 @@
+ # Customize below to fit your system
+ 
+ # paths
+-PREFIX = /usr/local
++PREFIX = @@MACPORTS_PREFIX@@
+ MANPREFIX = ${PREFIX}/share/man
+ LIBPREFIX = ${PREFIX}/lib/surf
+ 
+@@ -15,8 +15,8 @@
+ GTKLIB = `pkg-config --libs gtk+-3.0 webkit2gtk-4.0`
+ 
+ # includes and libs
+-INCS = -I. -I/usr/include -I${X11INC} ${GTKINC}
+-LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 ${GTKLIB} -lgthread-2.0
++INCS = -I. -I@@MACPORTS_PREFIX@@/include -I${X11INC} ${GTKINC}
++LIBS = -L@@MACPORTS_PREFIX@@/lib -lc -L${X11LIB} -lX11 ${GTKLIB} -lgthread-2.0
+ 
+ # flags
+ CPPFLAGS = -DVERSION=\"${VERSION}\" -DWEBEXTDIR=\"${LIBPREFIX}\" -D_DEFAULT_SOURCE

--- a/www/surf/files/patch-downloader.diff
+++ b/www/surf/files/patch-downloader.diff
@@ -1,0 +1,12 @@
+--- config.def.h.orig	2017-08-26 11:55:02.000000000 -0700
++++ config.def.h	2017-08-26 11:59:01.000000000 -0700
+@@ -58,7 +58,8 @@
+ /* DOWNLOAD(URI, referer) */
+ #define DOWNLOAD(d, r) { \
+         .v = (const char *[]){ "/bin/sh", "-c", \
+-             "st -e /bin/sh -c \"curl -g -L -J -O --user-agent '$1'" \
++             "cd ~/Downloads;" \
++             "xterm -e /bin/sh -c \"curl -g -L -J -O --user-agent '$1'" \
+              " --referer '$2' -b $3 -c $3 '$0';" \
+              " sleep 5;\"", \
+              d, useragent, r, cookiefile, NULL \

--- a/www/surf/files/patch-surf-Style-namecollision.diff
+++ b/www/surf/files/patch-surf-Style-namecollision.diff
@@ -1,0 +1,12 @@
+--- surf.c.orig	2017-08-26 10:51:26.000000000 -0700
++++ surf.c	2017-08-26 11:00:29.000000000 -0700
+@@ -57,6 +57,9 @@
+ 	OnAny   = OnDoc | OnLink | OnImg | OnMedia | OnEdit | OnBar | OnSel,
+ };
+ 
++// avoid name collision with QuickDraw globals
++#define Style Surf_Style
++
+ typedef enum {
+ 	AcceleratedCanvas,
+ 	CaretBrowsing,


### PR DESCRIPTION
simple webkit2-gtk browser
very lean: brings up webkit2-gtk then gets out of the way
needs new port dmenu for proper functionality
travis build will fail until dmenu is available in MacPorts

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6 to 10.12
Xcode 3.26 to 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
