### PR TITLE
FileZilla: update to 3.29.0

### DIFF
--- a/www/FileZilla/Portfile
+++ b/www/FileZilla/Portfile
@@ -6,8 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
 
 name                FileZilla
-version             3.28.0
-revision            2
+version             3.29.0
 categories          www aqua
 platforms           darwin
 maintainers         {@yan12125 gmail.com:yan12125} openmaintainer
@@ -22,8 +21,8 @@ long_description    FileZilla Client is a fast and reliable cross-platform \
 homepage            https://filezilla-project.org/
 master_sites        sourceforge:project/filezilla/FileZilla_Client/${version}
 
-checksums           rmd160  390456877d3a8d3ac0896b1ad1bb00355fa2d41e \
-                    sha256  e49621aeb07c89547508c9ef244e2226168e06b120f49d2c4d428d95f1adbfb7
+checksums           rmd160  ad9c8f1de0c81b50a0c06d074dd757d5a732c515 \
+                    sha256  ead1ed74f19cf33aadf814a45b742207de3a8c349dbe2a11c344966bb8705259
 
 # wxWidgets-3.0 with support for C++11 on < 10.9
 wxWidgets.use       wxWidgets-3.0-cxx11


### PR DESCRIPTION
#### Description

Upstream has applied [a patch](https://svn.filezilla-project.org/filezilla/FileZilla3/trunk/src/interface/file_utils_osx.m?r1=8290&r2=8637) for https://trac.macports.org/ticket/55252. Let's see if it fixes build errors.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update
###### Tested on
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
