### PR TITLE
ALPSCore: update to 1.0.0

### DIFF
--- a/science/ALPSCore/Portfile
+++ b/science/ALPSCore/Portfile
@@ -5,12 +5,11 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        ALPSCore ALPSCore 0.5.6-alpha3 v
-revision            2
+github.setup        ALPSCore ALPSCore 1.0.0 v
 categories          science
 platforms           darwin
 license             GPL-2
-maintainers         umich.edu:galexv
+maintainers         {umich.edu:galexv @galexv}
 
 description         A package for the simulation of condensed matter physics problems: Core Libraries
 long_description    ALPSCore contains the core libraries of the applications and libraries \
@@ -19,8 +18,8 @@ long_description    ALPSCore contains the core libraries of the applications and
 
 homepage            http://alpscore.org
 
-checksums           rmd160  4d3e625b51396e6407223cd743307a3650f9c9ee \
-                    sha256  ab0c10168cc5403d40688ef44fe1429d78fcd4536c819a5524d7c97d656b5d3a
+checksums           rmd160  bf0fac92dfaa831379198d19e1593a241378841a \
+                    sha256  5468f73a11e603cdfe7e99ec0b5cbb55915f7fadfc04201e6c97beaa16aed4b7
 
 compiler.blacklist  gcc-4.2
 
@@ -35,7 +34,6 @@ configure.args      -DTesting=ON \
                     -DBOOST_ROOT=${prefix} \
                     -DENABLE_MPI=OFF\
                     -DMPIEXEC:STRING="${mpi.exec}" \
-                    -DBuildPython=OFF \
                     -DTestXMLOutput=TRUE \
                     -DDocumentation=OFF
 


### PR DESCRIPTION
A new release. Also should resolve the tarball checksum mismatch.
See https://trac.macports.org/ticket/54839

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
