### PR TITLE
valgrind-devel: allow build on newer systems

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -60,6 +60,7 @@ pre-patch {
     }
 }
 
+
 pre-configure {
     if {[mpi_variant_isset]} {
         configure.args-delete --without-mpicc
@@ -82,8 +83,9 @@ if {$subport eq $name} {
     extract.post_args-append --exclude=${distname}/docs/html/FAQ.html
 
     pre-fetch {
-        if {${os.platform} eq "darwin" && (${os.major} < 9 || ${os.major} > 16)} {
-            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up to 10.12."
+        if {${os.platform} eq "darwin" && (${os.major} < 9 || [vercmp $xcodeversion 9.0] > 0)} {
+            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up and Xcode8 or less."
+            ui_error "Please install valgrind-devel to work with Xcode9 until version 3.14 is released."
             return -code error "incompatible macOS version"
         }
     }
@@ -104,8 +106,8 @@ subport valgrind-devel {
     git.branch      0a5ff8c309d18778bb919a1a661a1976b04a6483
 
     pre-fetch {
-        if {${os.platform} eq "darwin" && (${os.major} < 9 || ${os.major} > 16)} {
-            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up to 10.12."
+        if {${os.platform} eq "darwin" && ${os.major} < 9 } {
+            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up."
             return -code error "incompatible macOS version"
         }
     }


### PR DESCRIPTION
trunk has included a fix for Xcode9
add message in valgrind to use valgrind-devel

```
$ port -v installed valgrind-devel
The following ports are currently installed:
  valgrind-devel @3.14.0-r2017-11-21_0 (active) platform='darwin 17' archs='x86_64' date='2017-12-17T10:14:39-0800'
```