### PR TITLE
shfmt: new port

### DIFF
--- a/devel/shfmt/Portfile
+++ b/devel/shfmt/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        mvdan sh 2.3.0 v
+name                shfmt
+categories          devel
+platforms           darwin
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+license             BSD
+
+description         Autoformat shell script source code
+
+long_description    A shell script formatter supporting POSIX shell, Bash, and mksh.
+
+depends_build       port:go
+use_configure       no
+
+checksums           rmd160  958f20e3482c392c99828e67605a127cc307597b \
+                    sha256  6a42a146aefdce3234eba0b1e6210323a79c1668ecb2e00f8e63d901d810289f
+
+post-extract {
+    xinstall -d ${worksrcpath}/src/mvdan.cc/
+    ln -sf ${worksrcpath} ${worksrcpath}/src/mvdan.cc/${github.project}
+}
+
+build.cmd           go
+build.target        build
+build.args          -a -tags 'production brew' mvdan.cc/sh/cmd/shfmt
+build.env           GOPATH=${worksrcpath} \
+                    CC=${configure.cc}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description
shfmt is a shell script autoformatter, like py-autopep8 but for bash, etc.

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
