### PR TITLE
p11-kit: remove dependency on desktop-file-utils

### DIFF
--- a/security/p11-kit/Portfile
+++ b/security/p11-kit/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        p11-glue p11-kit 0.23.9
+revision            1
 license             Permissive
 description         Provides a way to load and enumerate PKCS#11 modules and a standard \
                     configuration setup for installing PKCS#11 modules in such a way that \
@@ -19,8 +20,7 @@ checksums           rmd160  d39b3f76d35aad67f07aa8728deb6179477f2bac \
 
 depends_build       port:pkgconfig
 
-depends_lib         port:desktop-file-utils \
-                    port:gettext \
+depends_lib         port:gettext \
                     port:libtasn1 \
                     port:libffi \
                     port:libxslt


### PR DESCRIPTION
This dependency has been present since the very beginning of this port,
however it does not seem to be used by upstream any longer.

I was not able to find any usages in the codebase, and the port is
building and working fine without desktop-file-utils installed.

---

Before merging I want to ask @dbevans: do you remember why `desktop-file-utils` was originally included in the list of dependencies? Just making sure I'm not missing anything. 