### PR TITLE
gnupg2: Enable TLS support, TOFU support

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 set my_name         gnupg
 name                ${my_name}2
 version             2.2.1
+revision            1
 categories          mail security
 maintainers         {jann @roederja} {ionic @ionic} openmaintainer
 license             GPL-3+
@@ -45,6 +46,8 @@ platform darwin {
     }
 }
 
+depends_build       port:pkgconfig
+
 depends_lib         port:libiconv           \
                     port:gettext            \
                     port:zlib               \
@@ -58,7 +61,8 @@ depends_lib         port:libiconv           \
                     port:readline           \
                     port:gnutls             \
                     port:libusb-compat      \
-                    port:npth
+                    port:npth               \
+                    port:sqlite3
 
 post-destroot {
     ln -s ${prefix}/bin/gpg ${destroot}${prefix}/bin/gpg2


### PR DESCRIPTION
###### Description
Without a build dependency on pkg-config, gnupg2 fails to find libgnutls
and does not enable TLS support. When building in trace mode, this lead
to a gpg2 that could not talk to its default keyserver.

Additionally, add a dependency on sqlite3 to enable trust-on-first-use
support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] bugfix
- [x] enhancement

###### Tested on
macOS 10.12.6 16G29
Xcode 9.1 9B55


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
