### PR TITLE
README: pass markdownlint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
-###### Description
-
+#### Description
 
 <!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
 <!-- (delete all below for minor changes) -->
 
 ###### Type(s)
 <!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
+
 - [ ] bugfix
 - [ ] enhancement
 - [ ] security fix
@@ -19,6 +19,7 @@ Xcode 8.x
 
 ###### Verification <!-- (delete not applicable items) -->
 Have you
+
 - [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
 - [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
 - [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?

--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
-## MacPorts Ports
+# MacPorts Ports
+
 This repository contains the source definitions for the open source software packages offered through MacPorts.
 
-### What software is available?
-> See: <https://www.macports.org/ports.php>
+## What software is available
 
-> Or: `port search <somename>`
+See: <https://www.macports.org/ports.php>
 
-### How do I install a port?
-> Install MacPorts: <https://www.macports.org/install.php>
+Or: `port search <somename>`
 
-> In Terminal, enter `sudo port install <someport>`
+## How to install ports
 
-### Problems?
-> Try `sudo port diagnose`
+Install MacPorts: <https://www.macports.org/install.php>
 
-> Get further help on our mailing list or via IRC: <https://www.macports.org/contact.php>
+In Terminal, enter `sudo port install <someport>`
 
-### Documentation
-> See `man port`
+## Diagnosing Problems
 
-> Official documentation:  <https://guide.macports.org>
+Try `sudo port diagnose`
+
+Get further help on our mailing list or via IRC: <https://www.macports.org/contact.php>
+
+## Documentation
+
+See `man port`
+
+Official documentation:  <https://guide.macports.org>


### PR DESCRIPTION
mdl (markdownlint) provides some useful lints for writing
markdown files. While it can be opinionated, the defaults are
reasonable writing 'portable' markdown files (to extent that
markdown can be portable).