### PR TITLE
xorg-libpthread-stubs: update to 0.4

### DIFF
--- a/x11/xorg-libpthread-stubs/Portfile
+++ b/x11/xorg-libpthread-stubs/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name		xorg-libpthread-stubs
-version		0.3
+version		0.4
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -15,9 +15,9 @@ master_sites	 ${homepage}/dist/
 distname	libpthread-stubs-${version}
 use_bzip2	yes
 
-checksums   md5     e8fa31b42e13f87e8f5a7a2b731db7ee \
-            sha1    7fc486ad0ec54938f8b781cc374218f50eac8b99 \
-            rmd160  a3a5f76e103c645749d7b8a8fc00ad472e59987b
+checksums   md5     48c1544854a94db0e51499cc3afd797f \
+            sha1    c42503a2ae0067b2238b2f3fefc86656baa4dd8e \
+            rmd160  d831b5b0370e88f752c454c4bb96c7bf2a240f10
 
 livecheck.type  regex
 livecheck.url   [lindex ${master_sites} 0]?C=M&O=D

--- a/x11/xorg-libpthread-stubs/Portfile
+++ b/x11/xorg-libpthread-stubs/Portfile
@@ -1,24 +1,26 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name		xorg-libpthread-stubs
-version		0.4
-categories	x11 devel
-license		X11
-maintainers	{jeremyhu @jeremyhu} openmaintainer
-description	X.org/Xcb libpthread stubs
-homepage	http://xcb.freedesktop.org
-platforms	darwin macosx
-supported_archs	noarch
-long_description Library that provides pthread stubs that are missing from your platform libc. (used for libxcb)
-master_sites	 ${homepage}/dist/
+PortSystem          1.0
 
-distname	libpthread-stubs-${version}
-use_bzip2	yes
+name                xorg-libpthread-stubs
+version             0.4
+categories          x11 devel
+license             X11
+maintainers         {jeremyhu @jeremyhu} openmaintainer
+description         X.org/Xcb libpthread stubs
+homepage            http://xcb.freedesktop.org
+platforms           darwin macosx
+supported_archs     noarch
+long_description    Library that provides pthread stubs that are missing from your platform libc. (used for libxcb)
+master_sites        ${homepage}/dist/
 
-checksums   md5     48c1544854a94db0e51499cc3afd797f \
-            sha1    c42503a2ae0067b2238b2f3fefc86656baa4dd8e \
-            rmd160  d831b5b0370e88f752c454c4bb96c7bf2a240f10
+distname            libpthread-stubs-${version}
+use_bzip2           yes
 
-livecheck.type  regex
-livecheck.url   [lindex ${master_sites} 0]?C=M&O=D
-livecheck.regex libpthread-stubs-(\\d+(?:\\.\\d+)*)
+checksums           md5 48c1544854a94db0e51499cc3afd797f \
+                    rmd160 d831b5b0370e88f752c454c4bb96c7bf2a240f10 \
+                    sha256 e4d05911a3165d3b18321cc067fdd2f023f06436e391c6a28dff618a78d2e733
+
+livecheck.type      regex
+livecheck.url       [lindex ${master_sites} 0]?C=M&O=D
+livecheck.regex     libpthread-stubs-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
###### Description
Update to 0.4.  Not really any changes, in fact they removed the only C code in this package.  And Darwin didn't even need that C code.

###### Type(s)


###### Tested on
macOS 10.12.6 16G29
Xcode 9.0.1 9A1004

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
