### PR TITLE
math/libfaiss: add port.

### DIFF
--- a/math/libfaiss/Portfile
+++ b/math/libfaiss/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           compilers 1.0
+
+github.setup        facebookresearch faiss 56383610bcb982d6591e2e2bea3516cb7723e04a
+name                libfaiss
+version             20180214
+checksums           rmd160  e699f7ec89d8c6d5c4957022d26d162ab3b85d62 \
+                    sha256  6ef05ff911e68bb4ff3f209d2abb3a2e57d36f308176e1555266ecd055c565bf
+categories          math
+license             BSD
+platforms           darwin
+maintainers         {@beauby fb.com:hoss} {@mdouze fb.com:matthijs} \
+                    openmaintainer
+
+description         Efficient similarity search library from Facebook AI Research.
+long_description    Library for efficient similarity search and clustering of \
+                    dense vectors. It contains algorithms that search in sets \
+                    of vectors of any size, up to ones that possibly do not \
+                    fit in RAM. It also contains supporting code for \
+                    evaluation and parameter tuning. Faiss is written in C++ \
+                    with complete wrappers for Python/numpy. Some of the most \
+                    useful algorithms are implemented on the GPU.
+
+compilers.choose    cxx
+# The Apple native llvm compiler does not support OpenMP.
+compiler.blacklist  llvm-gcc-4.2
+compiler.fallback   macports-gcc-7
+compilers.setup
+
+use_configure       no
+
+pre-build {
+    touch ${worksrcpath}/makefile.inc
+}
+
+build.env-append    CC="${configure.cxx}"
+build.env-append    CFLAGS="-fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp \
+                            -Wno-sign-compare -std=c++11 -I/usr/include/malloc/"
+build.env-append    LDFLAGS="-g -fPIC -fopenmp"
+build.env-append    SHAREDEXT="dylib"
+build.env-append    SHAREDFLAGS="-Wl,-F. -bundle -undefined dynamic_lookup"
+build.env-append    FAISSSHAREDFLAGS="-dynamiclib"
+build.env-append    BLASCFLAGS="-DFINTEGER=int"
+build.env-append    BLASLDFLAGS="-framework Accelerate"
+build.target        libfaiss.a libfaiss.dylib
+
+destroot.target
+destroot.destdir
+destroot.cmd        mkdir -p ${destroot}${prefix}/lib && \
+                    cp libfaiss.a libfaiss.dylib ${destroot}${prefix}/lib && \
+                    mkdir -p ${destroot}${prefix}/include/faiss && \
+                    cp -R ./*.h ${destroot}${prefix}/include/faiss/
+
+variant openblas description {Use OpenBLAS instead of Apple's Accelerate framework} {
+    depends_lib-append  port:openblas
+    build.env-delete    BLASLDFLAGS="-framework Accelerate"
+    build.env-append    BLASLDFLAGS="${prefix}/lib/libopenblas.dylib"
+}
+
+default_variants +openblas


### PR DESCRIPTION
#### Description

Add port for [Faiss](https://github.com/facebookresearch/faiss/), a library for efficient similarity search and clustering of dense vectors.

###### Tested on

macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
    -> Fails with `Failed to locate 'lbzip2' in path: '/opt/local/bin:/opt/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin' or at its MacPorts configuration time location, did you move it?` while attempting to extract `OpenBLAS` (a dependency of this port). Any ideas?
