### PR TITLE
bedtools: fix build error with Xcode 9.0

### DIFF
--- a/science/bedtools/Portfile
+++ b/science/bedtools/Portfile
@@ -27,7 +27,9 @@ depends_lib         port:zlib
 
 use_configure       no
 
-patchfiles          patch-docs-conf.py.diff
+patchfiles          patch-docs-conf.py.diff \
+                    patch-src-utils-FileRecordTools-Records-StrandQueue.cpp.diff \
+                    patch-src-utils-FileRecordTools-Records-StrandQueue.h.diff
 
 variant universal {}
 

--- a/science/bedtools/files/patch-src-utils-FileRecordTools-Records-StrandQueue.cpp.diff
+++ b/science/bedtools/files/patch-src-utils-FileRecordTools-Records-StrandQueue.cpp.diff
@@ -1,0 +1,67 @@
+--- src/utils/FileRecordTools/Records/StrandQueue.cpp.orig
++++ src/utils/FileRecordTools/Records/StrandQueue.cpp
+@@ -25,11 +25,11 @@ StrandQueue::~StrandQueue() {
+ 	}
+ }
+ 
+-Record *StrandQueue::top() const
++Record *StrandQueue::top()
+ {
+ 	int minIdx = getMinIdx();
+ 	if (minIdx == -1) return NULL;
+-	return const_cast<Record *>(_queues[minIdx]->top());
++	return _queues[minIdx]->top();
+ }
+ 
+ void StrandQueue::pop() {
+@@ -38,8 +38,8 @@ void StrandQueue::pop() {
+ 	_queues[minIdx]->pop();
+ }
+ 
+-Record * StrandQueue::top(Record::strandType strand) const {
+-	const Record *record = NULL;
++Record * StrandQueue::top(Record::strandType strand) {
++	Record *record = NULL;
+ 	switch (strand) {
+ 	case Record::FORWARD:
+ 		if (_queues[0]->empty()) return NULL;
+@@ -57,10 +57,10 @@ Record * StrandQueue::top(Record::strandType strand) const {
+ 	default:
+ 		break;
+ 	}
+-	return const_cast<Record *>(record);
++	return record;
+ }
+ 
+-void StrandQueue::pop(Record::strandType strand) const {
++void StrandQueue::pop(Record::strandType strand) {
+ 	switch (strand) {
+ 	case Record::FORWARD:
+ 		if (_queues[0]->empty()) return;
+@@ -95,7 +95,7 @@ void StrandQueue::push(Record *record) {
+ 	}
+ }
+ 
+-size_t StrandQueue::size() const {
++size_t StrandQueue::size() {
+ 	size_t sumSize = 0;
+ 	for (int i = 0; i < NUM_QUEUES; i++) {
+ 		sumSize += _queues[i]->size();
+@@ -103,7 +103,7 @@ size_t StrandQueue::size() const {
+ 	return sumSize;
+ }
+ 
+-bool StrandQueue::empty() const {
++bool StrandQueue::empty() {
+ 	for (int i = 0; i < NUM_QUEUES; i++) {
+ 		if (!_queues[i]->empty()) {
+ 			return false;
+@@ -113,7 +113,7 @@ bool StrandQueue::empty() const {
+ }
+ 
+ 
+-int StrandQueue::getMinIdx() const {
++int StrandQueue::getMinIdx() {
+ 	if (empty()) return -1;
+ 	const Record *minRec = NULL;
+ 	int minIdx = -1;

--- a/science/bedtools/files/patch-src-utils-FileRecordTools-Records-StrandQueue.h.diff
+++ b/science/bedtools/files/patch-src-utils-FileRecordTools-Records-StrandQueue.h.diff
@@ -1,0 +1,35 @@
+--- src/utils/FileRecordTools/Records/StrandQueue.h.orig
++++ src/utils/FileRecordTools/Records/StrandQueue.h
+@@ -20,17 +20,17 @@ class StrandQueue {
+ 	StrandQueue();
+ 	~StrandQueue();
+ 
+-	Record * top() const;
++	Record * top();
+ 	void pop();
+-	Record * top(Record::strandType strand) const;
+-	void pop(Record::strandType strand) const;
++	Record * top(Record::strandType strand);
++	void pop(Record::strandType strand);
+ 	void push(Record *record);
+-	size_t size() const;
+-	bool empty() const;
++	size_t size();
++	bool empty();
+ 
+ private:
+ //	static RecordPtrSortFunctor _recSortFunctor;
+-	typedef priority_queue<Record *, vector<const Record *>, RecordPtrSortDescFunctor > queueType;
++	typedef priority_queue<Record *, vector<Record *>, RecordPtrSortDescFunctor > queueType;
+ 	vector<queueType *> _queues;
+ 	static const int NUM_QUEUES = 3;
+ 
+@@ -39,7 +39,7 @@ class StrandQueue {
+ 	//do, so we'll use a suggestion found in a forum, and put the enum values into a vector.
+ 	vector<Record::strandType> _strandIdxs;
+ 
+-	int getMinIdx() const; //will return the idx of queue with the current min val.
++	int getMinIdx(); //will return the idx of queue with the current min val.
+ 
+ };
+ 


### PR DESCRIPTION
patch src/utils/FileRecordTools/Records/StrandQueue.cpp and src/utils/FileRecordTools/Records/StrandQueue.h using upstream pull request https://github.com/arq5x/bedtools2/pull/574. hopefully this will be included in the next release. This fixes https://trac.macports.org/ticket/54896.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
