### PR TITLE
md5deep: update version 4.3 -> 4.4.

### DIFF
--- a/security/md5deep/Portfile
+++ b/security/md5deep/Portfile
@@ -1,9 +1,10 @@
 PortSystem          1.0
+PortGroup           github 1.0
 
+github.setup        jessek hashdeep 4.4 v
 name                md5deep
-version             4.3
 categories          security sysutils
-license             public-domain
+license             {public-domain GPL-2}
 maintainers         nomaintainer
 description         Recursively compute digests on files/directories
 long_description \
@@ -13,18 +14,15 @@ long_description \
 
 platforms           darwin
 
-homepage            http://md5deep.sourceforge.net/
-master_sites        sourceforge:project/md5deep/md5deep/md5deep-${version}
+checksums           rmd160  d92dcc3d9154a84d79e7807918eb5abb2e80940a \
+                    sha256  ec9d74a20016ec4f03914b6c42776d5fe4c7ffa63b73c85d07330abcb8327b3f
 
-checksums           rmd160  a3c1a240f1f78265a99bcd4bf95673c67568753d \
-                    sha256  905bcf8bddf0e7e2650b280d5e7af8cb8cd41dad4f299751dfec397dcb4f8d54
+patchfiles          patch-src-hash.cpp.diff
+
+use_autoreconf      yes
 
 post-destroot {
    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
    xinstall -m 644 -W ${worksrcpath} AUTHORS COPYING ChangeLog FILEFORMAT \
       NEWS README TODO ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.type      regex
-livecheck.regex     ${name}-(\[.\\d\]+)\.tar\.gz
-livecheck.url       http://sourceforge.net/projects/${name}/files/${name}

--- a/security/md5deep/files/patch-src-hash.cpp.diff
+++ b/security/md5deep/files/patch-src-hash.cpp.diff
@@ -1,0 +1,11 @@
+--- src/hash.cpp.orig	2015-04-01 02:12:52.000000000 +0200
++++ src/hash.cpp	2017-10-07 16:05:39.000000000 +0200
+@@ -279,7 +279,7 @@
+ 		MAP_FILE|
+ #endif
+ 		MAP_SHARED,fd,0);
+-	    if(fdht->base>0){		
++	    if(fdht->base != (void *) -1){
+ 		/* mmap is successful, so set the bounds.
+ 		 * if it is not successful, we default to reading the fd
+ 		 */


### PR DESCRIPTION
###### Description

Update version from 4.3 to 4.4. Imported a fix to build it with Xcode 9.0 (see jessek/hashdeep#361).

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 9.0 9A235 

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?