### PR TITLE
Okapi: new port

### DIFF
--- a/aqua/Okapi/Portfile
+++ b/aqua/Okapi/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                Okapi
+version             0.35
+categories          aqua textproc java
+license             Apache-2
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+
+description         A set of tools for localization and translation
+long_description    The Okapi Framework is a cross-platform and free open-source set of \
+                    components and applications that offer extensive support for localizing \
+                    and translating documentation and software.
+homepage            http://okapiframework.org/
+platforms           darwin
+supported_archs     noarch
+distname            okapi-apps_cocoa-macosx-x86_64_${version}
+master_sites        https://dl.bintray.com/okapi/Distribution/
+
+checksums           rmd160  bab4a812fb8d520023d7c48085edde0628cd6fe6 \
+                    sha256  94033a291df167172271aab8004974dfd84feb2c9023c0213056c0fe58124250
+
+use_dmg             yes
+use_configure       no
+
+depends_run         bin:java:kaffe
+
+build.cmd           true
+
+destroot    {
+    set okapi_home ${applications_dir}/${name}
+    copy ${worksrcpath}/${name}_${version} ${destroot}${okapi_home}
+
+    proc wrapper_script {script_name script_target} {
+        global destroot prefix applications_dir name
+        upvar okapi_home ok_home
+        set cli_script ${destroot}${prefix}/bin/${script_name}
+        set fp [open $cli_script w]
+        puts $fp "#!/bin/sh"
+        puts $fp "exec \"${ok_home}/${script_target}\" \"$@\""
+        close $fp
+        system "chmod +x ${cli_script}"
+    }
+    wrapper_script tikal tikal.sh
+    wrapper_script rainbow Rainbow.app/Contents/MacOS/rainbow.sh
+}
+
+universal_variant   no
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     okapi-apps_cocoa-macosx-x86_64_(\\d+(\\.\\d+)?)\\.dmg


### PR DESCRIPTION
#### Description
Okapi is a framework and application suite for localization.

###### Tested on
macOS 10.13.2 17C88

Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
