### PR TITLE
kotlin: update to 1.1.51

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.1.50 v
+github.setup        JetBrains kotlin 1.1.51 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  2eeef0f63218a3c6ada687e1127c2f70e563f4ad \
-                    sha256  b5106298e10a934f11685b1c80e47a5b4960c039100d5640bb4a285e32a8c707
+checksums           rmd160  cb3174314272d2e1230f154099440fe65d304603 \
+                    sha256  0b346b138390eb0235a6700f52cc1e2b491cf1f6db179a6d06a279ef1af57ccd
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
###### Description

Update to Kotlin 1.1.51.

###### Tested on
macOS 10.13 17A365
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?