### PR TITLE
fswatch: add PortGroup cxx11 1.1

### DIFF
--- a/sysutils/fswatch/Portfile
+++ b/sysutils/fswatch/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cxx11 1.1
 
 github.setup        emcrisostomo fswatch 1.11.0
+revision            1
 github.tarball_from releases
 
 categories          sysutils
@@ -23,16 +24,5 @@ homepage            http://emcrisostomo.github.io/fswatch/
 
 checksums           rmd160 6ad2d3383d8560bf1e121a9fe260d87d9ad4a18e \
                     sha256 9ad5fc35f835d37445dd4bc87738c5824d98c1ed564d0491b0a6625073b6c128
-
-# Blacklist compilers not supporting C++11.
-compiler.blacklist-append \
-                    *gcc-4.0 *gcc-4.2 {clang < 137}
-
-# Blacklist compilers crashing on Snow Leopard.
-# http://trac.macports.org/ticket/44726
-compiler.blacklist-append \
-                    macports-clang-3.3 macports-clang-3.4
-compiler.fallback-append \
-                    macports-clang-3.5
 
 configure.args      ac_cv_prog_AWK=/usr/bin/awk


### PR DESCRIPTION
fixes build on older systems
simplifies compiler choice logic
