### PR TITLE
clang-4,5,devel: fix install names

### DIFF
--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -13,7 +13,7 @@ set clang_executable_version 4.0
 set lldb_executable_version 4.0.1
 name                    llvm-${llvm_version}
 revision                2
-subport                 clang-${llvm_version} { revision 3 }
+subport                 clang-${llvm_version} { revision 4 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -216,13 +216,12 @@ cmake.install_prefix ${sub_prefix}
 #     https://github.com/macports/macports-ports/pull/103
 # Also see:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
+#     https://trac.macports.org/ticket/53299
 configure.args-delete \
     -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
     -DCMAKE_INSTALL_RPATH=${prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -13,7 +13,7 @@ set clang_executable_version 5.0
 set lldb_executable_version 5.0.0
 name                    llvm-${llvm_version}
 revision                2
-subport                 clang-${llvm_version} { revision 4 }
+subport                 clang-${llvm_version} { revision 5 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -215,13 +215,12 @@ cmake.install_prefix ${sub_prefix}
 #     https://github.com/macports/macports-ports/pull/103
 # Also see:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
+#     https://trac.macports.org/ticket/53299
 configure.args-delete \
     -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
     -DCMAKE_INSTALL_RPATH=${prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -13,7 +13,7 @@ set clang_executable_version 6.0
 set lldb_executable_version 6.0.0
 name                    llvm-${llvm_version}
 revision                1
-subport                 clang-${llvm_version} { revision 4 }
+subport                 clang-${llvm_version} { revision 5 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -189,13 +189,12 @@ cmake.install_prefix ${sub_prefix}
 #     https://github.com/macports/macports-ports/pull/103
 # Also see:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
+#     https://trac.macports.org/ticket/53299
 configure.args-delete \
     -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
     -DCMAKE_INSTALL_RPATH=${prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
-    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"
 
 configure.args-append \


### PR DESCRIPTION
clang installs some libraries in places other than
${cmake.install_prefix}/lib so we need to allow the
clang internal rpath mechanisms to set this

closes: https://trac.macports.org/ticket/53299
