### PR TITLE
faust-devel: update to latest upstream

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -4,10 +4,10 @@ PortSystem              1.0
 PortGroup               cxx11 1.1
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust e03acc7549fb8e3dc5e0dcd5b6cc01529ce95d90
+github.setup            grame-cncm faust f67c2e48a855f0379623ff76cb424376e8879296
 # When updating faust-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.5-20180205
+version                 2.5-20180211
 
 name                    faust-devel
 conflicts               faust


### PR DESCRIPTION
Latest upstream, fixes a compiler bug.

Again, an update of faustlive-devel isn't needed as it still works ok with this version.

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b