### PR TITLE
git: update to 2.15.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                git
-version             2.14.3
+version             2.15.0
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -22,11 +22,11 @@ distfiles           git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
 
 checksums           git-${version}${extract.suffix} \
-                    rmd160  f88e0b91da03e8475dbf5550bbc1d4b826d536cd \
-                    sha256  5330960dd52467f6e5bf1931b9fd42b76d3f8ce9bc75150b54ecfb57d407151d \
+                    rmd160  f31d9fc976ebf0bb65590835241225fdb6bd9ffb \
+                    sha256  107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  283aff62601c87d54c6b9072307df5e2a8654807 \
-                    sha256  5b0e3d93bafd539046b67778db0b5d627fe08ee5ef1be8b5b924517ed141b001
+                    rmd160  86059be2cac8343b599a2b77fbada240940c1d4b \
+                    sha256  22ad09441490f77bca781168fc66fd6576f0175407c5a95c1cdc96dfd3731c77
 
 perl5.require_variant   yes
 perl5.conflict_variants no
@@ -142,8 +142,8 @@ variant pcre {
 variant doc description {Install HTML and plaintext documentation} {
     distfiles-append        git-htmldocs-${version}${extract.suffix}
     checksums-append        git-htmldocs-${version}${extract.suffix} \
-                            rmd160  62eb9f20cedf85b3635177d29db43246807a6182 \
-                            sha256  9d28b922ad861bf747ca34a4f083efa3ce41ca39cccb0dfab8bdcf0b58694ccb
+                            rmd160  21a2961f43f821cf6c9b4c5f4ed5497568ac66e5 \
+                            sha256  79b2029855eeab2a01f38baeeabf6fbd222ea6de02457f0d5b9f2325cf96c514
 
     patchfiles-append       git-subtree.html.diff
 

--- a/devel/git/files/git-subtree.1.diff
+++ b/devel/git/files/git-subtree.1.diff
@@ -5,12 +5,12 @@
 +.\"     Title: git-subtree
 +.\"    Author: [see the "AUTHOR" section]
 +.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-+.\"      Date: 10/23/2017
++.\"      Date: 10/30/2017
 +.\"    Manual: Git Manual
-+.\"    Source: Git 2.14.3
++.\"    Source: Git 2.15.0
 +.\"  Language: English
 +.\"
-+.TH "GIT\-SUBTREE" "1" "10/23/2017" "Git 2\&.14\&.3" "Git Manual"
++.TH "GIT\-SUBTREE" "1" "10/30/2017" "Git 2\&.15\&.0" "Git Manual"
 +.\" -----------------------------------------------------------------
 +.\" * Define some portability stuff
 +.\" -----------------------------------------------------------------

--- a/devel/git/files/git-subtree.html.diff
+++ b/devel/git/files/git-subtree.html.diff
@@ -1201,7 +1201,7 @@
 +<div id="footnotes"><hr /></div>
 +<div id="footer">
 +<div id="footer-text">
-+Last updated 2017-10-23 06:03:35 UTC
++Last updated 2017-10-30 05:56:17 UTC
 +</div>
 +</div>
 +</body>

--- a/devel/git/files/patch-Makefile.diff
+++ b/devel/git/files/patch-Makefile.diff
@@ -1,6 +1,6 @@
---- a/Makefile.orig	2017-08-04 16:34:57.000000000 +0000
-+++ b/Makefile	2017-08-05 06:21:04.000000000 +0000
-@@ -1050,7 +1050,7 @@
+--- a/Makefile.orig
++++ b/Makefile
+@@ -1065,7 +1065,7 @@
  ifeq ($(COMPUTE_HEADER_DEPENDENCIES),auto)
  dep_check = $(shell $(CC) $(ALL_CFLAGS) \
  	-c -MF /dev/null -MQ /dev/null -MMD -MP \
@@ -9,7 +9,7 @@
  	echo $$?)
  ifeq ($(dep_check),0)
  override COMPUTE_HEADER_DEPENDENCIES = yes
-@@ -1118,7 +1118,7 @@
+@@ -1133,7 +1133,7 @@
  	ifdef NO_R_TO_GCC_LINKER
  		# Some gcc does not accept and pass -R to the linker to specify
  		# the runtime dynamic library path.


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.0.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
