### PR TITLE
crossgcc: support xz downloads, update gcc to 7.2

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -49,8 +49,19 @@ options crossgcc.target \
 
 default crossgcc.languages {{c c++}}
 
+array set crossgcc.versions_info {
+    7.1.0 {bzip2 {
+        rmd160 a228dc45a09eda91b1a201d234f9013b3009b461
+        sha256 8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17
+    }}
+    7.2.0 {xz {
+        rmd160 fa8eed36c78cf135f9cc88e60845996b5cfaba52
+        sha256 1cf7adf8ff4b5aa49041c8734bbcf1ad18cc4c94d0029aae0f4e48841088479a
+    }}
+}
+
 proc crossgcc.setup {target version} {
-    global crossgcc.target crossgcc.version
+    global crossgcc.target crossgcc.version crossgcc.versions_info
 
     set crossgcc.target $target
     set crossgcc.version $version
@@ -70,10 +81,18 @@ proc crossgcc.setup {target version} {
 
         homepage        http://gcc.gnu.org/
         master_sites    gnu:gcc/gcc-${version}/:gcc
-        use_bzip2       yes
+
+        if {[info exists crossgcc.versions_info($version)]} {
+            use_[lindex [set crossgcc.versions_info($version)] 0] yes
+
+            checksums   {*}[lindex [set crossgcc.versions_info($version)] 1]
+        } else {
+            # the old default
+            use_bzip2   yes
+        }
 
         dist_subdir     gcc[lindex [split ${version} .] 0]
-        distfiles       gcc-${version}.tar.bz2:gcc
+        distfiles       gcc-${version}${extract.suffix}:gcc
 
         worksrcdir      gcc-${version}
 
@@ -88,7 +107,7 @@ proc crossgcc.setup {target version} {
 
         # Extract gcc distfiles only. libc tarball might be available as gzip only;
         # handled below in post-extract in the variant.
-        extract.only    gcc-${version}.tar.bz2
+        extract.only    gcc-${version}${extract.suffix}
 
         # Build in a different directory, as advised in the README file.
         post-extract {

--- a/cross/avr-gcc/Portfile
+++ b/cross/avr-gcc/Portfile
@@ -4,13 +4,10 @@ PortSystem              1.0
 PortGroup               crossgcc 1.0
 
 name                    avr-gcc
-crossgcc.setup          avr 7.1.0
+crossgcc.setup          avr 7.2.0
 
-maintainers             g5pw openmaintainer
+maintainers             {g5pw @g5pw} openmaintainer
 license                 {GPL-3+ Permissive}
-
-checksums               rmd160  a228dc45a09eda91b1a201d234f9013b3009b461 \
-                        sha256  8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17
 
 default_variants        +lto
 

--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -8,14 +8,11 @@ set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
 
-crossgcc.setup      ${mingw_target} 7.1.0
+crossgcc.setup      ${mingw_target} 7.2.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
 
 maintainers         {mojca @mojca} openmaintainer
-
-checksums           rmd160  a228dc45a09eda91b1a201d234f9013b3009b461 \
-                    sha256  8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17
 
  # these are build + runtime dependencies
 depends_lib-append  port:${mingw_target}-binutils \

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -8,14 +8,11 @@ set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
 
-crossgcc.setup      ${mingw_target} 7.1.0
+crossgcc.setup      ${mingw_target} 7.2.0
 crossgcc.languages  {c c++ fortran objc obj-c++}
 dist_subdir         gcc[lindex [split ${version} .] 0]
 
 maintainers         {mojca @mojca} openmaintainer
-
-checksums           rmd160  a228dc45a09eda91b1a201d234f9013b3009b461 \
-                    sha256  8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17
 
  # these are build + runtime dependencies
 depends_lib-append  port:${mingw_target}-binutils \


### PR DESCRIPTION
* The new versions of gcc starting with gcc 6.4 and 7.2 replaced the .tar.bz2 archives with .tar.xz.
* Update the version of avr-gcc and (i686|x86_64)-w64-mingw32-gcc to 7.2.0.

I'm submitting this PR for a review and perhaps better ideas about how to handle the switch from .tar.bz2 to .tar.xz in the distribution of GCC sources.

I would love to set the checksums already in the PortGroup if possible to reduce the need for repeating the same information in the individual ports. But I'm not yet sure how to properly code that.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
