### PR TITLE
py-kaitaistruct: update to 0.8

### DIFF
--- a/python/py-kaitaistruct/Portfile
+++ b/python/py-kaitaistruct/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-kaitaistruct
-version             0.7
+version             0.8
 platforms           darwin
 license             MIT
 maintainers         {gmail.com:yan12125 @yan12125} openmaintainer
@@ -17,9 +17,10 @@ homepage            http://kaitai.io
 master_sites        pypi:k/kaitaistruct
 distname            kaitaistruct-${version}
 
-checksums           md5     9df5f396d071c39b48276f36c6ae27d9 \
-                    rmd160  7cd1497e942f83dd85f6d234f52605c82b45456b \
-                    sha256  319caca6dd7051655b48457be4a06a236ce782606c347f1c226d6190abd543a6
+checksums           md5     dadc1ff2bd3958246214c0f546306bc7 \
+                    rmd160  bc96d8d4e051319b4e5b895b53dbc8702f90fd25 \
+                    sha256  d1d17c7f6839b3d28fc22b21295f787974786c2201e8788975e72e2a1d109ff5 \
+                    size    5158
 
 python.versions     27 36
 


### PR DESCRIPTION
#### Description

According to https://github.com/mitmproxy/mitmproxy/pull/2848/files, bumping kaitaistruct should be fine

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
I tested py-mitmproxy - `sudo port test py36-mitmproxy` (mitmproxy is the only port in this repo that uses kaitaistruct)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
I tested mitmproxy-3.6 for simple requests
