### PR TITLE
pkg: new port, version 1.10.4

### DIFF
--- a/sysutils/pkg/Portfile
+++ b/sysutils/pkg/Portfile
@@ -8,13 +8,15 @@ github.tarball_from releases
 categories          sysutils archivers
 platforms           darwin
 license             BSD
-maintainers         Email: ato.ms:apowers
+maintainers         ato.ms:apowers \
+                    openmaintainer
 description         Package management tool for FreeBSD
 long_description    Pkg is the Next Generation package management tool for FreeBSD. Its main goals are to faciliate remote binary package upgrades. It also works with ports without remote binary packages.
 homepage            https://wiki.freebsd.org/pkgng
 
 depends_lib         port:libarchive
 
-checksums           sha256 5669c3727e980885922402232268f1023bfc13b02bb3dab966f14e99266ad3eb
+checksums           sha256 5669c3727e980885922402232268f1023bfc13b02bb3dab966f14e99266ad3eb \
+                    rmd160 2b4768fd0b6df2875d6f9f1b8ccd4292f4be8d5b
 
 test.run            yes

--- a/sysutils/pkg/Portfile
+++ b/sysutils/pkg/Portfile
@@ -14,7 +14,7 @@ long_description    Pkg is the Next Generation package management tool for FreeB
 homepage            https://wiki.freebsd.org/pkgng
 
 depends_lib         port:libarchive \
-                    port:openssl
+                    path:libssl.dylib:openssl
 
 checksums           sha256 ced2627aae44b95a752565f2bc067888a6f4f3c2e856c233fc1567016788f6cb \
                     rmd160 b30e8e926fa44612347bfcd81f1896bb44e48198 \

--- a/sysutils/pkg/Portfile
+++ b/sysutils/pkg/Portfile
@@ -24,7 +24,7 @@ test.run            yes
 
 pre-configure {
     if {![file exists "${worksrcpath}/configure"]} {
-        system "cd ${worksrcpath} && ./autogen.sh"
+        system -W ${worksrcpath} ./autogen.sh
     }
 }
 

--- a/sysutils/pkg/Portfile
+++ b/sysutils/pkg/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        freebsd pkg 1.10.4
+github.tarball_from releases
+categories          sysutils archivers
+platforms           darwin
+license             BSD
+maintainers         Email: ato.ms:apowers
+description         Package management tool for FreeBSD
+long_description    Pkg is the Next Generation package management tool for FreeBSD. Its main goals are to faciliate remote binary package upgrades. It also works with ports without remote binary packages.
+homepage            https://wiki.freebsd.org/pkgng
+
+depends_lib         port:libarchive
+
+checksums           sha256 5669c3727e980885922402232268f1023bfc13b02bb3dab966f14e99266ad3eb
+
+test.run            yes

--- a/sysutils/pkg/Portfile
+++ b/sysutils/pkg/Portfile
@@ -7,7 +7,7 @@ github.setup        freebsd pkg 1.10.4
 categories          sysutils archivers
 platforms           darwin
 license             BSD
-maintainers         ato.ms:apowers \
+maintainers         {@apowers313 ato.ms:apowers} \
                     openmaintainer
 description         Package management tool for FreeBSD
 long_description    Pkg is the Next Generation package management tool for FreeBSD. Its main goals are to faciliate remote binary package upgrades. It also works with ports without remote binary packages.

--- a/sysutils/pkg/Portfile
+++ b/sysutils/pkg/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        freebsd pkg 1.10.4
-github.tarball_from releases
 categories          sysutils archivers
 platforms           darwin
 license             BSD
@@ -14,9 +13,19 @@ description         Package management tool for FreeBSD
 long_description    Pkg is the Next Generation package management tool for FreeBSD. Its main goals are to faciliate remote binary package upgrades. It also works with ports without remote binary packages.
 homepage            https://wiki.freebsd.org/pkgng
 
-depends_lib         port:libarchive
+depends_lib         port:libarchive \
+                    port:openssl
 
-checksums           sha256 5669c3727e980885922402232268f1023bfc13b02bb3dab966f14e99266ad3eb \
-                    rmd160 2b4768fd0b6df2875d6f9f1b8ccd4292f4be8d5b
+checksums           sha256 ced2627aae44b95a752565f2bc067888a6f4f3c2e856c233fc1567016788f6cb \
+                    rmd160 b30e8e926fa44612347bfcd81f1896bb44e48198 \
+                    size 3398284
 
 test.run            yes
+
+pre-configure {
+    if {![file exists "${worksrcpath}/configure"]} {
+        system "cd ${worksrcpath} && ./autogen.sh"
+    }
+}
+
+configure.pre_args-append --mandir=${prefix}/share/man


### PR DESCRIPTION
#### Description

FreeBSD pkg (a/k/a/ pkgng) package management system.

###### Type(s)
new Portfile

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
