### PR TITLE
plumed-devel: new subport

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -80,3 +80,20 @@ pre-configure {
     configure.ldflags-append ${linalglib}
 }
 
+# plumed-devel subport
+# This subport installs the developer version
+subport plumed-devel {
+    github.setup        plumed plumed2 2.4b v
+    description         ${description} (development version)
+    long_description    ${long_description} (development version)
+    conflicts plumed
+    checksums           rmd160  1c4eac7da0ba1cc954e271c4514010955502d1d6 \
+                        sha256  b057fe5654649b4866fd3009e013e082d0806bed6f61ecc8c3631edc6f85f99b
+    if {[variant_isset allmodules]} {
+# one of the optional modules installed within the +allmodules variant
+# requires boost_serialization
+      configure.args-append --enable-boost-serialization
+      configure.ldflags-append -lboost_serialization-mt
+      depends_lib-append port:boost
+    }
+}

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.3.2 v
+github.setup        plumed plumed2 2.3.3 v
 name                plumed
 
 categories          science
@@ -16,7 +16,6 @@ categories          science
 # http://www.ks.uiuc.edu/Research/vmd/plugins/molfile/
 license             LGPL-3 BSD
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
-
 description         PLUMED is a plugin for molecular dynamics
 long_description    PLUMED is a plugin for molecular dynamics that can be used \
                     in combination with popular molecular dynamics codes to perform biased simulations. \
@@ -26,8 +25,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  a9925428b2a5fa1d43a4ef677b216bcec0e2ac27 \
-                    sha256  6df6a31ec47da3ec81e3554224b0c66b49ca62dd9cac659d085e0b89c870d9f5
+checksums           rmd160  e8504f3b30fdc09c5ccfaace98491611f796c04a \
+                    sha256  ffcdc7bb88a41063b625e1f2c735e7f8eaf0c35f02246ea135f62e5ebbf1e7d0
+
 
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.


### PR DESCRIPTION
###### Description

I added a new subport `plumed-devel` which installs the developer version of plumed. I decided to use a subport (`plumed-devel`) rather than a variant (`plumed +devel`) since I am afraid that the propagation of variant to dependencies might influence them in some way. Hopefully I did it in the correct way.

Notice that I based this branch on #866 so that the other pull request should probably be closed first (though the two commits are independent).

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G1611
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
