### PR TITLE
FileZilla: update to 3.28 and fix building with Xcode < 8

### DIFF
--- a/www/FileZilla/Portfile
+++ b/www/FileZilla/Portfile
@@ -3,12 +3,13 @@
 PortSystem          1.0
 PortGroup           wxWidgets 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cxx11 1.1
 
 name                FileZilla
-version             3.27.1
+version             3.28.0
 categories          www aqua
 platforms           darwin
-maintainers         strasweb.fr:rudloff openmaintainer
+maintainers         {@yan12125 gmail.com:yan12125} openmaintainer
 license             GPL-2+
 
 description         Open-source FTP, FTPS, and SFTP client
@@ -20,8 +21,8 @@ long_description    FileZilla Client is a fast and reliable cross-platform \
 homepage            https://filezilla-project.org/
 master_sites        sourceforge:project/filezilla/FileZilla_Client/${version}
 
-checksums           rmd160  e4ad9a0df2659ba67bdd586008335e0a63da01c7 \
-                    sha256  4389fa81b62b7c816674a01f030592e44f2d8d5423f2cbcca4c7bb7417bd9a92
+checksums           rmd160  390456877d3a8d3ac0896b1ad1bb00355fa2d41e \
+                    sha256  e49621aeb07c89547508c9ef244e2226168e06b120f49d2c4d428d95f1adbfb7
 
 depends_build       port:pkgconfig
 
@@ -59,9 +60,14 @@ platform darwin {
 if {${os.major} <= 10} {
     compiler.whitelist macports-clang-3.4 macports-clang-3.5 macports-clang-3.6 macports-clang-3.7
 }
-# http://trac.macports.org/ticket/47273
-# In theory gcc could work, but we need to disable llvm-gcc and we need to match stdlib with wxWidgets (= use libc++)
-compiler.blacklist-append *gcc* {clang < 503}
+
+# FileZilla now requires thread_local keyword in C++11 (N2659), which is
+# supported since Xcode 8.0 [1][2], upstream clang 3.3 [3] and GCC 4.8 [4]
+# [1] https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html
+# [2] https://stackoverflow.com/a/29929949/3786245
+# [3] https://clang.llvm.org/cxx_status.html
+# [4] https://gcc.gnu.org/projects/cxx-status.html#cxx11
+compiler.blacklist-append {clang < 800}
 
 variant wxgtk30 conflicts wxwidgets30 wxwidgets30_libcxx description {Use wxWidgets 3.0 with GTK} {
     wxWidgets.use           wxGTK-3.0


### PR DESCRIPTION
###### Description

The latest FileZilla requires thread_local, which is not supported until Xcode 8.0.

This depends on #856

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?