### PR TITLE
boehmgc: update to v7.6.4; use tarball, not git repository

### DIFF
--- a/devel/boehmgc/Portfile
+++ b/devel/boehmgc/Portfile
@@ -1,16 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           muniversal 1.0
-
-github.setup        ivmai bdwgc 7_6_0 gc
-version             [string map {_ .} ${github.version}]
-checksums           rmd160  ae1f33e6106a80ed169589774f8da66160a3639a \
-                    sha256  6fbfb4b04627f6c2a58f436b00bcce84517a56d99398256eef1fb1193af8aaad
 
 name                boehmgc
 conflicts           boehmgc-devel
+version             7.6.4
+
+homepage            https://github.com/ivmai/bdwgc/
+master_sites        https://github.com/ivmai/bdwgc/releases/download/v${version}/
+distname            gc-${version}
+checksums           rmd160  3aae763358c2781209d3b5a68ead899942322304 \
+                    sha256  b94c1f2535f98354811ee644dccab6e84a0cf73e477ca03fb5a3758fb1fecd1c
 
 categories          devel
 platforms           darwin
@@ -27,8 +28,7 @@ long_description \
     by a number of programming language implementations that use C as \
     intermediate code.
 
-# needed since we use the github version; also has the benefit of teaching
-# glibtool about -stdlib=libc++.
+# This has the benefit of teaching glibtool about -stdlib=libc++.
 use_autoreconf  yes
 
 # autoreconf needs pkgconfig
@@ -36,8 +36,7 @@ depends_build-append \
                 port:pkgconfig \
                 port:libatomic_ops
 
-configure.args  --with-threads=posix \
-                --enable-cplusplus
+configure.args  --enable-cplusplus
 configure.cppflags-append \
                 -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
 


### PR DESCRIPTION
#### Description

- Update boehmgc package to version 7.6.4 (the latest stable release)
- Use the distributed source tarball instead of checking out source from git repository by tag or commit
- Remove --with-threads=posix configure option (because Posix threads are on by default)

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix (CVE-2016-9427)

###### Tested on

macOS 10.12.6 16G29
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
