### PR TITLE
python36: update to 3.6.4

### DIFF
--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -7,7 +7,7 @@ name                python36
 
 epoch               20170717
 # Remember to keep py36-tkinter and py36-gdbm's versions sync'd with this
-version             3.6.3
+version             3.6.4
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -25,9 +25,9 @@ master_sites        ${homepage}ftp/python/${version}/
 
 distname            Python-${version}
 use_xz              yes
-checksums           md5 b9c2c36c33fb89bda1fefd37ad5af9be \
-                    rmd160 b29962b7233c74149670d8b83284d4265de5e769 \
-                    sha256 cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da
+checksums           md5     1325134dd525b4a2c3272a1a0214dd54 \
+                    rmd160  0fd34bf6748133728106b0d12c354e8b45d62d79 \
+                    sha256  159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba
 
 patchfiles          patch-setup.py.diff \
                     patch-Lib-cgi.py.diff \

--- a/python/py-gdbm/Portfile
+++ b/python/py-gdbm/Portfile
@@ -100,13 +100,13 @@ subport py35-gdbm {
 }
 subport py36-gdbm {
     maintainers     {jmr @jmroot} openmaintainer
-    version         3.6.3
+    version         3.6.4
     epoch           20170717
     homepage        https://docs.python.org/release/${version}/library/dbm.html
     use_xz			yes
-    checksums       md5 b9c2c36c33fb89bda1fefd37ad5af9be \
-                    rmd160 b29962b7233c74149670d8b83284d4265de5e769 \
-                    sha256 cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da
+    checksums       md5     1325134dd525b4a2c3272a1a0214dd54 \
+                    rmd160  0fd34bf6748133728106b0d12c354e8b45d62d79 \
+                    sha256  159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba
     set setup_py "setup-py3k.py"
     set extract_files "Modules/_gdbmmodule.c Modules/clinic/_gdbmmodule.c.h"
     livecheck.regex	Python (3.6.\[0-9\]+)

--- a/python/py-tkinter/Portfile
+++ b/python/py-tkinter/Portfile
@@ -100,14 +100,14 @@ subport py35-tkinter {
 }
 subport py36-tkinter {
     maintainers {jmr @jmroot} openmaintainer
-    version     3.6.3
+    version     3.6.4
     revision    0
     epoch       20170717
     homepage    https://docs.python.org/release/${version}/library/tkinter.html
     use_xz      yes
-    checksums   md5 b9c2c36c33fb89bda1fefd37ad5af9be \
-                rmd160 b29962b7233c74149670d8b83284d4265de5e769 \
-                sha256 cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da
+    checksums   md5     1325134dd525b4a2c3272a1a0214dd54 \
+                rmd160  0fd34bf6748133728106b0d12c354e8b45d62d79 \
+                sha256  159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba
     append extract_files " Modules/tkinter.h Modules/clinic/_tkinter.c.h"
     set module_name tkinter
 }


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
except py36-tkinter
- [x] tested basic functionality of all binary files?
