### PR TITLE
maven{3,31}: delete no longer needed pre-activate

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -77,19 +77,6 @@ destroot {
     ln -s ../share/java/${name}/bin/mvn ${destroot}${prefix}/bin/mvn3
 }
 
-# Delete this pre-activate section after 2016-03-18, after which it
-# will have existed for a year to clean up cruft on people's systems.
-pre-activate {
-    # Remove stray files due to a destroot bug that has since been
-    # fixed.
-    foreach file {bin/mvn3} {
-        set filepath ${prefix}/${file}
-        if {![catch {file type ${filepath}}] && [registry_file_registered ${filepath}] == "0"} {
-            delete ${filepath}
-        }
-    }
-}
-
 notes \
 "To make maven $version the default, please run
 \tsudo port select --set ${select.group} $name"

--- a/java/maven31/Portfile
+++ b/java/maven31/Portfile
@@ -93,19 +93,6 @@ destroot {
     ln -s ../share/java/${maven_dir}/bin/mvn ${destroot}${prefix}/bin/mvn31
 }
 
-# Delete this pre-activate section after 2016-03-18, after which it
-# will have existed for a year to clean up cruft on people's systems.
-pre-activate {
-    # Remove stray files due to a destroot bug that has since been
-    # fixed.
-    foreach file {bin/mvn31} {
-        set filepath ${prefix}/${file}
-        if {![catch {file type ${filepath}}] && [registry_file_registered ${filepath}] == "0"} {
-            delete ${filepath}
-        }
-    }
-}
-
 notes \
 "To make maven $version the default, please run
 \tsudo port select --set ${select.group} $name"


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
