### PR TITLE
groovy: update to 2.4.13

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.4.12
+version         2.4.13
 
 categories      lang java
 maintainers     breun.nl:nils openmaintainer
@@ -37,8 +37,8 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  c58606af1cfbf02cba3f3307bcfb12fd9a87d9aa \
-                sha256  93b9a19c760c2af846afa0e9c78692d70186cdde36e070e9806fe11b84a8a7b6
+checksums       rmd160  9374551a29abb2034e4e3d7fa8e2506e7c55680d \
+                sha256  b9e4ad752affe37867a28e186dccddc8b541ea82ad3d86e4172a0fd9084c146f
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Updated to Groovy 2.4.13.

###### Tested on

macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?