### PR TITLE
changing libtool's "CC -dynamiclib" into "CC -dynamiclib -arch User's…

### DIFF
--- a/devel/npth/Portfile
+++ b/devel/npth/Portfile
@@ -22,6 +22,10 @@ use_bzip2           yes
 checksums           rmd160  17634221ca2bd0887e1d8edc8d0ca78212d51a76 \
                     sha256  294a690c1f537b92ed829d867bee537e46be93fbd60b16c04630fbbfcd9db3c2
 
+post-configure {
+    reinplace "s|CC -dynamiclib|CC -dynamiclib [get_canonical_archflags]|g" ${worksrcpath}/libtool
+}
+
 livecheck.type      regex
 livecheck.url       https://gnupg.org/ftp/gcrypt/${name}/
 livecheck.regex     ${name}-(\\d+\.\\d+)


### PR DESCRIPTION
…_Arch_Code" after "configure"

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 Sierra
Xcode 9.0 (Build version 9A235)

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
