### PR TITLE
ccache[-devel]: stop symlinking gcc

### DIFF
--- a/devel/ccache-devel/Portfile
+++ b/devel/ccache-devel/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 github.setup        ccache ccache 3.3.6 v
 name                ccache-devel
 epoch               1
+revision            1
 categories          devel
 platforms           darwin freebsd
 license             GPL-3+
@@ -50,21 +51,4 @@ post-patch {
 
 build.target-append ccache.1
 
-set symlinks_dir    ${prefix}/libexec/ccache
-
-post-destroot {
-    file mkdir ${destroot}${symlinks_dir}
-
-    foreach {bin} {
-        cc
-        gcc gcc2    gcc3    gcc-3.3 gcc-4.0 gcc-4.2
-        c++ c++3    c++-3.3 c++-4.0 c++-4.2
-        g++ g++2    g++3    g++-3.3 g++-4.0 g++-4.2
-    } {
-        ln -sf ${prefix}/bin/ccache ${destroot}${symlinks_dir}/${bin}
-    }
-}
-
 conflicts           ccache
-
-notes "The ccache symlinks are installed in ${symlinks_dir}"

--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                ccache
 version             3.3.6
+revision            1
 categories          devel
 platforms           darwin freebsd
 license             GPL-3+
@@ -28,24 +29,7 @@ checksums           rmd160  a93df032cb8a3bae3bca7809d70a52766af63140 \
 
 depends_lib         port:zlib
 
-set symlinks_dir    ${prefix}/libexec/ccache
-
-post-destroot {
-    file mkdir ${destroot}${symlinks_dir}
-
-    foreach {bin} {
-        cc
-        gcc gcc2    gcc3    gcc-3.3 gcc-4.0 gcc-4.2
-        c++ c++3    c++-3.3 c++-4.0 c++-4.2
-        g++ g++2    g++3    g++-3.3 g++-4.0 g++-4.2
-    } {
-        ln -sf ${prefix}/bin/ccache ${destroot}${symlinks_dir}/${bin}
-    }
-}
-
 conflicts           ccache-devel
-
-notes "The ccache symlinks are installed in ${symlinks_dir}"
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]


### PR DESCRIPTION
All of the installed symlinks are old, and do not match the binary names
installed by macports. While we could update them, they would likely go
out of date again, and having symlinks for binaries that are not
installed can be annoying to some users.