### PR TITLE
rust: update to 1.24.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                rust
-version             1.23.0
+version             1.24.0
 categories          lang devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -27,9 +27,7 @@ homepage            https://www.rust-lang.org/
 depends_build       bin:python2.7:python27 \
                     bin:cmake:cmake
 
-# Currently LLVM 4.0 is required, see this issue for LLVM 5.0 support:
-# https://github.com/rust-lang/rust/issues/43370 .
-depends_lib         port:llvm-4.0
+depends_lib         port:llvm-5.0
 
 master_sites        https://static.rust-lang.org/dist
 
@@ -43,40 +41,40 @@ if {${build_arch} eq "i386"} {
     set rust_platform i686-apple-darwin
 }
 
-set stage0(ruststd) rust-std-1.22.0-${rust_platform}
-set stage0(rustc)   rustc-1.22.0-${rust_platform}
-set stage0(cargo)   cargo-0.23.0-${rust_platform}
+set stage0(ruststd) rust-std-1.23.0-${rust_platform}
+set stage0(rustc)   rustc-1.23.0-${rust_platform}
+set stage0(cargo)   cargo-0.24.0-${rust_platform}
 
 distfiles-append    ${stage0(ruststd)}${extract.suffix} \
                     ${stage0(rustc)}${extract.suffix} \
                     ${stage0(cargo)}${extract.suffix}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f8dc31e9fbe1e2071d2307be5a38c73da8a637ee \
-                    sha256  7464953871dcfdfa8afcc536916a686dd156a83339d8ec4d5cb4eb2fe146cb91
+                    rmd160  5ba759d3620e5b37ca4d638b6511c8e4e6c3b009 \
+                    sha256  bb8276f6044e877e447f29f566e4bbf820fa51fea2f912d59b73233ffd95639f
 
 if {${build_arch} eq "i386"} {
     checksums-append \
                     ${stage0(ruststd)}${extract.suffix} \
-                    rmd160  8dc4f0eb39c34082021206de9556a6027a6a833c \
-                    sha256  4bdbe34a34fc99c231f59201253e0844ab8378eed0835c95ce80336c8626f799 \
+                    rmd160  2873bd63f74c1d225a0a3392bb8cfa5534679dc1 \
+                    sha256  e454d4f5fd1e66f48d6ea8f102a96a15325cf969079f4485aab8e4486b96e2d8 \
                     ${stage0(rustc)}${extract.suffix} \
-                    rmd160  4647f5eb4dde380c7d9cad982540df90598b48de \
-                    sha256  84b436ff4543ca9d734971dbd46cabdca4eaf9ba060a6314e48789eaba50101f \
+                    rmd160  e4622e6082c4666e06bc173ee669f8198661d04a \
+                    sha256  618b0dea1e1563d22cb58c1d54344c096e7a4e2d138a17413a349a3edc753745 \
                     ${stage0(cargo)}${extract.suffix} \
-                    rmd160  bfbe0a2040fbb5d5f378111dfb0cc7dbf1330e12 \
-                    sha256  25670bdc08a8134c0100bb4fa1b48d7c45cb1045098d6388fb668d1cdcbc940c
+                    rmd160  17458dce93eb7e644385bd82ecb511311765e5e6 \
+                    sha256  6b7a0a97e0d87cca7b7a5e090d168be6cdbb03298381bece33df493447e17e76
 } else {
     checksums-append \
                     ${stage0(ruststd)}${extract.suffix} \
-                    rmd160  cc0b60760e1d8262834511c7676005167d072db0 \
-                    sha256  773c091f678fd63af07a90fac406c1b9850b7a72b58a4aab39bc0489315ef33a \
+                    rmd160  5b2d5f9e7ed73112fc970d5d74eef392b5c490a8 \
+                    sha256  c2859aeb763edc07ec289a929c66f269373de67908d3a9be069868a8c103c833 \
                     ${stage0(rustc)}${extract.suffix} \
-                    rmd160  9cd4f59ae654315a74c368b85e29a48ab7bc654f \
-                    sha256  1383736371b4192de9f7feb14b6615f39c772b83b0771e1f9fe7c10036e3c9d1 \
+                    rmd160  f15d358053c4979a027299c68ba0dd8ca50df444 \
+                    sha256  61d8774c6e348addc1e82fe598b5d007f30d3d8992d95f0530048236dedf4e0d \
                     ${stage0(cargo)}${extract.suffix} \
-                    rmd160  1a08713350109f9bcf321af40f35fb06d0505bef \
-                    sha256  aee12927e3a670584119e795a1ade6f4579e565f4145c9e0b6d8410019dc5ba7
+                    rmd160  ac5eff8ae2489845f9761c275b03677a50309c1a \
+                    sha256  b6f7c662ea75a94f5a5e41c2fee95f09a5ba168429ac8cdd41f6ba2c78d1b07f
 }
 
 set stage0(dir)     ${worksrcpath}/build/stage0
@@ -100,7 +98,7 @@ configure.args      --build=${rust_platform} \
                     --default-linker=${configure.cc} \
                     --disable-codegen-tests \
                     --disable-docs \
-                    --llvm-root=${prefix}/libexec/llvm-4.0 \
+                    --llvm-root=${prefix}/libexec/llvm-5.0 \
                     --local-rust-root=${stage0(dir)} \
                     --release-channel=stable \
                     --set=target.${rust_platform}.cc=${configure.cc} \

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -107,6 +107,7 @@ configure.args      --build=${rust_platform} \
                     --set=target.${rust_platform}.cxx=${configure.cxx} \
                     --set=target.${rust_platform}.linker=${configure.cc}
 
+build.env           RUSTC_SAVE_ANALYSIS=api
 build.args          VERBOSE=1 BOOTSTRAP_ARGS="-v -j${build.jobs}"
 
 test.run            yes
@@ -116,6 +117,10 @@ test.args           VERBOSE=1
 destroot.args       VERBOSE=1
 post-destroot {
     if {${subport} eq ${name}} {
+        file copy \
+            ${worksrcpath}/build/${rust_platform}/stage1-std/${rust_platform}/release/deps/save-analysis \
+            ${destroot}${prefix}/lib/rustlib/${rust_platform}/analysis
+
         xinstall -d ${destroot}${prefix}/share/${name}
         xinstall -m 644 ${worksrcpath}/src/etc/ctags.rust \
             ${destroot}${prefix}/share/${name}


### PR DESCRIPTION
#### Description
Update Rust to 1.24.0 and update the LLVM dependency to version 5. I've also added the stdlib analysis files which are needed by RLS. Running `sudo port test` gives a file permission error, but compiling a test file with `rustc` works.

###### Tested on
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
