### PR TITLE
nsis: update to 3.03

### DIFF
--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                nsis
-version             3.02.1
+version             3.03
 set major           [lindex [split ${version} .] 0]
 revision            1
 categories          devel
@@ -27,11 +27,11 @@ distfiles-append    nsis-${version}.zip
 extract.only-delete nsis-${version}.zip
 
 checksums           nsis-${version}-src.tar.bz2 \
-                    rmd160  209f4234ba4199cbcce6843a6c8c5d06030e84d3 \
-                    sha256  5f6d135362c70f6305317b3af6d8398184ac1a22d3f23b9c4164543c13fb8d60 \
+                    rmd160  b97f524fcda4dc333d73593c41130db5f8dddde1 \
+                    sha256  abae7f4488bc6de7a4dd760d5f0e7cd3aad7747d4d7cd85786697c8991695eaa \
                     nsis-${version}.zip \
-                    rmd160  61fef3ba08ab0ee726b194148899a67da0502220 \
-                    sha256  deef3e3d90ab1a9e0ef294fff85eead25edbcb429344ad42fc9bc42b5c3b1fb5
+                    rmd160  806e501feff324f94e6d16e442cbaf6de4404837 \
+                    sha256  b53a79078f2c6abf21f11d9fe68807f35b228393eb17a0cd3873614190116ba7
 
 depends_build       port:scons
 

--- a/devel/nsis/Portfile
+++ b/devel/nsis/Portfile
@@ -5,7 +5,6 @@ PortSystem          1.0
 name                nsis
 version             3.03
 set major           [lindex [split ${version} .] 0]
-revision            1
 categories          devel
 license             zlib CPL-1 MIT
 platforms           darwin


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- x ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
