### PR TITLE
texstudio: update to 2.12.8

### DIFF
--- a/editors/texstudio/Portfile
+++ b/editors/texstudio/Portfile
@@ -2,9 +2,9 @@
 
 PortSystem              1.0
 PortGroup               qt5 1.0
+PortGroup               github 1.0
 
-name                    texstudio
-version                 2.12.6
+github.setup            texstudio-org texstudio 2.12.8
 categories              editors
 platforms               darwin
 license                 GPL-2+
@@ -15,14 +15,10 @@ description             TeX editor
 
 long_description        TeXstudio is a TeX editor forked off Texmaker.
 
-homepage                http://texstudio.sourceforge.net/
-master_sites            sourceforge:project/texstudio/texstudio/TeXstudio%20${version}
-extract.suffix          .tar.gz
+homepage                https://www.texstudio.org/
 
-worksrcdir              ${name}${version}
-
-checksums               rmd160  d184a71590c87610b4a8fb5540dd05f4d47b7df7 \
-                        sha256  cdae8c9f3fa84af2424cfef6d4a3abb2437cc71ecb24c1883e4ecca2f2693da3
+checksums               rmd160  27e6edcd4d27b24d5b98e7339d1504b2bad6265d \
+                        sha256  e61e6d1436c394c5e99ed78e03da060147cc1e7318faad3a8cc47aeebdb78e0d
 
 depends_lib-append      port:poppler-qt5 port:qt5-qtbase port:qt5-qtsvg port:qt5-qtscript
 


### PR DESCRIPTION
#### Description

It's moved to GitHub. From https://www.texstudio.org/:

> 2017-12-21 | We have migrated our version control system  from Mercurial to git. The mercurial repository remains, but won't be  updated any longer. From now on, you can obtain the latest source code  from our git repository on github.com.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
