### PR TITLE
rtmpdump: Crashfix for Mac OS 10.13 High Sierra

### DIFF
--- a/www/rtmpdump/Portfile
+++ b/www/rtmpdump/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                rtmpdump
 version             2.4
-revision            2
+revision            3
 categories          www net
 platforms           darwin
 maintainers         nomaintainer

--- a/www/rtmpdump/files/patch-librtmp-Makefile.diff
+++ b/www/rtmpdump/files/patch-librtmp-Makefile.diff
@@ -19,7 +19,7 @@
  
  SO_LDFLAGS_posix=-shared -Wl,-soname,$@
 -SO_LDFLAGS_darwin=-dynamiclib -flat_namespace -undefined suppress -fno-common \
-+SO_LDFLAGS_darwin=-dynamiclib -install_name $(prefix)/lib/$@ -flat_namespace -undefined suppress -fno-common \
++SO_LDFLAGS_darwin=-dynamiclib -lssl -lcrypto -install_name $(prefix)/lib/$@ -fno-common \
  	-headerpad_max_install_names
  SO_LDFLAGS_mingw=-shared
  SO_LDFLAGS=$(SO_LDFLAGS_$(SYS))


### PR DESCRIPTION
#### Description

librtmp crashes directly on Mac OS 10.13 High Sierra, because Apple decided to change the system OpenSSL with BoringSSL(Google's fork of OpenSSL). Because of the way librtmp is built it tries to load BoringSSL which have ABI incompatibility with OpenSSL and thus leads to crash.

The rtmpdump Portfile already requires OpenSSL so I think that adding explicit linking to it should not cause any issues.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10
macOS 10.11
macOS 10.12
macOS 10.13
Xcode 8.x
Xcode 9.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
