### PR TITLE
salt: update to 2017.7.2

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -3,7 +3,7 @@
 PortSystem        1.0
 
 name               salt
-version            2017.7.1
+version            2017.7.2
 categories         sysutils python
 platforms          darwin
 maintainers        {@aphor gmail.com:jeremy.mcmillan}
@@ -25,8 +25,8 @@ if {$subport eq $name} {
     python.versions         27 34 35 36
     categories              sysutils python
 
-    checksums           rmd160  fe86b7cb73d1836301796f62e8a5fc4e200d43ad \
-                        sha256  ea256ee31f7fd9057f843fa1f496a535cf0a41a02d190319d6fb66ea202fe4ee
+    checksums           rmd160  fd01c7bfc2878cab7d02dfb5fdf93d23faffa9d5 \
+                        sha256  1643dc8906d1ee10bea93fb39a979cbdbfd1895691c409d5d7eeebc4f09e8af2
 
     notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
     


### PR DESCRIPTION
* security CVE-2017-14695
* security CVE-2017-14696

Closes: https://trac.macports.org/ticket/55059

###### Description
[skip notification]

https://docs.saltstack.com/en/latest/topics/releases/2017.7.2.html

notably:
SECURITY FIX

CVE-2017-14695 Directory traversal vulnerability in minion id validation in SaltStack. Allows remote minions with incorrect credentials to authenticate to a master via a crafted minion ID. Credit for discovering the security flaw goes to: Julian Brost (julian@0x4a42.net)

CVE-2017-14696 Remote Denial of Service with a specially crafted authentication request. Credit for discovering the security flaw goes to: Julian Brost (julian@0x4a42.net)

Extended changelog courtesy of Todd Stansell (https://github.com/tjstansell/salt-changelogs):



###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [X] bugfix
- [ ] enhancement
- [X] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 8.0 8A218a 

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
