### PR TITLE
mpfr: update to 3.1.6

### DIFF
--- a/devel/mpfr/Portfile
+++ b/devel/mpfr/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                mpfr
 # The actual version is generated below, after patchfiles is defined.
-set base_version    3.1.5
+set base_version    3.1.6
 categories          devel math
 platforms           darwin
 license             LGPL-3+
@@ -33,8 +33,8 @@ distname            ${name}-${base_version}
 master_sites        http://www.mpfr.org/${distname}
 use_xz              yes
 checksums           ${distname}${extract.suffix} \
-                        rmd160  8586d89e8f5634d27d21b6cb38e3fc9d58760d12 \
-                        sha256  015fde82b3979fbe5f83501986d328331ba8ddf008c1ff3da3c238f49ca062bc
+                        rmd160  6b0949bafae2337effe919c927f1d4ab9b11f863 \
+                        sha256  7a62ac1a04408614fccdc506e4844b10cf0ad2c2b1677097f8f35d3a1344a950
 
 # Upstream patch names are not qualified with the base version.
 dist_subdir         ${name}/${base_version}


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
