### PR TITLE
bali-phy: Blacklist compilers that don't know -std=c++14

### DIFF
--- a/science/bali-phy/Portfile
+++ b/science/bali-phy/Portfile
@@ -43,6 +43,9 @@ depends_build-append \
 depends_lib         port:boost \
                     path:lib/pkgconfig/cairo.pc:cairo
 
+# Needs support for -std=c++14.
+compiler.blacklist  {clang < 602}
+
 # build in source directory until we switch to meson
 pre-configure       { system -W ${worksrcpath} "./bootstrap.sh"}
 


### PR DESCRIPTION
#### Description

Unbreak build-bots by blacklisting compilers that don't recognized -std=c++14