### PR TITLE
docbook-xsl: support docbook.sourceforge.net URIs

### DIFF
--- a/textproc/docbook-xsl/Portfile
+++ b/textproc/docbook-xsl/Portfile
@@ -6,6 +6,7 @@ PortGroup       xmlcatalog 1.0
 
 github.setup    docbook xslt10-stylesheets 1.79.2 release/
 name            docbook-xsl
+revision        1
 categories      textproc
 platforms       darwin
 license         MIT Permissive
@@ -46,7 +47,8 @@ set srcdocpaths "AUTHORS BUGS README RELEASE-NOTES.html RELEASE-NOTES.txt \
 set instxsldir  "share/xsl/${name}"
 set instdocdir  "share/doc/${name}"
 
-xml.catalog "${prefix}/${instxsldir}/catalog.xml"
+xml.catalog "${prefix}/${instxsldir}/catalog.xml" \
+            "${prefix}/${instxsldir}/catalog.sf.xml"
 
 destroot {
     foreach pathname "${instxsldir} ${instdocdir}" {
@@ -58,6 +60,10 @@ destroot {
     foreach pathname ${srcdocpaths} {
         copy ${worksrcpath}/${pathname} ${destroot}${prefix}/${instdocdir}
     }
+
+    # Also register docbook.sourceforge.net URIs for backward compatibility
+    copy ${destroot}${prefix}/${instxsldir}/catalog.xml ${destroot}${prefix}/${instxsldir}/catalog.sf.xml
+    reinplace "s/cdn\\.docbook\\.org/docbook.sourceforge.net/g" ${destroot}${prefix}/${instxsldir}/catalog.sf.xml
 }
 
 if {${registry.format} == "receipt_flat"} {


### PR DESCRIPTION
#### Description
Fixes: https://trac.macports.org/ticket/55255
Fixes: https://trac.macports.org/ticket/55253

@lbschenkel Fix confirmed for NeoMutt, other dependent ports are not tested yet.