### PR TITLE
pulseaudio: simplify c++11 needs to cxx11 1.1 PG

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -5,7 +5,7 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
-PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cxx11 1.1
 
 name                pulseaudio
 version             10.0
@@ -85,9 +85,6 @@ post-patch {
     xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}
     reinplace "s|@@MP_PERL@@|${prefix}/bin/perl${perl_branch}|" ${worksrcpath}/man/Makefile.am
 }
-
-# Blacklist compilers that do not support C11.
-compiler.blacklist  {*gcc-3*} {*gcc-4.[0-8]} {clang < 300} cc
 
 configure.cmd       ./autogen.sh
 


### PR DESCRIPTION
simplifies and consolidates compiler choices
closes: https://trac.macports.org/ticket/50057
consistent with other cxx11 ports
allows build on PPC
