### PR TITLE
rabbitmq-server: update to 3.6.12

### DIFF
--- a/net/rabbitmq-server/Portfile
+++ b/net/rabbitmq-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rabbitmq-server
-version             3.6.11
+version             3.6.12
 categories          net
 platforms           darwin
 maintainers         nomaintainer
@@ -24,8 +24,8 @@ use_xz              yes
 distfiles           ${name}-generic-unix-${version}${extract.suffix}
 worksrcdir          [string map {- _} $name]-$version
 
-checksums           rmd160  a9dd4c0ec89b6754f8f896fcae687b3485428cda \
-                    sha256  8270c8aa1d6b29a4700287603793caacdc8120bf12b6e286e264f3560295d14e
+checksums           rmd160  5f25455d42d7a786aae44a025deece3747865b3d \
+                    sha256  1c20bcfbcea922f1ceb14c95d2ad1211add4e1b03ba8491405640c384ea5a8df
 
 depends_lib         port:erlang
 depends_build       port:libxslt
@@ -90,9 +90,7 @@ destroot {
 
     copy {*}[glob ${worksrcpath}/*] ${destroot}${rootserver}/
 
-    reinplace -E "s:^SYS_PREFIX=\${RABBITMQ_HOME}$:SYS_PREFIX=${prefix}:" \
-        ${realsbin}/rabbitmq-defaults
-    reinplace -E "s:^SYS_PREFIX=$:SYS_PREFIX=${prefix}:" \
+    reinplace -E "s:^SYS_PREFIX=\\\${RABBITMQ_HOME}$:SYS_PREFIX=${prefix}:" \
         ${realsbin}/rabbitmq-defaults
 
     xinstall -m 755 ${filespath}/rabbitmq-script-wrapper \


### PR DESCRIPTION
###### Description
Fix reinplace introduced in 50851a30cfb6edf5280c88b8fce862246ba3668b.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
