### PR TITLE
Fix build failure with MacVim 8.0.snapshot138

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -51,9 +51,6 @@ post-extract {
 }
 
 post-patch {
-    reinplace "s|^# VIM_APP_DIR=/Applications$|VIM_APP_DIR=${applications_dir}|" \
-         ${worksrcpath}/src/MacVim/mvim
-    
     # recompile patched .nib
     foreach nib {Preferences MainMenu} {
         ui_info "--->  Running ibtool for ${nib}.nib"
@@ -64,6 +61,7 @@ post-patch {
 autoconf.dir        ${worksrcpath}/src
 
 configure.args      --enable-gui=macvim \
+                    --prefix=${applications_dir} \
                     --without-x \
                     --without-local-dir \
                     --disable-gpm \


### PR DESCRIPTION
`mvim` no longer contains the absolute path to the MacVim Applications
directory. Instead, it discovers that location from the absolute
location of the `mvim` script -- the script in `/opt/local/bin/mvim` is
now a symlink. Thus, the patch step in the current Portfile fails.

In addition, the install prefix for MacVim should be set to
`/Applications/MacPorts/MacVim` using the `configure` script, so that
similar issues don't rear their head in the future.

Possibly introduced in d7e94142f88d4502390f074a1f352bd7c2131c22.

See https://trac.macports.org/ticket/55062.

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G29
Xcode 9.0.1 9A1004

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
