### PR TITLE
Update pysam

### DIFF
--- a/python/py-pysam/Portfile
+++ b/python/py-pysam/Portfile
@@ -1,27 +1,48 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name                    py-pysam
-version                 0.5
-categories-append       science
-license                 MIT BSD
-maintainers             nomaintainer
-description             Python interface for the SAM/BAM sequence alignment and mapping format
-long_description        Pysam is a python module for reading and manipulating Samfiles. It's a lightweight wrapper of the samtools C-API.
-platforms               darwin
+name                py-pysam
+set realname        pysam
+version             0.12.0.1
+categories-append   science
+platforms           darwin
+license             MIT BSD
+maintainers         @SoapZA
 
-homepage                http://code.google.com/p/pysam/
-master_sites            googlecode:pysam
-distname                pysam-${version}
+description         Python interface for the SAM/BAM sequence \
+                    alignment and mapping format
+long_description    Pysam is a python module for reading and manipulating \
+                    Samfiles. It's a lightweight wrapper of the samtools C-API.
 
-checksums           rmd160  2a72beb9724bf193361fc042a72201be9837a290 \
-                    sha256  d74d1bfc462ec4f0f120be2ef0af2205d9964ec73e365f2c4ac6de3d810b6ef9
+homepage            http://pypi.python.org/pypi/${realname}
 
-python.versions         27
+master_sites        pypi:p/${realname}
+distname            ${realname}-${version}
 
-if {${name} eq ${subport}} {
+checksums           rmd160  315bdf74c211fad5372c1eb43751eff3609d3d27 \
+                    sha256  04837bf0b1313e57d50076f228463262b9982c410b973eb184c033528f83d523
+
+python.versions     27 34 35 36
+
+patchfiles          patch-pysam-remove-RPATH.diff
+
+if {${name} ne ${subport}} {
+    depends_build       port:py${python.version}-setuptools \
+                        port:py${python.version}-cython
+    depends_lib-append  port:htslib
+    livecheck.type      none
+} else {
     livecheck.name      pysam
     livecheck.regex     pysam-(\\d+(\\.\\d+)+)${extract.suffix}
 }
+
+post-patch {
+    # delete htslib, just to be safe
+    file delete -force htslib
+}
+
+configure.env       HTSLIB_MODE="external" \
+                    HTSLIB_INCLUDE_DIR="${prefix}"/include \
+                    HTSLIB_LIBRARY_DIR="${prefix}"/lib

--- a/python/py-pysam/files/patch-pysam-remove-RPATH.diff
+++ b/python/py-pysam/files/patch-pysam-remove-RPATH.diff
@@ -1,0 +1,11 @@
+prevent setup.py from adding RPATHs
+
+--- cy_build.py
++++ cy_build.py
+@@ -81,6 +81,5 @@
+             if not ext.extra_link_args:
+                 ext.extra_link_args = []
+ 
+-            ext.extra_link_args += ['-Wl,-rpath,$ORIGIN']
+                                     
+         build_ext.build_extension(self, ext)

--- a/python/py-pyvcf/Portfile
+++ b/python/py-pyvcf/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyvcf
+set realname        PyVCF
+version             0.6.8
+categories-append   science
+platforms           darwin
+license             MIT BSD
+maintainers         @SoapZA
+
+description         Python interface for the VCF variant file \
+                    common in sequence analysis
+long_description    PyVCF is a library to read and write VCF 4.0 \
+                    and 4.1 files with ease.
+
+homepage            http://pypi.python.org/pypi/${realname}
+
+master_sites        pypi:P/${realname}
+distname            ${realname}-${version}
+
+checksums           rmd160  26b3f906f30aed38cc1fc8440cd41fc1e94e9182 \
+                    sha256  e9d872513d179d229ab61da47a33f42726e9613784d1cb2bac3f8e2642f6f9d9
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+    depends_build       port:py${python.version}-setuptools \
+                        port:py${python.version}-cython
+    depends_lib-append  port:htslib
+    livecheck.type      none
+} else {
+    livecheck.name      PyVCF
+    livecheck.regex     PyVCF-(\\d+(\\.\\d+)+)${extract.suffix}
+}


### PR DESCRIPTION
###### Description
1. Update pysam to the latest version compatible with htslib 1.5
2. Also add PyVCF

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
