### PR TITLE
wget: explicit --options and missed dependencies

### DIFF
--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -5,6 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    wget
 version                 1.19.4
+revision                1
 categories              net www
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 GPL-3+
@@ -27,8 +28,34 @@ checksums               rmd160  fff40705c38d7415be1fce6e2d23a4ecd0b034fd \
                         sha256  2fc0ffb965a8dc8f1e4a89cbe834c0ae7b9c22f559ebafc84c7874ad1866559a \
                         size    2080228
 
-configure.args          --disable-silent-rules \
-                        --without-ssl
+configure.args          --enable-option-checking \
+                        --disable-silent-rules \
+                        --disable-opie \
+                        --disable-digest \
+                        --disable-ntlm \
+                        --disable-debug \
+                        --disable-valgrind-tests \
+                        --disable-assert \
+                        --enable-largefile \
+                        --enable-threads=posix \
+                        --enable-nls \
+                        --disable-rpath \
+                        --enable-ipv6 \
+                        --enable-iri \
+                        --enable-pcre \
+                        --disable-xattr \
+                        --without-ssl \
+                        --with-zlib \
+                        --with-metalink \
+                        --without-cares \
+                        --with-libiconv-prefix=${prefix} \
+                        --with-libintl-prefix=${prefix} \
+                        --with-libunistring-prefix=${prefix} \
+                        --without-libpth-prefix \
+                        --without-included-regex \
+                        --without-gpgme-prefix \
+                        --with-libidn \
+                        --without-libuuid
 
 # use a specific MacPorts perl version
 # older system perl versions (10.6 and earlier) do not support pod2man --utf8
@@ -44,12 +71,14 @@ depends_test            port:p${perl_version}-libwww-perl \
                         port:p${perl_version}-io-socket-ssl
 
 depends_lib \
+    port:libiconv \
     port:libidn2 \
     port:libunistring \
     port:libpsl \
     port:gettext \
     port:nettle \
-    port:pcre
+    port:pcre \
+    port:zlib
 
 patchfiles              prefix.patch
 


### PR DESCRIPTION
This adds explicit ./configure --options in ./configure --help order.
Also add the missed dependency on libiconv and zlib.

Tested on 10.13.2 and 10.5.8
