### PR TITLE
Update plumed to version 2.4

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -7,7 +7,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 
 name                gromacs
-revision            2
+revision            3
 version             5.1.4
 categories          science math
 license             LGPL-2.1

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -91,21 +91,23 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 2.4b v
-    revision            2
+    github.setup        plumed plumed2 c61d345792dc019888ae6f53d9e5a3403e7d02f4
+    version             2.5-20171215
+    revision            0
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  1c4eac7da0ba1cc954e271c4514010955502d1d6 \
-                        sha256  b057fe5654649b4866fd3009e013e082d0806bed6f61ecc8c3631edc6f85f99b
-    if {[variant_isset allmodules]} {
-# one of the optional modules installed within the +allmodules variant
-# requires boost_serialization
-      configure.args-append --enable-boost-serialization
-      configure.ldflags-append -lboost_serialization-mt
-      depends_lib-append port:boost
-    }
+    checksums           rmd160  d7ee29fd36038e0202c10bd35c47e27bfa0a07fc \
+                        sha256  6f1285f3d8aa741d8fd1949575f31d581439611e429bdaa87f055abb957e1853
+
+    configure.ldflags-delete -lmatheval
+    depends_lib-delete       port:libmatheval
+# plumed 2.5 supports python. However, I disable it here since it is
+# not correctly integrated with MacPorts yet
+    configure.args-append --disable-python
 }
+
 # Allow running tests from MacPorts
 test.run yes
 test.target check
+

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,13 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-# github.setup        plumed plumed2 2.3.3 v
-# include a fix that was commited just after 2.3.3
-# this hack will be removed at the next plumed release 
-github.setup        plumed plumed2 8fd0d4e37f0f35053cb5a48e2f76a73ea1128eaf
-version             2.3.3
-revision            2
-
+github.setup        plumed plumed2 2.4.0 v
 name                plumed
 
 categories          science
@@ -31,9 +25,8 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  2475ff31da9dc0a227656ad8ff8dd41caf94c662 \
-                    sha256  351135cbbe3327d378d1f807eaefca6878a8dcf71d8da371be7636ccf085a584
-
+checksums           rmd160  e3c5df528c00cdd5bc54a8d7ce2eaa5e8c5a8b04 \
+                    sha256  11f8c5a6bf7e2f6c133f9355924bbb5fa5f0cef0dc861d36726fa83a687ead44
 
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
@@ -63,6 +56,11 @@ mpi.setup
 # To enable mpi, replace a configure flag
 if {[mpi_variant_isset]} {
     configure.args-replace --disable-mpi --enable-mpi
+# command should be included in a pre-configure block to access properly the mpi.exec variable
+    pre-configure {
+# MPIEXEC is stored so that it can be used to perform tests
+        configure.args-append MPIEXEC="${mpi.exec}"
+    }
 }
 
 # Libraries.
@@ -76,8 +74,12 @@ depends_lib-append  port:gsl \
                     port:zlib
 
 # This variant enables optional modules in PLUMED.
+# Notice that one of the optional modules (drr) requires boost_serialization
 variant allmodules description {Enable all optional modules} {
     configure.args-append --enable-modules=all
+    configure.args-append --enable-boost-serialization
+    configure.ldflags-append -lboost_serialization-mt
+    depends_lib-append port:boost
 }
 
 # Link lapack/blas libraries
@@ -104,3 +106,6 @@ subport plumed-devel {
       depends_lib-append port:boost
     }
 }
+# Allow running tests from MacPorts
+test.run yes
+test.target check


### PR DESCRIPTION
#### Description

This pull request contains three commits:
- plumed port is updated from version 2.3.3 to version 2.4.0
- plumed-devel subport is updated from version 2.4b to version 2.5-20171215 (that is a snapshot of master branch taken today).
- gromacs-plumed subport revisions is increased.

Please let me know if it is ok as is or if I should reorganize stuff differently.

Many thanks!

Giovanni

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G18013
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
