### PR TITLE
webkit2-gtk: update to 2.18.0

### DIFF
--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -12,9 +12,8 @@ PortGroup           cxx11 1.1
 
 name                webkit2-gtk
 conflicts           webkit2-gtk-devel
-version             2.14.2
-revision            2
-description         Apple's WebKit2 HTML rendering library for GTK+3 (with optional support for GTK+2 plugins)
+version             2.18.0
+description         Apple's WebKit2 HTML rendering library for GTK+3
 long_description    ${description}
 maintainers         {jeremyhu @jeremyhu} {devans @dbevans}
 categories          www gnome
@@ -28,8 +27,8 @@ distname            webkitgtk-${version}
 
 dist_subdir         webkit-gtk
 
-checksums           rmd160  3fea1696539ba305367e36af803ce1a934b99b0d \
-                    sha256  2edbcbd5105046aea55af9671c4de8deedb5b0e3567c618034d440a760675556
+checksums           rmd160  786ffab37419fb68f83b20059fca98fd9fdf6cc1 \
+                    sha256  b583e46a3de36a3e80ba33b084ead60512a2046aca01ff61e50e519436e5038d
 
 # don't overwrite build dependencies provided by cmake portgroup
 depends_build-append \
@@ -72,11 +71,17 @@ depends_lib         port:atk \
 # PR-153138.patch: https://bugs.webkit.org/show_bug.cgi?id=153138
 # PR-157554.patch: https://bugs.webkit.org/show_bug.cgi?id=157554
 # PR-157574.patch: https://bugs.webkit.org/show_bug.cgi?id=157574
+# PR-176870.patch: https://bugs.webkit.org/show_bug.cgi?id=176870 (already landed in trunk)
 patchfiles-append \
     PR-152650-2.patch \
     PR-153138.patch \
-    PR-157554.patch \
-    PR-157574.patch
+    PR-157574.patch \
+    PR-176870.patch \
+    patch-disable-mach-exceptions.diff \
+    patch-ramsize.diff \
+    patch-bundle-link-webcore.diff \
+    patch-fix-include-path.diff
+
 
 # Build out-of-tree
 configure.post_args     ../${worksrcdir}
@@ -97,11 +102,8 @@ configure.args-append -DENABLE_GTKDOC=OFF
 # <rdar://problem/24031030>
 configure.optflags  -Os
 
-# clang 3.4, 503.0.35, and 600.0.57 (error: call to 'make_unique' is ambiguous, error: call to 'exchange' is ambiguous)
-# compiler.blacklist-append {clang < 602} macports-clang-3.4
-# clang 3.3 (error: no type named 'make_index_sequence' in namespace 'std')
-compiler.fallback-append macports-clang-4.0
-compiler.blacklist-append {clang < 602} macports-clang-3.4 macports-clang-3.3
+# additional compiler blacklisting beyond cxx11 1.1 PortGroup
+compiler.blacklist-append {clang < 602}
 
 pre-configure {
     if {![variant_isset quartz] && ![variant_isset x11]} {
@@ -110,29 +112,34 @@ pre-configure {
 }
 
 post-configure {
+    # Source/WebKit2 is renamed to Source/WebKit
+    # https://github.com/WebKit/webkit/commit/7f8a4a6dab6e75a624a97e5ce47de5626476b67d
+
     # https://bugs.webkit.org/show_bug.cgi?id=153176
     reinplace {s|\.\./\.\./lib/libWTFGTK\.a||} \
-        ${build.dir}/Source/WebKit2/CMakeFiles/WebKit2.dir/link.txt
+        ${build.dir}/Source/WebKit/CMakeFiles/WebKit2.dir/link.txt
     reinplace {s|\.\./\.\./lib/libbmalloc\.a||} \
         ${build.dir}/Source/JavaScriptCore/CMakeFiles/JavaScriptCore.dir/link.txt
+    # DatabaseProcess is renamed to StorageProcess
+    # https://bugs.webkit.org/show_bug.cgi?id=174879
     reinplace {s|[\./]*\.\./lib/lib[^\.]*\.a||g} \
         ${build.dir}/Source/JavaScriptCore/CMakeFiles/LLIntOffsetsExtractor.dir/link.txt \
         ${build.dir}/Source/JavaScriptCore/shell/CMakeFiles/jsc.dir/link.txt \
         ${build.dir}/Source/JavaScriptCore/shell/CMakeFiles/testb3.dir/link.txt \
-        ${build.dir}/Source/WebKit2/CMakeFiles/DatabaseProcess.dir/link.txt \
-        ${build.dir}/Source/WebKit2/CMakeFiles/NetworkProcess.dir/link.txt \
-        ${build.dir}/Source/WebKit2/CMakeFiles/webkit2gtkinjectedbundle.dir/link.txt \
-        ${build.dir}/Source/WebKit2/CMakeFiles/WebProcess.dir/link.txt
+        ${build.dir}/Source/WebKit/CMakeFiles/StorageProcess.dir/link.txt \
+        ${build.dir}/Source/WebKit/CMakeFiles/NetworkProcess.dir/link.txt \
+        ${build.dir}/Source/WebKit/CMakeFiles/webkit2gtkinjectedbundle.dir/link.txt \
+        ${build.dir}/Source/WebKit/CMakeFiles/WebProcess.dir/link.txt
     if {[variant_isset x11]} {
         # ENABLE_PLUGIN_PROCESS is only enabled with +x11
         reinplace {s|[\./]*\.\./lib/lib[^\.]*\.a||g} \
-            ${build.dir}/Source/WebKit2/CMakeFiles/PluginProcess.dir/link.txt
+            ${build.dir}/Source/WebKit/CMakeFiles/PluginProcess.dir/link.txt
 
         if {[variant_isset gtk2]} {
             reinplace {s|\.\./\.\./lib/libWTFGTK\.a||} \
-                ${build.dir}/Source/WebKit2/CMakeFiles/WebKitPluginProcess2.dir/link.txt
+                ${build.dir}/Source/WebKit/CMakeFiles/WebKitPluginProcess2.dir/link.txt
             reinplace {s|-Wl,-all_load||g} \
-                ${build.dir}/Source/WebKit2/CMakeFiles/WebKitPluginProcess2.dir/link.txt
+                ${build.dir}/Source/WebKit/CMakeFiles/WebKitPluginProcess2.dir/link.txt
         }
     }
     if {[variant_isset minibrowser]} {
@@ -149,20 +156,15 @@ post-configure {
 configure.cflags-append     -ftemplate-depth=256
 configure.cxxflags-append   -ftemplate-depth=256
 
-# fix build with clang on newer systems
-# https://trac.macports.org/ticket/54798
-if {${os.platform} eq "darwin" && ${os.major} > 13} {
-    configure.cxxflags-append    -std=c++14
-}
-
-
 if {![variant_isset quartz]} {
     default_variants-append +x11 +gtk2
 }
 
+
+
 # fix build on older systems
 if {${os.platform} eq "darwin" && ${os.major} < 13} {
-    
+
     # add dep for newer ruby and spec this for build
     # https://trac.macports.org/ticket/52016
     depends_build-append    port:ruby24
@@ -180,13 +182,40 @@ if {${os.platform} eq "darwin" && ${os.major} < 13} {
         patchfiles-append patch-snowleopard-npruntime-redefine-cursor.diff
     }
     
+    # gl cocoa build continues to fail due to use of API not available on darwin 12 or earlier
+    # so gstreamergl is not available at present for darwin 12 or earlier
+    configure.args-append -DUSE_GSTREAMER_GL=OFF
+
+    ### SNOWLEOPARD-ONLY FIXES ####
+
+    # the following work around the fact that webkit2-gtk running on darwin 
+    # uses security features of MacOS 10.7+ in several places
+    if { ${os.major} < 11 } {
+
+        # ENABLE_SUBTLE_CRYPTO used to be off by default, but now is on by default
+        # there are > 100 instances of #if ENABLE(SUBTLE_CRYPTO)
+        # may or may not be able to work without 10.7 features
+        configure.args-append -DENABLE_SUBTLE_CRYPTO=OFF
+        
+        # the darwin build uses 10.7+ only security features, but 
+        # the unix version does not, and seems to build OK so use that
+        # the ifdefs were cumbersome, so for now I just stripped those out and left
+        # the unix build behind - FIXME: sort the ifdefs out
+        patchfiles-append   patch-WTF-wtf-Randomdevice.diff
+    
+        # disable 10.7+ only security features
+        patchfiles-append   patch-Webcore-page-crypto.diff
+    }
+    
     # special case: fix build on 10.6 with macports-libstdc++
     # contents of snowmath.h should someday become part of gcc6 cmath
     if { ${configure.cxx_stdlib} eq "macports-libstdc++"  && ${os.major} < 11 } {
         configure.cxxflags-append -D_GLIBCXX_USE_C99_MATH_TR1=1
         configure.cxxflags-append -include ${portpath}/${filesdir}/snowmath.h
-    }
+    } 
+    ### END SNOWLEOPARD-ONLY FIXES ###
 }
+
 
 variant quartz conflicts x11 gtk2 {
     require_active_variants port:gtk3 quartz

--- a/www/webkit2-gtk/files/PR-152650-2.patch
+++ b/www/webkit2-gtk/files/PR-152650-2.patch
@@ -38,9 +38,9 @@ index 6b01f1a..b443d10 100644
 -    set(ENABLE_GTKDOC OFF)
 -endif ()
 -
- set(DERIVED_SOURCES_GOBJECT_DOM_BINDINGS_DIR ${DERIVED_SOURCES_DIR}/webkitdom)
  set(DERIVED_SOURCES_WEBKITGTK_DIR ${DERIVED_SOURCES_DIR}/webkitgtk)
  set(DERIVED_SOURCES_WEBKITGTK_API_DIR ${DERIVED_SOURCES_WEBKITGTK_DIR}/webkit)
+ set(DERIVED_SOURCES_WEBKIT2GTK_DIR ${DERIVED_SOURCES_DIR}/webkit2gtk)
 diff --git a/Tools/gtk/gtkdoc.py b/Tools/gtk/gtkdoc.py
 index 4c8237b..a628ae0 100644
 --- Tools/gtk/gtkdoc.py

--- a/www/webkit2-gtk/files/PR-157554.patch
+++ b/www/webkit2-gtk/files/PR-157554.patch
@@ -1,7 +1,7 @@
 https://bugs.webkit.org/show_bug.cgi?id=157554
 
---- Source/WTF/wtf/OSRandomSource.cpp
-+++ Source/WTF/wtf/OSRandomSource.cpp
+--- Source/WTF/wtf/RandomDevice.cpp
++++ Source/WTF/wtf/RandomDevice.cpp
 @@ -29,7 +29,7 @@
  #include <stdint.h>
  #include <stdlib.h>
@@ -21,13 +21,13 @@ https://bugs.webkit.org/show_bug.cgi?id=157554
  {
      CRASH();
 @@ -60,8 +56,8 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashUnableToReadFromURandom()
-     
- void cryptographicallyRandomValuesFromOS(unsigned char* buffer, size_t length)
+ // https://bugs.webkit.org/show_bug.cgi?id=170190
+ void RandomDevice::cryptographicallyRandomValues(unsigned char* buffer, size_t length)
  {
 -#if OS(DARWIN)
 -    RELEASE_ASSERT(!CCRandomCopyBytes(kCCRandomDefault, buffer, length));
 +#if OS(DARWIN) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
 +    return arc4random_buf(buffer, length);
  #elif OS(UNIX)
-     int fd = open("/dev/urandom", O_RDONLY, 0);
-     if (fd < 0)
+     ssize_t amountRead = 0;
+     while (static_cast<size_t>(amountRead) < length) {

--- a/www/webkit2-gtk/files/PR-157574.patch
+++ b/www/webkit2-gtk/files/PR-157574.patch
@@ -45,7 +45,7 @@ index ab53183..1310dec 100644
 -#define AVAILABLE_MAC_OS_X_VERSION_10_10_AND_LATER
 -#endif
 -
--#endif /* __MAC_OS_X_VERSION_MIN_REQUIRED <= 101100 */
+-#endif /* !TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MIN_REQUIRED < 101100 */
 -
 -#if defined(BUILDING_GTK__)
  #undef CF_AVAILABLE

--- a/www/webkit2-gtk/files/PR-176870.patch
+++ b/www/webkit2-gtk/files/PR-176870.patch
@@ -1,0 +1,10 @@
+Index: trunk/Source/WebCore/Modules/webaudio/AudioContext.h
+===================================================================
+--- Source/WebCore/Modules/webaudio/AudioContext.h
++++ Source/WebCore/Modules/webaudio/AudioContext.h
+@@ -37,4 +37,5 @@
+ #include "VisibilityChangeClient.h"
+ #include <atomic>
++#include <runtime/Float32Array.h>
+ #include <wtf/HashSet.h>
+ #include <wtf/MainThread.h>

--- a/www/webkit2-gtk/files/patch-WTF-wtf-Randomdevice.diff
+++ b/www/webkit2-gtk/files/patch-WTF-wtf-Randomdevice.diff
@@ -1,0 +1,115 @@
+diff --git Source/WTF/wtf/RandomDevice.cpp Source/WTF/wtf/RandomDevice.cpp
+index 61d6057..90fa30c 100644
+--- Source/WTF/wtf/RandomDevice.cpp
++++ Source/WTF/wtf/RandomDevice.cpp
+@@ -30,24 +30,12 @@
+ #include <stdint.h>
+ #include <stdlib.h>
+ 
+-#if !OS(DARWIN) && OS(UNIX)
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+-#endif
+-
+-#if OS(WINDOWS)
+-#include <windows.h>
+-#include <wincrypt.h> // windows.h must be included before wincrypt.h.
+-#endif
+-
+-#if OS(DARWIN)
+-#include "CommonCryptoSPI.h"
+-#endif
+ 
+ namespace WTF {
+ 
+-#if !OS(DARWIN) && OS(UNIX)
+ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashUnableToOpenURandom()
+ {
+     CRASH();
+@@ -57,9 +45,7 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashUnableToReadFromURandom()
+ {
+     CRASH();
+ }
+-#endif
+ 
+-#if !OS(DARWIN) && !OS(WINDOWS)
+ RandomDevice::RandomDevice()
+ {
+     int ret = 0;
+@@ -70,22 +56,16 @@ RandomDevice::RandomDevice()
+     if (m_fd < 0)
+         crashUnableToOpenURandom(); // We need /dev/urandom for this API to work...
+ }
+-#endif
+ 
+-#if !OS(DARWIN) && !OS(WINDOWS)
+ RandomDevice::~RandomDevice()
+ {
+     close(m_fd);
+ }
+-#endif
+ 
+ // FIXME: Make this call fast by creating the pool in RandomDevice.
+ // https://bugs.webkit.org/show_bug.cgi?id=170190
+ void RandomDevice::cryptographicallyRandomValues(unsigned char* buffer, size_t length)
+ {
+-#if OS(DARWIN)
+-    RELEASE_ASSERT(!CCRandomCopyBytes(kCCRandomDefault, buffer, length));
+-#elif OS(UNIX)
+     ssize_t amountRead = 0;
+     while (static_cast<size_t>(amountRead) < length) {
+         ssize_t currentRead = read(m_fd, buffer + amountRead, length - amountRead);
+@@ -97,20 +77,6 @@ void RandomDevice::cryptographicallyRandomValues(unsigned char* buffer, size_t l
+         } else
+             amountRead += currentRead;
+     }
+-#elif OS(WINDOWS)
+-    // FIXME: We cannot ensure that Cryptographic Service Provider context and CryptGenRandom are safe across threads.
+-    // If it is safe, we can acquire context per RandomDevice.
+-    HCRYPTPROV hCryptProv = 0;
+-    if (!CryptAcquireContext(&hCryptProv, 0, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+-        CRASH();
+-    if (!CryptGenRandom(hCryptProv, length, buffer))
+-        CRASH();
+-    CryptReleaseContext(hCryptProv, 0);
+-#else
+-#error "This configuration doesn't have a strong source of randomness."
+-// WARNING: When adding new sources of OS randomness, the randomness must
+-//          be of cryptographic quality!
+-#endif
+ }
+ 
+ }
+diff --git Source/WTF/wtf/RandomDevice.h Source/WTF/wtf/RandomDevice.h
+index 86636c9..410ccd0 100644
+--- Source/WTF/wtf/RandomDevice.h
++++ Source/WTF/wtf/RandomDevice.h
+@@ -34,12 +34,8 @@ namespace WTF {
+ class RandomDevice {
+     WTF_MAKE_NONCOPYABLE(RandomDevice);
+ public:
+-#if OS(DARWIN) || OS(WINDOWS)
+-    RandomDevice() = default;
+-#else
+     RandomDevice();
+     ~RandomDevice();
+-#endif
+ 
+     // This function attempts to fill buffer with randomness from the operating
+     // system. Rather than calling this function directly, consider calling
+@@ -47,14 +43,7 @@ public:
+     void cryptographicallyRandomValues(unsigned char* buffer, size_t length);
+ 
+ private:
+-#if OS(DARWIN) || OS(WINDOWS)
+-#elif OS(UNIX)
+     int m_fd { -1 };
+-#else
+-#error "This configuration doesn't have a strong source of randomness."
+-// WARNING: When adding new sources of OS randomness, the randomness must
+-//          be of cryptographic quality!
+-#endif
+ };
+ 
+ }

--- a/www/webkit2-gtk/files/patch-Webcore-page-crypto.diff
+++ b/www/webkit2-gtk/files/patch-Webcore-page-crypto.diff
@@ -1,0 +1,22 @@
+diff --git Source/WebCore/page/Crypto.cpp Source/WebCore/page/Crypto.cpp
+index ed1278b..f94db1b 100644
+--- Source/WebCore/page/Crypto.cpp
++++ Source/WebCore/page/Crypto.cpp
+@@ -31,7 +31,7 @@
+ #include "config.h"
+ #include "Crypto.h"
+ 
+-#if OS(DARWIN)
++#if OS(DARWIN) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ #include "CommonCryptoUtilities.h"
+ #endif
+ #include "Document.h"
+@@ -60,7 +60,7 @@ ExceptionOr<void> Crypto::getRandomValues(ArrayBufferView& array)
+         return Exception { TypeMismatchError };
+     if (array.byteLength() > 65536)
+         return Exception { QuotaExceededError };
+-#if OS(DARWIN)
++#if OS(DARWIN) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     int rc = CCRandomCopyBytes(kCCRandomDefault, array.baseAddress(), array.byteLength());
+     RELEASE_ASSERT(rc == kCCSuccess);
+ #else

--- a/www/webkit2-gtk/files/patch-bundle-link-webcore.diff
+++ b/www/webkit2-gtk/files/patch-bundle-link-webcore.diff
@@ -1,0 +1,11 @@
+--- Source/WebKit/PlatformGTK.cmake.orig	2017-09-29 02:02:31.000000000 +0800
++++ Source/WebKit/PlatformGTK.cmake	2017-09-29 02:02:53.000000000 +0800
+@@ -1092,7 +1092,7 @@
+ 
+ add_library(webkit2gtkinjectedbundle MODULE "${WEBKIT2_DIR}/WebProcess/InjectedBundle/API/glib/WebKitInjectedBundleMain.cpp")
+ add_webkit2_prefix_header(webkit2gtkinjectedbundle)
+-target_link_libraries(webkit2gtkinjectedbundle WebKit2)
++target_link_libraries(webkit2gtkinjectedbundle WebKit2 WebCore)
+ 
+ if (COMPILER_IS_GCC_OR_CLANG)
+     WEBKIT_ADD_TARGET_CXX_FLAGS(webkit2gtkinjectedbundle -Wno-unused-parameter)

--- a/www/webkit2-gtk/files/patch-disable-mach-exceptions.diff
+++ b/www/webkit2-gtk/files/patch-disable-mach-exceptions.diff
@@ -1,0 +1,15 @@
+diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
+index a91524b9664..09005661e6c 100644
+--- Source/WTF/wtf/Platform.h
++++ Source/WTF/wtf/Platform.h
+@@ -662,10 +662,6 @@
+ #define HAVE_READLINE 1
+ #define HAVE_SYS_TIMEB_H 1
+
+-#if __has_include(<mach/mach_exc.defs>) && !(PLATFORM(WATCHOS) || PLATFORM(APPLETV))
+-#define HAVE_MACH_EXCEPTIONS 1
+-#endif
+-
+ #if !PLATFORM(GTK)
+ #define USE_ACCELERATE 1
+ #endif

--- a/www/webkit2-gtk/files/patch-fix-include-path.diff
+++ b/www/webkit2-gtk/files/patch-fix-include-path.diff
@@ -1,0 +1,11 @@
+--- Source/WebCore/platform/graphics/cairo/BackingStoreBackendCairoImpl.h.orig	2017-09-29 02:01:09.000000000 +0800
++++ Source/WebCore/platform/graphics/cairo/BackingStoreBackendCairoImpl.h	2017-09-29 02:01:30.000000000 +0800
+@@ -20,7 +20,7 @@
+ 
+ #if USE(CAIRO)
+ #include "BackingStoreBackendCairo.h"
+-#include <WebCore/HysteresisActivity.h>
++#include <HysteresisActivity.h>
+ 
+ namespace WebCore {
+ 

--- a/www/webkit2-gtk/files/patch-ramsize.diff
+++ b/www/webkit2-gtk/files/patch-ramsize.diff
@@ -1,0 +1,93 @@
+diff --git Source/WTF/wtf/RAMSize.cpp Source/WTF/wtf/RAMSize.cpp
+index 5d34d3b..3dd516c 100644
+--- Source/WTF/wtf/RAMSize.cpp
++++ Source/WTF/wtf/RAMSize.cpp
+@@ -29,41 +29,61 @@
+ #include "StdLibExtras.h"
+ #include <mutex>
+ 
+-#if OS(WINDOWS)
++#if OS(DARWIN)
++#import <dispatch/dispatch.h>
++#import <mach/host_info.h>
++#import <mach/mach.h>
++#import <mach/mach_error.h>
++#import <math.h>
++#elif OS(UNIX)
++#include <unistd.h>
++#elif OS(WINDOWS)
+ #include <windows.h>
+-#elif defined(USE_SYSTEM_MALLOC) && USE_SYSTEM_MALLOC
+-#if OS(UNIX)
+-#include <sys/sysinfo.h>
+-#endif // OS(UNIX)
+-#else
+-#include <bmalloc/bmalloc.h>
+ #endif
+ 
+ namespace WTF {
+ 
+-#if OS(WINDOWS)
+ static const size_t ramSizeGuess = 512 * MB;
+-#endif
+ 
+ static size_t computeRAMSize()
+ {
+-#if OS(WINDOWS)
++#if PLATFORM(IOS_SIMULATOR)
++    // Pretend we have 512MB of memory to make cache sizes behave like on device.
++    return ramSizeGuess;
++#elif OS(DARWIN)
++    host_basic_info_data_t hostInfo;
++
++    mach_port_t host = mach_host_self();
++    mach_msg_type_number_t count = HOST_BASIC_INFO_COUNT;
++    kern_return_t r = host_info(host, HOST_BASIC_INFO, (host_info_t)&hostInfo, &count);
++    mach_port_deallocate(mach_task_self(), host);
++    if (r != KERN_SUCCESS) {
++        LOG_ERROR("%s : host_info(%d) : %s.\n", __FUNCTION__, r, mach_error_string(r));
++        return ramSizeGuess;
++    }
++
++    if (hostInfo.max_mem > std::numeric_limits<size_t>::max())
++        return std::numeric_limits<size_t>::max();
++
++    size_t sizeAccordingToKernel = static_cast<size_t>(hostInfo.max_mem);
++    size_t multiple = 128 * MB;
++
++    // Round up the memory size to a multiple of 128MB because max_mem may not be exactly 512MB
++    // (for example) and we have code that depends on those boundaries.
++    return ((sizeAccordingToKernel + multiple - 1) / multiple) * multiple;
++#elif OS(UNIX)
++    long pages = sysconf(_SC_PHYS_PAGES);
++    long pageSize = sysconf(_SC_PAGE_SIZE);
++    if (pages == -1 || pageSize == -1)
++        return ramSizeGuess;
++    return pages * pageSize;
++#elif OS(WINDOWS)
+     MEMORYSTATUSEX status;
+     status.dwLength = sizeof(status);
+     bool result = GlobalMemoryStatusEx(&status);
+     if (!result)
+         return ramSizeGuess;
+     return status.ullTotalPhys;
+-#elif defined(USE_SYSTEM_MALLOC) && USE_SYSTEM_MALLOC
+-#if OS(UNIX)
+-    struct sysinfo si;
+-    sysinfo(&si);
+-    return si.totalram * si.mem_unit;
+-#else
+-#error "Missing a platform specific way of determining the available RAM"
+-#endif // OS(UNIX)
+-#else
+-    return bmalloc::api::availableMemory();
+ #endif
+ }
+ 
+@@ -77,4 +97,4 @@ size_t ramSize()
+     return ramSize;
+ }
+ 
+-} // namespace WTF
++} // namespace WTF
+\ No newline at end of file


### PR DESCRIPTION
#### Description

Decided to bypass webkit2-gtk-devel and just update webkit2-gtk to this version. This enables epiphany 3.26 to build as well (coming next).

Note significant input from @yan12125 , greatly appreciated.

I plan on upgrading webkit2-gtk-devel to 2.19.1 to round that up later on. 

Tested (so far) on:
10.6/libc++
10.12
10.13