### PR TITLE
faust-devel: update to latest git revision

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -3,11 +3,10 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 10523e3c2f16444e188e4feb9e2e8399f6a39838
-version                 0.9.96-20170331
-
-checksums               rmd160  a257e307d38e3957f0b53b5b761769d7656d25cc \
-                        sha256  974326434347c0c0a39b2516b392ca0e699b5ac84ac875ae0e6feeafd1a63989
+github.setup            grame-cncm faust 279974a0c8c7e913f1d8e4f1414d8086de88798c
+# When updating faust-devel to a new version, please rebuild faustlive-devel
+# simultaneously by increasing its revision or updating it to a new version.
+version                 2.5-20180126
 
 name                    faust-devel
 conflicts               faust faust2-devel
@@ -21,12 +20,29 @@ description             functional programming language for realtime audio
 
 long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
-                        and plugins.
+                        and plugins. The latest version also offers \
+                        additional backends for C, Java and LLVM bitcode.
+
+fetch.type              git
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+set llvm_version        3.4
+if {${os.platform} eq "darwin" && ${os.major} > 14} {
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
+    set llvm_version    3.9
+}
+
+set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
+build.env               PATH=${llvm_prefix}/bin:$env(PATH)
 
 depends_build           port:pkgconfig
 
-depends_lib             port:libmicrohttpd \
+depends_lib             port:clang-${llvm_version} \
+                        port:libmicrohttpd \
                         port:libsndfile \
+                        port:llvm-${llvm_version} \
                         path:lib/libssl.dylib:openssl
 
 post-patch {

--- a/audio/faustlive-devel/Portfile
+++ b/audio/faustlive-devel/Portfile
@@ -3,11 +3,8 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faustlive c0334c926b1604a2c2f1f1a57aa9ed9a6227a75b
-version                 2.46-20170330
-
-checksums               rmd160  8c7150848a930eb1ecbb9c0d0b411d544b837227 \
-                        sha256  bb6dd8fe3fe783d91d5dd8d96c1326197106d5cf32e708f4416b24996cacb6f4
+github.setup            grame-cncm faustlive 69d6161c2a171a2ed3d7eda544cfdc5511ce85f6
+version                 2.46-20180119
 
 name                    faustlive-devel
 categories              audio
@@ -31,6 +28,11 @@ long_description        FaustLive is ${description}. \
 
 homepage                http://faust.grame.fr/
 
+fetch.type              git
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
 set llvm_version        3.4
 if {${os.platform} eq "darwin" && ${os.major} > 14} {
     # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
@@ -40,7 +42,7 @@ if {${os.platform} eq "darwin" && ${os.major} > 14} {
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
 build.env               PATH=${llvm_prefix}/bin:$env(PATH)
 
-depends_build           port:faust2-devel \
+depends_build           port:faust-devel \
                         port:clang-${llvm_version} \
                         port:llvm-${llvm_version}
 


### PR DESCRIPTION
#### Description
Update to latest from git. This also includes an update of the accompanying faustlive-level package.

###### Notes
- Both ports now involve git submodules and are thus built straight from git using the recommended procedure to invoke `git submodule update --init`.
- The faust-devel port now supersedes faust2-devel. There's no faust1 any more, mainline faust has become what faust2 was, so faust2-devel can/should subsequently be removed.

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b
