### PR TITLE
Review for pycairo fixes

### DIFF
--- a/graphics/comix/Portfile
+++ b/graphics/comix/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                comix
 version             4.0.4
-revision            3
+revision            4
 categories          graphics
 maintainers         perry openmaintainer
 platforms           darwin
@@ -25,7 +25,7 @@ livecheck.regex     {Comix (.*) released}
 livecheck.type      regex
 livecheck.url       ${homepage}
 
-set python.version  26
+set python.version  27
 set python.branch   "[string range ${python.version} 0 end-1].[string index ${python.version} end]"
 set python.pkgd     ${frameworks_dir}/Python.framework/Versions/${python.branch}/lib/python${python.branch}/site-packages
 set python.bin      ${prefix}/bin/python${python.branch}

--- a/mail/mu/Portfile
+++ b/mail/mu/Portfile
@@ -46,13 +46,13 @@ variant emacs description {Build with emacs bindings} {
 }
 
 subport mu-devel {
-    github.setup    djcb mu 0d9d8d26d082
+    github.setup    djcb mu e1c6fa4b95fc
     name            mu-devel
     version         0.9.18.99
-    revision        2
+    revision        3
 
-    checksums       rmd160  0a5d12b40a3f8ffa7ad29d026c1f8dbfe48961ad \
-                    sha256  89cde9820b243d72077baaab986b7fed56b59736de86bd8933bc31d76b5dd1aa
+    checksums       rmd160  b32d95914f5319839a6a214033e1f50569dddf5a \
+                    sha256  f31720a123848ed5dcd80878f825c3c19bfff945f0fc58a5e7db85edfdc2fcc7
 
     post-extract    {
         # set the displayed version to a 6-character string since most releases

--- a/python/py-cairo/Portfile
+++ b/python/py-cairo/Portfile
@@ -1,11 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:et:fenc=utf-8::et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               active_variants 1.1
 PortGroup               github 1.0
 PortGroup               python 1.0
 
 github.setup            pygobject pycairo 1.15.4 v
-revision                1
+# uncomment when upgrading to next version
+# github.tarball_from     releases
+
+revision                2
 name                    py-cairo
 categories-append       graphics
 license                 {LGPL-2.1 MPL-1.1}
@@ -20,12 +24,23 @@ checksums               rmd160  16ce1ad969a9fb06f8f28a7b07495b738d1af22f \
 
 python.versions         27 34 35 36
 
-# prevent precompiled binaries; see https://trac.macports.org/ticket/51957
-archive_sites
-
 if {${name} ne ${subport}} {
     depends_build           port:pkgconfig
     depends_lib-append      path:lib/pkgconfig/cairo.pc:cairo
+
+    variant quartz {
+        require_active_variants cairo quartz
+    }
+
+    variant x11 {
+        require_active_variants cairo x11
+    }
+
+    default_variants +quartz
+
+    if {[catch {set result [active_variants cairo x11]}]} {
+        default_variants-append +x11
+    }
 
     post-extract {
         fs-traverse item ${worksrcpath} {

--- a/python/py-gobject/Portfile
+++ b/python/py-gobject/Portfile
@@ -13,7 +13,7 @@ categories-append   gnome
 license         LGPL-2.1+
 maintainers     nomaintainer
 platforms       darwin
-python.versions	26 27 33 34 35 36
+python.versions	27 34 35 36
 
 description     Python bindings for GObject.
 

--- a/python/py-goocanvas/Portfile
+++ b/python/py-goocanvas/Portfile
@@ -9,8 +9,7 @@ license                 GPL-2+
 version                 0.14.1
 revision                6
 
-python.versions         26 27
-python.default_version  27
+python.versions         27
 
 categories              python gnome
 platforms               darwin

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -136,6 +136,7 @@ py-pygeocoder           1.1.4_1     26
 py-pygraphviz           1.1_1       26
 py-pygresql             4.1.1_1     26
 py-pygrib               2.0.2       33
+py-pygtk                2.24.0_4    26
 py-pygtksourceview      2.10.1_4    26
 py-pyke                 1.1.1_1     26 32 33
 py-pykerberos           1.1-10616_1 26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -88,6 +88,7 @@ py-gnome                2.28.1_9    26
 py-goocanvas            0.14.1_7    26
 py-google-apputils      0.4.2_1     26
 py-gnuplot              1.8_3       26
+py-gobject              2.28.6_3    26 33
 py-gobject3             3.18.2_1    33
 py-gst-python           0.10.22_3   26
 py-gtkhtml2             2.25.3_3    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -85,6 +85,7 @@ py-gitpython            2.0.2_1     26
 py-gmpy                 1.17_1      25 26 31 32 33
 py-gmpy2                2.0.7_1     26 31 32 33
 py-gnome                2.28.1_9    26
+py-goocanvas            0.14.1_7    26
 py-google-apputils      0.4.2_1     26
 py-gnuplot              1.8_3       26
 py-gobject3             3.18.2_1    33

--- a/python/py-pygtk/Portfile
+++ b/python/py-pygtk/Portfile
@@ -8,7 +8,7 @@ version         2.24.0
 revision        3
 set branch      [join [lrange [split ${version} .] 0 1] .]
 
-python.versions 26 27
+python.versions 27
 
 categories-append \
                 x11


### PR DESCRIPTION
This fixes all but one graveyard mistake I made by not archiving the dependents of py{26,33}-cairo. The only one left is opensync which doesn't build and I've [opened a ticket](https://trac.macports.org/ticket/55503) for that.

This PR also tries to fix the +quartz / +x11 variants of cairo by adding them to pycairo.