### PR TITLE
cadaver: change master_sites to fossies.org as webdav.org is down

### DIFF
--- a/www/cadaver/Portfile
+++ b/www/cadaver/Portfile
@@ -11,11 +11,11 @@ long_description    cadaver is a command-line WebDAV client for Unix.  It \
                     supports file upload, download, on-screen display, \
                     namespace operations (move/copy), collection creation \
                     and deletion, and locking operations.
-homepage            http://www.webdav.org/cadaver/
+homepage            http://fossies.org/linux/www/
 platforms           darwin
 license             GPL-2
 
-master_sites        http://www.webdav.org/cadaver/
+master_sites        ${homepage}
 
 checksums           rmd160  104f687cfd121b091ba2f509b37574509b4ffabd \
                     sha256  fd4ce68a3230ba459a92bcb747fc6afa91e46d803c1d5ffe964b661793c13fca


### PR DESCRIPTION
closes https://trac.macports.org/ticket/55328

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G1611
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
