### PR TITLE
new port: SoCLI

### DIFF
--- a/sysutils/SoCLI/Portfile
+++ b/sysutils/SoCLI/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# $Id$
+
+PortSystem			1.0
+PortGroup			github 1.0
+
+
+github.setup		gautamkrishnar socli 3.6
+github.tarball_from	releases
+
+
+categories			sysutils
+platforms			darwin
+license				BSD-3
+
+maintainers			gmail.com:r.gautamkrishna
+
+description			Stack Overflow CLI
+long_description	Stack Overflow command line written in python. \
+					Using SoCLI you can search and browse Stack Overflow \
+					without leaving the terminal
+
+
+homepage			http://www.github.com/gautamkrishnar/socli
+
+checksums			rmd160 f23f3bc03c722fe8eb45482bdb490b6f07971ae7
+					sha256 abf585ab347d8087870312f181c49f3b7f4a17084bd611adeadb03a6a063af41
+
+depends_lib			port:py-beautifulsoup4 \
+					port:py-colorama \
+					port:py-urwid \
+					port:py-requests \
+					lib:py-stackexchange
+use_zip				yes


### PR DESCRIPTION
#### Description
Added SOCLI port: https://github.com/gautamkrishnar/socli

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.3 17D47
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?