### PR TITLE
ntpsec, py-metakernel, py-octave_kernel: make distributable

### DIFF
--- a/python/py-metakernel/Portfile
+++ b/python/py-metakernel/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        Calysto metakernel 0.20.11 v
 set real_name       metakernel
 name                py-${real_name}
-license             BSD-3-Clause
+license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 description         A Jupyter/IPython kernel template
 long_description    ${description} which includes core magic functions (including \

--- a/python/py-octave_kernel/Portfile
+++ b/python/py-octave_kernel/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        Calysto octave_kernel 0.28.1 v
 set real_name       octave_kernel
 name                py-${real_name}
-license             BSD-3-Clause
+license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 description         A Jupyter kernel for Octave
 long_description    ${description}

--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -9,7 +9,7 @@ version             0.9.7
 categories          sysutils net
 maintainers         {lbschenkel @lbschenkel} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
-license             BSD-2-Clause BSD-3-Clause CC-BY-4 NTP MIT
+license             Permissive
 platforms           darwin
 long_description    A secure, hardened, and improved implementation of Network \
                     Time Protocol derived from NTP Classic, Dave Mills’s original.


### PR DESCRIPTION
###### Description
`BSD-2-Clause`, `BSD-3-Clause` and `NTP` licenses are not recognized as distributable by [port_binary_distributable.tcl](https://github.com/macports/macports-infrastructure/blob/master/jobs/port_binary_distributable.tcl).

See https://lists.macports.org/pipermail/macports-dev/2017-October/036715.html.