### PR TITLE
xdxf_makedict: new port

### DIFF
--- a/textproc/xdxf_makedict/Portfile
+++ b/textproc/xdxf_makedict/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        soshial xdxf_makedict a26b847fa785ccb87a0b67940c824e29da97c2fd
+version             20160728
+
+categories          textproc
+license             GPL-2+
+platforms           darwin
+maintainers         {schenkel.net:leonardo @lbschenkel} openmaintainer
+
+description         Dictionary coverter software (dictd/dsl/sdict/stardict/xdxf)
+long_description    Many-to-many dictionary converter. The main supported \
+                    format is XDXF (XML Dictionary eXchange Format), a \
+                    semantic format for storing dictionaries.
+
+checksums           rmd160  71fc474c4aee28cbe208f6855913363025f253b7 \
+                    sha256  b599f83e4692a54771b1fa5cd93b0101b201b3893a86b22e4cdcee74cfe9d90e
+
+depends_lib         port:expat \
+                    port:glib2 \
+                    port:intltool \
+                    port:libiconv \
+                    port:zlib
+


### PR DESCRIPTION
###### Description

Packaging of https://github.com/soshial/xdxf_makedict for MacPorts.
Unfortunately it has no formal tags or releases, so I'm packaging the latest commit and using the timestamp as a version. 

I'm volunteering to be the maintainer of this port.

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
