### PR TITLE
Update Portfile

### DIFF
--- a/science/bali-phy/Portfile
+++ b/science/bali-phy/Portfile
@@ -1,110 +1,41 @@
 PortSystem 1.0
 
 name                bali-phy
-version             2.1.1
-revision            5
-description         Bayesian Alignment and Phylogeny estimation
-long_description    BAli-Phy can estimate phylogenetic trees from sequence data when the alignment \
-                    is uncertain. Instead of conditioning on a single alignment estimate, BAli-Phy \
-                    accounts for alignment uncertainty by integrating over all alignments. \
-                    BAli-Phy does not rely on a guide tree because the alignment and the tree are \
-                    co-estimated. Therefore it can construct phylogeny estimates of widely \
-                    divergent sequences without bias toward a guide tree.
+version             3.0-beta6
+revision            6
+description         Estimation of phylogeny and multiple alignment via MCMC
+long_description    Estimation of phylogeny and multiple alignment via MCMC \
+                    BAli-Phy that estimates multiple sequence alignments and \
+		    evolutionary trees from DNA, amino acid, or codon sequences.\
+		    BAli-Phy uses MCMC and Bayesian  methods to estimate \
+		    evolutionary trees, positive selection, and branch lengths \
+		    while averaging over alternative alignments. \
+		     \
+		    BAli-Phy can also estimate phylogenies from a fixed \
+		    alignment (like MrBayes and BEAST) using substitution \
+		    models like GTR+gamma.  BAli-Phy automatically estimates \
+		    relative rates for each gene.
 categories          science
 platforms           darwin
 maintainers         nomaintainer
-homepage            http://www.biomath.ucla.edu/msuchard/bali-phy/
+homepage            http://www.bali-phy.org/
 
-master_sites        ${homepage}
-checksums           sha1 e72073a1c5b05c797668e476bfd8517594f074e6
+# By using a SHA, this should be completely reproduceable.
+fetch.type	    git
+git.url		    https://github.com/bredelings/BAli-Phy.git
+git.branch	    7c46f800d533947b34142fdcf9597f14335b8c37
 
-patchfiles          configure.patch scripts.patch src-tools-draw-tree.patch
+depends_build       port:pkgconfig port:meson port:ninja
+depends_lib         port:boost path:lib/pkgconfig/cairo.pc:cairo
 
-depends_lib         port:gsl port:boost path:lib/pkgconfig/cairo.pc:cairo
-depends_build       port:pkgconfig
+#configure:
+configure.env-append	CC=${configure.cc} CXX=${configure.cxx}
+configure.cmd	    meson
+configure.args	    builddir --prefix=${prefix} --buildtype=release -Dwith-system-boost=True
 
-configure.args      --with-system-boost --enable-cairo
-configure.env-append BOOST_SUFFIX=-mt
+#build: ${build.cmd} ${build.target} ${build.args} = ninja -C builddir
+build.cmd	    ninja
+build.target	    
+build.args          -C builddir
 
-variant no_cairo description {disable drawing routines} {
-    depends_lib-delete      path:lib/pkgconfig/cairo.pc:cairo
-    configure.args-delete   --enable-cairo
-    patchfiles-delete       src-tools-draw-tree.patch
-}
-
-variant openmpi description {enable OpenMPI parallelization} {
-    depends_lib-append      port:openmpi
-    configure.args-append   --with-mpi
-}
-
-set gcc_versions {4.3 4.4 4.5 4.6 4.7 4.8 4.9}
-set default_fortran_variant +gcc48
-
-foreach ver ${gcc_versions} {
-    set ver_no_dot [join [split ${ver} "."] ""]
-    set conflicts_list {}
-    foreach over ${gcc_versions} {
-        if {${ver} eq ${over}} {
-            continue
-        }
-
-        set over_no_dot [join [split ${over} "."] ""]
-        lappend conflicts_list gcc${over_no_dot}
-    }
-
-    variant gcc${ver_no_dot} description "build with gfortran from gcc${ver_no_dot}" \
-        conflicts {*}${conflicts_list} {}
-
-    if {[variant_isset gcc${ver_no_dot}]} {
-        if {${default_fortran_variant} != "+gcc${ver_no_dot}"} {
-            set default_fortran_variant ""
-        }
-    }
-}
-
-if {${default_fortran_variant} != ""} {
-    default_variants-append "${default_fortran_variant}"
-}
-
-foreach ver ${gcc_versions} {
-    set ver_no_dot [join [split ${ver} "."] ""]
-
-    if {[variant_isset gcc${ver_no_dot}]} {
-        depends_lib-append path:lib/libgcc/libgcc_s.1.dylib:libgcc
-        depends_build-append port:gcc${ver_no_dot}
-
-        configure.fc  ${prefix}/bin/gfortran-mp-${ver}
-        configure.f77 ${prefix}/bin/gfortran-mp-${ver}
-        configure.f90 ${prefix}/bin/gfortran-mp-${ver}
-    }
-}
-
-# The project doesn't even configure with clang.  Based on how long it's
-# been broken, I doubt this project is even used much, so it may not be
-# worh the effort to fix
-#
-# conftest.cpp:60:11: error: no type named 'default_name_check' in 'boost::filesystem::path'
-# fs::path::default_name_check(fs::portable_posix_name);
-# ~~~~~~~~~~^
-# conftest.cpp:60:34: error: definition or redeclaration of 'portable_posix_name' not allowed inside a function
-# fs::path::default_name_check(fs::portable_posix_name);
-#                              ~~~~^
-# 2 errors generated.
-compiler.blacklist *clang*
-
-platform darwin {
-    if {${os.major} >= 13} {
-        # TODO: Test Mavericks once the clang build failures are addressed
-
-        depends_build
-        depends_lib
-        pre-fetch {
-            ui_error "$name does not build on Mavericks or later."
-            error "unsupported platform"
-        }
-    }
-}
-
-livecheck.type  regex
-livecheck.url   ${master_sites}
-livecheck.regex {BAli-Phy (\d+\.\d+\.\d+) released}
+#destroot: ${build.cmd} ${destroot.target} = ninja install


### PR DESCRIPTION
This is an updated Portfile that should address some of the patches in the previous one.  A complication is that it uses meson build, which is a new autotools replacement.  BAli-Phy builds with clang++ on recent OSX versions now.  There is a working homebrew Formula at bredelings/homebrew-bioinformatics.  However, this goes beyond that because it uses the new build system.  This is the first Portfile I've tried to write, so any comments would be helpful.

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
