### PR TITLE
libressl: livecheck

### DIFF
--- a/security/libressl/Portfile
+++ b/security/libressl/Portfile
@@ -49,5 +49,5 @@ platform darwin {
 }
 
 livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "latest stable release is (\\d+\\.\\d+(?:\\.\\d+)*)"
+livecheck.url       https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/
+livecheck.regex     "(\\d+\\.\\d+\\.\\d+)"


### PR DESCRIPTION
Don't grep free-form prose on a homepage,
just look for a tarball version to download.

No package change.