### PR TITLE
wxWidgets-3.0-cxx11: fix build on PPC

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -120,6 +120,15 @@ if {[string match *clang* ${configure.cxx}]} {
                     -stdlib=${configure.cxx_stdlib}
 }
 
+platform darwin powerpc {
+    if {![catch {sysctl hw.vectorunit} result] && $result > 0} {
+        # Work around buggy header. https://trac.macports.org/ticket/55251
+        configure.cxxflags-append -faltivec
+        configure.cflags-append -faltivec
+    }
+}
+
+
 if {${subport} eq "wxPython-3.0"} {
     master_sites            sourceforge:project/wxwindows/${version} \
                             http://biolpc22.york.ac.uk/pub/${version}/ \


### PR DESCRIPTION
add missing -faltivec flag on suitable systems
closes: https://trac.macports.org/ticket/55251
