### PR TITLE
ncurses: update to 6.0-20171125

### DIFF
--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            ncurses
-version         6.0-20170916
+version         6.0-20171125
 categories      devel
 platforms       darwin freebsd
 license         MIT
@@ -17,8 +17,8 @@ long_description \
 homepage        http://invisible-island.net/ncurses/
 master_sites    http://invisible-mirror.net/archives/ncurses/current/
 extract.suffix	.tgz
-checksums       rmd160 8fc22ab24a94e4649b41b8ef5cb7d0ee9caa3a61 \
-                sha256 fa05594cf3d6cba350b18bb4cd399aa7ceec1def08fdd06166f7d61d4452b766
+checksums       rmd160 7d6513626ee64f1a1874a36e5b7f26811ea0fd59 \
+                sha256 22adbdd3c2ddfaabea8ea75de3c585d59d2a2cde4b5197dd7dd40a3481fc4d85
 
 # hex.diff from http://opensource.apple.com/source/ncurses/ncurses-44/patches.applied/
 patchfiles      hex.diff


### PR DESCRIPTION
#### Description
Fixes CVE-2017-16879

        + modify _nc_write_entry() to truncate too-long filename (report by
          Hosein Askari, Debian #882620).

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B1003
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
