### PR TITLE
afl: update to 2.51b

### DIFF
--- a/devel/afl/Portfile
+++ b/devel/afl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                afl
-version             2.49b
+version             2.51b
 categories          devel security
 platforms           darwin
 maintainers         {stevenmyint.com:git @myint} openmaintainer
@@ -21,8 +21,8 @@ homepage            http://lcamtuf.coredump.cx/afl
 master_sites        ${homepage}/releases
 extract.suffix      .tgz
 
-checksums           rmd160  ef960a70d2331850b1caa338fa3156fae5927397 \
-                    sha256  f7c52cb0243f2a186a40e7000db825545074b5773e9894688c61f945f9ad88d1
+checksums           rmd160  c9b774d0589e9be94120574045ae94d1633d922c \
+                    sha256  d435b94b35b844ea0bacbdb8516d2d5adffc2a4f4a5aad78785c5d2a5495bb97
 
 use_configure       no
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
