### PR TITLE
afl: update to 2.52b

### DIFF
--- a/devel/afl/Portfile
+++ b/devel/afl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                afl
-version             2.51b
+version             2.52b
 categories          devel security
 platforms           darwin
 maintainers         {stevenmyint.com:git @myint} openmaintainer
@@ -21,8 +21,8 @@ homepage            http://lcamtuf.coredump.cx/afl
 master_sites        ${homepage}/releases
 extract.suffix      .tgz
 
-checksums           rmd160  c9b774d0589e9be94120574045ae94d1633d922c \
-                    sha256  d435b94b35b844ea0bacbdb8516d2d5adffc2a4f4a5aad78785c5d2a5495bb97
+checksums           rmd160  b7c1174111cfc11d14a0982359ef903d5b8d1267 \
+                    sha256  43614b4b91c014d39ef086c5cc84ff5f068010c264c2c05bf199df60898ce045
 
 use_configure       no
 


### PR DESCRIPTION
###### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
