### PR TITLE
rust: update to 1.23.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -1,20 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           active_variants 1.1
-PortGroup           compiler_blacklist_versions 1.0
 
 name                rust
-version             1.16.0
+version             1.23.0
 categories          lang devel
 platforms           darwin
 supported_archs     i386 x86_64
-# https://github.com/mozilla/rust/issues/2024
-universal_variant   no
 license             {MIT Apache-2} BSD zlib NCSA Permissive
 maintainers         g5pw
 
 description         A safe, concurrent, practical language
+
 long_description    Rust is a curly-brace, block-structured expression \
                     language. It visually resembles the C language \
                     family, but differs significantly in syntactic and \
@@ -23,7 +20,63 @@ long_description    Rust is a curly-brace, block-structured expression \
                     creating and maintaining boundaries -- both abstract \
                     and operational -- that preserve large-system \
                     integrity, availability and concurrency.
-homepage            http://www.rust-lang.org/
+
+homepage            https://www.rust-lang.org/
+
+depends_build       bin:python2.7:python27 \
+                    port:cmake
+
+depends_lib         port:llvm-4.0
+
+master_sites        https://static.rust-lang.org/dist
+
+distname            ${name}c-${version}-src
+
+patchfiles          patch-src-librustc-llvm-lib.diff
+
+set rust_platform   ${build_arch}-apple-darwin
+
+if {${build_arch} eq "i386"} {
+    set rust_platform i686-apple-darwin
+}
+
+set stage0(ruststd) rust-std-1.22.0-${rust_platform}
+set stage0(rustc)   rustc-1.22.0-${rust_platform}
+set stage0(cargo)   cargo-0.23.0-${rust_platform}
+
+distfiles-append    ${stage0(ruststd)}${extract.suffix} \
+                    ${stage0(rustc)}${extract.suffix} \
+                    ${stage0(cargo)}${extract.suffix}
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  f8dc31e9fbe1e2071d2307be5a38c73da8a637ee \
+                    sha256  7464953871dcfdfa8afcc536916a686dd156a83339d8ec4d5cb4eb2fe146cb91
+
+if {${build_arch} eq "i386"} {
+    checksums-append \
+                    ${stage0(ruststd)}${extract.suffix} \
+                    rmd160  8dc4f0eb39c34082021206de9556a6027a6a833c \
+                    sha256  4bdbe34a34fc99c231f59201253e0844ab8378eed0835c95ce80336c8626f799 \
+                    ${stage0(rustc)}${extract.suffix} \
+                    rmd160  4647f5eb4dde380c7d9cad982540df90598b48de \
+                    sha256  84b436ff4543ca9d734971dbd46cabdca4eaf9ba060a6314e48789eaba50101f \
+                    ${stage0(cargo)}${extract.suffix} \
+                    rmd160  bfbe0a2040fbb5d5f378111dfb0cc7dbf1330e12 \
+                    sha256  25670bdc08a8134c0100bb4fa1b48d7c45cb1045098d6388fb668d1cdcbc940c
+} else {
+    checksums-append \
+                    ${stage0(ruststd)}${extract.suffix} \
+                    rmd160  cc0b60760e1d8262834511c7676005167d072db0 \
+                    sha256  773c091f678fd63af07a90fac406c1b9850b7a72b58a4aab39bc0489315ef33a \
+                    ${stage0(rustc)}${extract.suffix} \
+                    rmd160  9cd4f59ae654315a74c368b85e29a48ab7bc654f \
+                    sha256  1383736371b4192de9f7feb14b6615f39c772b83b0771e1f9fe7c10036e3c9d1 \
+                    ${stage0(cargo)}${extract.suffix} \
+                    rmd160  1a08713350109f9bcf321af40f35fb06d0505bef \
+                    sha256  aee12927e3a670584119e795a1ade6f4579e565f4145c9e0b6d8410019dc5ba7
+}
+
+set stage0(dir)     ${worksrcpath}/build/stage0
 
 pre-fetch {
     if {${os.platform} eq "darwin" && ${os.major} < 11} {
@@ -32,112 +85,32 @@ pre-fetch {
     }
 }
 
-# To take advantage of distfile mirroring and checksumming for the
-# snapshot compiler, we let base treat it as the distfile and deal with
-# the actual Rust source "manually".
-
-# stage0 is found from
-# https://github.com/rust-lang/rust/blob/${version}/src/stage0.txt
-set stage0(date)        2017-02-09
-set stage0(version)     1.15.1
-set stage0(platform)    ${configure.build_arch}-apple-darwin
-
-# Sigh...
-if { ${configure.build_arch} eq "i386"} {
-    set stage0(platform)    i686-apple-darwin
+post-extract {
+    file mkdir ${stage0(dir)}
+    system "cp -r ${workpath}/${stage0(ruststd)}/rust-std-${rust_platform}/* ${stage0(dir)}"
+    system "cp -r ${workpath}/${stage0(rustc)}/rustc/* ${stage0(dir)}"
+    system "cp -r ${workpath}/${stage0(cargo)}/cargo/* ${stage0(dir)}"
 }
 
-set stage0(distname)     [join "rustc ${stage0(version)}
-                                      ${stage0(platform)}" -]
-set stage0(distfile)     ${stage0(distname)}${extract.suffix}
+configure.args      --build=${rust_platform} \
+                    --enable-vendor \
+                    --default-linker=${configure.cc} \
+                    --disable-codegen-tests \
+                    --disable-docs \
+                    --llvm-root=${prefix}/libexec/llvm-4.0 \
+                    --local-rust-root=${stage0(dir)} \
+                    --release-channel=stable \
+                    --set=target.${rust_platform}.cc=${configure.cc} \
+                    --set=target.${rust_platform}.cxx=${configure.cxx} \
+                    --set=target.${rust_platform}.linker=${configure.cc}
 
-master_sites            https://static.rust-lang.org/dist/:main \
-                        https://static.rust-lang.org/dist/${stage0(date)}/:snap
+build.args          VERBOSE=1 BOOTSTRAP_ARGS="-v -j${build.jobs}"
 
-distfiles               ${name}c-${version}-src${extract.suffix}:main \
-                        ${stage0(distfile)}:snap
-
-worksrcdir              ${name}c-${version}-src
-
-checksums               ${name}c-${version}-src${extract.suffix} \
-                            rmd160  42bb8759c98787d07293d81e45183fe5cf55ebc2 \
-                            sha256  f966b31eb1cd9bd2df817c391a338eeb5b9253ae0a19bf8a11960c560f96e8b4
-
-switch ${configure.build_arch} {
-    i386    {checksums-append   ${stage0(distfile)} \
-                            rmd160  94de06a35775fe6d383b39cb907ef0794371ee16 \
-                            sha256  7db0489a35272b22aa63c8071bb74e40fdac0d63e19e86909003a9e842d22dfb}
-    default {checksums-append   ${stage0(distfile)} \
-                            rmd160  b142be055dff9dad14414adec9e31e9ecece4a06 \
-                            sha256  37c6b14f6b7820b7cae9e4e1cacb482c1cb4c31690f96e879cad4cbf4b5a990d}
-}
-
-# Only use compilers supported by upstream
-# (https://github.com/rust-lang/rust#building-from-source).
-compiler.blacklist  {clang < 211} \
-                    *dragonegg* \
-                    gcc-3.3 {*gcc-4.[0-6]}
-
-# Building the bundled LLVM requires Python 2.4-2.7. All supported
-# OS X releases have 2.6. (Using MacPorts' LLVM ports fails either
-# during build or during testing.)
-depends_build           bin:perl:perl5 \
-                        bin:python2.6:python27 \
-                        port:cmake
-depends_skip_archcheck  python27
-
-# The libs for both targets link to libgcc and libstdc++.
-if {[regexp {^macports-gcc-(\d+)\.(\d+)$} ${configure.compiler} \
-                                            -> major minor]} {
-    depends_lib-append      {path:lib/libstdc\\+\\+\\.6\\.dylib:libstdcxx}
-    require_active_variants gcc${major}${minor} universal
-    require_active_variants {path:lib/libstdc\\+\\+\\.6\\.dylib:libstdcxx} \
-                                universal
-}
-
-# TODO: Test whether i386 machines can cross-compile for x86_64.
-set tgts {i686-apple-darwin x86_64-apple-darwin}
-
-# TODO: Trying to build a cross-compiler breaks Intel 64 builds as
-# of 0.11.0. Worth fixing?
-#
-#configure.pre_args-append       --target=[join $tgts ,]
-
-if {${configure.build_arch} eq "i386"} {
-    configure.pre_args-append   --build=[lindex $tgts 0]
-} else {
-    configure.pre_args-append   --build=[lindex $tgts 1]
-}
-# We need to use "--enable-rpath" as of a0546de, otherwise the build
-# produces improperly linked binaries.
-# (https://github.com/rust-lang/rust/issues/11747)
-# TODO: Build docs also, probably in a subport.
-configure.args      --disable-docs \
-                    --disable-rustbuild \
-                    --enable-local-rust \
-                    --local-rust-root=${workpath}/${stage0(distname)}/rustc
-
-build.type          gnu
-build.args          VERBOSE=1 \
-                    CC=${configure.cc} \
-                    CXX=${configure.cxx} \
-                    CPP="${configure.cc} -E"
-
-# TODO: Add path-style dependency on python, whenever test dependencies
-# are implemented (#38208). Not critical, since all supported versions
-# of OS X come with Python 2.6.
 test.run            yes
 test.target         check
-test.env            VERBOSE=1
+test.args           VERBOSE=1
 
 destroot.args       VERBOSE=1
-post-destroot {
-    if {${subport} eq ${name}} {
-        xinstall -d ${destroot}${prefix}/share/${name}
-        xinstall -m 644 ${worksrcpath}/src/etc/ctags.rust \
-            ${destroot}${prefix}/share/${name}
-    }
-}
 
 livecheck.type      regex
 livecheck.url       https://github.com/rust-lang/rust/tags

--- a/lang/rust/files/patch-src-librustc-llvm-lib.diff
+++ b/lang/rust/files/patch-src-librustc-llvm-lib.diff
@@ -1,0 +1,8 @@
+--- src/librustc_llvm/lib.rs.orig	2018-01-15 17:44:30.000000000 +0400
++++ src/librustc_llvm/lib.rs	2018-01-16 02:36:38.000000000 +0400
+@@ -429,3 +429,5 @@
+         }
+     }
+ }
++
++#[link(name = "ffi")] extern {}


### PR DESCRIPTION
#### Description

Update rust to 1.23.0. Essentially a rewrite so I simplified things a bit, but it works. Uses MacPorts' LLVM instead of the bundled one for a (relatively) faster build.

###### Tested on
macOS 10.13.2 17C88
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?