### PR TITLE
Update to podofo @0.9.5 for changes to build dependency cppunit

### DIFF
--- a/graphics/podofo/Portfile
+++ b/graphics/podofo/Portfile
@@ -2,11 +2,13 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
+PortGroup           cxx11 1.1
 
 cmake.out_of_source yes
 
 name                podofo
 version             0.9.5
+revision            1
 license             GPL-2 LGPL-2
 categories          graphics
 maintainers         {devans @dbevans} openmaintainer
@@ -54,7 +56,8 @@ configure.args-append \
                     -DPODOFO_BUILD_STATIC:BOOL=TRUE \
                     -DCMAKE_INCLUDE_PATH=${prefix}/include \
                     -DCMAKE_LIBRARY_PATH=${prefix}/lib \
-                    -DCMAKE_EXE_LINKER_FLAGS=''
+                    -DCMAKE_EXE_LINKER_FLAGS='' \
+                    -DCMAKE_CXX_FLAGS='-std=c++11'
 
 livecheck.type      regex
 livecheck.url       http://podofo.sourceforge.net/download.html


### PR DESCRIPTION
Update to podofo @0.9.5 for changes to build dependency cppunit

The current version of cppunit, a podofo dependency, contains calls to std::bind, which Clang will error on if running in the default c++98 mode.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 8.3.3 8E3004b 


###### Verification <!-- (delete not applicable items) -->
Have you
- [] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?


