### PR TITLE
uchardet: update to 0.0.6

### DIFF
--- a/textproc/uchardet/Portfile
+++ b/textproc/uchardet/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        BYVoid uchardet 0.0.5 v
+name                uchardet
+version             0.0.6
 categories          textproc
 platforms           darwin
-maintainers         madlon-kay.com:aaron+macports openmaintainer
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
 license             {MPL-1.1 GPL-2+ LGPL-2.1+}
 
 description         A text encoding detector library and tool
@@ -19,5 +19,10 @@ long_description    uchardet is an encoding detector library and \
                     the encoding of the text. Returned encoding names \
                     are iconv-compatible.
 
-checksums           rmd160  44d3ee430f77de334ae81e3b9d8fd9c7d5e769e6 \
-                    sha256  823ad9b365eb38d697052403c58efd6859ade45da11f41f849a493018b1c1eff
+homepage            https://www.freedesktop.org/wiki/Software/uchardet/
+master_sites        https://www.freedesktop.org/software/uchardet/releases/
+
+use_xz              yes
+
+checksums           rmd160  a5d5a632f7bb0e3c214531b9a52a07f6b8f80571 \
+                    sha256  8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61


### PR DESCRIPTION
#### Description
Update uchardet to 0.0.6.

uchardet has moved from GitHub to the freedesktop project.

This PR addresses https://trac.macports.org/ticket/55402.
