### PR TITLE
hdf5: change master_sites to use https

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -25,7 +25,7 @@ long_description    HDF5 is a data model, library, and file format for storing\
 homepage            http://www.hdfgroup.org/HDF5/
 platforms           darwin
 master_sites \
-    http://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${version}/src
+    https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${version}/src
 checksums           rmd160  759e63ead405740dcf3260bdc9644b97480f3b8b \
                     sha256  9c5ce1e33d2463fb1a42dd04daacbc22104e57676e2204e3d66b1ef54b88ebf2
 mpi.setup           -gcc44 -gcc45


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/55004

###### Description
This is a very minor change: master_sites http --> https
The upstream master_sites web server appears to be broken for http, preventing port fetch step from succeeding. This works around the issue.
