### PR TITLE
py-pew: new port

### DIFF
--- a/python/py-pew/Portfile
+++ b/python/py-pew/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        berdario pew 1.1.5
+github.tarball_from releases
+name                py-${github.project}
+
+master_sites        ${github.homepage}/archive/
+distname            ${github.version}
+worksrcdir          ${github.project}-${github.version}
+
+categories          python
+platforms           darwin
+license             MIT
+
+python.versions     35 36
+
+maintainers         openmaintainer {gmail.com:esafak @esafak}
+description         A tool to manage multiple virtual environments written in pure python
+long_description    $description
+checksums           rmd160 4a132a0f5c552cf76122d432c057a0c294ad6cd5 \
+                    sha256 24b0fe0305a293acf4cc95136e73a313b4a749c5aa5ae2a56b4e384224b2381e
+use_zip             yes
+
+test.run            yes
+
+if {${name} ne ${subport}} {
+    depends_lib-append      port:py${python.version}-virtualenv-clone \
+                            port:py${python.version}-virtualenv \
+                            port:py${python.version}-setuptools
+    livecheck.type  none
+}


### PR DESCRIPTION
###### Description

A tool to manage multiple virtual environments written in pure python

###### Tested on
macOS 10.12.6
Xcode 9.1

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?