### PR TITLE
py-neovim: add the missing greenlet dependency and fix building with -t

### DIFF
--- a/python/py-neovim/Portfile
+++ b/python/py-neovim/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 
 github.setup        neovim python-client 0.1.13
 name                py-neovim
+revision            1
 maintainers         g5pw openmaintainer
 description         Python client for Neovim
 long_description    ${description}. Implements support for python plugins in \
@@ -19,7 +20,11 @@ supported_archs     noarch
 python.versions     27 35 36
 
 if { ${name} ne ${subport} } {
-    depends_lib-append  port:py${python.version}-msgpack
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append  port:py${python.version}-msgpack \
+                        port:py${python.version}-greenlet
 
     if { ${python.version} == 27 } {
         depends_lib-append  port:py${python.version}-trollius


### PR DESCRIPTION
###### Description

greenlet is required on Python implementations other than PyPy. [1]

[1] https://github.com/neovim/python-client/blob/master/setup.py#L22

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?