### PR TITLE
libalkimia: force export of visible symbols

### DIFF
--- a/kde/libalkimia/Portfile
+++ b/kde/libalkimia/Portfile
@@ -40,3 +40,9 @@ checksums           md5     8d7b529c7be5f72ae1cbb02e818e9b79 \
                     rmd160  33b231fea22f6e64be5bec2accd4fc4aff3636ab
 
 depends_lib-append  port:kdelibs4
+
+# darwin17 (and later?) does not export visibile symbols
+# https://trac.macports.org/ticket/55090
+if { ${os.platform} eq "darwin" && ${os.major} >= 17 } {
+    configure.cxxflags-append -D__KDE_HAVE_GCC_VISIBILITY
+}


### PR DESCRIPTION
requires __KDE_HAVE_GCC_VISIBILITY to export
symbols on darwin17 (and later?)
closes: https://trac.macports.org/ticket/55090

###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

forcing this define works to fix the build on darwin17
```
$ port -v installed libalkimia
The following ports are currently installed:
  libalkimia @4.3.2_4 (active) platform='darwin 17' archs='x86_64' date='2017-10-27T22:39:17-0700'
```

I'm not clear as yet why this is needed on darwin17 but not earlier systems. Trying the build with clang-4.0 did not succeed without this defined.