### PR TITLE
libgit2: set dist_subdir and update checksum

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -9,6 +9,7 @@ cmake.out_of_source yes
 # don't forget to update py-pygit2 and libgit2-glib as well
 github.setup        libgit2 libgit2 0.26.0 v
 epoch               1
+dist_subdir         ${name}/${version}_1
 categories          devel
 platforms           darwin
 maintainers         {devans @dbevans}
@@ -24,8 +25,8 @@ long_description    libgit2 is a portable, pure C implementation of the \
 
 homepage            http://libgit2.github.com/
 
-checksums           rmd160  2f8ee1ed0e71855d6326f658a020eae60e6a79d1 \
-                    sha256  4fcea9c8e6bf61718744a5dd70aff9946ea8e40c6711718d78583f7150a675e2
+checksums           rmd160  16b2041b29558c7d824e54b894e8600b81c5b2e5 \
+                    sha256  4c046ce48f8dd5ca45cff2b85101b9ae0111d183780a630ce9579bd925206f49
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
###### Description

github regenerated the tarball for libgit2 so for newly downloaded distfiles the checksum fails. See https://trac.macports.org/ticket/54839

As suggested, https://trac.macports.org/wiki/PortfileRecipes#stealth-updates is implemented to work around this issue.