### PR TITLE
Updates for LDAS Tools Suite

### DIFF
--- a/science/ldas-tools-al/Portfile
+++ b/science/ldas-tools-al/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-al
-version       2.5.5
+version       2.5.7
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -15,16 +15,13 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
-patchfiles    patch-Xcode9.diff
-
-checksums     rmd160 fc50f9c7911463fabd79f55e59fbcc8519bd45b1 \
-              sha256 5583e511bd680a43023b1d9a1c05d3e0c11ac70624032e8c918bdb47dd7a4b8e
+checksums     rmd160 182f0fc8715508fa44e3564f3b3bbed008d78bfe \
+              sha256 72fcc57378b45f96ecb573656e36e4ac45b52b847811c83c872dce1ea0f0fb8d
 
 depends_build  port:pkgconfig
 depends_lib    port:lib/libssl.dylib:openssl \
                port:zlib \
-               port:bzip2 \
-               port:flex
+               port:bzip2
 
 
 configure.args PYTHON=false \
@@ -37,8 +34,6 @@ configure.args PYTHON=false \
                --without-dot \
                --disable-latex
 
-#------------------------------------------------------------------------
-
 if {${configure.cxx_stdlib} eq "libstdc++" } {
     configure.args-append --disable-cxx11
 }
@@ -47,6 +42,13 @@ if {${configure.cxx_stdlib} eq "libstdc++" } {
 compiler.blacklist-append {clang < 500.2.75} llvm-gcc-4.2 gcc-4.2
 
 use_parallel_build yes
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} only runs on Mac OS X 10.7 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
 
 pre-activate {
   # ldas-tools-al now contains files that used to be provided by ldas-tools
@@ -59,7 +61,6 @@ pre-activate {
   }
 }
 
-#------------------------------------------------------------------------
 #------------------------------------------------------------------------
 
 livecheck.type   regex

--- a/science/ldas-tools-diskcacheAPI/Portfile
+++ b/science/ldas-tools-diskcacheAPI/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-diskcacheAPI
-version       2.5.5
+version       2.5.6
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -15,8 +15,8 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
-checksums     rmd160 580e1ffbafbd039906622a5b72c591a2ff8fcd9b \
-              sha256 22790bbd2437c190168fe1b137bdcd3b0179ba8ef53cad3d826788f70995907f
+checksums     rmd160 c544032228f5c93d1238f38daeba29c53bb3520c \
+              sha256 2e0be2e5193f900a3db0da8c495b277560b96f5228ee117d456c54782fb9e713
 
 depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-ldasgen
@@ -38,6 +38,15 @@ if {${configure.cxx_stdlib} eq "libstdc++" } {
 compiler.blacklist-append {clang < 500.2.75} llvm-gcc-4.2 gcc-4.2
 
 use_parallel_build yes
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} only runs on Mac OS X 10.7 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+#------------------------------------------------------------------------
 
 livecheck.type   regex
 livecheck.url    ${master_sites}
@@ -62,6 +71,7 @@ foreach v {27} {
 
     depends_build-append      port:swig-python
     depends_lib-append        port:${name}
+    depends_lib-append        port:py${python.version}-ldas-tools-al
     depends_lib-append        port:python${python.version}
 
     configure.python          ${python.bin}

--- a/science/ldas-tools-filters/Portfile
+++ b/science/ldas-tools-filters/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-filters
-version       2.5.1
+version       2.5.2
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -15,8 +15,8 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
-checksums     rmd160 ef9771271586b6b31c2f70687d5750ef5a61f276 \
-              sha256 44d475e625f5a59c9846a85d79419ef1303d3d9011bae56780156cab1a55f3b4
+checksums     rmd160 bbe90cc33b7841bf623b3c0aa2b01939f425f6eb \
+              sha256 f63305882c13bb03b1e47fca5e14ec09e905b91f6f0ea27f520db4c53801aee2
 
 depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-al
@@ -37,6 +37,15 @@ if {${configure.cxx_stdlib} eq "libstdc++" } {
 compiler.blacklist-append {clang < 500.2.75} llvm-gcc-4.2 gcc-4.2
 
 use_parallel_build yes
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} only runs on Mac OS X 10.7 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+#------------------------------------------------------------------------
 
 livecheck.type   regex
 livecheck.url    ${master_sites}

--- a/science/ldas-tools-frameAPI/Portfile
+++ b/science/ldas-tools-frameAPI/Portfile
@@ -5,6 +5,7 @@ PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-frameAPI
 version       2.5.2
+revision      1
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -14,6 +15,10 @@ long_description ${description}
 
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
+
+patchfiles    patch-config-autotools-make-python.mk.diff \
+              patch-swig-common-include-fix.diff \
+              patch-src-Makefile.in.diff
 
 checksums     rmd160 d8ca30fc0d10b05015591a87951ee7e0333218e0 \
               sha256 c7d58952e213a024dd6ac33dd907862b2c96baa7a4fb2ac4bb47ceef6bc45d50
@@ -41,6 +46,15 @@ compiler.blacklist-append {clang < 500.2.75} llvm-gcc-4.2 gcc-4.2
 
 use_parallel_build yes
 
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} only runs on Mac OS X 10.7 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+#------------------------------------------------------------------------
+
 livecheck.type   regex
 livecheck.url    ${master_sites}
 livecheck.regex  {ldas-tools-frameAPI-(\d+(?:\.\d+)*).tar.gz}
@@ -64,6 +78,7 @@ foreach v {27} {
 
     depends_build-append      port:swig-python
     depends_lib-append        port:${name}
+    depends_lib-append        port:py${python.version}-ldas-tools-al
     depends_lib-append        port:python${python.version}
 
     configure.python          ${python.bin}

--- a/science/ldas-tools-frameAPI/files/patch-config-autotools-make-python.mk.diff
+++ b/science/ldas-tools-frameAPI/files/patch-config-autotools-make-python.mk.diff
@@ -1,0 +1,22 @@
+--- config/autotools/make/python.mk
++++ config/autotools/make/python.mk
+@@ -28,12 +28,15 @@ clean-local-python:
+ %_python.stamp: $$($$*_SWIG) Makefile $$($$*_SWIG_INCLUDES) $$($$*_SWIG_AUXDEPS)
+ 	@rm -f $*_python.stamp
+ 	@touch $*_python.stamp.tmp
+-	$(AM_V_GEN)$(SWIG) $(PKG_SWIGFLAGS) $(SWIGFLAGS) \
+-		-shadow -c++ -importall -Wall \
++	$(AM_V_GEN)$(SWIG) $(SWIGFLAGS) \
++		-shadow \
++	        -c++ \
++	        -importall \
++	        -Wall \
++		-ignoremissing \
+ 		-I$(srcdir) \
+ 		-I$(top_srcdir)/config/swig $(PYTHON_INCLUDES) \
+-		 $(AM_CPPFLAGS) \
+-		-c++ \
++		 $(AM_CPPFLAGS) $(PKG_SWIGFLAGS) \
+ 		-python -classic \
+ 		-o $*_python_wrap.cc $<
+ 	@mv $*_python.stamp.tmp $*_python.stamp

--- a/science/ldas-tools-frameAPI/files/patch-src-Makefile.in.diff
+++ b/science/ldas-tools-frameAPI/files/patch-src-Makefile.in.diff
@@ -1,0 +1,19 @@
+--- src/Makefile.in.orig	2017-11-15 11:44:34.000000000 -0800
++++ src/Makefile.in	2017-11-15 11:38:59.000000000 -0800
+@@ -522,14 +522,14 @@
+ 	createRDS.hh \
+ 	filereader.hh \
+ 	Frame.hh \
++	Catalog.hh \
++	Channel.hh \
+ 	rdsframe.hh \
+ 	rdsreduce.hh \
+ 	rdsresample.hh \
+ 	util.hh
+ 
+ noinst_HEADERS = \
+-	Catalog.hh \
+-	Channel.hh \
+ 	ConditionData.hh \
+ 	DeviceIOConfiguration.hh \
+ 	FileCache.icc \

--- a/science/ldas-tools-frameAPI/files/patch-swig-common-include-fix.diff
+++ b/science/ldas-tools-frameAPI/files/patch-swig-common-include-fix.diff
@@ -1,0 +1,120 @@
+--- src/Catalog.cc
++++ src/Catalog.cc
+@@ -9,10 +9,10 @@
+ 
+ #include "framecpp/FrTOC.hh"
+ 
+-#include "Catalog.hh"
+-#include "Channel.hh"
+-#include "createRDS.hh"
+-#include "Frame.hh"
++#include "frameAPI/Catalog.hh"
++#include "frameAPI/Channel.hh"
++#include "frameAPI/createRDS.hh"
++#include "frameAPI/Frame.hh"
+ 
+ namespace FrameAPI
+ {
+--- src/Channel.cc
++++ src/Channel.cc
+@@ -1,4 +1,4 @@
+-#include "Channel.hh"
++#include "frameAPI/Channel.hh"
+ 
+ namespace FrameAPI
+ {
+--- src/Frame.cc
++++ src/Frame.cc
+@@ -2,8 +2,8 @@
+ 
+ #include "framecpp/FrRawData.hh"
+ 
+-#include "Channel.hh"
+-#include "Frame.hh"
++#include "frameAPI/Channel.hh"
++#include "frameAPI/Frame.hh"
+ 
+ namespace
+ {
+--- swig/common/Catalog.i
++++ swig/common/Catalog.i
+@@ -6,7 +6,7 @@
+ #include <string>
+ #include <list>
+ 
+-#include "Catalog.hh"
++#include "frameAPI/Catalog.hh"
+ 
+ using namespace FrameAPI;
+ using LDASTools::AL::GPSTime;
+--- swig/common/Channel.i
++++ swig/common/Channel.i
+@@ -4,7 +4,8 @@
+ 
+ %{
+ #include "framecpp/FrVect.hh"
+-#include "Channel.hh"
++
++#include "frameAPI/Channel.hh"
+ 
+   using FrameCPP::FrVect;
+   using FrameCPP::Common::FrameSpec;
+@@ -26,7 +27,7 @@
+ %import "framecpp/FrProcData.i"
+ %import "framecpp/FrSimData.i"
+ 
+-%import "Channel.hh"
++%import "frameAPI/Channel.hh"
+ 
+ %SharedPtr(FrVect)
+ 
+--- swig/common/Frame.i
++++ swig/common/Frame.i
+@@ -5,7 +5,7 @@
+ %{
+ #include "framecpp/FrameH.hh"
+ 
+-#include "Frame.hh"
++#include "frameAPI/Frame.hh"
+ 
+   using FrameAPI::Frame;
+   using FrameCPP::OFrameFStream;
+--- swig/common/LDASframe.i
++++ swig/common/LDASframe.i
+@@ -11,7 +11,7 @@ developers to interface with the frameAPI library create by the LDAS team."
+ %feature("autodoc","1");
+ 
+ %{
+-#include "Channel.hh"
++#include "frameAPI/Channel.hh"
+ 
+ using namespace FrameAPI;
+ %}
+--- swig/common/createRDS.i
++++ swig/common/createRDS.i
+@@ -6,7 +6,7 @@
+ #include <string>
+ #include <vector>
+ 
+-#include "createRDS.hh"
++#include "frameAPI/createRDS.hh"
+ 
+ using namespace FrameAPI;
+  typedef FrameAPI::RDS::Options::rds_level_type rds_level_type;
+--- test/test_createRDS_cpp.cc
++++ test/test_createRDS_cpp.cc
+@@ -8,10 +8,10 @@
+ #include "genericAPI/Logging.hh"
+ #include "genericAPI/LogText.hh"
+ 
+-#include "Catalog.hh"
+-#include "Channel.hh"
+-#include "createRDS.hh"
+-#include "Frame.hh"
++#include "frameAPI/Catalog.hh"
++#include "frameAPI/Channel.hh"
++#include "frameAPI/createRDS.hh"
++#include "frameAPI/Frame.hh"
+ 
+ //  LDAS_TEST_FRAMES_DIR -
+ 

--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-framecpp
-version       2.5.5
+version       2.5.8
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -15,21 +15,16 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
-checksums     rmd160 5a4eafe72975961707ab072d1c2df030e7a1f3bf \
-              sha256 15130fe497ec7697de58d58258999d3773cdd1912115ce8e506d095fe6fac2fc
+checksums     rmd160 575d7c502f5f9555538da2b8c832f04af59ffda2 \
+              sha256 4a0dd81baa9df2cd2d1691a4101ac4bf9a81dcbbd2d6f30e33a2c8ec0a7fe138
 
-depends_build  port:pkgconfig \
-               port:autoconf \
-               port:automake \
-               port:libtool \
-               port:libframe
-
+depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-al \
                port:openssl \
                port:zlib \
                port:bzip2
 
-configure.args  --disable-warnings-as-errors \
+configure.args --disable-warnings-as-errors \
                --disable-silent-rules \
                --with-optimization=high \
                --disable-tcl \
@@ -47,7 +42,13 @@ compiler.blacklist-append {clang < 500.2.75} llvm-gcc-4.2 gcc-4.2
 
 use_parallel_build yes
 
-#------------------------------------------------------------------------
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} only runs on Mac OS X 10.7 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
 #------------------------------------------------------------------------
 
 livecheck.type   regex
@@ -73,6 +74,7 @@ foreach v {27} {
 
     depends_build-append      port:swig-python
     depends_lib-append        port:${name}
+    depends_lib-append        port:py${python.version}-ldas-tools-al
     depends_lib-append        port:python${python.version}
 
     configure.python          ${python.bin}

--- a/science/ldas-tools-ldasgen/Portfile
+++ b/science/ldas-tools-ldasgen/Portfile
@@ -4,7 +4,7 @@ PortSystem    1.0
 PortGroup     compiler_blacklist_versions 1.0
 
 name          ldas-tools-ldasgen
-version       2.5.4
+version       2.5.5
 categories    science
 platforms     darwin
 maintainers   ligo.org:ed.maros
@@ -15,10 +15,12 @@ long_description ${description}
 homepage      https://wiki.ligo.org/DASWG/LDASTools
 master_sites  http://software.ligo.org/lscsoft/source/
 
-checksums     rmd160 b8f7600b992f599b183146732967582a942b4ad8 \
-              sha256 48b410aeb1b9718c5185c74fc9cba11c79da08f8bdc78a140db72b07a8ba099f
+checksums     rmd160 ba4f9388161772ab3840ece688c1178c3c559509 \
+              sha256 2a9130cb932fbe10ac1c9a22809e188a78d598f8419a3b45b161fda8b14bf5e2
 
-depends_build  port:pkgconfig
+depends_build  port:pkgconfig \
+               port:flex
+
 depends_lib    port:ldas-tools-al
 
 configure.args --disable-warnings-as-errors \
@@ -38,6 +40,15 @@ if {${configure.cxx_stdlib} eq "libstdc++" } {
 compiler.blacklist-append {clang < 500.2.75} llvm-gcc-4.2 gcc-4.2
 
 use_parallel_build yes
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} only runs on Mac OS X 10.7 or greater."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+#------------------------------------------------------------------------
 
 livecheck.type   regex
 livecheck.url    ${master_sites}
@@ -62,6 +73,7 @@ foreach v {27} {
 
     depends_build-append      port:swig-python
     depends_lib-append        port:${name}
+    depends_lib-append        port:py${python.version}-ldas-tools-al
     depends_lib-append        port:python${python.version}
 
     configure.python          ${python.bin}


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

ldas-tools-al: updatedto 2.5.7
ldas-tools-framecpp: update to 2.5.8
ldas-tools-filters: update to 2.5.2
ldas-tools-diskcacheAPI: update to 2.5.6
ldas-tools-frameAPI: correction for XCode 9.x

Fixed Tickets:
https://trac.macports.org/ticket/54904

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1033
Xcode 9.0 9A235

and

macOS 10.11.6 15G18013
Xcode 8.0 8A218a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
