### PR TITLE
lnav: fix build on 10.6 (and earlier)

### DIFF
--- a/sysutils/lnav/Portfile
+++ b/sysutils/lnav/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           snowleopard_fixes 1.0
 
 github.setup        tstack lnav 0.8.1 v
 revision            2
@@ -18,7 +19,7 @@ platforms           darwin
 license             BSD
 homepage            http://lnav.org
 
-depends_lib         port:curl \
+depends_lib-append  port:curl \
                     port:pcre \
                     port:sqlite3 \
                     port:ncurses \
@@ -37,5 +38,11 @@ configure.args      --disable-silent-rules \
                     --with-pcre \
                     --with-readline \
                     --with-sqlite3
+
+# see https://trac.macports.org/ticket/52067
+# in addition to library as above, requires the header for function def
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    configure.cxxflags-append -include ${prefix}/include/snowleopardfixes.h
+}
 
 use_autoreconf      yes


### PR DESCRIPTION
adds missing getline function
closes https://trac.macports.org/ticket/52067

no response from upstream after 14 months
```
$ port -v installed lnav
The following ports are currently installed:
  lnav @0.8.1_2 (active) platform='darwin 10' archs='x86_64' date='2017-10-22T17:40:47-0700'
```