### PR TITLE
fonttools: update to 3.21.2

### DIFF
--- a/print/fonttools/Portfile
+++ b/print/fonttools/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 name                fonttools
-github.setup        fonttools fonttools 3.19.0
+github.setup        fonttools fonttools 3.21.2
 description         XML<->TrueType/OpenType Converter
 long_description    TTX is a tool to convert OpenType and TrueType fonts to \
                     and from XML. FontTools is a library for manipulating \
@@ -13,11 +13,11 @@ long_description    TTX is a tool to convert OpenType and TrueType fonts to \
                     AFM and to an extent Type 1 and some Mac-specific formats.
 platforms           darwin
 categories          print
-license             BSD
+license             MIT
 maintainers         nomaintainer
 
-checksums           rmd160  738db47a74be78964cfb6d81214b3300d8c5d7a8 \
-                    sha256  0e890d7062d6fbd28d1453c6f8e80ab001c0d1efcf75f041e3d1308fe9dd944a
+checksums           rmd160  c7576e6a64ce69b7f956a4c790a33784bad54d7a \
+                    sha256  f06a7b758da1db38fe7947160d0218a7789e9f82b899aff53eb729d5ebe36080
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update fonttools to 3.21.2.

The license changed to MIT:
https://github.com/fonttools/fonttools/issues/1127

(Actually it was always MIT-like; before it was described incorrectly as BSD in the docs)
