### PR TITLE
gnomeicu, gauche: fix spelling of 'revision'

### DIFF
--- a/gnome/gnomeicu/Portfile
+++ b/gnome/gnomeicu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    gnomeicu
 version                 0.99.16
-revsion                 1
+revision                1
 license                 GPL-2+
 categories              gnome
 platforms               darwin

--- a/lang/gauche/Portfile
+++ b/lang/gauche/Portfile
@@ -5,7 +5,7 @@ PortGroup  compiler_blacklist_versions 1.0
 
 name                gauche
 version             0.9.4
-revsion             1
+revision            1
 categories          lang
 license             BSD
 maintainers         nomaintainer


### PR DESCRIPTION
introduced in 8b0fe470705d6ee45f4dd79515e4bea61b8f7de6

port lint would have catched this (by the way, there are still 8 warnings about variants without description in gauche)

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G18013
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
