### PR TITLE
Correct syntax for description for py-numpy

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -68,7 +68,7 @@ if {${name} ne ${subport}} {
         destroot.env-append     ARCHFLAGS="[get_canonical_archflags ld]"
     }
 
-    variant atlas description conflicts openblas {Use MacPorts ATLAS Libraries} {
+    variant atlas conflicts openblas description "Use MacPorts ATLAS Libraries" {
         depends_lib-append      port:atlas
     }
 


### PR DESCRIPTION
```
   atlas: Use MacPorts ATLAS Libraries
     * conflicts with openblas
```

vs
```
   atlas
     * conflicts with Use MacPorts ATLAS Libraries openblas
```