### PR TITLE
Updated to version 2

### DIFF
--- a/science/gpredict/Portfile
+++ b/science/gpredict/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                gpredict
-version             1.3
-revision            2
+version             2.0
 categories          science
 license             GPL-2+
 platforms           darwin
@@ -23,17 +22,17 @@ long_description    Gpredict is a real-time satellite tracking and orbit \
 homepage            http://gpredict.oz9aec.net/
 master_sites        sourceforge:project/gpredict/Gpredict/${version}
 
-checksums           sha1    a02a979fb68f9be8b9294a7c4ca248aaecd73b34 \
-                    rmd160  ad9104a332f91bf877ac2cb5328c168233c6fc5b
+checksums           sha256    508f882383eac326aecb0b058378fc71f13b431c581e0efc28ee3c4216c76e16 \
+                    rmd160  7bf681c89203c2963ab37ceca28b018314f0d2bd
 
 depends_build       port:intltool \
                     port:pkgconfig
-depends_lib         port:goocanvas \
+depends_lib         port:goocanvas2 \
                     port:curl
 
 # autoreconf to reconfigure with our intltool.m4
 
-use_autoreconf      yes
+use_autoreconf      no
 autoreconf.args     -fvi
 
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
need goocanvas2
disabled autoreconf

Tested on
macOS 10.13.2
Xcode 9.2

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
