### PR TITLE
ghc and ghc-bootstrap: specify compiler to clang-4.0

### DIFF
--- a/lang/ghc-bootstrap/Portfile
+++ b/lang/ghc-bootstrap/Portfile
@@ -7,7 +7,7 @@ name                ghc-bootstrap
 set canonicalname   ghc
 # Note: 7.6.3 doesn't have a i386 darwin version at http://www.haskell.org/ghc/dist/7.6.3
 version             7.6.2
-revision            1
+revision            2
 categories          lang haskell
 maintainers         cal openmaintainer
 license             BSD
@@ -51,6 +51,15 @@ compiler.blacklist-append \
                     gcc-4.2 \
                     {clang < 503.0.38} \
                     macports-clang-3.3
+
+# ghc needs a build and runtime dependency on the compiler used to build it
+# same is also set in ghc-bootstrap. clang-4.0 works, is needed on older systems anyway
+# also /usr/bin/clang does not work on 10.11, so override it there
+if { ${os.platform} eq "darwin" && ( ${os.major} < 13 || ${os.major} == 15 ) } {
+    compiler.whitelist    macports-clang-4.0
+    depends_build-append  port:clang-4.0
+    depends_run-append    port:clang-4.0
+}
 
 configure.pre_args  --prefix=${prefix}/share/ghc-bootstrap
 configure.args      --with-gcc=${configure.cc}

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -8,7 +8,7 @@ name                ghc
 # When updating GHC, make sure to revbump all Haskell ports.
 # Also make sure to update the version in the Haskell PortGroup.
 version             7.8.3
-revision            5
+revision            6
 categories          lang haskell
 maintainers         cal openmaintainer
 license             BSD
@@ -79,6 +79,15 @@ compiler.blacklist-append \
                 gcc-4.2 \
                 {clang < 503.0.38} \
                 macports-clang-3.3
+
+# ghc needs a build and runtime dependency on the compiler used to build it
+# same is also set in ghc-bootstrap. clang-4.0 works, is needed on older systems anyway
+# also /usr/bin/clang does not work on 10.11, so override it there
+if { ${os.platform} eq "darwin" && ( ${os.major} < 13 || ${os.major} == 15 ) } {
+    compiler.whitelist    macports-clang-4.0
+    depends_build-append  port:clang-4.0
+    depends_run-append    port:clang-4.0
+}
 
 set bootstraproot ${prefix}/share/ghc-bootstrap
 set llvmPrefix  ${prefix}/libexec/llvm-3.5


### PR DESCRIPTION
on older systems and on 10.11
and add a build and runtime dependency for clang-4.0
as this compiler needs to be present when ghc is used.
closes: https://trac.macports.org/ticket/54363
closes: https://trac.macports.org/ticket/53709
closes: https://trac.macports.org/ticket/50962
closes: https://trac.macports.org/ticket/50480

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
