### PR TITLE
xml2rfc: update to 2.8.0

### DIFF
--- a/textproc/xml2rfc/Portfile
+++ b/textproc/xml2rfc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                xml2rfc
-version             2.6.0
+version             2.8.0
 categories          textproc
 platforms           darwin
 license             BSD
@@ -19,15 +19,16 @@ long_description \
 homepage            https://xml2rfc.tools.ietf.org/
 master_sites        pypi:x/xml2rfc
 
-checksums           md5     93d79b645c8a157c92faff7ffc84beb1 \
-                    rmd160  c036746025e97d2bdf40cc4a600c0780dc943030 \
-                    sha256  8bfeba1f0115ab4e0903460f4a5c4e56832fe53536ab413054c70d77c487bcbc
+checksums           md5     6bd93e93a099303c131facd60fca3951 \
+                    rmd160  9649ec31915b30a1ac7874674d808948387a3ac8 \
+                    sha256  6e3e99a04593374c0a62aff73e6fc3683859d3e8e040709842eedfa9c7885bc7
 
 python.default_version  36
 
 depends_build-append    port:py${python.version}-setuptools
 depends_lib-append      port:py${python.version}-lxml \
-                        port:py${python.version}-requests
+                        port:py${python.version}-requests \
+                        port:py${python.version}-six
 
 livecheck.type      regex
 livecheck.url       https://pypi.python.org/pypi/${name}


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
