### PR TITLE
neomutt: fix build failure on macOS <= 10.6

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        neomutt neomutt 20171013 neomutt-
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -31,6 +32,11 @@ depends_lib         path:lib/libssl.dylib:openssl \
 depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 # needed by smime_keys
 depends_run-append  path:bin/perl:perl5
+
+# fixes build on macOS <= 10.6:
+# https://github.com/neomutt/neomutt/commit/d424b60dd1e1f11c871ae322ac3c4e61a19ce0ec
+patchfiles          patch-wcscasecmp.diff
+patch.pre_args      -p1
 
 configure.cmd       ./configure.autosetup
 configure.args      --disable-idn \

--- a/mail/neomutt/files/patch-wcscasecmp.diff
+++ b/mail/neomutt/files/patch-wcscasecmp.diff
@@ -1,0 +1,29 @@
+diff --git a/Makefile.autosetup b/Makefile.autosetup
+index 35000838a..9fc445ece 100644
+--- a/Makefile.autosetup
++++ b/Makefile.autosetup
+@@ -67,6 +67,10 @@ NEOMUTTOBJS=	account.o addrbook.o alias.o attach.o bcache.o body.o \
+ 		smtp.o sort.o state.o status.o system.o thread.o url.o \
+ 		version.o
+ 
++@if HAVE_WCSCASECMP
++@else
++NEOMUTTOBJS+=	wcscasecmp.o
++@endif
+ @if HAVE_RESIZETERM
+ NEOMUTTOBJS+=	resize.o
+ @endif
+diff --git a/auto.def b/auto.def
+index 6858211cb..39db97c95 100644
+--- a/auto.def
++++ b/auto.def
+@@ -258,7 +258,8 @@ if {1} {
+     iswblank \
+     mkdtemp \
+     strsep \
+-    vasprintf
++    vasprintf \
++    wcscasecmp
+ 
+   cc-check-function-in-lib gethostent nsl
+   cc-check-function-in-lib setsockopt socket


### PR DESCRIPTION
###### Description

This is a tentative fix for upstream regression reported on https://github.com/neomutt/neomutt/issues/879. I've incorporated the upstream patch however I don't have an old box to test if it works. I would like somebody to test it and I can report back to upstream so they can merge it.

If the fix works I might wait until the next upstream release instead of incorporating the patch as is. In that case I will change this PR accordingly. Please don't merge this PR in the meantime.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

