### PR TITLE
MacVim @ 8.0.snapshot142_0+cscope+huge+lua+python27+python36+tcl fails to build on 10.13.2

### DIFF
--- a/editors/MacVim/files/patch-tcl.diff
+++ b/editors/MacVim/files/patch-tcl.diff
@@ -1,5 +1,5 @@
---- /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_editors_MacVim/MacVim/work/macvim-142/src/configure.ac.orig	2017-11-10 11:54:42.000000000 +0200
-+++ /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_editors_MacVim/MacVim/work/macvim-142/src/configure.ac	2017-11-10 11:57:09.000000000 +0200
+--- src/configure.ac.orig	2017-11-10 11:54:42.000000000 +0200
++++ src/configure.ac	2017-11-10 11:57:09.000000000 +0200
 @@ -1783,12 +1783,7 @@
        tcldll=`echo 'puts libtcl[[info tclversion]][[info sharedlibextension]]' | $vi_cv_path_tcl -`
  

--- a/editors/MacVim/files/patch-tcl.diff
+++ b/editors/MacVim/files/patch-tcl.diff
@@ -1,32 +1,32 @@
---- src/configure.ac.orig       2017-11-10 10:31:27.000000000 +0200
-+++ src/configure.ac    2017-11-10 10:39:02.000000000 +0200
+--- /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_editors_MacVim/MacVim/work/macvim-142/src/configure.ac.orig	2017-11-10 11:54:42.000000000 +0200
++++ /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_editors_MacVim/MacVim/work/macvim-142/src/configure.ac	2017-11-10 11:57:09.000000000 +0200
 @@ -1783,12 +1783,7 @@
        tcldll=`echo 'puts libtcl[[info tclversion]][[info sharedlibextension]]' | $vi_cv_path_tcl -`
-
+ 
        AC_MSG_CHECKING(for location of Tcl include)
 -      if test "x$MACOS_X" != "xyes"; then
--       tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
+-	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
 -      else
--       dnl For Mac OS X 10.3, use the OS-provided framework location
--       tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
+-	dnl For Mac OS X 10.3, use the OS-provided framework location
+-	tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
 -      fi
 +      tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver"
        TCL_INC=
        for try in $tclinc; do
-        if test -f "$try/tcl.h"; then
+ 	if test -f "$try/tcl.h"; then
 @@ -1803,13 +1798,8 @@
        fi
        if test -z "$SKIP_TCL"; then
-        AC_MSG_CHECKING(for location of tclConfig.sh script)
--       if test "x$MACOS_X" != "xyes"; then
--         tclcnf=`echo $tclinc | sed s/include/lib/g`
--         tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
--       else
--         dnl For Mac OS X 10.3, use the OS-provided framework location
--         tclcnf="/System/Library/Frameworks/Tcl.framework"
--       fi
-+       tclcnf=`echo $tclinc | sed s/include/lib/g`
-+        tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
-        for try in $tclcnf; do
-          if test -f "$try/tclConfig.sh"; then
-            AC_MSG_RESULT($try/tclConfig.sh)
+ 	AC_MSG_CHECKING(for location of tclConfig.sh script)
+-	if test "x$MACOS_X" != "xyes"; then
+-	  tclcnf=`echo $tclinc | sed s/include/lib/g`
+-	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
+-	else
+-	  dnl For Mac OS X 10.3, use the OS-provided framework location
+-	  tclcnf="/System/Library/Frameworks/Tcl.framework"
+-	fi
++	tclcnf=`echo $tclinc | sed s/include/lib/g`
++	tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
+ 	for try in $tclcnf; do
+ 	  if test -f "$try/tclConfig.sh"; then
+ 	    AC_MSG_RESULT($try/tclConfig.sh)

--- a/editors/MacVim/files/patch-tcl.diff
+++ b/editors/MacVim/files/patch-tcl.diff
@@ -1,32 +1,32 @@
---- src/configure.ac.orig	2016-09-12 16:31:10.000000000 +0200
-+++ src/configure.ac	2016-09-12 19:28:57.000000000 +0200
-@@ -1721,12 +1721,7 @@
+--- src/configure.ac.orig       2017-11-10 10:31:27.000000000 +0200
++++ src/configure.ac    2017-11-10 10:39:02.000000000 +0200
+@@ -1783,12 +1783,7 @@
        tcldll=`echo 'puts libtcl[[info tclversion]][[info sharedlibextension]]' | $vi_cv_path_tcl -`
- 
+
        AC_MSG_CHECKING(for location of Tcl include)
--      if test "x$MACOSX" != "xyes"; then
--	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
+-      if test "x$MACOS_X" != "xyes"; then
+-       tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
 -      else
--	dnl For Mac OS X 10.3, use the OS-provided framework location
--	tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
+-       dnl For Mac OS X 10.3, use the OS-provided framework location
+-       tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
 -      fi
 +      tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver"
        TCL_INC=
        for try in $tclinc; do
- 	if test -f "$try/tcl.h"; then
-@@ -1741,13 +1736,8 @@
+        if test -f "$try/tcl.h"; then
+@@ -1803,13 +1798,8 @@
        fi
        if test -z "$SKIP_TCL"; then
- 	AC_MSG_CHECKING(for location of tclConfig.sh script)
--	if test "x$MACOSX" != "xyes"; then
--	  tclcnf=`echo $tclinc | sed s/include/lib/g`
--	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
--	else
--	  dnl For Mac OS X 10.3, use the OS-provided framework location
--	  tclcnf="/System/Library/Frameworks/Tcl.framework"
--	fi
-+	tclcnf=`echo $tclinc | sed s/include/lib/g`
-+	tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
- 	for try in $tclcnf; do
- 	  if test -f "$try/tclConfig.sh"; then
- 	    AC_MSG_RESULT($try/tclConfig.sh)
+        AC_MSG_CHECKING(for location of tclConfig.sh script)
+-       if test "x$MACOS_X" != "xyes"; then
+-         tclcnf=`echo $tclinc | sed s/include/lib/g`
+-         tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
+-       else
+-         dnl For Mac OS X 10.3, use the OS-provided framework location
+-         tclcnf="/System/Library/Frameworks/Tcl.framework"
+-       fi
++       tclcnf=`echo $tclinc | sed s/include/lib/g`
++        tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
+        for try in $tclcnf; do
+          if test -f "$try/tclConfig.sh"; then
+            AC_MSG_RESULT($try/tclConfig.sh)


### PR DESCRIPTION
#### Description
MacVim @ 8.0.snapshot142_0+cscope+huge+lua+python27+python36+tcl fails to build on 10.13.2

Closes: https://trac.macports.org/ticket/55285

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C67b
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?