### PR TITLE
py-spectral: update to 0.19

### DIFF
--- a/python/py-spectral/Portfile
+++ b/python/py-spectral/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        spectralpython spectral 0.15.0 v
+github.setup        spectralpython spectral 0.19 v
 name                py-spectral
 categories-append   science
 license             GPL-3
@@ -22,10 +22,10 @@ long_description    Spectral Python (SPy) is a pure Python module \
 
 homepage            http://spectralpython.net/
 
-checksums           rmd160  06a6754003b0587549d0a08d5bf8712c626dd360 \
-                    sha256  5bb5288fc1f27f62a3d0c8cec7bd548f1afd8c83803afb9a4b180298140a49e6
+checksums           rmd160  6f58072b076b4e12f17562a1f24497730056d3f2 \
+                    sha256  06b99a2f2209939cd399968e176dd5adf154b28e29f5ebd88ac919fe1326827c
 
-python.versions     26 27
+python.versions     26 27 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy


### PR DESCRIPTION
###### Description

* Version 0.15 -> 0.19
* Add py36 support

###### Type(s)
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13
Python 3.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?