### PR TITLE
gawk: fix build on Tiger

### DIFF
--- a/lang/gawk/Portfile
+++ b/lang/gawk/Portfile
@@ -33,6 +33,11 @@ configure.args          --with-libiconv-prefix=${prefix} \
                         ac_cv_libsigsegv=no \
                         ac_cv_prog_AWK=awk
 
+# fix build on Tiger see https://trac.macports.org/ticket/55145
+platform darwin 8 {
+    configure.cppflags-append -D__DARWIN_UNIX03
+}
+
 test.run                yes
 test.target             check
 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/55145

```
$ port -v installed | grep gawk
  gawk @4.2.0_0 (active) platform='darwin 8' archs='ppc' date='2017-10-22T07:29:31-0700'
```