### PR TITLE
get_iplayer: add/remove missing/obsolete dependencies

### DIFF
--- a/net/get_iplayer/Portfile
+++ b/net/get_iplayer/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 PortGroup           github 1.0
 
 github.setup        get-iplayer get_iplayer 3.06 v
+revision            1
 categories          net multimedia
 platforms           darwin
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -22,14 +23,9 @@ perl5.branches      5.26
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-libwww-perl \
+                    port:p${perl5.major}-mojolicious \
                     port:p${perl5.major}-xml-libxml \
-                    port:p${perl5.major}-mp3-tag \
-                    port:p${perl5.major}-mp3-info \
-                    port:p${perl5.major}-net-smtp-tls-butmaintained \
-                    port:p${perl5.major}-net-smtp-ssl \
-                    port:p${perl5.major}-authen-sasl \
                     port:atomicparsley \
-                    port:id3v2 \
                     path:bin/ffmpeg:ffmpeg
 
 post-patch {


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G17023
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
