### PR TITLE
gsmartcontrol: update to 1.1.0

### DIFF
--- a/sysutils/gsmartcontrol/Portfile
+++ b/sysutils/gsmartcontrol/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.1
 
 name                gsmartcontrol
-version             1.0.2
+version             1.1.0
 maintainers         cal openmaintainer
 
 categories          sysutils gnome
@@ -22,8 +22,8 @@ homepage            http://gsmartcontrol.sourceforge.net/
 master_sites        sourceforge:project/${name}/${version}/
 use_bzip2           yes
 
-checksums           rmd160  69949a0b176d1d0cdda17f4986ac3a4700f31546 \
-                    sha256  4f70451c359d95edc974498b860696b698f19b187340dc7207b4b38cbaf5e207
+checksums           rmd160  9187d326d94892fe5b45d17e329692c199aad874 \
+                    sha256  90c9ead852255f5e1a74a3ff6c265d1cbcba19ad2fc77059c60737c13a3cd2c8
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
###### Description

See https://lists.macports.org/pipermail/macports-users/2017-September/043745.html

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
