### PR TITLE
devel/git-crypt: submission of stable version

### DIFF
--- a/devel/git-crypt/Portfile
+++ b/devel/git-crypt/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            AGWA git-crypt 0.6.0
+homepage                https://www.agwa.name/projects/git-crypt/
+categories              devel
+platforms               darwin
+maintainers             @nareshov openmaintainer
+license                 {GPL-3+ OpenSSLException}
+checksums               rmd160  b151b4426cdf2c317f9ac15125ffbcb265511ba2 \
+                        sha256  d033017252a0bbec86dd67c2489eb59159b9c61856afc0502304fc32ded7bb80
+
+description             {Transparent file encryption in git.}
+long_description        git-crypt enables transparent encryption and \
+                        decryption of files in a git repository. Files which \
+                        you choose to protect are encrypted when committed, \
+                        and decrypted when checked out. git-crypt lets you \
+                        freely share a repository containing a mix of public \
+                        and private content. git-crypt gracefully degrades, \
+                        so developers without the secret key can still clone \
+                        and commit to a repository with encrypted files. \
+                        This lets you store your secret material (such as \
+                        keys or passwords) in the same repository as your \
+                        code, without requiring you to lock down your entire \
+                        repository.
+
+depends_lib-append      path:lib/libssl.dylib:openssl
+depends_build-append    bin:xsltproc:libxslt
+
+use_configure           no
+
+build.args-append       CXX=${configure.cxx}
+destroot.args           ENABLE_MAN=yes PREFIX=${prefix}


### PR DESCRIPTION
* current stable version 0.6.0

Closes: https://trac.macports.org/ticket/43471

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] submissiion

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.1 17B1003
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
