### PR TITLE
rsync: update to version 3.1.3

### DIFF
--- a/net/rsync/Portfile
+++ b/net/rsync/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rsync
-version             3.1.2
+version             3.1.3
 revision            0
 categories          net
 license             GPL-3+
@@ -20,19 +20,19 @@ homepage            http://samba.org/rsync/
 master_sites        http://rsync.samba.org/ftp/rsync/ \
                     http://rsync.samba.org/ftp/rsync/src/
 
-checksums           md5     0f758d7e000c0f7f7d3792610fad70cb \
-                    sha1    0d4c7fb7fe3fc80eeff922a7c1d81df11dbb8a1a \
-                    rmd160  f7d6c0c9752af8d9eb933cffc6032c1763490a04 \
-                    sha256  ecfa62a7fa3c4c18b9eccd8c16eaddee4bd308a76ea50b5c02a5840f09c0a1c2
+checksums           md5     1581a588fde9d89f6bc6201e8129afaf \
+                    sha1    82e7829c0b3cefbd33c233005341e2073c425629 \
+                    rmd160  95a040e0c32e09d01f37fc7d2defd2c41a184db6 \
+                    sha256  55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0
 
 depends_lib         port:popt port:libiconv
 
-# these come from http://rsync.samba.org/ftp/rsync/rsync-patches-3.1.2.tar.gz
+# these come from http://rsync.samba.org/ftp/rsync/rsync-patches-3.1.3.tar.gz
 # and need to be updated with each release
+# hfs-compression.diff is marked by upstream as broken as of 3.1.3
+# don't use: patch-hfs-compression.diff patch-hfs-compression-options.diff
 patchfiles          patch-fileflags.diff \
                     patch-crtimes.diff \
-                    patch-hfs-compression.diff \
-                    patch-hfs-compression-options.diff \
                     patch-acls-unpack-error.diff
 patch.pre_args      -p1
 

--- a/net/rsync/files/patch-crtimes.diff
+++ b/net/rsync/files/patch-crtimes.diff
@@ -42,7 +42,7 @@ diff --git a/compat.c b/compat.c
 diff --git a/flist.c b/flist.c
 --- a/flist.c
 +++ b/flist.c
-@@ -54,6 +54,7 @@ extern int preserve_fileflags;
+@@ -56,6 +56,7 @@ extern int preserve_fileflags;
  extern int delete_during;
  extern int missing_args;
  extern int eol_nulls;
@@ -50,7 +50,7 @@ diff --git a/flist.c b/flist.c
  extern int relative_paths;
  extern int implied_dirs;
  extern int ignore_perishable;
-@@ -398,7 +399,7 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -380,7 +381,7 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  #endif
  			    int ndx, int first_ndx)
  {
@@ -59,7 +59,7 @@ diff --git a/flist.c b/flist.c
  	static mode_t mode;
  #ifdef SUPPORT_FILEFLAGS
  	static uint32 fileflags;
-@@ -509,6 +510,13 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -491,6 +492,13 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  		modtime = file->modtime;
  	if (NSEC_BUMP(file) && protocol_version >= 31)
  		xflags |= XMIT_MOD_NSEC;
@@ -73,7 +73,7 @@ diff --git a/flist.c b/flist.c
  
  #ifdef SUPPORT_HARD_LINKS
  	if (tmp_dev != -1) {
-@@ -593,6 +601,8 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -575,6 +583,8 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  	}
  	if (xflags & XMIT_MOD_NSEC)
  		write_varint(f, F_MOD_NSEC(file));
@@ -82,7 +82,7 @@ diff --git a/flist.c b/flist.c
  	if (!(xflags & XMIT_SAME_MODE))
  		write_int(f, to_wire_mode(mode));
  #ifdef SUPPORT_FILEFLAGS
-@@ -686,7 +696,7 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -668,7 +678,7 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  
  static struct file_struct *recv_file_entry(int f, struct file_list *flist, int xflags)
  {
@@ -91,7 +91,7 @@ diff --git a/flist.c b/flist.c
  	static mode_t mode;
  #ifdef SUPPORT_FILEFLAGS
  	static uint32 fileflags;
-@@ -838,6 +848,19 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -820,6 +830,19 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  		modtime_nsec = read_varint(f);
  	else
  		modtime_nsec = 0;
@@ -111,7 +111,7 @@ diff --git a/flist.c b/flist.c
  	if (!(xflags & XMIT_SAME_MODE))
  		mode = from_wire_mode(read_int(f));
  
-@@ -1015,6 +1038,8 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -997,6 +1020,8 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  		F_GROUP(file) = gid;
  		file->flags |= gid_flags;
  	}
@@ -120,7 +120,7 @@ diff --git a/flist.c b/flist.c
  	if (unsort_ndx)
  		F_NDX(file) = flist->used + flist->ndx_start;
  
-@@ -1416,6 +1441,8 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
+@@ -1398,6 +1423,8 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
  		F_GROUP(file) = st.st_gid;
  	if (am_generator && st.st_uid == our_uid)
  		file->flags |= FLAG_OWNED_BY_US;
@@ -140,55 +140,55 @@ diff --git a/generator.c b/generator.c
  extern int preserve_hard_links;
  extern int preserve_executability;
  extern int preserve_fileflags;
-@@ -384,8 +385,15 @@ static void do_delete_pass(void)
- 		rprintf(FINFO, "                    \r");
+@@ -394,6 +395,16 @@ static inline int time_diff(STRUCT_STAT *stp, struct file_struct *file)
+ #endif
  }
  
--static inline int time_differs(struct file_struct *file, stat_x *sxp)
-+static inline int time_differs(struct file_struct *file, stat_x *sxp, const char *fname)
- {
-+	if (crtimes_ndx) {
-+		if (sxp->crtime == 0)
-+			sxp->crtime = get_create_time(fname);
-+		if (cmp_time(sxp->crtime, f_crtime(file)) != 0)
-+			return 1;
-+	}
++static inline int all_time_diff(stat_x *sxp, struct file_struct *file, const char *fname)
++{
++	int diff = time_diff(&sxp->st, file);
++	if (diff || !crtimes_ndx)
++		return diff;
++	if (sxp->crtime == 0)
++		sxp->crtime = get_create_time(fname);
++	return cmp_time(sxp->crtime, 0, f_crtime(file), 0);
++}
 +
- 	return cmp_time(sxp->st.st_mtime, file->modtime);
- }
- 
-@@ -443,7 +451,7 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
+ static inline int perms_differ(struct file_struct *file, stat_x *sxp)
+ {
+ 	if (preserve_perms)
+@@ -448,7 +459,7 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
  {
  	if (S_ISLNK(file->mode)) {
  #ifdef CAN_SET_SYMLINK_TIMES
--		if (preserve_times & PRESERVE_LINK_TIMES && time_differs(file, sxp))
-+		if (preserve_times & PRESERVE_LINK_TIMES && time_differs(file, sxp, fname))
+-		if (preserve_times & PRESERVE_LINK_TIMES && time_diff(&sxp->st, file))
++		if (preserve_times & PRESERVE_LINK_TIMES && all_time_diff(sxp, file, fname))
  			return 0;
  #endif
  #ifdef CAN_CHMOD_SYMLINK
-@@ -463,7 +471,7 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
+@@ -468,7 +479,7 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
  			return 0;
  #endif
  	} else {
--		if (preserve_times && time_differs(file, sxp))
-+		if (preserve_times && time_differs(file, sxp, fname))
+-		if (preserve_times && time_diff(&sxp->st, file))
++		if (preserve_times && all_time_diff(sxp, file, fname))
  			return 0;
  		if (perms_differ(file, sxp))
  			return 0;
-@@ -506,6 +514,12 @@ void itemize(const char *fnamecmp, struct file_struct *file, int ndx, int statre
+@@ -511,6 +522,12 @@ void itemize(const char *fnamecmp, struct file_struct *file, int ndx, int statre
  		 : iflags & (ITEM_TRANSFER|ITEM_LOCAL_CHANGE) && !(iflags & ITEM_MATCHED)
  		  && (!(iflags & ITEM_XNAME_FOLLOWS) || *xname))
  			iflags |= ITEM_REPORT_TIME;
 +		if (crtimes_ndx) {
 +			if (sxp->crtime == 0)
 +				sxp->crtime = get_create_time(fnamecmp);
-+			if (cmp_time(sxp->crtime, f_crtime(file)) != 0)
++			if (cmp_time(sxp->crtime, 0, f_crtime(file), 0) != 0)
 +				iflags |= ITEM_REPORT_CRTIME;
 +		}
  #if !defined HAVE_LCHMOD && !defined HAVE_SETATTRLIST
  		if (S_ISLNK(file->mode)) {
  			;
-@@ -1130,6 +1144,7 @@ static int try_dests_non(struct file_struct *file, char *fname, int ndx,
+@@ -1135,6 +1152,7 @@ static int try_dests_non(struct file_struct *file, char *fname, int ndx,
  static void list_file_entry(struct file_struct *f)
  {
  	char permbuf[PERMSTRING_SIZE];
@@ -196,7 +196,7 @@ diff --git a/generator.c b/generator.c
  	int64 len;
  	int colwidth = human_readable ? 14 : 11;
  
-@@ -1145,10 +1160,12 @@ static void list_file_entry(struct file_struct *f)
+@@ -1150,10 +1168,12 @@ static void list_file_entry(struct file_struct *f)
  
  #ifdef SUPPORT_LINKS
  	if (preserve_links && S_ISLNK(f->mode)) {
@@ -212,7 +212,7 @@ diff --git a/generator.c b/generator.c
  	} else
  #endif
  	if (missing_args == 2 && f->mode == 0) {
-@@ -1156,9 +1173,12 @@ static void list_file_entry(struct file_struct *f)
+@@ -1161,9 +1181,12 @@ static void list_file_entry(struct file_struct *f)
  			colwidth + 31, "*missing",
  			f_name(f, NULL));
  	} else {
@@ -227,7 +227,7 @@ diff --git a/generator.c b/generator.c
  	}
  }
  
-@@ -1251,6 +1271,7 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1258,6 +1281,7 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  			return;
  		}
  	}
@@ -270,7 +270,7 @@ diff --git a/ifuncs.h b/ifuncs.h
 diff --git a/log.c b/log.c
 --- a/log.c
 +++ b/log.c
-@@ -712,7 +712,8 @@ static void log_formatted(enum logcode code, const char *format, const char *op,
+@@ -716,7 +716,8 @@ static void log_formatted(enum logcode code, const char *format, const char *op,
  			c[8] = !(iflags & ITEM_REPORT_FFLAGS) ? '.' : 'f';
  			c[9] = !(iflags & ITEM_REPORT_ACL) ? '.' : 'a';
  			c[10] = !(iflags & ITEM_REPORT_XATTR) ? '.' : 'x';
@@ -291,7 +291,7 @@ diff --git a/options.c b/options.c
  int update_only = 0;
  int cvs_exclude = 0;
  int dry_run = 0;
-@@ -716,6 +717,7 @@ void usage(enum logcode F)
+@@ -717,6 +718,7 @@ void usage(enum logcode F)
    rprintf(F,"     --specials              preserve special files\n");
    rprintf(F," -D                          same as --devices --specials\n");
    rprintf(F," -t, --times                 preserve modification times\n");
@@ -299,7 +299,7 @@ diff --git a/options.c b/options.c
    rprintf(F," -O, --omit-dir-times        omit directories from --times\n");
    rprintf(F," -J, --omit-link-times       omit symlinks from --times\n");
    rprintf(F,"     --super                 receiver attempts super-user activities\n");
-@@ -883,6 +885,9 @@ static struct poptOption long_options[] = {
+@@ -885,6 +887,9 @@ static struct poptOption long_options[] = {
    {"times",           't', POPT_ARG_VAL,    &preserve_times, 1, 0, 0 },
    {"no-times",         0,  POPT_ARG_VAL,    &preserve_times, 0, 0, 0 },
    {"no-t",             0,  POPT_ARG_VAL,    &preserve_times, 0, 0, 0 },
@@ -309,7 +309,7 @@ diff --git a/options.c b/options.c
    {"omit-dir-times",  'O', POPT_ARG_VAL,    &omit_dir_times, 1, 0, 0 },
    {"no-omit-dir-times",0,  POPT_ARG_VAL,    &omit_dir_times, 0, 0, 0 },
    {"no-O",             0,  POPT_ARG_VAL,    &omit_dir_times, 0, 0, 0 },
-@@ -2463,6 +2468,8 @@ void server_options(char **args, int *argc_p)
+@@ -2491,6 +2496,8 @@ void server_options(char **args, int *argc_p)
  		argstr[x++] = 'D';
  	if (preserve_times)
  		argstr[x++] = 't';
@@ -321,7 +321,7 @@ diff --git a/options.c b/options.c
 diff --git a/rsync.c b/rsync.c
 --- a/rsync.c
 +++ b/rsync.c
-@@ -581,6 +581,9 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -587,6 +587,9 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  	 || (!(preserve_times & PRESERVE_DIR_TIMES) && S_ISDIR(sxp->st.st_mode))
  	 || (!(preserve_times & PRESERVE_LINK_TIMES) && S_ISLNK(sxp->st.st_mode)))
  		flags |= ATTRS_SKIP_MTIME;
@@ -331,7 +331,7 @@ diff --git a/rsync.c b/rsync.c
  	if (!(flags & ATTRS_SKIP_MTIME)
  	 && (sxp->st.st_mtime != file->modtime
  #ifdef ST_MTIME_NSEC
-@@ -598,6 +601,14 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -604,6 +607,14 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  		else
  			file->flags |= FLAG_TIME_FAILED;
  	}
@@ -339,28 +339,28 @@ diff --git a/rsync.c b/rsync.c
 +		time_t file_crtime = f_crtime(file);
 +		if (sxp->crtime == 0)
 +			sxp->crtime = get_create_time(fname);
-+		if (cmp_time(sxp->crtime, file_crtime) != 0
++		if (cmp_time(sxp->crtime, 0, file_crtime, 0) != 0
 +		 && set_create_time(fname, file_crtime) == 0)
 +			updated = 1;
 +	}
  
  #ifdef SUPPORT_ACLS
  	/* It's OK to call set_acl() now, even for a dir, as the generator
-@@ -714,7 +725,7 @@ int finish_transfer(const char *fname, const char *fnametmp,
+@@ -720,7 +731,7 @@ int finish_transfer(const char *fname, const char *fnametmp,
  	/* Change permissions before putting the file into place. */
  	set_file_attrs(fnametmp, file, NULL, fnamecmp,
  		       ATTRS_DELAY_IMMUTABLE
--		       | (ok_to_set_time ? 0 : ATTRS_SKIP_MTIME));
-+		       | (ok_to_set_time ? 0 : ATTRS_SKIP_MTIME | ATTRS_SKIP_CRTIME));
+-		       | (ok_to_set_time ? ATTRS_SET_NANO : ATTRS_SKIP_MTIME));
++		       | (ok_to_set_time ? ATTRS_SET_NANO : ATTRS_SKIP_MTIME | ATTRS_SKIP_CRTIME));
  
  	/* move tmp file over real file */
  	if (DEBUG_GTE(RECV, 1))
-@@ -743,7 +754,7 @@ int finish_transfer(const char *fname, const char *fnametmp,
+@@ -749,7 +760,7 @@ int finish_transfer(const char *fname, const char *fnametmp,
  
    do_set_file_attrs:
  	set_file_attrs(fnametmp, file, NULL, fnamecmp,
--		       ok_to_set_time ? 0 : ATTRS_SKIP_MTIME);
-+		       ok_to_set_time ? 0 : ATTRS_SKIP_MTIME | ATTRS_SKIP_CRTIME);
+-		       ok_to_set_time ? ATTRS_SET_NANO : ATTRS_SKIP_MTIME);
++		       ok_to_set_time ? ATTRS_SET_NANO : ATTRS_SKIP_MTIME | ATTRS_SKIP_CRTIME);
  
  	if (temp_copy_name) {
  		if (do_rename(fnametmp, fname) < 0) {
@@ -377,15 +377,15 @@ diff --git a/rsync.h b/rsync.h
  
  /* These flags are used in the live flist data. */
  
-@@ -167,6 +168,7 @@
- #define ATTRS_REPORT		(1<<0)
+@@ -168,6 +169,7 @@
  #define ATTRS_SKIP_MTIME	(1<<1)
- #define ATTRS_DELAY_IMMUTABLE	(1<<2)
-+#define ATTRS_SKIP_CRTIME	(1<<3)
+ #define ATTRS_SET_NANO		(1<<2)
+ #define ATTRS_DELAY_IMMUTABLE	(1<<4)
++#define ATTRS_SKIP_CRTIME	(1<<5)
  
  #define FULL_FLUSH	1
  #define NORMAL_FLUSH	0
-@@ -183,7 +185,7 @@
+@@ -184,7 +186,7 @@
  #define FNAMECMP_FUZZY		0x83
  
  /* For use by the itemize_changes code */
@@ -394,7 +394,7 @@ diff --git a/rsync.h b/rsync.h
  #define ITEM_REPORT_CHANGE (1<<1)
  #define ITEM_REPORT_SIZE (1<<2)     /* regular files only */
  #define ITEM_REPORT_TIMEFAIL (1<<2) /* symlinks only */
-@@ -734,6 +736,7 @@ extern int file_extra_cnt;
+@@ -741,6 +743,7 @@ extern int file_extra_cnt;
  extern int inc_recurse;
  extern int uid_ndx;
  extern int gid_ndx;
@@ -402,7 +402,7 @@ diff --git a/rsync.h b/rsync.h
  extern int fileflags_ndx;
  extern int acls_ndx;
  extern int xattrs_ndx;
-@@ -741,6 +744,7 @@ extern int xattrs_ndx;
+@@ -748,6 +751,7 @@ extern int xattrs_ndx;
  #define FILE_STRUCT_LEN (offsetof(struct file_struct, basename))
  #define EXTRA_LEN (sizeof (union file_extras))
  #define PTR_EXTRA_CNT ((sizeof (char *) + EXTRA_LEN - 1) / EXTRA_LEN)
@@ -410,7 +410,7 @@ diff --git a/rsync.h b/rsync.h
  #define DEV_EXTRA_CNT 2
  #define DIRNODE_EXTRA_CNT 3
  #define SUM_EXTRA_CNT ((MAX_DIGEST_LEN + EXTRA_LEN - 1) / EXTRA_LEN)
-@@ -1021,6 +1025,7 @@ typedef struct {
+@@ -1033,6 +1037,7 @@ typedef struct {
  
  typedef struct {
      STRUCT_STAT st;
@@ -429,7 +429,7 @@ diff --git a/rsync.yo b/rsync.yo
   -O, --omit-dir-times        omit directories from --times
   -J, --omit-link-times       omit symlinks from --times
       --super                 receiver attempts super-user activities
-@@ -1208,6 +1209,9 @@ cause the next transfer to behave as if it used bf(-I), causing all files to be
+@@ -1242,6 +1243,9 @@ cause the next transfer to behave as if it used bf(-I), causing all files to be
  updated (though rsync's delta-transfer algorithm will make the update fairly efficient
  if the files haven't actually changed, you're much better off using bf(-t)).
  
@@ -439,7 +439,7 @@ diff --git a/rsync.yo b/rsync.yo
  dit(bf(-O, --omit-dir-times)) This tells rsync to omit directories when
  it is preserving modification times (see bf(--times)).  If NFS is sharing
  the directories on the receiving side, it is a good idea to use bf(-O).
-@@ -2110,7 +2114,7 @@ with older versions of rsync, but that also turns on the output of other
+@@ -2173,7 +2177,7 @@ with older versions of rsync, but that also turns on the output of other
  verbose messages).
  
  The "%i" escape has a cryptic output that is 11 letters long.  The general
@@ -448,7 +448,7 @@ diff --git a/rsync.yo b/rsync.yo
  type of update being done, bf(X) is replaced by the file-type, and the
  other letters represent attributes that may be output if they are being
  modified.
-@@ -2169,6 +2173,8 @@ quote(itemization(
+@@ -2232,6 +2236,8 @@ quote(itemization(
    it() The bf(f) means that the fileflags information changed.
    it() The bf(a) means that the ACL information changed.
    it() The bf(x) means that the extended attribute information changed.
@@ -460,9 +460,9 @@ diff --git a/rsync.yo b/rsync.yo
 diff --git a/syscall.c b/syscall.c
 --- a/syscall.c
 +++ b/syscall.c
-@@ -42,6 +42,13 @@ extern int force_change;
- extern int preserve_perms;
- extern int preserve_executability;
+@@ -54,6 +54,13 @@ extern int preserve_executability;
+ # endif
+ #endif
  
 +#pragma pack(push, 4)
 +struct create_time {
@@ -474,9 +474,9 @@ diff --git a/syscall.c b/syscall.c
  #define RETURN_ERROR_IF(x,e) \
  	do { \
  		if (x) { \
-@@ -460,6 +467,36 @@ OFF_T do_lseek(int fd, OFF_T offset, int whence)
- #endif
+@@ -491,6 +498,36 @@ int do_setattrlist_times(const char *fname, time_t modtime, uint32 mod_nsec)
  }
+ #endif
  
 +time_t get_create_time(const char *path)
 +{
@@ -559,7 +559,7 @@ diff --git a/testsuite/rsync.fns b/testsuite/rsync.fns
 diff --git a/tls.c b/tls.c
 --- a/tls.c
 +++ b/tls.c
-@@ -109,6 +109,8 @@ static int stat_xattr(const char *fname, STRUCT_STAT *fst)
+@@ -111,6 +111,8 @@ static int stat_xattr(const char *fname, STRUCT_STAT *fst)
  
  #endif
  
@@ -568,7 +568,7 @@ diff --git a/tls.c b/tls.c
  static void failed(char const *what, char const *where)
  {
  	fprintf(stderr, PROGRAM ": %s %s: %s\n",
-@@ -116,16 +118,44 @@ static void failed(char const *what, char const *where)
+@@ -118,16 +120,44 @@ static void failed(char const *what, char const *where)
  	exit(1);
  }
  
@@ -615,7 +615,7 @@ diff --git a/tls.c b/tls.c
  #ifdef SUPPORT_XATTRS
  	if (am_root < 0)
  		stat_xattr(fname, &buf);
-@@ -159,30 +189,17 @@ static void list_file(const char *fname)
+@@ -161,30 +191,17 @@ static void list_file(const char *fname)
  	}
  
  	permstring(permbuf, buf.st_mode);
@@ -655,7 +655,7 @@ diff --git a/tls.c b/tls.c
  
  	/* TODO: Perhaps escape special characters in fname? */
  
-@@ -193,13 +210,14 @@ static void list_file(const char *fname)
+@@ -195,13 +212,14 @@ static void list_file(const char *fname)
  		    (long)minor(buf.st_rdev));
  	} else
  		printf("%15s", do_big_num(buf.st_size, 1, NULL));
@@ -672,7 +672,7 @@ diff --git a/tls.c b/tls.c
    {"link-times",      'l', POPT_ARG_NONE,   &link_times, 0, 0, 0 },
    {"link-owner",      'L', POPT_ARG_NONE,   &link_owner, 0, 0, 0 },
  #ifdef SUPPORT_XATTRS
-@@ -218,6 +236,7 @@ static void tls_usage(int ret)
+@@ -220,6 +238,7 @@ static void tls_usage(int ret)
    fprintf(F,"usage: " PROGRAM " [OPTIONS] FILE ...\n");
    fprintf(F,"Trivial file listing program for portably checking rsync\n");
    fprintf(F,"\nOptions:\n");
@@ -683,10 +683,10 @@ diff --git a/tls.c b/tls.c
 diff -Nurp a/proto.h b/proto.h
 --- a/proto.h
 +++ b/proto.h
-@@ -328,6 +328,8 @@ int do_stat(const char *fname, STRUCT_ST
- int do_lstat(const char *fname, STRUCT_STAT *st);
+@@ -340,6 +340,8 @@ int do_lstat(const char *fname, STRUCT_S
  int do_fstat(int fd, STRUCT_STAT *st);
  OFF_T do_lseek(int fd, OFF_T offset, int whence);
+ int do_setattrlist_times(const char *fname, time_t modtime, uint32 mod_nsec);
 +time_t get_create_time(const char *path);
 +int set_create_time(const char *path, time_t crtime);
  int do_utimensat(const char *fname, time_t modtime, uint32 mod_nsec);
@@ -703,7 +703,7 @@ diff -Nurp a/rsync.1 b/rsync.1
   \-O, \-\-omit\-dir\-times        omit directories from \-\-times
   \-J, \-\-omit\-link\-times       omit symlinks from \-\-times
       \-\-super                 receiver attempts super\-user activities
-@@ -1386,6 +1387,10 @@ cause the next transfer to behave as if
+@@ -1427,6 +1428,10 @@ cause the next transfer to behave as if
  updated (though rsync\(cq\&s delta\-transfer algorithm will make the update fairly efficient
  if the files haven\(cq\&t actually changed, you\(cq\&re much better off using \fB\-t\fP).
  .IP 
@@ -714,7 +714,7 @@ diff -Nurp a/rsync.1 b/rsync.1
  .IP "\fB\-O, \-\-omit\-dir\-times\fP"
  This tells rsync to omit directories when
  it is preserving modification times (see \fB\-\-times\fP).  If NFS is sharing
-@@ -2397,7 +2402,7 @@ with older versions of rsync, but that a
+@@ -2462,7 +2467,7 @@ with older versions of rsync, but that a
  verbose messages).
  .IP 
  The \(dq\&%i\(dq\& escape has a cryptic output that is 11 letters long.  The general
@@ -723,7 +723,7 @@ diff -Nurp a/rsync.1 b/rsync.1
  type of update being done, \fBX\fP is replaced by the file\-type, and the
  other letters represent attributes that may be output if they are being
  modified.
-@@ -2472,6 +2477,9 @@ The \fBf\fP means that the fileflags inf
+@@ -2537,6 +2542,9 @@ The \fBf\fP means that the fileflags inf
  The \fBa\fP means that the ACL information changed.
  .IP o 
  The \fBx\fP means that the extended attribute information changed.

--- a/net/rsync/files/patch-fileflags.diff
+++ b/net/rsync/files/patch-fileflags.diff
@@ -8,7 +8,7 @@ To use this patch, run these commands for a successful build:
     ./configure
     make
 
-based-on: 16b49716d55a50f2e985b879b720b2c53c892a3a
+based-on: d73762eea3f15f2c56bb3fa9394ad1883c25c949
 diff --git a/Makefile.in b/Makefile.in
 --- a/Makefile.in
 +++ b/Makefile.in
@@ -66,7 +66,7 @@ diff --git a/compat.c b/compat.c
 diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
-@@ -593,6 +593,7 @@ AC_FUNC_UTIME_NULL
+@@ -594,6 +594,7 @@ AC_FUNC_UTIME_NULL
  AC_FUNC_ALLOCA
  AC_CHECK_FUNCS(waitpid wait4 getcwd strdup chown chmod lchmod mknod mkfifo \
      fchmod fstat ftruncate strchr readlink link utime utimes lutimes strftime \
@@ -122,7 +122,7 @@ diff --git a/delete.c b/delete.c
 diff --git a/flist.c b/flist.c
 --- a/flist.c
 +++ b/flist.c
-@@ -50,6 +50,7 @@ extern int preserve_links;
+@@ -52,6 +52,7 @@ extern int preserve_links;
  extern int preserve_hard_links;
  extern int preserve_devices;
  extern int preserve_specials;
@@ -130,7 +130,7 @@ diff --git a/flist.c b/flist.c
  extern int delete_during;
  extern int missing_args;
  extern int eol_nulls;
-@@ -399,6 +400,9 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -381,6 +382,9 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  {
  	static time_t modtime;
  	static mode_t mode;
@@ -140,7 +140,7 @@ diff --git a/flist.c b/flist.c
  #ifdef SUPPORT_HARD_LINKS
  	static int64 dev;
  #endif
-@@ -442,6 +446,14 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -424,6 +428,14 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  		xflags |= XMIT_SAME_MODE;
  	else
  		mode = file->mode;
@@ -155,7 +155,7 @@ diff --git a/flist.c b/flist.c
  
  	if (preserve_devices && IS_DEVICE(mode)) {
  		if (protocol_version < 28) {
-@@ -583,6 +595,10 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
+@@ -565,6 +577,10 @@ static void send_file_entry(int f, const char *fname, struct file_struct *file,
  		write_varint(f, F_MOD_NSEC(file));
  	if (!(xflags & XMIT_SAME_MODE))
  		write_int(f, to_wire_mode(mode));
@@ -166,7 +166,7 @@ diff --git a/flist.c b/flist.c
  	if (preserve_uid && !(xflags & XMIT_SAME_UID)) {
  		if (protocol_version < 30)
  			write_int(f, uid);
-@@ -672,6 +688,9 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -654,6 +670,9 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  {
  	static int64 modtime;
  	static mode_t mode;
@@ -176,7 +176,7 @@ diff --git a/flist.c b/flist.c
  #ifdef SUPPORT_HARD_LINKS
  	static int64 dev;
  #endif
-@@ -779,6 +798,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -761,6 +780,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  			modtime = first->modtime;
  			modtime_nsec = F_MOD_NSEC(first);
  			mode = first->mode;
@@ -187,7 +187,7 @@ diff --git a/flist.c b/flist.c
  			if (preserve_uid)
  				uid = F_OWNER(first);
  			if (preserve_gid)
-@@ -820,6 +843,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -802,6 +825,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  
  	if (chmod_modes && !S_ISLNK(mode) && mode)
  		mode = tweak_mode(mode, chmod_modes);
@@ -198,7 +198,7 @@ diff --git a/flist.c b/flist.c
  
  	if (preserve_uid && !(xflags & XMIT_SAME_UID)) {
  		if (protocol_version < 30)
-@@ -978,6 +1005,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
+@@ -960,6 +987,10 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
  	}
  #endif
  	file->mode = mode;
@@ -209,7 +209,7 @@ diff --git a/flist.c b/flist.c
  	if (preserve_uid)
  		F_OWNER(file) = uid;
  	if (preserve_gid) {
-@@ -1375,6 +1406,10 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
+@@ -1357,6 +1388,10 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
  	}
  #endif
  	file->mode = st.st_mode;
@@ -234,7 +234,7 @@ diff --git a/generator.c b/generator.c
  extern int delete_mode;
  extern int delete_before;
  extern int delete_during;
-@@ -465,6 +467,10 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
+@@ -470,6 +472,10 @@ int unchanged_attrs(const char *fname, struct file_struct *file, stat_x *sxp)
  			return 0;
  		if (perms_differ(file, sxp))
  			return 0;
@@ -245,7 +245,7 @@ diff --git a/generator.c b/generator.c
  		if (ownership_differs(file, sxp))
  			return 0;
  #ifdef SUPPORT_ACLS
-@@ -516,6 +522,11 @@ void itemize(const char *fnamecmp, struct file_struct *file, int ndx, int statre
+@@ -521,6 +527,11 @@ void itemize(const char *fnamecmp, struct file_struct *file, int ndx, int statre
  		if (gid_ndx && !(file->flags & FLAG_SKIP_GROUP)
  		    && sxp->st.st_gid != (gid_t)F_GROUP(file))
  			iflags |= ITEM_REPORT_GROUP;
@@ -257,7 +257,7 @@ diff --git a/generator.c b/generator.c
  #ifdef SUPPORT_ACLS
  		if (preserve_acls && !S_ISLNK(file->mode)) {
  			if (!ACL_READY(*sxp))
-@@ -1408,6 +1419,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1415,6 +1426,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  			file->mode = dest_mode(file->mode, sx.st.st_mode,
  					       dflt_perms, statret == 0);
  		}
@@ -268,7 +268,7 @@ diff --git a/generator.c b/generator.c
  		if (statret != 0 && basis_dir[0] != NULL) {
  			int j = try_dests_non(file, fname, ndx, fnamecmpbuf, &sx,
  					      itemizing, code);
-@@ -1452,10 +1467,15 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1459,10 +1474,15 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  		 * readable and writable permissions during the time we are
  		 * putting files within them.  This is then restored to the
  		 * former permissions after the transfer is done. */
@@ -285,7 +285,7 @@ diff --git a/generator.c b/generator.c
  				rsyserr(FERROR_XFER, errno,
  					"failed to modify permissions on %s",
  					full_fname(fname));
-@@ -1491,6 +1511,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+@@ -1498,6 +1518,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
  		file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms,
  				       exists);
  	}
@@ -296,7 +296,7 @@ diff --git a/generator.c b/generator.c
  
  #ifdef SUPPORT_HARD_LINKS
  	if (preserve_hard_links && F_HLINK_NOT_FIRST(file)
-@@ -2059,13 +2083,17 @@ static void touch_up_dirs(struct file_list *flist, int ndx)
+@@ -2065,12 +2089,16 @@ static void touch_up_dirs(struct file_list *flist, int ndx)
  			continue;
  		fname = f_name(file, NULL);
  		if (fix_dir_perms)
@@ -304,8 +304,7 @@ diff --git a/generator.c b/generator.c
 +			do_chmod(fname, file->mode, 0);
  		if (need_retouch_dir_times) {
  			STRUCT_STAT st;
- 			if (link_stat(fname, &st, 0) == 0
- 			 && cmp_time(st.st_mtime, file->modtime) != 0)
+ 			if (link_stat(fname, &st, 0) == 0 && time_diff(&st, file))
 -				set_modtime(fname, file->modtime, F_MOD_NSEC(file), file->mode);
 +				set_modtime(fname, file->modtime, F_MOD_NSEC(file), file->mode, 0);
  		}
@@ -319,7 +318,7 @@ diff --git a/generator.c b/generator.c
 diff --git a/log.c b/log.c
 --- a/log.c
 +++ b/log.c
-@@ -709,7 +709,7 @@ static void log_formatted(enum logcode code, const char *format, const char *op,
+@@ -713,7 +713,7 @@ static void log_formatted(enum logcode code, const char *format, const char *op,
  			c[5] = !(iflags & ITEM_REPORT_PERMS) ? '.' : 'p';
  			c[6] = !(iflags & ITEM_REPORT_OWNER) ? '.' : 'o';
  			c[7] = !(iflags & ITEM_REPORT_GROUP) ? '.' : 'g';
@@ -349,7 +348,7 @@ diff --git a/main.c b/main.c
  extern int file_total;
  extern int recurse;
  extern int xfer_dirs;
-@@ -840,6 +844,22 @@ static int do_recv(int f_in, int f_out, char *local_name)
+@@ -850,6 +854,22 @@ static int do_recv(int f_in, int f_out, char *local_name)
  	 * points to an identical file won't be replaced by the referent. */
  	copy_links = copy_dirlinks = copy_unsafe_links = 0;
  
@@ -391,7 +390,7 @@ diff --git a/options.c b/options.c
  int io_timeout = 0;
  int prune_empty_dirs = 0;
  int use_qsort = 0;
-@@ -572,6 +574,7 @@ static void print_rsync_version(enum logcode f)
+@@ -573,6 +575,7 @@ static void print_rsync_version(enum logcode f)
  	char const *links = "no ";
  	char const *iconv = "no ";
  	char const *ipv6 = "no ";
@@ -399,7 +398,7 @@ diff --git a/options.c b/options.c
  	STRUCT_STAT *dumstat;
  
  #if SUBPROTOCOL_VERSION != 0
-@@ -608,6 +611,9 @@ static void print_rsync_version(enum logcode f)
+@@ -609,6 +612,9 @@ static void print_rsync_version(enum logcode f)
  #ifdef CAN_SET_SYMLINK_TIMES
  	symtimes = "";
  #endif
@@ -409,7 +408,7 @@ diff --git a/options.c b/options.c
  
  	rprintf(f, "%s  version %s  protocol version %d%s\n",
  		RSYNC_NAME, RSYNC_VERSION, PROTOCOL_VERSION, subprotocol);
-@@ -621,8 +627,8 @@ static void print_rsync_version(enum logcode f)
+@@ -622,8 +628,8 @@ static void print_rsync_version(enum logcode f)
  		(int)(sizeof (int64) * 8));
  	rprintf(f, "    %ssocketpairs, %shardlinks, %ssymlinks, %sIPv6, batchfiles, %sinplace,\n",
  		got_socketpair, hardlinks, links, ipv6, have_inplace);
@@ -420,7 +419,7 @@ diff --git a/options.c b/options.c
  
  #ifdef MAINTAINER_MODE
  	rprintf(f, "Panic Action: \"%s\"\n", get_panic_action());
-@@ -693,6 +699,9 @@ void usage(enum logcode F)
+@@ -694,6 +700,9 @@ void usage(enum logcode F)
    rprintf(F," -K, --keep-dirlinks         treat symlinked dir on receiver as dir\n");
    rprintf(F," -H, --hard-links            preserve hard links\n");
    rprintf(F," -p, --perms                 preserve permissions\n");
@@ -430,7 +429,7 @@ diff --git a/options.c b/options.c
    rprintf(F," -E, --executability         preserve the file's executability\n");
    rprintf(F,"     --chmod=CHMOD           affect file and/or directory permissions\n");
  #ifdef SUPPORT_ACLS
-@@ -738,7 +747,12 @@ void usage(enum logcode F)
+@@ -740,7 +749,12 @@ void usage(enum logcode F)
    rprintf(F,"     --ignore-missing-args   ignore missing source args without error\n");
    rprintf(F,"     --delete-missing-args   delete missing source args from destination\n");
    rprintf(F,"     --ignore-errors         delete even if there are I/O errors\n");
@@ -444,7 +443,7 @@ diff --git a/options.c b/options.c
    rprintf(F,"     --max-delete=NUM        don't delete more than NUM files\n");
    rprintf(F,"     --max-size=SIZE         don't transfer any file larger than SIZE\n");
    rprintf(F,"     --min-size=SIZE         don't transfer any file smaller than SIZE\n");
-@@ -855,6 +869,10 @@ static struct poptOption long_options[] = {
+@@ -857,6 +871,10 @@ static struct poptOption long_options[] = {
    {"perms",           'p', POPT_ARG_VAL,    &preserve_perms, 1, 0, 0 },
    {"no-perms",         0,  POPT_ARG_VAL,    &preserve_perms, 0, 0, 0 },
    {"no-p",             0,  POPT_ARG_VAL,    &preserve_perms, 0, 0, 0 },
@@ -455,7 +454,7 @@ diff --git a/options.c b/options.c
    {"executability",   'E', POPT_ARG_NONE,   &preserve_executability, 0, 0, 0 },
    {"acls",            'A', POPT_ARG_NONE,   0, 'A', 0, 0 },
    {"no-acls",          0,  POPT_ARG_VAL,    &preserve_acls, 0, 0, 0 },
-@@ -941,6 +959,14 @@ static struct poptOption long_options[] = {
+@@ -943,6 +961,14 @@ static struct poptOption long_options[] = {
    {"remove-source-files",0,POPT_ARG_VAL,    &remove_source_files, 1, 0, 0 },
    {"force",            0,  POPT_ARG_VAL,    &force_delete, 1, 0, 0 },
    {"no-force",         0,  POPT_ARG_VAL,    &force_delete, 0, 0, 0 },
@@ -470,7 +469,7 @@ diff --git a/options.c b/options.c
    {"ignore-errors",    0,  POPT_ARG_VAL,    &ignore_errors, 1, 0, 0 },
    {"no-ignore-errors", 0,  POPT_ARG_VAL,    &ignore_errors, 0, 0, 0 },
    {"max-delete",       0,  POPT_ARG_INT,    &max_delete, 0, 0, 0 },
-@@ -2539,6 +2565,9 @@ void server_options(char **args, int *argc_p)
+@@ -2567,6 +2593,9 @@ void server_options(char **args, int *argc_p)
  	if (xfer_dirs && !recurse && delete_mode && am_sender)
  		args[ac++] = "--no-r";
  
@@ -480,7 +479,7 @@ diff --git a/options.c b/options.c
  	if (do_compression && def_compress_level != Z_DEFAULT_COMPRESSION) {
  		if (asprintf(&arg, "--compress-level=%d", def_compress_level) < 0)
  			goto oom;
-@@ -2626,6 +2655,16 @@ void server_options(char **args, int *argc_p)
+@@ -2660,6 +2689,16 @@ void server_options(char **args, int *argc_p)
  			args[ac++] = "--delete-excluded";
  		if (force_delete)
  			args[ac++] = "--force";
@@ -508,7 +507,7 @@ diff --git a/rsync.c b/rsync.c
  extern int preserve_executability;
  extern int preserve_times;
  extern int am_root;
-@@ -452,6 +453,39 @@ mode_t dest_mode(mode_t flist_mode, mode_t stat_mode, int dflt_perms,
+@@ -458,6 +459,39 @@ mode_t dest_mode(mode_t flist_mode, mode_t stat_mode, int dflt_perms,
  	return new_mode;
  }
  
@@ -548,7 +547,7 @@ diff --git a/rsync.c b/rsync.c
  int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  		   const char *fnamecmp, int flags)
  {
-@@ -513,7 +547,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -519,7 +553,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  		if (am_root >= 0) {
  			uid_t uid = change_uid ? (uid_t)F_OWNER(file) : sxp->st.st_uid;
  			gid_t gid = change_gid ? (gid_t)F_GROUP(file) : sxp->st.st_gid;
@@ -557,8 +556,8 @@ diff --git a/rsync.c b/rsync.c
  				/* We shouldn't have attempted to change uid
  				 * or gid unless have the privilege. */
  				rsyserr(FERROR_XFER, errno, "%s %s failed",
-@@ -553,7 +587,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
- 	  || (NSEC_BUMP(file) && (uint32)sxp->st.ST_MTIME_NSEC != F_MOD_NSEC(file))
+@@ -559,7 +593,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+ 	  || (flags & ATTRS_SET_NANO && NSEC_BUMP(file) && (uint32)sxp->st.ST_MTIME_NSEC != F_MOD_NSEC(file))
  #endif
  	  )) {
 -		int ret = set_modtime(fname, file->modtime, F_MOD_NSEC(file), sxp->st.st_mode);
@@ -566,7 +565,7 @@ diff --git a/rsync.c b/rsync.c
  		if (ret < 0) {
  			rsyserr(FERROR_XFER, errno, "failed to set times on %s",
  				full_fname(fname));
-@@ -580,7 +614,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -586,7 +620,7 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  
  #ifdef HAVE_CHMOD
  	if (!BITS_EQUAL(sxp->st.st_mode, new_mode, CHMOD_BITS)) {
@@ -575,7 +574,7 @@ diff --git a/rsync.c b/rsync.c
  		if (ret < 0) {
  			rsyserr(FERROR_XFER, errno,
  				"failed to set permissions on %s",
-@@ -592,6 +626,19 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
+@@ -598,6 +632,19 @@ int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  	}
  #endif
  
@@ -595,17 +594,17 @@ diff --git a/rsync.c b/rsync.c
  	if (INFO_GTE(NAME, 2) && flags & ATTRS_REPORT) {
  		if (updated)
  			rprintf(FCLIENT, "%s\n", fname);
-@@ -666,7 +713,8 @@ int finish_transfer(const char *fname, const char *fnametmp,
+@@ -672,7 +719,8 @@ int finish_transfer(const char *fname, const char *fnametmp,
  
  	/* Change permissions before putting the file into place. */
  	set_file_attrs(fnametmp, file, NULL, fnamecmp,
--		       ok_to_set_time ? 0 : ATTRS_SKIP_MTIME);
+-		       ok_to_set_time ? ATTRS_SET_NANO : ATTRS_SKIP_MTIME);
 +		       ATTRS_DELAY_IMMUTABLE
-+		       | (ok_to_set_time ? 0 : ATTRS_SKIP_MTIME));
++		       | (ok_to_set_time ? ATTRS_SET_NANO : ATTRS_SKIP_MTIME));
  
  	/* move tmp file over real file */
  	if (DEBUG_GTE(RECV, 1))
-@@ -683,6 +731,10 @@ int finish_transfer(const char *fname, const char *fnametmp,
+@@ -689,6 +737,10 @@ int finish_transfer(const char *fname, const char *fnametmp,
  	}
  	if (ret == 0) {
  		/* The file was moved into place (not copied), so it's done. */
@@ -627,15 +626,15 @@ diff --git a/rsync.h b/rsync.h
  
  /* These flags are used in the live flist data. */
  
-@@ -165,6 +166,7 @@
- 
+@@ -166,6 +167,7 @@
  #define ATTRS_REPORT		(1<<0)
  #define ATTRS_SKIP_MTIME	(1<<1)
-+#define ATTRS_DELAY_IMMUTABLE	(1<<2)
+ #define ATTRS_SET_NANO		(1<<2)
++#define ATTRS_DELAY_IMMUTABLE	(1<<4)
  
  #define FULL_FLUSH	1
  #define NORMAL_FLUSH	0
-@@ -191,6 +193,7 @@
+@@ -192,6 +194,7 @@
  #define ITEM_REPORT_GROUP (1<<6)
  #define ITEM_REPORT_ACL (1<<7)
  #define ITEM_REPORT_XATTR (1<<8)
@@ -643,7 +642,7 @@ diff --git a/rsync.h b/rsync.h
  #define ITEM_BASIS_TYPE_FOLLOWS (1<<11)
  #define ITEM_XNAME_FOLLOWS (1<<12)
  #define ITEM_IS_NEW (1<<13)
-@@ -522,6 +525,28 @@ typedef unsigned int size_t;
+@@ -529,6 +532,28 @@ typedef unsigned int size_t;
  #endif
  #endif
  
@@ -672,7 +671,7 @@ diff --git a/rsync.h b/rsync.h
  /* Find a variable that is either exactly 32-bits or longer.
   * If some code depends on 32-bit truncation, it will need to
   * take special action in a "#if SIZEOF_INT32 > 4" section. */
-@@ -709,6 +734,7 @@ extern int file_extra_cnt;
+@@ -716,6 +741,7 @@ extern int file_extra_cnt;
  extern int inc_recurse;
  extern int uid_ndx;
  extern int gid_ndx;
@@ -680,7 +679,7 @@ diff --git a/rsync.h b/rsync.h
  extern int acls_ndx;
  extern int xattrs_ndx;
  
-@@ -750,6 +776,11 @@ extern int xattrs_ndx;
+@@ -757,6 +783,11 @@ extern int xattrs_ndx;
  /* When the associated option is on, all entries will have these present: */
  #define F_OWNER(f) REQ_EXTRA(f, uid_ndx)->unum
  #define F_GROUP(f) REQ_EXTRA(f, gid_ndx)->unum
@@ -703,7 +702,7 @@ diff --git a/rsync.yo b/rsync.yo
   -E, --executability         preserve executability
       --chmod=CHMOD           affect file and/or directory permissions
   -A, --acls                  preserve ACLs (implies -p)
-@@ -397,7 +398,10 @@ to the detailed description below for a complete description.  verb(
+@@ -398,7 +399,10 @@ to the detailed description below for a complete description.  verb(
       --ignore-missing-args   ignore missing source args without error
       --delete-missing-args   delete missing source args from destination
       --ignore-errors         delete even if there are I/O errors
@@ -715,7 +714,7 @@ diff --git a/rsync.yo b/rsync.yo
       --max-delete=NUM        don't delete more than NUM files
       --max-size=SIZE         don't transfer any file larger than SIZE
       --min-size=SIZE         don't transfer any file smaller than SIZE
-@@ -646,7 +650,8 @@ specified, in which case bf(-r) is not implied.
+@@ -658,7 +662,8 @@ specified, in which case bf(-r) is not implied.
  
  Note that bf(-a) bf(does not preserve hardlinks), because
  finding multiply-linked files is expensive.  You must separately
@@ -725,7 +724,7 @@ diff --git a/rsync.yo b/rsync.yo
  
  dit(--no-OPTION) You may turn off one or more implied options by prefixing
  the option name with "no-".  Not all options may be prefixed with a "no-":
-@@ -950,7 +955,7 @@ they would be using bf(--copy-links).
+@@ -963,7 +968,7 @@ they would be using bf(--copy-links).
  Without this option, if the sending side has replaced a directory with a
  symlink to a directory, the receiving side will delete anything that is in
  the way of the new symlink, including a directory hierarchy (as long as
@@ -734,9 +733,9 @@ diff --git a/rsync.yo b/rsync.yo
  
  See also bf(--keep-dirlinks) for an analogous option for the receiving
  side.
-@@ -1113,6 +1118,29 @@ Note that this option does not copy rsyncs special xattr values (e.g. those
- used by bf(--fake-super)) unless you repeat the option (e.g. -XX).  This
- "copy all xattrs" mode cannot be used with bf(--fake-super).
+@@ -1147,6 +1152,29 @@ Note that the bf(-X) option does not copy rsync's special xattr values (e.g.
+ those used by bf(--fake-super)) unless you repeat the option (e.g. -XX).
+ This "copy all xattrs" mode cannot be used with bf(--fake-super).
  
 +dit(bf(--fileflags)) This option causes rsync to update the file-flags to be
 +the same as the source files and directories (if your OS supports the
@@ -764,7 +763,7 @@ diff --git a/rsync.yo b/rsync.yo
  dit(bf(--chmod)) This option tells rsync to apply one or more
  comma-separated "chmod" modes to the permission of the files in the
  transfer.  The resulting value is treated as though it were the permissions
-@@ -1442,12 +1470,13 @@ display as a "*missing" entry in the bf(--list-only) output.
+@@ -1502,12 +1530,13 @@ display as a "*missing" entry in the bf(--list-only) output.
  dit(bf(--ignore-errors)) Tells bf(--delete) to go ahead and delete files
  even when there are I/O errors.
  
@@ -781,7 +780,7 @@ diff --git a/rsync.yo b/rsync.yo
  bf(--recursive) option was also enabled.
  
  dit(bf(--max-delete=NUM)) This tells rsync not to delete more than NUM
-@@ -2081,7 +2110,7 @@ with older versions of rsync, but that also turns on the output of other
+@@ -2144,7 +2173,7 @@ with older versions of rsync, but that also turns on the output of other
  verbose messages).
  
  The "%i" escape has a cryptic output that is 11 letters long.  The general
@@ -790,7 +789,7 @@ diff --git a/rsync.yo b/rsync.yo
  type of update being done, bf(X) is replaced by the file-type, and the
  other letters represent attributes that may be output if they are being
  modified.
-@@ -2137,7 +2166,7 @@ quote(itemization(
+@@ -2200,7 +2229,7 @@ quote(itemization(
    sender's value (requires bf(--owner) and super-user privileges).
    it() A bf(g) means the group is different and is being updated to the
    sender's value (requires bf(--group) and the authority to set the group).
@@ -807,10 +806,10 @@ diff --git a/syscall.c b/syscall.c
  extern int read_only;
  extern int list_only;
 +extern int force_change;
+ extern int inplace;
+ extern int preallocate_files;
  extern int preserve_perms;
- extern int preserve_executability;
- 
-@@ -55,7 +56,23 @@ int do_unlink(const char *fname)
+@@ -67,7 +68,23 @@ int do_unlink(const char *fname)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -835,7 +834,7 @@ diff --git a/syscall.c b/syscall.c
  }
  
  #ifdef SUPPORT_LINKS
-@@ -116,14 +133,37 @@ int do_link(const char *fname1, const char *fname2)
+@@ -128,14 +145,37 @@ int do_link(const char *fname1, const char *fname2)
  }
  #endif
  
@@ -875,7 +874,7 @@ diff --git a/syscall.c b/syscall.c
  }
  
  int do_mknod(const char *pathname, mode_t mode, dev_t dev)
-@@ -163,7 +203,7 @@ int do_mknod(const char *pathname, mode_t mode, dev_t dev)
+@@ -175,7 +215,7 @@ int do_mknod(const char *pathname, mode_t mode, dev_t dev)
  			return -1;
  		close(sock);
  #ifdef HAVE_CHMOD
@@ -884,7 +883,7 @@ diff --git a/syscall.c b/syscall.c
  #else
  		return 0;
  #endif
-@@ -180,7 +220,22 @@ int do_rmdir(const char *pathname)
+@@ -192,7 +232,22 @@ int do_rmdir(const char *pathname)
  {
  	if (dry_run) return 0;
  	RETURN_ERROR_IF_RO_OR_LO;
@@ -908,7 +907,7 @@ diff --git a/syscall.c b/syscall.c
  }
  
  int do_open(const char *pathname, int flags, mode_t mode)
-@@ -194,7 +249,7 @@ int do_open(const char *pathname, int flags, mode_t mode)
+@@ -206,7 +261,7 @@ int do_open(const char *pathname, int flags, mode_t mode)
  }
  
  #ifdef HAVE_CHMOD
@@ -917,7 +916,7 @@ diff --git a/syscall.c b/syscall.c
  {
  	int code;
  	if (dry_run) return 0;
-@@ -217,17 +272,74 @@ int do_chmod(const char *path, mode_t mode)
+@@ -229,17 +284,74 @@ int do_chmod(const char *path, mode_t mode)
  	} else
  		code = chmod(path, mode & CHMOD_BITS); /* DISCOURAGED FUNCTION */
  #endif /* !HAVE_LCHMOD */
@@ -996,17 +995,17 @@ diff --git a/syscall.c b/syscall.c
 diff --git a/t_stub.c b/t_stub.c
 --- a/t_stub.c
 +++ b/t_stub.c
-@@ -28,6 +28,7 @@ int module_id = -1;
- int checksum_len = 0;
+@@ -28,6 +28,7 @@ int protect_args = 0;
+ int module_id = -1;
  int relative_paths = 0;
  int module_dirlen = 0;
 +int force_change = 0;
  int preserve_acls = 0;
  int preserve_times = 0;
  int preserve_xattrs = 0;
-@@ -97,3 +98,23 @@ filter_rule_list daemon_filter_list;
+@@ -102,3 +103,23 @@ filter_rule_list daemon_filter_list;
  {
- 	return "tester";
+ 	return cst || !flg ? 16 : 1;
  }
 +
 +#if defined SUPPORT_FILEFLAGS || defined SUPPORT_FORCE_CHANGE
@@ -1077,7 +1076,7 @@ diff --git a/util.c b/util.c
  {
  	static int switch_step = 0;
  
-@@ -132,6 +160,11 @@ int set_modtime(const char *fname, time_t modtime, uint32 mod_nsec, mode_t mode)
+@@ -142,6 +170,11 @@ int set_modtime(const char *fname, time_t modtime, uint32 mod_nsec, mode_t mode)
  #include "case_N.h"
  		if (do_utimensat(fname, modtime, mod_nsec) == 0)
  			break;
@@ -1089,7 +1088,7 @@ diff --git a/util.c b/util.c
  		if (errno != ENOSYS)
  			return -1;
  		switch_step++;
-@@ -142,6 +175,11 @@ int set_modtime(const char *fname, time_t modtime, uint32 mod_nsec, mode_t mode)
+@@ -152,6 +185,11 @@ int set_modtime(const char *fname, time_t modtime, uint32 mod_nsec, mode_t mode)
  #include "case_N.h"
  		if (do_lutimes(fname, modtime, mod_nsec) == 0)
  			break;
@@ -1101,7 +1100,7 @@ diff --git a/util.c b/util.c
  		if (errno != ENOSYS)
  			return -1;
  		switch_step++;
-@@ -165,6 +203,13 @@ int set_modtime(const char *fname, time_t modtime, uint32 mod_nsec, mode_t mode)
+@@ -175,6 +213,13 @@ int set_modtime(const char *fname, time_t modtime, uint32 mod_nsec, mode_t mode)
  		if (do_utime(fname, modtime, mod_nsec) == 0)
  			break;
  #endif
@@ -1118,7 +1117,7 @@ diff --git a/util.c b/util.c
 diff --git a/xattrs.c b/xattrs.c
 --- a/xattrs.c
 +++ b/xattrs.c
-@@ -1045,7 +1045,7 @@ int set_stat_xattr(const char *fname, struct file_struct *file, mode_t new_mode)
+@@ -1224,7 +1224,7 @@ int set_stat_xattr(const char *fname, struct file_struct *file, mode_t new_mode)
  	mode = (fst.st_mode & _S_IFMT) | (fmode & ACCESSPERMS)
  	     | (S_ISDIR(fst.st_mode) ? 0700 : 0600);
  	if (fst.st_mode != mode)
@@ -1143,7 +1142,7 @@ diff -Nurp a/config.h.in b/config.h.in
 diff -Nurp a/configure.sh b/configure.sh
 --- a/configure.sh
 +++ b/configure.sh
-@@ -7687,6 +7687,7 @@ fi
+@@ -7706,6 +7706,7 @@ fi
  
  for ac_func in waitpid wait4 getcwd strdup chown chmod lchmod mknod mkfifo \
      fchmod fstat ftruncate strchr readlink link utime utimes lutimes strftime \
@@ -1154,7 +1153,7 @@ diff -Nurp a/configure.sh b/configure.sh
 diff -Nurp a/proto.h b/proto.h
 --- a/proto.h
 +++ b/proto.h
-@@ -287,6 +287,8 @@ int read_ndx_and_attrs(int f_in, int f_o
+@@ -298,6 +298,8 @@ int read_ndx_and_attrs(int f_in, int f_o
  void free_sums(struct sum_struct *s);
  mode_t dest_mode(mode_t flist_mode, mode_t stat_mode, int dflt_perms,
  		 int exists);
@@ -1163,7 +1162,7 @@ diff -Nurp a/proto.h b/proto.h
  int set_file_attrs(const char *fname, struct file_struct *file, stat_x *sxp,
  		   const char *fnamecmp, int flags);
  void sig_int(int sig_num);
-@@ -311,11 +313,12 @@ int do_unlink(const char *fname);
+@@ -322,11 +324,12 @@ int do_unlink(const char *fname);
  int do_symlink(const char *lnk, const char *fname);
  ssize_t do_readlink(const char *path, char *buf, size_t bufsiz);
  int do_link(const char *fname1, const char *fname2);
@@ -1178,7 +1177,7 @@ diff -Nurp a/proto.h b/proto.h
  int do_rename(const char *fname1, const char *fname2);
  int do_ftruncate(int fd, OFF_T size);
  void trim_trailing_slashes(char *name);
-@@ -354,7 +357,7 @@ void set_nonblocking(int fd);
+@@ -367,7 +370,7 @@ void set_nonblocking(int fd);
  void set_blocking(int fd);
  int fd_pair(int fd[2]);
  void print_child_argv(const char *prefix, char **cmd);
@@ -1198,7 +1197,7 @@ diff -Nurp a/rsync.1 b/rsync.1
   \-E, \-\-executability         preserve executability
       \-\-chmod=CHMOD           affect file and/or directory permissions
   \-A, \-\-acls                  preserve ACLs (implies \-p)
-@@ -473,7 +474,10 @@ to the detailed description below for a
+@@ -474,7 +475,10 @@ to the detailed description below for a
       \-\-ignore\-missing\-args   ignore missing source args without error
       \-\-delete\-missing\-args   delete missing source args from destination
       \-\-ignore\-errors         delete even if there are I/O errors
@@ -1210,7 +1209,7 @@ diff -Nurp a/rsync.1 b/rsync.1
       \-\-max\-delete=NUM        don'\&t delete more than NUM files
       \-\-max\-size=SIZE         don'\&t transfer any file larger than SIZE
       \-\-min\-size=SIZE         don'\&t transfer any file smaller than SIZE
-@@ -745,7 +749,8 @@ specified, in which case \fB\-r\fP is no
+@@ -761,7 +765,8 @@ specified, in which case \fB\-r\fP is no
  .IP 
  Note that \fB\-a\fP \fBdoes not preserve hardlinks\fP, because
  finding multiply\-linked files is expensive.  You must separately
@@ -1220,7 +1219,7 @@ diff -Nurp a/rsync.1 b/rsync.1
  .IP 
  .IP "\-\-no\-OPTION"
  You may turn off one or more implied options by prefixing
-@@ -1087,7 +1092,7 @@ they would be using \fB\-\-copy\-links\f
+@@ -1101,7 +1106,7 @@ they would be using \fB\-\-copy\-links\f
  Without this option, if the sending side has replaced a directory with a
  symlink to a directory, the receiving side will delete anything that is in
  the way of the new symlink, including a directory hierarchy (as long as
@@ -1229,9 +1228,9 @@ diff -Nurp a/rsync.1 b/rsync.1
  .IP 
  See also \fB\-\-keep\-dirlinks\fP for an analogous option for the receiving
  side.
-@@ -1274,6 +1279,33 @@ Note that this option does not copy rsyn
- used by \fB\-\-fake\-super\fP) unless you repeat the option (e.g. \-XX).  This
- \(dq\&copy all xattrs\(dq\& mode cannot be used with \fB\-\-fake\-super\fP.
+@@ -1315,6 +1320,33 @@ Note that the \fB\-X\fP option does not
+ those used by \fB\-\-fake\-super\fP) unless you repeat the option (e.g. \-XX).
+ This \(dq\&copy all xattrs\(dq\& mode cannot be used with \fB\-\-fake\-super\fP.
  .IP 
 +.IP "\fB\-\-fileflags\fP"
 +This option causes rsync to update the file\-flags to be
@@ -1263,7 +1262,7 @@ diff -Nurp a/rsync.1 b/rsync.1
  .IP "\fB\-\-chmod\fP"
  This option tells rsync to apply one or more
  comma\-separated \(dq\&chmod\(dq\& modes to the permission of the files in the
-@@ -1640,13 +1672,14 @@ display as a \(dq\&*missing\(dq\& entry
+@@ -1705,13 +1737,14 @@ display as a \(dq\&*missing\(dq\& entry
  Tells \fB\-\-delete\fP to go ahead and delete files
  even when there are I/O errors.
  .IP 
@@ -1281,7 +1280,7 @@ diff -Nurp a/rsync.1 b/rsync.1
  \fB\-\-recursive\fP option was also enabled.
  .IP 
  .IP "\fB\-\-max\-delete=NUM\fP"
-@@ -2364,7 +2397,7 @@ with older versions of rsync, but that a
+@@ -2429,7 +2462,7 @@ with older versions of rsync, but that a
  verbose messages).
  .IP 
  The \(dq\&%i\(dq\& escape has a cryptic output that is 11 letters long.  The general
@@ -1290,7 +1289,7 @@ diff -Nurp a/rsync.1 b/rsync.1
  type of update being done, \fBX\fP is replaced by the file\-type, and the
  other letters represent attributes that may be output if they are being
  modified.
-@@ -2434,7 +2467,7 @@ sender\(cq\&s value (requires \fB\-\-own
+@@ -2499,7 +2532,7 @@ sender\(cq\&s value (requires \fB\-\-own
  A \fBg\fP means the group is different and is being updated to the
  sender\(cq\&s value (requires \fB\-\-group\fP and the authority to set the group).
  .IP o 


### PR DESCRIPTION
#### Description
* update to version 3.1.3
* disable hfs-compression patches which are broken upstream

`sudo port test` fails with an error (below), but the port builds, installs, and functions correctly. Fixes an error where rsync 3.1.2 was crashing when syncing with a 3.1.3 client.

```
--->  Testing rsync
Executing:  cd "/opt/local/var/macports/build/_Users_agamemnon_ports_net_rsync/rsync/work/rsync-3.1.3" && /usr/bin/make check 
/usr/bin/clang -I. -I. -I./zlib -pipe -Os -arch x86_64 -DHAVE_CONFIG_H -Wall -W -I/opt/local/include -c tls.c -o tls.o
/usr/bin/clang -I. -I. -I./zlib -pipe -Os -arch x86_64 -DHAVE_CONFIG_H -Wall -W -I/opt/local/include -c t_stub.c -o t_stub.o
/usr/bin/clang -I./zlib -pipe -Os -arch x86_64 -DHAVE_CONFIG_H -Wall -W -L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64 -o tls tls.o syscall.o t_stub.o lib/compat.o lib/snprintf.o lib/permstring.o lib/sysxattrs.o  -lpopt -liconv 
duplicate symbol _inplace in:
    tls.o
    t_stub.o
duplicate symbol _preallocate_files in:
    tls.o
    t_stub.o
ld: 2 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [tls] Error 1
Command failed:  cd "/opt/local/var/macports/build/_Users_agamemnon_ports_net_rsync/rsync/work/rsync-3.1.3" && /usr/bin/make check 
Exit code: 2
Error: Failed to test rsync: command execution failed
Error: See /opt/local/var/macports/logs/_Users_agamemnon_ports_net_rsync/rsync/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port rsync failed
```

###### Type(s)
- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

macOS 10.5.8 9L31a
Xcode 3.1.3 DevToolsSupport-1186.0 9M2736 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?