### PR TITLE
py-pyregion: update to v2.0

### DIFF
--- a/python/py-pyregion/Portfile
+++ b/python/py-pyregion/Portfile
@@ -7,10 +7,10 @@ set _name           pyregion
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             1.2
+version             2.0
 categories-append   science
 platforms           darwin
-maintainers         robitaille openmaintainer
+maintainers         gmail.com:Deil.Christoph robitaille openmaintainer
 
 description         pyregion is a Python module to parse ds9 region files
 long_description    ${description}
@@ -19,9 +19,9 @@ homepage            https://github.com/astropy/pyregion
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     b776fc3ac848e17270508023ea1c94a0 \
-                    rmd160  3e13a8c532b4ec34f23046578bdd11bf59eb4dc9 \
-                    sha256  4f57070564526974661bbbf96cd1d509a708909002dd34f0354ac80c391b5e61
+checksums           md5     c228b133a1573d2017e0857a9fbf23c5 \
+                    rmd160  fb1bf3b692c799a05b39ba3b284af731502b8df0 \
+                    sha256  a8ac5f764b53ec332f6bc43f6f2193ca13e8b7d5a3fb2e20ced6b2ea42a9d094
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
This PR updates `py-pyregion` to version 2.0

* https://pypi.org/project/pyregion/2.0/
* http://pyregion.readthedocs.io/en/latest/changelog.html#oct-14-2017

I locally ran this and all tests passed:
```
cd python/py-pyregion/
sudo port install subport=py36-pyregion
PYTHONPATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages /opt/local/bin/python3.6 -c 'import pyregion; pyregion.test()'
```

I made the upstream release, and I'm adding myself here as co-maintainer of the Portfile.

cc @astrofrog