### PR TITLE
nss: update to 3.33, prioritize seurce fetch protocol

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
 name                nss
-version             3.32.1
+version             3.33
 set NSS_VMAJOR      [lindex [split ${version} .] 0]
 set NSS_VMINOR      [lindex [split ${version} .] 1]
 set NSS_VPATCH      [lindex [split ${version} .] 2]
@@ -26,11 +26,11 @@ platforms           darwin
 set my_release      NSS_[strsed ${version} {g/\./_/}]_RTM
 
 use_bzip2           no
-master_sites        ftp://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${my_release}/src/ \
-                    http://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${my_release}/src/
+master_sites        https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${my_release}/src/ \
+                    ftp://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${my_release}/src/
 
-checksums           rmd160  080c36c0a9b64ad24dfc90b5a21e94abb09e9306 \
-                    sha256  4de59ca7f5bf4a56fbcfdbb4a054f254ba9f408f56476957404a091048624652
+checksums           rmd160  fe4d2fb56f15db3531e0efbdff8eda4aced41a03 \
+                    sha256  98f0dabd36408e83dd3a11727336cc3cdfee4cbdd9aede2b2831eb2389c284e4
 
 depends_lib     port:nspr \
                 port:zlib \


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
