### PR TITLE
diffoscope: fix dependency type

### DIFF
--- a/sysutils/diffoscope/Portfile
+++ b/sysutils/diffoscope/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                diffoscope
 version             86
+revision            1
 platforms           darwin
 supported_archs     noarch
 license             GPL-3+
@@ -29,7 +30,7 @@ checksums           md5     d45dc64277559c773db0f609f197ccc6 \
 
 python.default_version 36
 
-depends_build-append \
+depends_lib-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-libarchive-c \
                     port:py${python.version}-magic


### PR DESCRIPTION
###### Description
These three dependencies are needed at run time too.

Should I bump the revision?