### PR TITLE
tomcat-native: update to 1.2.14

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                tomcat-native
-version             1.2.12
+version             1.2.14
 categories          java www
 maintainers         thebishops.org:matt
 license             Apache-2
@@ -16,8 +16,8 @@ long_description    This port provides access to native apr and other \
 homepage            http://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  53cdf35424c6d9289ceab6617029822e4aa99eec \
-                    sha256  e7add177c98a7f07220c306d65e182c45dbcd7501115e9ed56f1690c5472ded9
+checksums           rmd160  68111c6206beea728a0f912ff97393b797c2804a \
+                    sha256  a7f1649f7c384b2d4e6c4c96f20aea980efeba327dba874d4bc7c765b6229f5e
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native


### PR DESCRIPTION
###### Description
tomcat-native: update 1.2.14
Closes https://trac.macports.org/ticket/54802

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
