### PR TITLE
 courier-unicode: update to 2.0

### DIFF
--- a/devel/courier-unicode/Portfile
+++ b/devel/courier-unicode/Portfile
@@ -3,9 +3,9 @@
 PortSystem 1.0
 
 name                    courier-unicode
-version                 1.4
-checksums               rmd160  a5006b510799b341e6f3d266b34b3df31be5bf11 \
-                        sha256  2174f4cdd2cd3fe554d4cbbd9557abac0e54c0226084f368bcb2e66b0e78cf96
+version                 2.0
+checksums               rmd160  c175b119bab12a819a5aeccca3c4c003b02a7319 \
+                        sha256  6b46011d465918af7d0ed41fbf21d918449820bd3ef7e651dbc56eb2933a8711
 
 categories              devel mail
 license                 GPL-3
@@ -15,7 +15,7 @@ description             Courier Unicode Library implements several algorithms re
 long_description        ${description}
 
 homepage                http://www.courier-mta.org/unicode/
-master_sites            sourceforge:courier
+master_sites            sourceforge:project/courier/courier-unicode/${version}
 use_bzip2               yes
 
 depends_lib             port:libiconv

--- a/devel/courier-unicode/files/patch-courier-unicode.h.in-add-missing-includes.diff
+++ b/devel/courier-unicode/files/patch-courier-unicode.h.in-add-missing-includes.diff
@@ -1,6 +1,6 @@
---- ./courier-unicode.h.in.orig	2016-03-15 15:34:19.000000000 +0100
-+++ ./courier-unicode.h.in	2016-03-15 15:34:53.000000000 +0100
-@@ -41,6 +41,9 @@
+--- courier-unicode.h.in.orig	2017-03-09 13:51:25.000000000 +0000
++++ courier-unicode.h.in	2017-11-30 10:38:17.000000000 +0000
+@@ -55,6 +55,9 @@
  extern const char *unicode_locale_chset();
  
  #if @LANGINFO_L@

--- a/mail/maildrop/Portfile
+++ b/mail/maildrop/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                maildrop
-version             2.8.5
+version             2.9.2
 categories          mail
 license             {GPL-3 OpenSSLException}
 maintainers         nomaintainer
@@ -13,8 +13,10 @@ homepage            http://www.courier-mta.org/maildrop/
 platforms           darwin
 master_sites        sourceforge:project/courier/maildrop/${version}/
 use_bzip2           yes
-checksums           rmd160  a627cc83ff5bd185a47db90a5249708cc8656185 \
-                    sha256  c21174ef882aeb169031bb5886b55959687074415153232f4c60695405fcddb1
+
+checksums           rmd160  6d2de506a7b6e5a85e2d8bd544a5be10ffb97363 \
+                    sha256  599341e63b7e430cb719a1295f8d2a948ce9ed4fdcfe67e05203cf27727ce7c5
+
 configure.args      --mandir=${prefix}/share/man \
                     --with-etcdir=${prefix}/etc \
                     --enable-syslog=1

--- a/security/courier-authlib/Portfile
+++ b/security/courier-authlib/Portfile
@@ -3,9 +3,9 @@
 PortSystem 1.0
 
 name                    courier-authlib
-version                 0.66.4
-checksums               rmd160  5a550a038cd7f6e4d22d7b6e432a65b3caca94da \
-                        sha256  a874fa50e83d9b1385f97a47879af781a1aa09f49cdaa7d77e7ea3e5983a4a26
+version                 0.68.0
+checksums               rmd160  17154b04f0097f0a5a8505f865186bb300c99224 \
+                        sha256  9096118823ababfac8f46a1a7393765a414ea3628c9413bfba39af5d70fd3e2e
 
 categories              security mail
 license                 GPL-3
@@ -15,10 +15,10 @@ description             Courier Authentication Library is a generic authenticati
 long_description        ${description}
 
 homepage                http://www.courier-mta.org/authlib/
-master_sites            sourceforge:courier
+master_sites            sourceforge:project/courier/authlib/${version}
 use_bzip2               yes
 
-depends_lib             port:db44 \
+depends_lib             port:db48 \
                         port:libtool \
                         port:courier-unicode
 
@@ -28,8 +28,8 @@ configure.args          --with-db=db \
                         --without-authldap \
                         --without-authpam \
                         -C
-configure.cflags-append     -I${prefix}/include/db44
-configure.ldflags-append    -L${prefix}/lib/db44
+configure.cflags-append     -I${prefix}/include/db48
+configure.ldflags-append    -L${prefix}/lib/db48
 
 post-destroot {
     system -W "${destroot}${prefix}/lib/courier-authlib" "rm -f *.a *.la"


### PR DESCRIPTION
#### Description


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B1002
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
(done for port `courier-unicode`)