### PR TITLE
fetchmail: add devel subport, +ssl by default

### DIFF
--- a/mail/fetchmail/Portfile
+++ b/mail/fetchmail/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fetchmail
 version             6.3.26
-revision            1
+revision            2
 categories          mail
 platforms           darwin
 license             {GPL-2 OpenSSLException}
@@ -30,23 +30,39 @@ long_description \
     read the mail, offline if you want, using Pine, \
     mutt, or any standard mail user agent.
 
+if {${name} eq ${subport}} {
+    checksums       rmd160  ce9a54b6d11da4c5e042c760284f8b3c6ac5a4ff \
+                    sha256  79b4c54cdbaf02c1a9a691d9948fcb1a77a1591a813e904283a8b614b757e850
+
+    conflicts       fetchmail-devel
+
+    patchfiles      no-ssl3.patch
+}
+
+subport fetchmail-devel {
+    version         6.4.0.beta2
+    revision        0
+
+    checksums       rmd160  c337d0b615d8a900eefab215a697f07db989eb7e \
+                    sha256  da6e50df42f37cab5e92be0acd476ff8abf3824f3e18eac2bd8ff818d4ca11dc
+
+    conflicts       fetchmail
+}
+
 homepage            http://www.fetchmail.info
 set branch          [join [lrange [split ${version} .] 0 1] .]
 master_sites        sourceforge:project/${name}/branch_${branch}
 
 use_xz              yes
 
-checksums           rmd160  ce9a54b6d11da4c5e042c760284f8b3c6ac5a4ff \
-                    sha256  79b4c54cdbaf02c1a9a691d9948fcb1a77a1591a813e904283a8b614b757e850
-
 depends_lib         port:gettext \
                     port:kerberos5
-
-patchfiles          no-ssl3.patch
 
 configure.args      --mandir=${prefix}/share/man \
                     --with-libiconv-prefix=${prefix} \
                     --without-ssl --with-kerberos5=${prefix} --with-gssapi
+
+default_variants    +ssl
 
 post-destroot {
     if { ! [variant_isset fetchmailconf] } {
@@ -65,10 +81,15 @@ variant fetchmailconf description "Install a graphical configurator" {
 variant ntlm description "Enable NTLM authentication" {
     configure.args-append   --enable-NTLM
 }
+
 variant ssl description "Support secure connections using OpenSSL" {
     depends_lib-append      path:lib/libssl.dylib:openssl
     configure.args-delete   --without-ssl
     configure.args-append   --with-ssl=${prefix}
 }
 
-livecheck.regex     fetchmail-(\\d+(?:\\.\\d+)*)${extract.suffix}
+if {${name} eq ${subport}} {
+    livecheck.regex fetchmail-(\\d+(?:\\.\\d+)*)${extract.suffix}
+} else {
+    livecheck.regex fetchmail-(\\d+(?:\\.\\d+)*(?:\\.beta\\d+)?)${extract.suffix}
+}


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B48
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
