### PR TITLE
news/slrn-devel: Replace slrn-devel with slrn

### DIFF
--- a/news/slrn-devel/Portfile
+++ b/news/slrn-devel/Portfile
@@ -1,43 +1,11 @@
-PortSystem		1.0
-name			slrn-devel
-version			1.0.0pre18
-categories		news net
-platforms		darwin
-maintainers		gmail.com:sbranzo
-homepage		http://slrn.sourceforge.net/
-description		A powerful console-based newsreader
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-long_description	slrn is an easy to use but powerful NNTP/spool based \
-			newsreader.  It is highly customizable, supports \
-			scoring, free key bindings, and can be extended using \
-			the SLang macro language.
-			
-fetch.type		svn
-svn.url			http://slrn.svn.sourceforge.net/svnroot/slrn/trunk
-svn.revision		323
-worksrcdir		trunk
+PortSystem          1.0
 
-depends_lib		port:slang2 \
-			port:libiconv
+replaced_by         slrn
+PortGroup           obsolete 1.0
 
-configure.args		--with-libiconv-prefix=${prefix} \
-			--mandir=${prefix}/share/man \
-			--with-slang-library=${prefix}/lib \
-			--with-slang-includes=${prefix}/include
-
-# adds slrnpull
-variant	pull		{ configure.args-append	--with-slrnpull }
-
-# ssl variant 		
-variant ssl		{ 
-			configure.args-append 	--with-ssl=${prefix} \
-						--with-ssl-includes=${prefix}/include/openssl
-			
-			depends_lib-append	path:lib/libssl.dylib:openssl
-}
-
-variant uudeview description {Use uudeview library to decode uuencoded articles} {
-	# build dependency because uudeview provides only the static library libuu.a
-	depends_build-append	port:uudeview
-	configure.args-append	--with-uu=${prefix}
-}
+name                slrn-devel
+revision            1
+version             1.0.0pre18
+categories          news


### PR DESCRIPTION
There has not been a release of slrn since October 23rd, 2016. This port
is older than the released version. Replace it.