### PR TITLE
gpgme: Add +gnupg20 and +gnupg21 variants

### DIFF
--- a/devel/gpgme/Portfile
+++ b/devel/gpgme/Portfile
@@ -25,24 +25,39 @@ use_bzip2           yes
 checksums           rmd160  55719b4a7263ae8d0ef79205e26409ff5693ea27 \
                     sha256  1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb
 
-# either gnupg2 (the default) or gnupg21 is needed for running the unit tests
-# and at runtime but does not link directly with gpgme
-depends_build       port:pkgconfig \
-                    path:bin/gpg2:gnupg2
+depends_build       port:pkgconfig
 
 depends_lib         port:pth \
                     port:libgpg-error \
                     port:libassuan
 
-depends_run         path:bin/gpg2:gnupg2
-
 patchfiles          patch-configure.ac.diff \
-                    patch-fixup-GpgmeppConfig.cmake.diff \
-                    patch-tests-gpg-Makefile.am.diff
+                    patch-fixup-GpgmeppConfig.cmake.diff
+
+variant gnupg20 conflicts gnupg21 description {Use GnuPG 2.0.x} {
+    depends_build-append    port:gnupg2
+    depends_run             port:gnupg2
+    patchfiles-append       patch-tests-gpg-Makefile.am.diff
+
+    post-patch {
+        reinplace "s|@GPG@|${prefix}/bin/gpg2|" ${worksrcpath}/src/gpgme-config.in
+    }
+}
+variant gnupg21 conflicts gnupg20 description {Use GnuPG 2.1.x} {
+    depends_build-append    port:gnupg21
+    depends_run             port:gnupg21
+
+    post-patch {
+        reinplace "s|@GPG@|${prefix}/bin/gpg|" ${worksrcpath}/src/gpgme-config.in
+    }
+}
+# default to gnupg20 for now for backwards compatibility
+if {![variant_isset gnupg20] && ![variant_isset gnupg21]} {
+    variant_set             gnupg20
+}
 
 post-patch {
     reinplace "s|thread_modules=\"\"|thread_modules=\"pthread\"|" ${worksrcpath}/src/gpgme-config.in
-    reinplace "s|@GPG@|${prefix}/bin/gpg2|" ${worksrcpath}/src/gpgme-config.in
     reinplace "s|@GPGSM@|${prefix}/bin/gpgsm|" ${worksrcpath}/src/gpgme-config.in
 }
 


### PR DESCRIPTION
(I'm the co-maintainer for this port.)

###### Description

GnuPG 2.1.x (port gnupg21) now installs as ${prefix}/bin/gpg instead of
${prefix}/bin/gpg2, which makes it conflict with this port due to the
dependency on path:bin/gnupg2 -- this forces the installation of gnupg2
but that is not satisfiable (gnupg2 conflicts with gnupg21).

This commit addresses this issue by adding two variants, gnupg20 and
gnupg21, which allow the specific version that this port will depend on.
If none is explicitly chosen, gnupg20 is selected to preserve the old
behaviour.

Closes: https://trac.macports.org/ticket/54749

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
