### PR TITLE
sslh: update to 1.19b

### DIFF
--- a/net/sslh/Portfile
+++ b/net/sslh/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 
 name                sslh
 epoch               1
-version             1.19
-revision            1
+version             1.19b
 categories          net security www
 platforms           darwin
 maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
@@ -24,8 +23,8 @@ master_sites        http://rutschle.net/tech/sslh/
 
 distname            ${name}-v${version}
 
-checksums           rmd160  00a6f679f3f6d97ef6e55b3f1f306b4f6545b8bb \
-                    sha256  ef9cb18396da404bb705b2c4cd4562aa5feb554de6f9bd074b24e7ac4713669c
+checksums           rmd160  65c890632de4215fbef26a23729cbb2cf0b33b2f \
+                    sha256  10dfc4deffbca94c3ef7535d3f71b213abc78d53ed1e900873d3ca1cc943659c
 
 depends_lib         port:libconfig-hr \
                     port:pcre


### PR DESCRIPTION
#### Description
Update sslh to 1.19b, a bugfix release of 1.19. The 1.19 distfile has been removed so the port is not buildable from source at the moment.
