### PR TITLE
qpid-proton: new port

### DIFF
--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                qpid-proton
+description         Qpid Proton is a high-performance, lightweight AMQP \
+                    1.0 messaging library.
+long_description    Qpid Proton is a high-performance, lightweight messaging library. It can \
+                    be used in the widest range of messaging applications, including brokers, \
+                    client libraries, routers, bridges, proxies, and more. Proton makes it \
+                    trivial to integrate with the AMQP 1.0 ecosystem from any platform, \
+                    environment, or language.
+categories          net
+license             Apache-2
+maintainers         {unifiedsoftworx.com:roddie.kieley @roddiekieley} openmaintainer
+platforms           darwin freebsd linux
+homepage            https://qpid.apache.org
+
+PortGroup           github 1.0
+
+github.setup        apache qpid-proton fa80534c87940b44fefd36abff4c5a9a79b99f47
+version             0.18.1
+
+checksums           rmd160  61841dd0416cc738b02e5137316bf9fd46821ced \
+                    sha256  d762c7b07ed6092ebdbcc49da731425bc5a71bef084fd9c29a0e26e6e18f275b
+
+PortGroup           cmake 1.0
+
+cmake.out_of_source yes
+configure.args-append \
+                    -DSASL_IMPL=none \
+                    -DSSL_IMPL=none \
+                    -DLIB_SUFFIX="" \
+                    -DBUILD_PERL=OFF \
+                    -DBUILD_PYTHON=OFF \
+                    -DBUILD_GO=OFF \
+                    -DBUILD_RUBY=OFF
+
+default_variants    +openssl
+
+variant openssl description {With built-in support for OpenSSL} {
+    configure.args-replace -DSSL_IMPL=none -DSSL_IMPL=openssl
+
+    depends_lib-append      port:openssl
+}
+
+variant swig description {With built-in support for SWIG so the bindings can be built} {
+    configure.args-replace -DBUILD_PERL=OFF -DBUILD_PERL=ON
+    configure.args-replace -DBUILD_PYTHON=OFF -DBUILD_PYTHON=ON
+    configure.args-replace -DBUILD_GO=OFF -DBUILD_GO=ON
+    configure.args-replace -DBUILD_RUBY=OFF -DBUILD_RUBY=ON
+
+    depends_lib-append      port:swig \
+                            port:swig-perl \
+                            port:swig-python \
+                            port:swig-go \
+                            port:swig-ruby
+}


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G1611
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
--->  Verifying Portfile for qpid-proton
--->  0 errors and 0 warnings found.
- [X] tried existing tests with `sudo port test`?
-- Tests pass with same success rate as upstream which was not 100% due to spurious failures
-- test.run removed
- [X] tried a full install with `sudo port -vst install`?
-- Complained that the source first generates headers that are then used in the build
-- -vs was ok
- [ ] tested basic functionality of all binary files?
-- No; built installed cpp examples but didn't ensure 100% coverage