### PR TITLE
guile: fix build for older systems

### DIFF
--- a/lang/guile/Portfile
+++ b/lang/guile/Portfile
@@ -1,14 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
+
+# only these systems need this at present, so restrict it to avoid
+# unrequired dependencies and revbumps
+if {${os.arch} eq "i386" && ${os.major} < 11} {
+    PortGroup           cxx11 1.1
+}
 
 name                guile
-version             2.2.2
-#revision            0
 categories          lang
 maintainers         nomaintainer
 platforms           darwin
 license             LGPL-2.1+
+
+# current version
+version             2.2.2
+checksums           rmd160  1299dac3a5c218b6aebd7471c6562a9ad7825edc \
+                    sha256  3d9b94183b19f04dd4317da87beedafd1c947142f3d861ca1f0224e7a75127ee
+
+# previous version of guile that works well on PPC - was last at rev 1
+platform darwin powerpc {
+    version             2.0.14
+    revision            1
+    checksums           rmd160  754aaf1bf3c6bed9afdde49c5154b87047408a1e \
+                        sha256  8aeb2f353881282fe01694cce76bb72f7ffdd296a12c7a1a39255c27b0dfe5f1
+}
 
 # Failed to destroot guile:
 # /opt/local/lib/guile/2.0/ccache/ice-9/and-let-star.go differs in ... and
@@ -34,9 +51,6 @@ long_description    \
 distname            guile-${version}
 homepage            http://www.gnu.org/software/guile/guile.html
 master_sites        gnu
-
-checksums           rmd160  1299dac3a5c218b6aebd7471c6562a9ad7825edc \
-                    sha256  3d9b94183b19f04dd4317da87beedafd1c947142f3d861ca1f0224e7a75127ee
 
 depends_lib         port:readline \
                     port:gettext \


### PR DESCRIPTION
fixes build of guile 2.2.2 on 10.6

offers version 2.0.14 (last working) to PPC
when / if a guile20 port is developed this can
be readdressed for PPC only

closes: https://trac.macports.org/ticket/54124

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
