### PR TITLE
wxWidgets-3.0: patch for High Sierra

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -94,7 +94,8 @@ depends_lib         port:jpeg \
 depends_run         port:wxWidgets-common \
                     port:wxWidgets_select
 
-patchfiles-append   patch-configure.diff
+patchfiles-append   patch-configure.diff \
+                    patch-upstream-configure-highsierra.diff
 #                    patch-upstream-src-osx-carbon-fontdlgosx.mm.diff 
 #                    patch-upstream-src-stc-scintilla-src-Editor.cxx.diff
 #                    patch-upstream-webkit-proper-types.diff

--- a/graphics/wxWidgets-3.0/files/patch-upstream-configure-highsierra.diff
+++ b/graphics/wxWidgets-3.0/files/patch-upstream-configure-highsierra.diff
@@ -1,0 +1,10 @@
+--- configure.orig
++++ configure
+@@ -19769,6 +19769,7 @@ esac
+ 
+ case "${host}" in
+   *-*-darwin* )
++    CPPFLAGS="-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1 $CPPFLAGS"
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if CoreFoundation/CFBase.h is usable" >&5
+ $as_echo_n "checking if CoreFoundation/CFBase.h is usable... " >&6; }
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext


### PR DESCRIPTION
Blindly copied an upstream patch (no access to 10.13 yet). Feel free to merge if it works for you. I have other changes pending, but this one has a higher priority.

Closes: https://trac.macports.org/ticket/54902

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
