### PR TITLE
opusfile: patch libressl version confusion

### DIFF
--- a/audio/opusfile/Portfile
+++ b/audio/opusfile/Portfile
@@ -24,6 +24,7 @@ depends_lib         path:lib/libssl.dylib:openssl \
                     port:libogg \
                     port:libopus
 
+patchfiles          patch-libressl.diff
 configure.args      --disable-silent-rules
 
 livecheck.type      regex

--- a/audio/opusfile/files/patch-libressl.diff
+++ b/audio/opusfile/files/patch-libressl.diff
@@ -1,0 +1,99 @@
+--- src/http.c.orig	2017-08-03 02:27:06.000000000 +0200
++++ src/http.c	2018-01-11 17:23:29.000000000 +0100
+@@ -1530,7 +1530,7 @@ static long op_bio_retry_ctrl(BIO *_b,in
+   return ret;
+ }
+ 
+-# if OPENSSL_VERSION_NUMBER<0x10100000L
++# if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #  define BIO_set_data(_b,_ptr) ((_b)->ptr=(_ptr))
+ #  define BIO_set_init(_b,_init) ((_b)->init=(_init))
+ #  define ASN1_STRING_get0_data ASN1_STRING_data
+@@ -1538,7 +1538,7 @@ static long op_bio_retry_ctrl(BIO *_b,in
+ 
+ static int op_bio_retry_new(BIO *_b){
+   BIO_set_init(_b,1);
+-# if OPENSSL_VERSION_NUMBER<0x10100000L
++# if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+   _b->num=0;
+ # endif
+   BIO_set_data(_b,NULL);
+@@ -1549,7 +1549,7 @@ static int op_bio_retry_free(BIO *_b){
+   return _b!=NULL;
+ }
+ 
+-# if OPENSSL_VERSION_NUMBER<0x10100000L
++# if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ /*This is not const because OpenSSL doesn't allow it, even though it won't
+    write to it.*/
+ static BIO_METHOD op_bio_retry_method={
+@@ -1570,7 +1570,7 @@ static BIO_METHOD op_bio_retry_method={
+    proxying https URL requests.*/
+ static int op_http_conn_establish_tunnel(OpusHTTPStream *_stream,
+  OpusHTTPConn *_conn,op_sock _fd,SSL *_ssl_conn,BIO *_ssl_bio){
+-# if OPENSSL_VERSION_NUMBER>=0x10100000L
++# if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+   BIO_METHOD *bio_retry_method;
+ # endif
+   BIO  *retry_bio;
+@@ -1583,7 +1583,7 @@ static int op_http_conn_establish_tunnel
+   ret=op_http_conn_write_fully(_conn,
+    _stream->proxy_connect.buf,_stream->proxy_connect.nbuf);
+   if(OP_UNLIKELY(ret<0))return ret;
+-# if OPENSSL_VERSION_NUMBER>=0x10100000L
++# if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+   bio_retry_method=BIO_meth_new(BIO_TYPE_NULL,"retry");
+   if(bio_retry_method==NULL)return OP_EFAULT;
+   BIO_meth_set_write(bio_retry_method,op_bio_retry_write);
+@@ -1606,7 +1606,7 @@ static int op_http_conn_establish_tunnel
+   /*This shouldn't succeed, since we can't read yet.*/
+   OP_ALWAYS_TRUE(SSL_connect(_ssl_conn)<0);
+   SSL_set_bio(_ssl_conn,_ssl_bio,_ssl_bio);
+-# if OPENSSL_VERSION_NUMBER>=0x10100000L
++# if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+   BIO_meth_free(bio_retry_method);
+ # endif
+   /*Only now do we disable write coalescing, to allow the CONNECT
+@@ -1635,7 +1635,7 @@ static struct addrinfo *op_inet_pton(con
+   return NULL;
+ }
+ 
+-# if OPENSSL_VERSION_NUMBER<0x10002000L
++# if OPENSSL_VERSION_NUMBER<0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+ /*Match a host name against a host with a possible wildcard pattern according
+    to the rules of RFC 6125 Section 6.4.3.
+   Return: 0 if the pattern doesn't match, and a non-zero value if it does.*/
+@@ -1893,7 +1893,7 @@ static int op_http_conn_start_tls(OpusHT
+   SSL_set_tlsext_host_name(_ssl_conn,_stream->url.host);
+ # endif
+   skip_certificate_check=_stream->skip_certificate_check;
+-# if OPENSSL_VERSION_NUMBER>=0x10002000L
++# if OPENSSL_VERSION_NUMBER>=0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+   /*As of version 1.0.2, OpenSSL can finally do hostname checks automatically.
+     Of course, they make it much more complicated than it needs to be.*/
+   if(!skip_certificate_check){
+@@ -1956,13 +1956,13 @@ static int op_http_conn_start_tls(OpusHT
+   if(OP_UNLIKELY(ret<=0))return OP_FALSE;
+   ssl_session=_stream->ssl_session;
+   if(ssl_session==NULL
+-# if OPENSSL_VERSION_NUMBER<0x10002000L
++# if OPENSSL_VERSION_NUMBER<0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+    ||!skip_certificate_check
+ # endif
+    ){
+     ret=op_do_ssl_step(_ssl_conn,_fd,SSL_do_handshake);
+     if(OP_UNLIKELY(ret<=0))return OP_FALSE;
+-# if OPENSSL_VERSION_NUMBER<0x10002000L
++# if OPENSSL_VERSION_NUMBER<0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+     /*OpenSSL before version 1.0.2 does not do automatic hostname verification,
+        despite the fact that we just passed it the hostname above in the call
+        to SSL_set_tlsext_host_name().
+@@ -2314,7 +2314,7 @@ static int op_http_stream_open(OpusHTTPS
+     /*Initialize the SSL library if necessary.*/
+     if(OP_URL_IS_SSL(&_stream->url)&&_stream->ssl_ctx==NULL){
+       SSL_CTX *ssl_ctx;
+-# if OPENSSL_VERSION_NUMBER<0x10100000L
++# if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #  if !defined(OPENSSL_NO_LOCKING)
+       /*The documentation says SSL_library_init() is not reentrant.
+         We don't want to add our own depenencies on a threading library, and it


### PR DESCRIPTION
LibreSSL declares its OPENSSL_VERSION_NUMBER as 0x20000000L
which makes it satisfy e.g. OPENSSL_VERSION_NUMBER>=0x10100000L,
about which opusfile makes certain assumptions not met in LibreSSL.
Explicitly negate those for now, to compile with LibreSSL.

Tested on macOS 10.13.2 with  Xcode 9.2
