### PR TITLE
ffmpeg: fix build against openjpeg 2.3

### DIFF
--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -10,6 +10,7 @@ name                ffmpeg
 conflicts           ffmpeg-devel
 epoch               1
 version             3.3.4
+revision            1
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -92,7 +93,7 @@ depends_lib         port:lame \
                     port:zlib
 
 patchfiles          patch-libavcodec-audiotoolboxenc.c.diff \
-                    patch-openjpeg-2.2.diff \
+                    patch-openjpeg-2.3.diff \
                     patch-configure-no-static-libopenjpeg.diff
 
 #

--- a/multimedia/ffmpeg/files/patch-configure-no-static-libopenjpeg.diff
+++ b/multimedia/ffmpeg/files/patch-configure-no-static-libopenjpeg.diff
@@ -4,11 +4,11 @@
                                   require opencv opencv2/core/core_c.h cvCreateImageHeader -lopencv_core -lopencv_imgproc; } ||
                                 require_pkg_config opencv opencv/cxcore.h cvCreateImageHeader; }
  enabled libopenh264       && require_pkg_config openh264 wels/codec_api.h WelsGetCodecVersion
--enabled libopenjpeg       && { { check_lib openjpeg-2.2/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
--                               check_lib openjpeg-2.2/openjpeg.h opj_version -lopenjp2 ||
+-enabled libopenjpeg       && { { check_lib openjpeg-2.3/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
+-                               check_lib openjpeg-2.3/openjpeg.h opj_version -lopenjp2 ||
 -                               { check_lib openjpeg-2.1/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
-+enabled libopenjpeg       && { check_lib openjpeg-2.2/openjpeg.h opj_version -lopenjp2 ||
-+                               { check_lib openjpeg-2.2/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
++enabled libopenjpeg       && { check_lib openjpeg-2.3/openjpeg.h opj_version -lopenjp2 ||
++                               { check_lib openjpeg-2.3/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
                                 check_lib openjpeg-2.1/openjpeg.h opj_version -lopenjp2 ||
 +                               { check_lib openjpeg-2.1/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
                                 { check_lib openjpeg-2.0/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||

--- a/multimedia/ffmpeg/files/patch-openjpeg-2.3.diff
+++ b/multimedia/ffmpeg/files/patch-openjpeg-2.3.diff
@@ -5,7 +5,7 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
      machine_ioctl_meteor_h
      malloc_h
      opencv2_core_core_c_h
-+    openjpeg_2_2_openjpeg_h
++    openjpeg_2_3_openjpeg_h
      openjpeg_2_1_openjpeg_h
      openjpeg_2_0_openjpeg_h
      openjpeg_1_5_openjpeg_h
@@ -14,8 +14,8 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
                                 require_pkg_config opencv opencv/cxcore.h cvCreateImageHeader; }
  enabled libopenh264       && require_pkg_config openh264 wels/codec_api.h WelsGetCodecVersion
 -enabled libopenjpeg       && { { check_lib openjpeg-2.1/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
-+enabled libopenjpeg       && { { check_lib openjpeg-2.2/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
-+                               check_lib openjpeg-2.2/openjpeg.h opj_version -lopenjp2 ||
++enabled libopenjpeg       && { { check_lib openjpeg-2.3/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
++                               check_lib openjpeg-2.3/openjpeg.h opj_version -lopenjp2 ||
 +                               { check_lib openjpeg-2.1/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
                                 check_lib openjpeg-2.1/openjpeg.h opj_version -lopenjp2 ||
                                 { check_lib openjpeg-2.0/openjpeg.h opj_version -lopenjp2 -DOPJ_STATIC && add_cppflags -DOPJ_STATIC; } ||
@@ -27,8 +27,8 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
  #include "thread.h"
  
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H
-+#  include <openjpeg-2.2/openjpeg.h>
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H
++#  include <openjpeg-2.3/openjpeg.h>
 +#elif HAVE_OPENJPEG_2_1_OPENJPEG_H
  #  include <openjpeg-2.1/openjpeg.h>
  #elif HAVE_OPENJPEG_2_0_OPENJPEG_H
@@ -38,7 +38,7 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
  #endif
  
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H || HAVE_OPENJPEG_2_0_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H || HAVE_OPENJPEG_2_0_OPENJPEG_H
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H || HAVE_OPENJPEG_2_0_OPENJPEG_H
  #  define OPENJPEG_MAJOR_VERSION 2
  #  define OPJ(x) OPJ_##x
  #else
@@ -47,7 +47,7 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
      opj_stream_set_skip_function(stream, stream_skip);
      opj_stream_set_seek_function(stream, stream_seek);
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H
      opj_stream_set_user_data(stream, &reader, NULL);
  #elif HAVE_OPENJPEG_2_0_OPENJPEG_H
      opj_stream_set_user_data(stream, &reader);
@@ -58,8 +58,8 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
  #include "internal.h"
  
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H
-+#  include <openjpeg-2.2/openjpeg.h>
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H
++#  include <openjpeg-2.3/openjpeg.h>
 +#elif HAVE_OPENJPEG_2_1_OPENJPEG_H
  #  include <openjpeg-2.1/openjpeg.h>
  #elif HAVE_OPENJPEG_2_0_OPENJPEG_H
@@ -69,7 +69,7 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
  #endif
  
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H || HAVE_OPENJPEG_2_0_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H || HAVE_OPENJPEG_2_0_OPENJPEG_H
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H || HAVE_OPENJPEG_2_0_OPENJPEG_H
  #  define OPENJPEG_MAJOR_VERSION 2
  #  define OPJ(x) OPJ_##x
  #else
@@ -78,7 +78,7 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
      opj_set_default_encoder_parameters(&ctx->enc_params);
  
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H
      switch (ctx->cinema_mode) {
      case OPJ_CINEMA2K_24:
          ctx->enc_params.rsiz = OPJ_PROFILE_CINEMA_2K;
@@ -87,7 +87,7 @@ https://github.com/FFmpeg/FFmpeg/commit/078322f33ced4b2db6ac3e5002f98233d6fbf643
      opj_stream_set_skip_function(stream, stream_skip);
      opj_stream_set_seek_function(stream, stream_seek);
 -#if HAVE_OPENJPEG_2_1_OPENJPEG_H
-+#if HAVE_OPENJPEG_2_2_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H
++#if HAVE_OPENJPEG_2_3_OPENJPEG_H || HAVE_OPENJPEG_2_1_OPENJPEG_H
      opj_stream_set_user_data(stream, &writer, NULL);
  #elif HAVE_OPENJPEG_2_0_OPENJPEG_H
      opj_stream_set_user_data(stream, &writer);


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/55023

###### Description

I updated the openjpeg-2.2 patch to openjpeg-2.3. It built through to completion on highsierra, against openjpeg 2.3.

Alternatively, we could change plan completely and use pkgconfig rather than this approach. There didn't seem to be any easy-to-set env variables in ffmpeg to allow that, though.