### PR TITLE
chez-scheme: update to 9.5

### DIFF
--- a/lang/chez-scheme/Portfile
+++ b/lang/chez-scheme/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cisco ChezScheme 9.4 v
+github.setup        cisco ChezScheme 9.5 v
 name                chez-scheme
 categories          lang
 platforms           darwin
@@ -20,8 +20,8 @@ long_description    Chez Scheme is both a programming language and an \
 
 homepage            https://cisco.github.io/ChezScheme/
 
-checksums           rmd160  7d2e07c85d13a9f6852b34a2a788394bf959097c \
-                    sha256  7b78a497af2498c84ccc3c0b06f25ea2466815cf6ecbb4ca2a6f58bfca7d704d
+checksums           rmd160  79059beab471921b53ef3cf168919042792b26b4 \
+                    sha256  59a16aeaa57b5cd594279d21c06d5c5968662251da832a29e332676ecc08e851
 
 depends_build       port:nanopass-scheme port:zlib
 depends_lib         port:libiconv port:ncurses port:xorg-libX11

--- a/lang/chez-scheme/files/patch-c-Mf-base.diff
+++ b/lang/chez-scheme/files/patch-c-Mf-base.diff
@@ -1,18 +1,17 @@
---- c/Mf-base.orig	2016-05-13 20:59:20.000000000 +0400
-+++ c/Mf-base	2017-04-26 20:22:45.000000000 +0400
-@@ -16,7 +16,6 @@
- include Mf-config
- 
- Include=../boot/$m
--ZlibInclude=../zlib
- PetiteBoot=../boot/$m/petite.boot
- SchemeBoot=../boot/$m/scheme.boot
- Kernel=../boot/$m/kernel.$o
-@@ -50,7 +49,6 @@
+--- c/Mf-base.orig	2018-01-02 21:20:41.000000000 +0400
++++ c/Mf-base	2018-01-02 21:24:18.000000000 +0400
+@@ -54,14 +54,8 @@
  ${kernelobj}: system.h types.h version.h externs.h globals.h segment.h thread.h sort.h
  ${kernelobj}: ${Include}/equates.h ${Include}/scheme.h
  ${mainobj}: ${Include}/scheme.h
--scheme.o io.o new-io.o: ${ZlibInclude}/zconf.h ${ZlibInclude}/zlib.h
+-${kernelobj}: ../zlib/zconf.h ../zlib/zlib.h
  gc-ocd.o gc-oce.o: gc.c
  
+-../zlib/zlib.h ../zlib/zconf.h: ../zlib/configure.log
+-
+-../zlib/libz.a: ../zlib/configure.log
+-	(cd ../zlib; ${MAKE})
+-
  clean:
+ 	rm -f *.$o ${mdclean}
+ 	rm -f Make.out

--- a/lang/chez-scheme/files/patch-c-Mf-ta6osx.diff
+++ b/lang/chez-scheme/files/patch-c-Mf-ta6osx.diff
@@ -1,19 +1,19 @@
---- c/Mf-ta6osx.orig	2016-05-13 20:59:20.000000000 +0400
-+++ c/Mf-ta6osx	2017-04-26 23:05:58.000000000 +0400
+--- c/Mf-ta6osx.orig	2018-01-02 21:20:41.000000000 +0400
++++ c/Mf-ta6osx	2018-01-02 21:31:11.000000000 +0400
 @@ -17,7 +17,7 @@
  Cpu = X86_64
  
  mdclib = -liconv -lm -lncurses
--C = gcc ${CPPFLAGS} -m64 -Wpointer-arith -Wall -Wextra -Werror -O2 -I/opt/X11/include/ ${CFLAGS}
+-C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wall -Wextra -Werror -O2 -I/opt/X11/include/ ${CFLAGS}
 +C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wall -Wextra -Werror -O2 ${CFLAGS}
  o = o
  mdsrc = i3le.c
  mdobj = i3le.o
-@@ -26,16 +26,12 @@
+@@ -26,15 +26,12 @@
  .SUFFIXES: .c .o
  
  .c.o:
--	$C -c -D${Cpu} -I${Include} -I${ZlibInclude} $*.c
+-	$C -c -D${Cpu} -I${Include} -I../zlib $*.c
 +	$C -c -D${Cpu} -I${Include} $*.c
  
  include Mf-base
@@ -26,6 +26,5 @@
  ${Scheme}: ${Kernel} ${Main}
  	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
 -
--${ZlibInclude}/zlib.h ${ZlibInclude}/zconf.h ../zlib/libz.a:
+-../zlib/configure.log:
 -	(cd ../zlib; CFLAGS=-m64 ./configure --64)
--	(cd ../zlib; make)

--- a/lang/chez-scheme/files/patch-c-Mf-ti3osx.diff
+++ b/lang/chez-scheme/files/patch-c-Mf-ti3osx.diff
@@ -1,19 +1,19 @@
---- c/Mf-ti3osx.orig	2016-05-13 20:59:20.000000000 +0400
-+++ c/Mf-ti3osx	2017-04-26 23:08:36.000000000 +0400
+--- c/Mf-ti3osx.orig	2018-01-02 21:20:41.000000000 +0400
++++ c/Mf-ti3osx	2018-01-02 21:31:37.000000000 +0400
 @@ -17,7 +17,7 @@
  Cpu = I386
  
  mdclib = -liconv -lm -lncurses
--C = gcc ${CPPFLAGS} -m32 -Wpointer-arith -Wall -Wextra -Werror -O2 -msse2 -I/opt/X11/include/ ${CFLAGS}
+-C = ${CC} ${CPPFLAGS} -m32 -Wpointer-arith -Wall -Wextra -Werror -O2 -msse2 -I/opt/X11/include/ ${CFLAGS}
 +C = ${CC} ${CPPFLAGS} -m32 -Wpointer-arith -Wall -Wextra -Werror -O2 -msse2 ${CFLAGS}
  o = o
  mdsrc = i3le.c
  mdobj = i3le.o
-@@ -26,16 +26,12 @@
+@@ -26,15 +26,12 @@
  .SUFFIXES: .c .o
  
  .c.o:
--	$C -c -D${Cpu} -I${Include} -I${ZlibInclude} $*.c
+-	$C -c -D${Cpu} -I${Include} -I../zlib $*.c
 +	$C -c -D${Cpu} -I${Include} $*.c
  
  include Mf-base
@@ -26,6 +26,5 @@
  ${Scheme}: ${Kernel} ${Main}
  	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
 -
--${ZlibInclude}/zlib.h ${ZlibInclude}/zconf.h ../zlib/libz.a:
+-../zlib/configure.log:
 -	(cd ../zlib; CFLAGS=-m32 ./configure)
--	(cd ../zlib; make)

--- a/lang/chez-scheme/files/patch-configure.diff
+++ b/lang/chez-scheme/files/patch-configure.diff
@@ -1,39 +1,25 @@
---- configure.orig	2016-05-13 20:59:20.000000000 +0400
-+++ configure	2017-04-28 21:56:31.000000000 +0400
-@@ -37,9 +37,6 @@
- installschemename="scheme"
- installpetitename="petite"
- installscriptname="scheme-script"
--CPPFLAGS=""
--CFLAGS=""
--LDFLAGS=""
+--- configure.orig	2018-01-02 21:21:01.000000000 +0400
++++ configure	2018-01-02 21:21:28.000000000 +0400
+@@ -310,22 +310,6 @@
+   exit 1
+ fi
  
- case `uname` in
-   Linux)
-@@ -290,18 +287,6 @@
- 
- if [ -d '.git' ] ; then
-   git submodule init && git submodule update || exit 1
+-if [ -d '.git' ] && command -v git >/dev/null 2>&1 ; then
+-  git submodule init && git submodule update || exit 1
 -else
 -  if [ ! -f 'nanopass/nanopass.ss' ] ; then
 -    rmdir nanopass && (curl  -L -o v1.9.tar.gz https://github.com/nanopass/nanopass-framework-scheme/archive/v1.9.tar.gz && tar -zxf v1.9.tar.gz && mv nanopass-framework-scheme-1.9 nanopass && rm v1.9.tar.gz) || exit 1
 -  fi
 -
 -  if [ ! -f 'zlib/configure' ] ; then
--    rmdir zlib && (curl -L -o v1.2.8.tar.gz https://github.com/madler/zlib/archive/v1.2.8.tar.gz && tar -xzf v1.2.8.tar.gz && mv zlib-1.2.8 zlib && rm v1.2.8.tar.gz) || exit 1
+-    rmdir zlib && (curl -L -o v1.2.11.tar.gz https://github.com/madler/zlib/archive/v1.2.11.tar.gz && tar -xzf v1.2.11.tar.gz && mv zlib-1.2.11 zlib && rm v1.2.11.tar.gz) || exit 1
 -  fi
 -
 -  if [ ! -f 'stex/Mf-stex' ] ; then
 -    rmdir stex && (curl -L -o v1.2.1.tar.gz https://github.com/dybvig/stex/archive/v1.2.1.tar.gz && tar -zxf v1.2.1.tar.gz && mv stex-1.2.1 stex && rm v1.2.1.tar.gz) || exit 1
 -  fi
- fi
- 
+-fi
+-
  ./workarea $m $w
-@@ -336,6 +321,7 @@
- END
  
- cat > $w/c/Mf-config << END
-+CC=$CC
- CPPFLAGS=$CPPFLAGS
- CFLAGS=$CFLAGS
- LDFLAGS=$LDFLAGS
+ sed -e 's/$(m)/'$m'/g'\

--- a/lang/chez-scheme/files/patch-s-Mf-base.diff
+++ b/lang/chez-scheme/files/patch-s-Mf-base.diff
@@ -1,6 +1,6 @@
---- s/Mf-base.orig	2017-05-06 21:45:27.000000000 +0400
-+++ s/Mf-base	2017-05-06 22:24:10.000000000 +0400
-@@ -342,18 +342,7 @@
+--- s/Mf-base.orig	2018-01-02 21:21:02.000000000 +0400
++++ s/Mf-base	2018-01-02 21:34:32.000000000 +0400
+@@ -358,18 +358,7 @@
               '(compile-file "$*.ss" "$*.so")'\
               | ${Scheme} -q cmacros.so priminfo.so primvars.so env.so
  
@@ -15,8 +15,8 @@
 -             '(collect-request-handler (lambda () (collect 0 1)))'\
 -             '(collect 1 2)'\
 -             '(compile-library "../nanopass/nanopass.ss" "nanopass.so")'\
--             | ${Scheme} -q --libdirs "../nanopass::." --compile-imported-libraries
+-             | ${Scheme} -q --libdirs "../nanopass${dirsep}${dirsep}." --compile-imported-libraries
 +nanopass.so: ;
  
  rootsrc = $(shell cd ../../s; echo *)
- ${rootsrc}: ; ln -s ../../s/$@ $@
+ ${rootsrc}:


### PR DESCRIPTION
#### Description

Update to 9.5. Could not install with tracing mode because of [ticket 55575](https://trac.macports.org/ticket/55575).

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?