### PR TITLE
qemu: Fix build

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -64,7 +64,6 @@ configure.args-append   --disable-cocoa \
                         --disable-opengl \
                         --enable-curl \
                         --enable-bzip2 \
-                        --with-system-pixman \
                         --disable-attr \
                         --disable-vde \
                         --disable-brlapi \


### PR DESCRIPTION
qemu 2.11.x no longer seems to have the --with-system-pixman option and
now always uses a system-provided pixman. Drop the flag, since it causes
configure to fail.

#### Description

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
