### PR TITLE
libidn: Address CVE-2017-14062

### DIFF
--- a/mail/libidn/Portfile
+++ b/mail/libidn/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                libidn
 version             1.33
+revision            1
 categories          mail
 license             {LGPL-2.1+ GPL-3+}
 description         GNU International Domain Name Library (legacy version 1).
@@ -21,7 +22,8 @@ checksums           rmd160  b6bff80e6d5b5e3ee15a52378d42c7b9074a627d \
 
 depends_lib         port:libiconv port:gettext
 
-patchfiles          configure-no-nawk.patch
+patchfiles          configure-no-nawk.patch \
+                    patch-CVE-2017-14062.diff
 
 post-patch {
     # avoid automake invocation

--- a/mail/libidn/files/patch-CVE-2017-14062.diff
+++ b/mail/libidn/files/patch-CVE-2017-14062.diff
@@ -1,0 +1,19 @@
+https://gitlab.com/libidn/libidn2/commit/3284eb342cd0ed1a18786e3fcdf0cdd7e76676bd
+--- lib/punycode.c.orig	2016-01-14 13:42:33.000000000 +0000
++++ lib/punycode.c	2017-10-24 02:00:00.000000000 +0000
+@@ -88,11 +88,11 @@
+ /* point (for use in representing integers) in the range 0 to */
+ /* base-1, or base if cp does not represent a value.          */
+ 
+-static punycode_uint
+-decode_digit (punycode_uint cp)
++static unsigned
++decode_digit (int cp)
+ {
+-  return cp - 48 < 10 ? cp - 22 : cp - 65 < 26 ? cp - 65 :
+-    cp - 97 < 26 ? cp - 97 : base;
++  return (unsigned) (cp - 48 < 10 ? cp - 22 : cp - 65 < 26 ? cp - 65 :
++    cp - 97 < 26 ? cp - 97 : base);
+ }
+ 
+ /* encode_digit(d,flag) returns the basic code point whose value      */


### PR DESCRIPTION
###### Description
http://git.savannah.gnu.org/cgit/libidn.git/commit/?id=e9e81b8063b095b02cf104bb992fa9bf9515b9d8
http://git.savannah.gnu.org/cgit/libidn.git/commit/?id=6c8a9375641ca283b50f9680c90dcd57f9c44798

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
