### PR TITLE
php-xdebug: update to 2.6.0 and add support for php72

### DIFF
--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -12,10 +12,16 @@ license                 Xdebug-1.01
 homepage                http://www.xdebug.org/
 master_sites            ${homepage}files/
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2
 php.extensions.zend     xdebug
 
-if {[vercmp ${php.branch} 5.5] >= 0} {
+if {[vercmp ${php.branch} 7.0] >= 0} {
+    version             2.6.0
+    revision            0
+    checksums           rmd160  8d3f60a50ca69588fc1936384df044802bf31edf \
+                        sha256  b5264cc03bf68fcbb04b97229f96dca505d7b87ec2fb3bd4249896783d29cbdc \
+                        size    283644
+} elseif {[vercmp ${php.branch} 5.5] >= 0} {
     version             2.5.5
     revision            0
     checksums           rmd160  ad7939d2d2f453c0f2ccb12ce8f745db7163ad9d \


### PR DESCRIPTION
Xdebug 2.6 supports >= PHP 7.0, including PHP 7.2 for the first time

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
