### PR TITLE
faust: update to 2.5.17

### DIFF
--- a/audio/faust/Portfile
+++ b/audio/faust/Portfile
@@ -1,17 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
 
-name                    faust
+github.setup            grame-cncm faust 2.5.17
+github.tarball_from     releases
+
 conflicts               faust-devel
-version                 0.9.85
 categories              audio lang
 platforms               darwin
 maintainers             {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license                 GPL-2
-master_sites            sourceforge:project/faudiostream
 homepage                http://faust.grame.fr/
-extract.suffix          .tgz
 
 description             functional programming language for realtime audio
 
@@ -19,11 +19,30 @@ long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
                         and plugins.
 
-checksums               rmd160  c9b1848201757890f37a4712be2b496171b5f22e \
-                        sha256  50e37744a7c7baef1f806a8824e0776e86e9125f45ead7422d569885a97c121c \
-                        size    29505382
+checksums               rmd160  bd22e6b42ba8ef7a12f0903711500ca0ea1a6aa3 \
+                        sha256  5e9e76dc4754efbf31eb8b63ee4f3e2e5ec5f6fe20dac611af859357bf4a1893 \
+                        size    47142694
+
+set llvm_version        3.4
+if {${os.platform} eq "darwin" && ${os.major} > 14} {
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
+    set llvm_version    3.9
+}
+
+set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
+build.env               PATH=${llvm_prefix}/bin:$env(PATH)
+
+depends_build           port:pkgconfig
+
+depends_lib             port:clang-${llvm_version} \
+                        port:libmicrohttpd \
+                        port:libsndfile \
+                        port:llvm-${llvm_version} \
+                        path:lib/libssl.dylib:openssl
 
 post-patch {
+    reinplace "s|/usr/local/|/usr/./local/|g" \
+        ${worksrcpath}/tools/faust2appls/faust2faustvst
     reinplace "s|/usr/local|${prefix}|g" \
         ${worksrcpath}/compiler/parser/enrobage.cpp \
         ${worksrcpath}/compiler/tlib/compatibility.cpp \
@@ -37,6 +56,8 @@ post-patch {
             }
         }
     }
+    reinplace "s|/usr/./local/|/usr/local/|g" \
+        ${worksrcpath}/tools/faust2appls/faust2faustvst
 }
 
 use_configure           no
@@ -45,15 +66,17 @@ variant universal {}
 
 build.args-append       ARCHFLAGS="[get_canonical_archflags cxx]" \
                         CXX="${configure.cxx} [get_canonical_archflags cxx]"
+build.target            world
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${subport}
     xinstall -d ${docdir}
     xinstall -m 644 -W ${worksrcpath} \
         COPYING \
-        README \
+        README.md \
         WHATSNEW \
         ${docdir}
 }
 
-livecheck.regex         ${name}-(\[0-9a-z.\]+)${extract.suffix}
+# fixme
+livecheck.type          none


### PR DESCRIPTION
#### Description
Update to latest stable release from Github at https://github.com/grame-cncm/faust/releases/tag/2.5.17.

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b