### PR TITLE
cask: new port

### DIFF
--- a/devel/cask/Portfile
+++ b/devel/cask/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+PortGroup           elisp 1.0
+
+name                cask
+github.setup        cask cask 0.8.1 v
+description         Project management tool for Emacs
+long_description    Cask is a project management tool for Emacs that helps \
+                    automate the package development cycle\; development, \
+                    dependencies, testing, building, packaging and more. \
+                    Cask can also be used to manage dependencies for your \
+                    local Emacs configuration.
+platforms           darwin
+supported_archs     noarch
+categories          devel
+license             GPL-3+
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+
+checksums           rmd160  2e17328b3c0d2f3275442b09a37399f922a9a8d8 \
+                    sha256  bff6a48543617c35126697e4afc2047bc2e722d300c13de34220932c11ce9567
+
+python.default_version 27
+
+build {}
+
+destroot {
+    set trgdir ${destroot}${prefix}/share/${name}
+
+    xinstall -d ${trgdir}
+
+    copy ${worksrcpath}/templates ${trgdir}
+    xinstall -d ${trgdir}/bin
+    xinstall -m 755 ${worksrcpath}/bin/cask ${trgdir}/bin/cask
+    xinstall {*}[glob ${worksrcpath}/*.el] ${trgdir}
+
+    reinplace "s|#!/usr/bin/env python|#!${python.bin}|" ${trgdir}/bin/cask
+    ln -s ${prefix}/share/${name}/bin/cask ${destroot}${prefix}/bin
+
+    xinstall -d ${destroot}${emacs_lispdir}
+    ln -s ${prefix}/share/${name}/cask.el ${destroot}${emacs_lispdir}/cask.el
+    ln -s ${prefix}/share/${name}/cask-bootstrap.el ${destroot}${emacs_lispdir}/cask-bootstrap.el
+
+    # Prevent from self-updating
+    touch ${trgdir}/.no-upgrade
+}


### PR DESCRIPTION
#### Description

Cask is a project management tool for Emacs.

###### Tested on
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`? ⇒ can't due to https://trac.macports.org/ticket/55575
- [x] tested basic functionality of all binary files?
