### PR TITLE
emacs-app: add multicolor_font variant

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -221,6 +221,12 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
         build.target        bootstrap
     }
 
+    variant multicolor_font description {Apply multicolor font patch} {
+        # Revert "Disable multicolor fonts on OS X..."
+        # This reverts commit 9344612d3cd164317170b6189ec43175757e4231.
+        patchfiles-append   patch-enable-multicolor-fonts.diff
+    }
+
     variant imagemagick description {Use ImageMagick} {
         depends_lib-append  port:ImageMagick
         configure.args-append --with-imagemagick

--- a/editors/emacs/files/patch-enable-multicolor-fonts.diff
+++ b/editors/emacs/files/patch-enable-multicolor-fonts.diff
@@ -1,0 +1,15 @@
+--- src/macfont.m.orig	2017-04-14 15:02:47.000000000 +0000
++++ src/macfont.m	2017-11-18 14:00:00.000000000 +0000
+@@ -2373,9 +2373,9 @@
+                   != (spacing >= FONT_SPACING_MONO)))
+             continue;
+ 
+-          /* Don't use a color bitmap font until it is supported on
+-	     free platforms.  */
+-          if (sym_traits & kCTFontTraitColorGlyphs)
++          /* Don't use a color bitmap font unless its family is
++             explicitly specified.  */
++          if ((sym_traits & kCTFontTraitColorGlyphs) && NILP (family))
+             continue;
+ 
+           if (j > 0


### PR DESCRIPTION
#### Description
https://lists.gnu.org/archive/html/emacs-devel/2016-06/msg00630.html
>Support for multi-color font is provided by the system, but is being actively 
prevented by code in Emacs for political reasons.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
