### PR TITLE
mandoc: install files under expected names

### DIFF
--- a/sysutils/groff/Portfile
+++ b/sysutils/groff/Portfile
@@ -6,6 +6,7 @@ name                groff
 version             1.22.3
 revision            3
 categories          sysutils textproc
+conflicts           mandoc
 platforms           darwin
 maintainers         nomaintainer
 license             GPL-3+

--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -4,10 +4,11 @@ PortSystem          1.0
 
 name                mandoc
 version             1.14.3
+revision            1
 description         UNIX manpage compiler
 homepage            http://mandoc.bsd.lv/
 categories          textproc
-conflicts           man
+conflicts           man groff
 license             ISC
 maintainers         eitanadler.com:lists stare.cz:hans openmaintainer
 platforms           openbsd freebsd netbsd darwin
@@ -28,19 +29,6 @@ pre-configure {
 
 PREFIX="${prefix}"
 MANDIR="${prefix}/share/man"
-
-MANM_MANCONF="mandoc.conf"
-MANM_MAN="mandoc_man"
-MANM_MDOC="mandoc_mdoc"
-MANM_ROFF="mandoc_roff"
-MANM_EQN="mandoc_eqn"
-MANM_TBL="mandoc_tbl"
-
-BINM_MAN="mman"
-BINM_APROPOS="mapropos"
-BINM_WHATIS="mwhatis"
-BINM_MAKEWHATIS="mandocdb"
-BINM_SOELIM="msoelim"
 
 INSTALL_PROGRAM="${configure.install} -m 0755"
 INSTALL_LIB="${configure.install} -m 0644"


### PR DESCRIPTION
This tweaks mandoc to install `man`, `apropos` etc as expected, and declares a conflict with groff.
This continues https://trac.macports.org/ticket/53902
Tested on 10.13.2 with XCode 9.2
