### PR TITLE
mandoc: ./configure detects the compiler just fine

### DIFF
--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mandoc
 version             1.14.3
-revision            1
+revision            2
 description         UNIX manpage compiler
 homepage            http://mandoc.bsd.lv/
 categories          textproc
@@ -49,14 +49,3 @@ LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
     puts "${fd}" "${content}"
     close "${fd}"
 }
-
-# Without declaring a universal variant before using get_canonical_archflags,
-# only non-universal arch flags are returned.
-# This works around it.
-# Another way around the problem would be setting build.env in pre-build.
-# Kudos to jmr and ryandesign for explaining that.
-variant universal   {}
-
-build.args          CC="${configure.cc}"
-build.env           CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc]" \
-                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"


### PR DESCRIPTION
No need for the CC dance the port currently does.
The whole difference seems to be that we add an explicit `CC="/usr/bin/clang"`
(or whichever compiler it has found) to the environment.

Tested on 10.13.2 with XCode 9.2
