### PR TITLE
ntfs-3g: update to 2017.3.23

### DIFF
--- a/fuse/ntfs-3g/Portfile
+++ b/fuse/ntfs-3g/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                ntfs-3g
-version             2015.3.14
+version             2017.3.23
 categories          fuse
 platforms           darwin
 maintainers         nomaintainer
@@ -24,8 +24,8 @@ extract.suffix      .tgz
 
 master_sites        http://tuxera.com/opensource/
 
-checksums           rmd160  67cbb81ab619c0941fe23a73e9a187a73008d51e \
-                    sha256  97f996015d8316d4a272bd2629978e5e97072dd3cc148ce39802f8037c6538f2
+checksums           rmd160  aae0cd7a2560ad87ba41832f1b34af5aaaa38739 \
+                    sha256  3e5a021d7b761261836dcb305370af299793eedbded731df3d6943802e1262d5
 
 livecheck.type      regex
 livecheck.regex     {stable version</span></b> is <a href="https://tuxera.com/opensource/ntfs-3g_ntfsprogs-(.+?)\.tgz"}
@@ -43,6 +43,9 @@ universal_variant   no
 patchfiles          patch-configure.diff
 
 configure.args      --exec-prefix=${prefix} --with-fuse=external
+# do not try to use this function in macOS 10.13 to avoid compilation error
+# (older versions don't have this function)
+configure.env       ac_cv_func_utimensat=no
 
 platform darwin {
     depends_lib-append          port:gettext
@@ -51,25 +54,6 @@ platform darwin {
 
 pre-destroot {
     file mkdir ${destroot}/sbin
-}
-
-post-destroot {
-    # ntfs-3g symlinks /sbin/mount.ntfs-3g to ${prefix}/bin/ntfs-3g
-    # but on darwin mount wants mount_* instead of mount.*
-
-    # /sbin/mount.ntfs-3g is no longer installed with recent versions of ntfs-3g
-    # but check here to verify so updates don't miss it if it's turned back on
-    if {[file exists ${destroot}/sbin/mount.ntfs-3g]} {
-       # This violated the tree restrictions, hopefully fixed by now.
-       file rename -- ${destroot}/sbin/mount.ntfs-3g \
-                      ${destroot}${prefix}/sbin/mount_ntfs-3g
-    }
-    file rename -- ${destroot}${prefix}/share/man/man8/mount.ntfs-3g.8 \
-                   ${destroot}${prefix}/share/man/man8/mount_ntfs-3g.8
-
-    # This violated the tree restrictions, hopefully fixed by now.
-    file rename -- ${destroot}/sbin/mkfs.ntfs \
-                   ${destroot}${prefix}/sbin/mkfs.ntfs
 }
 
 notes "


### PR DESCRIPTION
###### Description

I upgraded the port to 2017.3.23. The workarounds for mtree violations are no longer necessary.
Closes https://trac.macports.org/ticket/53536

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] security fix
- [x] enhancement

###### Tested on
macOS 10.13 17A365
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
