### PR TITLE
ssh-copy-id: deactivate hack

### DIFF
--- a/net/ssh-copy-id/Portfile
+++ b/net/ssh-copy-id/Portfile
@@ -29,6 +29,17 @@ destroot {
     xinstall -m 644 ${worksrcpath}/contrib/ssh-copy-id.1 ${destroot}${prefix}/share/man/man1
 }
 
+pre-activate {
+    if {![catch {set installed [lindex [registry_active openssh] 0]}]} {
+        set _version [lindex $installed 1]
+        set _revision [lindex $installed 2]
+        if {[vercmp $_version 7.3p1] < 0 || ([vercmp $_version 7.3p1] == 0 && $_revision < 1)} {
+            # openssh @7.3p1 and earlier used to install some files now provided by ssh-copy-id
+            registry_deactivate_composite openssh "" [list ports_nodepcheck 1]
+        }
+    }
+}
+
 livecheck.type      regex
 livecheck.url       https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/
 livecheck.regex     openssh-(\[5-9\].\[0-9\]p\[0-9\])[quotemeta ${extract.suffix}]


### PR DESCRIPTION
###### Description
@raimue @ryandesign 

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
