### PR TITLE
xmlsec: update to 1.2.25

### DIFF
--- a/security/xmlsec/Portfile
+++ b/security/xmlsec/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 
 name                        xmlsec
-version                     1.2.24
+version                     1.2.25
 categories                  security textproc devel
 license                     MIT
 platforms                   darwin
@@ -20,8 +20,8 @@ master_sites                ${homepage}download/ \
                             ftp://ftp.xmlsoft.org/xmlsec/releases/
 distname                    xmlsec1-${version}
 
-checksums                   rmd160  b203056b392723364d3a0bcb151602758ada8f87 \
-                            sha256  99a8643f118bb1261a72162f83e2deba0f4f690893b4b90e1be4f708e8d481cc
+checksums                   rmd160  f81aed97a5cc7de1a71ea32de02b73c32f7bdbf5 \
+                            sha256  967ca83edf25ccb5b48a3c4a09ad3405a63365576503bf34290a42de1b92fcd2
 
 depends_build               port:pkgconfig
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
