### PR TITLE
caffe: install headers and binaries

### DIFF
--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 name                caffe
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
+revision            1
 categories          math science
 maintainers         nomaintainer
 
@@ -47,24 +48,25 @@ set defs "-DGTEST_HAS_TR1_TUPLE=0 -Wno-deprecated -Wunused-local-typedef"
 build.args          CXX="${configure.cxx}" \
                     _CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx] ${defs}" \
                     _PREFIX=${prefix}
+build.target        tools/
 
 test.run            yes
 test.args           ${build.args}
 test.target         test runtest
 
 set caffe_root ${prefix}/libexec/${name}
+destroot.args       ${build.args} \
+                    DISTRIBUTE_DIR=${destroot}${prefix}
+destroot.target     dist
 
-destroot {
-    # install libraries
-    xinstall -m 644 -W ${worksrcpath}/.build_release/lib \
-        libcaffe.a libcaffe.so \
-        ${destroot}${prefix}/lib
+post-destroot {
+    # fix libraries
     system "install_name_tool -id ${prefix}/lib/libcaffe.so \
             ${destroot}${prefix}/lib/libcaffe.so"
 
     # copy files to caffe_root
     xinstall -m 755 -d ${destroot}${caffe_root}
-    foreach dir {data examples models python scripts tools} {
+    foreach dir {data examples models scripts} {
         copy ${worksrcpath}/${dir} ${destroot}${caffe_root}
     }
 
@@ -136,7 +138,7 @@ variant python27 description {Install Python 2.7 interface} {
             ${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
         xinstall -m 755 -d ${destroot}${packages_dir}
         system "install_name_tool -change @rpath/libcaffe.so.1.0.0 ${prefix}/lib/libcaffe.so \
-                ${destroot}${caffe_root}/python/caffe/_caffe.so"
-        copy ${destroot}${caffe_root}/python/caffe ${destroot}${packages_dir}
+                ${worksrcpath}/python/caffe/_caffe.so"
+        copy ${worksrcpath}/python/caffe ${destroot}${packages_dir}
     }
 }

--- a/math/caffe/files/patch-Makefile.diff
+++ b/math/caffe/files/patch-Makefile.diff
@@ -45,3 +45,27 @@
  
  $(TOOL_BINS): %.bin : %.o | $(DYNAMIC_NAME)
  	@ echo CXX/LD -o $@
+@@ -681,19 +681,18 @@ $(DIST_ALIASES): $(DISTRIBUTE_DIR)
+
+ $(DISTRIBUTE_DIR): all py | $(DISTRIBUTE_SUBDIRS)
+ 	# add proto
+-	cp -r src/caffe/proto $(DISTRIBUTE_DIR)/
++	mkdir -p $(DISTRIBUTE_DIR)/share/caffe
++	cp -r src/caffe/proto $(DISTRIBUTE_DIR)/share/caffe/
+ 	# add include
+ 	cp -r include $(DISTRIBUTE_DIR)/
+ 	mkdir -p $(DISTRIBUTE_DIR)/include/caffe/proto
+ 	cp $(PROTO_GEN_HEADER_SRCS) $(DISTRIBUTE_DIR)/include/caffe/proto
+ 	# add tool and example binaries
+-	cp $(TOOL_BINS) $(DISTRIBUTE_DIR)/bin
+-	cp $(EXAMPLE_BINS) $(DISTRIBUTE_DIR)/bin
++	for f in $(TOOL_BINS) $(EXAMPLE_BINS); do cp -v "$$f" "$(DISTRIBUTE_DIR)/bin/`basename -s.bin $$f`"; done
+ 	# add libraries
+ 	cp $(STATIC_NAME) $(DISTRIBUTE_DIR)/lib
+ 	install -m 644 $(DYNAMIC_NAME) $(DISTRIBUTE_DIR)/lib
+ 	cd $(DISTRIBUTE_DIR)/lib; rm -f $(DYNAMIC_NAME_SHORT);   ln -s $(DYNAMIC_VERSIONED_NAME_SHORT) $(DYNAMIC_NAME_SHORT)
+ 	# add python - it's not the standard way, indeed...
+-	cp -r python $(DISTRIBUTE_DIR)/python
+
+ -include $(DEPS)
+


### PR DESCRIPTION
Following FreeBSD port:
* Install C headers in ${prefix}/include
* Install binaries in ${prefix}/bin

###### Description


###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
