### PR TITLE
npm5: exclude pre-release version from livecheck

### DIFF
--- a/devel/npm5/Portfile
+++ b/devel/npm5/Portfile
@@ -103,4 +103,4 @@ ${prefix}/lib/node_modules/ until you manually delete them.
 
 livecheck.type      regex
 livecheck.url       http://registry.npmjs.org/npm
-livecheck.regex     {"next-5":"(.*?)"}
+livecheck.regex     {"latest-5":"(.*?)"}


### PR DESCRIPTION
#### Description
npm v5.7.0 (a pre-release) could cause some ownership changes on system files when running from some directories when also using `sudo`. (See https://github.com/npm/npm/releases/tag/v5.7.1)

We shouldn't update `npm5` to pre-releases. If needed, these versions should be put into `npm5-devel`.