### PR TITLE
py-jsbeautifier: update to 1.7.5

### DIFF
--- a/python/py-jsbeautifier/Portfile
+++ b/python/py-jsbeautifier/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup python 1.0
 
 name                py-jsbeautifier
-version             1.7.3
+version             1.7.5
 categories-append   textproc
 platforms           darwin
 supported_archs     noarch
@@ -18,8 +18,8 @@ homepage            http://jsbeautifier.org/
 master_sites        pypi:j/jsbeautifier
 distname            jsbeautifier-${version}
 
-checksums           rmd160  09df607d9f166575a06b8eba07624d670bad5c89 \
-                    sha256  0092fe4f5ee631faaaadb2990de611de5915d623d52059d26efd70066134e15e
+checksums           rmd160  be3413dce3822903c6f685f8cea4d88143a154db \
+                    sha256  78eb1e5c8535484f0d0b588aca38da3fb5e0e34de2d1ab53c077e71c55757473
 
 python.versions     27 36
 


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.2 17C205
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
