### PR TITLE
PG snowleopard_fixes: don't require depends_lib-append

### DIFF
--- a/_resources/port1.0/group/snowleopard_fixes-1.0.tcl
+++ b/_resources/port1.0/group/snowleopard_fixes-1.0.tcl
@@ -29,10 +29,26 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #
-# This portgroup provides access to back ports for Snow Leopard
-# (Mac OS X 10.6.8).
+# This portgroup provides access to many missing library functions for 
+# Snow Leopard (Mac OS X 10.6.8) and earlier.
+# adding the header is sometimes needed, but sometimes incompatible
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
+options snowleopard_fixes.addheader
+default snowleopard_fixes.addheader no
+
+proc add_libsnowleopardfixes {} {
+    global snowleopard_fixes.addheader
+    global prefix
+    
 	depends_lib-append          port:snowleopardfixes
 	configure.ldflags-append   -lsnowleopardfixes
+
+    if {${snowleopard_fixes.addheader} eq "yes"} {
+        configure.cxxflags-append -include ${prefix}/include/snowleopardfixes.h
+    }
+}
+
+# do not force all Portfiles to switch from depends_lib to depends_lib-append
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    port::register_callback add_libsnowleopardfixes
 }


### PR DESCRIPTION
alter portgroup to a callback
add option to add header if needed

This will prevent every port from needing to change to depends_lib-append (eg. wine) and also easily allow the header to be added (which is sometimes required (eg lnav) but sometimes causes troubles).

This is the first such modification I've done; I based it on Marcus' recent changes to cxx11 1.1 Portgroup.