### PR TITLE
py-poppler-qt4: patch PyList_SET_ITEM -> PyList_SetItem

### DIFF
--- a/python/py-poppler-qt4/Portfile
+++ b/python/py-poppler-qt4/Portfile
@@ -7,7 +7,7 @@ name                py-poppler-qt4
 python.rootname     python-poppler-qt4
 set _n              [string index ${python.rootname} 0]
 version             0.24.0
-revision            1
+revision            2
 platforms           darwin
 license             LGPL-2.1+
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -37,6 +37,8 @@ if {${name} ne ${subport}} {
                             port:qt4-mac \
                             port:py${python.version}-sip \
                             port:py${python.version}-pyqt4
+
+    patchfiles              patch-types.sip.diff
 
     post-destroot {
         set doc_dir ${destroot}${prefix}/share/doc/${subport}

--- a/python/py-poppler-qt4/files/patch-types.sip.diff
+++ b/python/py-poppler-qt4/files/patch-types.sip.diff
@@ -1,0 +1,13 @@
+https://trac.macports.org/ticket/55014
+https://github.com/wbsoft/python-poppler-qt4/issues/17
+--- types.sip
++++ types.sip
+@@ -27,7 +27,7 @@
+     foreach (Poppler::Document::RenderBackend value, set)
+     {
+         PyObject *obj = PyLong_FromLong ((long) value);
+-        if (obj == NULL || PyList_SET_ITEM (l, i, obj) < 0)
++        if (obj == NULL || PyList_SetItem(l, i, obj) < 0)
+         {
+             Py_DECREF(l);
+ 

--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -9,7 +9,7 @@ name                py-poppler-qt5
 python.rootname     python-poppler-qt5
 set _n              [string index ${python.rootname} 0]
 version             0.24.2
-revision            1
+revision            2
 platforms           darwin
 license             LGPL-2.1+
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -43,7 +43,8 @@ if {${name} ne ${subport}} {
     patchfiles              patch-fix-qtxml.diff \
                             patch-fix-qt-dirs.diff \
                             patch-fix-cxx11.diff \
-                            patch-fix-demo.diff
+                            patch-fix-demo.diff \
+                            patch-types.sip.diff
 
     post-patch {
         reinplace "s|%%QMAKE%%|${qt_bins_dir}/qmake|g" ${worksrcpath}/setup.py

--- a/python/py-poppler-qt5/files/patch-types.sip.diff
+++ b/python/py-poppler-qt5/files/patch-types.sip.diff
@@ -1,0 +1,13 @@
+https://trac.macports.org/ticket/55014
+https://github.com/wbsoft/python-poppler-qt4/issues/17
+--- types.sip
++++ types.sip
+@@ -27,7 +27,7 @@
+     foreach (Poppler::Document::RenderBackend value, set)
+     {
+         PyObject *obj = PyLong_FromLong ((long) value);
+-        if (obj == NULL || PyList_SET_ITEM (l, i, obj) < 0)
++        if (obj == NULL || PyList_SetItem(l, i, obj) < 0)
+         {
+             Py_DECREF(l);
+ 


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/55014

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G17023
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
