### PR TITLE
faust: update to 2.5.21

### DIFF
--- a/audio/faust/Portfile
+++ b/audio/faust/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cxx11 1.1
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 2.5.17
+github.setup            grame-cncm faust 2.5.21
 github.tarball_from     releases
 
 conflicts               faust-devel
@@ -20,9 +20,9 @@ long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
                         and plugins.
 
-checksums               rmd160  bd22e6b42ba8ef7a12f0903711500ca0ea1a6aa3 \
-                        sha256  5e9e76dc4754efbf31eb8b63ee4f3e2e5ec5f6fe20dac611af859357bf4a1893 \
-                        size    47142694
+checksums               rmd160  6a356de1a359fdc93f5d93405606a69bd3d83ccb \
+                        sha256  6de2214316f9137cabf95bf075a599963cfe5305ab83d944e869bec417956f2f \
+                        size    47453689
 
 set llvm_version        3.4
 if {${os.platform} eq "darwin" && ${os.major} > 14} {


### PR DESCRIPTION
Update to latest release from upstream.

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b