### PR TITLE
octave: needs newer RANLIB on snowleopard

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -114,8 +114,16 @@ pre-patch {
 # avoid depends_build-append port:coreutils
 configure.env-append MKDIR_P="/bin/mkdir -p"
 
-# avoid depends_build-append port:cctools
-configure.env-append RANLIB=/usr/bin/ranlib
+
+if { ${os.major} > 10 } {
+    # avoid depends_build-append port:cctools
+    configure.env-append RANLIB=/usr/bin/ranlib
+} else {
+    # ranlib on older systems is too old to handle newer clang output
+    # https://trac.macports.org/ticket/54228
+    depends_build-append port:cctools
+    configure.env-append RANLIB=${prefix}/bin/ranlib
+}
 
 # main octave port lists as a depends_lib
 # configure.ac list it among the "[p]rograms used in Makefiles"


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/54228

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
