### PR TITLE
ocaml: fix build on 32bit Intel

### DIFF
--- a/lang/ocaml/Portfile
+++ b/lang/ocaml/Portfile
@@ -28,11 +28,6 @@ long_description    OCaml, originally named Objective Caml, is an industrial str
 
 use_xz              yes
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
-    patchfiles-append  patch-strnlen-socketaddr.diff
-}
-
-
 depends_lib         port:ncurses
 
 use_parallel_build  no
@@ -41,6 +36,16 @@ universal_variant   no
 set docdir          ${prefix}/share/doc/${name}
 
 compiler.blacklist  gcc-4.0 *gcc-4.2 {clang < 400}
+
+platform darwin {
+    if {${os.major} < 11} {
+        patchfiles-append  patch-strnlen-socketaddr.diff
+    }
+
+    if {${build_arch} eq "i386"} {
+        patchfiles-append  patch-configure-darwin32.diff
+    }
+}
 
 # Configure.
 configure.pre_args  -prefix ${prefix}

--- a/lang/ocaml/files/patch-configure-darwin32.diff
+++ b/lang/ocaml/files/patch-configure-darwin32.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2017-12-16 13:52:33.000000000 -0800
++++ configure	2017-12-16 13:57:05.000000000 -0800
+@@ -799,7 +799,7 @@
+       shared_libraries_supported=true;;
+     *-apple-darwin*)
+       mksharedlib="$bytecc -bundle -flat_namespace -undefined suppress \
+-                   -Wl,-no_compact_unwind"
++                   -Wl,-no_compact_unwind -read_only_relocs suppress"
+       bytecccompopts="$dl_defs $bytecccompopts"
+       dl_needs_underscore=false
+       shared_libraries_supported=true;;


### PR DESCRIPTION
Looks like this should do it.
```
$ port -v installed ocaml
The following ports are currently installed:
  ocaml @4.05.0_0 (active) platform='darwin 10' archs='i386' date='2017-12-16T15:02:14-0800'
```