### PR TITLE
git: update to 2.14.2

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.14.1
-revision            1
+version             2.14.2
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -23,11 +22,11 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}${extract.suffix} \
-                    rmd160  20883121f8b167d52cd54107e78a9d8a0a7502a9 \
-                    sha256  6f724c6d0e9e13114ab35db6f67e1b2c1934b641e89366e6a0e37618231f2cc6 \
+                    rmd160  3be9f533f87f4f9d4a468ab20d5d46b70c562ba8 \
+                    sha256  50e9723996114ad1eec4dda89960d9fe34461749ae42031008a261fedd03c7a1 \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  f4497508842187ebedf5867cddc17dc988c57458 \
-                    sha256  7ebce1e0e862af1367e24f14765c7b67f08b63fb01b80949f55479c562d414f2
+                    rmd160  e4706afe70fe4b49a2c6d0bac65396cac8f4d9dc \
+                    sha256  6dd350d1e9d00159a549f0fad08a9f954b1d12576fc8d5865fbed9dee15105fc
 
 perl5.require_variant   yes
 perl5.conflict_variants no
@@ -143,8 +142,8 @@ variant pcre {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}${extract.suffix} \
-                            rmd160  f50f16964f1def5cdbea08fdf214dc6b3c845025 \
-                            sha256  9c1970c7f87f37c8b3044e01e0500d84d8bc4eb4dfa5ca881c32c351f20769fb
+                            rmd160  06b2fffc596143425e684564327359b7242a7571 \
+                            sha256  a36661e81e5b21e788cd84e11860bcd0cafa402eff06e6371415a5a0e0b80dfb
 
     patchfiles-append       git-subtree.html.diff
 

--- a/devel/git/files/git-subtree.1.diff
+++ b/devel/git/files/git-subtree.1.diff
@@ -5,12 +5,12 @@
 +.\"     Title: git-subtree
 +.\"    Author: [see the "AUTHOR" section]
 +.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-+.\"      Date: 08/09/2017
++.\"      Date: 09/24/2017
 +.\"    Manual: Git Manual
-+.\"    Source: Git 2.14.1
++.\"    Source: Git 2.14.2
 +.\"  Language: English
 +.\"
-+.TH "GIT\-SUBTREE" "1" "08/09/2017" "Git 2\&.14\&.1" "Git Manual"
++.TH "GIT\-SUBTREE" "1" "09/24/2017" "Git 2\&.14\&.2" "Git Manual"
 +.\" -----------------------------------------------------------------
 +.\" * Define some portability stuff
 +.\" -----------------------------------------------------------------

--- a/devel/git/files/git-subtree.html.diff
+++ b/devel/git/files/git-subtree.html.diff
@@ -1201,7 +1201,7 @@
 +<div id="footnotes"><hr /></div>
 +<div id="footer">
 +<div id="footer-text">
-+Last updated 2017-08-09 19:54:31 UTC
++Last updated 2017-09-24 07:12:40 UTC
 +</div>
 +</div>
 +</body>


### PR DESCRIPTION
###### Description
See http://www.openwall.com/lists/oss-security/2017/09/26/9.

```
 * "git cvsserver" no longer is invoked by "git daemon" by default,
   as it is old and largely unmaintained.

 * Various Perl scripts did not use safe_pipe_capture() instead of
   backticks, leaving them susceptible to end-user input.  They have
   been corrected.
```
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?