### PR TITLE
ghc: broaden sierra patch to later systems

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -58,7 +58,7 @@ patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \
                 patch-configure-disable-docs.diff \
                 patch-unix_lib_osx_sandbox_compatibility.diff
 
-platform darwin 16 {
+if { ${os.platform} eq "darwin" && ${os.major} >= 16 } {
     patchfiles-append   patch-sierra-compatibility.diff
 }
 


### PR DESCRIPTION
I don't have a system running darwin 17 to test this, but it should fix the issue raised in the referenced ticket. 

closes: https://trac.macports.org/ticket/54878

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
