### PR TITLE
spring-boot-cli: update to 1.5.9

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.8
+version         1.5.9
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  fd0c3a613d059305a318890c4ee1c11c30c43806 \
-                sha256  422608ab63fa05bf8806b5ee2bea4fdf1a270f3780252e57b18c9010f37f4230
+checksums       rmd160  5ee13b85e68fc0a6adb01796d4ceba7428c14e17 \
+                sha256  44fe67ce80fc6f272ebac36bafbffe36a6c794d991deb46bc480db0113b42e9b
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update Spring Boot CLI to 1.5.9.

###### Tested on

macOS 10.13.1 17B1002
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?