### PR TITLE
sysutils/fswatch: update to @1.11.2

### DIFF
--- a/sysutils/fswatch/Portfile
+++ b/sysutils/fswatch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
-github.setup        emcrisostomo fswatch 1.11.1
+github.setup        emcrisostomo fswatch 1.11.2
 github.tarball_from releases
 
 categories          sysutils
@@ -21,7 +21,9 @@ long_description    A cross-platform file change monitor with multiple \
 
 homepage            http://emcrisostomo.github.io/fswatch/
 
-checksums           rmd160 0d291c9f04a1cf34a126489ba95046f02e4254cc \
-                    sha256 bdb1d22fa3d5a9c562e001d5f989005d013b02fe1f661f6269aae5f508d46294
+checksums           rmd160 17f06907d047c4295a48135795d707a9899df3b3 \
+                    sha256 b7dadb84848ce666aac0311f9b4c739fbfee6a90c6097807a1f45ad4367294c2
 
 configure.args      ac_cv_prog_AWK=/usr/bin/awk
+
+livecheck.url       ${github.homepage}/releases/latest


### PR DESCRIPTION
Add livecheck

#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1
Xcode 9.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
