### PR TITLE
flake8: update and fix dependency version of pyflakes

### DIFF
--- a/python/py-flake8/Portfile
+++ b/python/py-flake8/Portfile
@@ -8,7 +8,7 @@ set _name           flake8
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             3.3.0
+version             3.4.1
 revision            1
 categories-append   devel
 platforms           darwin
@@ -31,12 +31,15 @@ homepage            http://flake8.readthedocs.org/
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-checksums           rmd160  296cdce03fe383d436f2fd954dff1d3d40702dbf \
-                    sha256  b907a26dcf5580753d8f80f1be0ec1d5c45b719f7bac441120793d1a70b03f12
+checksums           rmd160  f366a867f4d241edbefcf88a9c6717559ad28a83 \
+                    sha256  c20044779ff848f67f89c56a0e4624c04298cd476e25253ac0c36f910a1a11d8
 
 python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
+    # https://gitlab.com/pycqa/flake8/commit/b714bdff0bba39f653ded12b70f41b0f04cc003f
+    patchfiles-append       patch-setup.py.diff
+
     depends_build-append    port:py${python.version}-setuptools
 
     depends_lib-append      port:py${python.version}-pyflakes \

--- a/python/py-flake8/files/patch-setup.py.diff
+++ b/python/py-flake8/files/patch-setup.py.diff
@@ -1,11 +1,11 @@
---- setup.orig.py	2016-02-10 23:07:13.000000000 +0100
-+++ setup.py	2016-03-15 16:58:59.000000000 +0100
-@@ -49,7 +49,7 @@
-     url="https://gitlab.com/pycqa/flake8",
-     packages=["flake8", "flake8.tests"],
-     install_requires=[
--        "pyflakes >= 0.8.1, < 1.1",
-+        "pyflakes >= 0.8.1, < 1.2",
-         "pep8 >= 1.5.7, != 1.6.0, != 1.6.1, != 1.6.2",
-         "mccabe >= 0.2.1, < 0.5",
-     ],
+--- setup.py.orig	2017-09-17 12:18:21.000000000 +0800
++++ setup.py	2017-09-17 12:18:56.000000000 +0800
+@@ -17,7 +17,7 @@
+ # NOTE(sigmavirus24): When updating these requirements, update them in
+ # setup.cfg as well.
+ requires = [
+-    "pyflakes >= 1.5.0, < 1.6.0",
++    "pyflakes >= 1.5.0, < 1.7.0",
+     "pycodestyle >= 2.0.0, < 2.4.0",
+     "mccabe >= 0.6.0, < 0.7.0",
+     "setuptools >= 30",


### PR DESCRIPTION
###### Description

This is a backport of https://gitlab.com/pycqa/flake8/commit/b714bdff0bba39f653ded12b70f41b0f04cc003f

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?