### PR TITLE
sslh: Add missing depencency

### DIFF
--- a/net/sslh/Portfile
+++ b/net/sslh/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 name                sslh
 epoch               1
 version             1.19
+revision            1
 categories          net security www
 platforms           darwin
 maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
@@ -26,7 +27,8 @@ distname            ${name}-v${version}
 checksums           rmd160  00a6f679f3f6d97ef6e55b3f1f306b4f6545b8bb \
                     sha256  ef9cb18396da404bb705b2c4cd4562aa5feb554de6f9bd074b24e7ac4713669c
 
-depends_lib         port:libconfig-hr
+depends_lib         port:libconfig-hr \
+                    port:pcre
 
 use_configure       no
 use_parallel_build  no


### PR DESCRIPTION
#### Description

In the last update I accidentally left off the `pcre` dependency as I already had it installed.