### PR TITLE
github-backup: update to v0.14.1; add GitHub handle

### DIFF
--- a/python/github-backup/Portfile
+++ b/python/github-backup/Portfile
@@ -5,10 +5,10 @@ PortGroup           python 1.0
 
 name                github-backup
 set _n              [string index ${name} 0]
-version             0.9.0
+version             0.14.1
 platforms           darwin
 license             MIT
-maintainers         gmail.com:davide.liessi openmaintainer
+maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
 
 description         Backup a GitHub user or organization
 long_description    ${description}
@@ -16,8 +16,8 @@ long_description    ${description}
 homepage            http://github.com/josegonzalez/python-github-backup
 master_sites        pypi:${_n}/${name}
 
-checksums           rmd160  221e594dd54c1777f806830149c4e08a65514c2f \
-                    sha256  375edd04b5bec475135f9e152142f98ef49457071426ab2fbdf29cb9170f0271
+checksums           rmd160  908bed9d654168c3033ff89174130a3f52838cae \
+                    sha256  e36a6405102b1db83b4341cf2767c4f5b900200ac058f8fa47df1cb7898289b2
 
 python.default_version  27
 


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G17023
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
