### PR TITLE
tmux: update to 2.6 / tmux-devel: update to latest commit

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,13 +3,13 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 2.5
+github.setup    tmux tmux 2.6
 if {${subport} eq ${name}} {
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux bfd7209053669f58cf2ddfa86bb3ed2f9340acd8
-    version         20170529-[string range ${github.version} 0 6]
+    github.setup    tmux tmux 8aaf86a6ead9852631342d0d2d526a7eaede15cf
+    version         20171005-[string range ${github.version} 0 6]
     conflicts       tmux
 }
 categories      sysutils
@@ -28,12 +28,12 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  c4b10cb03326fffece5dcb76b94938b5a7a2a645 \
-                            sha256  ae135ec37c1bf6b7750a84e3a35e93d91033a806943e034521c8af51b12d95df
+    checksums               rmd160  32aa9e62fe5a0a6a11c4b3877a4e8e07381201f9 \
+                            sha256  b17cd170a94d7b58c0698752e1f4f263ab6dc47425230df7e53a6435cc7cd7e8
 }
 subport tmux-devel {
-    checksums               rmd160  1ce3cbbe09c9cbbd2965a4eec31dde79e204b996 \
-                            sha256  ae5005670e75ecee52b53737e52d0e2a74df5dd1d3c565c532d18033956fc073
+    checksums               rmd160  be4d2651f032f0797536c843a0e5d1d4ca0df1d4 \
+                            sha256  5ed6a3b73de33e9f6dc0c4d785a463b83e96364b3ce2fc116ed54ca642b2c20b
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
###### Description
update tmux to 2.6
update tmux-devel to latest commit (Oct. 5)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
