### PR TITLE
libsndfile: description

### DIFF
--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -8,9 +8,14 @@ categories          audio
 maintainers         {stare.cz:hans @janstary}
 platforms           darwin
 
-description         a C library for reading and writing files containing \
-                    sampled sound through one standard library interface.
-long_description    ${description}
+description         read and write files containing sampled sound
+long_description    \
+	libsndfile is a C library for reading and writing files	\
+	containing sampled sound through one standard library interface. \
+	libsndfile has the following main features: \
+	ability to read and write a large number of file formats, \
+	a simple, elegant and easy to use API, \
+	and on the fly format conversion.
 license             LGPL-2.1+
 homepage            http://www.mega-nerd.com/libsndfile/
 master_sites        ${homepage}files/


### PR DESCRIPTION
Make the short description fit `port search --line`
and take long description from the homepage.
No functional change.

  