### PR TITLE
kotlin: update to 1.2.10

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.2.0 v
+github.setup        JetBrains kotlin 1.2.10 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
 platforms           darwin
-maintainers         madlon-kay.com:aaron+macports openmaintainer
+maintainers         {@breun breun.nl:nils} openmaintainer
 license             Apache-2
 
 description         Statically typed programming language for the JVM, \
@@ -21,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  b6023bbfa8db75d731f2c313262c74ba7092fc25 \
-                    sha256  895d0f8286db3e4f43d67cd5e09b600af6e0a5017cb74072d1b09c78b697775a
+checksums           rmd160  eff365de06d5566414f967ae4b222d6969d0312f \
+                    sha256  95874568919121acb694bec0d6c92c60bdceea53f4c202e23ab734e94a0c26e3
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Updated Kotlin to 1.2.10. Also changed maintainer from @amake to myself, as suggested here: https://github.com/macports/macports-ports/pull/1068#issuecomment-348089774

###### Tested on

macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?