### PR TITLE
byacc: Fix master_sites

### DIFF
--- a/devel/byacc/Portfile
+++ b/devel/byacc/Portfile
@@ -16,7 +16,7 @@ long_description \
 homepage         http://invisible-island.net/byacc/
 platforms        darwin
 
-master_sites     ftp://invisible-island.net/byacc/
+master_sites     ftp://ftp.invisible-island.net/byacc/
 extract.suffix   .tgz
 
 checksums        rmd160 6868a7ba60e52d46b14fbe99dc4318051eff2e2b \


### PR DESCRIPTION
The byacc master_sites ftp site changed location slightly. Tested with
a local Portfile.

Re: https://trac.macports.org/ticket/54814