### PR TITLE
kmymoney4: Fix failing build due to cmake rules

### DIFF
--- a/kde/kmymoney4/Portfile
+++ b/kde/kmymoney4/Portfile
@@ -45,7 +45,8 @@ depends_lib-append  port:libofx \
 patch.dir           ${workpath}/${distname}
 patch.pre_args      -p1
 patchfiles          patch-mainRaster.diff \
-                    patch-CMakeLists_QGPGME.txt.diff
+                    patch-CMakeLists_QGPGME.txt.diff \
+                    patch-CMakeLists_kmymoneysettings.h.diff
 #
 # OK, let's try building with documentation and see whether we end up with meinproc crashing again:
 #

--- a/kde/kmymoney4/files/patch-CMakeLists_kmymoneysettings.h.diff
+++ b/kde/kmymoney4/files/patch-CMakeLists_kmymoneysettings.h.diff
@@ -1,0 +1,38 @@
+From b0a68ca075928aa29ee1e0007bfb14d714f5a948 Mon Sep 17 00:00:00 2001
+From: Ralf Habacker <ralf.habacker@freenet.de>
+Date: Thu, 10 Aug 2017 13:45:04 +0200
+Subject: Fix 'Compile error on Fedora 26'
+
+CMake build system used some outdated variables which has been replaced
+by cmake build in variables to fix the issue.
+
+FIXED-IN:4.8.1
+BUG:383351
+---
+ kmymoney/dialogs/settings/CMakeLists.txt | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/kmymoney/dialogs/settings/CMakeLists.txt b/kmymoney/dialogs/settings/CMakeLists.txt
+index 5aacbea..b007dfb 100644
+--- a/kmymoney/dialogs/settings/CMakeLists.txt
++++ b/kmymoney/dialogs/settings/CMakeLists.txt
+@@ -1,12 +1,11 @@
+ add_custom_command(
+-  OUTPUT ${KMyMoney2_BINARY_DIR}/kmymoneysettings.h  ${KMyMoney2_BINARY_DIR}/kmymoneysettings.cpp
+-  DEPENDS ${KMyMoney2_SOURCE_DIR}/kmymoney.kcfg ${KMyMoney2_SOURCE_DIR}/kmymoneysettings.kcfgc
+-  COMMAND ${KDE4_KCFGC_EXECUTABLE} -d ${KMyMoney2_BINARY_DIR}/ ${KMyMoney2_SOURCE_DIR}/kmymoney.kcfg ${KMyMoney2_SOURCE_DIR}/kmymoneysettings.kcfgc
++  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/kmymoneysettings.h  ${CMAKE_CURRENT_BINARY_DIR}/kmymoneysettings.cpp
++  DEPENDS ${CMAKE_SOURCE_DIR}/kmymoney/kmymoney.kcfg ${CMAKE_SOURCE_DIR}/kmymoney/kmymoneysettings.kcfgc
++  COMMAND ${KDE4_KCFGC_EXECUTABLE} -d ${CMAKE_CURRENT_BINARY_DIR}/ ${CMAKE_SOURCE_DIR}/kmymoney/kmymoney.kcfg ${CMAKE_SOURCE_DIR}/kmymoney/kmymoneysettings.kcfgc
+   )
+ 
+-
+ set (libsettings_a_SOURCES
+-  ${KMyMoney2_BINARY_DIR}/kmymoneysettings.h
++  ${CMAKE_CURRENT_BINARY_DIR}/kmymoneysettings.cpp
+   ksettingscolors.cpp
+   ksettingsfonts.cpp
+   ksettingsforecast.cpp
+-- 
+cgit v0.11.2
+


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/54604
See: https://lists.macports.org/pipermail/macports-users/2017-September/043713.html

###### Description

This is an attempt to fix kmymoney4, although I have not tested this at all. kmymoney4 has way too many dependencies I would have to build.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
