### PR TITLE
nghttp2: change to cxx11 1.1 PortGroup

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cxx11 1.0
+PortGroup           cxx11 1.1
 PortGroup           github 1.0
 PortGroup           snowleopard_fixes 1.0
 


### PR DESCRIPTION
fixes build on older systems
closes: https://trac.macports.org/ticket/55190

```
$ port -v installed nghttp2
The following ports are currently installed:
  nghttp2 @1.26.0_0+python27 (active) platform='darwin 9' archs='ppc' date='2017-10-28T11:29:51-0700'
```