### PR TITLE
spring-boot-cli: Update to 1.5.10.RELEASE

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.9
+version         1.5.10
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  5ee13b85e68fc0a6adb01796d4ceba7428c14e17 \
-                sha256  44fe67ce80fc6f272ebac36bafbffe36a6c794d991deb46bc480db0113b42e9b
+checksums       rmd160  bf4f27645dee361cca58ff8dd73787dca7684aa0 \
+                sha256  1d0a6a6660a2e2245c2d5f65d193f8a96115dc7ed1df36634c30e749825742f5
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot 1.5.10.RELEASE.

###### Tested on

macOS 10.13.3 17D47
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?