### PR TITLE
py27-matplotlib: add backport-functools_lru_cache as a dependency

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        matplotlib matplotlib 2.1.0 v
-revision            1
+revision            2
 
 name                py-matplotlib
 categories-append   graphics math
@@ -51,7 +51,8 @@ if {${name} ne ${subport}} {
 
     if {${python.version} == 27} {
         depends_lib-append port:py27-functools32 \
-                           port:py27-subprocess32
+                           port:py27-subprocess32 \
+                           port:py27-backports-functools_lru_cache
     }
 
     patchfiles-append   patch-setup.cfg.diff \


### PR DESCRIPTION
For py27 version only. Addresses ticket #55038 . Simple fix / change, so I deleted all of the below.