### PR TITLE
rust: can use cmake or cmake-devel; default to cmake.

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -23,8 +23,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 
 homepage            https://www.rust-lang.org/
 
+# can use cmake or cmake-devel; default to cmake.
 depends_build       bin:python2.7:python27 \
-                    port:cmake
+                    bin:cmake:cmake
 
 # Currently LLVM 4.0 is required, see this issue for LLVM 5.0 support:
 # https://github.com/rust-lang/rust/issues/43370 .


### PR DESCRIPTION
subject says it all. simple change but I prefer a review by the port owner.