### PR TITLE
iperf3: allow building against LibreSSL

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -22,7 +22,7 @@ conflicts           ${name}-devel
 checksums           rmd160  3cec3959b047dace2ba9598db2d236316cfa2593 \
                     sha256  9b5b6709ae294217c573fe8e9d88f59ddedf599f9b44af22355e57e38997acc2
 
-depends_lib-append  port:openssl
+depends_lib-append  path:lib/libssl.dylib:openssl
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix
