### PR TITLE
libressl-devel: update to 2.6.2

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                libressl-devel
-version             2.6.1
+version             2.6.2
 distname            libressl-${version}
 
 categories          security devel
@@ -24,8 +24,8 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160  ebf5fdbf83c81625d78afd473e83dcbd89ae139d \
-                    sha256  c293b3b5f1fc1d6349c019c3905355d577df32734b631d7e656503894e09127e
+checksums           rmd160  4e83f3c89e8b81c5a6565e0e1639e67547e788f6 \
+                    sha256  b029d2492b72a9ba5b5fcd9f3d602c9fd0baa087912f2aaecc28f52f567ec478
 
 patchfiles \
     openssldir-cert.pem.patch

--- a/security/libressl-devel/files/openssldir-cert.pem.patch
+++ b/security/libressl-devel/files/openssldir-cert.pem.patch
@@ -1,7 +1,7 @@
---- include/openssl/opensslconf.h.orig	2016-03-21 19:45:22.000000000 -0700
-+++ include/openssl/opensslconf.h	2016-04-11 01:33:38.000000000 -0700
-@@ -9,7 +9,7 @@
- #undef I386_ONLY
+--- include/openssl/opensslconf.h.orig	2017-09-26 04:06:52.000000000 +0000
++++ include/openssl/opensslconf.h	2017-11-04 14:29:18.000000000 +0000
+@@ -6,7 +6,7 @@
+ #endif
  
  #if defined(HEADER_CRYPTLIB_H) && !defined(OPENSSLDIR)
 -#define OPENSSLDIR "/etc/ssl"


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
