### PR TITLE
calcurse: disable rpath

### DIFF
--- a/sysutils/calcurse/Portfile
+++ b/sysutils/calcurse/Portfile
@@ -20,6 +20,8 @@ checksums       rmd160  5f6f839e62e0ee7241d055f86a96eb8411a87d0c \
 
 depends_lib     port:gettext port:libiconv port:ncurses
 
+configure.args-append --disable-rpath
+
 livecheck.type  regex
 livecheck.url   ${homepage}/downloads/
 livecheck.regex "latest.*>(\\d+(?:\\.\\d+)*)</"


### PR DESCRIPTION
fix build on 10.8 and 10.9

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G1611
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
