### PR TITLE
libfilezilla: new port, version 0.10.1

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cxx11 1.1
+
+name                libfilezilla
+version             0.10.1
+categories          devel
+platforms           darwin
+maintainers         {@yan12125 gmail.com:yan12125} openmaintainer
+license             GPL-2+
+
+description         Shared component for Filezilla programs
+
+long_description    Small and modern C++ library, offering some basic \
+                    functionality to build high-performing, \
+                    platform-independent programs.
+
+homepage            https://lib.filezilla-project.org/
+master_sites        http://download.filezilla-project.org/libfilezilla/
+
+checksums           rmd160  0150b725d477493c6dadd3029e417350ee6936a7 \
+                    sha256  a097536689f92320f8ee03eed68fe0b82457a53a7f4d287d7c03f60bc16a29fa
+
+depends_build       port:pkgconfig \
+                    port:cppunit \
+                    bin:perl:perl5
+
+use_bzip2           yes
+
+test.run            yes
+test.dir            ${worksrcpath}/tests
+test.cmd            ./test
+test.target
+
+pre-test {
+    system -W ${test.dir} "${build.cmd} test"
+}
+
+variant doc description "Install API documents" {
+    depends_build-append    port:doxygen \
+                            port:graphviz \
+                            port:texlive-fonts-recommended \
+                            port:texlive-latex \
+                            port:texlive-latex-extra \
+                            port:texlive-latex-recommended
+
+    post-build {
+        system -W ${worksrcpath}/doc/ "${build.cmd} html pdf"
+    }
+
+    post-destroot {
+        set docdir ${destroot}${prefix}/share/doc/${name}
+
+        xinstall -m 755 -d ${docdir}/html
+        copy {*}[glob ${worksrcpath}/doc/doxygen-doc/html/*] ${docdir}/html
+        delete {*}[glob ${docdir}/html/*.md5]
+        xinstall -m 644 ${worksrcpath}/doc/doxygen-doc/libfilezilla.pdf ${docdir}
+    }
+}
+
+default_variants    +doc
+
+livecheck.type      regex
+livecheck.url       ${homepage}download.php
+livecheck.regex     /${name}-(\[0-9.\]+)


### PR DESCRIPTION
###### Description

Required by newer FileZilla.

Closes: https://trac.macports.org/ticket/50514

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
