### PR TITLE
qscintilla: only add stdlib if compiler is clang

### DIFF
--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -44,9 +44,11 @@ patchfiles-append   patch-add_debug.diff
 configure.cxxflags-append -std=c++11
 
 # set the correct stdlib for linking for older compilers.
-if {${configure.cxx_stdlib} eq "macports-libstdc++" ||
-    ${configure.cxx_stdlib} eq "libstdc++"} {
-    configure.ldflags-append -stdlib=macports-libstdc++
+if {[string match *clang* ${configure.compiler}]} {
+    if {${configure.cxx_stdlib} eq "macports-libstdc++" ||
+        ${configure.cxx_stdlib} eq "libstdc++"} {
+        configure.ldflags-append -stdlib=macports-libstdc++
+    }
 }
 
 post-patch {


### PR DESCRIPTION
fixes build if compiler is not clang

```
$ port -v installed qscintilla
The following ports are currently installed:
  qscintilla @2.10.1_0 (active) platform='darwin 9' archs='ppc' date='2017-09-10T10:49:59-0700'
```

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4 and 10.5 PPC (gcc), 10.6.8 (clang)
Xcode 2.5, 3.2.6, 4.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
