### PR TITLE
cad/gtkwave: v3.3.87, using gtk-osx-application-gtk2

### DIFF
--- a/cad/gtkwave/Portfile
+++ b/cad/gtkwave/Portfile
@@ -1,36 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 PortSystem 1.0
 
-name		gtkwave
-version		3.3.48
-categories	cad
-platforms	darwin
-license		GPL-2+
-maintainers	nomaintainer
-description	A viewer for common electronic CAD waveform files.
-long_description	\
-	GTKWave is a fully featured GTK+ based wave viewer for Unix	\
-	and Win32 which reads LXT, LXT2, VZT, and GHW files as well	\
-	as standard Verilog VCD/EVCD files and allows their viewing.
+name            gtkwave
+version         3.3.48
+categories      cad
+platforms       darwin
+license         GPL-2+
+maintainers     nomaintainer
+description     A viewer for common electronic CAD waveform files.
+long_description        \
+        GTKWave is a fully featured GTK+ based wave viewer for Unix     \
+        and Win32 which reads LXT, LXT2, VZT, and GHW files as well     \
+        as standard Verilog VCD/EVCD files and allows their viewing.
 
-homepage	http://gtkwave.sourceforge.net
-master_sites	sourceforge:project/gtkwave/gtkwave-${version}
+homepage        http://gtkwave.sourceforge.net
+master_sites    sourceforge:project/gtkwave/gtkwave-${version}
  
-checksums	rmd160  04d1d0a67a25d5cd19f6bb80d613c362e19c91e2 \
-		sha256  420e25a0eddcb54fa137a9ffee9642d3b6fccebfbaf8d2296c687447015165fd
+checksums       rmd160  04d1d0a67a25d5cd19f6bb80d613c362e19c91e2 \
+                sha256  420e25a0eddcb54fa137a9ffee9642d3b6fccebfbaf8d2296c687447015165fd
 
-depends_build	port:pkgconfig
+depends_build   port:pkgconfig
 
-depends_lib	port:bzip2 \
-		port:gtk2 \
-		port:tk \
-		port:xz \
-		port:zlib
+depends_lib     port:bzip2 \
+                port:gtk2 \
+                port:gtk-osx-application-gtk2 \
+                port:tk \
+                port:xz \
+                port:zlib
 
-configure.args	--with-tcl=${prefix}/lib \
-		--with-tk=${prefix}/lib \
-		--disable-mime-update
+post-patch {
+    reinplace {s/GtkOSXApplication/GtkosxApplication/g
+        s/GTK_TYPE_OSX_APPLICATION/GTKOSX_TYPE_APPLICATION/g
+        s/gtk_osxapplication/gtkosx_application/g
+        s/quartz_application/gtkosx_application/g} \
+        ${worksrcpath}/src/main.c \
+        ${worksrcpath}/src/menu.c \
+        ${worksrcpath}/src/rc.c \
+        ${worksrcpath}/src/savefile.c \
+        ${worksrcpath}/src/savefile.h
+}
+
+configure.args  --with-tcl=${prefix}/lib \
+                --with-tk=${prefix}/lib \
+                --disable-mime-update \
+                "GTK_MAC_CFLAGS=\"\$(${prefix}/bin/pkg-config --cflags gtk-mac-integration-gtk2)\"" \
+                "GTK_MAC_LIBS=\"\$(${prefix}/bin/pkg-config --libs gtk-mac-integration-gtk2)\""
 
 post-activate {
-	system "${prefix}/bin/update-desktop-database -q ${prefix}/share/applications; true"
-	system "${prefix}/bin/update-mime-database ${prefix}/share/mime; true"
+        system "${prefix}/bin/update-desktop-database -q ${prefix}/share/applications; true"
+        system "${prefix}/bin/update-mime-database ${prefix}/share/mime; true"
 }

--- a/cad/gtkwave/Portfile
+++ b/cad/gtkwave/Portfile
@@ -2,7 +2,7 @@
 PortSystem 1.0
 
 name            gtkwave
-version         3.3.48
+version         3.3.87
 categories      cad
 platforms       darwin
 license         GPL-2+
@@ -16,8 +16,9 @@ long_description        \
 homepage        http://gtkwave.sourceforge.net
 master_sites    sourceforge:project/gtkwave/gtkwave-${version}
  
-checksums       rmd160  04d1d0a67a25d5cd19f6bb80d613c362e19c91e2 \
-                sha256  420e25a0eddcb54fa137a9ffee9642d3b6fccebfbaf8d2296c687447015165fd
+checksums       sha1 8aa13b6ce1c20483562a210beae9078ddd3428a3 \
+                rmd160 acb85f76024b75d2fc5fc9817c07e32c787da47f \
+                sha256 c6e552716876c8b88c8f6e36e3614a8c53a32cef7895e2c1e6e608daf0ee5b7a
 
 depends_build   port:pkgconfig
 
@@ -27,18 +28,6 @@ depends_lib     port:bzip2 \
                 port:tk \
                 port:xz \
                 port:zlib
-
-post-patch {
-    reinplace {s/GtkOSXApplication/GtkosxApplication/g
-        s/GTK_TYPE_OSX_APPLICATION/GTKOSX_TYPE_APPLICATION/g
-        s/gtk_osxapplication/gtkosx_application/g
-        s/quartz_application/gtkosx_application/g} \
-        ${worksrcpath}/src/main.c \
-        ${worksrcpath}/src/menu.c \
-        ${worksrcpath}/src/rc.c \
-        ${worksrcpath}/src/savefile.c \
-        ${worksrcpath}/src/savefile.h
-}
 
 configure.args  --with-tcl=${prefix}/lib \
                 --with-tk=${prefix}/lib \


### PR DESCRIPTION
#### Description

This fixes failures of `port install gtkwave` similar to [Ticket 41523](https://trac.macports.org/ticket/41523) where `configure` complained about not finding `gtk-mac-integration`. I added `port:gtk-osx-application-gtk2` to the dependencies and patched (by `reinplace`) the naming schemes used by `gtkwave` to those offered by the `gtk-osx-application-gtk2` port.

While at that, I also added a modeline and normalized whitespace by piping through `expand`. Since this step clutters the diff a bit, here is the `git diff -b` version:

~~~ diff
--- a/cad/gtkwave/Portfile
+++ b/cad/gtkwave/Portfile
@@ -1,3 +1,4 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 PortSystem 1.0
 
 name            gtkwave
@@ -22,13 +23,28 @@ depends_build	port:pkgconfig
 
 depends_lib     port:bzip2 \
                 port:gtk2 \
+                port:gtk-osx-application-gtk2 \
                 port:tk \
                 port:xz \
                 port:zlib
 
+post-patch {
+    reinplace {s/GtkOSXApplication/GtkosxApplication/g
+        s/GTK_TYPE_OSX_APPLICATION/GTKOSX_TYPE_APPLICATION/g
+        s/gtk_osxapplication/gtkosx_application/g
+        s/quartz_application/gtkosx_application/g} \
+        ${worksrcpath}/src/main.c \
+        ${worksrcpath}/src/menu.c \
+        ${worksrcpath}/src/rc.c \
+        ${worksrcpath}/src/savefile.c \
+        ${worksrcpath}/src/savefile.h
+}
+
 configure.args  --with-tcl=${prefix}/lib \
                 --with-tk=${prefix}/lib \
-		--disable-mime-update
+                --disable-mime-update \
+                "GTK_MAC_CFLAGS=\"\$(${prefix}/bin/pkg-config --cflags gtk-mac-integration-gtk2)\"" \
+                "GTK_MAC_LIBS=\"\$(${prefix}/bin/pkg-config --libs gtk-mac-integration-gtk2)\""
 
 post-activate {
         system "${prefix}/bin/update-desktop-database -q ${prefix}/share/applications; true"
~~~
**Update:** Turns out that upgrading to 3.3.87 no longer needs the `post-patch`. I have added another commit to that effect.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8 9L31a `darwin9-powerpc`
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
