### PR TITLE
switchaudio-osx: new port

### DIFF
--- a/audio/switchaudio-osx/Portfile
+++ b/audio/switchaudio-osx/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               xcode 1.0
+
+github.setup            deweller switchaudio-osx 1.0.0
+categories              audio
+platforms               darwin
+maintainers             kencu openmaintainer
+license                 MIT
+
+description             A command-line utility to switch the audio source on Mac OS X.
+long_description        ${description}
+
+checksums               rmd160  3ed089efb7dfbe09f12aedbfca2ce293f0529938 \
+                        sha256  8c50d0c9d5d4818be36f98cd0000790d2e2f2ed28577a9ef69024568f57e86ac
+
+xcode.project           AudioSwitcher.xcodeproj
+xcode.configuration     Release
+xcode.build.settings    SYMROOT=build
+xcode.target            SwitchAudioSource
+
+destroot {
+    copy ${worksrcpath}/build/Release/SwitchAudioSource ${destroot}${prefix}/bin
+}
+
+test.run                yes
+test.cmd                ${worksrcpath}/build/Release/SwitchAudioSource
+test.target
+test.args               -a
+


### PR DESCRIPTION
switches audio devices from command line
closes: https://trac.macports.org/ticket/54971
