### PR TITLE
libssh: update to 0.7.5

### DIFF
--- a/devel/libssh/Portfile
+++ b/devel/libssh/Portfile
@@ -5,12 +5,12 @@ PortGroup           cmake 1.0
 
 name                libssh
 epoch               1
-version             0.7.4
+version             0.7.5
 revision            0
 master_sites        https://git.libssh.org/projects/libssh.git/snapshot/
 use_bzip2           yes
-checksums           rmd160  ae7a59880ec608c06b96225d6fa187793407e452 \
-                    sha256  4c8bc918b350a3b350d83a6e4d10db5b836f76765139fd54bdf09f358ac24cc2
+checksums           rmd160  5c9b3b39e3496af42ed83ba5c0364922dbbb991f \
+                    sha256  ff914e2ec6596badec453efaa63ef68c82c60074466f951167a4c60e49903336
 
 categories          devel security net
 platforms           darwin


### PR DESCRIPTION
###### Description
> We are happy to announce the release of libssh 0.7.5. The most import fixed issue is bug in the buffer parsing which can allocate a lot of memory. Thanks to Alex Gaynor from Google for the reporting the issue!

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
