### PR TITLE
cargo: can use cmake or cmake-devel; default to cmake.

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -18,7 +18,8 @@ long_description    Cargo downloads your Rust project’s dependencies and \
 
 homepage            https://crates.io
 
-depends_build       port:cmake \
+# can use cmake or cmake-devel; default to cmake.
+depends_build       bin:cmake:cmake \
                     bin:python:python27
 
 depends_lib         port:openssl \


### PR DESCRIPTION
subject says it all. simple change but I prefer a review by the port owner.