### PR TITLE
mc: Workaround on missing 'utimensat' on 10.13

### DIFF
--- a/sysutils/mc/Portfile
+++ b/sysutils/mc/Portfile
@@ -33,6 +33,10 @@ patchfiles          patch-src_subshell_common.c.diff
 
 configure.args      --without-x
 
+if {[vercmp ${macosx_version} 10.13] >= 0} {
+    configure.env-append    ac_cv_func_utimensat=no
+}
+
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}
     xinstall -d ${docdir}


### PR DESCRIPTION
###### Description
mc: Workaround on missing 'utimensat' on 10.13
closes: https://trac.macports.org/ticket/54774

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13 17A365
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?