### PR TITLE
qt4-mac: backport qt5 QSettings fix + support building on Tiger + maybe support High Sierra

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -11,12 +11,12 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                qt4-mac
 version             4.8.7
-revision            5
+revision            6
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          aqua
 platforms           macosx
-maintainers         michaelld openmaintainer
+maintainers         {michaelld @michaelld} openmaintainer
 license             {LGPL-2.1 GPL-3}
 
 homepage            http://www.qt.io/
@@ -40,7 +40,7 @@ depends_lib-append  port:zlib \
                     port:tiff \
                     port:libpng \
                     port:libmng \
-                    port:jpeg
+                    path:lib/libjpeg.dylib:jpeg
 
 # find a way to specify the OS MINOR version.  For OSX 10.X, this
 # value will be X.  The type is this variable is integer, so we can
@@ -217,7 +217,8 @@ patchfiles-append   \
 
 platform darwin {
     if {${MINOR} == 4} {
-        patchfiles-append patch-QtHelp_10.4_only.diff
+        # this breaks the framework build
+        #patchfiles-append patch-QtHelp_10.4_only.diff
     }
 }
 
@@ -292,15 +293,40 @@ patchfiles-append patch-better-invalid-fonttable-handling.diff
 
 patchfiles-append patch-fix_pointer_comparison_to_0.diff
 
+# (30) Fix build on 10.13; comment out assertions
+# won't hurt current builds, but allows building on 10.13 / Xcode 9
+
+patchfiles-append patch-src_gui_kernel_qt_cocoa_helpers_mac.mm.diff
+
+# (30) an alternate Patch to fix build on macOS High Sierra
+# enable assertions without underscores
+# patchfiles-append patch-qt4-versions-without-underscores.diff
+
+# (31) Backport of Qt5 patch to fix an issue with null bytes in QSetting strings (QTBUG-56124).
+patchfiles-append patch-qsettings-null.diff
+
+# (32) Mac OS X 10.4 Tiger patches
+platform darwin {
+    if {${MINOR} == 4} {
+        patchfiles-append patch-src_corelib_io_qfilesystemengine_unix.cpp-tiger.diff
+        patchfiles-append patch-src_network_kernel_qnetworkproxy_mac.cpp-tiger.diff
+        patchfiles-append patch-src_gui_painting_qprintengine_mac.mm-tiger.diff
+        patchfiles-append patch-src_gui_dialogs_qfontdialog_mac.mm-tiger.diff
+        patchfiles-append patch-src_gui_text_qfontdatabase_mac.cpp-tiger.diff
+        patchfiles-append patch-src_gui_painting_qpaintengine_mac.cpp-tiger.diff
+    }
+}
+
+
 # error out if trying to build on a new OSX version (> 10.12).
 
 platform darwin {
-    if {${MINOR} > 12} {
+    if {${MINOR} > 13} {
         # This project needs to be updated to build with clang++ against libc++
         depends_lib
         depends_run
         pre-fetch {
-            ui_error "$name does not currently build on Mac OS X later than 10.12 'Sierra'."
+            ui_error "$name does not currently build on Mac OS X later than 10.13 'High Sierra'."
             error "unsupported platform"
         }
     }
@@ -337,7 +363,7 @@ if {${SDK} eq ""} {
 post-patch {
     # set ARCHES in configure (per the third patchfile above), for
     # building QMake.  join any 2 or more arch entries with the GCC
-    # arch flag (join does not effect a single entry).  first "-arch"
+    # arch flag (join does not affect a single entry).  first "-arch"
     # is already in place in the 'configure' script (since there has
     # to be at least 1 arch).
 
@@ -985,7 +1011,7 @@ post-destroot {
         set dest_dir ${dr_qt_frameworks_dir}/${include_dir}.framework/Headers/private
         xinstall -m 755 -d ${dest_dir}
         set files [exec find ${worksrcpath}/src/${src_dir} -type f -name "*_p.h"]
-        eval xinstall -m 644 [split ${files}] ${dest_dir}
+        xinstall -m 644 {*}[split ${files}] ${dest_dir}
     }
 
     # Move .apps into the applications_dir, and link each .apps'

--- a/aqua/qt4-mac/files/patch-qmake_generators_unix_unixmakke.cpp.diff
+++ b/aqua/qt4-mac/files/patch-qmake_generators_unix_unixmakke.cpp.diff
@@ -1,0 +1,108 @@
+--- qmake/generators/unix/unixmake.cpp.orig	2013-02-24 21:46:23.000000000 -0500
++++ qmake/generators/unix/unixmake.cpp	2013-02-25 11:40:24.000000000 -0500
+@@ -472,8 +472,9 @@
+ UnixMakefileGenerator::findLibraries()
+ {
+     QList<QMakeLocalFileName> libdirs, frameworkdirs;
++    frameworkdirs.append(QMakeLocalFileName("@PREFIX@/Library/Frameworks"));
+     frameworkdirs.append(QMakeLocalFileName("/System/Library/Frameworks"));
+-    frameworkdirs.append(QMakeLocalFileName("/Library/Frameworks"));
++    libdirs.append(QMakeLocalFileName("@PREFIX@/lib"));
+     const QString lflags[] = { "QMAKE_LIBDIR_FLAGS", "QMAKE_FRAMEWORKPATH_FLAGS", "QMAKE_LFLAGS", "QMAKE_LIBS", "QMAKE_LIBS_PRIVATE", QString() };
+     for(int i = 0; !lflags[i].isNull(); i++) {
+         QStringList &l = project->values(lflags[i]);
+@@ -583,7 +584,9 @@
+ UnixMakefileGenerator::processPrlFiles()
+ {
+     QList<QMakeLocalFileName> libdirs, frameworkdirs;
++    frameworkdirs.append(QMakeLocalFileName("@PREFIX@/Library/Frameworks"));
+     frameworkdirs.append(QMakeLocalFileName("/System/Library/Frameworks"));
++    libdirs.append(QMakeLocalFileName("@PREFIX@/lib"));
+     const QString lflags[] = { "QMAKE_LIBDIR_FLAGS", "QMAKE_FRAMEWORKPATH_FLAGS", "QMAKE_LFLAGS", "QMAKE_LIBS", QString() };
+     for(int i = 0; !lflags[i].isNull(); i++) {
+         QStringList &l = project->values(lflags[i]);
+@@ -627,13 +630,78 @@
+                     else
+                         opt = l.at(++lit);
+                     opt = opt.trimmed();
+-                    const QList<QMakeLocalFileName> dirs = frameworkdirs + libdirs;
+-                    for(int dep_i = 0; dep_i < dirs.size(); ++dep_i) {
++
++		    // See if this framework is specified as
++		    // "foo,bar", which to Apple's LD means to look
++		    // for "foo" with the addition "bar" first in all
++		    // paths, then if not found do the same for just
++		    // "foo".  Tricky looking for "," but not "\,"
++
++#if 0
++		    warn_msg(WarnLogic, "out before: '%s'\n", opt.toLatin1().constData());
++#endif
++		    int num_cs = 0;
++		    int loc_1 = -1;
++		    int loc = opt.indexOf(",");
++		    bool found = false;
++		    while (!found && (loc != -1)) { 
++		      found = (loc == 0);
++		      if (!found) {
++			found = (opt[loc-1] != '\\');
++		      }
++		      if (found) {
++			if (loc_1 == -1) {
++			  loc_1 = loc;
++			}
++			++num_cs;
++		      } else {
++			loc = opt.indexOf(",", loc);
++		      }
++		    }
++#if 0
++		    warn_msg(WarnLogic, "found == %s, loc == %d\n",
++			     (found ? "true" : "false"), loc);
++#endif
++		    if (found) {
++		      // split into name and extension
++		      if (num_cs > 1) {
++			warn_msg(WarnLogic, "When parsing -framework '%s', found more than one ',' in the name.  Assuming the first ',' is used to delineate between the framework name and the optional extension.\n", opt.toLatin1().constData());
++		      }
++		      QString ext = opt.mid(loc_1+1);
++		      opt = opt.left(loc_1);
++		      found = false;
++		      const QList<QMakeLocalFileName> dirs = frameworkdirs + libdirs;
++		      for(int dep_i = 0; dep_i < dirs.size(); ++dep_i) {
++                        QString prl = dirs[dep_i].local() + "/" + opt + ".framework/" + opt + ext + Option::prl_ext;
++#if 0
++			warn_msg(WarnLogic, "Looking for PRL '%s'\n", prl.toLatin1().constData());
++#endif
++                        if(processPrlFile(prl)) {
++#if 0
++			  warn_msg(WarnLogic, "Found PRL for framework '%s' with optional extension '%s': '%s'\n", opt.toLatin1().constData(), ext.toLatin1().constData(), prl.toLatin1().constData());
++#endif
++			  found = true;
++			  break;
++			}
++		      }
++		    }
++		    // if not found yet, try the primary name
++		    if (!found) {
++		      const QList<QMakeLocalFileName> dirs = frameworkdirs + libdirs;
++		      for(int dep_i = 0; dep_i < dirs.size(); ++dep_i) {
+                         QString prl = dirs[dep_i].local() + "/" + opt + ".framework/" + opt + Option::prl_ext;
+-                        if(processPrlFile(prl))
+-                            break;
+-                    }
+-                }
++#if 0
++			warn_msg(WarnLogic, "Looking for PRL '%s'\n", prl.toLatin1().constData());
++#endif
++                        if(processPrlFile(prl)) {
++#if 0
++			  warn_msg(WarnLogic, "Found PRL for framework '%s': '%s'\n", opt.toLatin1().constData(), prl.toLatin1().constData());
++#endif
++			  break;
++			}
++		      }
++		    }
++		}
+             } else if(!opt.isNull()) {
+                 QString lib = opt;
+                 processPrlFile(lib);

--- a/aqua/qt4-mac/files/patch-qsettings-null.diff
+++ b/aqua/qt4-mac/files/patch-qsettings-null.diff
@@ -1,0 +1,76 @@
+From 38ca587a64499707cb375738758430f8d105fc7d Mon Sep 17 00:00:00 2001
+From: Mikkel Krautz <mikkel@krautz.dk>
+Date: Fri, 2 Dec 2016 22:55:56 +0100
+Subject: [PATCH] Backport
+ qt5-macos-handle-qsetting-strings-with-embedded-zero-bytes-QTBUG-56124.patch
+ from mumble-releng to Qt 4.
+
+---
+ src/corelib/io/qsettings.cpp     |  6 +++++-
+ src/corelib/io/qsettings_mac.cpp | 22 +++++++++++++++++++---
+ 2 files changed, 24 insertions(+), 4 deletions(-)
+
+diff --git src/corelib/io/qsettings.cpp.orig src/corelib/io/qsettings.cpp
+index a4750c5..eb8ab5e 100644
+--- src/corelib/io/qsettings.cpp
++++ src/corelib/io/qsettings.cpp
+@@ -487,7 +487,9 @@ QString QSettingsPrivate::variantToString(const QVariant &v)
+         case QVariant::Double:
+         case QVariant::KeySequence: {
+             result = v.toString();
+-            if (result.startsWith(QLatin1Char('@')))
++            if (result.contains(QChar::Null))
++                result = QLatin1String("@String(") + result + QLatin1Char(')');
++            else if (result.startsWith(QLatin1Char('@')))
+                 result.prepend(QLatin1Char('@'));
+             break;
+         }
+@@ -554,6 +556,8 @@ QVariant QSettingsPrivate::stringToVariant(const QString &s)
+         if (s.endsWith(QLatin1Char(')'))) {
+             if (s.startsWith(QLatin1String("@ByteArray("))) {
+                 return QVariant(s.toLatin1().mid(11, s.size() - 12));
++            } else if (s.startsWith(QLatin1String("@String("))) {
++                return QVariant(s.midRef(8, s.size() - 9).toString());
+             } else if (s.startsWith(QLatin1String("@Variant("))) {
+ #ifndef QT_NO_DATASTREAM
+                 QByteArray a(s.toLatin1().mid(9));
+diff --git src/corelib/io/qsettings_mac.cpp.orig src/corelib/io/qsettings_mac.cpp
+index 3504907..edbe103 100644
+--- src/corelib/io/qsettings_mac.cpp
++++ src/corelib/io/qsettings_mac.cpp
+@@ -218,7 +218,14 @@ static QCFType<CFPropertyListRef> macValue(const QVariant &value)
+     case QVariant::String:
+     string_case:
+     default:
+-        result = QCFString::toCFStringRef(QSettingsPrivate::variantToString(value));
++        QString string = QSettingsPrivate::variantToString(value);
++        if (string.contains(QChar::Null)) {
++            QByteArray ba = string.toUtf8();
++            result = CFDataCreate(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(ba.data()),
++                                  CFIndex(ba.size()));
++        } else {
++            result = QCFString::toCFStringRef(string);
++        }
+     }
+     return result;
+ }
+@@ -269,8 +276,17 @@ static QVariant qtValue(CFPropertyListRef cfvalue)
+         return (bool)CFBooleanGetValue(static_cast<CFBooleanRef>(cfvalue));
+     } else if (typeId == CFDataGetTypeID()) {
+         CFDataRef cfdata = static_cast<CFDataRef>(cfvalue);
+-        return QByteArray(reinterpret_cast<const char *>(CFDataGetBytePtr(cfdata)),
+-                          CFDataGetLength(cfdata));
++        QByteArray byteArray = QByteArray(reinterpret_cast<const char *>(CFDataGetBytePtr(cfdata)),
++                                          CFDataGetLength(cfdata));
++
++        // Fast-path for QByteArray, so that we don't have to go
++        // though the expensive and lossy conversion via UTF-8.
++        if (!byteArray.startsWith('@'))
++            return byteArray;
++
++        const QString str = QString::fromUtf8(byteArray.constData(), byteArray.size());
++        return QSettingsPrivate::stringToVariant(str);
++
+     } else if (typeId == CFDictionaryGetTypeID()) {
+         CFDictionaryRef cfdict = static_cast<CFDictionaryRef>(cfvalue);
+         CFTypeID arrayTypeId = CFArrayGetTypeID();

--- a/aqua/qt4-mac/files/patch-qt4-versions-without-underscores.diff
+++ b/aqua/qt4-mac/files/patch-qt4-versions-without-underscores.diff
@@ -1,0 +1,12 @@
+--- src/gui/kernel/qt_cocoa_helpers_mac.mm.orig	2017-08-01 09:43:40.000000000 -0400
++++ src/gui/kernel/qt_cocoa_helpers_mac.mm	2017-08-01 09:47:33.000000000 -0400
+@@ -73,6 +73,9 @@
+ **
+ ****************************************************************************/
+ 
++// Workaround for macOS 10.13 and later
++#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 1
++
+ #include <private/qcore_mac_p.h>
+ #include <qaction.h>
+ #include <qwidget.h>

--- a/aqua/qt4-mac/files/patch-src_corelib_io_qfilesystemengine_unix.cpp-tiger.diff
+++ b/aqua/qt4-mac/files/patch-src_corelib_io_qfilesystemengine_unix.cpp-tiger.diff
@@ -1,0 +1,41 @@
+--- src/corelib/io/qfilesystemengine_unix.cpp.orig	2017-08-31 20:54:04.000000000 +0200
++++ src/corelib/io/qfilesystemengine_unix.cpp	2017-08-31 20:58:13.000000000 +0200
+@@ -83,6 +83,7 @@
+     return (fileInfo->finderFlags & kIsInvisible);
+ }
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
+ static bool isPackage(const QFileSystemMetaData &data, const QFileSystemEntry &entry)
+ {
+     if (!data.isDirectory())
+@@ -138,6 +139,7 @@
+     FolderInfo *folderInfo = reinterpret_cast<FolderInfo *>(catalogInfo.finderInfo);
+     return folderInfo->finderFlags & kHasBundle;
+ }
++#endif
+ 
+ #else
+ static inline bool _q_isMacHidden(const char *nativePath)
+@@ -529,8 +531,22 @@
+ 
+ #if !defined(QWS) && !defined(Q_WS_QPA) && defined(Q_OS_MAC)
+     if (what & QFileSystemMetaData::BundleType) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
+         if (entryExists && isPackage(data, entry))
+             data.entryFlags |= QFileSystemMetaData::BundleType;
++#else
++        if (entryExists && data.isDirectory()) {
++            QCFType<CFStringRef> path = CFStringCreateWithBytes(0,
++                    (const UInt8*)nativeFilePath, nativeFilePathLength,
++                    kCFStringEncodingUTF8, false);
++            QCFType<CFURLRef> url = CFURLCreateWithFileSystemPath(0, path,
++                    kCFURLPOSIXPathStyle, true);
++
++            UInt32 type, creator;
++            if (CFBundleGetPackageInfoInDirectory(url, &type, &creator))
++                data.entryFlags |= QFileSystemMetaData::BundleType;
++        }
++#endif
+         data.knownFlagsMask |= QFileSystemMetaData::BundleType;
+     }
+ #endif

--- a/aqua/qt4-mac/files/patch-src_gui_dialogs_qfontdialog_mac.mm-tiger.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_dialogs_qfontdialog_mac.mm-tiger.diff
@@ -1,0 +1,34 @@
+--- src/gui/dialogs/qfontdialog_mac.mm.orig	2017-08-31 21:41:56.000000000 +0200
++++ src/gui/dialogs/qfontdialog_mac.mm	2017-08-31 21:55:51.000000000 +0200
+@@ -141,6 +141,7 @@
+     QFont newFont;
+     if (cocoaFont) {
+         int pSize = qRound([cocoaFont pointSize]);
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+         CTFontDescriptorRef font = CTFontCopyFontDescriptor((CTFontRef)cocoaFont);
+         // QCoreTextFontDatabase::populateFontDatabase() is using localized names
+         QString family = QCFString::toQString((CFStringRef) CTFontDescriptorCopyLocalizedAttribute(font, kCTFontFamilyNameAttribute, NULL));
+@@ -151,6 +152,23 @@
+         newFont.setStrikeOut(resolveFont.strikeOut());
+ 
+         CFRelease(font);
++#else
++	// This pre-Leopard version is buggy and was fixed in 717e36037cf246aa201c0aaf15a5dcbd7883f159
++	// see QTBUG-27415 https://codereview.qt-project.org/#/c/42830/
++        QString family(qt_mac_NSStringToQString([cocoaFont familyName]));
++        QString typeface(qt_mac_NSStringToQString([cocoaFont fontName]));
++
++        int hyphenPos = typeface.indexOf(QLatin1Char('-'));
++        if (hyphenPos != -1) {
++            typeface.remove(0, hyphenPos + 1);
++        } else {
++            typeface = QLatin1String("Normal");
++        }
++
++        newFont = QFontDatabase().font(family, typeface, pSize);
++        newFont.setUnderline(resolveFont.underline());
++        newFont.setStrikeOut(resolveFont.strikeOut());
++#endif
+     }
+     return newFont;
+ }

--- a/aqua/qt4-mac/files/patch-src_gui_kernel_qt_cocoa_helpers_mac.mm.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_kernel_qt_cocoa_helpers_mac.mm.diff
@@ -1,0 +1,15 @@
+--- src/gui/kernel/qt_cocoa_helpers_mac.mm.orig
++++ src/gui/kernel/qt_cocoa_helpers_mac.mm
+@@ -351,9 +351,9 @@
+     // Verbatim copy if HIViewDrawCGImage (as shown on Carbon-Dev)
+     OSStatus err = noErr;
+ 
+-    require_action(inContext != NULL, InvalidContext, err = paramErr);
+-    require_action(inBounds != NULL, InvalidBounds, err = paramErr);
+-    require_action(inImage != NULL, InvalidImage, err = paramErr);
++//    require_action(inContext != NULL, InvalidContext, err = paramErr);
++//    require_action(inBounds != NULL, InvalidBounds, err = paramErr);
++//    require_action(inImage != NULL, InvalidImage, err = paramErr);
+ 
+     CGContextSaveGState( inContext );
+     CGContextTranslateCTM (inContext, 0, inBounds->origin.y + CGRectGetMaxY(*inBounds));

--- a/aqua/qt4-mac/files/patch-src_gui_painting_qpaintengine_mac.cpp-tiger.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_painting_qpaintengine_mac.cpp-tiger.diff
@@ -1,0 +1,19 @@
+--- src/gui/painting/qpaintengine_mac.cpp.orig	2017-08-31 22:56:01.000000000 +0200
++++ src/gui/painting/qpaintengine_mac.cpp	2017-08-31 23:10:20.000000000 +0200
+@@ -334,7 +334,16 @@
+     if ((colorSpace = m_displayColorSpaceHash.value(displayID)))
+         return colorSpace;
+ 
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+     colorSpace = CGDisplayCopyColorSpace(displayID);
++#else
++    CMProfileRef displayProfile = 0;
++    CMError err = CMGetProfileByAVID((CMDisplayIDType)displayID, &displayProfile);
++    if (err == noErr) {
++        colorSpace = CGColorSpaceCreateWithPlatformColorSpace(displayProfile);
++        CMCloseProfile(displayProfile);
++    }
++#endif
+     if (colorSpace == 0)
+         colorSpace = CGColorSpaceCreateDeviceRGB();
+ 

--- a/aqua/qt4-mac/files/patch-src_gui_painting_qprintengine_mac.mm-tiger.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_painting_qprintengine_mac.mm-tiger.diff
@@ -1,0 +1,14 @@
+--- src/gui/painting/qprintengine_mac.mm.orig	2017-08-31 21:35:19.000000000 +0200
++++ src/gui/painting/qprintengine_mac.mm	2017-08-31 21:37:56.000000000 +0200
+@@ -187,7 +187,11 @@
+             paperMargins.top = topMargin;
+             paperMargins.right = rightMargin;
+             paperMargins.bottom = bottomMargin;
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+             PMPaperCreateCustom(printer, paperId, QCFString("Custom size"), customSize.width(), customSize.height(), &paperMargins, &customPaper);
++#else
++            PMPaperCreate(printer, paperId, QCFString("Custom size"), customSize.width(), customSize.height(), &paperMargins, &customPaper);
++#endif
+             PMPageFormat tmp;
+             PMCreatePageFormatWithPMPaper(&tmp, customPaper);
+             PMCopyPageFormat(tmp, format);

--- a/aqua/qt4-mac/files/patch-src_gui_text_qfontdatabase_mac.cpp-tiger.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_text_qfontdatabase_mac.cpp-tiger.diff
@@ -1,0 +1,21 @@
+--- src/gui/text/qfontdatabase_mac.cpp.orig	2017-08-31 22:45:17.000000000 +0200
++++ src/gui/text/qfontdatabase_mac.cpp	2017-08-31 23:10:46.000000000 +0200
+@@ -546,6 +546,7 @@
+ 
+ QString QFontDatabase::resolveFontFamilyAlias(const QString &family)
+ {
++#if defined(QT_MAC_USE_COCOA) && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+     QCFString expectedFamily = QCFString(family);
+ 
+     QCFType<CFMutableDictionaryRef> attributes = CFDictionaryCreateMutable(NULL, 0,
+@@ -563,6 +564,10 @@
+ 
+     QCFString familyName = (CFStringRef) CTFontDescriptorCopyLocalizedAttribute(matched, kCTFontFamilyNameAttribute, NULL);
+     return familyName;
++#else
++    // https://bugreports.qt.io/browse/QTBUG-25417?focusedCommentId=185393&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-185393
++    return family;
++#endif
+ }
+ 
+ QT_END_NAMESPACE

--- a/aqua/qt4-mac/files/patch-src_network_kernel_qnetworkproxy_mac.cpp-tiger.diff
+++ b/aqua/qt4-mac/files/patch-src_network_kernel_qnetworkproxy_mac.cpp-tiger.diff
@@ -1,0 +1,18 @@
+--- src/network/kernel/qnetworkproxy_mac.cpp.orig	2017-08-31 21:05:13.000000000 +0200
++++ src/network/kernel/qnetworkproxy_mac.cpp	2017-08-31 21:05:44.000000000 +0200
+@@ -148,6 +148,7 @@
+ }
+ 
+ 
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+ static QNetworkProxy proxyFromDictionary(CFDictionaryRef dict)
+ {
+     QNetworkProxy::ProxyType proxyType = QNetworkProxy::DefaultProxy;
+@@ -180,6 +181,7 @@
+ 
+     return QNetworkProxy(proxyType, hostName, port, user, password);
+ }
++#endif
+ 
+ const char * cfurlErrorDescription(SInt32 errorCode)
+ {


### PR DESCRIPTION
###### Description


All the tiger-specific patches are suffixed with -tiger, and don't break anything when compiling with more recent SDKs.

Only one patch, patch-src_gui_dialogs_qfontdialog_mac.mm-tiger.diff, reintroduces in the Tiger version only a Qt bug (QTBUG-27415) which cannot be fixed with the Tiger SDK (the fix requires Leopard).

Patch (19) seems wrong when building frameworks and breaks the build (older versions of qt4-mac allowed building with libraries only, I guess this patch is remnant from that time). I commented it out, and did not remove the patch file in case someone wants to take a closer look at it.

Also, since qt4-mac only uses the JPEG 8 API, libjpeg-turbo can be used instead (see https://trac.macports.org/ticket/38907)

Patches (30) (backport qt5 QSettings fix) and (31) (support High Sierra) were taken from homebrew. I did not test building on macOS High Sierra, and thus left the restriction.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12 and 10.4
Xcode 8.3.3 8E3004b and Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
