### PR TITLE
libfilezilla: update to 0.11.2

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.1
 
 name                libfilezilla
-version             0.11.1
+version             0.11.2
 categories          devel
 platforms           darwin
 maintainers         {@yan12125 gmail.com:yan12125} openmaintainer
@@ -19,8 +19,8 @@ long_description    Small and modern C++ library, offering some basic \
 homepage            https://lib.filezilla-project.org/
 master_sites        http://download.filezilla-project.org/libfilezilla/
 
-checksums           rmd160  d5ff932d4d8088429940d1041d943bf9055a6c44 \
-                    sha256  ecbaa674c0ad0b63df842b8cde17935a497dd58c3749baa281c67cf5878e64f7
+checksums           rmd160  8d9011d64d6577493e2924f6661ef1e42a99f617 \
+                    sha256  96e59946fcf6f9444abfb4aea9f9275b9fa66f868bed00571bc32898bb178472
 
 depends_build       port:pkgconfig \
                     port:cppunit \


### PR DESCRIPTION
#### Description

Add sha512 sum, which is from https://download.filezilla-project.org/libfilezilla/libfilezilla-0.11.2.sha512

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
