### PR TITLE
gsoap: update to 2.8.57

### DIFF
--- a/devel/gsoap/Portfile
+++ b/devel/gsoap/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gsoap
-version             2.8.55
+version             2.8.57
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 categories          devel
@@ -26,8 +26,8 @@ use_zip             yes
 distname            ${name}_${version}
 worksrcdir          ${name}-${branch}
 
-checksums           rmd160  9d21f1460f70e40682b2de96eacf73e92350e136 \
-                    sha256  fe883f79e730b066ddc6917bc68248f5f785578ffddb7066ab83b09defb2a736
+checksums           rmd160  403e29afd4f4c2a199279a9b3fea92c4ce7d4320 \
+                    sha256  b27956be1105d99d769ab51b16cc45ec185b1ff501d4b7a73a2813708a9983dd
 
 depends_lib         path:lib/libssl.dylib:openssl
 


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
