### PR TITLE
py-thrift: add support for py35, py36, drop py26

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -169,6 +169,7 @@ py-spyder               2.3.7_1     33
 py-spyder-devel         2.3.4_1     33
 py-sqlite               2.6.3_1     26
 py-storm                0.18_1      26
+py-thrift               0.10.0_1    26
 py-threadpool           1.2.7_1     26
 py-tre                  0.8.0_2     26
 py-tweepy               1.12_1      26

--- a/python/py-thrift/Portfile
+++ b/python/py-thrift/Portfile
@@ -29,8 +29,8 @@ checksums       sha1   5c67fb6d2e01fa4ee02823a9c577f4d985f0ecfe \
                 rmd160 cf7d49bf4d39c980c7549088e947c12df4d1046d \
                 sha256 2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b
 
-python.versions 26 27
-python.default_version 27
+python.versions 27 35 36
+python.default_version 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:thrift


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
