### PR TITLE
pdns-recursor: update to 4.0.7

### DIFF
--- a/net/pdns-recursor/Portfile
+++ b/net/pdns-recursor/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                pdns-recursor
-version             4.0.6
-revision            1
+version             4.0.7
 categories          net
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -23,8 +22,8 @@ homepage            https://www.powerdns.com/recursor.html
 master_sites        https://downloads.powerdns.com/releases/
 use_bzip2           yes
 
-checksums           rmd160  93aeaaa2b26834f0a2cbea7421b6fe01a82d048e \
-                    sha256  f2182ac644268bb08b865a71351f11d75c5015ac0608a1469eb4c1cd5494d60d
+checksums           rmd160  e4a7f0e77d85c1c3f357cf63e01c46938380b53e \
+                    sha256  966d1654c32c72bd0cc9b301ae5b723a34e36f3c02e62c73a7643260122f94e7
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description
- 2017-03: Insufficient validation of DNSSEC signatures
(CVE-2017-15090, Recursor >= 4.0.0)
- 2017-05: Cross-Site Scripting in the web interface (CVE-2017-15092,
Recursor >= 4.0.0)
- 2017-06: Configuration file injection in the API (CVE-2017-15093,
Recursor)
- 2017-07: Memory leak in DNSSEC parsing (CVE-2017-15094, Recursor >=
4.0.0)
