### PR TITLE
woff2: new port

### DIFF
--- a/print/woff2/Portfile
+++ b/print/woff2/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        google woff2 1.0.1 v
+categories          print www
+platforms           darwin
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+license             MIT
+
+description         A set of tools for converting ttf fonts to/from woff2
+
+long_description    ${description}
+
+checksums           rmd160  edd83368e079b1c521afdaae23ff1aa79bcdd667 \
+                    sha256  9ccafa54162af64c46b2b48b9ae29997d8552d3fead671995c7d725178cfe69d
+
+depends_lib         port:brotli
+
+patchfiles          6859cef2674bf44384dd5ec6eac69d741698d58a.patch
+patch.pre_args      -p1
+
+configure.pre_args-append -DINSTALL_TOOLS=ON

--- a/print/woff2/files/6859cef2674bf44384dd5ec6eac69d741698d58a.patch
+++ b/print/woff2/files/6859cef2674bf44384dd5ec6eac69d741698d58a.patch
@@ -1,0 +1,33 @@
+From 6859cef2674bf44384dd5ec6eac69d741698d58a Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Wed, 25 Oct 2017 14:47:16 +0300
+Subject: [PATCH] cmake: Introduce a INSTALL_TOOLS build option
+
+Packagers and distributors which use the CMake-based build system may
+want to install the woff2_{decompress,compress,info} tools as well when
+building shared libraries. Using "cmake -DINSTALL_TOOLS=ON" allows that.
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68d1c62..619dc20 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,7 @@ include(GNUInstallDirs)
+ 
+ # Build options
+ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
++option(INSTALL_TOOLS "Install tools when building shared libraries" OFF)
+ option(CANONICAL_PREFIXES "Canonical prefixes" OFF)
+ option(NOISY_LOGGING "Noisy logging" ON)
+ 
+@@ -260,7 +261,7 @@ generate_pkg_config ("${CMAKE_CURRENT_BINARY_DIR}/libwoff2enc.pc"
+   LIBRARIES woff2enc)
+ 
+ # Installation
+-if (NOT BUILD_SHARED_LIBS)
++if (NOT BUILD_SHARED_LIBS OR INSTALL_TOOLS)
+   install(
+     TARGETS woff2_decompress woff2_compress woff2_info
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"


### PR DESCRIPTION
###### Description
This is a library and set of tools for working with woff2 fonts:
https://github.com/google/woff2

The included patch allows installing the binaries along with the shared libs, and was taken from this PR:
https://github.com/google/woff2/pull/101

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
