### PR TITLE
 py-m2crypto: fix reinplace warning, add swig build.env

### DIFF
--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -35,6 +35,8 @@ if {${name} ne ${subport}} {
         ${worksrcpath}/setup.py
   }
 
+  build.env-append   SWIG_FEATURES=-I${prefix}/include
+
   test.run           yes
 
   livecheck.type     none

--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -29,8 +29,8 @@ if {${name} ne ${subport}} {
                      port:py${python.version}-typing \
                      path:lib/libssl.dylib:openssl
 
+  patchfiles         patch-setup.py
   post-patch {
-    reinplace "s|#extra_link_args|extra_link_args|g" ${worksrcpath}/setup.py
     reinplace "s|self.openssl = '/usr'|self.openssl = '${prefix}'|g" \
         ${worksrcpath}/setup.py
   }

--- a/python/py-m2crypto/files/patch-setup.py
+++ b/python/py-m2crypto/files/patch-setup.py
@@ -1,0 +1,11 @@
+--- setup.py	2017-10-15 01:36:00.000000000 -0500
++++ setup.py	2017-10-15 01:36:50.000000000 -0500
+@@ -229,8 +229,8 @@
+                                 sources=lib_sources,
+                                 extra_compile_args=list(x_comp_args),
+                                 # Uncomment to build Universal Mac binaries
+-                                # extra_link_args =
+-                                #     ['-Wl,-search_paths_first'],
++                                extra_link_args =
++                                    ['-Wl,-search_paths_first'],
+                                 )


### PR DESCRIPTION
###### Description
Minor bugfix.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13 17A405
Xcode 9.0 9A235 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
