### PR TITLE
fonttools: update to 3.19.0

### DIFF
--- a/print/fonttools/Portfile
+++ b/print/fonttools/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 
 name                fonttools
-version             2.4
+github.setup        fonttools fonttools 3.19.0
 description         XML<->TrueType/OpenType Converter
 long_description    TTX is a tool to convert OpenType and TrueType fonts to \
                     and from XML. FontTools is a library for manipulating \
@@ -14,15 +15,41 @@ platforms           darwin
 categories          print
 license             BSD
 maintainers         nomaintainer
-homepage            http://fonttools.sourceforge.net/
-master_sites        sourceforge
 
-checksums           rmd160  392a8b4df387bfd45a572d97839799b1b876176a \
-                    sha256  95e5d8a67e2dae3ea237f9bebc449e0af42f12f03683db34f617e5b15d9d4fb0
+checksums           rmd160  738db47a74be78964cfb6d81214b3300d8c5d7a8 \
+                    sha256  0e890d7062d6fbd28d1453c6f8e80ab001c0d1efcf75f041e3d1308fe9dd944a
 
 python.default_version 27
 
-depends_build-append port:py27-numpy
+depends_build-append port:py27-setuptools
+
+default_variants     +woff2
+
+variant woff2 description {Install dependencies for WOFF 2.0 font support} {
+    depends_run-append port:py27-brotli
+}
+
+variant sym description {Install dependencies for symbolic font statistics analysis} {
+    depends_run-append port:py27-sympy
+}
+
+variant cocoa description {Install dependencies for Cocoa glyph drawing} {
+    depends_run-append port:py27-pyobjc
+}
+
+variant qt description {Install dependencies for Qt glyph drawing} {
+    depends_run-append port:py27-pyqt5
+}
+
+variant png description {Install dependencies for PNG glyph drawing} {
+    depends_run-append port:py27-reportlab
+}
+
+variant gui description {Install dependencies for GUI font inspector} {
+    depends_run-append port:py27-pygtk
+}
+
+variant all requires woff2 sym cocoa qt png gui description {Install all available optional dependencies} {}
 
 post-destroot {
     foreach manfile [glob -tails -directory ${destroot}${python.prefix}/share/man/man1 *] {


### PR DESCRIPTION
###### Description
Update fonttools to 3.19.0. The project has moved to GitHub. It has no required dependencies, but several optional dependencies that unlock additional functionality; I have added variants for the deps currently available in MacPorts.
