### PR TITLE
dovecot2, dovecot2-sieve: update to 2.3.0 & 0.5.0.1

### DIFF
--- a/mail/dovecot2-sieve/Portfile
+++ b/mail/dovecot2-sieve/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dovecot2-sieve
-version             0.4.19
+version             0.5.0.1
 # set hg.tag to tag or rev.
 hg.tag              ${version}
 #hg.tag              2027
@@ -17,7 +17,7 @@ revision            0
 # Please keep port:dovecot2 major.minor version in sync.
 # On port:dovecot2 major.minor version change please find the new version
 # of port:dovecot2-sieve.
-set dovecot2        2.2
+set dovecot2        2.3
 
 categories          mail
 maintainers         pixilla openmaintainer
@@ -32,8 +32,8 @@ master_sites        http://pigeonhole.dovecot.org/releases/${dovecot2}
 
 distname            dovecot-${dovecot2}-pigeonhole-${version}
 
-checksums           rmd160  45614b72ecce000410f9261c89ddca5258352ab1 \
-                    sha256  629204bfbdcd3480e1ebcdc246da438323c3ea5fea57480ab859e8b201ad8793
+checksums           rmd160  8149f94a0dc3421b025d43180d6a4c5e9b1b3eff \
+                    sha256  56356d14b10c45aa472074e85bfc582c2f08a15a43ecf24f481df39b206efad2
 
 depends_build       port:libtool port:autoconf port:automake
 depends_lib         port:dovecot2

--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -6,7 +6,7 @@ name                dovecot2
 set base_name       dovecot
 # Please revbump port:dovecot2-sieve and port:dovecot2-antispam
 # on port:dovecot2 version changes.
-version             2.2.32
+version             2.3.0
 # set hg.tag to tag or rev.
 hg.tag              ${version}
 #hg.tag              69630e6048fd
@@ -26,6 +26,7 @@ homepage            http://dovecot.org/
 master_sites        http://dovecot.org/releases/${branch}
 
 distname            ${base_name}-${version}
+worksrcdir          ${base_name}-ce-${version}
 
 use_parallel_build  no
 
@@ -53,8 +54,8 @@ add_users ${default_login_user}    group=${default_login_user}    realname=Doven
 patch.pre_args      -p1
 patchfiles          patch-doc-example-config-conf.d-10-master.conf.diff
 
-checksums           rmd160  ff583c903b774e1e691718088ec9ab305b342cdb \
-                    sha256  160b2151e2af359877f69cb2dcdfe1a3f4138ad3766e3b8562b96616e2f6bc2e
+checksums           rmd160  f78c06acc7e729fd1d80d7128df8a44a67bdf391 \
+                    sha256  de60cb470d025e4dd0f8e8fbbb4b9316dfd4930eb949d307330669ffbeaf8581
 
 post-patch {
     reinplace "s|@@default_internal_user@@|${default_internal_user}|g" \


### PR DESCRIPTION
* update dovecot2 to 2.3.0
* update dovecot2-sieve to 0.5.0.1.

#### Description

This updates dovecot2 & dovecot2-sieve to the latest versions.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (no tickets)
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`? (no tests)
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
