### PR TITLE
cpan2port: fetch from github, use perl5.26

### DIFF
--- a/sysutils/cpan2port/Portfile
+++ b/sysutils/cpan2port/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           perl5 1.0
 
+set git_shasum      4207b22
+set git_date        20180228
+
+github.setup        macports macports-contrib ${git_shasum}
 name                cpan2port
-svn.revision        148568
-version             0.1.0-r${svn.revision}
-revision            3
+version             0.1.1_${git_date}
 categories          sysutils macports perl
 platforms           darwin
 maintainers         gwmail.gwu.edu:egall openmaintainer
@@ -17,16 +20,10 @@ description         A perl script to generate MacPorts portfiles
 long_description    ${description} from CPAN modules.
 homepage            https://trac.macports.org/wiki/howto/${name}
 
-fetch.type          svn
-svn.url             https://svn.macports.org/repository/macports/contrib/${name}
+checksums           rmd160  01bba5817f02fef13cbec6a87e10008a4b491e81 \
+                    sha256  50b1a7df150f0f2e0f8bba35912e2921d687a23da1e7aa110c05775aaf093608
 
-# use perl5 port group to create variants
-# set default variant to p5.24 (#52081)
-
-perl5.conflict_variants yes
-perl5.branches 5.24
-perl5.default_branch 5.24
-perl5.create_variants ${perl5.branches}
+perl5.branches      5.26
 
 depends_run-append  port:p${perl5.major}-carp-clan \
                     port:p${perl5.major}-cpan-meta-yaml \
@@ -38,10 +35,8 @@ depends_run-append  port:p${perl5.major}-carp-clan \
                     port:p${perl5.major}-pod-simple \
                     port:p${perl5.major}-yaml
 
-worksrcdir          ${name}
-
 configure {
-    reinplace "s|#! /usr/bin/env perl|#!${prefix}/bin/perl${perl5.major}|g" ${worksrcpath}/${name}
+    reinplace "s|#! /usr/bin/env perl|#!${prefix}/bin/perl${perl5.major}|g" ${worksrcpath}/${name}/${name}
 }
 
 # should be implied by overriding configure:
@@ -50,10 +45,10 @@ configure.ccache    no
 build {}
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/${name}
     xinstall -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}/COPYING
+    xinstall -m 644 ${worksrcpath}/${name}/COPYING ${destroot}${prefix}/share/doc/${name}/COPYING
 }
 
-# TODO: check the latest svn revision of the file
+# TODO: check the latest revision of the file
 livecheck.type      none


### PR DESCRIPTION
The port is fetched from github rather than the old SVN. It makes sure that the latest version of perl is used.

See: https://trac.macports.org/ticket/55208

@dbevans 

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
