### PR TITLE
salt: update to version 2017.7.3

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -3,7 +3,7 @@
 PortSystem        1.0
 
 name               salt
-version            2017.7.2
+version            2017.7.3
 categories         sysutils python
 platforms          darwin
 maintainers        {@aphor gmail.com:jeremy.mcmillan}
@@ -25,11 +25,11 @@ if {$subport eq $name} {
     python.versions         27 34 35 36
     categories              sysutils python
 
-    checksums           rmd160  fd01c7bfc2878cab7d02dfb5fdf93d23faffa9d5 \
-                        sha256  1643dc8906d1ee10bea93fb39a979cbdbfd1895691c409d5d7eeebc4f09e8af2
+    checksums           rmd160  a50e20349ac6feea60a122f1b01aaa2f2224fb9d \
+                        sha256  249cfbd895c9cfb5283812d6e2ca047c643244cd9b02d030d3e20b8dd0ec2c8e
 
     notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
-    
+
     if {![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36]} {
         default_variants +python27
     }
@@ -37,62 +37,76 @@ if {$subport eq $name} {
     variant python27 conflicts python34 python35 python36 description {experimental python-2.7 support} {
         python.default_version 27
         depends_build       port:py${python.version}-setuptools
-    
+
         depends_lib-append  port:py${python.version}-yaml \
                             port:py${python.version}-jinja2 \
                             port:py${python.version}-msgpack \
               port:py${python.version}-tornado \
               port:py${python.version}-zmq
-                            
+
+        destroot.cmd-append --with-salt-version=${version}
+
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
     }
-    
+
     variant python34 conflicts python27 python35 python36 description {experimental python-3.4 support} {
         python.default_version 34
         depends_build       port:py${python.version}-setuptools
-    
+
         depends_lib-append  port:py${python.version}-yaml \
                             port:py${python.version}-jinja2 \
                             port:py${python.version}-msgpack \
               port:py${python.version}-tornado \
               port:py${python.version}-zmq
-                            
+
+        destroot.cmd-append --with-salt-version=${version}
+
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
                 "Support for Python 3 versions is experimental."
     }
-    
+
     variant python35 conflicts python27 python34 python36 description {experimental python-3.5 support} {
         python.default_version 35
         depends_build       port:py${python.version}-setuptools
-    
+
         depends_lib-append  port:py${python.version}-yaml \
                             port:py${python.version}-jinja2 \
                             port:py${python.version}-msgpack \
               port:py${python.version}-tornado \
               port:py${python.version}-zmq
-                            
+
+        destroot.cmd-append --with-salt-version=${version}
+
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
                 "Support for Python 3 versions is experimental."
     }
-    
+
     variant python36 conflicts python27 python34 python35 description {experimental python-3.6 support} {
         python.default_version 36
         depends_build       port:py${python.version}-setuptools
-    
+
         depends_lib-append  port:py${python.version}-yaml \
                             port:py${python.version}-jinja2 \
                             port:py${python.version}-msgpack \
               port:py${python.version}-tornado \
               port:py${python.version}-zmq
-                            
+
+        destroot.cmd-append --with-salt-version=${version}
+
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
                 "Support for Python 3 versions is experimental."
     }
+
+    patchfiles patch-macports_syspaths.diff
+
 }
 
 test {
+    system -W ${worksrcpath}/build "cp -r ${worksrcpath}/conf ${worksrcpath}/test"
+    system -W ${worksrcpath}/build "mkdir ${worksrcpath}/test/cache"
+    system -W ${worksrcpath}/build "echo cachedir: ${worksrcpath}/test/cache >> ${worksrcpath}/test/minion"
     system -W ${worksrcpath}/build \
-        "PYTHONPATH=${worksrcpath}/build/lib ${python.bin} scripts-${python.branch}/salt-call --log-file=${worksrcpath}/build/minion.log --config-dir=${worksrcpath}/conf --local test.versions_information"
+        "PYTHONPATH=${worksrcpath}/build/lib ${python.bin} scripts-${python.branch}/salt-call --log-file=${worksrcpath}/build/minion.log --config-dir=${worksrcpath}/test --hard-crash --local --id=local test.versions_information"
 }
 
 foreach daemon [list minion master syndic api] {

--- a/sysutils/salt/files/patch-macports_syspaths.diff
+++ b/sysutils/salt/files/patch-macports_syspaths.diff
@@ -1,0 +1,19 @@
+--- setup.cfg	1969-12-31 18:00:00.000000000 -0600
++++ setup.cfg	2018-02-09 19:17:18.000000000 -0600
+@@ -0,0 +1,16 @@
++[global]
++salt-root-dir=/opt/local
++salt-share-dir=/opt/local/share
++salt-config-dir=/opt/local/etc/salt
++salt-cache-dir=/opt/local/var/cache/salt
++salt-sock-dir=/opt/local/var/run
++salt-srv-root-dir=/opt/local/srv
++salt-base-file-roots-dir=/opt/local/srv/salt
++salt-base-pillar-roots-dir=/opt/local/srv/pillar
++salt-base-master-roots-dir=/opt/local/srv/salt-master
++salt-base-thorium-roots-dir=/opt/local/srv/thorium
++salt-logs-dir=/opt/local/var/log/salt
++salt-pidfile-dir=/opt/local/var/run
++salt-spm-formula-dir=/opt/local/srv/spm/salt
++salt-spm-pillar-dir=/opt/local/srv/spm/pillar
++salt-spm-reactor-dir=/opt/local/srv/spm/reactor


### PR DESCRIPTION
* update to version 2017.7.3
* fix default config/path locations
* fix test cache file access error

Closes: https://trac.macports.org/ticket/54348

#### Description
[skip notification]

version bump, and default paths changed to sane macports paths

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b 
python 3.6.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
