### PR TITLE
libedit: Fix history length reporting

### DIFF
--- a/devel/libedit/Portfile
+++ b/devel/libedit/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 name                libedit
 epoch               20090923
 version             20170329-3.1
-revision            1
+revision            2
 categories          devel
 platforms           darwin
 license             BSD
@@ -37,6 +37,12 @@ patchfiles          doc__Makefile.in.patch \
 # this patch is taken from
 #    https://opensource.apple.com/source/libedit/libedit-48/src/el.c.auto.html
 patchfiles-append   patch-non_ascii.diff
+
+# Fixes an issue that calling history_get_history_state() immediately after
+# read_history() results in wrong history length.
+# The patch is backported from the upstream fix at [1]
+# [1] http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libedit/readline.c.diff?r1=1.143&r2=1.144&only_with_tag=MAIN&f=u
+patchfiles-append   patch-read_history-save-length.diff
 
 post-patch {
     copy ${filespath}/getline.c ${worksrcpath}/src

--- a/devel/libedit/files/patch-read_history-save-length.diff
+++ b/devel/libedit/files/patch-read_history-save-length.diff
@@ -1,0 +1,19 @@
+--- src/readline.c.orig	2017-09-17 00:10:05.000000000 +0800
++++ src/readline.c	2017-09-17 00:44:18.000000000 +0800
+@@ -1355,8 +1355,14 @@ read_history(const char *filename)
+ 		rl_initialize();
+ 	if (filename == NULL && (filename = _default_history_file()) == NULL)
+ 		return errno;
+-	return history(h, &ev, H_LOAD, filename) == -1 ?
+-	    (errno ? errno : EINVAL) : 0;
++	errno = 0;
++	if (history(h, &ev, H_LOAD, filename) == -1)
++	    return errno ? errno : EINVAL;
++	if (history(h, &ev, H_GETSIZE) == 0)
++		history_length = ev.num;
++	if (history_length < 0)
++		return EINVAL;
++	return 0;
+ }
+ 
+ 


### PR DESCRIPTION
###### Description
See comments in Portfile for what's broken.

Steps to reproduce:
1. Install python36 but not py36-gnureadline
2. Create a file readline_history.txt
```
_HiStOrY_V2_
1+1
1+2
```
3. Create a test Python script
```Python
import readline
print(readline)
history = 'readline_history.txt'
readline.read_history_file(history)
print(readline.get_current_history_length())
```
4. Run the script with the following command:
```
python3.6 -I readline_test.py
```

Before the fix, the number is zero:
```
<module 'readline' from '/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/lib-dynload/readline.cpython-36m-darwin.so'>
0
```
After the fix, the number is correct - there are two history entries:
```
<module 'readline' from '/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/lib-dynload/readline.cpython-36m-darwin.so'>
2
```
If py36-gnureadline is installed, the path in the output would be different. The readline module is loaded from readline/readline.py rather than readline.cpython-36m-darwin.so
```
<module 'readline' from '/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/readline/readline.py'>
3
```
###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (There are no relevant bug reports)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (There are no tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
