### PR TITLE
iperf3-devel: update to 20171013

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -35,12 +35,11 @@ post-destroot {
 }
 
 subport ${name}-devel {
-    github.setup        esnet iperf 88d907f7fb58bfab5d086c5da60c922e1c582c92
-    version             20170626
-    revision            1
+    github.setup        esnet iperf 24da2caa09dc9932b3705d4327d846caf98f928b
+    version             20171013
 
-    checksums           rmd160  3793eefb303ffebadbbe6ba2055683c1eca15374 \
-                        sha256  3098ae6787da9ba08dad6cb6329d3b6282f058711033ff7edbb6ad145cd6d088
+    checksums           rmd160  3bda99713540f074d4e125e1f3d912fb0c7133b1 \
+                        sha256  ae722bdfb8883dd66d5836fa562244d1c32fe01c5f044eef5c404432894636e4
 
     conflicts           ${name}
 


### PR DESCRIPTION
###### Description
update to upstream version 20171013

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13 17A405
Xcode 9.0 9A235

macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?