### PR TITLE
Depend on python36; not python27

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 name                git
 version             2.16.2
+revision            1
 
 description         A fast version control system
 long_description    Git is a fast, scalable, distributed open source version \
@@ -39,7 +40,7 @@ depends_lib-append  port:curl \
                     path:lib/libssl.dylib:openssl \
                     port:expat \
                     port:libiconv \
-                    port:python27
+                    port:python36
 
 depends_run-append  port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-error \
@@ -69,7 +70,7 @@ build.args          CFLAGS="${CFLAGS}" \
                     OPENSSLDIR=${prefix} \
                     ICONVDIR=${prefix} \
                     PERL_PATH="${prefix}/bin/perl${perl5.major}" \
-                    PYTHON_PATH="${prefix}/bin/python2.7" \
+                    PYTHON_PATH="${prefix}/bin/python3.6" \
                     NO_FINK=1 \
                     NO_DARWIN_PORTS=1 \
                     NO_R_TO_GCC_LINKER=1 \


### PR DESCRIPTION
git's few python files will work with python 2 or 3. Prefer python 3
since python 2 is on its way out.