### PR TITLE
libressl-devel: fix livecheck

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -51,5 +51,5 @@ platform darwin {
 }
 
 livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "latest development release is (\\d+\\.\\d+(?:\\.\\d+)*)"
+livecheck.url       https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/
+livecheck.regex     "(\\d+\\.\\d+\\.\\d+)"


### PR DESCRIPTION
LibreSSL makes "releases" and makes no distinction of "development" releases.
Instead of greping for free-form text in a webpage, look for a tarball to download.