### PR TITLE
submission: dupd: version 1.5: initial port

### DIFF
--- a/sysutils/dupd/Portfile
+++ b/sysutils/dupd/Portfile
@@ -12,6 +12,7 @@ platforms             darwin
 use_configure         no
 build.target          dupd
 use_parallel_build    no
+test.run              yes
 
 maintainers           {@jvirkki virkki.com:jyri}
 

--- a/sysutils/dupd/Portfile
+++ b/sysutils/dupd/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+
+name                  dupd
+version               1.5
+description           Convenient and fast CLI to find duplicate files.
+homepage              http://www.virkki.com/dupd
+license               GPL-3
+categories            sysutils
+platforms             darwin
+use_configure         no
+build.target          dupd
+use_parallel_build    no
+
+maintainers           {@jvirkki virkki.com:jyri}
+
+long_description      Convenient and fast CLI to find duplicate files. Supports an interactive style for exploring duplicates in the filesystem.
+
+master_sites          http://www.virkki.com/dupd
+checksums             rmd160 10aee57ec23764250cdb10da599deba06c31d84c \
+                      sha256 28073847aa6a7b7704e1684e7bda99344715f364976046144e8fe16efec3b2f3
+
+destroot.destdir      DESTDIR=${destroot}${prefix} \
+                      MAN_BASE=${destroot}${prefix}/share/man


### PR DESCRIPTION
#### Description

New port submission: dupd (version 1.5): Convenient and fast CLI to find duplicate files.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G17023
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
