### PR TITLE
plumed: small fix

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,7 +6,13 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.3.3 v
+# github.setup        plumed plumed2 2.3.3 v
+# include a fix that was commited just after 2.3.3
+# this hack will be removed at the next plumed release 
+github.setup        plumed plumed2 8fd0d4e37f0f35053cb5a48e2f76a73ea1128eaf
+version             2.3.3
+revision            1
+
 name                plumed
 
 categories          science
@@ -25,8 +31,8 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  e8504f3b30fdc09c5ccfaace98491611f796c04a \
-                    sha256  ffcdc7bb88a41063b625e1f2c735e7f8eaf0c35f02246ea135f62e5ebbf1e7d0
+checksums           rmd160  2475ff31da9dc0a227656ad8ff8dd41caf94c662 \
+                    sha256  351135cbbe3327d378d1f807eaefca6878a8dcf71d8da371be7636ccf085a584
 
 
 # Disable additional features.
@@ -84,6 +90,7 @@ pre-configure {
 # This subport installs the developer version
 subport plumed-devel {
     github.setup        plumed plumed2 2.4b v
+    revision            0
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed


### PR DESCRIPTION
###### Description

Minor fix. It's a fix added just after release of plumed 2.3.3 and, if possible, I would include it now rather than wait for 2.3.4 or 2.4.0. This fix is not critical, but might simplify the life in maintaining gromacs-plumed subport (see #727) is case the latter is merged.

Notice that the installed code is totally unaffected by this fix. However, the behavior of one of the scripts installed with the code (`plumed-patch`) is changed by this fix.

Also notice that subport `plumed-devel` is not affected since, luckily, the bug fix made it into version 2.4beta.

Thanks!

###### Type(s)
- [X] bugfix