### PR TITLE
MenuMeters: update to 1.9.6

### DIFF
--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 PortGroup           github 1.0
 PortGroup           xcode 1.0
+PortGroup           xcodeversion 1.0
 
 github.setup        yujitach MenuMeters 1.9.6
 categories          aqua sysutils
@@ -36,9 +37,4 @@ destroot    {
         ${destroot}/Library/PreferencePanes
 }
 
-pre-fetch {
-    if {${os.subplatform} eq "macosx" && [vercmp ${macosx_version} 10.10] < 0} {
-        ui_error "${name} ${version} requires OS X 10.10 or greater."
-        return -code error "incompatible macOS version"
-    }
-}
+minimum_xcodeversions {14 7.0}

--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        yujitach MenuMeters 1.9.5
+github.setup        yujitach MenuMeters 1.9.6
 categories          aqua sysutils
 maintainers         {stevenmyint.com:git @myint} openmaintainer
 license             GPL-2
@@ -19,8 +19,8 @@ long_description    The MenuMeters monitors are true SystemUIServer plugins     
                     using command-drag and remember their positions in the menubar  \
                     across logins and restarts.
 
-checksums           rmd160  214299100e47c576ccb4c6c702afef8380b79f59 \
-                    sha256  fc1da6bd44df522b787c90ccded23e700429e18ffc287cb64a59e209c1203f24
+checksums           rmd160  80e7fe3437aa2e9d1e62e632bc4e2e0092773252 \
+                    sha256  d559d74d5018bd4e395636030f3946072f2945dbf6f5ab8ebf06e81420e3538e
 
 patchfiles          patch-MenuMeters.xcodeproj-project.pbxproj.diff
 


### PR DESCRIPTION
This version supports APFS, which is the default in High Sierra.