### PR TITLE
kotlin: update to 1.1.61

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.1.60 v
+github.setup        JetBrains kotlin 1.1.61 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  46ff86aa43225a25ee3af4dab0d9d0f481ae2d38 \
-                    sha256  49870ecd8cc0f9c22aa920a23a45d94fa701c612bcb4ab1e5be05d91d8857413
+checksums           rmd160  8c01cb0ac8c45fc68d89ac6fe0c69afa7ca9ac48 \
+                    sha256  46103d3f65c4016cb62ff8b77ee3e072ff930e69edf69444d723bb22b12a0d83
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update Kotlin to 1.1.61.

###### Tested on

macOS 10.13.1 17B48
Xcode 9.1 9B55 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?