### PR TITLE
php-igbinary: major update to 2.0.4

### DIFF
--- a/php/php-igbinary/Portfile
+++ b/php/php-igbinary/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           php 1.1
 
 name                php-igbinary
-version             1.2.1
+version             2.0.4
 categories-append   net devel
 license             BSD PHP-3.01
 platforms           darwin freebsd openbsd
 maintainers         pixilla openmaintainer
 
-php.branches        5.3 5.4 5.5 5.6
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1
 php.pecl            yes
 
 description         PHP serializer.
@@ -22,7 +22,7 @@ long_description    Igbinary is a drop in replacement for the standard PHP \
                     using memcached or similar memory based storages for \
                     serialized data.
 
-checksums           rmd160  edb9a5175c87a04146968331c0dc059c033e74b7 \
-                    sha256  168e51d41a417bbbfe6da0e3cb9b71ef93594f4034f489a951f3b874d03dfdb8
+checksums           rmd160  69516eac72dc469607072c1a6785c604a64f6813 \
+                    sha256  ed98a5704f46bb62d1dad3bd24d07b8a474b4293960ca88d1b6ebd051ca1a528
 
 test.run            yes


### PR DESCRIPTION
Update to latest version available in pecl
Adds support for php70 and php71 while maintaining BC to php52

Re: https://trac.macports.org/ticket/53971

###### Description

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13 17A405
Xcode 9.0 9A235

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
