### PR TITLE
hunspell-dict-en_GB: fix version of obsolete port

### DIFF
--- a/textproc/hunspell-dict-en_GB/Portfile
+++ b/textproc/hunspell-dict-en_GB/Portfile
@@ -5,7 +5,7 @@ replaced_by     hunspell-en
 PortGroup       obsolete 1.0
 
 name            hunspell-dict-en_GB
-version         008-04-24
+version         2008-04-24
 revision        1
 
 # Remove after September 25, 2018


### PR DESCRIPTION
###### Description

Fix the version in the obsolete port hunspell-dict-en_GB, otherwise it is not considered outdated.