### PR TITLE
py-astropy: remove -ap suffix from bin filenames

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
 version             2.0.2
+revision            1
 maintainers         robitaille gmail.com:Deil.Christoph
 
 dist_subdir         ${name}/${version}
@@ -46,19 +47,5 @@ if {${name} ne ${subport}} {
     # The --offline and --no-git flags prevent this and use a bundled version.
     build.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
     destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
-
-    # Don't let the python portgroup create symlinks to the binaries, because
-    # the python portgroup's post-destroot block will run before ours, so the
-    # files won't have the right names yet, and the symlinks will be broken.
-    python.link_binaries no
-
-    post-destroot {
-        # Don't conflict with files installed by py-pyfits.
-        set ap_suffix -ap
-        foreach bin {fitscheck fitsdiff fitsheader volint fits2bitmap samp_hub wcslint} {
-            move ${destroot}${python.prefix}/bin/${bin} ${destroot}${python.prefix}/bin/${bin}${ap_suffix}
-            ln -s ${python.prefix}/bin/${bin}${ap_suffix} ${destroot}${prefix}/bin/${bin}${ap_suffix}${python.link_binaries_suffix}
-        }
-    }
 
 }


### PR DESCRIPTION
#### Description

The suffix was there to prevent a conflict with py-pyfits. However, py-pyfits is now an obsolete stub port, so there will no longer be a conflict.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
