### PR TITLE
portaudio: explicit ./configure --options

### DIFF
--- a/audio/portaudio/Portfile
+++ b/audio/portaudio/Portfile
@@ -35,7 +35,16 @@ worksrcdir          ${name}
 # To build a non-universal library for the host architecture,
 # simply use the --disable-mac-universal option with configure.
 # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/MacintoshCoreAudio
-configure.args      --disable-mac-universal --enable-cxx
+configure.args			\
+    --enable-option-checking	\
+    --enable-cxx		\
+    --disable-mac-universal	\
+    --without-alsa		\
+    --without-jack		\
+    --without-oss		\
+    --without-asihpi		\
+    --without-winapi
+
 
 # patch-configure removes -Werror, and adds -DNDEBUG.
 patchfiles          patch-configure \

--- a/audio/portaudio/Portfile
+++ b/audio/portaudio/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                portaudio
 version             19.20140130
-revision            1
+revision            2
 categories          audio devel
 platforms           darwin macosx
 maintainers         nomaintainer


### PR DESCRIPTION
Explicitly disable ALSA and WINAPI and all the other audio output drivers
that do not exist here. Enable option checking while here.

This should be functionally the same, except now `./configure`
does not check for`-lasound`, `linux/soundcard.h`, etc.

Tested on 10.13.2 and 10.6.8 an 10.5.8.


