### PR TITLE
wcslib: update to 5.17

### DIFF
--- a/science/wcslib/Portfile
+++ b/science/wcslib/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 
 name                wcslib
-version             5.15
-revision            1
+version             5.17
 categories          science
 license             LGPL-3+
 platforms           darwin
@@ -20,8 +19,8 @@ master_sites        ftp://ftp.atnf.csiro.au/pub/software/wcslib/ \
                     ftp://ftp.eso.org/pub/dfs/pipelines/libraries/wcslib/
 use_bzip2           yes
 
-checksums           rmd160  9e05b06ad6f5e41ae925fa6c3977f51ca5cac07a \
-                    sha256  8bbe40a7b055578d1a6b77e92a733d2a01ce439814ea9e5a8d8bbc23c68b56e8
+checksums           rmd160  425e227f0293b73e2cbfd3ec6e1c68d7d7400f1f \
+                    sha256  5c9cb5c86be01703f6488774ef3ea44fd6918a4dcdfddc70855905c05de8436c
 
 depends_lib         port:cfitsio
 configure.args      --disable-fortran


### PR DESCRIPTION
Note that the upstream tarball is neither signed nor presented on an https URL, so I verified its hash with the maintainer of the corresponding Debian package.
