### PR TITLE
kotlin: fix 'kotlin -version'

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 
 github.setup        JetBrains kotlin 1.2.21 v
 github.tarball_from releases
+revision            1
 distname            ${name}-compiler-${version}
 categories          lang java
 platforms           darwin
@@ -43,8 +44,6 @@ destroot {
          ${destroot}${prefix}/share/java/${name}
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/
     file rename ${destroot}${prefix}/share/java/${name}/license \
-        ${destroot}${prefix}/share/doc/${name}
-    file rename ${destroot}${prefix}/share/java/${name}/build.txt \
         ${destroot}${prefix}/share/doc/${name}
 
     foreach f [glob -tails -directory ${destroot}${prefix}/share/java/${name}/bin *] {


### PR DESCRIPTION
#### Description

Leave build.txt in its default location, because 'kotlin -version'
expects it to be there.

Closes: https://trac.macports.org/ticket/55806

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?