### PR TITLE
ocaml: fix build error due to missing strnlen

### DIFF
--- a/lang/ocaml/Portfile
+++ b/lang/ocaml/Portfile
@@ -27,6 +27,11 @@ long_description    OCaml, originally named Objective Caml, is an industrial str
 
 use_xz              yes
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    patchfiles-append  patch-strnlen-socketaddr.diff
+}
+
+
 depends_lib         port:ncurses
 
 use_parallel_build  no
@@ -49,15 +54,6 @@ destroot.target     install
 destroot.destdir    BINDIR=${destroot}${prefix}/bin \
                     LIBDIR=${destroot}${prefix}/lib/ocaml \
                     MANDIR=${destroot}${prefix}/share/man
-
-# Don't build on 10.6 or earlier
-pre-fetch {
-    if {${os.subplatform} eq "macosx" &&
-            [vercmp ${macosx_version} 10.7] < 0} {
-        ui_error "${name} @${version} requires OS X 10.7 or later."
-        return -code error "incompatible OS X version"
-    }
-}
 
 post-destroot {
     # Change "ld.conf" to remove ${destroot} in paths.

--- a/lang/ocaml/files/patch-strnlen-socketaddr.diff
+++ b/lang/ocaml/files/patch-strnlen-socketaddr.diff
@@ -1,0 +1,23 @@
+--- ./otherlibs/unix/socketaddr.c.orig	2017-12-15 13:57:16.000000000 -0800
++++ ./otherlibs/unix/socketaddr.c	2017-12-15 14:02:56.000000000 -0800
+@@ -29,6 +29,20 @@
+ #define EAFNOSUPPORT WSAEAFNOSUPPORT
+ #endif
+ 
++static size_t
++strnlen(const char *s, size_t maxlen)
++{
++	size_t len;
++
++	for (len = 0; len < maxlen; len++, s++) {
++		if (!*s)
++			break;
++	}
++	return (len);
++}
++
++
++
+ CAMLexport value alloc_inet_addr(struct in_addr * a)
+ {
+   value res;


### PR DESCRIPTION
fixes build on 10.6.8 and earlier
closes: https://trac.macports.org/ticket/55385
