### PR TITLE
macvim: Add override_system_vim variant

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -81,6 +81,16 @@ destroot {
     ln -s ${applications_dir}/MacVim.app/Contents/bin/mvim ${destroot}${prefix}/bin/mview
     # Link as mvimex as bin/mex conflicts with texlive
     ln -s ${applications_dir}/MacVim.app/Contents/bin/mvim ${destroot}${prefix}/bin/mvimex
+
+    if {[variant_isset override_system_vim]} {
+        # Create MacVim vi, vim, vimdiff, view, ex equivalents
+        foreach cmd {vim view vimdiff} {
+            ln -s ${applications_dir}/MacVim.app/Contents/bin/${cmd} ${destroot}${prefix}/bin/${cmd}
+        }
+        foreach cmd {vi ex} {
+            ln -s ${applications_dir}/MacVim.app/Contents/bin/vim ${destroot}${prefix}/bin/${cmd}
+        }
+    }
 }
 
 test.run            yes
@@ -203,4 +213,8 @@ variant lua description {Enable Lua scripting} {
 
 variant cscope description {Enable source code browsing with cscope} {
     configure.args-append   --enable-cscope
+}
+
+variant override_system_vim description {Override the system vi, vim, vimdiff, view, and ex commands} {
+    # see destroot
 }


### PR DESCRIPTION
#### Description
This variant installs symlinks to override the system-supplied `vi`, `vim`, `vimdiff`, `view`, and `ex` commands.

Closes: https://trac.macports.org/ticket/55881

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?