### PR TITLE
mandoc: don't repeat the ./configure's job

### DIFF
--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mandoc
 version             1.14.3
-revision            2
+revision            3
 description         UNIX manpage compiler
 homepage            http://mandoc.bsd.lv/
 categories          textproc
@@ -30,18 +30,9 @@ pre-configure {
 PREFIX="${prefix}"
 MANDIR="${prefix}/share/man"
 
-INSTALL_PROGRAM="${configure.install} -m 0755"
-INSTALL_LIB="${configure.install} -m 0644"
-INSTALL_MAN="${configure.install} -m 0644"
-INSTALL_DATA="${configure.install} -m 0644"
-
 INSTALL_LIBMANDOC=0
 BUILD_CGI=0
 BUILD_CATMAN=0
-
-CC="${configure.cc}"
-CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc]"
-LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
 
 } ]
 


### PR DESCRIPTION
Don't set CC and INSTALL_PROGRAM etc in a Portfile,
the software's ./configure finds them just fine.

Tested on 10.13.2, 10.6.8 and 10.5.8
No package change.

PR: #1330