### PR TITLE
FileZilla: fix building with Xcode < 8

### DIFF
--- a/www/FileZilla/Portfile
+++ b/www/FileZilla/Portfile
@@ -61,7 +61,14 @@ if {${os.major} <= 10} {
 }
 # http://trac.macports.org/ticket/47273
 # In theory gcc could work, but we need to disable llvm-gcc and we need to match stdlib with wxWidgets (= use libc++)
-compiler.blacklist-append *gcc* {clang < 503}
+#
+# FileZilla now requires thread_local keyword in C++11 (N2659), which is
+# supported since Xcode 8.0 [1][2], upstream clang 3.3 [3] and GCC 4.8 [4]
+# [1] https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html
+# [2] https://stackoverflow.com/a/29929949/3786245
+# [3] https://clang.llvm.org/cxx_status.html
+# [4] https://gcc.gnu.org/projects/cxx-status.html#cxx11
+compiler.blacklist-append *gcc* {clang < 800}
 
 variant wxgtk30 conflicts wxwidgets30 wxwidgets30_libcxx description {Use wxWidgets 3.0 with GTK} {
     wxWidgets.use           wxGTK-3.0


### PR DESCRIPTION
###### Description

The latest FileZilla requires thread_local, which is not supported until
Xcode 8.0.

This is a follow-up of https://github.com/macports/macports-ports/pull/767#issuecomment-328545162. I'm not sure how stdlib configurations should be changed.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (There are not tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?