### PR TITLE
libunwind: needs cctools on older systems

### DIFF
--- a/devel/libunwind/Portfile
+++ b/devel/libunwind/Portfile
@@ -109,8 +109,8 @@ if {${subport} == "${name}-headers"} {
         RC_ARCHS="[get_canonical_archs]" \
         LIBUNWIND_CURRENT_VERSION=${version}
 
-    if {[vercmp $xcodeversion 3.2] < 0 && [string match "*macports*" ${configure.compiler}]} {
-        # Xcode 3.1.4 fails with load commands in the newer toolchain
+    if {[vercmp $xcodeversion 4.3] < 0 && [string match "*macports*" ${configure.compiler}]} {
+        # Xcode 4.2 fails with load commands in the newer toolchain
         depends_build-append port:cctools
 
         build.args-append \


### PR DESCRIPTION
newer toolchains create objects that
require current cctools to manage
