### PR TITLE
Depend on python_select; not python27

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -40,7 +40,7 @@ depends_lib-append  port:curl \
                     path:lib/libssl.dylib:openssl \
                     port:expat \
                     port:libiconv \
-                    port:python27
+                    port:python_select
 
 depends_run-append  port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-error \
@@ -70,7 +70,7 @@ build.args          CFLAGS="${CFLAGS}" \
                     OPENSSLDIR=${prefix} \
                     ICONVDIR=${prefix} \
                     PERL_PATH="${prefix}/bin/perl${perl5.major}" \
-                    PYTHON_PATH="${prefix}/bin/python2.7" \
+                    PYTHON_PATH="${prefix}/bin/python" \
                     NO_FINK=1 \
                     NO_DARWIN_PORTS=1 \
                     NO_R_TO_GCC_LINKER=1 \


### PR DESCRIPTION
git's few python files will work with python 2 or 3. Let the user pick
which one by relying on .../bin/python instead of an explicit version.