### PR TITLE
gtest: install source files, the preferred way to distribute gtest

### DIFF
--- a/devel/gtest/Portfile
+++ b/devel/gtest/Portfile
@@ -5,6 +5,7 @@ PortGroup       cmake 1.0
 PortGroup       github 1.0
 
 github.setup    google googletest 1.8.0 release-
+revision        1
 name            gtest
 categories      devel
 maintainers     blair
@@ -28,6 +29,12 @@ checksums       rmd160  fd6ff05f0b287e23dae59d30e6b7f1a27377c049 \
 cmake.out_of_source     yes
 configure.optflags      -g
 configure.args-append   -Dgtest_build_tests=ON
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/src/
+    file copy ${worksrcpath}/googlemock ${destroot}${prefix}/src/
+    file copy ${worksrcpath}/googletest ${destroot}${prefix}/src/
+}
 
 test.run    yes
 test.cmd    "ulimit -c 0; make"


### PR DESCRIPTION
Google recommends that projects compile their own copies of gtest in order to have the same compiler flags. As such, it is better distributed as a source package rather than a compiled library/headers. We discussed this in https://trac.macports.org/ticket/48800

This patch doesn't remove the compiled library, but adds in a copy of the source in $prefix/src.

(My immediate motivation here is a port (gnucash-devel 2.7) that uses gtest as a build dependency, and its autoconf scripts look for a copy of the source, not a library.)

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1114                                                          
Xcode 9.2 9C40b
