### PR TITLE
kotlin: update to 1.2.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.2.20 v
+github.setup        JetBrains kotlin 1.2.21 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  bb3fb0879ad530100027ebbbdc456b6c74062977 \
-                    sha256  fb63d3d9f37b43f37575e3623c058d42a4b5dc8da08479ab065c4994e421a057
+checksums           rmd160  ff46907dacdaeb0808ccaff3357ab75c6a87527d \
+                    sha256  c5f2cbd35daa6c5c394e92e6c06b8eb41d85ad8da64762733874166b6807af22
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.2.21.

###### Tested on

macOS 10.13.3 17D47
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?