### PR TITLE
spring-boot-cli: update to 1.5.8

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.7
+version         1.5.8
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  cd2a8e07c2682c192e0a8d0d6aa691995c8abd21 \
-                sha256  fc8481a5c2fd6bac11a56705878bf870b8a98d427b255ae45ef4f8e1c2c08922
+checksums       rmd160  fd0c3a613d059305a318890c4ee1c11c30c43806 \
+                sha256  422608ab63fa05bf8806b5ee2bea4fdf1a270f3780252e57b18c9010f37f4230
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
###### Description

Update to Spring Boot CLI 1.5.8.

###### Tested on
macOS 10.13 17A405
Xcode 9.0.1 9A1004

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?