### PR TITLE
hunspell-dict-sv_SE: new port

### DIFF
--- a/textproc/hunspell-dict-sv_SE/Portfile
+++ b/textproc/hunspell-dict-sv_SE/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           hunspelldict 1.0
+
+hunspelldict.setup  sv_SE 2.40 {Swedish (Sweden)} ooo
+maintainers         {schenkel.net:leonardo @lbschenkel} openmaintainer
+homepage            https://sfol.se/
+license             LGPL-3
+
+set extension.url   https://extensions.libreoffice.org/extensions/swedish-spelling-dictionary-den-stora-svenska-ordlistan
+
+master_sites        ${extension.url}/${version}/@@download/file/
+checksums           rmd160  8dde75f2692b92089bfd35095fd50f11d7a3669d \
+                    sha256  b982881cc75f5c4af1199535bd4735ee476bdc48edf63e3f05fb4f715654a7bc
+
+post-extract {
+    # portgroup expects dictionaries to be in the work dir
+    move {*}[glob ${worksrcpath}/dictionaries/*] ${worksrcpath}
+}
+
+livecheck.url       ${extension.url}
+livecheck.regex     ${extension.url}/(\\d+\\.\\d+)/


### PR DESCRIPTION
###### Description

Swedish dictionary from SFOL (Svenska fria ordlistan) <https://sfol.se>.
This is the same dictionary shipped with LibreOffice and Firefox.

I'm volunteering to be the maintainer for this port.

###### Tested on
macOS 10.13 17A365
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
