### PR TITLE
auto-multiple-choice-devel: update to version 1.3.0.2162

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -33,11 +33,11 @@ if {${subport} eq ${name}} {
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set bitbucket_commit    "74c619d2a6ac"
-    set amc_revision        "2134"
-    set amc_date            "201711231020"
-    checksums               rmd160  7b9304264d3fa069ea7f0b1122c9ca254c56d0f1 \
-                            sha256  7361beaabf58254b26977693908ab3528309e7d87ded23695350dba6ead0a77f
+    set bitbucket_commit    "9592fa9f3258"
+    set amc_revision        "2162"
+    set amc_date            "201802050752"
+    checksums               rmd160  3df52b76f01120fb2ea3ae3702afbaf3cc9c91e7 \
+                            sha256  c3b9d7c76c69a9fd2c26f246c36d47c7050f37cc47ea616c753b91b45830321f
     conflicts               auto-multiple-choice
 }
 


### PR DESCRIPTION
auto-multiple-choice-devel: update to version 1.3.0.2162

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->
auto-multiple-choice-devel: update to version 1.3.0.2162

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b

macOS 10.12.6 16G1212
Xcode 9.2 9C40b

macOS 10.11.6 15G19009
Xcode 8.2.1 8C1002

macOS 10.10.5 14F2511
Xcode 7.2.1 7C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
