### PR TITLE
libfilezilla: fix build error applying upstream patch to buffer.cpp

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -18,6 +18,7 @@ long_description    Small and modern C++ library, offering some basic \
 
 homepage            https://lib.filezilla-project.org/
 master_sites        http://download.filezilla-project.org/libfilezilla/
+patchfiles          patch-buffer-abort.patch
 
 checksums           rmd160  6dd64427183c022e31cfbcca9660b57edb08531e \
                     sha256  cc7467241c8905de98773b414ce445d6f9ff3bf3105f2d16cecab76404879ed0

--- a/devel/libfilezilla/files/patch-buffer-abort.patch
+++ b/devel/libfilezilla/files/patch-buffer-abort.patch
@@ -1,0 +1,28 @@
+--- lib/buffer.cpp	2017/10/04 11:39:57	8594
++++ lib/buffer.cpp	2017/10/06 14:09:02	8595
+@@ -1,6 +1,7 @@
+ #include "libfilezilla/buffer.hpp"
+ 
+ #include <algorithm>
++#include <cstdlib>
+ 
+ #include <string.h>
+ 
+@@ -89,7 +90,7 @@
+ {
+ 	if (capacity_ - (pos_ - data_) - size_ < added) {
+ 		// Hang, draw and quarter the caller.
+-		abort();
++		std::abort();
+ 	}
+ 	size_ += added;
+ }
+@@ -97,7 +98,7 @@
+ void buffer::consume(size_t consumed)
+ {
+ 	if (consumed > size_) {
+-		abort();
++		std::abort();
+ 	}
+ 	if (consumed == size_) {
+ 		pos_ = data_;


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 8.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
