### PR TITLE
scmpc: update to 0.4.1

### DIFF
--- a/audio/scmpc/Portfile
+++ b/audio/scmpc/Portfile
@@ -1,39 +1,32 @@
-# -*- Mode: Tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
+PortGroup       bitbucket 1.0
 
-name            scmpc
-version         0.2.2
-revision        2
-description     Scrobbler for mpd
+bitbucket.setup cmende scmpc 0.4.1
 categories      audio
-maintainers     nomaintainer
-long_description \
-    scmpc is a client for MPD which submits your tracks to Audioscrobbler.
-
-homepage        http://${name}.berlios.de/
 platforms       darwin
-master_sites    http://download.berlios.de/${name} \
-                http://download2.berlios.de/${name}
+license         GPL-2+
+maintainers     nomaintainer
+description     a client for MPD that submits your tracks to last.fm
+long_description \
+    scmpc is ${description}.
+
+bitbucket.tarball_from downloads
 use_bzip2       yes
-checksums       md5 f42482e4dbf398df92a36d5610b403e5 \
-                sha1 4105ef32f543c4babc20bf1569ca00426c7128fe \
-                rmd160 b5aab6b72fff1910c8e245fa801ed788bd98eece
+checksums       rmd160  f30c5ea2dbcff560961ba7ae8daa83b267f6901a \
+                sha256  f89958dc0449f1dfbcbe81b453986812196dc86200153ac700cf606297c3fde3
+
+depends_build   port:pkgconfig
 
 depends_lib     port:curl \
-                port:argtable \
+                port:glib2 \
                 port:libconfuse \
-                port:libdaemon
+                port:libmpdclient
 
-configure.cflags-append -I${prefix}/include
-
-post-install {
-    ui_msg "*** Please note that scmpc may have some strange behavior on OS X, possibly"
-    ui_msg "*** relating to the cache file and SIGKILL. Please read the manpage before"
-    ui_msg "*** using, and make sure that scmpc is taking up a reasonable amount of cpu"
-    ui_msg "*** and otherwise behaving properly before you leave it on overnight!"
-}
-
-livecheck.type  regex
-livecheck.url   http://developer.berlios.de/projects/${name}
-livecheck.regex {(\d+\.\d+\.\d+)}
+notes "
+Please note that scmpc may have some strange behavior on OS X, possibly
+relating to the cache file and SIGKILL. Please read the manpage before
+using, and make sure that scmpc is taking up a reasonable amount of cpu
+and otherwise behaving properly before you leave it on overnight!
+"


### PR DESCRIPTION
###### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
`Warning: no license set`
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?