### PR TITLE
neomutt: update to 20171013

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -38,7 +38,7 @@ configure.args      --disable-idn \
                     --with-nls=${prefix} \
                     --with-ssl=${prefix}
 
-default_variants    +idn
+default_variants    +idn +mutt
 if {${install.user} ne "root"} {
     default_variants-append     +homespool
 }
@@ -84,6 +84,11 @@ variant lmdb description {Support LMDB database} {
 variant lua description {Lua scripting support} {
     configure.args-append       --with-lua=${prefix}
     depends_lib-append          port:lua
+}
+variant mutt description {Create 'mutt' symlink} {
+    post-destroot {
+        file link -symbolic ${destroot}${prefix}/bin/mutt neomutt
+    }
 }
 variant notmuch description {Notmuch support} {
     configure.args-append       --with-notmuch=${prefix}

--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -43,11 +43,6 @@ if {${install.user} ne "root"} {
     default_variants-append     +homespool
 }
 
-post-destroot {
-    # delete pgpring to avoid a conflict with signing-party
-    delete ${destroot}${prefix}/bin/pgpring ${destroot}${prefix}/share/man/man1/pgpring.1
-}
-
 variant db4 description {Support Berkeley DB database} {
     configure.args-append       --with-bdb=${prefix}
     configure.cppflags-append   "-I${prefix}/include/db48"
@@ -123,5 +118,3 @@ post-destroot {
     move ${destroot}${prefix}/share/doc/neomutt/samples \
          ${destroot}${prefix}/share/examples/neomutt
 }
-
-notes "This port does not install the pgpring binary. Please install the signing-party port if you need it."

--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        neomutt neomutt 20170912 neomutt-
+github.setup        neomutt neomutt 20171013 neomutt-
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -19,42 +19,28 @@ long_description    Mutt is a small but very powerful text-based MIME \
                     groups of messages.
 homepage            https://www.neomutt.org
 
-conflicts           mutt
-depends_lib         port:gettext \
+checksums           rmd160  e1533dc0df2d9c60a26fce6d2b8e05cd1301d800 \
+                    sha256  23147c3f90dc64e627517ff5c8d3fb3d5eb4da2f8bbc3f18c4cf1553fb52d082
+
+depends_build       port:docbook-xml-4.2 port:docbook-xsl port:libxslt port:w3m
+depends_lib         path:lib/libssl.dylib:openssl \
+                    port:gettext \
                     port:libiconv \
-                    port:ncurses
-
+                    port:ncurses \
+                    port:zlib
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
+# needed by smime_keys
+depends_run-append  path:bin/perl:perl5
 
-checksums           rmd160  f7fdbc4ea913a9097036bbafd287250aaa14508f \
-                    sha256  9b40d577e417d36aa8cdcfd5ec4ad63c05e010476cccadde83065489c09b5226
+configure.cmd       ./configure.autosetup
+configure.args      --disable-idn \
+                    --with-ncurses=${prefix} \
+                    --with-nls=${prefix} \
+                    --with-ssl=${prefix}
 
-# Build from tags because upstream keeps omitting files from the release
-# tarballs (https://trac.macports.org/ticket/52485).
-use_autoreconf      yes
-configure.args      --disable-debug \
-                    --disable-gpgme \
-                    --disable-notmuch \
-                    --disable-silent-rules \
-                    --mandir=${prefix}/share/man \
-                    --with-docdir=${prefix}/share/doc/mutt \
-                    --with-libiconv-prefix=${prefix} \
-                    --with-curses=${prefix} \
-                    --without-bdb \
-                    --without-gdbm \
-                    --without-gnutls \
-                    --without-gss \
-                    --without-idn \
-                    --without-kyotocabinet \
-                    --without-lmdb \
-                    --without-qdbm \
-                    --without-sasl \
-                    --without-ssl \
-                    --without-tokyocabinet
-
-default_variants    +idn +ssl
+default_variants    +idn
 if {${install.user} ne "root"} {
-    default_variants-append +homespool
+    default_variants-append     +homespool
 }
 
 post-destroot {
@@ -63,61 +49,74 @@ post-destroot {
 }
 
 variant db4 description {Support Berkeley DB database} {
-    configure.args-replace      --without-bdb --with-bdb=${prefix}
+    configure.args-append       --with-bdb=${prefix}
     configure.cppflags-append   "-I${prefix}/include/db48"
     configure.ldflags-append    "-L${prefix}/lib/db48"
     depends_lib-append          port:db48
 }
-variant debug description {Debugging support} {
-    configure.args-replace      --disable-debug --enable-debug
-}
 variant gdbm description {Support GNU dbm database} {
-    configure.args-replace      --without-gdbm --with-gdbm=${prefix}
+    configure.args-append       --with-gdbm=${prefix}
     depends_lib-append          port:gdbm
 }
 variant gpgme description {Enable GPGME crypto support} {
-    configure.args-replace      --disable-gpgme --enable-gpgme
-    configure.args-append       --with-gpgme-prefix=${prefix}
+    configure.args-append       --with-gpgme=${prefix}
     depends_lib-append          port:gpgme
 }
+variant gss description {Support GSS API (Kerberos)} {
+    configure.args-append       --with-gss=${prefix}
+    depends_lib-append          port:kerberos5
+}
 variant homespool description {Spool mail in home directory (allows installing without root privileges)} {
-    configure.args-append       --with-homespool
+    configure.args-append       --homespool
 }
 variant idn description {Internationalized Domain Name support} {
-    configure.args-replace      --without-idn --with-idn=${prefix}
-    depends_lib-append          port:libidn port:zlib
+    configure.args-replace      --disable-idn --with-idn=${prefix}
+    depends_lib-append          port:libidn
 }
 variant kyotocabinet description {Support Kyoto Cabinet database} {
-    configure.args-replace      --without-kyotocabinet --with-kyotocabinet=${prefix}
+    configure.args-append       --with-kyotocabinet=${prefix}
     depends_lib-append          port:kyotocabinet
 }
 variant lmdb description {Support LMDB database} {
-    configure.args-replace      --without-lmdb --with-lmdb=${prefix}
+    configure.args-append       --with-lmdb=${prefix}
     depends_lib-append          port:lmdb
 }
+variant lua description {Lua scripting support} {
+    configure.args-append       --with-lua=${prefix}
+    depends_lib-append          port:lua
+}
 variant notmuch description {Notmuch support} {
-    configure.args-replace      --disable-notmuch --enable-notmuch
+    configure.args-append       --with-notmuch=${prefix}
     depends_lib-append          port:notmuch
 }
 variant qdbm description {Support QDBM database} {
-    configure.args-replace      --without-qdbm --with-qdbm=${prefix}
+    configure.args-append       --with-qdbm=${prefix}
     depends_lib-append          port:qdbm
 }
 variant sasl description {Simple Authentication and Security Layer support} {
-    configure.args-replace      --without-sasl --with-sasl=${prefix}
+    configure.args-append       --with-sasl=${prefix}
     depends_lib-append          port:cyrus-sasl2
 }
 variant slang description {Use S-lang instead of ncurses} {
-    configure.args-replace      --with-curses=${prefix} --with-slang=${prefix}
-    depends_lib-replace          port:ncurses port:slang2
-}
-variant ssl description {Secure Sockets Layer support} {
-    configure.args-replace      --without-ssl --with-ssl=${prefix}
-    depends_lib-append          path:lib/libssl.dylib:openssl
+    configure.args-append       --with-ui=slang --with-slang=${prefix}
+    depends_lib-replace         port:ncurses port:slang2
 }
 variant tokyocabinet description {Support Tokyo Cabinet database} {
-    configure.args-replace      --without-tokyocabinet --with-tokyocabinet=${prefix}
+    configure.args-append       --with-tokyocabinet=${prefix}
     depends_lib-append          port:tokyocabinet
+}
+
+post-extract {
+    reinplace -W ${worksrcpath}/contrib "s|/usr/bin/|${prefix}/bin/|g" \
+              smime_keys
+    reinplace -W ${worksrcpath}/contrib "s|/usr/lib/|${prefix}/lib/|g" \
+              gpg.rc pgp5.rc smime.rc
+}
+post-destroot {
+    # install examples in ${prefix}/share/examples
+    xinstall -d ${destroot}${prefix}/share/examples
+    move ${destroot}${prefix}/share/doc/neomutt/samples \
+         ${destroot}${prefix}/share/examples/neomutt
 }
 
 notes "This port does not install the pgpring binary. Please install the signing-party port if you need it."

--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -113,8 +113,21 @@ post-extract {
               gpg.rc pgp5.rc smime.rc
 }
 post-destroot {
+    move ${destroot}${prefix}/etc/neomuttrc \
+         ${destroot}${prefix}/etc/neomuttrc.sample
+    # install mime.types in ${prefix}/etc as previous versions used to do
+    copy ${destroot}${prefix}/share/doc/neomutt/mime.types \
+         ${destroot}${prefix}/etc/mime.types.sample
     # install examples in ${prefix}/share/examples
     xinstall -d ${destroot}${prefix}/share/examples
     move ${destroot}${prefix}/share/doc/neomutt/samples \
          ${destroot}${prefix}/share/examples/neomutt
+}
+post-activate {
+    foreach f { mime.types neomuttrc } {
+        if {![file exists ${prefix}/etc/${f}]} {
+            copy ${prefix}/etc/${f}.sample \
+                 ${prefix}/etc/${f}
+        }
+    }
 }


### PR DESCRIPTION
###### Description

- Updated to NeoMutt 20171013
  - upstream now uses `autosetup` to build
  - upstream now installs as `neomutt`
- Build using `autosetup`
- Install `mutt` symlink by default to keep existing behaviour (configurable via `+mutt` variant)
- Add new `+gss` and `+lua` variants 
- Handle config files properly (do not overwrite user changes)
- Fix documentation generation bug (https://trac.macports.org/ticket/54219)
- Do not block installation of `pgpring`, auxiliary binaries are now installed to a new location that does not conflict with other ports

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13 17A405
Xcode 9.0 9A235 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
