### PR TITLE
devel/boost: fix circular dependency of boost on itself.

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -6,7 +6,7 @@ PortGroup       mpi 1.0
 
 name            boost
 version         1.65.1
-revision        3
+revision        4
 license         Boost-1
 categories      devel
 platforms       darwin
@@ -45,7 +45,8 @@ post-extract {
 
 patchfiles      patch-tools-build-src-engine-build.sh.diff \
                 patch-tools-build-src-engine-build.jam.diff \
-                patch-apple-clang-no-libcxx.diff
+                patch-apple-clang-no-libcxx.diff \
+                patch-disable-numpy-extension.diff
                 # patch-apple-clang-no-libcxx.diff fixes a clang configuration
                 # error that occurs on OS X 10.7 and 10.8 due to the assumption
                 # that if clang is the compiler in use it must be using libc++.
@@ -200,7 +201,7 @@ foreach s ${pythons_suffixes} {
         # The issue has been reported to both the MacPorts team and the boost team, as per:
         # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
 
-        depends_lib-append      port:${p} port:py${s}-numpy
+        depends_lib-append      port:${p}
         configure.args-delete   --without-libraries=python
         configure.args-append   --with-python=${prefix}/bin/python${v} --with-python-root=${prefix}/bin/python${v}
 
@@ -252,6 +253,15 @@ http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub
     post-patch {
         reinplace {/#define BOOST_REGEX_MATCH_EXTRA/s:^// ::} \
             ${worksrcpath}/boost/regex/user.hpp
+    }
+}
+
+variant numpy description {Enable Numpy support} {
+    patchfiles-delete patch-disable-numpy-extension.diff
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            depends_lib-append port:py${s}-numpy
+        }
     }
 }
 

--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -6,8 +6,12 @@ PortGroup       mpi 1.0
 PortGroup       active_variants 1.1
 
 name            boost
-version         1.65.1
-revision        4
+
+version         1.66.0
+checksums       rmd160  ee5dafdfa49adf50a5333cef1f55dac4f70b4c14 \
+                sha256  5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9 \
+                size    85995778
+
 license         Boost-1
 categories      devel
 platforms       darwin
@@ -25,10 +29,6 @@ master_sites    https://dl.bintray.com/boostorg/release/${version}/source/
 set distver     [join [split ${version} .] _]
 distname        ${name}_${distver}
 use_bzip2       yes
-
-checksums       rmd160  695537a00f6f9ae80e4d682b155ce097017c49a9 \
-                sha256  9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81 \
-                size    82594767
 
 depends_lib     port:zlib \
                 port:expat \

--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -241,6 +241,7 @@ http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub
 subport boost-numpy {
     description Boost.Numpy library
     long_description ${description}
+    depends_lib port:boost
     foreach s ${pythons_suffixes} {
         if {[variant_isset python${s}]} {
             depends_lib-append port:py${s}-numpy

--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -3,6 +3,7 @@
 PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       mpi 1.0
+PortGroup       active_variants 1.1
 
 name            boost
 version         1.65.1
@@ -45,8 +46,7 @@ post-extract {
 
 patchfiles      patch-tools-build-src-engine-build.sh.diff \
                 patch-tools-build-src-engine-build.jam.diff \
-                patch-apple-clang-no-libcxx.diff \
-                patch-disable-numpy-extension.diff
+                patch-apple-clang-no-libcxx.diff
                 # patch-apple-clang-no-libcxx.diff fixes a clang configuration
                 # error that occurs on OS X 10.7 and 10.8 due to the assumption
                 # that if clang is the compiler in use it must be using libc++.
@@ -152,24 +152,6 @@ pre-destroot {
     system "find ${worksrcpath} -type f -name '*.gch' -exec rm {} \\;"
 }
 
-post-destroot {
-    set docdir ${prefix}/share/doc/${name}
-    xinstall -d ${destroot}${docdir}
-    set l [expr [string length ${worksrcpath}] + 1]
-    fs-traverse f [glob -directory ${worksrcpath} *] {
-        set dest ${destroot}${docdir}/[string range ${f} ${l} end]
-        if {[file isdirectory ${f}]} {
-            if {[file tail ${f}] eq "example"} {
-                copy ${f} ${dest}
-                continue
-            }
-            xinstall -d ${dest}
-        } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
-            xinstall -m 644 ${f} ${dest}
-        }
-    }
-}
-
 set pythons_suffixes {26 27 33 34 35 36}
 
 set pythons_ports {}
@@ -256,45 +238,78 @@ http://www.boost.org/doc/libs/${distver}/libs/regex/doc/html/boost_regex/ref/sub
     }
 }
 
-variant numpy description {Enable Numpy support} {
-    patchfiles-delete patch-disable-numpy-extension.diff
+subport boost-numpy {
+    description Boost.Numpy library
+    long_description ${description}
     foreach s ${pythons_suffixes} {
         if {[variant_isset python${s}]} {
             depends_lib-append port:py${s}-numpy
+            require_active_variants boost python${s} 
         }
     }
 }
 
-if {[mpi_variant_isset]} {
-
-    # There is a conflict with debug support.
-    # The issue has been reported to both the MacPorts team and the boost team, as per:
-    # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
-    if {[variant_isset debug]} {
-        return -code error "+debug variant conflicts with mpi"
+if {$subport eq $name} {
+    patchfiles-append patch-disable-numpy-extension.diff
+    post-destroot {
+        set docdir ${prefix}/share/doc/${name}
+        xinstall -d ${destroot}${docdir}
+        set l [expr [string length ${worksrcpath}] + 1]
+        fs-traverse f [glob -directory ${worksrcpath} *] {
+            set dest ${destroot}${docdir}/[string range ${f} ${l} end]
+            if {[file isdirectory ${f}]} {
+                if {[file tail ${f}] eq "example"} {
+                    copy ${f} ${dest}
+                    continue
+                }
+                xinstall -d ${dest}
+            } elseif {[lsearch -exact {css htm html png svg} [string range [file extension ${f}] 1 end]] != -1} {
+                xinstall -m 644 ${f} ${dest}
+            }
+        }
     }
 
-    configure.args-delete   --without-libraries=mpi
+    if {[mpi_variant_isset]} {
 
-    post-configure {
-        write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
-    }
-
-    if {![catch python_dir]} {
-
-        patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
-
-        post-destroot {
-            set site_packages [python_dir]
-            xinstall -d ${destroot}${site_packages}/boost
-            xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
-                ${destroot}${site_packages}/boost
-
-            set l ${site_packages}/boost/mpi.so
-            move ${destroot}${prefix}/lib/mpi.so ${destroot}${l}
-            system "install_name_tool -id ${l} ${destroot}${l}"
+        # There is a conflict with debug support.
+        # The issue has been reported to both the MacPorts team and the boost team, as per:
+        # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>
+        if {[variant_isset debug]} {
+            return -code error "+debug variant conflicts with mpi"
         }
 
+        configure.args-delete   --without-libraries=mpi
+
+        post-configure {
+            write_jam "using mpi : ${mpi.cxx} : : ${mpi.exec} ;"
+        }
+
+        if {![catch python_dir]} {
+
+            patchfiles-append patch-libs-mpi-build-Jamfile.v2.diff
+
+            post-destroot {
+                set site_packages [python_dir]
+                xinstall -d ${destroot}${site_packages}/boost
+                xinstall -m 644 ${worksrcpath}/libs/mpi/build/__init__.py \
+                    ${destroot}${site_packages}/boost
+
+                set l ${site_packages}/boost/mpi.so
+                move ${destroot}${prefix}/lib/mpi.so ${destroot}${l}
+                system "install_name_tool -id ${l} ${destroot}${l}"
+            }
+
+        }
+    }
+} else {
+    post-destroot {
+        move {*}[glob ${destroot}${prefix}/lib/libboost_numpy*] ${destroot}${prefix}
+        delete ${destroot}${prefix}/Library \
+            ${destroot}${prefix}/include \
+            ${destroot}${prefix}/lib \
+            ${destroot}${prefix}/share
+        file mkdir ${destroot}${prefix}/lib
+        move {*}[glob ${destroot}${prefix}/libboost_numpy*] ${destroot}${prefix}/lib
     }
 }
 

--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -8,6 +8,7 @@ PortGroup       active_variants 1.1
 name            boost
 
 version         1.66.0
+revision        1
 checksums       rmd160  ee5dafdfa49adf50a5333cef1f55dac4f70b4c14 \
                 sha256  5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9 \
                 size    85995778

--- a/devel/boost/files/patch-disable-numpy-extension.diff
+++ b/devel/boost/files/patch-disable-numpy-extension.diff
@@ -1,0 +1,22 @@
+--- tools/build/src/tools/python.jam.orig	2018-02-12 14:59:36.000000000 -0600
++++ tools/build/src/tools/python.jam	2018-02-12 15:11:25.000000000 -0600
+@@ -841,18 +841,7 @@
+     local full-cmd = $(interpreter-cmd)" -c \"$(full-cmd)\"" ;
+     debug-message "running command '$(full-cmd)'" ;
+     local result = [ SHELL $(full-cmd) : strip-eol : exit-status ] ;
+-    if $(result[2]) = 0
+-    {
+-        .numpy = true ;
+-        .numpy-include = $(result[1]) ;
+-        debug-message "NumPy enabled" ;
+-    }
+-    else
+-    {
+-        debug-message "NumPy disabled. Reason:" ;
+-        debug-message "  $(full-cmd) aborted with " ;
+-        debug-message "  $(result[1])" ;
+-    }
++    debug-message "NumPy disabled." ;
+ 
+     #
+     # End autoconfiguration sequence.


### PR DESCRIPTION

#### Description

fix circular dependency of boost on itself.
add numpy variant. See https://trac.macports.org/ticket/55807

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?