### PR TITLE
py-pytest: An attempt to fix build errors on OS X <= 10.11

### DIFF
--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -29,6 +29,9 @@ checksums           rmd160  21ce162286979f09371bb60d690c005552200b01 \
                     sha256  f46e49e0340a532764991c498244a60e3a37d7424a532b3ff1a6a7653f1a403a
 
 if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools_scm
+
     depends_lib-append  port:py${python.version}-setuptools \
                         port:py${python.version}-py
 


### PR DESCRIPTION
###### Description

Closes: https://trac.macports.org/ticket/54310

Apparently Python's SSL module does not work fine with https://pypi.python.org/ on OS X <= 10.11 [1]. Hopefully using MacPorts' packages can work around it.

[1] A recent build result: https://travis-ci.org/macports/macports-ports/builds/276438001

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?