### PR TITLE
Gildas: updated to version 201802a.

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1 
 
 name                gildas
-version             201802a
+version             201802c
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -30,8 +30,8 @@ master_sites        http://www.iram.fr/~gildas/dist/ \
                     http://www.iram.fr/~gildas/dist/archive/gildas/
 distname            ${name}-src-${my_version}
 
-checksums           rmd160  78b817738bad1e3fd28f9803481428b83c0782cb \
-                    sha256  82e7fd4246cbdde693736febf4a9c7863c8666c62502ff9cb9d5f1b4799dd6c6
+checksums           rmd160  6ecb9e0b6098f771c396344fb7b3cdea4280ab8b \
+                    sha256  976efb5e7ce10949ba194de88aa8c28d3f1a769c3bcf7e73d41fa5434d262f90
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \

--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1 
 
 name                gildas
-version             201712a
+version             201802a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -30,8 +30,8 @@ master_sites        http://www.iram.fr/~gildas/dist/ \
                     http://www.iram.fr/~gildas/dist/archive/gildas/
 distname            ${name}-src-${my_version}
 
-checksums           rmd160  505b6df0ce10a835fa3fdf7600de218ab2f2fbef \
-                    sha256  309fd9a383a7b4b85aacb09f21c0150eb3a6af95f6c4bcc95c5cc4cdef3d1ceb
+checksums           rmd160  78b817738bad1e3fd28f9803481428b83c0782cb \
+                    sha256  82e7fd4246cbdde693736febf4a9c7863c8666c62502ff9cb9d5f1b4799dd6c6
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \
@@ -84,7 +84,7 @@ configure {
 }
 
 build {
-    system -W ${worksrcpath} "source admin/gildas-env.sh -c ${configure.fc} -s ${prefix}/include:${prefix}/lib:/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/Current/ && export GAG_SLDFLAGS='-shared -o ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@) -install_name ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@)' && export DYLD_LIBRARY_PATH=${worksrcpath}/integ/x86_64-darwin-gfortran/lib && export GAG_ADDONS=yes && make install"
+    system -W ${worksrcpath} "source admin/gildas-env.sh -c ${configure.fc} -s ${prefix}/include:${prefix}/lib:/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/Current/ && export GAG_SLDFLAGS='-shared -o ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@) -install_name ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@)' && export DYLD_LIBRARY_PATH=${worksrcpath}/integ/x86_64-darwin-gfortran/lib && export GAG_ADDONS=yes && make -w depend && make -w install"
 }
 
 destroot {

--- a/science/gildas/files/patch-admin-gildas-env.sh.diff
+++ b/science/gildas/files/patch-admin-gildas-env.sh.diff
@@ -1,6 +1,6 @@
---- gildas-src-dec15a/admin/gildas-env.sh.orig	2015-11-30 13:25:52.000000000 +0100
-+++ gildas-src-dec15a/admin/gildas-env.sh	2015-12-04 17:04:00.000000000 +0100
-@@ -442,34 +442,34 @@
+--- gildas-src-feb18a/admin/gildas-env.sh.orig	2018-02-07 11:00:57.000000000 +0100
++++ gildas-src-feb18a/admin/gildas-env.sh	2018-02-07 11:01:17.000000000 +0100
+@@ -449,34 +449,34 @@
          NUMPY_PRESENT=no
          NUMERIC_PRESENT=no
          SQLITE3_PRESENT=no
@@ -44,10 +44,10 @@
          	    SQLITE3_PRESENT=yes
          	fi
              fi
-@@ -545,11 +545,11 @@
-             ATM2003_PRESENT=yes
-             ATM2003_LIB_DIR=$DIR
-         fi
+@@ -556,11 +556,11 @@
+     SDM_MISSING=
+     #
+     for DIR in $GAGENV_SEARCH_PATH; do
 -        if file_present "liblapack." "${DIR}"; then
 +        if file_present "libLAPACK." "${DIR}"; then
              LAPACK_PRESENT=yes
@@ -58,7 +58,7 @@
              BLAS_PRESENT=yes
              BLAS_LIB_DIR=$DIR
          fi
-@@ -557,13 +557,13 @@
+@@ -568,13 +568,13 @@
              SLATEC_PRESENT=yes
              SLATEC_LIB_DIR=$DIR
          fi
@@ -79,7 +79,7 @@
          if file_present "libasdmStandalone." "${DIR}"; then
              SDM_PRESENT=yes
              if [ "$SDM_PRESENT" = "yes" ]; then
-@@ -597,6 +597,8 @@
+@@ -608,6 +608,8 @@
      XML_PRESENT="yes"
      #
      unset GAG_LIB_DEP_PATH GAG_INC_DEP_PATH


### PR DESCRIPTION
@smaret can you please accept this PR? This time I think that's worth you try to compile it by yourself before merge, as I had an issue regarding Makefiles. My commit message is reproduced below.

This version also bypasses a MacPorts issue which does not seem to honor
the GNU Making-Makefiles rules (see
https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html
, paragrah 2). This issue is to be confirmed. For the time being,
our "make depend" is added before "make" or "make install", while
GNU make ensures it should be useless.

Also added -w flag to "make" calls. This adds entering/leaving
directory traces for a better compilation log.