### PR TITLE
qgis: fix typo; allow for QT5 error to be shown

### DIFF
--- a/gis/qgis/Portfile
+++ b/gis/qgis/Portfile
@@ -134,7 +134,7 @@ pre-configure {
 # QT5 is no longer supported. Use QGIS 3 instead
 
 variant qt5 description "Build with Qt5" {
-    ui_err "Qt5 option is deprecated. Please use the qgis3 port instead"
+    ui_error "Qt5 option is deprecated. Please use the qgis3 port instead"
 }
 
 # Database variants (from the GDAL port)


### PR DESCRIPTION
There's a typo in the QGIS Portfile.

Current behavior:

```console
$ sudo port install qgis +qt5
Error: qgis: Error executing qt5: invalid command name "ui_err"
Error: Unable to open port: Error evaluating variants
```

PR behavior:

```console
$ sudo port clean qgis +qt5
Error: Qt5 option is deprecated. Please use the qgis3 port instead
--->  Cleaning qgis
```