### PR TITLE
fswatch @1.11.0 update

### DIFF
--- a/sysutils/fswatch/Portfile
+++ b/sysutils/fswatch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        emcrisostomo fswatch 1.10.0
+github.setup        emcrisostomo fswatch 1.11.0
 github.tarball_from releases
 
 categories          sysutils
@@ -21,8 +21,8 @@ long_description    A cross-platform file change monitor with multiple \
 
 homepage            http://emcrisostomo.github.io/fswatch/
 
-checksums           rmd160 0719cff16901b5a6c537b6d14d5147034c7c6358 \
-                    sha256 f0b35bcc27e73dbeeb2e74567f978e11b239a2ea229f870ce27b39593ab0eb72
+checksums           rmd160 6ad2d3383d8560bf1e121a9fe260d87d9ad4a18e \
+                    sha256 9ad5fc35f835d37445dd4bc87738c5824d98c1ed564d0491b0a6625073b6c128
 
 # Blacklist compilers not supporting C++11.
 compiler.blacklist-append \


### PR DESCRIPTION
###### Description

fswatch @1.11.0 update

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
