### PR TITLE
lowdown: new port

### DIFF
--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -1,4 +1,5 @@
 PortSystem		1.0
+PortGroup		snowleopard_fixes 1.0
 
 name			lowdown
 categories		textproc

--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -1,0 +1,20 @@
+PortSystem		1.0
+
+name			lowdown
+categories		textproc
+version			0.3.1
+
+description		simple markdown translator
+long_description	lowdown translates markdown to either HTML	\
+			or a roff document using either -man or -ms
+homepage		https://kristaps.bsd.lv/lowdown/
+master_sites		https://kristaps.bsd.lv/lowdown/snapshots/
+maintainers		{stare.cz:hans @janstary}
+platforms		openbsd darwin linux
+
+checksums \
+	rmd160 bb93c94c974d8f68b2912f840829fc05e665a314 \
+	sha256 9e3796c7f819a3d28a8e304eac60da62e98fa996cae4131da971d8deaea44766
+
+configure.pre_args	""
+configure.args		"PREFIX=${prefix}"

--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -3,6 +3,7 @@ PortSystem		1.0
 name			lowdown
 categories		textproc
 version			0.3.1
+license			BSD
 
 description		simple markdown translator
 long_description	lowdown translates markdown to either HTML	\


### PR DESCRIPTION
lowdown translates markdown to either HTML or roff

Works on 10.13.2, fails on 10.5.8 and 10.6.8 which do not have `strndup()`.
Does anyone now since when does MacOS have `strndup()` please?