### PR TITLE
ntpsec: use MacPorts python

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 
 name                ntpsec
 version             1.0.0
+revision            1
 categories          sysutils net
 maintainers         {lbschenkel @lbschenkel} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -23,6 +24,12 @@ checksums           rmd160  73e00a1efd37aa2fe7cc0b72e01766db6b0de98b \
 
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}
+
+post-patch {
+    foreach f {ntpq ntploggps ntplogtemp ntpkeygen ntpwait ntptrace ntpmon ntpviz ntpdig ntpsweep} {
+        reinplace "s,^#!/usr/bin/env python,#!${python.bin}," ${worksrcpath}/ntpclients/$f
+    }
+}
 
 use_configure       yes
 configure.args      --alltests \


### PR DESCRIPTION
#### Description
Fixes
```
$ ntpmon
ntpmon: can't find Python NTP library.
No module named ntp.packet
$ ntpdig
ntpdig: can't find Python NTP library.
No module named ntp.packet
```

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
