### PR TITLE
collectd: fixed build of variant +postgresql

### DIFF
--- a/sysutils/collectd/Portfile
+++ b/sysutils/collectd/Portfile
@@ -591,8 +591,10 @@ variant postgresql description {PostgreSQL database statistics} {
     configure.args-delete --disable-postgresql
     configure.args-append --enable-postgresql
 
-    depends_lib-delete port:postgresql91
-    depends_lib-append port:postgresql91
+    configure.cflags-append -I${prefix}/include/postgresql96/
+
+    depends_lib-delete port:postgresql96
+    depends_lib-append port:postgresql96
 }
 
 variant powerdns description {PowerDNS statistics} {


### PR DESCRIPTION
#### Description

Collectd's postgresql variant did not properly set the include path for the postgresql91 headers.
The include path is now properly set and the postgresql version is bumped to 9.6.

###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.2 17C88
Xcode 9.2 9C40b 

###### Verification

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
