### PR TITLE
libsbml: update to version 5.16.0

### DIFF
--- a/science/libsbml/Portfile
+++ b/science/libsbml/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 
 name                libsbml
-version             5.13.0
+version             5.16.0
 categories          science
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@funasoul gmail.com:funasoul} openmaintainer
 license             LGPL-2.1+
 
 description         The Systems Biology Markup Language library
@@ -18,32 +19,117 @@ long_description    LibSBML is a free, open-source programming library to \
                     rather a library you can embed in your own applications.
 
 homepage            http://sbml.org/Software/libSBML
-master_sites        sourceforge:project/sbml/libsbml/${version}/stable
+master_sites        sourceforge:project/sbml/libsbml/${version}/experimental/source
+patchfiles          patch-python-mp.diff
 
-distname            libSBML-${version}-core-src
-worksrcdir          libsbml-${version}
+distname            libSBML-${version}-Source
 
-checksums           rmd160  3742e7b95a35a102b0cbf9f04d118c84c1aa03ea \
-                    sha256  01fc7149d9464147a0ec0994f1f7d8107a468b294455cb21ad642ff99c1f19fe
+checksums           rmd160  e331901fdc87a733cdc113e83b1d3eaa27a76538 \
+                    sha256  4a2114ce1b48ff19f9be088ce75be57d54c262541a464775929e1cc66e9c943b
 
-depends_lib         port:bzip2 \
-                    port:libxml2 \
-                    port:zlib
+depends_lib-append  port:bzip2 \
+                    port:zlib \
+                    port:pkgconfig
 
-configure.args      --with-bzip2=${prefix} \
-                    --with-libxml=${prefix} \
-                    --with-zlib=${prefix}
+configure.args-append -DWITH_EXAMPLES:BOOL=ON
 
-configure.universal_args-delete --disable-dependency-tracking
+variant arrays description {Enable libSBML support for the SBML Level 3 Arrays and Sets ('arrays')} {
+    configure.args-append   -DENABLE_ARRAYS:BOOL=ON
+}
+
+variant comp description {Enable libSBML support for the SBML Level 3 Hierarchical Model ('comp')} {
+    configure.args-append   -DENABLE_COMP:BOOL=ON
+}
+
+variant cppnamespace description {Use a C++ namespace for libSBML} {
+    configure.args-append   -DWITH_CPP_NAMESPACE:BOOL=ON
+}
+
+variant distrib description {Enable libSBML support for the SBML Level 3 Distributions ('distrib')} {
+    configure.args-append   -DENABLE_DISTRIB:BOOL=ON
+}
+
+variant dyn description {Enable libSBML support for the SBML Level 3 Dynamic Structures ('dyn')} {
+    configure.args-append   -DENABLE_DYN:BOOL=ON
+}
+
+variant expat conflicts libxml2 description {Use the Expat XML parser library} {
+    depends_lib-append      port:expat
+    configure.args-append   -DWITH_EXPAT:BOOL=ON
+    configure.args-append   -DWITH_LIBXML:BOOL=OFF
+    configure.args-append   -DWITH_XERCES:BOOL=OFF
+}
+
+variant fbc description {Enable libSBML support for the SBML Level 3 Flux Balance Constraints ('fbc')} {
+    configure.args-append   -DENABLE_FBC:BOOL=ON
+}
+
+variant groups description {Enable libSBML support for the SBML Level 3 Groups ('groups')} {
+    configure.args-append   -DENABLE_GROUPS:BOOL=ON
+}
+
+variant java description {Configure to use Java} {
+    depends_build-append   port:swig port:swig-java
+    configure.args-append  -DWITH_JAVA:BOOL=ON
+}
+
+variant layout description {Enable libSBML support for the SBML Level 3 Graphical Layout ('layout')} {
+    configure.args-append   -DENABLE_LAYOUT:BOOL=ON
+}
+
+variant libxml2 conflicts expat description {Use the libxml2 XML parser library} {
+    depends_lib-append      port:libxml2
+    configure.args-append   -DWITH_EXPAT:BOOL=OFF
+    configure.args-append   -DWITH_LIBXML:BOOL=ON
+    configure.args-append   -DWITH_XERCES:BOOL=OFF
+}
+
+variant multi description {Enable libSBML support for the SBML Level 3 Multistate and Multicomponent ('multi')} {
+    configure.args-append   -DENABLE_MULTI:BOOL=ON
+}
 
 variant python27 conflicts python34 description {Configure to use Python version 2.7} {
+    depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python27
-    configure.args-append   --with-python --with-python-interpreter=${prefix}/bin/python2.7
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python34 conflicts python27 description {Configure to use Python version 3.4} {
+variant python34 conflicts python27 python35 python36 description {Configure to use Python version 3.4} {
+    depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python34
-    configure.args-append   --with-python --with-python-interpreter=${prefix}/bin/python3.4
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.4 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-livecheck.regex     /libSBML-(\[0-9.\]+)-core-src${extract.suffix}
+variant python35 conflicts python27 python34 python36 description {Configure to use Python version 3.5} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python35
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.5 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
+}
+
+variant python36 conflicts python27 python34 python35 description {Configure to use Python version 3.6} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python36
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
+}
+
+variant qual description {Enable libSBML support for the SBML Level 3 Qualitative Models ('qual')} {
+    configure.args-append   -DENABLE_QUAL:BOOL=ON
+}
+
+variant render description {Enable libSBML support for the SBML Level 3 Rendering ('render')} {
+    configure.args-append   -DENABLE_RENDER:BOOL=ON
+}
+
+variant req description {Enable libSBML support for the SBML Level 3 Required Elements ('req')} {
+    configure.args-append   -DENABLE_REQUIREDELEMENTS:BOOL=ON
+}
+
+variant spatial description {Enable libSBML support for the SBML Level 3 Spatial Processes ('spatial')} {
+    configure.args-append   -DENABLE_SPATIAL:BOOL=ON
+}
+
+if {![variant_isset expat] && ![variant_isset libxml2]} {
+      default_variants +libxml2
+}
+
+livecheck.regex     /libSBML-(\[0-9.\]+)-Source${extract.suffix}

--- a/science/libsbml/files/patch-python-mp.diff
+++ b/science/libsbml/files/patch-python-mp.diff
@@ -1,0 +1,14 @@
+--- src/bindings/python/CMakeLists.txt.dist	2017-12-01 20:10:51.000000000 +0900
++++ src/bindings/python/CMakeLists.txt	2017-12-08 01:03:41.000000000 +0900
+@@ -333,6 +333,11 @@
+ else()
+     set(PYTHON_PACKAGE_INSTALL_DIR ${MISC_PREFIX}bindings/python)
+ endif()
++if (APPLE)
++    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib())"
++        OUTPUT_VARIABLE PYTHON_PACKAGE_INSTALL_DIR)
++endif(APPLE)
++MESSAGE( STATUS "PYTHON_PACKAGE_INSTALL_DIR: " ${PYTHON_PACKAGE_INSTALL_DIR} )
+ 
+ ####################################################################
+ #


### PR DESCRIPTION
* update to version 5.16.0
* use cmake to build libSBML
* add maintainer
* add SBML Level 3 extension packages
* add Java, Python35 and Python36 bindings
* add cppnamespace, expat and libxml2 variants

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? (`sudo port -vs install` worked, but `sudo port -vst install` failed. see https://trac.macports.org/ticket/55575)
- [x] tested basic functionality of all binary files?