### PR TITLE
bedtools: fix building docs

### DIFF
--- a/science/bedtools/Portfile
+++ b/science/bedtools/Portfile
@@ -27,6 +27,8 @@ depends_lib         port:zlib
 
 use_configure       no
 
+patchfiles          patch-docs-conf.py.diff
+
 variant universal {}
 
 configure.optflags  -O2

--- a/science/bedtools/files/patch-docs-conf.py.diff
+++ b/science/bedtools/files/patch-docs-conf.py.diff
@@ -1,0 +1,30 @@
+--- docs/conf.py.orig	2017-09-06 19:16:13.000000000 -0400
++++ docs/conf.py	2017-09-05 16:54:48.000000000 -0400
+@@ -26,7 +26,7 @@
+ # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 
+               'sphinx.ext.intersphinx', 'sphinx.ext.todo', 
+-              'sphinx.ext.coverage', 'sphinx.ext.pngmath', 
++              'sphinx.ext.coverage',
+               'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
+ 			        'matplotlib.sphinxext.plot_directive']
+ 
+@@ -225,7 +225,7 @@
+ # Example configuration for intersphinx: refer to the Python standard library.
+ intersphinx_mapping = {'bedtools': ('http://bedtools.readthedocs.org/en/latest/', None)}
+ 
+-class Mock(object):
++class Mock(list):
+     def __init__(self, *args, **kwargs):
+         pass
+ 
+@@ -241,6 +241,9 @@
+         else:
+             return Mock()
+ 
++    def setup(self, *args, **kargs):
++        pass
++
+ MOCK_MODULES = ['numpy', 'matplotlib', 'matplotlib.pyplot', 
+                 'matplotlib.sphinxext', 'matplotlib.sphinxext.plot_directive']
+ for mod_name in MOCK_MODULES:


### PR DESCRIPTION
fix issue https://trac.macports.org/ticket/54759

this patches docs/conf.py to comply with current version of sphinx. i proposed this fix upstream too, in pull request ​https://github.com/arq5x/bedtools2/pull/566.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
