### PR TITLE
aria2: switch to cxx11 1.1 PG

### DIFF
--- a/net/aria2/Portfile
+++ b/net/aria2/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           cxx11 1.0
+PortGroup           cxx11 1.1
 
 github.setup        aria2 aria2 1.33.0 release-
 github.tarball_from releases
@@ -19,8 +19,8 @@ use_xz              yes
 checksums           rmd160  ef7839a306b02da639efb6b937e214971975a12d \
                     sha256  996e3fc2fd07ce2dd517e20a1f79b8b3dbaa5c7e27953b5fc19dae38f3874b8c
 
-depends_build       port:pkgconfig
-depends_lib         port:gettext port:libiconv port:gnutls port:libxml2
+depends_build-append    port:pkgconfig
+depends_lib-append      port:gettext port:libiconv port:gnutls port:libxml2
 
 # use_* must be defined after depends_*, otherwise the automatic dependencies
 # will be overwritten.


### PR DESCRIPTION
fixes build on older systems
closes https://trac.macports.org/ticket/40494
```
$ port -v installed aria2
The following ports are currently installed:
  aria2 @1.33.0_0 (active) platform='darwin 8' archs='ppc' date='2017-10-18T11:34:26-0700'

$ port -v installed aria2
The following ports are currently installed:
  aria2 @1.33.0_0 (active) platform='darwin 9' archs='ppc' date='2017-10-18T11:34:24-0700'

$ port -v installed aria2
The following ports are currently installed:
  aria2 @1.33.0_0 (active) platform='darwin 10' archs='x86_64' date='2017-10-18T11:15:59-0700'

$ port -v installed aria2
The following ports are currently installed:
  aria2 @1.33.0_0 (active) platform='darwin 11' archs='x86_64' date='2017-10-18T11:28:19-0700'
```