### PR TITLE
neomutt: update to 20171215

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        neomutt neomutt 20171208 neomutt-
+github.setup        neomutt neomutt 20171215 neomutt-
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -19,8 +19,8 @@ long_description    Mutt is a small but very powerful text-based MIME \
                     groups of messages.
 homepage            https://www.neomutt.org
 
-checksums           rmd160  588f4987b0676051a904300bc498d649084a3e8c \
-                    sha256  427625d2214c0cc47cf2459139d575cefff0b58b47ea57f2ef6f2fbbad7c9de8
+checksums           rmd160  f6ba1df9a39c76b6185c0318f864b2f9cf79dd49 \
+                    sha256  f98a21079a9f1af626b29d34e81d24083116b7e87f515d99118aaaf9592835ac
 
 depends_build       port:docbook-xml-4.2 port:docbook-xsl port:libxslt port:w3m
 depends_lib         path:lib/libssl.dylib:openssl \
@@ -32,7 +32,6 @@ depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 # needed by smime_keys
 depends_run-append  path:bin/perl:perl5
 
-configure.cmd       ./configure.autosetup
 configure.args      --disable-idn \
                     --with-ncurses=${prefix} \
                     --with-nls=${prefix} \


### PR DESCRIPTION
#### Description
The autosetup configure.autosetup script has been renamed to configure.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
