### PR TITLE
librsvg: peg older version 2.40.20 for < 10.7

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -42,6 +42,19 @@ depends_run         port:python[join [split ${pyversion} "."] ""]
 # https://trac.macports.org/ticket/55783
 universal_variant   no
 
+# older systems support
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # version 2.42.0 requires cargo, rustc to build
+    # rust requires 10.7+
+    version             2.40.20
+    checksums           rmd160  e697e1220779f77e81a890718ef5cda5b5e6b740 \
+                        sha256  cff4dd3c3b78bfe99d8fcfad3b8ba1eee3289a0823c0e118d78106be6b84c92b
+    depends_build-delete \
+                        port:cargo \
+                        port:rust
+    universal_variant   yes
+}
+
 gobject_introspection yes
 
 configure.args      --enable-vala=yes \


### PR DESCRIPTION
new versions of librsvg require rust to build
rust is 10.7+ only
closes: https://trac.macports.org/ticket/55794
