### PR TITLE
ldas-tools-al: fix build with Xcode9

### DIFF
--- a/science/ldas-tools-al/Portfile
+++ b/science/ldas-tools-al/Portfile
@@ -15,6 +15,8 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
+patchfiles    patch-Xcode9.diff
+
 checksums     rmd160 fc50f9c7911463fabd79f55e59fbcc8519bd45b1 \
               sha256 5583e511bd680a43023b1d9a1c05d3e0c11ac70624032e8c918bdb47dd7a4b8e
 

--- a/science/ldas-tools-al/files/patch-Xcode9.diff
+++ b/science/ldas-tools-al/files/patch-Xcode9.diff
@@ -1,0 +1,22 @@
+--- src/AtExit.cc	2015-12-17 00:34:48.000000000 +0100
++++ src/AtExit.cc	2017-10-08 10:40:59.000000000 +0200
+@@ -194,7 +194,7 @@
+ 
+   private:
+     typedef std::map< int, ExitQueueNode, std::less< int >,
+-		      malloc_allocator< std::pair< int, ExitQueueNode > > >
++		      malloc_allocator< std::pair< const int, ExitQueueNode > > >
+     exit_queue_type;
+ 
+     bool			is_exiting;
+--- src/MemChecker.cc	2016-06-17 23:36:24.000000000 +0200
++++ src/MemChecker.cc	2017-10-08 10:40:40.000000000 +0200
+@@ -245,7 +245,7 @@
+ 
+   private:
+     typedef std::map< int, GCQueueNode, std::less< int >,
+-		      malloc_allocator< std::pair< int, GCQueueNode > > >
++		      malloc_allocator< std::pair< const int, GCQueueNode > > >
+     gc_queue_type;
+ 
+     bool			is_exiting;


### PR DESCRIPTION
This fixes the build with Xcode9 on both Sierra and High Sierra
