### PR TITLE
Simplified octave-devel from hg TIP

### DIFF
--- a/math/octave-devel/Portfile
+++ b/math/octave-devel/Portfile
@@ -22,7 +22,7 @@ homepage            http://www.gnu.org/software/octave
 fetch.type          hg
 hg.url              http://hg.savannah.gnu.org/hgweb/octave/
 hg.tag              -1
-version             20171102
+version             4.3.0+_20171102
 
 
 
@@ -88,7 +88,7 @@ depends_build-append        port:bison
 configure.env-append        YACC="${prefix}/bin/bison -y"
 
 depends_build-append        port:gperf
-configure.env-append        GPERF=/usr/bin/gperf
+configure.env-append        GPERF=${prefix}/bin/gperf
 
 depends_build-append        port:perl5
 configure.perl              ${prefix}/bin/perl5
@@ -144,7 +144,7 @@ depends_run-append          port:pstoedit
 configure.env-append "ac_cv_func_mkostemp=no"
 
 # patch for GUI hang
-patchfiles                  octave-qt_wait_on_worker_thread-2017sep25.patch
+patchfiles                  octave-qt_wait_on_worker_thread-2017sep24.patch
 
 
 ########## Build commands
@@ -158,9 +158,7 @@ pre-configure {
     configure.args-append --with-blas="-L${prefix}/lib ${linalglib}" --with-lapack=""
 }
 
-configure.args-append       --disable-dependency-tracking           \
-                            --without-OSMesa                        \
-                            --disable-silent-rules                  \
+configure.args-append       --disable-silent-rules                  \
                             --enable-link-all-dependencies          \
                             --enable-shared                         \
                             --disable-static                        \

--- a/math/octave-devel/Portfile
+++ b/math/octave-devel/Portfile
@@ -144,7 +144,7 @@ depends_run-append          port:pstoedit
 configure.env-append "ac_cv_func_mkostemp=no"
 
 # patch for GUI hang
-patchfiles                  octave-qt_wait_on_worker_thread-2017sep24.patch
+patchfiles                  octave-qt_wait_on_worker_thread-2017sep25.patch
 
 
 ########## Build commands

--- a/math/octave-devel/Portfile
+++ b/math/octave-devel/Portfile
@@ -163,7 +163,7 @@ configure.args-append       --disable-silent-rules                  \
                             --enable-shared                         \
                             --disable-static                        \
                             --disable-docs                          \
-                            --without-OSMesa                        \
+                            --without-osmesa                        \
                             --with-framework-carbon                 \
                             --without-x                             \
                             --with-portaudio                        \

--- a/math/octave-devel/Portfile
+++ b/math/octave-devel/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem          1.0
 PortGroup           compilers  1.0
-PortGroup           muniversal 1.0
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           linear_algebra 1.0
-PortGroup           select     1.0
+PortGroup           cxx11 1.1
+PortGroup           qt4 1.0
 
 name                octave-devel
 categories          math science
@@ -13,241 +12,27 @@ platforms           darwin
 license             GPL-3+
 maintainers         mcalhoun openmaintainer
 description         a high-level language for numerical computations
-long_description    \
-    GNU Octave is a high-level language, primarily intended for numerical \
-    computations. It provides a convenient command-line interface for \
-    solving linear and nonlinear problems numerically.
+long_description    ${description}
 
 homepage            http://www.gnu.org/software/octave
 
-#fetch.type          hg
-#hg.url              http://hg.savannah.gnu.org/hgweb/octave/
 
-set version_release 4.0.3
-set version_rc      4.2.0-rc4
-set version_tip     4.2.0-rc4
+### Fetch tip of dev tree - change version to today's date
 
-if { ${name} eq ${subport} } {
-    version         ${version_tip}
-    revision        3
-    hg.tag          e078f5607762
+fetch.type          hg
+hg.url              http://hg.savannah.gnu.org/hgweb/octave/
+hg.tag              -1
+version             20171102
 
-    # see http://savannah.gnu.org/bugs/?48773
-    patchfiles-append \
-        patch-qscintilla2.diff
 
-    checksums-append               \
-        ${hg.tag}${extract.suffix} \
-        rmd160  e5d7103a820d9cd6362fb7e2f3c70a678f30c622 \
-        sha256  2d079ab1f89c90559ef94e6f7025501963f030b3ccc16f0b52607867105cd93b
 
-    livecheck.regex   "<a href=\"/hgweb/octave/rev/(\[a-zA-Z0-9.\]+)\">\ntip"
-}
-
-subport octave-devel-rc {
-    version         ${version_rc}
-    revision        4
-    hg.tag          69ac19073ae6
-
-    if {${version_rc} eq ${version_release}} {
-        conflicts-append octave-devel-release
-    }
-
-    # see http://savannah.gnu.org/bugs/?48773
-    patchfiles-append \
-        patch-qscintilla2.diff
-
-    checksums-append               \
-        ${hg.tag}${extract.suffix} \
-        rmd160  d5c405d684ea3d3a8114db1bf8a03a214112e77e \
-        sha256  f29857e2c642361ffc26519784468fda330c1c4dcc7eeb54e53ba0aa00412d8d
-
-    livecheck.regex   "<a href=\"/hgweb/octave/rev/(\[a-zA-Z0-9.\]+)\">\nrc-"
-}
-
-subport octave-devel-release {
-    version         ${version_release}
-    revision        4
-    hg.tag          00f7b278defd
-
-    if {${version_release} eq ${version_rc}} {
-        conflicts-append octave-devel-release
-    }
-
-    # see http://savannah.gnu.org/bugs/?func=detailitem&item_id=46592
-    patchfiles-append \
-        patch-e870a68742a6.diff
-
-    # see http://savannah.gnu.org/bugs/?41027
-    patchfiles-append   \
-        octave-bug_41027.patch
-
-    checksums-append               \
-        ${hg.tag}${extract.suffix} \
-        rmd160  3506df6b7c142448bddd50bdf4d47a8f593f7603 \
-        sha256  2409aca13faeff3afa0f25d8d39dad200fc49fdf69bec4fa004becefcf71f25a
-
-    livecheck.regex   "<a href=\"/hgweb/octave/rev/(\[a-zA-Z0-9.\]+)\">\nrelease-"
-}
-
-# Block compilers: Some older versions of CLANG do not honor the CPATH
-# environment variables, which is required for compiling this port
-# when using MacPorts.  The versions seem to be: MacPorts CLANG 2.9 or
-# earlier, and Apple CLANG 318.0.58 or older.
-#
-# See also < http://llvm.org/bugs/show_bug.cgi?id=8971 >
-#          < https://trac.macports.org/ticket/40250 >.
-compiler.blacklist-append { clang <= 318.0.61 }
-
-select.group octave
-select.file  ${filespath}/${subport}
-
-# see ${worksrcpath}/.hgsubstate to find revision of gnulib or gnulib-hg subrepository that should be used
-if { ${subport} eq "octave-devel-release" } {
-    set hg_gnu_tag      c2b547926f34
-
-    checksums-append \
-        ${hg_gnu_tag}${extract.suffix} \
-        rmd160  a1b1f6326862b2a4905de42a42ab85b21fe17499 \
-        sha256  4f1dc6ecc7e27891f317e064f789f305dd4d9ab2b4ca7a762c3ec8a8ec9777dd
-} elseif { ${subport} eq "octave-devel-rc" } {
-    set hg_gnu_tag      a05c0ede6620
-
-    checksums-append \
-        ${hg_gnu_tag}${extract.suffix} \
-        rmd160  07d7528f0cc77e0d5ab3dd4497fabebf7882295c \
-        sha256  1ecb78b45c9b6c72d4c3b36d120491b58e22dc3e44095255aec306c1a80db2c9
-} else {
-    # check http://hg.octave.org/gnulib for latest version
-    set hg_gnu_tag      a05c0ede6620
-
-    checksums-append \
-        ${hg_gnu_tag}${extract.suffix} \
-        rmd160  07d7528f0cc77e0d5ab3dd4497fabebf7882295c \
-        sha256  1ecb78b45c9b6c72d4c3b36d120491b58e22dc3e44095255aec306c1a80db2c9
-}
-
-master_sites        http://hg.savannah.gnu.org/hgweb/octave/archive:octave \
-                    http://hg.octave.org/gnulib/archive:gnulib \
-                    http://hg.savannah.gnu.org/hgweb/octave/gnulib-hg/archive:gnulib
-
-distfiles           \
-    ${hg.tag}${extract.suffix}:octave \
-    ${hg_gnu_tag}${extract.suffix}:gnulib
-
-worksrcdir          octave-${hg.tag}
-
-post-extract {
-    # mimic presence of mercurial subrepository
-    if { ${subport} eq "octave-devel-release" } {
-        move ${worksrcpath}/../gnulib-hg-${hg_gnu_tag} ${worksrcpath}/gnulib-hg
-    } else {
-        move ${worksrcpath}/../gnulib-${hg_gnu_tag} ${worksrcpath}/gnulib
-    }
-}
-
-pre-patch {
-    # code located in pre-patch because variants from PortGroup compilers must
-    #    be evaluated before it can be determined if clang is being used
-
-    # see http://trac.macports.org/ticket/45011
-    # see http://savannah.gnu.org/bugs/?43298
-    set libcxxbug no
-    if { ${configure.cc} eq "/usr/bin/clang" && [lindex [split ${xcodeversion} .] 0] eq 6 } {
-        set libcxxbug yes
-    } elseif { [variant_exists clang35] && [variant_isset clang35] } {
-        set libcxxbug yes
-    }
-    if { ${libcxxbug} } {
-        patchfiles-append   \
-            clang-libcxx-fix.patch
-    }
-
-    # see https://trac.macports.org/ticket/44704
-    set gl2psbug no
-    if { ${configure.cc} eq "/usr/bin/clang" && [vercmp ${xcodeversion} 5.0.0] < 0 } {
-        set gl2psbug yes
-    } elseif { [variant_exists clang33] && [variant_isset clang33] } {
-        set gl2psbug yes
-    }
-    if { ${gl2psbug} && ${subport} eq "octave-devel-release" } {
-        patchfiles-append   patch-gl2ps_renderer.diff
-    }
-}
-
-# need for autoconf
-depends_build-append \
-    port:autoconf    \
-    port:automake    \
-    port:libtool
-
-use_autoconf         yes
-autoconf.cmd         ./bootstrap
-if { ${subport} eq "octave-devel-release" } {
-    autoconf.args        --gnulib-srcdir=gnulib-hg --no-git
-} else {
-    autoconf.args        --gnulib-srcdir=gnulib    --no-git
-}
-
-# avoid depends_build-append port:coreutils
-configure.env-append MKDIR_P="/bin/mkdir -p"
-
-# avoid depends_build-append port:cctools
-configure.env-append RANLIB=/usr/bin/ranlib
-
-# workaround for build failure with Xcode8 (#52301)
-configure.env-append "ac_cv_func_mkostemp=no"
-
-# main octave port lists as a depends_lib
-# configure.ac list it among the "[p]rograms used in Makefiles"
-depends_build-append port:gawk
-configure.awk ${prefix}/bin/gawk
-
-# in configure.ac, said to be "[p]rograms used to generate icons file formats
-depends_build-append \
-    port:icoutils    \
-    port:librsvg
-configure.env-append              \
-    ICOTOOL=${prefix}/bin/icotool \
-    RSVG_CONVERT=${prefix}/bin/rsvg-convert
-
-# main octave port lists as a depends_lib
-# configure.ac list it among the "[p]rograms used in Makefiles"
-depends_build-append port:grep
-configure.env-append  GREP=${prefix}/bin/grep
-configure.env-append EGREP=${prefix}/bin/egrep
-configure.env-append FGREP=${prefix}/bin/fgrep
-
-# configure.ac list it among the "[p]rograms used in Makefiles"
-depends_build-append port:findutils
-configure.env-append FIND=${prefix}/bin/gfind
-
-# main octave port lists as a depends_lib
-# configure.ac list it among the "[p]rograms used in Makefiles"
-depends_build-append port:gsed
-configure.env-append SED=${prefix}/bin/gsed
-
-depends_build-append port:flex
-configure.env-append LEX=${prefix}/bin/flex
-
-depends_build-append port:bison
-configure.env-append YACC="${prefix}/bin/bison -y"
-
-depends_build-append port:gperf
-configure.env-append GPERF=/usr/bin/gperf
-
-# configure.ac list it among the "[p]rograms used in Makefiles"
-depends_build-append port:perl5
-configure.perl ${prefix}/bin/perl5
-
-# avoid depends_build-append port:desktop-file-utils
-#configure.env-append DESKTOP_FILE_INSTALL=""
-configure.env-append ac_cv_prog_DESKTOP_FILE_INSTALL=""
-
-depends_build-append \
-    port:pkgconfig
+######### Compiler Setup ###########
 
 compilers.choose    fc f77 f90 cc cxx
+
+# overrule cxx11 PortGroup because octave can use GCC compilers
+#    even if configure.cxx_stdlib is libc++
+compiler.blacklist-delete *gcc*
 
 # for now, limit the number of variants
 # some of these compilers may work fine
@@ -267,441 +52,126 @@ compilers.setup     \
     -clang34        \
     -clang33
 
-# help prevent conflicts with various octave ports
-configure.args-append \
-    --infodir=${prefix}/share/info/octave_${version}
 
-# offscreen rendering with OpenGL via osmesa would be nice to have, but the following
-#    causes a segmentation fault:
-#    h = figure ("visible", "off"); fn = tempname (); sombrero (); __osmesa_print__ (h, fn, "svg");
-#
-# solution is ???
-#
-#depends_lib-append port:mesa
-configure.args-append       \
-    --without-OSMesa
 
-#configure.args-append --with-shell=???
 
-configure.args-append       \
-    --with-framework-carbon \
-    --without-x             \
-    --enable-static
+######### Build Deps #####
 
-configure.args-append       \
-    --disable-openmp
+depends_build-append        port:autoconf    \
+                            port:automake    \
+                            port:libtool     \
+                            port:coreutils   \
+                            port:cctools     \
+                            port:desktop-file-utils
 
-configure.args-append       \
-    --disable-java          \
-    --without-fltk          \
-    --without-opengl        \
-    --disable-jit           \
-    --without-sndfile       \
-    --without-portaudio     \
-    --without-magick        \
-    --disable-docs
+depends_build-append        port:icoutils
+configure.env-append        ICOTOOL=${prefix}/bin/icotool
 
-if { ${subport} eq "octave-devel-release" } {
-    configure.args-append       \
-        --disable-gui
-} else {
-    configure.args-append       \
-        --without-qt
-}
+depends_build-append        port:librsvg
+configure.env-append        RSVG_CONVERT=${prefix}/bin/rsvg-convert
 
-# in configure.ac, listed as one of "[p]rograms used when running Octave"
-depends_lib-append port:python27
-configure.python ${prefix}/bin/python2.7
+depends_build-append        port:grep
+configure.env-append        GREP=${prefix}/bin/grep
+configure.env-append        EGREP=${prefix}/bin/egrep
+configure.env-append        FGREP=${prefix}/bin/fgrep
 
-# in configure.ac, listed as one of "[p]rograms used when running Octave"
-depends_lib-append port:ghostscript
-configure.env-append GHOSTSCRIPT=${prefix}/bin/gs
+depends_build-append        port:findutils
+configure.env-append        FIND=${prefix}/bin/gfind
 
-# in configure.ac, listed as one of "[p]rograms used when running Octave"
-depends_lib-append port:gnuplot
-configure.env-append GNUPLOT=${prefix}/bin/gnuplot
+depends_build-append        port:gsed
+configure.env-append        SED=${prefix}/bin/gsed
 
-# in configure.ac, listed as one of "[p]rograms used when running Octave"
-depends_lib-append port:less
-configure.env-append DEFAULT_PAGER=${prefix}/bin/less
+depends_build-append        port:flex
+configure.env-append        LEX=${prefix}/bin/flex
 
-depends_lib-append   port:ncurses
-depends_lib-append   port:readline
-depends_lib-append   port:pcre
+depends_build-append        port:bison
+configure.env-append        YACC="${prefix}/bin/bison -y"
 
-#--without-amd
-#--without-camd
-#--without-colamd
-#--without-cholmod
-#--without-cxsparse
-#--without-umfpack
-depends_lib-append  port:SuiteSparse
-foreach lib {amd camd colamd cholmod cxsparse umfpack} {
-    configure.args-append \
-        --with-${lib}="-l${lib} -lsuitesparseconfig"
-}
+depends_build-append        port:gperf
+configure.env-append        GPERF=/usr/bin/gperf
 
-#--without-qhull
-depends_lib-append  port:qhull
+depends_build-append        port:perl5
+configure.perl              ${prefix}/bin/perl5
 
-#--without-z
-depends_lib-append  port:zlib
-if { ${subport} eq "octave-devel-release" } {
-    patchfiles-append patch-libinterp-Makefile.in.diff
-}
+depends_build-append        port:gawk
+configure.awk               ${prefix}/bin/gawk
 
-#--without-hdf5
-if { ${name} eq ${subport} } {
-    # see #51080
-    # see http://savannah.gnu.org/bugs/?47858 for upstream report
-    depends_lib-append  port:hdf5-18
-    configure.args-append \
-        --with-hdf5-libdir=${prefix}/lib/hdf5-18/lib \
-        --with-hdf5-includedir=${prefix}/lib/hdf5-18/include
-} else {
-    depends_lib-append  port:hdf5
-}
 
-#--disable-fftw-threads
-#--without-fftw3
-#--without-fftw3f
-depends_lib-append  port:fftw-3
-depends_lib-append  port:fftw-3-single
 
-#--without-glpk
-depends_lib-append  port:glpk
 
-#--without-curl
-depends_lib-append  port:curl
+######### Lib Deps #####
 
-#--without-qrupdate
-depends_lib-append port:qrupdate
 
-#--without-arpack
-depends_lib-append port:arpack
+depends_lib-append          port:python27
+configure.python            ${prefix}/bin/python2.7
 
-#--without-openssl
-depends_lib-append port:openssl
+depends_lib-append          port:ghostscript
+configure.env-append        GHOSTSCRIPT=${prefix}/bin/gs
 
-# fortran arch flag is not set automatically
-if {![variant_isset universal]} {
-    if {${build_arch} eq "x86_64" || ${build_arch} eq "ppc64"} {
-        configure.fflags-append -m64
-    } else {
-        configure.fflags-append -m32
-    }
-}
+depends_lib-append          port:gnuplot
+configure.env-append        GNUPLOT=${prefix}/bin/gnuplot
 
-# see etc/README.MacOS
-depends_run-append   \
-    port:epstool     \
-    port:ghostscript \
-    port:fig2dev    \
-    port:pstoedit
+depends_lib-append          port:less
+configure.env-append        DEFAULT_PAGER=${prefix}/bin/less
 
-depends_run-append port:octave_select
+depends_lib-append          port:qscintilla
+depends_lib-append          port:ncurses
+depends_lib-append          port:readline
+depends_lib-append          port:pcre
+depends_lib-append          port:hdf5
+depends_lib-append          port:fftw-3
+depends_lib-append          port:fftw-3-single
+depends_lib-append          port:glpk
+depends_lib-append          port:curl
+depends_lib-append          port:qrupdate
+depends_lib-append          port:arpack
+depends_lib-append          port:openssl
+depends_lib-append          port:sundials
 
+
+
+######### Run Deps #####
+
+
+depends_run-append          port:epstool
+depends_run-append          port:fig2dev
+depends_run-append          port:pstoedit
+
+
+########## Hacks
+
+# workaround for build failure with Xcode8 (#52301)
+configure.env-append "ac_cv_func_mkostemp=no"
+
+# patch for GUI hang
+patchfiles                  octave-qt_wait_on_worker_thread-2017sep25.patch
+
+
+########## Build commands
+
+use_autoconf                yes
+autoconf.cmd                ./bootstrap
+autoconf.args
+
+# has to be like this for linear algrebra PG to work
 pre-configure {
     configure.args-append --with-blas="-L${prefix}/lib ${linalglib}" --with-lapack=""
 }
 
-variant java description {enable Java interface} {
-    PortGroup java 1.0
-    configure.args-replace --disable-java --enable-java
-}
-# java variant seems to cause problems for both users and build bots
-#    https://lists.macosforge.org/pipermail/macports-users/2016-May/thread.html#41052
-#    #51480
-#default_variants-append +java
+configure.args-append       --disable-dependency-tracking           \
+                            --without-OSMesa                        \
+                            --disable-silent-rules                  \
+                            --enable-link-all-dependencies          \
+                            --enable-shared                         \
+                            --disable-static                        \
+                            --disable-docs                          \
+                            --without-OSMesa                        \
+                            --with-framework-carbon                 \
+                            --without-x                             \
+                            --with-portaudio                        \
+                            --with-sndfile                          \
+                            --disable-java                          \
+                            --with-qt=4
 
-variant qt4 conflicts qt5 description {build the GUI using Qt4} {
-    PortGroup qt4 1.0
-
-    depends_lib-append  port:qscintilla
-
-    if { ${subport} eq "octave-devel-release" } {
-        configure.args-replace --disable-gui --enable-gui
-    } else {
-        configure.args-replace --without-qt --with-qt=4
-    }
-}
-
-if { ${subport} ne "octave-devel-release" } {
-    variant qt5 conflicts qt4 description {build the GUI using Qt5} {
-        PortGroup qt5 1.0
-
-        depends_lib-append port:qscintilla2
-
-        # see http://savannah.gnu.org/bugs/?41027
-        patchfiles-append   \
-            patch-iconsize.diff
-
-        # location of libqscintilla2.dylib
-        configure.ldflags-append \
-            -L${qt_libs_dir}
-
-        configure.args-replace --without-qt --with-qt=5
-
-        configure.env-append PATH=${qt_dir}/bin:$env(PATH)
-        build.env-append     PATH=${qt_dir}/bin:$env(PATH)
-    }
-    if { ![variant_isset qt4] && ![variant_isset qt5] } {
-        default_variants-append +qt5
-    }
-} else {
-    default_variants-append +qt4
-}
-
-variant fltk description {enable fltk as a graphics toolkit for plotting} {
-    depends_lib-append path:lib/libfltk.dylib:fltk
-
-    configure.args-replace --without-fltk --with-fltk
-}
-default_variants-append +fltk
-
-if {[variant_isset fltk] || [variant_isset qt4] || [variant_isset qt5]} {
-
-    # native_graphics (fltk) and gui (Qt) require OpenGL and font and printing capabilities
-    depends_lib-append  \
-        port:fontconfig \
-        port:freetype   \
-        port:gl2ps
-
-    configure.args-replace --without-opengl --with-framework-opengl
-}
-
-if { ([variant_isset fltk] && [variant_isset qt4]) || ([variant_isset fltk] && [variant_isset qt5]) } {
-    notes-append "unless octave is run with --no-gui-libs, graphics_toolkit(\"fltk\") will cause a crash"
-}
-
-variant jit description {enable JIT compiler (EXPERIMENTAL)} {
-    # JIT requires LLVM, so select a version to use
-    set llvm_ver 3.8
-
-    # prevent multiple versions of llvm being required
-    # if clangXY compiler is requested, use llvm-X.Y
-    foreach clang ${compilers.clang_variants} {
-        if { [variant_exists ${clang}] && [variant_isset ${clang}] } {
-            set llvm_ver [string index ${clang} end-1].[string index ${clang} end]
-        }
-    }
-
-    depends_lib-append port:llvm-${llvm_ver}
-    configure.args-replace --disable-jit --enable-jit
-    configure.env-append LLVM_CONFIG=${prefix}/bin/llvm-config-mp-${llvm_ver}
-    configure.cxxflags-append -std=c++11
-}
-
-variant sound description {enable audio support (file I/O and playback)} {
-    depends_lib-append port:libsndfile
-    depends_lib-append port:portaudio
-
-    configure.args-replace --without-sndfile   --with-sndfile
-    configure.args-replace --without-portaudio --with-portaudio
-}
-default_variants-append +sound
-
-variant app description "build application bundle to launch ${subport}" {
-    depends_build-append port:librsvg
-
-    if {[vercmp ${xcodeversion} 4.5] < 0} {
-        # need a way to generate icns file for XCode prior to 4.5
-        # see #51487
-        depends_build-append port:libicns
-    }
-
-    global appName
-    set appName Octave_${version}.app
-
-    post-build {
-        xinstall -d -m 0755 ${worksrcpath}/${appName}/Contents
-        xinstall -d -m 0755 ${worksrcpath}/${appName}/Contents/Resources
-        xinstall -d -m 0755 ${worksrcpath}/${appName}/Contents/MacOS
-
-        set script [open "${worksrcpath}/${appName}/Contents/MacOS/Octave" w 0755]
-        if { [variant_isset qt4] || [variant_isset qt5] } {
-            puts ${script} "#!/bin/sh"
-            puts ${script} ""
-            puts ${script} "${prefix}/bin/octave-${version} --force-gui"
-        } else {
-            puts ${script} "#!/usr/bin/osascript"
-            puts ${script} ""
-            puts ${script} "tell application \"Terminal\" to do script \"${prefix}/bin/octave-${version} --no-gui-libs; exit\""
-        }
-        close ${script}
-
-        #NSHumanReadableCopyright      ''
-        #LSUIElement                   1
-        set values "
-            CFBundleDevelopmentRegion                         string  English
-            CFBundleExecutable                                string  Octave
-            CFBundleIconFile                                  string  Octave.icns
-            CFBundleIdentifier                                string  org.octave.Octave
-            CFBundleInfoDictionaryVersion                     string  6.0
-            CFBundleSignature                                 string  Octave
-            CFBundleVersion                                   string  ${version}
-            CFBundleShortVersionString                        string  ${version}
-            CFBundleDocumentTypes                             array   {}
-            CFBundleDocumentTypes:                            dict    {}
-            CFBundleDocumentTypes:0:CFBundleTypeRole          string  \"Editor\"
-            CFBundleDocumentTypes:0:CFBundleTypeExtensions    array   {}
-            CFBundleDocumentTypes:0:CFBundleTypeExtensions:   string  \"m\"
-            CFBundleDocumentTypes:0:CFBundleTypeOSTypes       array   {}
-            CFBundleDocumentTypes:0:CFBundleTypeOSTypes:      string  \"Mfile\"
-        "
-
-        foreach {key type value} ${values} {
-            system -W "${worksrcpath}/${appName}/Contents" "/usr/libexec/PlistBuddy -c \"Add :${key} ${type} ${value}\" Info.plist"
-        }
-
-        # have Info.plist be human readable
-        system "/usr/bin/plutil -convert xml1 ${worksrcpath}/${appName}/Contents/Info.plist"
-
-        # conversion by plutil set verys limited permissions
-        system "/bin/chmod 0644 ${worksrcpath}/${appName}/Contents/Info.plist"
-
-        xinstall -d -m 0755 ${worksrcpath}/Octave.iconset
-
-        # values from original SVG file
-        set svg    etc/icons/octave-logo.svg
-        set width  283.28912
-        set height 283.28833
-        set dpi    90
-
-        foreach res {16 32 128 256 512} {
-
-            set hres [expr 2*${res}]
-
-            # see http://savannah.gnu.org/bugs/?37062
-            # see http://hg.savannah.gnu.org/hgweb/octave/rev/1687269e31e4
-            system -W ${worksrcpath} "${prefix}/bin/rsvg-convert -w ${res} ${svg}  > Octave.iconset/icon_${res}x${res}.png"
-            system -W ${worksrcpath} "${prefix}/bin/rsvg-convert -w ${hres} ${svg} > Octave.iconset/icon_${res}x${res}@2x.png"
-        }
-
-        if {[vercmp ${xcodeversion} 4.5] >= 0} {
-            system -W ${worksrcpath} "/usr/bin/iconutil -c icns -o ${appName}/Contents/Resources/Octave.icns Octave.iconset"
-        } else {
-            # /usr/bin/iconutil introduced in XCode 4.5
-            # see #51487
-            system -W ${worksrcpath}/Octave.iconset \
-                "${prefix}/bin/png2icns ${worksrcpath}/${appName}/Contents/Resources/Octave.icns icon_16x16.png icon_32x32.png icon_128x128.png icon_256x256.png icon_512x512.png"
-        }
-    }
-
-    post-destroot {
-        copy ${worksrcpath}/${appName} ${destroot}${applications_dir}
-    }
-}
-default_variants-append +app
-
-variant docs description {build documentation files} {
-    depends_build-append port:texinfo
-    configure.env-append                \
-        MAKEINFO=${prefix}/bin/makeinfo \
-        TEXI2DVI=${prefix}/bin/texi2dvi \
-        TEXI2PDF=${prefix}/bin/texi2pdf
-
-    # see https://lists.macosforge.org/pipermail/macports-dev/2016-January/032293.html
-    depends_build-append \
-        port:texlive-basic \
-        port:texlive-latex
-
-    # see #51132
-    depends_build-append \
-        port:texlive-fonts-recommended
-
-    configure.args-replace --disable-docs --enable-docs
-}
-default_variants-append +docs
-
-# GraphicsMagick and octave need to be built with the same C++ standard library
-# or else undefined symbols:
-#    "Magick::Image::ping(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)"
-set magickConflict {}
-set magickDefault yes
-if {${configure.cxx_stdlib} ne "libstdc++"} {
-    foreach gccVar ${compilers.gcc_variants} {
-        if {[variant_exists ${gccVar}] } {
-            lappend magickConflict ${gccVar}
-
-            if {[variant_isset ${gccVar}] } {
-                set magickDefault no
-            }
-        }
-    }
-}
-eval "variant graphicsmagick description {use GraphicsMagick for image I/O} conflicts ${magickConflict} {
-    depends_lib-append port:GraphicsMagick
-    configure.args-replace --without-magick --with-magick=GraphicsMagick
-}"
-if {${magickDefault}} {
-    default_variants-append +graphicsmagick
-}
-
-if { ${subport} eq "octave-devel-release" } {
-    # remove architecture flags from header file
-    if { [variant_exists universal] && [variant_isset universal] } {
-        merger-post-destroot {
-            foreach arch ${universal_archs_to_use} {
-                set hfile ${destroot}-${arch}${prefix}/include/octave-${version}/octave/oct-conf.h
-                reinplace -E "s:\\w*-arch ${arch}::g" ${hfile}
-                reinplace -E {s:\\w*-m32::g}          ${hfile}
-                reinplace -E {s:\\w*-m64::g}          ${hfile}
-            }
-        }
-    } else {
-        post-destroot {
-            set hfile ${destroot}${prefix}/include/octave-${version}/octave/oct-conf.h
-            reinplace -E "s:\\w*-arch ${build_arch}::g" ${hfile}
-            reinplace -E {s:\\w*-m32::g}                ${hfile}
-            reinplace -E {s:\\w*-m64::g}                ${hfile}
-        }
-    }
-}
-
-# remove or rename conflicting files
-post-destroot {
-    foreach bin {mkoctfile octave octave-cli octave-config} {
-        # delete since just a link to versioned name
-        file delete ${destroot}${prefix}/bin/${bin}
-
-        if { [variant_isset docs] } {
-            # put version number in man file to avoid conflict
-            move ${destroot}${prefix}/share/man/man1/${bin}.1 ${destroot}${prefix}/share/man/man1/${bin}-${version}.1
-        }
-    }
-
-    # put any startup commands in ${destroot}${prefix}/share/octave/${version}/m/startup/octaverc
-    # see https://www.gnu.org/software/octave/doc/interpreter/Startup-Files.html
-    file delete ${destroot}${prefix}/share/octave/site/m/startup/octaverc
-
-    # move appdata and icons into a versioned directory
-    xinstall -d -m 0755 ${destroot}${prefix}/share/octave/${version}/appdata
-    move \
-        ${destroot}${prefix}/share/appdata/www.octave.org-octave.appdata.xml \
-        ${destroot}${prefix}/share/octave/${version}/appdata/
-    foreach num {16 22 24 32 48 64 128 256 512} {
-        xinstall -d -m 0755 ${destroot}${prefix}/share/octave/${version}/icons/hicolor/${num}x${num}/apps
-        move \
-            ${destroot}${prefix}/share/icons/hicolor/${num}x${num}/apps/octave.png \
-            ${destroot}${prefix}/share/octave/${version}/icons/hicolor/${num}x${num}/apps/octave.png
-    }
-    xinstall -d -m 0755 ${destroot}${prefix}/share/octave/${version}/icons/hicolor/scalable/apps
-    move \
-        ${destroot}${prefix}/share/icons/hicolor/scalable/apps/octave.svg \
-        ${destroot}${prefix}/share/octave/${version}/icons/hicolor/scalable/apps/octave.svg
-
-    if {[file exists ${worksrcpath}/liboctave/operators/libcxx-fix.h]} {
-        # install the libc++ fix, no matter if used or not, since it is
-        # required for projects including these headers.
-        xinstall -m 644 ${worksrcpath}/liboctave/operators/libcxx-fix.h \
-            ${destroot}${prefix}/include/${name}-${version}/${name}/libcxx-fix.h
-    }
-}
-
-test.run    yes
-test.target check
-
-livecheck.type    regexm
-livecheck.url     http://hg.savannah.gnu.org/hgweb/octave/tags
-livecheck.version ${hg.tag}
+                            
+                            

--- a/math/octave-devel/Portfile
+++ b/math/octave-devel/Portfile
@@ -171,5 +171,97 @@ configure.args-append       --disable-silent-rules                  \
                             --disable-java                          \
                             --with-qt=4
 
-                            
+variant app description "build application bundle to launch octave-devel" {
+    depends_build-append port:librsvg
+
+    if {[vercmp ${xcodeversion} 4.5] < 0} {
+        # need a way to generate icns file for XCode prior to 4.5
+        # see #51487
+        depends_build-append port:libicns
+    }
+
+    global appName
+    set appName Octave_${version}.app
+
+    post-build {
+        xinstall -d -m 0755 ${worksrcpath}/${appName}/Contents
+        xinstall -d -m 0755 ${worksrcpath}/${appName}/Contents/Resources
+        xinstall -d -m 0755 ${worksrcpath}/${appName}/Contents/MacOS
+
+        set script [open "${worksrcpath}/${appName}/Contents/MacOS/Octave" w 0755]
+        if { [variant_isset qt4] || [variant_isset qt5] } {
+            puts ${script} "#!/bin/sh"
+            puts ${script} ""
+            puts ${script} "${prefix}/bin/octave-${version} --force-gui"
+        } else {
+            puts ${script} "#!/usr/bin/osascript"
+            puts ${script} ""
+            puts ${script} "tell application \"Terminal\" to do script \"${prefix}/bin/octave-${version} --no-gui-libs; exit\""
+        }
+        close ${script}
+
+        #NSHumanReadableCopyright      ''
+        #LSUIElement                   1
+        set values "
+            CFBundleDevelopmentRegion                         string  English
+            CFBundleExecutable                                string  Octave
+            CFBundleIconFile                                  string  Octave.icns
+            CFBundleIdentifier                                string  org.octave.Octave
+            CFBundleInfoDictionaryVersion                     string  6.0
+            CFBundleSignature                                 string  Octave
+            CFBundleVersion                                   string  ${version}
+            CFBundleShortVersionString                        string  ${version}
+            CFBundleDocumentTypes                             array   {}
+            CFBundleDocumentTypes:                            dict    {}
+            CFBundleDocumentTypes:0:CFBundleTypeRole          string  \"Editor\"
+            CFBundleDocumentTypes:0:CFBundleTypeExtensions    array   {}
+            CFBundleDocumentTypes:0:CFBundleTypeExtensions:   string  \"m\"
+            CFBundleDocumentTypes:0:CFBundleTypeOSTypes       array   {}
+            CFBundleDocumentTypes:0:CFBundleTypeOSTypes:      string  \"Mfile\"
+        "
+
+        foreach {key type value} ${values} {
+            system -W "${worksrcpath}/${appName}/Contents" "/usr/libexec/PlistBuddy -c \"Add :${key} ${type} ${value}\" Info.plist"
+        }
+
+        # have Info.plist be human readable
+        system "/usr/bin/plutil -convert xml1 ${worksrcpath}/${appName}/Contents/Info.plist"
+
+        # conversion by plutil set verys limited permissions
+        system "/bin/chmod 0644 ${worksrcpath}/${appName}/Contents/Info.plist"
+
+        xinstall -d -m 0755 ${worksrcpath}/Octave.iconset
+
+        # values from original SVG file
+        set svg    etc/icons/octave-logo.svg
+        set width  283.28912
+        set height 283.28833
+        set dpi    90
+
+        foreach res {16 32 128 256 512} {
+
+            set hres [expr 2*${res}]
+
+            # see http://savannah.gnu.org/bugs/?37062
+            # see http://hg.savannah.gnu.org/hgweb/octave/rev/1687269e31e4
+            system -W ${worksrcpath} "${prefix}/bin/rsvg-convert -w ${res} ${svg}  > Octave.iconset/icon_${res}x${res}.png"
+            system -W ${worksrcpath} "${prefix}/bin/rsvg-convert -w ${hres} ${svg} > Octave.iconset/icon_${res}x${res}@2x.png"
+        }
+
+        if {[vercmp ${xcodeversion} 4.5] >= 0} {
+            system -W ${worksrcpath} "/usr/bin/iconutil -c icns -o ${appName}/Contents/Resources/Octave.icns Octave.iconset"
+        } else {
+            # /usr/bin/iconutil introduced in XCode 4.5
+            # see #51487
+            system -W ${worksrcpath}/Octave.iconset \
+                "${prefix}/bin/png2icns ${worksrcpath}/${appName}/Contents/Resources/Octave.icns icon_16x16.png icon_32x32.png icon_128x128.png icon_256x256.png icon_512x512.png"
+        }
+    }
+
+    post-destroot {
+        copy ${worksrcpath}/${appName} ${destroot}${applications_dir}
+    }
+}
+default_variants-append +app
+
                             

--- a/math/octave-devel/files/octave-qt_wait_on_worker_thread-2017sep24.patch
+++ b/math/octave-devel/files/octave-qt_wait_on_worker_thread-2017sep24.patch
@@ -1,0 +1,37 @@
+exporting patch:
+# HG changeset patch
+# User Daniel J Sebald <daniel.sebald@ieee.org>
+# Date 1506287098 18000
+#      Sun Sep 24 16:04:58 2017 -0500
+# Node ID fbbbbddc5dd836c35f9dad704062de8eb4328837
+# Parent  1265c7f0119a75356f1b4950e9a2f8ec819d81bc
+Move worker thread shutdown to main window handling finish (bug #50025)
+
+* main-window.cc (main_window::main_window): Remove octave_finished_signal()
+  connection from m_interpreter--which runs in m_main_thread--to
+  m_main_thread's quit().
+  (main_window::handle_octave_finished): Quit and wait on the worker thread.
+
+diff --git a/libgui/src/main-window.cc b/libgui/src/main-window.cc
+--- a/libgui/src/main-window.cc
++++ b/libgui/src/main-window.cc
+@@ -217,9 +217,6 @@ main_window::main_window (QWidget *p, oc
+   connect (m_interpreter, SIGNAL (octave_finished_signal (int)),
+            this, SLOT (handle_octave_finished (int)));
+ 
+-  connect (m_interpreter, SIGNAL (octave_finished_signal (int)),
+-           m_main_thread, SLOT (quit (void)));
+-
+   connect (m_main_thread, SIGNAL (finished (void)),
+            m_main_thread, SLOT (deleteLater (void)));
+ 
+@@ -1579,6 +1576,9 @@ main_window::handle_octave_ready (void)
+ void
+ main_window::handle_octave_finished (int exit_status)
+ {
++  m_main_thread->quit();
++  m_main_thread->wait();
++
+   qApp->exit (exit_status);
+ }
+ 

--- a/math/octave-devel/files/octave-qt_wait_on_worker_thread-2017sep24.patch
+++ b/math/octave-devel/files/octave-qt_wait_on_worker_thread-2017sep24.patch
@@ -12,9 +12,9 @@ Move worker thread shutdown to main window handling finish (bug #50025)
   m_main_thread's quit().
   (main_window::handle_octave_finished): Quit and wait on the worker thread.
 
-diff --git a/libgui/src/main-window.cc b/libgui/src/main-window.cc
---- a/libgui/src/main-window.cc
-+++ b/libgui/src/main-window.cc
+diff --git libgui/src/main-window.cc b/libgui/src/main-window.cc
+--- libgui/src/main-window.cc
++++ libgui/src/main-window.cc
 @@ -217,9 +217,6 @@ main_window::main_window (QWidget *p, oc
    connect (m_interpreter, SIGNAL (octave_finished_signal (int)),
             this, SLOT (handle_octave_finished (int)));

--- a/math/octave-devel/files/octave-qt_wait_on_worker_thread-2017sep25.patch
+++ b/math/octave-devel/files/octave-qt_wait_on_worker_thread-2017sep25.patch
@@ -1,0 +1,43 @@
+exporting patch:
+# HG changeset patch
+# User Daniel J Sebald <daniel.sebald@ieee.org>
+# Date 1506353400 18000
+#      Mon Sep 25 10:30:00 2017 -0500
+# Node ID f3c4a7256d65d42baab6bc77dd51a8c0fb12eb06
+# Parent  1265c7f0119a75356f1b4950e9a2f8ec819d81bc
+Move worker thread shutdown to main window handling finish (bug #50025)
+
+* main-window.cc (main_window::main_window): Remove octave_finished_signal()
+  connection from m_interpreter--which runs in m_main_thread--to
+  m_main_thread's quit().
+  (main_window::handle_octave_finished): Quit and wait on the worker thread.
+  Put some fprintfs in the code for debugging assistance.
+
+diff --git a/libgui/src/main-window.cc b/libgui/src/main-window.cc
+--- libgui/src/main-window.cc
++++ libgui/src/main-window.cc
+@@ -217,9 +217,6 @@ main_window::main_window (QWidget *p, oc
+   connect (m_interpreter, SIGNAL (octave_finished_signal (int)),
+            this, SLOT (handle_octave_finished (int)));
+ 
+-  connect (m_interpreter, SIGNAL (octave_finished_signal (int)),
+-           m_main_thread, SLOT (quit (void)));
+-
+   connect (m_main_thread, SIGNAL (finished (void)),
+            m_main_thread, SLOT (deleteLater (void)));
+ 
+@@ -1579,7 +1576,14 @@ main_window::handle_octave_ready (void)
+ void
+ main_window::handle_octave_finished (int exit_status)
+ {
++fprintf(stderr, "HANDLE_OCTAVE_FINISHED: 111111111111111111111111111111111111111111\n");
++  m_main_thread->quit();
++fprintf(stderr, "HANDLE_OCTAVE_FINISHED: 222222222222222222222222222222222222222222\n");
++  m_main_thread->wait();
++fprintf(stderr, "HANDLE_OCTAVE_FINISHED: 333333333333333333333333333333333333333333\n");
++
+   qApp->exit (exit_status);
++fprintf(stderr, "HANDLE_OCTAVE_FINISHED: 444444444444444444444444444444444444444444\n");
+ }
+ 
+ void


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 9.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

Based on a discussion on macports-devel regarding the state of octave, i.e. that there is no working build from the octave mercurial repository. Some additional features probably should be added back in, e.g.:

- qt5 variant
- doc variant
- java variant
- launcher app