### PR TITLE
auto-multiple-choice: change build to use the good Perl version

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -25,7 +25,6 @@ subport auto-multiple-choice-devel {}
 
 if {${subport} eq ${name}} {
     # release
-    set revision            1
     set bitbucket_commit    "ac9013f9ddd7"
     set amc_revision        "2141"
     set amc_date            "201712262328"

--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -25,11 +25,12 @@ subport auto-multiple-choice-devel {}
 
 if {${subport} eq ${name}} {
     # release
-    set bitbucket_commit    "15d39fd2d4aa"
-    set amc_revision        "2132"
-    set amc_date            "2017111201428"
-    checksums               rmd160  325cce4d2c16b503f2de74922282188843c8131f \
-                            sha256  6c19ac832039b22ca266310c471aeff744c0e547d148e537969e6ba7668179dc
+    set revision            1
+    set bitbucket_commit    "ac9013f9ddd7"
+    set amc_revision        "2141"
+    set amc_date            "201712262328"
+    checksums               rmd160  f39c23b3311bb03994d0f6d77c67c108ae3da123 \
+                            sha256  47fa3d7291e4703d2302526ee3a2df0ab83bc93501805f2a697ad7fa9ec1641f
     conflicts               auto-multiple-choice-devel
 } else {
     # devel


### PR DESCRIPTION
auto-multiple-choice: Change build to use the good perl version

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->
Change build to use the good perl version.

Fixes: https://trac.macports.org/ticket/55478.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.2 17C88
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Fixes: https://trac.macports.org/ticket/55478.