### PR TITLE
qscintilla: add -stdlib only with clang

### DIFF
--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -44,7 +44,9 @@ foreach qt_major {4 5} {
             # enable C++11
             configure.cxxflags-append -std=c++11
             # respect configure.cxx_stdlib when linking
-            configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+            if {[string match *clang* ${configure.cxx}]} {
+                configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+            }
         } else {
             qt${qt_major}.depends_component qtmacextras
             configure.args-append CONFIG+=absolute_library_soname


### PR DESCRIPTION
fixes build on older systems using gcc6

