### PR TITLE
libsamplerate: explicit ./configure --options

### DIFF
--- a/audio/libsamplerate/Portfile
+++ b/audio/libsamplerate/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name            libsamplerate
 version         0.1.9
+revision        1
 categories      audio
 license         BSD
 maintainers     {stare.cz:hans @janstary} openmaintainer

--- a/audio/libsamplerate/Portfile
+++ b/audio/libsamplerate/Portfile
@@ -30,7 +30,12 @@ depends_lib     port:fftw-3 port:libsndfile
 
 patchfiles      patch-src-samplerate.h.diff patch_examples_Makefile.in.diff
 
-configure.args  --disable-silent-rules
+configure.args  \
+                --enable-option-checking	\
+                --disable-silent-rules		\
+                --enable-fftw			\
+                --disable-cpu-clip		\
+                --enable-sndfile
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}

--- a/audio/libsamplerate/Portfile
+++ b/audio/libsamplerate/Portfile
@@ -26,14 +26,14 @@ checksums       rmd160  ec6f3542b5e43f398ad7e5dfd9dc35902b06d762 \
                 sha256 0a7eb168e2f21353fb6d84da152e4512126f7dc48ccb0be80578c565413444c1
 
 depends_build   port:pkgconfig
-depends_lib     port:fftw-3 port:libsndfile
+depends_lib     port:libsndfile
 
 patchfiles      patch-src-samplerate.h.diff patch_examples_Makefile.in.diff
 
 configure.args  \
                 --enable-option-checking	\
                 --disable-silent-rules		\
-                --enable-fftw			\
+                --disable-fftw			\
                 --disable-cpu-clip		\
                 --enable-sndfile
 


### PR DESCRIPTION
This adds explicit `./configure` options to libsamplerate, as per `./configure --help`.

  