### PR TITLE
WIP: relax port:openssl to path:lib/libssl.dylib:openssl

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1093,7 +1093,7 @@ foreach {module module_info} [array get modules] {
 
                 # see https://trac.macports.org/ticket/51358
                 #     for why not a path dependency
-                depends_lib-append port:openssl
+                depends_lib-append path:lib/libssl.dylib:openssl
             }
             default_variants-append +openssl
 

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -1017,7 +1017,7 @@ foreach {module module_info} [array get modules] {
 
                 # see https://trac.macports.org/ticket/51358
                 #     for why not a path dependency
-                depends_lib-append port:openssl
+                depends_lib-append path:lib/libssl.dylib:openssl
             }
             default_variants-append +openssl
 

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -1058,7 +1058,7 @@ foreach {module module_info} [array get modules] {
 
                 # see https://trac.macports.org/ticket/51358
                 #     for why not a path dependency
-                depends_lib-append port:openssl
+                depends_lib-append path:lib/libssl.dylib:openssl
             }
             default_variants-append +openssl
 

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -1109,7 +1109,7 @@ foreach {module module_info} [array get modules] {
 
                 # see https://trac.macports.org/ticket/51358
                 #     for why not a path dependency
-                depends_lib-append port:openssl
+                depends_lib-append path:lib/libssl.dylib:openssl
             }
             default_variants-append +openssl
 

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -1106,7 +1106,7 @@ foreach {module module_info} [array get modules] {
 
                 # see https://trac.macports.org/ticket/51358
                 #     for why not a path dependency
-                depends_lib-append port:openssl
+                depends_lib-append path:lib/libssl.dylib:openssl
             }
             default_variants-append +openssl
 

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1089,7 +1089,7 @@ foreach {module module_info} [array get modules] {
 
                 # see https://trac.macports.org/ticket/51358
                 #     for why not a path dependency
-                depends_lib-append port:openssl
+                depends_lib-append path:lib/libssl.dylib:openssl
             }
             default_variants-append +openssl
 

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -41,7 +41,7 @@ depends_lib-append  port:boost \
                     port:double-conversion \
                     port:libevent \
                     port:snappy \
-                    port:openssl \
+                    path:lib/libssl.dylib:openssl \
                     port:mstch \
                     port:wangle \
                     port:folly

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -38,6 +38,6 @@ depends_lib-append  port:boost \
                     port:lz4 \
                     port:lzma \
                     port:xz \
-                    port:openssl \
+                    path:lib/libssl.dylib:openssl \
                     port:zlib \
                     port:zstd

--- a/devel/lua-luasec/Portfile
+++ b/devel/lua-luasec/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  1944ed72f389d85f785093d1ea12b6c4e7a2c685 \
 # so dependency on lua-luasocket is not necessary.
 
 depends_lib         port:lua \
-                    port:openssl
+                    path:lib/libssl.dylib:openssl
 
 patchfiles          patch-Makefile.diff \
                     patch-src-Makefile.diff

--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -152,7 +152,7 @@ set qt.versions     {"" "-qt5"}
 foreach qv ${qt.versions} {
     subport ${name}${qv}-ossl {
         license                 LGPL-2.1+
-        depends_lib-append      port:${name}${qv} port:openssl
+        depends_lib-append      port:${name}${qv} path:lib/libssl.dylib:openssl
         configure.args-delete   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
         configure.args-append   -DBUILD_PLUGINS:STRING="ossl"
         build.dir               ${workpath}/build/plugins/qca-ossl

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -32,7 +32,7 @@ depends_lib-append  port:folly \
                     port:boost \
                     port:gflags \
                     port:google-glog \
-                    port:openssl
+                    path:lib/libssl.dylib:openssl
 
 configure.args-append \
                     -DBUILD_TESTS=OFF \

--- a/emulators/scummvm/Portfile
+++ b/emulators/scummvm/Portfile
@@ -104,7 +104,7 @@ variant mpeg2 description {add mpeg2 support - has many dependencies} {
                     port:db48 \
                     port:libsdl \
                     port:libxml2 \
-                    port:openssl \
+                    path:lib/libssl.dylib:openssl
                     port:python27 \
                     port:python2_select \
                     port:python_select \

--- a/net/libstrophe/Portfile
+++ b/net/libstrophe/Portfile
@@ -22,7 +22,7 @@ checksums          rmd160  ad91c0a0c2eb2726efd854dd696eb086204c608b \
 depends_build      port:m4 \
                    port:pkgconfig
 depends_lib        port:expat \
-                   port:openssl
+                   path:lib/libssl.dylib:openssl
 
 use_autoreconf     yes
 

--- a/net/profanity/Portfile
+++ b/net/profanity/Portfile
@@ -25,7 +25,7 @@ depends_build-append \
 depends_lib-append port:ncurses \
                    port:libstrophe \
                    port:curl \
-                   port:openssl \
+                   path:lib/libssl.dylib:openssl \
                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
                    port:expat \
                    port:libotr \

--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -41,7 +41,7 @@ default_variants    +openssl
 variant openssl description {With built-in support for OpenSSL} {
     configure.args-replace -DSSL_IMPL=none -DSSL_IMPL=openssl
 
-    depends_lib-append      port:openssl
+    depends_lib-append      path:lib/libssl.dylib:openssl
 }
 
 variant swig description {With built-in support for SWIG so the bindings can be built} {

--- a/net/snort/Portfile
+++ b/net/snort/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  c0ce78ab3de5c8bfb06ab3ad3e592fae95c58faa \
                     sha256  23a45e3ea1e155a3d871c691a10fe23f2bfcfe4d6abc0ebbcdc2ab1fccca14ee
 
 depends_lib      port:daq \
-                 port:openssl
+                 path:lib/libssl.dylib:openssl
 
 #patchfiles       patch-src-strlcatu.h.diff patch-src-strlcpyu.h.diff
 

--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -20,7 +20,7 @@ checksums     rmd160 575d7c502f5f9555538da2b8c832f04af59ffda2 \
 
 depends_build  port:pkgconfig
 depends_lib    port:ldas-tools-al \
-               port:openssl \
+               path:lib/libssl.dylib:openssl \
                port:zlib \
                port:bzip2
 

--- a/textproc/html-xml-utils/Portfile
+++ b/textproc/html-xml-utils/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  832c7815b8bc1f9b9b15df9b622d38c4d71609d0 \
 
 depends_lib         port:libiconv \
                     port:curl \
-                    port:openssl \
+                    path:lib/libssl.dylib:openssl \
                     port:nghttp2 \
                     port:libidn \
                     port:zlib

--- a/www/phantomjs/Portfile
+++ b/www/phantomjs/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  84f80e82a4dc48110f02dc4734c938c9abd8acb0 \
                     sha256  cc81249eaa059cc138414390cade9cb6509b9d6fa0df16f4f43de70b174b3bfe
 
 depends_lib         port:icu \
-                    port:openssl
+                    path:lib/libssl.dylib:openssl
 
 patchfiles          patch-tools_preconfig.sh.diff \
                     patch-qcocoaapplicationdelegate.mm.diff \


### PR DESCRIPTION
These are exactly the ports that specify `port:openssl`
as opposed to `path:lib/libssl.dylib:openssl`,
which all the other ssl-dependent ports do.

This is work in progress.
Please test whether this breaks your port.

1. uninstall openssl and everything that depends on it
2. install libressl instead, providing `libssl.dylib`
3. rebuild you port with `port -vs install`
4. see how it works or breaks; please report here.

I'm testing on MacOS 10.13.2. with Xcode 9.2
