### PR TITLE
inkscape: fix build in High Sierra

### DIFF
--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -54,7 +54,8 @@ depends_lib         port:desktop-file-utils \
                     port:py27-lxml \
                     port:py27-numpy
 
-patchfiles          patch-use-configured-perl.diff
+patchfiles          patch-use-configured-perl.diff \
+                    libavoid-abs-ambiguous.diff
 
 post-patch {
     reinplace "s|@@MP_PERL@@|${prefix}/bin/perl${perl_version}|" ${worksrcpath}/Makefile.am

--- a/graphics/inkscape/files/libavoid-abs-ambiguous.diff
+++ b/graphics/inkscape/files/libavoid-abs-ambiguous.diff
@@ -1,0 +1,11 @@
+--- src/libavoid/connector.cpp	2017-10-06 14:07:08.000000000 +0200
++++ src/libavoid/connector.cpp	2017-10-06 14:07:12.000000000 +0200
+@@ -885,7 +885,7 @@
+             {
+                 // Check for consecutive points on opposite 
+                 // corners of two touching shapes.
+-                COLA_ASSERT(abs(i->pathNext->id.objID - i->id.objID) != 2);
++                COLA_ASSERT(abs((long)i->pathNext->id.objID - i->id.objID) != 2);
+             }
+         }
+     }


### PR DESCRIPTION
The current version of Inkscape fails with a build error due to an
ambigious call to abs(). Indeed, i->pathNext->id.objID is of type
unsigned int, for which abs() does not make much sense. Adding a cast
to 'int' fixes it.

(Suggested by Michael Lass)

Fixes: https://trac.macports.org/ticket/54886

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12
Xcode 9.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tested basic functionality of all binary files?
