### PR TITLE
xhyve: add patch to fix build

### DIFF
--- a/emulators/xhyve/Portfile
+++ b/emulators/xhyve/Portfile
@@ -22,6 +22,9 @@ long_description \
 checksums           rmd160  3372c403dd82c103c88469a2e72192c8daf0f12a \
                     sha256  777dbe14c484a4a29e61c11937d3cc36497f3fa3064114722f6e24d7a8c06763
 
+patch.pre_args      -p1
+patchfiles          missing-include.diff
+
 post-patch {
     reinplace "s|test/|${prefix}/share/${name}/test/|" ${worksrcpath}/${name}run.sh
     reinplace "s|build/${name}|${prefix}/bin/${name}|" ${worksrcpath}/${name}run.sh

--- a/emulators/xhyve/Portfile
+++ b/emulators/xhyve/Portfile
@@ -49,10 +49,6 @@ post-destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/${name}
     xinstall -m 644 -W ${worksrcpath} src/xhyve-entitlements.plist ${destroot}${prefix}/share/${name}/entitlements.plist
 }
-post-activate {
-    ui_msg "Please codesign ${prefix}/bin/xhyve with an appropriate identity and entitlements.plist:"
-    ui_msg "    sudo /usr/bin/codesign --force --sign <identity> -o library --entitlements ${prefix}/share/${name}/entitlements.plist ${xcode.destroot.path}/xhyve"
-}
 
 post-destroot {
     xinstall -d -m 755 ${destroot}${prefix}/libexec/${name}
@@ -62,6 +58,9 @@ post-destroot {
 }
 
 notes "
+    Please codesign ${prefix}/bin/xhyve with an appropriate identity and entitlements.plist:
+    sudo /usr/bin/codesign --force --sign <identity> -o library --entitlements ${prefix}/share/${name}/entitlements.plist ${xcode.destroot.path}/xhyve
+
     The shell script to run xhyve is installed as ${prefix}/libexec/${name}/${name}run.sh.sample.
     Copy the script for editing. ${name}run.sh.sample will be overwritten when the port is updated.
 "

--- a/emulators/xhyve/files/missing-include.diff
+++ b/emulators/xhyve/files/missing-include.diff
@@ -1,0 +1,36 @@
+From 2f963fbacdfd93ff419b9ecd21338ec97b594448 Mon Sep 17 00:00:00 2001
+From: Dan Villiom Podlaski Christiansen <dan@magenta.dk>
+Date: Fri, 17 Nov 2017 17:41:50 +0100
+Subject: [PATCH] fix Xcode build by adding two missing includes
+
+I'm not sure why Xcode requires these, whereas the Makefile build does
+not, but adding them fixes it, and with it the MacPorts port.
+---
+ src/consport.c           | 1 +
+ src/pci_virtio_net_tap.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/consport.c b/src/consport.c
+index f5d0b73..abfcc86 100644
+--- a/src/consport.c
++++ b/src/consport.c
+@@ -33,6 +33,7 @@
+ #include <termios.h>
+ #include <unistd.h>
+ #include <stdbool.h>
++#include <sys/time.h>
+ #include <sys/types.h>
+ #include <sys/select.h>
+ #include <xhyve/support/misc.h>
+diff --git a/src/pci_virtio_net_tap.c b/src/pci_virtio_net_tap.c
+index 4268528..cab61cb 100644
+--- a/src/pci_virtio_net_tap.c
++++ b/src/pci_virtio_net_tap.c
+@@ -37,6 +37,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <assert.h>
++#include <sys/time.h>
+ #include <sys/select.h>
+ #include <sys/param.h>
+ #include <sys/uio.h>


### PR DESCRIPTION
#### Description

I also submitted this patch directly as xhyve-xyz/xhyve#9. You're the maintainer of that as well, so if you'd rather apply that and make a new release, feel free to do so. Regardless, I've posted the patch here as well since it fixes the build on High Sierra.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
