### PR TITLE
fontconfig: Fix weak-linked mkostemp before Sierra

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -5,6 +5,7 @@ PortGroup                   muniversal 1.0
 
 name                        fontconfig
 version                     2.12.6
+revision                    1
 categories                  graphics
 maintainers                 {ryandesign @ryandesign}
 license                     fontconfig
@@ -45,6 +46,15 @@ configure.args              --disable-silent-rules HASDOCBOOK=no
 # We put this into a pre-configure block so it can be evaluated _after_ platform selection.
 pre-configure {
     configure.args-append   --with-add-fonts=[join ${add_fonts} ,]
+
+    # Fix building for older macOS versions via MACOSX_DEPLOYMENT_TARGET
+    # https://github.com/macports/macports-ports/pull/802
+    if {${os.platform} eq "darwin" && [vercmp $macosx_version 10.12] >= 0} {
+        if {[vercmp $macosx_deployment_target 10.12] < 0 } {
+            ui_info "Disabling mkostemp for older versions of macOS..."
+            configure.args-append ac_cv_func_mkostemp=no
+        }
+    }
 }
 
 post-destroot {


### PR DESCRIPTION
If built on Sierra, fontconfig cannot be used on any older version of macOS because mkostemp will be weak-linked and it is not present on previous versions of libSystem.B.dylib, regardless of whether a deployment target was set or not.

This fixes it by checking whether we are on Sierra and then checking whether we are targetting an earlier version of the OS.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 8.3.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
