### PR TITLE
spring-boot-cli: update to 1.5.7

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,11 +3,11 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.6
+version         1.5.7
 
 categories      java
 platforms       darwin
-maintainers     breun.nl:nils openmaintainer
+maintainers     {@breun breun.nl:nils} openmaintainer
 license         Apache-2
 supported_archs noarch
 
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  e8f1b35242a641eea6a56010060a04674dd1ee2f \
-                sha256  d129e7952f8cc687da436db1fff091991e8b85500894e3bc655ecbda7da6d8ae
+checksums       rmd160  cd2a8e07c2682c192e0a8d0d6aa691995c8abd21 \
+                sha256  fc8481a5c2fd6bac11a56705878bf870b8a98d427b255ae45ef4f8e1c2c08922
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
###### Description
Update to Spring Boot CLI 1.5.7.

###### Tested on
macOS 10.13 17A362a
Xcode 9.0 9A235 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?