### PR TITLE
iTerm2: Fix version number in about dialog

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 github.setup        gnachman iTerm2 3.1.5 v
+revision            1
 categories          aqua shells
 platforms           darwin
 maintainers         emer.net:emer
@@ -26,6 +27,11 @@ patchfiles          patch-Makefile.diff
 
 post-patch {
     reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
+
+    # Fix version number
+    set versionfd [open ${worksrcpath}/version.txt "w"]
+    puts $versionfd "${version}"
+    close $versionfd
 }
 
 compiler.cpath


### PR DESCRIPTION
The about dialog of iTerm2.app displayed 3.1.0 as the upstream source
code does not identify itself correctly.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
