### PR TITLE
 py-typing: update to 3.6.2 and remove python35

### DIFF
--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typing
-version             3.6.1
+version             3.6.2
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -24,9 +24,9 @@ homepage            http://pypi.python.org/pypi/${python.rootname}/
 
 master_sites        pypi:t/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           md5     3fec97415bae6f742fb3c3013dedeb89 \
-                    rmd160  315f0d1236eb05035cadcba94f1e0b62b8e53c0d \
-                    sha256  c36dec260238e7464213dcd50d4b5ef63a507972f5780652e835d0228d0edace
+checksums           md5     143af0bf3afd1887622771f2f1ffe8e1 \
+                    rmd160  7980d3c187ba68832978f08fc99ebe3b801fedff \
+                    sha256  d514bd84b284dd3e844f0305ac07511f097e325171f6cc4a20878d11ad771849
 
 python.versions     27 33 34 35
 

--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -13,7 +13,7 @@ maintainers         {gmail.com:allan.que @aque} openmaintainer
 
 description         Type hints for Python
 long_description    Typing is a backport of the standard library \
-                    'typing' module to Python versions older than 3.6. \
+                    'typing' module to Python versions older than 3.5. \
                     It defines a standard notation for Python function \
                     and variable type annotations. The notation can be \
                     used for documenting code in a concise, standard \
@@ -28,7 +28,7 @@ checksums           md5     143af0bf3afd1887622771f2f1ffe8e1 \
                     rmd160  7980d3c187ba68832978f08fc99ebe3b801fedff \
                     sha256  d514bd84b284dd3e844f0305ac07511f097e325171f6cc4a20878d11ad771849
 
-python.versions     27 33 34 35
+python.versions     27 33 34
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -31,6 +31,8 @@ checksums           md5     143af0bf3afd1887622771f2f1ffe8e1 \
 python.versions     27 33 34
 
 if {${name} ne ${subport}} {
+    depends_build   port:py${python.version}-setuptools
+
     livecheck.type  none
 } else {
     # Work around incorrect PyPI versioning (3.5.2 vs. 3.5.2.2).


### PR DESCRIPTION
###### Description
upstream does not list python3.5 for version [3.6.2](https://pypi.python.org/pypi/typing/3.6.2) unlike [3.6.1](https://pypi.python.org/pypi/typing/3.6.1).

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13 17A405
Xcode 9.0 9A235 

macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?