### PR TITLE
courier-authlib: Add startupitem

### DIFF
--- a/security/courier-authlib/Portfile
+++ b/security/courier-authlib/Portfile
@@ -35,6 +35,12 @@ post-destroot {
     system -W "${destroot}${prefix}/lib/courier-authlib" "rm -f *.a *.la"
 }
 
+startupitem.create	yes
+startupitem.start	"${prefix}/sbin/authdaemond start"
+startupitem.stop	"${prefix}/sbin/authdaemond stop"
+startupitem.restart	"${prefix}/sbin/authdaemond restart"
+startupitem.pidfile	clean ${prefix}/var/spool/authdaemon/pid
+
 # Limit the length of the minor and patch version components to avoid picking
 # up development versions (that contain a YYYYMMDD timestamp).
 livecheck.regex         "[quotemeta ${name}]-(\\d+(\\.\\d{1,7})*)[quotemeta ${extract.suffix}]"


### PR DESCRIPTION
#### Description

Add startupitem to courier-authlib

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G18013
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?  Always builds from source
- [x] tested basic functionality of all binary files?  Been using patched Portfile
