### PR TITLE
New port: tnftp (lukemftp) FTP client

### DIFF
--- a/net/tnftp/Portfile
+++ b/net/tnftp/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                tnftp
+version             20151004
+categories          net
+license             BSD
+maintainers         {samodelkin.net:fjoe @mkhon} openmaintainer
+description         Internet File Transfer Protocol client
+long_description    ${name} is the Internet File Transfer Protocol client.
+
+homepage            ftp://ftp.netbsd.org/pub/NetBSD/misc/tnftp/
+platforms           darwin
+
+master_sites        ${homepage}
+checksums           rmd160  7d270cf05d4d9c89584d2759a33af98df2b9000d \
+                    sha256  c94a8a49d3f4aec1965feea831d4d5bf6f90c65fd8381ee0863d11a5029a43a0
+
+depends_lib         path:lib/libssl.dylib:openssl
+
+livecheck.url       http://ftp.netbsd.org/pub/NetBSD/misc/tnftp/
+livecheck.regex     ${name}-(\\d+)


### PR DESCRIPTION
#### Description
tnftp (lukemftp, BSD ftp, NetBSD ftp) is the FTP client which was shipped with the base system before macOS High Sierra

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
