### PR TITLE
nagios-plugins: Add patch file fixing check_load plugin

### DIFF
--- a/net/nagios-plugins/Portfile
+++ b/net/nagios-plugins/Portfile
@@ -23,7 +23,8 @@ master_sites        http://nagios-plugins.org/download/
 checksums           rmd160  39c364ac08854a1829d47562d4add1ae58a49334 \
                     sha256  647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18
 
-patchfiles          patch-plugins-check_nt.c.diff
+patchfiles          patch-plugins-check_nt.c.diff \
+                    patch-plugins-check_load.c.diff
 
 perl5.branches      5.26
 

--- a/net/nagios-plugins/files/patch-plugins-check_load.c.diff
+++ b/net/nagios-plugins/files/patch-plugins-check_load.c.diff
@@ -1,0 +1,11 @@
+--- plugins/check_load.c.orig	2017-01-19 17:01:31.000000000 +0100
++++ plugins/check_load.c	2017-11-16 18:10:11.000000000 +0100
+@@ -157,7 +157,7 @@
+ 	    sscanf (input_buffer, "%*[^l]load average: %lf, %lf, %lf", &la1, &la5, &la15);
+     }
+     else if(strstr(input_buffer, "load averages:")) {
+-	    sscanf (input_buffer, "%*[^l]load averages: %lf, %lf, %lf", &la1, &la5, &la15);
++	    sscanf (input_buffer, "%*[^l]load averages: %lf %lf %lf", &la1, &la5, &la15);
+     }
+     else {
+ 		printf (_("could not parse load from uptime: %s\n"), result, PATH_TO_UPTIME);


### PR DESCRIPTION
Patch fixes parsing of uptime command output.
load5 and load15 values are now parsed and displayed.

Closes: https://trac.macports.org/ticket/54775

#### Description

`check_load` parses `uptime` output. It expects string in following forms:

```
%*[^l]load average: %lf, %lf, %lf
%*[^l]load averages: %lf, %lf, %lf
```

However macOS `uptime` output lacks commas between load values:

```
19:01  up 8 days, 20:29, 8 users, load averages: 1.27 1.21 1.29
```

This patch modifies second case so it matches macOS `uptime` output:

```
%*[^l]load averages: %lf %lf %lf
```


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G17023
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

