### PR TITLE
tbb: add fixes for snowleopard and earlier

### DIFF
--- a/devel/tbb/Portfile
+++ b/devel/tbb/Portfile
@@ -28,7 +28,7 @@ use_configure       no
 # Force a compatible compiler
 compiler.blacklist-append *gcc* {clang < 602} macports-clang-3.3 macports-clang-3.4 \
                           macports-clang-3.5 macports-clang-3.6 macports-clang-3.7
-compiler.whitelist clang macports-clang-3.9 macports-clang-3.8 
+compiler.whitelist clang macports-clang-3.9 macports-clang-3.8
 
 set tbb_arch(i386)      ia32
 set tbb_arch(ppc)       ppc32
@@ -44,6 +44,8 @@ if {[string match *clang* ${configure.compiler}]} {
 }
 
 set tbb_build_prefix macports
+
+patchfiles        patch-tbb-older-malloc.diff
 
 post-patch {
     reinplace "/^CONLY *=/s|=.*$|= ${configure.cc}|g" ${worksrcpath}/build/macos.${tbb_compiler}.inc

--- a/devel/tbb/files/patch-tbb-older-malloc.diff
+++ b/devel/tbb/files/patch-tbb-older-malloc.diff
@@ -1,0 +1,28 @@
+diff --git src/tbbmalloc/proxy_overload_osx.h src/tbbmalloc/proxy_overload_osx.h
+index 53afe13..98f622d 100644
+--- src/tbbmalloc/proxy_overload_osx.h
++++ src/tbbmalloc/proxy_overload_osx.h
+@@ -139,10 +139,11 @@ struct DoMallocReplacement {
+         introspect.force_unlock = &zone_force_unlock;
+         introspect.statistics = zone_statistics;
+         introspect.zone_locked = &zone_locked;
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+         introspect.enable_discharge_checking = &impl_zone_enable_discharge_checking;
+         introspect.disable_discharge_checking = &impl_zone_disable_discharge_checking;
+         introspect.discharge = &impl_zone_discharge;
+-
++#endif
+         zone.size = &impl_malloc_usable_size;
+         zone.malloc = &impl_malloc;
+         zone.calloc = &impl_calloc;
+@@ -155,8 +156,9 @@ struct DoMallocReplacement {
+         zone.version = 8;
+         zone.memalign = impl_memalign;
+         zone.free_definite_size = &impl_free_definite_size;
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+         zone.pressure_relief = &impl_pressure_relief;
+-
++#endif
+         // make sure that default purgeable zone is initialized
+         malloc_default_purgeable_zone();
+         void* ptr = malloc(1);


### PR DESCRIPTION
block malloc functions missing prior to 10.7
closes https://trac.macports.org/ticket/44941
closes https://trac.macports.org/ticket/55180

=======

installs on 10.6 without error. 
```
$ port -v installed tbb
The following ports are currently installed:
  tbb @2017_U8_0 (active) platform='darwin 10' archs='x86_64' date='2017-10-26T17:21:38-0700'
```

some tests have errors, however. These may be expected errors based on the age of 10.6, I'm not sure.

```
./test_malloc_pools.exe  1:4
done
./test_malloc_atexit.exe 
done
sh ../../build/test_launcher.sh  -l libtbbmalloc_proxy_debug.dylib ./test_malloc_overload.exe 
done
sh ../../build/test_launcher.sh  ./test_malloc_overload_proxy.exe 
done
sh ../../build/test_launcher.sh  ./test_malloc_lib_unload.exe 
done
sh ../../build/test_launcher.sh  ./test_malloc_used_by_lib.exe
done
./test_malloc_whitebox.exe  1:4
done
sh ../../build/test_launcher.sh  -u ./test_malloc_compliance.exe  1:4
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
done
./test_ScalableAllocator.exe 
done
./test_ScalableAllocator_STL.exe 
done
./test_malloc_regression.exe 
done
./test_malloc_init_shutdown.exe 
done
./test_malloc_pure_c.exe 
done
/usr/bin/make -C "./build/macports_debug"  -r -f ../../build/Makefile.test cfg=debug
/opt/local/bin/clang++-mp-3.9 -o test_assembly.o -c -MMD -g -O0 -DTBB_USE_DEBUG -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm   -DHARNESS_USE_RUNTIME_LOADER -Wall -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor    -I../../src -I../../src/rml/include -I../../include -I.  ../../src/test/test_assembly.cpp
/opt/local/bin/clang++-mp-3.9 -o test_assembly.exe -g -O0 -DTBB_USE_DEBUG -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm   -DHARNESS_USE_RUNTIME_LOADER -Wall -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor  test_assembly.o    -lpthread -ldl  -m64 
Undefined symbols for architecture x86_64:
  "tbb::assertion_failure(char const*, int, char const*, char const*)", referenced from:
      long __TBB_machine_lg<unsigned long>(unsigned long) in test_assembly.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [test_assembly.exe] Error 1
make: [test] Error 2 (ignored)
/usr/bin/make -C "./build/macports_release"  -r -f ../../build/Makefile.tbbmalloc cfg=release malloc_test
/opt/local/bin/clang++-mp-3.9 -o test_ScalableAllocator.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall    -I../../src -I../../src/rml/include -I../../include ../../src/test/test_ScalableAllocator.cpp
/opt/local/bin/clang++-mp-3.9 -o test_ScalableAllocator.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_ScalableAllocator.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_ScalableAllocator_STL.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall    -I../../src -I../../src/rml/include -I../../include ../../src/test/test_ScalableAllocator_STL.cpp
/opt/local/bin/clang++-mp-3.9 -o test_ScalableAllocator_STL.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_ScalableAllocator_STL.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_malloc_compliance.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall    -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_compliance.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_compliance.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_malloc_compliance.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_malloc_regression.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall    -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_regression.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_regression.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_malloc_regression.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_malloc_init_shutdown.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall    -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_init_shutdown.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_init_shutdown.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_malloc_init_shutdown.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_malloc_pools.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall    -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_pools.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_pools.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_malloc_pools.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang-mp-3.9 -c -MMD -o test_malloc_pure_c.o -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_pure_c.c
/opt/local/bin/clang++-mp-3.9 -o test_malloc_pure_c.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_malloc_pure_c.o libtbbmalloc.dylib   -lpthread  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_malloc_whitebox.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc -I. ../../src/test/test_malloc_whitebox.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_whitebox.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_whitebox.o     -lpthread  -m64  -ldl
/opt/local/bin/clang++-mp-3.9 -c -MMD -o test_malloc_used_by_lib_dll.o -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 -fPIC -D_USRDLL -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/test/test_malloc_used_by_lib.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_used_by_lib_dll.dylib -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_used_by_lib_dll.o   libtbbmalloc.dylib -lpthread  -m64   -fPIC -dynamiclib -install_name /opt/local/lib/test_malloc_used_by_lib_dll.dylib
/opt/local/bin/clang++-mp-3.9 -o test_malloc_used_by_lib.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/test/test_malloc_used_by_lib.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_used_by_lib.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_used_by_lib.o  test_malloc_used_by_lib_dll.dylib  -lpthread  -m64  -ldl
/opt/local/bin/clang++-mp-3.9 -c -MMD -o test_malloc_lib_unload_dll.o -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  -fPIC -D_USRDLL -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_lib_unload.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_lib_unload_dll.dylib -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm  -Wall  test_malloc_lib_unload_dll.o   -lpthread  -m64  -ldl -fPIC -dynamiclib -install_name /opt/local/lib/test_malloc_lib_unload_dll.dylib
/opt/local/bin/clang++-mp-3.9 -o test_malloc_lib_unload.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/test/test_malloc_lib_unload.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_lib_unload.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_lib_unload.o  test_malloc_lib_unload_dll.dylib  -lpthread  -m64  -ldl
/opt/local/bin/clang++-mp-3.9 -o test_malloc_overload.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/test/test_malloc_overload.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_overload.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_overload.o    -lpthread  -m64  -ldl
/opt/local/bin/clang++-mp-3.9 -o test_malloc_overload_proxy.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include -I../../src/tbbmalloc -I../../src/tbbmalloc ../../src/test/test_malloc_overload.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_overload_proxy.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_overload_proxy.o libtbbmalloc_proxy.dylib   -lpthread  -m64  -ldl
/opt/local/bin/clang++-mp-3.9 -c -MMD -o test_malloc_atexit_dll.o -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 -fPIC -D_USRDLL -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_atexit.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_atexit_dll.dylib -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_atexit_dll.o libtbbmalloc.dylib libtbbmalloc_proxy.dylib  -lpthread  -m64  -ldl -fPIC -dynamiclib -install_name /opt/local/lib/test_malloc_atexit_dll.dylib
/opt/local/bin/clang++-mp-3.9 -o test_malloc_atexit.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1   -I../../src -I../../src/rml/include -I../../include ../../src/test/test_malloc_atexit.cpp
/opt/local/bin/clang++-mp-3.9 -o test_malloc_atexit.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm    -fno-rtti -fno-exceptions -D__TBBMALLOC_BUILD=1 test_malloc_atexit.o libtbbmalloc.dylib libtbbmalloc_proxy.dylib test_malloc_atexit_dll.dylib  -lpthread  -m64  -ldl
./test_malloc_pools.exe  1:4
done
./test_malloc_atexit.exe 
done
sh ../../build/test_launcher.sh  -l libtbbmalloc_proxy.dylib ./test_malloc_overload.exe 
done
sh ../../build/test_launcher.sh  ./test_malloc_overload_proxy.exe 
done
sh ../../build/test_launcher.sh  ./test_malloc_lib_unload.exe 
done
sh ../../build/test_launcher.sh  ./test_malloc_used_by_lib.exe
done
./test_malloc_whitebox.exe  1:4
done
sh ../../build/test_launcher.sh  -u ./test_malloc_compliance.exe  1:4
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
Known issue: some tests are skipped on macOS
done
./test_ScalableAllocator.exe 
done
./test_ScalableAllocator_STL.exe 
done
./test_malloc_regression.exe 
done
./test_malloc_init_shutdown.exe 
done
./test_malloc_pure_c.exe 
done
/usr/bin/make -C "./build/macports_release"  -r -f ../../build/Makefile.test cfg=release
/opt/local/bin/clang++-mp-3.9 -o test_assembly.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm   -DHARNESS_USE_RUNTIME_LOADER -Wall -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor    -I../../src -I../../src/rml/include -I../../include -I.  ../../src/test/test_assembly.cpp
/opt/local/bin/clang++-mp-3.9 -o test_assembly.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm   -DHARNESS_USE_RUNTIME_LOADER -Wall -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor  test_assembly.o    -lpthread -ldl  -m64 
/opt/local/bin/clang++-mp-3.9 -o test_global_control.o -c -MMD -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm   -DHARNESS_USE_RUNTIME_LOADER -Wall -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor    -I../../src -I../../src/rml/include -I../../include -I.  ../../src/test/test_global_control.cpp
/opt/local/bin/clang++-mp-3.9 -o test_global_control.exe -g -O2 -DUSE_PTHREAD -stdlib=libc++ -m64 -mrtm   -DHARNESS_USE_RUNTIME_LOADER -Wall -Wextra -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor  test_global_control.o    -lpthread -ldl  -m64 
Undefined symbols for architecture x86_64:
  "tbb::interface5::internal::task_base::destroy(tbb::task&)", referenced from:
      TestForgottenEnqueuedTasks() in test_global_control.o
  "tbb::interface7::internal::task_arena_base::internal_terminate()", referenced from:
      TestConcurrentArenas() in test_global_control.o
      ArenaUserRun::operator()(int) const in test_global_control.o
  "tbb::interface7::internal::task_arena_base::internal_initialize()", referenced from:
      ArenaUserRun::operator()(int) const in test_global_control.o
  "tbb::interface9::global_control::active_value(int)", referenced from:
      TestStackSizeSimpleControl() in test_global_control.o
      TSI_and_RunWorkers(int, unsigned long, unsigned long) in test_global_control.o
      TestWorkers(unsigned long) in test_global_control.o
      TestWorkersConstraints() in test_global_control.o
      TestAutoInit() in test_global_control.o
      TestInvalidParallelism() in test_global_control.o
      TestTooBigStack() in test_global_control.o
      ...
  "tbb::interface9::global_control::internal_create()", referenced from:
      TestStackSizeSimpleControl() in test_global_control.o
      RunWorkersLimited(int, unsigned long, bool) in test_global_control.o
      TestWorkers(unsigned long) in test_global_control.o
      TestWorkersConstraints() in test_global_control.o
      TestAutoInit() in test_global_control.o
      TestInvalidParallelism() in test_global_control.o
      TestTooBigStack() in test_global_control.o
      ...
  "tbb::interface9::global_control::internal_destroy()", referenced from:
      TestStackSizeSimpleControl() in test_global_control.o
      RunWorkersLimited(int, unsigned long, bool) in test_global_control.o
      TestWorkers(unsigned long) in test_global_control.o
      TestWorkersConstraints() in test_global_control.o
      TestAutoInit() in test_global_control.o
      TestInvalidParallelism() in test_global_control.o
      TestTooBigStack() in test_global_control.o
      ...
  "tbb::assertion_failure(char const*, int, char const*, char const*)", referenced from:
      RunWorkersLimited(int, unsigned long, bool) in test_global_control.o
      TestWorkers(unsigned long) in test_global_control.o
      TestWorkersConstraints() in test_global_control.o
      TestAutoInit() in test_global_control.o
      TestInvalidParallelism() in test_global_control.o
  "tbb::task_group_context::init()", referenced from:
      tbb::interface9::internal::start_for<tbb::blocked_range<unsigned long>, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long>, tbb::simple_partitioner const>::run(tbb::blocked_range<unsigned long> const&, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long> const&, tbb::simple_partitioner const&) in test_global_control.o
      tbb::interface9::internal::start_for<tbb::blocked_range<int>, tbb::internal::parallel_for_body<DummyBody, int>, tbb::simple_partitioner const>::run(tbb::blocked_range<int> const&, tbb::internal::parallel_for_body<DummyBody, int> const&, tbb::simple_partitioner const&) in test_global_control.o
  "tbb::task_group_context::~task_group_context()", referenced from:
      tbb::interface9::internal::start_for<tbb::blocked_range<unsigned long>, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long>, tbb::simple_partitioner const>::run(tbb::blocked_range<unsigned long> const&, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long> const&, tbb::simple_partitioner const&) in test_global_control.o
      tbb::interface9::internal::start_for<tbb::blocked_range<int>, tbb::internal::parallel_for_body<DummyBody, int>, tbb::simple_partitioner const>::run(tbb::blocked_range<int> const&, tbb::internal::parallel_for_body<DummyBody, int> const&, tbb::simple_partitioner const&) in test_global_control.o
  "tbb::task_scheduler_init::initialize(int, unsigned long)", referenced from:
      TSI_and_RunWorkers(int, unsigned long, unsigned long) in test_global_control.o
      TestWorkersConstraints() in test_global_control.o
      TestTaskEnqueue() in test_global_control.o
      TestConcurrentArenas() in test_global_control.o
      TestParallelismRestored() in test_global_control.o
      TestNoUnwantedEnforced() in test_global_control.o
      TestMultipleControls() in test_global_control.o
      ...
  "tbb::task_scheduler_init::internal_blocking_terminate(bool)", referenced from:
      blocking_task_scheduler_init::~blocking_task_scheduler_init() in test_global_control.o
  "tbb::task_scheduler_init::terminate()", referenced from:
      TestForgottenEnqueuedTasks() in test_global_control.o
      TestMain() in test_global_control.o
      blocking_task_scheduler_init::~blocking_task_scheduler_init() in test_global_control.o
  "tbb::set_assertion_handler(void (*)(char const*, int, char const*, char const*))", referenced from:
      TestInvalidParallelism() in test_global_control.o
  "tbb::task::note_affinity(unsigned short)", referenced from:
      vtable for tbb::interface9::internal::flag_task in test_global_control.o
      vtable for WaiterTask in test_global_control.o
      vtable for FFTask in test_global_control.o
      vtable for WorkAndEnqueueTask in test_global_control.o
      vtable for tbb::empty_task in test_global_control.o
      vtable for CountWorkersTask in test_global_control.o
      vtable for tbb::internal::function_task<ArenaRun> in test_global_control.o
      ...
  "tbb::internal::NFS_Allocate(unsigned long, unsigned long, void*)", referenced from:
      tbb::interface6::enumerable_thread_specific<unsigned long, tbb::cache_aligned_allocator<unsigned long>, (tbb::ets_key_usage_type)1>::create_array(unsigned long) in test_global_control.o
      tbb::concurrent_vector<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul>, tbb::cache_aligned_allocator<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul> > >::internal_allocator(tbb::internal::concurrent_vector_base_v3&, unsigned long) in test_global_control.o
  "tbb::internal::handle_perror(int, char const*)", referenced from:
      Harness::ExactConcurrencyLevel::check(unsigned long, Harness::ExactConcurrencyLevel::Mode) in test_global_control.o
      __GLOBAL__sub_I_test_global_control.cpp in test_global_control.o
  "tbb::internal::tbb_thread_v3::hardware_concurrency()", referenced from:
      RunWorkersLimited(int, unsigned long, bool) in test_global_control.o
      TestWorkers(unsigned long) in test_global_control.o
      TestAutoInit() in test_global_control.o
      TestMain() in test_global_control.o
  "tbb::internal::thread_get_id_v3()", referenced from:
      tbb::interface6::internal::ets_base<(tbb::ets_key_usage_type)1>::table_lookup(bool&) in test_global_control.o
  "tbb::internal::allocate_root_proxy::allocate(unsigned long)", referenced from:
      TestTaskEnqueue() in test_global_control.o
      TestParallelismRestored() in test_global_control.o
      TestForgottenEnqueuedTasks() in test_global_control.o
      WorkAndEnqueueTask::execute() in test_global_control.o
      FFTasksRun::operator()(int) const in test_global_control.o
      ArenasObserveRun::operator()(int) const in test_global_control.o
      NoUnwantedEnforcedRun::operator()(int) const in test_global_control.o
      ...
  "tbb::internal::allocate_via_handler_v3(unsigned long)", referenced from:
      Harness::ExactConcurrencyLevel::run() in test_global_control.o
      tbb::interface6::internal::callback_leaf<unsigned long, tbb::interface6::internal::construct_by_default<unsigned long> >::clone() const in test_global_control.o
      NoUnwantedEnforcedRun::operator()(int) const in test_global_control.o
      __GLOBAL__sub_I_test_global_control.cpp in test_global_control.o
  "tbb::internal::concurrent_vector_base_v3::internal_clear(void (*)(void*, unsigned long))", referenced from:
      tbb::concurrent_vector<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul>, tbb::cache_aligned_allocator<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul> > >::~concurrent_vector() in test_global_control.o
  "tbb::internal::concurrent_vector_base_v3::internal_grow_by(unsigned long, unsigned long, void (*)(void*, void const*, unsigned long), void const*)", referenced from:
      tbb::interface6::enumerable_thread_specific<unsigned long, tbb::cache_aligned_allocator<unsigned long>, (tbb::ets_key_usage_type)1>::create_local() in test_global_control.o
  "tbb::internal::concurrent_vector_base_v3::~concurrent_vector_base_v3()", referenced from:
      tbb::concurrent_vector<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul>, tbb::cache_aligned_allocator<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul> > >::~concurrent_vector() in test_global_control.o
  "tbb::internal::deallocate_via_handler_v3(void*)", referenced from:
      tbb::interface6::internal::callback_leaf<unsigned long, tbb::interface6::internal::construct_by_default<unsigned long> >::destroy() in test_global_control.o
  "tbb::internal::task_scheduler_observer_v3::observe(bool)", referenced from:
      TestConcurrentArenas() in test_global_control.o
      tbb::internal::task_scheduler_observer_v3::~task_scheduler_observer_v3() in test_global_control.o
      tbb::internal::task_scheduler_observer_v3::~task_scheduler_observer_v3() in test_global_control.o
      tbb::interface6::task_scheduler_observer::~task_scheduler_observer() in test_global_control.o
      ArenasObserveRun::operator()(int) const in test_global_control.o
  "tbb::internal::NFS_Free(void*)", referenced from:
      tbb::interface6::enumerable_thread_specific<unsigned long, tbb::cache_aligned_allocator<unsigned long>, (tbb::ets_key_usage_type)1>::free_array(void*, unsigned long) in test_global_control.o
      tbb::concurrent_vector<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul>, tbb::cache_aligned_allocator<tbb::internal::padded<tbb::interface6::internal::ets_element<unsigned long>, 128ul> > >::~concurrent_vector() in test_global_control.o
  "tbb::interface7::internal::task_arena_base::internal_enqueue(tbb::task&, long) const", referenced from:
      ArenaUserRun::operator()(int) const in test_global_control.o
  "tbb::internal::allocate_child_proxy::allocate(unsigned long) const", referenced from:
      TestForgottenEnqueuedTasks() in test_global_control.o
      tbb::interface9::internal::start_for<tbb::blocked_range<unsigned long>, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long>, tbb::simple_partitioner const>::execute() in test_global_control.o
      tbb::interface9::internal::start_for<tbb::blocked_range<int>, tbb::internal::parallel_for_body<DummyBody, int>, tbb::simple_partitioner const>::execute() in test_global_control.o
  "tbb::internal::concurrent_vector_base_v3::internal_capacity() const", referenced from:
      unsigned long tbb::interface6::enumerable_thread_specific<unsigned long, tbb::cache_aligned_allocator<unsigned long>, (tbb::ets_key_usage_type)1>::combine<std::__1::plus<unsigned long> >(std::__1::plus<unsigned long>) in test_global_control.o
  "tbb::internal::allocate_continuation_proxy::allocate(unsigned long) const", referenced from:
      tbb::interface9::internal::start_for<tbb::blocked_range<unsigned long>, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long>, tbb::simple_partitioner const>::execute() in test_global_control.o
      tbb::interface9::internal::start_for<tbb::blocked_range<int>, tbb::internal::parallel_for_body<DummyBody, int>, tbb::simple_partitioner const>::execute() in test_global_control.o
  "tbb::internal::allocate_root_with_context_proxy::allocate(unsigned long) const", referenced from:
      tbb::interface9::internal::start_for<tbb::blocked_range<unsigned long>, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long>, tbb::simple_partitioner const>::run(tbb::blocked_range<unsigned long> const&, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long> const&, tbb::simple_partitioner const&) in test_global_control.o
      tbb::interface9::internal::start_for<tbb::blocked_range<int>, tbb::internal::parallel_for_body<DummyBody, int>, tbb::simple_partitioner const>::run(tbb::blocked_range<int> const&, tbb::internal::parallel_for_body<DummyBody, int> const&, tbb::simple_partitioner const&) in test_global_control.o
      ArenaUserRun::operator()(int) const in test_global_control.o
  "typeinfo for tbb::task", referenced from:
      typeinfo for tbb::interface9::internal::start_for<tbb::blocked_range<unsigned long>, tbb::internal::parallel_for_body<Harness::ExactConcurrencyLevel, unsigned long>, tbb::simple_partitioner const> in test_global_control.o
      typeinfo for tbb::interface9::internal::flag_task in test_global_control.o
      typeinfo for WaiterTask in test_global_control.o
      typeinfo for FFTask in test_global_control.o
      typeinfo for WorkAndEnqueueTask in test_global_control.o
      typeinfo for tbb::empty_task in test_global_control.o
      typeinfo for tbb::interface9::internal::start_for<tbb::blocked_range<int>, tbb::internal::parallel_for_body<DummyBody, int>, tbb::simple_partitioner const> in test_global_control.o
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
