### PR TITLE
Add work around for compiling gcc{5,6,7,8} + related libgcc ports on APFS filesystems

### DIFF
--- a/lang/gcc5/Portfile
+++ b/lang/gcc5/Portfile
@@ -137,7 +137,15 @@ configure.cxx_stdlib
 
 build.dir           ${configure.dir}
 build.target        bootstrap-lean
-use_parallel_build  yes
+
+# Temporary fix to disable parallel builds on macOS 10.13 
+# See https://trac.macports.org/ticket/54829
+#     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+if { ${os.major} < 17 } {
+    use_parallel_build yes
+} else {
+    use_parallel_build no
+}
 
 destroot.target     install install-info-host
 

--- a/lang/gcc6/Portfile
+++ b/lang/gcc6/Portfile
@@ -134,7 +134,15 @@ configure.cxx_stdlib
 
 build.dir           ${configure.dir}
 build.target        bootstrap-lean
-use_parallel_build  yes
+
+# Temporary fix to disable parallel builds on macOS 10.13 
+# See https://trac.macports.org/ticket/54829
+#     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+if { ${os.major} < 17 } {
+    use_parallel_build yes
+} else {
+    use_parallel_build no
+}
 
 destroot.target     install install-info-host
 

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -139,7 +139,15 @@ configure.cxx_stdlib
 
 build.dir           ${configure.dir}
 build.target        bootstrap-lean
-use_parallel_build  yes
+
+# Temporary fix to disable parallel builds on macOS 10.13 
+# See https://trac.macports.org/ticket/54829
+#     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+if { ${os.major} < 17 } {
+    use_parallel_build yes
+} else {
+    use_parallel_build no
+}
 
 destroot.target     install install-info-host
 

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -135,7 +135,15 @@ configure.cxx_stdlib
 
 build.dir           ${configure.dir}
 build.target        bootstrap-lean
-use_parallel_build  yes
+
+# Temporary fix to disable parallel builds on macOS 10.13 
+# See https://trac.macports.org/ticket/54829
+#     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+if { ${os.major} < 17 } {
+    use_parallel_build yes
+} else {
+    use_parallel_build no
+}
 
 destroot.target     install install-info-host
 


### PR DESCRIPTION
###### Description

Fixes compilation of gcc{5,6,7,8} and related libgcc ports on APFS filesystems.

Fixes https://trac.macports.org/ticket/54829
Fixes https://trac.macports.org/ticket/54900

Upstream bug report

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.13
Xcode 9.0
