### PR TITLE
lowdown: use a http:// master site

### DIFF
--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -9,8 +9,8 @@ license			BSD
 description		simple markdown translator
 long_description	lowdown translates markdown to either HTML	\
 			or a roff document using either -man or -ms
-homepage		https://kristaps.bsd.lv/lowdown/
-master_sites		https://kristaps.bsd.lv/lowdown/snapshots/
+homepage		http://kristaps.bsd.lv/lowdown/
+master_sites		http://kristaps.bsd.lv/lowdown/snapshots/
 maintainers		{stare.cz:hans @janstary}
 platforms		openbsd darwin linux
 


### PR DESCRIPTION
With th current https:// master, buildbots for systems < 10.9 fail while _fetching_,
because the https master rejects their weak ssl. There is no harm in downloading
from the same master via http:// -- switch to that so old buildbots can fetch.