### PR TITLE
plumed: cxx11 portgroup

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -2,11 +2,15 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+# Notice that this rules out gcc variants.
+# See https://github.com/macports/macports-ports/pull/1252
+PortGroup           cxx11 1.1
 PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
 github.setup        plumed plumed2 2.4.0 v
+revision            1
 name                plumed
 
 categories          science
@@ -91,15 +95,14 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 c61d345792dc019888ae6f53d9e5a3403e7d02f4
-    version             2.5-20171215
-    revision            0
+    github.setup        plumed plumed2 d9be97c7bba3d165e130562033286537c23819d0
+    version             2.5-20180129
+    revision            1
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  d7ee29fd36038e0202c10bd35c47e27bfa0a07fc \
-                        sha256  6f1285f3d8aa741d8fd1949575f31d581439611e429bdaa87f055abb957e1853
-
+    checksums           rmd160  e54b52d0c51ca92f3045c619c45f5cdf7358ce8e \
+                        sha256  24cf68700aaf5321415898e7cee934ff5b4993677e3ac362c0a397a8cd9da196
     configure.ldflags-delete -lmatheval
     depends_lib-delete       port:libmatheval
 # plumed 2.5 supports python. However, I disable it here since it is


### PR DESCRIPTION
I included cxx11 PortGroup (see hint from @kencu at #1252). Compilers from gcc family will be disabled now. I took the occasion to update the snapshot used in `plumed-devel` subport (development branch).
