### PR TITLE
libcdr-0.1: add cxx11 1.1 PG

### DIFF
--- a/graphics/libcdr-0.1/Portfile
+++ b/graphics/libcdr-0.1/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
 
 name                libcdr-0.1
 set dname           libcdr
@@ -33,34 +34,10 @@ depends_lib         port:librevenge \
                     port:lcms2 \
                     port:zlib
 
-# build fix for gcc-4.2 (#43487)
-if {[string match "*gcc*" ${configure.compiler}]} {
-    configure.cxxflags-append -Wno-long-long
-}
 
 # The packaged glibtool in 0.1.1 doesn't pass --stdlib=libc++ down at link time
 use_autoreconf  yes
 autoreconf.args -fvi
-
-# questionable fix for libstdc++ build failures with boost 1.59 and (indirect) inclusion of boost/thread/detail/move.hpp
-# libstdc++ supports rvalue references but defining BOOST_NO_CXX11_RVALUE_REFERENCES disables the
-# inclusion of <type_traits> which is not libstdc++ compatible
-#
-# In file included from CDRParser.cpp:20:
-# In file included from /opt/local/include/boost/spirit/include/classic.hpp:11:
-# In file included from /opt/local/include/boost/spirit/home/classic.hpp:29:
-# In file included from /opt/local/include/boost/spirit/home/classic/utility.hpp:37:
-# In file included from /opt/local/include/boost/spirit/home/classic/utility/scoped_lock.hpp:13:
-# In file included from /opt/local/include/boost/thread/lock_types.hpp:11:
-# /opt/local/include/boost/thread/detail/move.hpp:31:10: fatal error: 'type_traits' file not found
-# #include <type_traits>
-
-platform darwin {
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-        configure.cppflags-append \
-            -DBOOST_NO_CXX11_RVALUE_REFERENCES
-    }
-}
 
 configure.args      --disable-werror \
                     --disable-silent-rules \


### PR DESCRIPTION
remove other c++11 fixes, no longer needed
closes: https://trac.macports.org/ticket/55098

Tested on 10.5 PPC and 10.6 through 10.8 