### PR TITLE
py-poppler-qt5: add py36, require C++11, pypi-style livecheck

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -3,33 +3,34 @@
 PortSystem          1.0
 PortGroup           qt5 1.0
 PortGroup           python 1.0
-
-set _name           python-poppler-qt5
-set _n              [string index ${_name} 0]
+PortGroup           cxx11 1.1
 
 name                py-poppler-qt5
+python.rootname     python-poppler-qt5
+set _n              [string index ${python.rootname} 0]
 version             0.24.2
+revision            1
 platforms           darwin
 license             LGPL-2.1+
-maintainers         gmail.com:davide.liessi openmaintainer
+maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
 
 description         Python binding for Poppler-Qt5
-long_description    ${_name} is a Python binding for Poppler-Qt5 \
+long_description    ${python.rootname} is a Python binding for Poppler-Qt5 \
                     that aims for completeness \
                     and for being actively maintained. \
                     Using this module you can access \
                     the contents of PDF files \
                     inside PyQt5 applications.
 
-homepage            https://github.com/wbsoft/${_name}
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+homepage            https://github.com/wbsoft/${python.rootname}
+master_sites        pypi:${_n}/${python.rootname}/
+distname            ${python.rootname}-${version}
 
 checksums           md5     1f45ed0f7f3cacc1d0f9e626bd5fb5c8 \
                     rmd160  baa134c6a9e466dddcb15a23f7238b88d1eed8af \
                     sha256  3970c35ce1f0f1464a6c2746bea4c479b9780b4e17030c92479f7f1738a5c950
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
@@ -41,6 +42,7 @@ if {${name} ne ${subport}} {
 
     patchfiles              patch-fix-qtxml.diff \
                             patch-fix-qt-dirs.diff \
+                            patch-fix-cxx11.diff \
                             patch-fix-demo.diff
 
     post-patch {
@@ -63,7 +65,5 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}
-    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
+    livecheck.type  pypi
 }

--- a/python/py-poppler-qt5/files/patch-fix-cxx11.diff
+++ b/python/py-poppler-qt5/files/patch-fix-cxx11.diff
@@ -1,0 +1,10 @@
+--- setup.py
++++ setup.py
+@@ -114,6 +114,7 @@ def pkg_config_version(package):
+         sys.stderr.write("Can't determine version of %s\n" % package)
+ 
+ ext_args = {}
++ext_args['extra_compile_args'] = ['-std=c++11']
+ pkg_config('poppler-qt5', ext_args)
+ 
+ if 'libraries' not in ext_args:


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G17023
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
