### PR TITLE
autogen: fix build against newer guile 2.2.2

### DIFF
--- a/devel/autogen/Portfile
+++ b/devel/autogen/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                autogen
 version             5.18.12
+revision            1
 categories          devel
 platforms           darwin
 maintainers         nomaintainer
@@ -32,6 +33,13 @@ universal_variant   no
 # Don't accidentally create flat-namespace dylibs on Yosemite (#44596).
 patchfiles          yosemite-libtool.patch
 
+# fix build against guile-2.2
+# see <https://trac.macports.org/ticket/54112>
+patchfiles-append   patch-autogen-guile-2.2.diff
+
+# patch changes m4 file, so need to autoreconf
+use_autoreconf      yes
+
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info
 
@@ -45,3 +53,8 @@ platform darwin 8 {
 livecheck.type      regex
 livecheck.url       http://ftp.gnu.org/gnu/${name}/?C=M&O=D
 livecheck.regex     rel(\\d+(?:\\.\\d+)*)
+
+notes "
+autogen has not been officially certified when built against guile-2.2.
+If unexpected results appear, consider building against an earlier version of guile.
+"

--- a/devel/autogen/files/patch-autogen-guile-2.2.diff
+++ b/devel/autogen/files/patch-autogen-guile-2.2.diff
@@ -1,0 +1,48 @@
+Index: autogen-5.18.12/agen5/guile-iface.h
+===================================================================
+--- agen5/guile-iface.h
++++ agen5/guile-iface.h
+@@ -9,16 +9,13 @@
+ # error AutoGen does not work with this version of Guile
+   choke me.
+ 
+-#elif GUILE_VERSION < 201000
++#else
+ # define AG_SCM_IS_PROC(_p)           scm_is_true( scm_procedure_p(_p))
+ # define AG_SCM_LIST_P(_l)            scm_is_true( scm_list_p(_l))
+ # define AG_SCM_PAIR_P(_p)            scm_is_true( scm_pair_p(_p))
+ # define AG_SCM_TO_LONG(_v)           scm_to_long(_v)
+ # define AG_SCM_TO_ULONG(_v)          ((unsigned long)scm_to_ulong(_v))
+ 
+-#else
+-# error unknown GUILE_VERSION
+-  choke me.
+ #endif
+ 
+ #endif /* MUTATING_GUILE_IFACE_H_GUARD */
+Index: autogen-5.18.12/configure
+===================================================================
+--- configure
++++ configure
+@@ -14198,7 +14198,7 @@ $as_echo "no" >&6; }
+ 		PKG_CONFIG=""
+ 	fi
+ fi
+-  _guile_versions_to_search="2.0 1.8"
++  _guile_versions_to_search="2.2 2.0 1.8"
+   if test -n "$GUILE_EFFECTIVE_VERSION"; then
+     _guile_tmp=""
+     for v in $_guile_versions_to_search; do
+Index: autogen-5.18.12/config/guile.m4
+===================================================================
+--- config/guile.m4
++++ config/guile.m4
+@@ -61,7 +61,7 @@
+ #
+ AC_DEFUN([GUILE_PKG],
+  [PKG_PROG_PKG_CONFIG
+-  _guile_versions_to_search="m4_default([$1], [2.0 1.8])"
++  _guile_versions_to_search="m4_default([$1], [2.2 2.0 1.8])"
+   if test -n "$GUILE_EFFECTIVE_VERSION"; then
+     _guile_tmp=""
+     for v in $_guile_versions_to_search; do


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/54112

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5 PPC, 10.6 to 10.12 inclusive
Xcode 3.26 to 8.3 inclusive

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
