### PR TITLE
libsamplerate: have a short and long description

### DIFF
--- a/audio/libsamplerate/Portfile
+++ b/audio/libsamplerate/Portfile
@@ -7,9 +7,17 @@ version         0.1.9
 categories      audio
 license         GPL-2+
 maintainers     {stare.cz:hans @janstary} openmaintainer
-description     libsamplerate (also known as Secret Rabbit Code) is a library \
-                for performing sample rate conversion of audio data.
-long_description    ${description}
+description     library for sample rate conversion of audio data
+long_description libsamplerate is a Sample Rate Converter for audio.	\
+		One example of where such a thing would be useful	\
+		is converting audio from the CD sample rate of 44.1kHz	\
+		to the 48kHz sample rate used by DAT players. 		\
+		The library is capable of arbitrary and time varying 	\
+		conversions from downsampling by a factor of 256 to 	\
+		upsampling by the same factor. Arbitrary in this case 	\
+		means that the ratio of input and output sample rates 	\
+		can be an irrational number. The conversion ratio can 	\
+		also vary with time for speeding up and slowing down effects.
 homepage        http://www.mega-nerd.com/libsamplerate/
 platforms       darwin
 use_parallel_build  yes


### PR DESCRIPTION
* Let the short description fit one line in port search
* Have a long description, taken from the homepage

No functional change
