### PR TITLE
gromacs: update to 2016.4

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -68,6 +68,11 @@ pre-test {
     system -W ${worksrcpath} "install_name_tool -id @executable_path/../lib/libgromacs${suffix}.1.dylib lib/libgromacs${suffix}.1.dylib"
 }
 post-test {
+    if {[mpi_variant_isset]} {
+        set suffix _mpi
+    } else {
+        set suffix ""
+    }
     # undo changes, in case 'install' is done afterward
     system -W ${worksrcpath} "install_name_tool -change @executable_path/../lib/libgromacs${suffix}.1.dylib ${prefix}/lib/libgromacs.1.dylib bin/gmx${suffix}"
     system -W ${worksrcpath} "install_name_tool -id ${prefix}/lib/libgromacs${suffix}.1.dylib lib/libgromacs${suffix}.1.dylib"

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           cmake 1.0
+PortGroup           cxx11 1.1
 PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 
 name                gromacs
-version             5.1.5
+version             2016.4
 categories          science math
 license             LGPL-2.1
 maintainers         dstrubbe openmaintainer
@@ -26,14 +27,14 @@ homepage            http://www.gromacs.org/
 master_sites        http://ftp.gromacs.org/pub/gromacs
 
 # md5 published at http://www.gromacs.org/Downloads
-checksums           rmd160  306677985aa89ae9857145ce1a3a56966a0ecb94 \
-                    sha256  c25266abf07690ecad16ed3996899b1d489cbb1ef733a1befb3b5c75c91a703e \
-                    md5     831fe741bcd9f1612155dffc919885f2
+checksums           rmd160  76d85579ae322ef61e7382984e66f48f63d1cba9 \
+                    sha256  4be9d3bfda0bdf3b5c53041e0b8344f7d22b75128759d9bfa9442fe65c289264 \
+                    md5     19c8b5c85f3ec62df79d2249a3c272f8
 
 depends_build-append \
                     port:pkgconfig
 
-depends_lib-append  port:fftw-3-single port:libxml2
+depends_lib-append  port:fftw-3-single port:libxml2 port:hwloc port:zlib
 
 # FIXME: enable use of avx when appropriate, instead of just SSE
 configure.args-append  -DGMX_SIMD:STRING="SSE4.1" -DBUILD_TESTING:BOOL=ON -DGMX_X11:BOOL=OFF
@@ -63,9 +64,9 @@ pre-test {
     } else {
         set suffix ""
     }
-    system -W ${worksrcpath} "install_name_tool -change ${prefix}/lib/libgromacs${suffix}.1.dylib @executable_path/../lib/libgromacs${suffix}.1.dylib bin/gmx${suffix}"
+    system -W ${worksrcpath} "install_name_tool -change ${prefix}/lib/libgromacs${suffix}.2.dylib @executable_path/../lib/libgromacs${suffix}.2.dylib bin/gmx${suffix}"
     # reset name for new executables that will be built in this phase
-    system -W ${worksrcpath} "install_name_tool -id @executable_path/../lib/libgromacs${suffix}.1.dylib lib/libgromacs${suffix}.1.dylib"
+    system -W ${worksrcpath} "install_name_tool -id @executable_path/../lib/libgromacs${suffix}.2.dylib lib/libgromacs${suffix}.2.dylib"
 }
 post-test {
     if {[mpi_variant_isset]} {
@@ -74,8 +75,8 @@ post-test {
         set suffix ""
     }
     # undo changes, in case 'install' is done afterward
-    system -W ${worksrcpath} "install_name_tool -change @executable_path/../lib/libgromacs${suffix}.1.dylib ${prefix}/lib/libgromacs.1.dylib bin/gmx${suffix}"
-    system -W ${worksrcpath} "install_name_tool -id ${prefix}/lib/libgromacs${suffix}.1.dylib lib/libgromacs${suffix}.1.dylib"
+    system -W ${worksrcpath} "install_name_tool -change @executable_path/../lib/libgromacs${suffix}.2.dylib ${prefix}/lib/libgromacs.2.dylib bin/gmx${suffix}"
+    system -W ${worksrcpath} "install_name_tool -id ${prefix}/lib/libgromacs${suffix}.2.dylib lib/libgromacs${suffix}.2.dylib"
 }
 # look into this:
 #NOTE: Regression tests have not been run. If you want to run them from the build system, get the correct version of the regression tests package and set REGRESSIONTEST_PATH in CMake to point to it, or set REGRESSIONTEST_DOWNLOAD=ON.
@@ -112,7 +113,7 @@ subport gromacs-plumed {
 # override the choice setting the PLUMED_KERNEL environment variable.
 # Also notice that gromacs version is hardcoded here. Plumed patch is not always
 # updated when gromacs is.
-      exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-5.1.4 --runtime -p
+      exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-2016.4 --runtime -p
     }
     notes "
 PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\

--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -103,8 +103,7 @@ subport gromacs-plumed {
 # make sure that thread MPI is disabled, since it does not work with plumed
     configure.args-append -DGMX_THREAD_MPI=OFF
 
-    depends_build-append   path:${prefix}/bin/plumed:plumed
-    depends_lib-append     path:${prefix}/lib/libplumedKernel.dylib:plumed
+    depends_build-append   path:${prefix}/bin/plumed:plumed path:${prefix}/lib/libplumedWrapper.a:plumed
     pre-configure {
 # I need to execute with full path since PATH variable is not properly set here
 # Also notice that I am patching with runtime. Notice that 


### PR DESCRIPTION
#### Description

Updated to version 2016.4. Notice that:
- This PR contains https://github.com/macports/macports-ports/pull/1294 (though they are independent). In case it is necessary, I remove those commits from this request (the first two commits actually).
- Gromacs 2016 requires C++11. I used the corresponding portgroup. This disables gcc compilers on new OSs (see discussion [here](https://github.com/macports/macports-ports/pull/1252)).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G18013
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
