### PR TITLE
geda-gaf: allow build against guile18

### DIFF
--- a/science/geda-gaf/Portfile
+++ b/science/geda-gaf/Portfile
@@ -5,6 +5,7 @@ PortSystem 1.0
 name                geda-gaf
 epoch               1
 version             1.8.2
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 categories          science electronics
@@ -34,6 +35,28 @@ depends_lib         port:gtk2 \
 configure.args-append   --disable-update-xdg-database
 
 destroot.destdir    DESTDIR=${destroot}/
+
+default_variants +useguile18
+variant useguile18 description "Build against MacPorts' guile18" {
+    # geda-gaf does not build against MacPorts current guile (guile 2.2)
+    # it will build against guile 1.8 or guile 2.0
+
+    depends_lib-replace     port:guile port:guile18
+
+    patchfiles-append       patch-geda-gaf-libguile-header.diff
+
+    # pkg-config may not be installed yet; only installed when build deps are processed and installed
+    if {[file exists ${prefix}/bin/pkg-config]} {
+        configure.env-append    GUILE_CFLAGS=[exec ${prefix}/bin/pkg-config --cflags guile-1.8]
+        configure.env-append    GUILE_LIBS=[exec ${prefix}/bin/pkg-config --libs guile-1.8]
+    } else {
+        configure.env-append    GUILE_CFLAGS="-D_THREAD_SAFE -I${prefix}/include/guile18 -I${prefix}/include"
+        configure.env-append    GUILE_LIBS="-L${prefix}/lib/guile18 -L${prefix}/lib -lguile18 -lgmp -lm -lltdl"
+    }
+
+    configure.env-append    GUILE="${prefix}/bin/guile18"
+    configure.env-append    GUILE_SNARF="${prefix}/bin/guile18-snarf"
+}
 
 variant enable_xdg description {enable XDG database update} {
     depends_lib-append      port:desktop-file-utils

--- a/science/geda-gaf/files/patch-geda-gaf-libguile-header.diff
+++ b/science/geda-gaf/files/patch-geda-gaf-libguile-header.diff
@@ -1,0 +1,39 @@
+diff --git a/gschem/include/gschem.h b/gschem/include/gschem.h
+index 60115dc..0351dda 100644
+--- gschem/include/gschem.h
++++ gschem/include/gschem.h
+@@ -1,7 +1,7 @@
+ /* System headers which gschem headers rely on */
+ #include <glib.h>
+ #include <gtk/gtk.h>
+-#include <libguile.h>
++#include <libguile18.h>
+ #include <libgeda/libgeda.h>
+ #include <libgeda/libgedaguile.h>
+ 
+diff --git a/libgeda/include/libgeda/libgeda.h b/libgeda/include/libgeda/libgeda.h
+index 90e9e5b..7577b87 100644
+--- libgeda/include/libgeda/libgeda.h
++++ libgeda/include/libgeda/libgeda.h
+@@ -24,7 +24,7 @@
+ #include <glib.h>
+ 
+ #include <stdio.h>
+-#include <libguile.h>
++#include <libguile18.h>
+ #include <gdk-pixbuf/gdk-pixbuf.h>
+ 
+ #include <libgeda/defines.h>
+diff --git a/libgeda/include/libgeda_priv.h b/libgeda/include/libgeda_priv.h
+index d5d5d4d..636707f 100644
+--- libgeda/include/libgeda_priv.h
++++ libgeda/include/libgeda_priv.h
+@@ -1,7 +1,7 @@
+ /* System headers which libgeda headers rely on */
+ #include <glib.h>
+ #include <glib-object.h>
+-#include <libguile.h>
++#include <libguile18.h>
+ #include <gdk-pixbuf/gdk-pixbuf.h>
+ #include <glib/gstdio.h>
+ 


### PR DESCRIPTION
geda-gaf does not build against guile 2.2
guile 2.0 is not presently available as a separate port
builds against guile 1.8 which exists as guile18

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6, 10.12
Xcode 4.2, 8.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
