### PR TITLE
libatomic_ops[-devel]: update to v7.6.2

### DIFF
--- a/devel/libatomic_ops/Portfile
+++ b/devel/libatomic_ops/Portfile
@@ -7,22 +7,12 @@ PortGroup           muniversal 1.0
 name                libatomic_ops
 subport             libatomic_ops-devel {}
 
-if {${subport} eq ${name}} {
-    github.setup    ivmai libatomic_ops 7_4_4 libatomic_ops-
-    version         [string map {_ .} ${version}]
+github.setup        ivmai libatomic_ops 7.6.2 v
+checksums           rmd160  b726bcf9dcb92c9304555342144ecd79e8589663 \
+                    sha256  f0290ebe34bc8f62d153aab4b644e4365b82a63820f1ff861282d460e44f10f6
 
-    checksums       rmd160  c35b899b9a3b2ca58acb322d625c7cb258dac87b \
-                    sha256  5442bf5df1bd10d3abe8aa658f1e3bf6081f56ddfdb84b2b2a1f396f54a7f086
-} else {
-    github.setup    ivmai libatomic_ops f98d476f
-    version         7.5.0-git-20170112
-
-    checksums       rmd160  1fbac9a603a6680cb741df2d6d9465a694c9c2f2 \
-                    sha256  34f13e0e9a9ec91c985d6140a99dc554fb315be01083841f6e62db54da274a4a
-
-    # not sure if there is any reasonable alternative
-    livecheck.type  none
-}
+# not sure if there is any reasonable alternative
+livecheck.type  none
 
 maintainers         nomaintainer
 categories          devel
@@ -35,6 +25,7 @@ description         library for hardware-provided atomic memory operations
 long_description    This package provides semi-portable access to \
                     hardware-provided atomic memory operations.
 
+# needed since we use the github version
 use_autoreconf      yes
 
 test.run            yes


### PR DESCRIPTION
#### Description

- Update libatomic_ops and libatomic_ops-devel packages to version 7.6.2 (the latest stable release)
- Use the distributed source tarball instead of checking out source from git repository by tag or commit
- Do not use autoreconf (not needed because the tarball already contains generated configure/Makefile
- Add maintainer email
- Add regex livecheck

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on

macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tested basic functionality of all binary files?
