### PR TITLE
haproxy: update to 1.8.1

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                haproxy
-version             1.7.9
+version             1.8.1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          net
 platforms           darwin
@@ -24,8 +24,8 @@ long_description    HAproxy is a high-performance and highly-robust TCP/HTTP \
 homepage            http://www.haproxy.org/
 master_sites        ${homepage}download/${branch}/src/
 
-checksums           rmd160  b0a44cfe9a71ec2c82300c1099d3c3b4f3815fef \
-                    sha256  1072337e54fa188dc6e0cfe3ba4c2200b07082e321cbfe5a0882d85d54db068e
+checksums           rmd160  514e4dd4cb76813e20cb57ddda9f8bb0de8ae2e5 \
+                    sha256  02ded32524353da2f3e29e952e656cc2f6b5f0189400831401f9de70a6560b30
 
 depends_lib         port:pcre
 


### PR DESCRIPTION
#### Description
Maintainer fixed https://trac.macports.org/ticket/55447
##### Upstream announcement:
https://www.mail-archive.com/haproxy@formilux.org/msg28004.html
[skip notification]