### PR TITLE
fonttools-utils: new port

### DIFF
--- a/print/fonttools-utils/Portfile
+++ b/print/fonttools-utils/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                fonttools-utils
+github.setup        twardoch fonttools-utils 43062f972f5e7d95181ea57bfeb68b00812cf357
+version             20170111
+description         Font-related tools based on FontTools
+long_description    Font-related tools that use the Python FontTools \
+                    package: MacOSXSystemFontReplacer replaces UI fonts\; \
+                    pyftfeatfreeze "freezes" OpenType features into a font
+platforms           darwin
+categories          print
+license             Apache-2.0
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+
+checksums           rmd160  43c26e7810bee3d07f9fdf3e67158892b19384e3 \
+                    sha256  5b4943ec68e937f8da3119edc11e080e7c4a8ff5cdf61378fdc327a9e3b7aa9f
+
+python.default_version 27
+
+depends_run         port:fonttools
+
+build {}
+
+destroot {
+    set docdir ${prefix}/share/doc/${name}
+
+    foreach tool {mac-os-x-system-font-replacer pyftfeatfreeze} {
+        set tool_dir ${docdir}/${tool}
+        xinstall -d ${destroot}${tool_dir}
+        xinstall -m 0644 -W ${worksrcpath}/${tool} \
+            AUTHORS CONTRIBUTORS LICENSE README.md ${destroot}${tool_dir}
+        set script [glob ${worksrcpath}/${tool}/*.py]
+        reinplace "s|#!/usr/bin/env python|#!${python.bin}|" ${script}
+        xinstall -m 0755 ${script} ${destroot}${prefix}/bin
+    }
+}


### PR DESCRIPTION
#### Description
This port installs third-party tools related to the FontTools Python package.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
