### PR TITLE
.travis.yml: remove xcode6.4 / OS X 10.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
     osx_image: xcode8.3
   - os: osx
     osx_image: xcode7.3
-  - os: osx
-    osx_image: xcode6.4
 env:
 - COLUMNS=78
 before_install:


### PR DESCRIPTION
###### Description
Travis CI now limits the concurrent macOS builds to a maximum of two, see https://blog.travis-ci.com/2017-09-22-macos-update.

Also `/usr/lib/libgcc_s.10.5.dylib` is missing on their 10.10 VMs, see https://github.com/macports/macports-ports/pull/677#issuecomment-323616011.

/cc @mojca @neverpanic