### PR TITLE
libmovit: new port submission

### DIFF
--- a/multimedia/libmovit/Portfile
+++ b/multimedia/libmovit/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           conflicts_build 1.0
+
+name                libmovit
+version             1.5.3
+
+categories          multimedia
+platforms           darwin linux
+license             GPL-2+
+maintainers         gmail.com:rjvbertin openmaintainer
+
+description         Modern Video Toolkit - open-source library for GPU-accelerated video filters
+long_description    Movit is the Modern Video Toolkit. It aims to be a high-quality, \
+                    high-performance, open-source library for GPU-accelerated video filters.
+
+homepage            https://movit.sesse.net
+
+master_sites        ${homepage}
+
+distname            movit-${version}
+
+checksums           rmd160  ce29a03233672ada255400a1041381a89acd3b6a \
+                    sha256  ead191d717dbefbe914260ed0335cf04a7dfc6fde8f23293c5ca7f88e45ace81
+
+depends_lib-append  port:eigen3 \
+                    port:libpng
+
+platform darwin {
+    # the current port:gtest is out-of-date, doesn't install everything required
+    # and it will thus break our build.
+    conflicts_build-append \
+                    gtest
+    depends_lib-append \
+                    port:fftw-3 \
+                    port:libepoxy \
+                    port:libsdl2 \
+                    port:libsdl2_image
+    post-extract {
+        file delete -force ${worksrcpath}/libtool
+    }
+
+    patchfiles-append \
+                    patch-nolibrt.diff \
+                    patch-no-features_h.diff \
+                    patch-notests.diff
+
+    use_autoreconf  yes
+    autoreconf.args -fvi
+}
+
+platform linux {
+    configure.env-append \
+                    PKG_CONFIG=${prefix}/bin/pkg-config
+}
+
+post-destroot {
+    delete ${destroot}${prefix}/lib/libmovit.a
+    xinstall -m 644 ${worksrcpath}/vs-color.130.vert ${destroot}${prefix}/share/movit/
+    xinstall -m 644 ${worksrcpath}/vs-color.150.vert ${destroot}${prefix}/share/movit/
+    xinstall -m 644 ${worksrcpath}/color.130.frag ${destroot}${prefix}/share/movit/
+    xinstall -m 644 ${worksrcpath}/color.150.frag ${destroot}${prefix}/share/movit/
+}
+
+livecheck.regex     "movit-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+
+variant installdemo description "Install Demo Application" {
+
+    post-patch {
+        reinplace "s|\"\.\"|\"${prefix}/share/movit/\"|g" ${worksrcpath}/demo.cpp
+        reinplace "s|\"blg_wheels_woman_1.jpg\"|\"/Users/Shared/blg_wheels_woman_1.jpg\"|g" ${worksrcpath}/demo.cpp
+    }
+
+    post-destroot {
+        xinstall -m 755 ${worksrcpath}/.libs/demo ${destroot}${prefix}/bin/movit_demo
+    }
+
+    notes {
+        ***** To run the movit_demo applications, obtain the image
+        ***** "http://home.samfundet.no/~sesse/blg_wheels_woman_1.jpg"
+        ***** or "https://digitalfilms.files.wordpress.com/2010/03/blg_wheels_woman_1.jpg"
+        ***** and place as "/Users/Shared/blg_wheels_woman_1.jpg"
+        ***** The demo program generates a number of working files,
+        ***** so I suggest you run it from within a folder you can delete.
+    }
+
+}

--- a/multimedia/libmovit/files/patch-no-features_h.diff
+++ b/multimedia/libmovit/files/patch-no-features_h.diff
@@ -1,0 +1,12 @@
+--- orig.demo.cpp	2017-03-21 19:40:17.000000000 +0100
++++ demo.cpp	2017-04-30 14:12:53.000000000 +0200
+@@ -25,7 +25,9 @@
+ #endif
+ 
+ #include <assert.h>
++#ifndef __APPLE__
+ #include <features.h>
++#endif
+ #include <math.h>
+ #include <png.h>
+ #include <pngconf.h>

--- a/multimedia/libmovit/files/patch-nolibrt.diff
+++ b/multimedia/libmovit/files/patch-nolibrt.diff
@@ -1,0 +1,11 @@
+--- orig.Makefile.in	2017-03-21 19:40:17.000000000 +0100
++++ Makefile.in	2017-04-30 14:14:43.000000000 +0200
+@@ -29,7 +29,7 @@
+ LDFLAGS=@LDFLAGS@
+ LDLIBS=@epoxy_LIBS@ @FFTW3_LIBS@ -lpthread
+ TEST_LDLIBS=@epoxy_LIBS@ @SDL2_LIBS@ @SDL_LIBS@ -lpthread
+-DEMO_LDLIBS=@SDL2_image_LIBS@ @SDL_image_LIBS@ -lrt -lpthread @libpng_LIBS@ @FFTW3_LIBS@
++DEMO_LDLIBS=@SDL2_image_LIBS@ @SDL_image_LIBS@ -lpthread @libpng_LIBS@ @FFTW3_LIBS@
+ SHELL=@SHELL@
+ LIBTOOL=@LIBTOOL@ --tag=CXX
+ RANLIB=ranlib

--- a/multimedia/libmovit/files/patch-notests.diff
+++ b/multimedia/libmovit/files/patch-notests.diff
@@ -1,0 +1,22 @@
+--- orig.Makefile.in	2017-03-21 19:40:17.000000000 +0100
++++ Makefile.in	2017-04-30 14:14:43.000000000 +0200
+@@ -93,7 +93,7 @@
+ LIB_OBJS=effect_util.o util.o effect.o effect_chain.o init.o resource_pool.o fp16.o ycbcr.o $(INPUTS:=.o) $(EFFECTS:=.o)
+ 
+ # Default target:
+-all: libmovit.la $(TESTS)
++all: libmovit.la
+ 
+ ifeq ($(with_demo_app),yes)
+ all: demo
+@@ -112,8 +112,8 @@
+ $(TESTS): %: %.o $(TEST_OBJS) libmovit.la
+ 	$(LIBTOOL) --mode=link $(CXX) $(LDFLAGS) -o $@ $^ $(TEST_LDLIBS)
+ 
+-OWN_OBJS=$(DEMO_OBJS) $(LIB_OBJS) $(OWN_TEST_OBJS) $(TESTS:=.o)
+-OBJS=$(DEMO_OBJS) $(LIB_OBJS) $(TEST_OBJS) $(TESTS:=.o)
++OWN_OBJS=$(DEMO_OBJS) $(LIB_OBJS)
++OBJS=$(DEMO_OBJS) $(LIB_OBJS)
+ 
+ # A small demo program.
+ demo: libmovit.la $(DEMO_OBJS)


### PR DESCRIPTION
open-source library for GPU-accelerated video filters
closes: https://trac.macports.org/ticket/54093

Submission by @RJVB 

I made a few minor modifications. Updated to 1.5.3. Deleted the unnecessary static library. Moved the demo application to a variant. Provided notes on how to obtain the required demo test image, and changed it's searched location to something easily accessible. 

I did not make installing the test image automatic as a distfile on purpose, to keep licensing clean.

Tested on my MacPro running High Sierra, worked smoothly and apparently correctly with my Radeon HD 5770.