### PR TITLE
unixODBC: update to 2.3.5

### DIFF
--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 
 name                unixODBC
 conflicts           libiodbc virtuoso virtuoso-7
-version             2.3.2
-revision            1
+version             2.3.5
 categories          databases
 platforms           darwin
 maintainers         nomaintainer
@@ -32,8 +31,8 @@ homepage            http://www.unixodbc.org/
 master_sites        ${homepage} \
                     ftp://ftp.unixodbc.org/pub/unixODBC/
 
-checksums           rmd160  023122427bd8bdabdbfddf727d16210bb32c60f3 \
-                    sha256  9c3459742f25df5aa3c10a61429bde51a6d4f11552c03095f1d33d7eb02b5c9a
+checksums           rmd160  72ed87df0d59ce6a7c5459e1ca72e585c8619d51 \
+                    sha256  760972e05cc6361aee49d676fb7da8244e0f3a225cd4d3449a951378551b495b
 
 depends_lib         port:libiconv port:libtool port:readline
 


### PR DESCRIPTION
#### Description
CVE-2018-7409

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
