### PR TITLE
gromacs-plumed: added note

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -109,6 +109,11 @@ subport gromacs-plumed {
 # updated when gromacs is.
       exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-5.1.4 --runtime -p
     }
+    notes "
+PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\
+to the path of libplumedKernel.dylib you can replace your own PLUMED library at runtime.\
+By default, /opt/local/lib/libplumedKernel.dylib is linked.
+"
 }
 ## END ADDITION FOR PLUMED SUBPORT ONLY
 

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -112,7 +112,7 @@ subport gromacs-plumed {
     notes "
 PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\
 to the path of libplumedKernel.dylib you can replace your own PLUMED library at runtime.\
-By default, /opt/local/lib/libplumedKernel.dylib is linked.
+By default, ${prefix}/lib/libplumedKernel.dylib is linked.
 "
 }
 ## END ADDITION FOR PLUMED SUBPORT ONLY


### PR DESCRIPTION
#### Description

I just added a note to explain users that by setting the `PLUMED_KERNEL` environment
variable they can link at runtime gromacs with their own version of plumed.

The note is only written in gromacs-plumed subport.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->
