### PR TITLE
Submission: lang/ruby25

### DIFF
--- a/lang/ruby25/Portfile
+++ b/lang/ruby25/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           select 1.0
 PortGroup           github 1.0
 
-github.setup        ruby ruby 2_5_0_rc1 v
+github.setup        ruby ruby 2_5_0 v
 name                ruby25
 version             2.5
-epoch               2
 
 categories          lang ruby
 maintainers         kimuraw openmaintainer
@@ -23,8 +22,8 @@ long_description    Ruby is the interpreted scripting language for quick \
 homepage            https://www.ruby-lang.org/
 license             {Ruby BSD}
 
-checksums           rmd160 4abf6439a740296de37aab15b859bbcc12ad38bd \
-                    sha256 545e4e178a1c4eade361cd325cf5e774fadb8fb270945a9e48b47bb74fc5a6b4
+checksums           rmd160 a791addd4bea18d4bc7b8e01566a92740951f991 \
+                    sha256 af4262e64f97996b2cdac011641d1ac1c70120d20cb8e21d687a62a08b9422a8
 
 use_parallel_build  no
 

--- a/lang/ruby25/Portfile
+++ b/lang/ruby25/Portfile
@@ -1,0 +1,125 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           select 1.0
+PortGroup           github 1.0
+
+github.setup        ruby ruby 2_5_0_rc1 v
+name                ruby25
+version             2.5
+epoch               2
+
+categories          lang ruby
+maintainers         kimuraw openmaintainer
+platforms           darwin
+
+description         Powerful and clean object-oriented scripting language
+long_description    Ruby is the interpreted scripting language for quick \
+                    and easy object-oriented programming. It has many \
+                    features to process text files and to do system \
+                    management tasks (as in Perl). It is simple, \
+                    straight-forward, extensible, and portable.
+
+homepage            https://www.ruby-lang.org/
+license             {Ruby BSD}
+
+checksums           rmd160 4abf6439a740296de37aab15b859bbcc12ad38bd \
+                    sha256 545e4e178a1c4eade361cd325cf5e774fadb8fb270945a9e48b47bb74fc5a6b4
+
+use_parallel_build  no
+
+depends_lib         port:readline \
+                    path:lib/libssl.dylib:openssl \
+                    port:zlib \
+                    port:libyaml \
+                    port:libffi \
+                    port:gdbm
+
+depends_run         port:ruby_select
+
+depends_build       port:pkgconfig \
+                    port:autoconf
+
+# depends_skip_archcheck \
+#                     pkgconfig
+
+select.group        ruby
+select.file         ${filespath}/ruby25
+
+configure.args      --enable-shared \
+                    --enable-install-static-library \
+                    --disable-install-doc \
+                    --mandir="${prefix}/share/man" \
+                    --enable-pthread \
+                    --without-gmp \
+                    --with-opt-dir="${prefix}" \
+                    --program-suffix=2.5 \
+                    --with-rubylibprefix="${prefix}/lib/ruby2.5"
+
+configure.cmd       autoreconf -fi && ./configure
+
+platform darwin {
+    if {${os.major} < 10} {
+        configure.args-append --disable-dtrace
+    }
+}
+
+# Add the architecture flag as required
+if {[info exists build_arch] && ${build_arch} != ""} {
+    configure.args-append "--with-arch=${build_arch}"
+}
+
+post-destroot {
+    foreach type {site vendor} {
+        set libdir ${destroot}${prefix}/lib/ruby2.5/${type}_ruby/2.5.0
+        xinstall -m 0755 -d ${libdir}
+    }
+
+    foreach subdir [exec find ${libdir} -type d -empty] {
+        destroot.keepdirs-append ${subdir}
+    }
+
+    # workaround to fix #54866
+    # generate past versions of libruby as symlink
+    # - libruby.2.4.0.dylib -> libruby.2.4.2.dylib
+    # - libruby.2.4.1.dylib -> libruby.2.4.2.dylib
+    # foreach v {2.4.0 2.4.1} {
+    #         copy ${destroot}${prefix}/lib/libruby.2.4.dylib \
+    #             ${destroot}${prefix}/lib/libruby.${v}.dylib
+    # }
+    # install destination of commands from port:rb21-*
+    # xinstall -m 0755 -d ${destroot}${prefix}/libexec/ruby2.5
+    # destroot.keepdirs-append ${destroot}${prefix}/libexec/ruby2.5
+}
+
+variant doc description "Install rdoc indexes and C API documents" {
+        configure.args-delete   --disable-install-doc
+}
+
+# note: use gem or port:rb-tk for ruby/tk since ruby-2.4
+
+variant gmp description "use gmp" {
+        configure.args-delete   --without-gmp
+        depends_lib-append      port:gmp
+}
+
+variant jemalloc description "use jemalloc" {
+        configure.args-delete   --without-jemalloc
+        configure.args-append   --with-jemalloc
+        depends_lib-append      port:jemalloc
+}
+
+variant universal {
+        # use ruby built-in universal mechanism.
+        configure.args-append   --with-arch=[join ${universal_archs} ,]
+        # clear macports' universal flags
+        configure.universal_cflags
+        configure.universal_cppflags
+        configure.universal_cxxflags
+        configure.universal_ldflags
+}
+
+variant relative description "Enable relative loading of libraries to allow for relocation of binaries." {
+        #enable relative loading
+        configure.args-append  --enable-load-relative
+}

--- a/lang/ruby25/files/ruby25
+++ b/lang/ruby25/files/ruby25
@@ -1,0 +1,13 @@
+bin/erb2.5
+bin/gem2.5
+bin/irb2.5
+-
+bin/rdoc2.5
+bin/ri2.5
+bin/ruby2.5
+-
+share/man/man1/erb2.5.1.gz
+share/man/man1/irb2.5.1.gz
+-
+share/man/man1/ri2.5.1.gz
+share/man/man1/ruby2.5.1.gz


### PR DESCRIPTION
#### Description
ruby25 provides Ruby v2.5.0 per https://trac.macports.org/ticket/55588.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1114
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?