### PR TITLE
geda-gaf: rework build against guile18

### DIFF
--- a/science/geda-gaf/Portfile
+++ b/science/geda-gaf/Portfile
@@ -45,17 +45,20 @@ variant useguile18 description "Build against MacPorts' guile18" {
 
     patchfiles-append       patch-geda-gaf-libguile-header.diff
 
-    # pkg-config may not be installed yet; only installed when build deps are processed and installed
-    if {[file exists ${prefix}/bin/pkg-config]} {
-        configure.env-append    GUILE_CFLAGS=[exec ${prefix}/bin/pkg-config --cflags guile-1.8]
-        configure.env-append    GUILE_LIBS=[exec ${prefix}/bin/pkg-config --libs guile-1.8]
+    # fix build on some mac systesm <http://comments.gmane.org/gmane.comp.cad.geda.user/43564>
+    patchfiles-append       patch-geda-gaf-scheme-object.diff
+
+    # pkg-config and guile18 are only installed when build deps are processed and installed
+    if {[file exists ${prefix}/bin/pkg-config] && [file exists ${prefix}/lib/pkgconfig/guile-1.8.pc]} {
+        configure.args-append    GUILE_CFLAGS="[exec ${prefix}/bin/pkg-config --cflags guile-1.8]"
+        configure.args-append    GUILE_LIBS="[exec ${prefix}/bin/pkg-config --libs guile-1.8]"
     } else {
-        configure.env-append    GUILE_CFLAGS="-D_THREAD_SAFE -I${prefix}/include/guile18 -I${prefix}/include"
-        configure.env-append    GUILE_LIBS="-L${prefix}/lib/guile18 -L${prefix}/lib -lguile18 -lgmp -lm -lltdl"
+        configure.args-append    GUILE_CFLAGS="-D_THREAD_SAFE -I${prefix}/include/guile18 -I${prefix}/include"
+        configure.args-append    GUILE_LIBS="-L${prefix}/lib/guile18 -L${prefix}/lib -lguile18 -lgmp -lm -lltdl"
     }
 
-    configure.env-append    GUILE="${prefix}/bin/guile18"
-    configure.env-append    GUILE_SNARF="${prefix}/bin/guile18-snarf"
+    configure.args-append    GUILE="${prefix}/bin/guile18"
+    configure.args-append    GUILE_SNARF="${prefix}/bin/guile18-snarf"
 }
 
 variant enable_xdg description {enable XDG database update} {

--- a/science/geda-gaf/files/patch-geda-gaf-scheme-object.diff
+++ b/science/geda-gaf/files/patch-geda-gaf-scheme-object.diff
@@ -1,0 +1,14 @@
+diff -Naur geda-gaf-1.8.2.orig/libgeda/src/scheme_object.c geda-gaf-1.8.2/libgeda/src/scheme_object.c
+--- libgeda/src/scheme_object.c	2013-09-25 16:59:27.000000000 -0400
++++ libgeda/src/scheme_object.c	2014-07-20 17:29:15.000000000 -0400
+@@ -1986,8 +1986,8 @@
+  * \param filename_s  New filename for \a obj_s.
+  * \return \a obj_s.
+  */
+-SCM_DEFINE (set_picture_data_vector_x, "%set-picture-data/vector!",
+-            3, 0, 0, (SCM obj_s, SCM data_s, SCM filename_s),
++SCM_DEFINE (set_picture_data_vector_x, "%set-picture-data/vector!", 3, 0, 0,
++		(SCM obj_s, SCM data_s, SCM filename_s),
+             "Set a picture object's data from a vector.")
+ {
+   SCM vec_s = scm_any_to_s8vector (data_s);


### PR DESCRIPTION
change to configure args instead of ENV vars
add test for installed guile18 before pkg-config is run
closes: https://trac.macports.org/ticket/54865

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
