### PR TITLE
neomutt: fix build/runtime issues for +db4 variant

### DIFF
--- a/mail/neomutt/Portfile
+++ b/mail/neomutt/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        neomutt neomutt 20171215 neomutt-
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-2+
@@ -32,12 +33,15 @@ depends_run         path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 # needed by smime_keys
 depends_run-append  path:bin/perl:perl5
 
+patch.pre_args      -p1
+
 configure.args      --disable-idn \
                     --with-ncurses=${prefix} \
                     --with-nls=${prefix} \
                     --with-ssl=${prefix}
 
-# disable auto-detection of ccache, as MacPorts already adds it
+# disable ccache, build issues with autosetup
+configure.ccache     no
 configure.env-append CCACHE=none
 
 default_variants    +idn +mutt
@@ -46,9 +50,8 @@ if {${install.user} ne "root"} {
 }
 
 variant db4 description {Support Berkeley DB database} {
+    patchfiles-append           patch-bdb4.diff
     configure.args-append       --with-bdb=${prefix}
-    configure.cppflags-append   "-I${prefix}/include/db48"
-    configure.ldflags-append    "-L${prefix}/lib/db48"
     depends_lib-append          port:db48
 }
 variant gdbm description {Support GNU dbm database} {

--- a/mail/neomutt/files/patch-bdb4.diff
+++ b/mail/neomutt/files/patch-bdb4.diff
@@ -1,0 +1,12 @@
+diff --git a/auto.def b/auto.def
+--- a/auto.def
++++ b/auto.def
+@@ -627,7 +627,7 @@
+ ###############################################################################
+ # Header cache - bdb
+ if {[get-define want-bdb]} {
+-  set bdb_versions { 5.3 6.2 4.8 } ;# Will be checked in order
++  set bdb_versions { 4.8 } ;# Will be checked in order
+   set bdb_prefix [opt-val with-bdb $prefix]
+ 
+   foreach ver $bdb_versions {


### PR DESCRIPTION
There were two issues when `+db4` variant is enabled:

- when `ccache` is installed/enabled, the configure script fails
- when both `db48` and `db53` are installed, the build links against both
  `db48` and `db53` which causes issues at runtime

This commit addresses both issues by completely disabling the use of
`ccache` and by patching the build in order to disable autodetection of
other `db` versions besides the desired version (currently 4.8).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
