### PR TITLE
freetype: update to 2.8.1

### DIFF
--- a/print/freetype/Portfile
+++ b/print/freetype/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    freetype
-version                 2.8
+version                 2.8.1
 categories              print graphics
 maintainers             {ryandesign @ryandesign}
 license                 {FreeType GPL-2}
@@ -34,11 +34,11 @@ distfiles               ${distname}${extract.suffix}:source \
                         ${docdistname}${extract.suffix}:docs
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  518184d2be032b9807345367265cc7cd49df0da5 \
-                        sha256  a3c603ed84c3c2495f9c9331fe6bba3bb0ee65e06ec331e0a0fb52158291b40b \
+                        rmd160  4b31c73b38d1f03c431b12408f800569e0724cc4 \
+                        sha256  e5435f02e02d2b87bb8e4efdcaa14b1f78c9cf3ab1ed80f94b6382fb6acc7d78 \
                         ${docdistname}${extract.suffix} \
-                        rmd160  ad81e3ca016e583a949cbb9bd4ce40bc0493fa79 \
-                        sha256  427ba04d11f450df4bac4c95fec247be1b835ccdcf85d8b081f3f39d31811154
+                        rmd160  5ef58133218fa1ba8106cdaada4a3e6f56c793ad \
+                        sha256  e6251ab44adcb075c7ca4205163c43b6539cbe5265b8a24ec0afa07f8b9213f3
 
 patchfiles \
     patch-src_base_ftrfork.c.diff \


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
