### PR TITLE
Fix qt4-mac build on OSX10.13

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -292,10 +292,14 @@ patchfiles-append patch-better-invalid-fonttable-handling.diff
 
 patchfiles-append patch-fix_pointer_comparison_to_0.diff
 
-# error out if trying to build on a new OSX version (> 10.12).
+# (30) Fix compilation error on XCode9.0 (defaul compiler for 10.13 High Sierra) 
+
+patchfiles-append patch-src_gui_kernel_qt_cocoa_helpers_mac.diff
+
+# error out if trying to build on a new OSX version (> 10.13).
 
 platform darwin {
-    if {${MINOR} > 12} {
+    if {${MINOR} > 13} {
         # This project needs to be updated to build with clang++ against libc++
         depends_lib
         depends_run
@@ -337,7 +341,7 @@ if {${SDK} eq ""} {
 post-patch {
     # set ARCHES in configure (per the third patchfile above), for
     # building QMake.  join any 2 or more arch entries with the GCC
-    # arch flag (join does not affect a single entry).  first "-arch"
+    # arch flag (join does not effect a single entry).  first "-arch"
     # is already in place in the 'configure' script (since there has
     # to be at least 1 arch).
 

--- a/aqua/qt4-mac/files/patch-src_gui_kernel_qt_cocoa_helpers_mac.diff
+++ b/aqua/qt4-mac/files/patch-src_gui_kernel_qt_cocoa_helpers_mac.diff
@@ -1,0 +1,8 @@
+354,356c354,356
+<     require_action(inContext != NULL, InvalidContext, err = paramErr);
+<     require_action(inBounds != NULL, InvalidBounds, err = paramErr);
+<     require_action(inImage != NULL, InvalidImage, err = paramErr);
+---
+>     //require_action(inContext != NULL, InvalidContext, err = paramErr);
+>     //require_action(inBounds != NULL, InvalidBounds, err = paramErr);
+>     //require_action(inImage != NULL, InvalidImage, err = paramErr);


### PR DESCRIPTION
This patch allows qt4-mac to compile on OSX10.13/XCode9.