### PR TITLE
gpsd: fix self-id of libgps.

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 
 name                    gpsd
 version                 3.17
+revision                1
 license                 BSD
 categories              net
 maintainers             {ryandesign @ryandesign} openmaintainer
@@ -109,6 +110,7 @@ post-destroot {
         reinplace "s|#!/usr/bin/env python|#!${configure.python}|" \
             ${destroot}${prefix}/bin/xgpsspeed
     }
+    system -W ${destroot}${prefix}/lib "install_name_tool -id ${prefix}/lib/libgps.dylib libgps.dylib"
 }
 
 # Although GPSD has successfully been built with Qt5 at one time, that build


### PR DESCRIPTION
Simple fix for a nasty problem: the self-id of the recently updated libgps.dylib is just "libgps.dylib" when it should be "${prefix}/lib/libgps.dylib". Make it so and rev-bump to take effect.

Once this is fixed, all ports that depend on gpsd need to be rev-bumped.