### PR TITLE
py-mdtraj: new port submission

### DIFF
--- a/python/py-mdtraj/Portfile
+++ b/python/py-mdtraj/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        mdtraj mdtraj 1.9.0
+name                py-mdtraj
+homepage            http://www.mdtraj.org
+platforms           darwin
+license             LGPL-2.1+
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+
+description         A modern, open library for the analysis of molecular dynamics trajectories
+long_description    Read, write and analyze MD trajectories with only a few lines of Python code. \
+                    For details, see the website at mdtraj.org. MDTraj is research software. \
+                    If you make use of MDTraj in scientific publications, please cite it.
+
+supported_archs     i386 x86_64
+
+checksums           rmd160  58a3684fdf7a81813699aa281c411c04b130b91b \
+                    sha256  e93db244035b7551488cea24d96dd813e67ce655461fc50f53c4d8a9cd8bd7ca
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    depends_build-append port:py${python.version}-cython
+
+    depends_lib-append port:py${python.version}-numpy \
+                       port:py${python.version}-scipy \
+                       port:py${python.version}-pandas \
+                       port:py${python.version}-setuptools \
+                       port:py${python.version}-tables
+
+# tests cannot be implemented since they require too many packages
+# not available on MacPorts
+}
+


### PR DESCRIPTION
#### Description

Portfile for the [mdtraj python module](http://www.mdtraj.org).

Notice that mdtraj compiles some C code. For this reason, I added this line:
````
supported_archs     i386 x86_64
````
instead of `noarch`. Hopefully it is correct.

###### Tested on
macOS 10.11.6 15G18013
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
