### PR TITLE
mandoc: set default MANPATH

### DIFF
--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mandoc
 version             1.14.3
-revision            4
+revision            5
 description         UNIX manpage compiler
 homepage            https://mandoc.bsd.lv/
 categories          textproc
@@ -29,6 +29,9 @@ pre-configure {
 
 PREFIX="${prefix}"
 MANDIR="${prefix}/share/man"
+
+MANPATH_DEFAULT="${prefix}/share/man:/usr/local/share/man:/usr/share/man"
+MANPATH_BASE="/usr/share/man"
 
 INSTALL_PROGRAM="${configure.install} -m 0755"
 INSTALL_LIB="${configure.install} -m 0644"


### PR DESCRIPTION
This sets the default MANPATH used by mandoc to `/opt/local/share/man:/usr/share/man`.
Are there any other paths the installed man(1) should be searching in?
