### PR TITLE
markdown-mode.el: update to v2.3

### DIFF
--- a/editors/markdown-mode.el/Portfile
+++ b/editors/markdown-mode.el/Portfile
@@ -1,28 +1,34 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-PortSystem 1.0
 
-name                   markdown-mode.el
-version                201410300
+PortSystem             1.0
+PortGroup              github 1.0
+
+platforms              darwin
 categories             editors
-license                none
+license                GPL-3+
 maintainers            easieste openmaintainer
 description            An Emacs mode for editing Markdown files
 long_description       ${description}
-homepage               http://jblevins.org/projects/markdown-mode/
-platforms              darwin
 
-fetch.type             git
-git.url                git://jblevins.org/git/markdown-mode.git
-git.branch             0d12efd2939b0735c8b730041f168132d6df96ab
+github.setup           jrblevin markdown-mode 2.3 v
+name                   markdown-mode.el
+epoch                  1
+checksums              rmd160  3f53e748765f978de86eff6ec83013ecb5dd499e \
+                       sha256  a8de02e2d2b58ade8fba91b1a89e02461b6e942fc17d0e5b1163cbbf3213bf14
 
-depends_lib port:emacs
+depends_lib-append     port:emacs
 
-use_configure no
+use_configure          no
+
+# if the following line is commented out, the build system
+# generates a compiled version markdown-mode.elc
+# the destroot block needs to be updated in that case
 build {}
+
 destroot {
-    file mkdir ${destroot}${prefix}/share/emacs/site-lisp
-    file copy  ${workpath}/${worksrcdir}/markdown-mode.el  \
-        ${destroot}${prefix}/share/emacs/site-lisp
+    xinstall -d ${destroot}${prefix}/share/emacs/site-lisp
+    copy        ${workpath}/${worksrcdir}/markdown-mode.el  \
+                ${destroot}${prefix}/share/emacs/site-lisp
 }
 
 notes {


### PR DESCRIPTION
change to github repo
change epoch of naming scheme to X.Y
closes: https://trac.macports.org/ticket/55073

I don't use emacs or this port, but it updates without too much issue, and appears to put the proper files in the proper places