### PR TITLE
net/teleport: update to v2.4.0

### DIFF
--- a/net/teleport/Portfile
+++ b/net/teleport/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        gravitational teleport 2.3.0 v
+github.setup        gravitational teleport 2.4.0 v
 
 homepage            http://gravitational.com/teleport/
 categories          net
@@ -16,8 +16,8 @@ long_description    Teleport is a modern SSH server and CA for managing clusters
                     and a Web UI.  Built on the Golang SSH library, and compatible with OpenSSH
 license             Apache-2
 
-checksums           rmd160  be61ebe4e5d1d0adc74c48cfb892049a1bd30897 \
-                    sha256  5c1a377ea674feff4e0b39051f62576b9f0ad9ccec87d21946b94dd72f19c42f
+checksums           rmd160  a6cbab11919414fc9cba11b6a1f30ad92e7bbfa6 \
+                    sha256  e1f1462f499f883fd167b4c76cf7dc11f353ed113654a6eb89ce39f7f0ded065
 
 depends_lib         port:go port:zip
 platforms           darwin


### PR DESCRIPTION
#### Description

Update net/teleport (https://gravitational.com/teleport/) to v2.4.0

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.2 17C88
Xcode 8.1 8B62

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
