### PR TITLE
Rebuild port with boost 1.66.0

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -104,7 +104,6 @@ pre-configure {
 subport plumed-devel {
     github.setup        plumed plumed2 d9be97c7bba3d165e130562033286537c23819d0
     version             2.5-20180129
-    revision            1
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed


### PR DESCRIPTION
Subport plumed-devel should be rebuilt as well.

See 38c08eb5d757ac7790bceeb1a3f69a26223f7a2f