### PR TITLE
vit: use perl5.26

### DIFF
--- a/office/vit/Portfile
+++ b/office/vit/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           perl5 1.0
 
 name                vit
 version             1.2
-revision            4
+revision            5
+perl5.branches      5.26
 maintainers         g5pw openmaintainer
 categories          office
 description         Vit is a full-screen terminal interface for Taskwarrior
@@ -22,15 +24,19 @@ master_sites        http://taskwarrior.org/download/
 checksums           rmd160  492f50e2f8b3cefb766dd78750a00e69083550ef \
                     sha256  a78dee573130c8d6bc92cf60fafac0abc78dd2109acfba587cb0ae202ea5bbd0
 
-depends_lib         port:p5.24-curses \
+depends_lib         port:p${perl5.major}-curses \
                     port:task
 
 patchfiles          patch-configure.diff \
                     patch-vit.pl.diff
 
-configure.perl      ${prefix}/bin/perl5.24
+configure.perl      ${perl5.bin}
 
 build.target
+
+post-patch {
+    reinplace "s|#!/usr/bin/env perl.*|#!${perl5.bin} -w|g" ${worksrcpath}/vit.pl
+}
 
 destroot {
     xinstall -m 775 ${worksrcpath}/vit ${destroot}${prefix}/bin/


### PR DESCRIPTION
See: https://trac.macports.org/ticket/55208

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
