### PR TITLE
libsamplerate: BSD licensed now

### DIFF
--- a/audio/libsamplerate/Portfile
+++ b/audio/libsamplerate/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name            libsamplerate
 version         0.1.9
 categories      audio
-license         GPL-2+
+license         BSD
 maintainers     {stare.cz:hans @janstary} openmaintainer
 description     library for sample rate conversion of audio data
 long_description libsamplerate is a Sample Rate Converter for audio.	\


### PR DESCRIPTION
libsamplerate is BSD-licensed since 2016
http://www.mega-nerd.com/SRC/license.html

No functional change.
