### PR TITLE
sane-backends: enable avahi by default, add variant disable_avahi

### DIFF
--- a/graphics/sane-backends/Portfile
+++ b/graphics/sane-backends/Portfile
@@ -4,6 +4,7 @@ PortSystem                  1.0
 
 name                        sane-backends
 version                     1.0.27
+revision                    1
 set download_id             4224
 categories                  graphics
 platforms                   darwin
@@ -38,6 +39,7 @@ configure.args              --mandir=${prefix}/share/man \
                             --with-docdir=${prefix}/share/doc/${name} \
                             --enable-local-backends \
                             --enable-libusb \
+                            --disable-avahi \
                             --disable-latex \
                             --without-gphoto2
 
@@ -56,6 +58,8 @@ pre-destroot {
 
 destroot.keepdirs ${destroot}${prefix}/var/lock
 
+default_variants            +avahi
+
 variant disable_localbackends conflicts enable_pnmbackend with_gphoto2 description "turn off compilation of all backends but net" {
     depends_lib-delete      port:libusb-compat
     configure.args-delete   --enable-local-backends --enable-libusb
@@ -72,6 +76,12 @@ variant with_gphoto2 conflicts disable_localbackends description "include the gp
                             port:pkgconfig
     configure.args-delete   --without-gphoto2
     configure.args-append   --with-gphoto2
+}
+
+variant avahi description "enable Avahi support for saned and the net backend" {
+    depends_lib-append      port:avahi
+    configure.args-delete   --disable-avahi
+    configure.args-append   --enable-avahi
 }
 
 # This project uses u_long *everywhere* and doesn't bother including sys/types.h


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G1611
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
