### PR TITLE
gromacs: fix license

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -10,7 +10,7 @@ name                gromacs
 revision            1
 version             5.1.4
 categories          science math
-license             GPL-2
+license             LGPL-2.1
 maintainers         dstrubbe openmaintainer
 description         The World's fastest Molecular Dynamics package
 long_description    GROMACS is a versatile package to perform molecular \


### PR DESCRIPTION
Notice that gromacs license is LGPL-2.1 and not GPL-2

See: https://github.com/gromacs/gromacs/blob/v5.1.4/COPYING

As a side note, the wrong license (GPL-2) makes the subport `gromacs-plumed` not binary redistributable. With the correct license (LGPL-2.1) the subport `gromacs-plumed` would be redistributable. If possible, I would like to also trigger a build of the `gromacs-plumed` subport so that it is available in binary form.

Thanks!

Giovanni