### PR TITLE
pysam: use bundled htslib instead of system lib

### DIFF
--- a/python/py-pysam/Portfile
+++ b/python/py-pysam/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 name                py-pysam
 set realname        pysam
 version             0.12.0.1
+revision            1
 categories-append   science
 platforms           darwin
 license             MIT BSD
@@ -31,18 +32,10 @@ patchfiles          patch-pysam-remove-RPATH.diff
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools \
                         port:py${python.version}-cython
-    depends_lib-append  port:htslib
     livecheck.type      none
 } else {
     livecheck.name      pysam
     livecheck.regex     pysam-(\\d+(\\.\\d+)+)${extract.suffix}
 }
 
-post-patch {
-    # delete htslib, just to be safe
-    file delete -force htslib
-}
-
-configure.env       HTSLIB_MODE="external" \
-                    HTSLIB_INCLUDE_DIR="${prefix}"/include \
-                    HTSLIB_LIBRARY_DIR="${prefix}"/lib
+configure.env       HTSLIB_MODE="shared"


### PR DESCRIPTION
* pysam follows upstream htslib changes, but is generally
  1-2 months behind and using an htslib-(X+1) with a pysam
  designed around htslib-X is discouraged.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
