### PR TITLE
libfilezilla: Update to 0.11.0

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.1
 
 name                libfilezilla
-version             0.10.1
+version             0.11.0
 categories          devel
 platforms           darwin
 maintainers         {@yan12125 gmail.com:yan12125} openmaintainer
@@ -19,8 +19,8 @@ long_description    Small and modern C++ library, offering some basic \
 homepage            https://lib.filezilla-project.org/
 master_sites        http://download.filezilla-project.org/libfilezilla/
 
-checksums           rmd160  0150b725d477493c6dadd3029e417350ee6936a7 \
-                    sha256  a097536689f92320f8ee03eed68fe0b82457a53a7f4d287d7c03f60bc16a29fa
+checksums           rmd160  6dd64427183c022e31cfbcca9660b57edb08531e \
+                    sha256  cc7467241c8905de98773b414ce445d6f9ff3bf3105f2d16cecab76404879ed0
 
 depends_build       port:pkgconfig \
                     port:cppunit \


### PR DESCRIPTION
###### Description
Bump libfilezilla to 0.11.0

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?