### PR TITLE
opencore-amr: drop maintainer, remove from sox

### DIFF
--- a/audio/opencore-amr/Portfile
+++ b/audio/opencore-amr/Portfile
@@ -6,7 +6,7 @@ name                opencore-amr
 version             0.1.5
 categories          audio
 platforms           darwin
-maintainers         openmaintainer
+maintainers         nomaintainer
 license             Apache-2
 
 description         implementation of the Adaptive Multi Rate speech codec

--- a/audio/opencore-amr/Portfile
+++ b/audio/opencore-amr/Portfile
@@ -6,7 +6,7 @@ name                opencore-amr
 version             0.1.5
 categories          audio
 platforms           darwin
-maintainers         {stare.cz:hans @janstary}
+maintainers         openmaintainer
 license             Apache-2
 
 description         implementation of the Adaptive Multi Rate speech codec

--- a/audio/sox/Portfile
+++ b/audio/sox/Portfile
@@ -8,9 +8,7 @@ version          14.4.2
 categories       audio
 platforms        darwin
 maintainers      {stare.cz:hans @janstary}
-license          GPL-2+ LGPL-2.1+
-# SoX itself is GPLv2+, but opencore-amr is Apache,
-# so use GPLv3 to avoid license conflict
+license          GPL-2+
 
 description      the Swiss Army knife of audio manipulation
 long_description \
@@ -50,7 +48,6 @@ depends_lib	\
 		port:libpng		\
 		port:libsndfile		\
 		port:libvorbis		\
-		port:opencore-amr	\
 		port:opusfile		\
 		port:twolame		\
 		port:wavpack		\
@@ -77,8 +74,8 @@ configure.args-append \
 		--with-oggvorbis	\
 		--with-opus		\
 		--with-flac		\
-		--with-amrwb		\
-		--with-amrnb		\
+		--without-amrwb		\
+		--without-amrnb		\
 		--with-wavpack		\
 		--with-sndfile		\
 		--with-mp3		\


### PR DESCRIPTION
I no longer use opencore-amr, so I am
* dropping maintainership
* removing the dep from sox (maintainer)

Tested on 10.13.2 with XCode 9.2
