### PR TITLE
tortoisehg: update to 4.4.1

### DIFF
--- a/devel/tortoisehg/Portfile
+++ b/devel/tortoisehg/Portfile
@@ -5,8 +5,7 @@ PortGroup           python 1.0
 PortGroup           app 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     tortoisehg thg 4.3.1
-revision            1
+bitbucket.setup     tortoisehg thg 4.4.1
 name                tortoisehg
 categories          devel python
 platforms           darwin
@@ -19,8 +18,8 @@ description         A set of graphical tools for Mercurial
 long_description    A set of graphical tools for the Mercurial distributed \
                     source control management system.
 
-checksums           rmd160  7d366212856c2d65878d970d26fdb81435604152 \
-                    sha256  2dc03a1f6b08ccaac3288288b7b3b571ff301c68005444975f4633b2dfbf6da0
+checksums           rmd160  37072d0a75a0c12a23a75e05ec8c9a5e86201b23 \
+                    sha256  12616d349ad1cec7fb25a5721eb38528a6674747e945cdb6d46b45543b5a53e4
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

This is update for TortoiseHG. The existing version doesn't like the latest version Mercurial.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B1003
Xcode 9.1 9B55 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
