### PR TITLE
MinGW-w64: support POSIX threads

### DIFF
--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -131,6 +131,7 @@ proc crossgcc.setup {target version} {
                     gcc/doc     gcc/Makefile.in          gccinstall   info
                     gcc/fortran gcc/fortran/Make-lang.in gfortran     texi
                     libquadmath libquadmath/Makefile.in  libquadmath  info
+                    libgomp     libgomp/Makefile.in      libgomp      info
                 }
 
                 foreach { path makefile name suffix } $infopages {

--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -74,7 +74,19 @@ if {${subport} eq ${name}} {
     configure.args-append   --enable-threads=posix \
                             --enable-libgomp
 
-    # TODO: and add notes how to fix wine in regedit
+    notes "
+        If you want your MinGW-generated windows binaries to work under wine out-of-the-box
+        (and they are not statically linked), you can instruct wine
+        to automatically search for dll-s by running:
+            wine regedit
+        Nagivate to:
+            \[HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\Environment\]
+        or
+            \[HKEY_CURRENT_USER\\Environment\]
+        and add
+            Z:[string map {/ \\} ${prefix}]\\${mingw_target}\\bin
+        to the 'PATH' variable.
+    "
 }
 
 if {${subport} ne "${name}-bootstrap"} {

--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -21,6 +21,8 @@ depends_lib-append  port:${mingw_target}-headers
 #                   port:cloog
 #                   port:ppl
 
+patchfiles-append   notparallel-install-headers.patch
+
 configure.args-replace \
                     --enable-multilib \
                     --disable-multilib

--- a/cross/i686-w64-mingw32-gcc/Portfile
+++ b/cross/i686-w64-mingw32-gcc/Portfile
@@ -14,9 +14,9 @@ dist_subdir         gcc[lindex [split ${version} .] 0]
 
 maintainers         {mojca @mojca} openmaintainer
 
- # these are build + runtime dependencies
-depends_lib-append  port:${mingw_target}-binutils \
-                    port:${mingw_target}-headers
+# these are build + runtime dependencies
+# (binutils are already added by the portgroup)
+depends_lib-append  port:${mingw_target}-headers
 # not sure if useful:
 #                   port:cloog
 #                   port:ppl
@@ -45,34 +45,49 @@ configure.args-append \
 #       Installs libgcc/libstdc++ and other target support libraries in such a
 #       way that multiple GCC installs can coexist simultaneously.
 #       (add once you have the default working as it needs some extra tweaking)
-#   --enable-libgomp
-#       Enable OpenMP support, it is not enabled by default on MinGW platforms.
-#       Requires pthreads-win32 (target) installed.
 
+# First bootstrapping phase
 subport ${mingw_target}-gcc-bootstrap {
     build.target    all-gcc
     destroot.target install-gcc
 }
 
-# Supporting pthread requires an additional bootstrapping phase:
-#
-# subport ${mingw_target}-libgcc {
-#   depends_lib-append      port:${mingw_target}-crt
-#   depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
-#
-#   build.target            all-target-libgcc
-#   destroot.target         install-target-libgcc
-#   # move libgcc_*.dll to a more suitable place
-# }
+# Second bootstrapping phase
+subport ${mingw_target}-gcc-nothreads {
+    # these two are not needed since we are not yet requesting posix threads
+    # build.target          all-target-libgcc
+    # destroot.target       install-target-libgcc
 
-if {${subport} eq ${name}} {
     depends_lib-append      port:${mingw_target}-crt
     depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
+}
 
+# Final phase
+if {${subport} eq ${name}} {
+    revision                1
+
+    depends_lib-append      port:${mingw_target}-crt \
+                            port:${mingw_target}-winpthreads
+
+    depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
+
+    configure.args-append   --enable-threads=posix \
+                            --enable-libgomp
+
+    # TODO: and add notes how to fix wine in regedit
+}
+
+if {${subport} ne "${name}-bootstrap"} {
+    post-destroot {
+        move {*}[glob ${destroot}${prefix}/${mingw_target}/lib/*.dll] \
+            ${destroot}${prefix}/${mingw_target}/bin
+    }
     pre-activate {
-        set gcc ${mingw_target}-gcc-bootstrap
-        if {![catch {set installed [lindex [registry_active ${gcc}] 0]}]} {
-            registry_deactivate_composite ${gcc} "" [list ports_nodepcheck 1]
+        foreach flavour {gcc-bootstrap gcc-nothreads gcc} {
+            set gcc ${mingw_target}-${flavour}
+            if {![catch {set installed [lindex [registry_active ${gcc}] 0]}]} {
+                registry_deactivate_composite ${gcc} "" [list ports_nodepcheck 1]
+            }
         }
     }
 }

--- a/cross/i686-w64-mingw32-gcc/files/notparallel-install-headers.patch
+++ b/cross/i686-w64-mingw32-gcc/files/notparallel-install-headers.patch
@@ -1,0 +1,17 @@
+Work around parallel building issue on APFS
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+
+https://trac.macports.org/ticket/54829
+https://trac.macports.org/ticket/55213
+
+--- libstdc++-v3/include/Makefile.in.orig
++++ libstdc++-v3/include/Makefile.in
+@@ -1764,6 +1764,8 @@
+ @GLIBCXX_HOSTED_TRUE@install-data-local: install-headers
+ @GLIBCXX_HOSTED_FALSE@install-data-local: install-freestanding-headers
+ 
++.NOTPARALLEL: install-headers
++
+ # This is a subset of the full install-headers rule.  We only need <ciso646>,
+ # <cstddef>, <cfloat>, <limits>, <climits>, <cstdint>, <cstdlib>, <new>,
+ # <typeinfo>, <exception>, <initializer_list>, <cstdalign>, <cstdarg>,

--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -8,6 +8,7 @@ set mingw_name      w64-mingw32
 
 platforms           darwin
 license             ZPL-2.1
+categories          cross devel
 maintainers         {mojca @mojca} openmaintainer
 
 description         GCC cross-compiler for Windows 64 & 32 bits
@@ -24,16 +25,23 @@ configure.dir       ${workpath}/build
 build.dir           ${configure.dir}
 post-extract {      file mkdir "${build.dir}" }
 
-# create four subports:
+# create six subports:
 # - i686-w64-mingw32-headers
 # - i686-w64-mingw32-crt
+# - i686-w64-mingw32-winpthreads
 # - x86_64-w64-mingw32-headers
 # - x86_64-w64-mingw32-crt
+# - x86_64-w64-mingw32-winpthreads
 foreach arch {i686 x86_64} {
-    foreach component {crt headers} {
+    foreach component {crt headers winpthreads} {
         subport ${arch}-${mingw_name}-${component} {
-            set mingw_arch  ${arch}
-            set mingw_dir   ${component}
+            set mingw_arch      ${arch}
+            set mingw_comp      ${component}
+            if {${component} eq "winpthreads"} {
+                set mingw_dir   mingw-w64-libraries/${component}
+            } else {
+                set mingw_dir   mingw-w64-${component}
+            }
         }
     }
 }
@@ -41,26 +49,51 @@ foreach arch {i686 x86_64} {
 if {${subport} ne ${name}} {
     set mingw_target            ${mingw_arch}-${mingw_name}
 
-    configure.cmd               ${worksrcpath}/mingw-w64-${mingw_dir}/configure
+    configure.cmd               ${worksrcpath}/${mingw_dir}/configure
     configure.pre_args-replace  --prefix=${prefix} --prefix=${prefix}/${mingw_target}
     configure.args-append       --host=${mingw_target}
 
     # *-headers subports
-    if {${mingw_dir} eq "headers"} {
+    if {${mingw_comp} eq "headers"} {
+        revision                1
         supported_archs         noarch
-    }
 
-    # *-crt subports
-    if {${mingw_dir} eq "crt"} {
+        # winpthreads install three files which conflict with placeholders provided by "headers"
+        #
+        # a relatively ugly workaround is to copy those three files from "winpthreads" to "headers"
+        # and then delete them from "winpthreads" again
+        post-extract {
+            foreach f {signal time unistd} {
+                set f_src  ${worksrcpath}/mingw-w64-libraries/winpthreads/include/pthread_${f}.h
+                set f_dest ${worksrcpath}/${mingw_dir}/crt
+                copy -force ${f_src} ${f_dest}
+            }
+        }
+    # *-crt and *-winpthreads subports
+    } else {
         # We only need a dependency on either of the two GCC compilers:
         #   - ${mingw_target}-gcc-bootstrap
         #   - ${mingw_target}-gcc
         # to build. The rest of dependencies (*-headers, *-binutils)
-        # are pulled in by either of those two ports.
+        # are pulled in by one of those two ports.
         #
         # Runtime dependency on GCC is not added to avoid dependency cycles,
         # but in fact it's GCC that needs CRT at runtime, not the other way around.
-        depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
+        if {${mingw_comp} eq "crt"} {
+            depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
+        # *-winpthreads
+        } else {
+            # winpthreads needs at least stage 2 compiler (or the final one)
+            depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
+
+            # see above
+            post-destroot {
+                foreach f {signal time unistd} {
+                    delete ${destroot}${prefix}/${mingw_target}/include/pthread_${f}.h
+                }
+            }
+        }
+
         #depends_run-append     bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
         #depends_lib-append     port:${mingw_target}-binutils
         #depends_lib-append     port:${mingw_target}-headers

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -21,6 +21,8 @@ depends_lib-append  port:${mingw_target}-headers
 #                   port:cloog
 #                   port:ppl
 
+patchfiles-append   notparallel-install-headers.patch
+
 configure.args-replace \
                     --enable-multilib \
                     --disable-multilib

--- a/cross/x86_64-w64-mingw32-gcc/Portfile
+++ b/cross/x86_64-w64-mingw32-gcc/Portfile
@@ -14,9 +14,9 @@ dist_subdir         gcc[lindex [split ${version} .] 0]
 
 maintainers         {mojca @mojca} openmaintainer
 
- # these are build + runtime dependencies
-depends_lib-append  port:${mingw_target}-binutils \
-                    port:${mingw_target}-headers
+# these are build + runtime dependencies
+# (binutils are already added by the portgroup)
+depends_lib-append  port:${mingw_target}-headers
 # not sure if useful:
 #                   port:cloog
 #                   port:ppl
@@ -45,34 +45,49 @@ configure.args-append \
 #       Installs libgcc/libstdc++ and other target support libraries in such a
 #       way that multiple GCC installs can coexist simultaneously.
 #       (add once you have the default working as it needs some extra tweaking)
-#   --enable-libgomp
-#       Enable OpenMP support, it is not enabled by default on MinGW platforms.
-#       Requires pthreads-win32 (target) installed.
 
+# First bootstrapping phase
 subport ${mingw_target}-gcc-bootstrap {
     build.target    all-gcc
     destroot.target install-gcc
 }
 
-# Supporting pthread requires an additional bootstrapping phase:
-#
-# subport ${mingw_target}-libgcc {
-#   depends_lib-append      port:${mingw_target}-crt
-#   depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
-#
-#   build.target            all-target-libgcc
-#   destroot.target         install-target-libgcc
-#   # move libgcc_*.dll to a more suitable place
-# }
+# Second bootstrapping phase
+subport ${mingw_target}-gcc-nothreads {
+    # these two are not needed since we are not yet requesting posix threads
+    # build.target          all-target-libgcc
+    # destroot.target       install-target-libgcc
 
-if {${subport} eq ${name}} {
     depends_lib-append      port:${mingw_target}-crt
     depends_build-append    bin:${mingw_target}-gcc:${mingw_target}-gcc-bootstrap
+}
 
+# Final phase
+if {${subport} eq ${name}} {
+    revision                1
+
+    depends_lib-append      port:${mingw_target}-crt \
+                            port:${mingw_target}-winpthreads
+
+    depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
+
+    configure.args-append   --enable-threads=posix \
+                            --enable-libgomp
+
+    # TODO: and add notes how to fix wine in regedit
+}
+
+if {${subport} ne "${name}-bootstrap"} {
+    post-destroot {
+        move {*}[glob ${destroot}${prefix}/${mingw_target}/lib/*.dll] \
+            ${destroot}${prefix}/${mingw_target}/bin
+    }
     pre-activate {
-        set gcc ${mingw_target}-gcc-bootstrap
-        if {![catch {set installed [lindex [registry_active ${gcc}] 0]}]} {
-            registry_deactivate_composite ${gcc} "" [list ports_nodepcheck 1]
+        foreach flavour {gcc-bootstrap gcc-nothreads gcc} {
+            set gcc ${mingw_target}-${flavour}
+            if {![catch {set installed [lindex [registry_active ${gcc}] 0]}]} {
+                registry_deactivate_composite ${gcc} "" [list ports_nodepcheck 1]
+            }
         }
     }
 }

--- a/cross/x86_64-w64-mingw32-gcc/files/notparallel-install-headers.patch
+++ b/cross/x86_64-w64-mingw32-gcc/files/notparallel-install-headers.patch
@@ -1,0 +1,17 @@
+Work around parallel building issue on APFS
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+
+https://trac.macports.org/ticket/54829
+https://trac.macports.org/ticket/55213
+
+--- libstdc++-v3/include/Makefile.in.orig
++++ libstdc++-v3/include/Makefile.in
+@@ -1764,6 +1764,8 @@
+ @GLIBCXX_HOSTED_TRUE@install-data-local: install-headers
+ @GLIBCXX_HOSTED_FALSE@install-data-local: install-freestanding-headers
+ 
++.NOTPARALLEL: install-headers
++
+ # This is a subset of the full install-headers rule.  We only need <ciso646>,
+ # <cstddef>, <cfloat>, <limits>, <climits>, <cstdint>, <cstdlib>, <new>,
+ # <typeinfo>, <exception>, <initializer_list>, <cstdalign>, <cstdarg>,


### PR DESCRIPTION
#### Description

These patches introduce support for posix threads and OpenMP to the MinGW-w64 cross-compiler and addresses a few other minor issues.

Here's a full list of tickets:
* [#55265](https://trac.macports.org/ticket/55265): add support for POSIX threads
* [#55273](https://trac.macports.org/ticket/55273): add notes for Wine users
* [#55213](https://trac.macports.org/ticket/55213): fix builds on APFS
* Add support for OpenMP
* Patch the PortGroup to fix location of openmp's info file.

I would be grateful for a review.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
