### PR TITLE
go: update to 1.9.4

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                go
 epoch               2
-version             1.9.3
+version             1.9.4
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
@@ -27,8 +27,8 @@ master_sites        https://storage.googleapis.com/golang/
 distfiles           ${name}${version}.src.tar.gz
 worksrcdir          ${name}
 
-checksums           rmd160  0088a287f3a3c4bd4c152101f684e22173c59fa4 \
-                    sha256  4e3d0ad6e91e02efa77d54e86c8b9e34fbe1cbc2935b6d38784dca93331c47ae
+checksums           rmd160  801d6a8a57d2dc0fefba283ea1ae456b869a7398 \
+                    sha256  0573a8df33168977185aa44173305e5a0450f55213600e94541604b75d46dc06
 
 depends_build       port:go-1.4
 


### PR DESCRIPTION
#### Description
CVE-2018-6574