### PR TITLE
plumed: change default compiler on old OS

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -28,6 +28,13 @@ homepage            http://www.plumed.org/
 checksums           rmd160  e3c5df528c00cdd5bc54a8d7ce2eaa5e8c5a8b04 \
                     sha256  11f8c5a6bf7e2f6c133f9355924bbb5fa5f0cef0dc861d36726fa83a687ead44
 
+# This allows building plumed on machines with old system compilers.
+# Setting this in the Portfile should allow buildbots to build the 
+# correct variant.
+if { ${os.major} < 13 } {
+    default_variants +gcc7
+}
+
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
 # --disable-libsearch:    Avoid searching libraries using their default names.


### PR DESCRIPTION
Set +gcc7 as default variant on old OS (${os.major} < 13).

This allows building plumed on machines with old system compilers. Setting this in the Portfile should allow buildbots to build the correct variant.

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G18013
Xcode 8.1 8B62 

macOS 10.6.8 10K594
Xcode 8.1 DevToolsSupport-1806.0 10M2518 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
