### PR TITLE
faust-devel: update to latest upstream

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -4,10 +4,10 @@ PortSystem              1.0
 PortGroup               cxx11 1.1
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 279974a0c8c7e913f1d8e4f1414d8086de88798c
+github.setup            grame-cncm faust e03acc7549fb8e3dc5e0dcd5b6cc01529ce95d90
 # When updating faust-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.5-20180126
+version                 2.5-20180205
 
 name                    faust-devel
 conflicts               faust


### PR DESCRIPTION
Update once more to the latest upstream source as of today, so that it's ahead of the stable faust package again. (No update of faustlive-devel needed this time, as the Faust API hasn't changed, so faustlive continues to work without rebuild, I've tested that.)

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b