### PR TITLE
npm5: update to version 5.4.2

### DIFF
--- a/devel/npm5/Portfile
+++ b/devel/npm5/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm5
-version             5.4.1
+version             5.4.2
 
 categories          devel
 platforms           darwin
@@ -27,8 +27,8 @@ distname            npm-${version}
 
 extract.suffix      .tgz
 
-checksums           rmd160  752ccfbe0d71caa26d02005e1b3d6f56af4de69e \
-                    sha256  1d43fad63e4be2c8c28ec58fc8c1c14fc0f106018802c83fe75d163ae1435178
+checksums           rmd160  e88659f51e2ceaea011cfeab1a228670931eae51 \
+                    sha256  04dc5f87b1079d59d51404d4b4c4aacbe385807a33bd15a8f2da2fabe27bf443
 
 worksrcdir          "package"
 


### PR DESCRIPTION
###### Description
Update to npm 5.4.2

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
