### PR TITLE
elasticsearch @6.1.2: new port

### DIFF
--- a/databases/elasticsearch/Portfile
+++ b/databases/elasticsearch/Portfile
@@ -3,11 +3,10 @@
 PortSystem          1.0
 
 name                elasticsearch
-version             6.1.1
-revision            1
+version             6.1.2
 
 categories          databases java
-maintainers         nomaintainer
+maintainers         @gerardsoleca openmaintainer
 
 description         Distributed RESTful search engine built for the cloud
 long_description    Elasticsearch is a highly scalable open-source full-text \
@@ -25,11 +24,11 @@ license             Apache-2
 
 homepage            https://www.elastic.co/
 master_sites        https://artifacts.elastic.co/downloads/elasticsearch/
-distname            ${name}-${version}
 distfiles           ${distname}.zip
-checksums           rmd160 cc4bd477503e276d7f075eb26a784450627328fc \
-                    sha256 51ad59e698212fcf436e7dbe4b1937939239da8bd53a1d9c602b9d8df51b347a
-            
+checksums           rmd160  a6d687bcbae51ca42c43263c7ccff9e36c6b09e9 \
+                    sha256  6cc60fc08e8d40b25357d0b4d464e15fba803aad075c00c9b42bc6d578fd7f7e \
+                    size    28497714
+
 use_zip             yes
 use_configure       no
 build {}
@@ -60,7 +59,7 @@ destroot {
         ${destroot}${confdir} \
         ${destroot}${logdir} \
         ${destroot}${dbdir}
-    
+ 
     # This two directories are empty, so we need to preserve them
     destroot.keepdirs-append \
         ${destroot}/${logdir} \
@@ -72,14 +71,14 @@ destroot {
         ${worksrcpath}/lib \
         ${worksrcpath}/modules \
         ${destroot}${elasticdir}
-    
+ 
     # Copy config files to etc
     file copy \
         ${worksrcpath}/config/elasticsearch.yml \
         ${worksrcpath}/config/jvm.options \
         ${worksrcpath}/config/log4j2.properties \
         ${destroot}${confdir}
-    
+ 
     # Symlink the two required binaries to be used
     ln -s ../share/${name}/bin/${name} ${destroot}${prefix}/bin/${name}
     ln -s ../share/${name}/bin/${name}-env ${destroot}${prefix}/bin/${name}-env

--- a/databases/elasticsearch/Portfile
+++ b/databases/elasticsearch/Portfile
@@ -1,0 +1,108 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                elasticsearch
+version             6.1.1
+revision            1
+
+categories          databases java
+maintainers         nomaintainer
+
+description         Distributed RESTful search engine built for the cloud
+long_description    Elasticsearch is a highly scalable open-source full-text \
+                    search and analytics engine. It allows you to store search, \
+                    and analyze big volumes of data quickly and in near \
+                    real time. It is generally used as the underlying \
+                    engine/technology that powers applications that have complex \
+                    search features and requirements. \
+                    Elasticsearch requires Java, Java version can be up to Java 8. \
+                    Java 9 is not supported and Elasticsearch won't work.
+
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+
+homepage            https://www.elastic.co/
+master_sites        https://artifacts.elastic.co/downloads/elasticsearch/
+distname            ${name}-${version}
+distfiles           ${distname}.zip
+checksums           rmd160 cc4bd477503e276d7f075eb26a784450627328fc \
+                    sha256 51ad59e698212fcf436e7dbe4b1937939239da8bd53a1d9c602b9d8df51b347a
+            
+use_zip             yes
+use_configure       no
+build {}
+
+patchfiles          patch-elasticsearch-yml.diff \
+                    patch-elasticsearch-env.diff
+
+set elasticdir      ${prefix}/share/${name}
+set confdir         ${prefix}/etc/${name}
+set logdir          ${prefix}/var/log/${name}
+set dbdir           ${prefix}/lib/${name}
+set user            ${name}
+set group           ${user}
+
+# Elasticsearch cannot run as root, so dedicated user is required
+add_users           ${user} group=${group} realname=Elasticsearch\ Server
+
+pre-build {
+    # Change the PREFIX in the config files. They are already patched.
+    reinplace s|@PREFIX@|${prefix}| ${worksrcpath}/config/elasticsearch.yml
+    reinplace s|@PREFIX@|${prefix}| ${worksrcpath}/bin/elasticsearch-env
+}
+
+destroot {
+    # Setup the directories used by elasticsearch
+    xinstall -m 755 -o ${user} -g ${group} -d \
+        ${destroot}${elasticdir} \
+        ${destroot}${confdir} \
+        ${destroot}${logdir} \
+        ${destroot}${dbdir}
+    
+    # This two directories are empty, so we need to preserve them
+    destroot.keepdirs-append \
+        ${destroot}/${logdir} \
+        ${destroot}/${dbdir}
+
+    # Copy elasticsearch to destroot
+    file copy \
+        ${worksrcpath}/bin \
+        ${worksrcpath}/lib \
+        ${worksrcpath}/modules \
+        ${destroot}${elasticdir}
+    
+    # Copy config files to etc
+    file copy \
+        ${worksrcpath}/config/elasticsearch.yml \
+        ${worksrcpath}/config/jvm.options \
+        ${worksrcpath}/config/log4j2.properties \
+        ${destroot}${confdir}
+    
+    # Symlink the two required binaries to be used
+    ln -s ../share/${name}/bin/${name} ${destroot}${prefix}/bin/${name}
+    ln -s ../share/${name}/bin/${name}-env ${destroot}${prefix}/bin/${name}-env
+}
+
+post-activate {
+    # Plugins needs to be an empty folder or elastic crashes,
+    # so it is created here to avoid .turd_elasticsearch file
+    system "mkdir -p ${elasticdir}/plugins/"
+
+    # Give the appropiate permissions on the file system
+    system "chown -R root:${group} ${elasticdir}"
+    system "chown -R ${user}:${group} ${logdir}"
+    system "chown -R ${user}:${group} ${dbdir}"
+    
+    ui_msg "###########################################################"
+    ui_msg "# Elasticsearch requires Java 8. If you have installed"
+    ui_msg "# Java 9 it won't work"
+    ui_msg "# Use sudo \"port load elasticsearch\" to start the service"
+    ui_msg "###########################################################"
+}
+
+startupitem.create  yes
+startupitem.logfile ${logdir}/daemon.log
+startupitem.executable sudo -u elasticsearch ${prefix}/bin/${name}
+

--- a/databases/elasticsearch/files/patch-elasticsearch-env.diff
+++ b/databases/elasticsearch/files/patch-elasticsearch-env.diff
@@ -1,0 +1,34 @@
+--- bin/elasticsearch-env	2017-12-17 20:22:14.000000000 +0100
++++ bin/elasticsearch-env	2018-01-06 19:26:13.000000000 +0100
+@@ -19,18 +19,8 @@
+   fi
+ done
+
+-# determine Elasticsearch home; to do this, we strip from the path until we find
+-# bin, and then strip bin (there is an assumption here that there is no nested
+-# directory under bin also named bin)
+-ES_HOME=`dirname "$SCRIPT"`
+-
+-# now make ES_HOME absolute
+-ES_HOME=`cd "$ES_HOME"; pwd`
+-
+-while [ "`basename "$ES_HOME"`" != "bin" ]; do
+-  ES_HOME=`dirname "$ES_HOME"`
+-done
+-ES_HOME=`dirname "$ES_HOME"`
++ES_HOME="@PREFIX@/share/elasticsearch"
++ES_PATH_CONF="@PREFIX@/etc/elasticsearch"
+
+ # now set the classpath
+ ES_CLASSPATH="$ES_HOME/lib/*"
+@@ -66,10 +56,3 @@
+ "$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
+
+ export HOSTNAME=$HOSTNAME
+-
+-if [ -z "$ES_PATH_CONF" ]; then ES_PATH_CONF="$ES_HOME"/config; fi
+-
+-if [ -z "$ES_PATH_CONF" ]; then
+-  echo "ES_PATH_CONF must be set to the configuration path"
+-  exit 1
+-fi

--- a/databases/elasticsearch/files/patch-elasticsearch-yml.diff
+++ b/databases/elasticsearch/files/patch-elasticsearch-yml.diff
@@ -1,0 +1,25 @@
+--- config/elasticsearch.yml	2017-12-17 20:22:14.000000000 +0100
++++ config/elasticsearch.yml	2018-01-05 20:20:27.000000000 +0100
+@@ -14,7 +14,7 @@
+ #
+ # Use a descriptive name for your cluster:
+ #
+-#cluster.name: my-application
++cluster.name: elasticsearch
+ #
+ # ------------------------------------ Node ------------------------------------
+ #
+@@ -30,11 +30,11 @@
+ #
+ # Path to directory where to store the data (separate multiple locations by comma):
+ #
+-#path.data: /path/to/data
++path.data: @PREFIX@/lib/elasticsearch
+ #
+ # Path to log files:
+ #
+-#path.logs: /path/to/logs
++path.logs: @PREFIX@/var/log/elasticsearch
+ #
+ # ----------------------------------- Memory -----------------------------------
+ #


### PR DESCRIPTION
#### Description
Elasticsearch is an open-source, RESTful, distributed search and analytics engine built on Apache Lucene
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1036
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
