### PR TITLE
Revbump ports to use perl5.26

### DIFF
--- a/_resources/port1.0/group/perl5-1.0.tcl
+++ b/_resources/port1.0/group/perl5-1.0.tcl
@@ -44,11 +44,11 @@ default perl5.use_search_cpan_org {false}
 
 proc perl5_get_default_branch {} {
     global prefix perl5.branches
-    # use whatever ${prefix}/bin/perl5 was chosen, and if none, fall back to 5.24
+    # use whatever ${prefix}/bin/perl5 was chosen, and if none, fall back to 5.26
     if {![catch {set val [lindex [split [exec ${prefix}/bin/perl5 -V:version] {'}] 1]}]} {
         set ret [join [lrange [split $val .] 0 1] .]
     } else {
-        set ret 5.24
+        set ret 5.26
     }
     # if the above default is not supported by this module, use the latest it does support
     if {[info exists perl5.branches] && [lsearch -exact ${perl5.branches} $ret] == -1} {

--- a/aqua/PsyncX/Portfile
+++ b/aqua/PsyncX/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcode 1.0
 
 name                PsyncX
 version             2.2.2
-revision            4
+revision            5
 categories          aqua sysutils
 maintainers         ryandesign openmaintainer
 homepage            http://psyncx.sourceforge.net/
@@ -23,7 +23,7 @@ svn.url             http://svn.code.sf.net/p/psyncx/code/trunk/
 svn.revision        29
 worksrcdir          trunk
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major} \
                     port:p${perl5.major}-macosx-file

--- a/databases/mysql-zrm/Portfile
+++ b/databases/mysql-zrm/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                mysql-zrm
 version             3.0
-revision            1
+revision            2
 categories          databases sysutils
 maintainers         bitwrangler.com:kmayer
 description         Zmanda Recovery Manager for MySQL
@@ -22,7 +22,7 @@ distname            MySQL-zrm-${version}-release
 checksums           rmd160  0573cfbeee98626e17411fb17bda6d76c9ad041d \
                     sha256  05e0342b190b6475f220014a126ed213442e24af7b6e3295fa914fcb47b1b931
 
-perl5.branches      5.24
+perl5.branches      5.26
 # these are probably just runtime dependencies?
 depends_lib         port:p${perl5.major}-dbi \
                     port:p${perl5.major}-xml-parser

--- a/databases/percona-toolkit/Portfile
+++ b/databases/percona-toolkit/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                percona-toolkit
 version             2.2.20
+revision            1
 categories          databases
 platforms           darwin
 license             GPL
@@ -18,7 +19,7 @@ checksums           rmd160  03181ed37d2348a830acd93fab0b579631ab42e3 \
                     sha256  8439be616ee43b22ba7526135719ef6f40af6621327acc30b84be5f18cd426b1
 
 set mp.perl.versions {
-    5.24
+    5.26
 }
 set mp.perl.select  [lindex ${mp.perl.versions} end]
 set mp.names        {}

--- a/databases/postgresql_autodoc/Portfile
+++ b/databases/postgresql_autodoc/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                postgresql_autodoc
 version             1.41
-revision            2
+revision            3
 categories          databases textproc
 license             BSD
 platforms           darwin
@@ -24,7 +24,7 @@ master_sites        http://www.rbt.ca/autodoc/binaries/
 checksums           rmd160  c588ef93e955b5c41b6175f3f2762c35accbb567 \
                     sha256  8fd8300a1913bd60be7b8214aadc8e193575c1fabe7797cbb6dcaed2b90eb8e9
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major}
 depends_run         port:p${perl5.major}-dbi \

--- a/devel/archway/Portfile
+++ b/devel/archway/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                archway
 version             0.2.1
-revision            4
+revision            5
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -22,7 +22,7 @@ checksums           md5 130b7aaec6fc57a5bc0d132158455ce9 \
                     sha1 a8be0c8105b1647c1570dc903727e3e9100c6917 \
                     rmd160 ac30f3df2db502ab5e162957264628e8fd540fa0
 
-set perl_version    5.24
+set perl_version    5.26
 
 use_configure       no
 build               {}

--- a/devel/cutter/Portfile
+++ b/devel/cutter/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           perl5 1.0
 
 name                cutter
 version             1.2.4
@@ -24,7 +25,7 @@ checksums           rmd160  e744ea0374222c32b7ba5d92ae4279908ba35216 \
 
 depends_build       port:intltool \
                     port:pkgconfig \
-                    port:p5.24-xml-parser
+                    port:p${perl5.major}-xml-parser
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gtk-doc \

--- a/devel/ghsum/Portfile
+++ b/devel/ghsum/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           perl5 1.0
 
 github.setup        rodnaph ghsum 0.1.0 v
-revision            4
-perl5.branches      5.24
+revision            5
+perl5.branches      5.26
 categories          devel shells macports
 platforms           darwin
 maintainers         pu-gh.com:rod

--- a/devel/git-cal/Portfile
+++ b/devel/git-cal/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               perl5 1.0
 
 github.setup            k4rthik git-cal 0.9.1 v
-revision                3
+revision                4
 categories              devel
 platforms               darwin
 supported_archs         noarch
@@ -20,7 +20,7 @@ long_description \
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.24
+perl5.branches          5.26
 perl5.create_variants   ${perl5.branches}
 
 checksums               rmd160  9a4b489979fa62c064e8af35c9c968e86d596257 \

--- a/devel/mtn-browse/Portfile
+++ b/devel/mtn-browse/Portfile
@@ -5,7 +5,8 @@ PortGroup           perl5 1.0
 
 name                mtn-browse
 version             1.20
-perl5.branches      5.24
+perl5.branches      5.26
+revision            1
 categories          devel
 license             GPL-3+
 platforms           darwin

--- a/devel/myrepos/Portfile
+++ b/devel/myrepos/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           perl5 1.0
 
 github.setup        joeyh myrepos 1.20160123
-revision            1
+revision            2
 
 categories          devel
 platforms           darwin
@@ -29,7 +29,7 @@ supported_archs     noarch
 use_configure       no
 build.target        build
 
-perl5.branches      5.24
+perl5.branches      5.26
 depends_lib         port:perl${perl5.major}
 
 depends_run         port:p${perl5.major}-html-parser \

--- a/devel/ossp-uuid/Portfile
+++ b/devel/ossp-uuid/Portfile
@@ -6,7 +6,7 @@ PortGroup               perl5 1.0
 
 name                    ossp-uuid
 version                 1.6.2
-revision                10
+revision                11
 categories              devel
 license                 MIT
 platforms               darwin
@@ -69,7 +69,7 @@ post-destroot {
     file rename -force ${destroot}${prefix}/share/man/man1/uuid.1 ${destroot}${prefix}/share/man/man1/ossp-uuid.1
     file rename -force ${destroot}${prefix}/share/man/man1/uuid-config.1 ${destroot}${prefix}/share/man/man1/ossp-uuid-config.1
 
-    if {[variant_isset perl5_24] || [variant_isset perl5_26]} {
+    if {[variant_isset perl5_26]} {
         delete {*}[glob ${destroot}${prefix}/lib/perl5/*/*/perllocal.pod]
     }
 }
@@ -78,10 +78,10 @@ post-destroot {
 # perl support is possibly required by dependents rpm5[234] (unverified)
 
 perl5.conflict_variants yes
-perl5.branches 5.24 5.26
+perl5.branches 5.26
 perl5.create_variants ${perl5.branches}
 
-if {[variant_isset perl5_24] || [variant_isset perl5_26]} {
+if {[variant_isset perl5_26]} {
     configure.perl          ${perl5.bin}
     configure.args-delete   --without-perl
     configure.args-append   --with-perl --with-perl-compat

--- a/devel/patchutils/Portfile
+++ b/devel/patchutils/Portfile
@@ -5,6 +5,7 @@ PortGroup               perl5 1.0
 
 name                    patchutils
 version                 0.3.4
+revision                1
 platforms               darwin
 categories              devel
 license                 GPL-2+

--- a/devel/pearl/Portfile
+++ b/devel/pearl/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           perl5 1.0
 
 github.setup        rodnaph pearl 0.2.0 v
-revision            3
-perl5.branches      5.24
+revision            4
+perl5.branches      5.26
 categories          devel macports
 platforms           darwin
 maintainers         pu-gh.com:rod

--- a/devel/thieriot/Portfile
+++ b/devel/thieriot/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           perl5 1.0
 
 github.setup        rodnaph thieriot 1.1.1 v
-revision            2
-perl5.branches      5.24
+revision            3
+perl5.branches      5.26
 categories          devel shells
 platforms           darwin
 maintainers         pu-gh.com:rod

--- a/erlang/tsung/Portfile
+++ b/erlang/tsung/Portfile
@@ -5,7 +5,8 @@ PortGroup           perl5 1.0
 
 name                tsung
 version             1.7.0
-perl5.branches      5.24
+revision            1
+perl5.branches      5.26
 categories          erlang devel
 platforms           darwin
 maintainers         nomaintainer

--- a/games/frozenbubble2/Portfile
+++ b/games/frozenbubble2/Portfile
@@ -5,8 +5,9 @@ PortGroup           app 1.0
 PortGroup           perl5 1.0
 
 name                frozenbubble2
-perl5.branches      5.24
+perl5.branches      5.26
 perl5.setup         Games-FrozenBubble 2.212
+revision            1
 categories          games
 platforms           darwin
 maintainers         ryandesign openmaintainer

--- a/gnome/xchat-gnome/Portfile
+++ b/gnome/xchat-gnome/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                xchat-gnome
 version             0.26.1
-revision            9
+revision            10
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         xchat-gnome is a frontend to X-Chat.
 long_description    xchat-gnome is a frontend to the popular X-Chat IRC client which is \
@@ -24,7 +24,7 @@ checksums           rmd160  ff2228aa5258a2c5a3bd7c391e83a15b2f030aff \
 
 use_bzip2           yes
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_build       port:pkgconfig \
                     port:intltool \

--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                perl5
-version             5.24.2
+version             5.26.1
 categories          lang
 platforms           darwin freebsd linux
 license             {Artistic-1 GPL}
@@ -192,8 +192,8 @@ if {$subport eq $name} {
 
     perl5.require_variant   yes
     perl5.conflict_variants yes
-    perl5.branches          5.24 5.26
-    perl5.default_branch    5.24
+    perl5.branches          5.26
+    perl5.default_branch    5.26
     perl5.create_variants   ${perl5.branches}
 
     distfiles

--- a/mail/amavisd-new/Portfile
+++ b/mail/amavisd-new/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                amavisd-new
 version             2.10.1
-revision            5
+revision            6
 categories          mail
 license             GPL-2
 maintainers         pixilla openmaintainer
@@ -29,8 +29,8 @@ checksums           rmd160  233eb8ebfd5bb15eba152553424ef0622602430b \
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.24
-perl5.default_branch    5.24
+perl5.branches          5.26
+perl5.default_branch    5.26
 perl5.create_variants   ${perl5.branches}
 
 set daemon_user     _amavisd

--- a/mail/lbdb/Portfile
+++ b/mail/lbdb/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           perl5 1.0
 
 name                lbdb
 version             0.42
-revision            1
+revision            2
 categories          mail
 maintainers         nomaintainer
 platforms           darwin freebsd
@@ -29,10 +30,10 @@ checksums           sha1    2a15cc30b04f76341f14a84b59dfd1da92151c47 \
 distname            ${name}_${version}
 worksrcdir          ${name}-${version}
 
-set perl_version    5.24
+perl5.branches      5.26
 
 depends_lib         port:libiconv \
-                    port:perl${perl_version}
+                    port:perl${perl5.major}
 
 depends_run         port:gsed
 
@@ -42,7 +43,7 @@ post-patch  {
 
 configure.args      --libdir=${prefix}/lib/lbdb/ \
                     --without-gpg \
-                    ac_cv_path_PERL=${prefix}/bin/perl${perl_version}
+                    ac_cv_path_PERL=${perl5.bin}
 
 destroot.destdir    install_prefix=${destroot}
 

--- a/mail/mailqfmt/Portfile
+++ b/mail/mailqfmt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 name                mailqfmt
 version             0.6
-revision            5
+revision            6
 categories          mail
 license             GPL-2
 maintainers         nomaintainer
@@ -19,7 +19,7 @@ distfiles           ${name}.pl
 checksums           rmd160  d5e24479642537db03f3ab82eee380fefce1bdf9 \
                     sha256  11e6410cdc811cebc8212b73eeaad2386cb15569b526d73376d35a69bda54b95
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib-append  port:postfix \
                     port:p${perl5.major}-libwww-perl

--- a/mail/mb2md/Portfile
+++ b/mail/mb2md/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                mb2md
 version             3.20
-revision            4
+revision            5
 categories          mail
 license             public-domain
 maintainers         nomaintainer
@@ -28,7 +28,7 @@ checksums           rmd160  03ee1e543ba070c222aa7e20624aaf5fa390785c \
 platforms           darwin
 supported_archs     noarch
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-timedate

--- a/mail/muttprint/Portfile
+++ b/mail/muttprint/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                muttprint
 version             0.72d
-revision            4
-perl5.branches      5.24
+revision            5
+perl5.branches      5.26
 categories          mail
 license             GPL-2
 maintainers         nomaintainer

--- a/mail/pemail/Portfile
+++ b/mail/pemail/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                pemail
 version             1.2
-revision            4
+revision            5
 categories          mail
 license             GPL-2+
 platforms           darwin
@@ -24,7 +24,7 @@ master_sites        sourceforge
 checksums           rmd160  c306823b850bafdbbba3513c3c986835d479a0bf \
                     sha256  da06564bf93e5ee497d5fd221d90c639a5f2d6aaec8c55742e0258de50a77c05
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major}
 depends_run         port:p${perl5.major}-mail-pop3client \

--- a/mail/perfect_maildir/Portfile
+++ b/mail/perfect_maildir/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                perfect_maildir
 version             0.3
-revision            4
+revision            5
 categories          mail
 platforms           darwin
 supported_archs     noarch
@@ -21,7 +21,7 @@ checksums           rmd160  f076ea65732d1c49996f68c19956aa33b2eaaed3 \
 
 distfiles           ${name}.pl
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-timedate

--- a/mail/pflogsumm/Portfile
+++ b/mail/pflogsumm/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                pflogsumm
 version             1.1.3
-revision            3
+revision            4
 categories          mail
 license             GPL-2+
 maintainers         nomaintainer
@@ -38,7 +38,7 @@ extract.only        ${distname}${extract.suffix}
 platforms           darwin freebsd
 supported_archs     noarch
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major}
 depends_run         port:p${perl5.major}-date-calc

--- a/mail/postgrey/Portfile
+++ b/mail/postgrey/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                postgrey
 version             1.35
-revision            2
+revision            3
 categories          mail
 license             GPL-2
 maintainers         nomaintainer
@@ -26,7 +26,7 @@ master_sites        ${homepage}pub \
 checksums           rmd160  7dc67fb3df37094da3039297d3885ccde5f08c06 \
                     sha256  f6a6956630803e6f79ebff6ad0cc0d46ba32046ed6cc260e38e6f591de7bbdcf
 
-perl5.branches      5.24
+perl5.branches      5.26
 depends_lib-append  port:p${perl5.major}-berkeleydb \
                     port:p${perl5.major}-io-multiplex \
                     port:p${perl5.major}-net-server

--- a/mail/signing-party/Portfile
+++ b/mail/signing-party/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                signing-party
 version             2.6
-revision            1
+revision            2
 checksums           rmd160  1d700c835449e8cbe350c032f0ad4d9a26afaa17 \
                     sha256  d9458db6c5a01298838af99655c0edbebd0c955f50866c6e0f6f277a1dbbabd8
 
@@ -32,7 +32,7 @@ use_configure       no
 depends_build       port:automake \
                     port:autoconf
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major} \
                     port:p${perl5.major}-class-methodmaker \

--- a/mail/sqlgrey/Portfile
+++ b/mail/sqlgrey/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                sqlgrey
 version             1.8.0-rc2
-revision            5
+revision            6
 categories          mail
 license             GPL-2
 maintainers         pixilla openmaintainer
@@ -20,7 +20,7 @@ checksums           rmd160  0404df3987ceb4732e73fee09388454995754c1c \
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.24
+perl5.branches          5.26
 perl5.create_variants   ${perl5.branches}
 
 supported_archs     noarch

--- a/mail/sympa/Portfile
+++ b/mail/sympa/Portfile
@@ -5,9 +5,9 @@ PortGroup           perl5 1.0
 
 name                sympa
 version             6.1.23
-revision            6
+revision            7
 set branch          [join [lrange [split ${version} .] 0 1] .]
-perl5.branches      5.24
+perl5.branches      5.26
 categories          mail
 license             GPL-2
 maintainers         nomaintainer

--- a/mail/t-prot/Portfile
+++ b/mail/t-prot/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                t-prot
 version             3.4
-revision            1
-perl5.branches      5.24
+revision            2
+perl5.branches      5.26
 categories          mail
 license             BSD-old
 platforms           darwin

--- a/multimedia/tablet-encode/Portfile
+++ b/multimedia/tablet-encode/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                tablet-encode
 license             Artistic-1
 version             2.30
-revision            3
+revision            4
 categories          multimedia
 maintainers         nomaintainer
 platforms           darwin
@@ -21,7 +21,7 @@ master_sites        https://garage.maemo.org/frs/download.php/6892
 checksums           rmd160  71aa43d56df5c70484dda3dd882033e8639ae8e0 \
                     sha256  ce1f413c111429db14f41ca611297896357065d0934b7dce9e341a77e178f557
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run         port:perl${perl5.major} \
                     path:bin/mplayer:mplayer-devel

--- a/net/ddclient/Portfile
+++ b/net/ddclient/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
+PortGroup           perl5 1.0
 
 name                ddclient
 version             3.8.3
-revision            2
+perl5.branches      5.26
+revision            3
 platforms           darwin
 categories          net
 license             GPL
@@ -19,8 +21,8 @@ master_sites        sourceforge
 checksums           rmd160  e0b0f8ee11700f04022f322a2163d9fde9487b31 \
                     sha256  debd5fec69eeb65e2331b86f5280f382416d97ed103839a65c201eef8e6d1fc9
 
-depends_lib         port:p5.24-io-socket-ssl
-depends_run         port:perl5.24 \
+depends_lib         port:p${perl5.major}-io-socket-ssl
+depends_run         port:perl${perl5.major} \
                     path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
 
 patchfiles          patch-ddclient.diff

--- a/net/fwknop/Portfile
+++ b/net/fwknop/Portfile
@@ -3,7 +3,7 @@ PortGroup       perl5 1.0
 
 name            fwknop
 version         1.9.12
-revision        5
+revision        6
 conflicts       fwknop-client
 categories      net security
 license         GPL-2
@@ -38,7 +38,7 @@ checksums       md5    4e190dfd31921ddcc0aa6ded8cdae6ae \
 
 use_bzip2       yes
 
-perl5.branches  5.24
+perl5.branches  5.26
 
 depends_lib     port:p${perl5.major}-crypt-cbc \
                 port:p${perl5.major}-crypt-rijndael \

--- a/net/liboping/Portfile
+++ b/net/liboping/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 
 name                liboping
 subport             liboping-devel {}
-perl5.branches      5.24
+perl5.branches      5.26
 
 categories          net
 platforms           darwin
@@ -21,7 +21,7 @@ if {${subport} eq ${name}} {
 #   github.setup    octo liboping 1.8.0 liboping-
     conflicts       liboping-devel
     version         1.8.0
-    revision        2
+    revision        3
 
     master_sites    ${homepage}files/
 
@@ -32,7 +32,7 @@ if {${subport} eq ${name}} {
     github.setup    octo liboping 74470ba
     conflicts       liboping
     version         20150213
-    revision        2
+    revision        3
 
     checksums       rmd160  9ccebb45977595b249019b64986e128197621c6a \
                     sha256  62b8108fa1713d0a037d9af9fe10bcd89d13307649e529a65f8ddefd8790ba46

--- a/net/mediaserv/Portfile
+++ b/net/mediaserv/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                mediaserv
 version             0.05
-revision            5
+revision            6
 categories          net
 license             Artistic-1
 maintainers         nomaintainer
@@ -31,7 +31,7 @@ checksums           rmd160  78e824cd8b28effc58543e75aaf63e2cdc958941 \
 
 worksrcdir          ${name}
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-libwww-perl \

--- a/net/monarch/Portfile
+++ b/net/monarch/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 PortGroup           perl5 1.0
-perl5.branches      5.24
+perl5.branches      5.26
 
 name                monarch
 version             2.5.0
-revision            4
+revision            5
 license             GPL-2
 categories          net
 maintainers         nomaintainer

--- a/net/munin/Portfile
+++ b/net/munin/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                munin
 version             1.4.7
-revision            5
+revision            6
 license             GPL-2
 categories          net
 maintainers         nomaintainer
@@ -31,7 +31,7 @@ master_sites        sourceforge:project/munin/munin%20stable/${version}
 checksums           rmd160  b25c0a4d7d7613592757132290b7158228ea2a67 \
                     sha256  9a87356b1f8662f444a7a2a86ff36809124ffe787c442de0ea35850194d602af
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major} \
                     port:p${perl5.major}-module-build \

--- a/net/nedi/Portfile
+++ b/net/nedi/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                nedi
 version             1.0.9
-revision            3
+revision            4
 license             GPL-3
 categories          net
 maintainers         nomaintainer
@@ -25,7 +25,7 @@ extract.suffix      .tgz
 checksums           rmd160  776b178b4fd3fe139796dbc367ae0e626f6ccaa1 \
                     sha256  cf004dafb781f1ac638b2291ea565d3c3972eb5dd049f9119b46dbc66f722f13
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major} \
                     path:bin/mysql_config5:mysql5 \

--- a/net/net-snmp/Portfile
+++ b/net/net-snmp/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    net-snmp
 version                 5.7.3
-revision                6
+revision                7
 categories              net
 license                 BSD
 platforms               darwin
@@ -26,7 +26,7 @@ long_description        This is net-snmp, a derivative of CMU's SNMP \
 checksums               rmd160  c5cf54d5723ee417e07f1f9fa3936aef505104a2 \
                         sha256  12ef89613c7707dc96d13335f153c1921efc9d61d3708ef09f3fc4a7014fb4f0
 
-perl5.branches          5.24
+perl5.branches          5.26
 
 depends_lib             port:bzip2 \
                         port:perl${perl5.major} \

--- a/net/nfsen/Portfile
+++ b/net/nfsen/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 # port is broken, see https://trac.macports.org/ticket/38276
 name                nfsen
 version             1.3.7
-revision            1
+revision            2
 categories          net
 maintainers         nomaintainer
 license             BSD
@@ -21,7 +21,7 @@ master_sites        sourceforge:project/nfsen/stable/nfsen-${version}
 checksums           rmd160  60981d49f6fa4de434c8849ff326b6568fb17937 \
                     sha256  635ba97564fe81cbeee0a3950735b9651677b69e1f53a67c654ddd5b00db469d
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major} \
                     port:p${perl5.major}-mailtools \

--- a/net/nrg/Portfile
+++ b/net/nrg/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                nrg
 version             0.99.27
-revision            4
+revision            5
 categories          net
 maintainers         nomaintainer
 platforms           darwin
@@ -25,7 +25,7 @@ master_sites        ftp://noc.hep.wisc.edu/src/nrg/ \
 checksums           rmd160  1192ce02d14447abdcff994671693eeb4ca67e28 \
                     sha256  ef851705f9ebd2bf55892823f258c7cffc079ae0276df4f40860c520262971c2
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major} \
                     port:p${perl5.major}-time-hires \

--- a/net/sendpage/Portfile
+++ b/net/sendpage/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                sendpage
 version             1.000003
-revision            4
+revision            5
 categories          net
 license             GPL-2+
 maintainers         nomaintainer
@@ -24,7 +24,7 @@ master_sites        sourceforge
 checksums           rmd160  a427a662dceef09a3b9f881429b18c429c2fdf97 \
                     sha256  88a128c077ca0573cfe456bd9f595ccf8f9335ba44a339144a0c70163e209317
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:p${perl5.major}-net-snpp \
                     port:p${perl5.major}-device-serialport \

--- a/net/shelldap/Portfile
+++ b/net/shelldap/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 name                shelldap
 version             1.3.2
+revision            1
 
 categories          net sysutils
 license             BSD
@@ -28,7 +29,7 @@ worksrcdir          ${name}-v${version}
 checksums           rmd160  f21c8b7e7fb358363a45632f27d5f62f08438e48 \
                     sha256  f863c5abe1b2411d6eac14d0754f7fa1466d17e1f1db2373a092b3dece972d60
 
-perl5.branches      5.24
+perl5.branches      5.26
 depends_build       port:perl${perl5.major}
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-algorithm-diff \

--- a/net/smokeping/Portfile
+++ b/net/smokeping/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                smokeping
 version             2.6.11
-revision            2
+revision            3
 license             GPL-2+
 categories          net perl
 maintainers         nomaintainer
@@ -30,7 +30,7 @@ patchfiles          patch-etc-config.dist.diff \
                     patch-bin-smokeinfo.diff \
                     patch-bin-smokeping_cgi.diff
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib-append  port:perl${perl5.major} \
                     port:p${perl5.major}-cgi \

--- a/net/snmptt/Portfile
+++ b/net/snmptt/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                snmptt
 version             1.4
-revision            1
+revision            2
 categories          net
 license             GPL-2+
 maintainers         nomaintainer
@@ -22,7 +22,7 @@ distname            ${name}_${version}
 checksums           rmd160  91514f21f05d41a4ccaf789f2033f3389f2ed989 \
                     sha256  512c33ecdf06da8b3c75082c1506e4b4091ddb714d0d9564771aa12ddc98ef99
 
-perl5.branches      5.24
+perl5.branches      5.26
 depends_lib         port:perl${perl5.major} \
                     port:p${perl5.major}-config-inifiles
 

--- a/net/snownews/Portfile
+++ b/net/snownews/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                snownews
 version             1.5.12
-revision            7
-perl5.branches      5.24
+revision            8
+perl5.branches      5.26
 platforms           darwin
 categories          net www
 license             GPL-2

--- a/net/torrentsniff/Portfile
+++ b/net/torrentsniff/Portfile
@@ -5,7 +5,7 @@ PortGroup perl5     1.0
 
 name                torrentsniff
 version             0.3.0
-revision            6
+revision            7
 categories          net perl
 license             MIT
 maintainers         nomaintainer
@@ -20,7 +20,7 @@ master_sites        http://www.highprogrammer.com/alan/perl/
 checksums           rmd160  c52eb178784b759406e4f08688f44d92870d1a81 \
                     sha256  8af4f672a0ec6c4ad85665f90e65dadf38d15fab9df65aed1d2e50de8f6a4476
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run-append  port:p${perl5.major}-libwww-perl \
                     port:p${perl5.major}-digest-sha1

--- a/net/wallet/Portfile
+++ b/net/wallet/Portfile
@@ -2,11 +2,11 @@
 
 PortSystem          1.0
 PortGroup           perl5 1.0
-perl5.branches      5.24
+perl5.branches      5.26
 
 name                wallet
 version             1.3
-revision            0
+revision            1
 categories          net security
 license             MIT
 maintainers         kornel.us:karl openmaintainer

--- a/perl/eperl/Portfile
+++ b/perl/eperl/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    eperl
 version                 2.2.14
-revision                5
+revision                6
 
 maintainers             cal openmaintainer
 categories              perl www
@@ -25,7 +25,7 @@ checksums               rmd160  708c72d4a2bc494e9b3e953aa13efd0fe7933b98 \
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.24
+perl5.branches          5.26
 perl5.create_variants   ${perl5.branches}
 
 use_configure           yes

--- a/perl/swaks/Portfile
+++ b/perl/swaks/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                swaks
 version             20130209.0
-revision            2
+revision            3
 license             GPL-2
 maintainers         nomaintainer
 categories          perl
@@ -25,7 +25,7 @@ long_description \
 checksums           rmd160  31b52e046ac4529056e66c6a8bcf1a2ac44c7a8f \
                     sha256  0b0967256dca82776f610f1db862bc47644b236f325fa48cbdb2651babd41f7c
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 supported_archs     noarch
 use_configure       no

--- a/science/demeter/Portfile
+++ b/science/demeter/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 PortGroup           github 1.0
 
-set perl-version    5.24
+set perl-version    5.26
 perl5.branches      ${perl-version}
-revision            1
+revision            2
 
 github.setup        bruceravel demeter 0.9.25
 

--- a/science/gpredict/Portfile
+++ b/science/gpredict/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 name                gpredict
 version             2.2.1
+revision            1
 categories          science
 license             GPL-2+
 platforms           darwin
@@ -28,7 +29,7 @@ checksums           rmd160  a9f99c6284a8f9facd16b53a98f12949020c7512 \
 
 use_bzip2           yes
 
-perl5.branches      5.24 5.26
+perl5.branches      5.26
 
 depends_build       port:intltool \
                     port:p${perl5.major}-xml-parser \

--- a/science/metar/Portfile
+++ b/science/metar/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                metar
 version             0.2
-revision            2
+revision            3
 categories          science
 platforms           darwin linux
 maintainers         gmail.com:fernando.iazeolla
@@ -22,7 +22,7 @@ master_sites        http://www.autistici.org/0xFE/software/releases/metar/
 checksums           rmd160  28644bc6b2507352236b2e2cf8e0975724678b77 \
                     sha256  194b17dc559f91c45847b5fdecceb0d8f71b97ce77b989a728a7416406edfdfa
 
-perl5.branches      5.24
+perl5.branches      5.26
 depends_lib-append  port:p${perl5.major}-libwww-perl
 worksrcdir          ${name}
 

--- a/science/perlprimer/Portfile
+++ b/science/perlprimer/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                perlprimer
 version             1.1.21
-revision            2
-perl5.branches      5.24
+revision            3
+perl5.branches      5.26
 categories          science perl
 license             GPL-2+
 maintainers         nomaintainer

--- a/science/xraylib/Portfile
+++ b/science/xraylib/Portfile
@@ -7,7 +7,7 @@ PortGroup           compilers 1.0
 
 name                xraylib
 version             3.2.0
-revision            1
+revision            2
 categories          science
 platforms           darwin
 license             BSD
@@ -47,11 +47,11 @@ use_parallel_build  no
 configure.ccache    no
 
 perl5.conflict_variants yes
-perl5.branches 5.24
-perl5.default_branch 5.24
+perl5.branches 5.26
+perl5.default_branch 5.26
 perl5.create_variants ${perl5.branches}
 
-if {[variant_isset perl5_24]} {
+if {[variant_isset perl5_26]} {
     configure.perl ${perl5.bin}
     configure.args-delete --disable-perl
     configure.args-append --enable-perl --enable-perl-integration

--- a/security/log2timeline/Portfile
+++ b/security/log2timeline/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                log2timeline
 version             0.65
-revision            6
+revision            7
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -32,7 +32,7 @@ supported_archs     noarch
 # allow perl5 port group to determine default variant
 
 perl5.conflict_variants yes
-perl5.branches          5.24
+perl5.branches          5.26
 perl5.create_variants   ${perl5.branches}
 
 depends_lib         port:perl${perl5.major} \

--- a/security/makepasswd/Portfile
+++ b/security/makepasswd/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                makepasswd
 version             1.10-9
-revision            1
+revision            2
 categories          security
 license             GPL-2
 platforms           darwin
@@ -22,7 +22,7 @@ patchfiles          patch-usr-bin-makepasswd.diff
 checksums           rmd160  f9030e907dda724d46e71675fc97e9594de70924 \
                     sha256  a20939a863dc262cbb22c2e7061e5bd22839149d59a5b82ebfbc1e149f4d9d5e
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run         port:p${perl5.major}-crypt-passwdmd5 \
                     port:p${perl5.major}-crypt-openssl-random

--- a/security/metasploit2/Portfile
+++ b/security/metasploit2/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                metasploit2
 conflicts           metasploit3
 version             2.7
-revision            3
+revision            4
 categories          security
 license             {Artistic-1 GPL-2} GPL-2+ APSL-1.1 Noncommercial Restrictive
 maintainers         nomaintainer
@@ -32,7 +32,7 @@ distname            framework-${version}
 checksums           rmd160  cfdf2705522c845bb4405413207a7df0f3873b94 \
                     sha256  516952772aaa8982628460b927c9119850925f870903c5a131a9c9f0390cf77f
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_run         port:perl${perl5.major} \
                     port:p${perl5.major}-net-ssleay \

--- a/security/tinyca2/Portfile
+++ b/security/tinyca2/Portfile
@@ -4,8 +4,8 @@ PortGroup           perl5 1.0
 
 name                tinyca2
 version             0.7.5
-revision            6
-perl5.branches      5.24
+revision            7
+perl5.branches      5.26
 license             GPL
 categories          security net
 maintainers         nomaintainer

--- a/shells/psh/Portfile
+++ b/shells/psh/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                psh
-perl5.branches      5.24
+perl5.branches      5.26
 perl5.setup         psh 1.8.1
-revision            2
+revision            3
 perl5.link_binaries_suffix
 categories          shells perl
 license             {Artistic-1 GPL}

--- a/sysutils/amttools/Portfile
+++ b/sysutils/amttools/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                amttools
 set my_distname     amtterm
 version             1.4
-revision            2
+revision            3
 categories          sysutils
 license             GPL-2+
 maintainers         ionic openmaintainer
@@ -33,7 +33,7 @@ distname            ${my_distname}-${version}
 checksums           rmd160  fac39807990870f88884e541f4b062db8b8d1236 \
                     sha256  e10af2b02dbf66fb24abd292b9ddc6d86b31eea09887da5cb0eb8fb2ee900e21
 
-set perl_branch     5.24
+set perl_branch     5.26
 depends_build       port:pkgconfig
 depends_run         port:p${perl_branch}-soap-lite
 

--- a/sysutils/openbrowser/Portfile
+++ b/sysutils/openbrowser/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    openbrowser
 version                 1.0.1
-revision                7
+revision                8
 categories              sysutils
 platforms               macosx
 maintainers             {ryandesign @ryandesign} openmaintainer
@@ -24,10 +24,7 @@ homepage                https://www.macports.org
 
 distfiles
 
-perl5.require_variant   yes
-perl5.conflict_variants yes
-perl5.branches          5.24 5.26
-perl5.create_variants   ${perl5.branches}
+perl5.branches          5.26
 
 depends_lib
 depends_run-append      port:perl${perl5.major} \
@@ -40,7 +37,7 @@ configure {
 }
 
 build {
-    reinplace "s|/usr/bin/env perl|${prefix}/bin/perl${perl5.major}|g" ${worksrcpath}/${name}
+    reinplace "s|/usr/bin/env perl|${perl5.bin}|g" ${worksrcpath}/${name}
 
     # Use correct plist file
     if {${os.major} < 15} {

--- a/sysutils/rex/Portfile
+++ b/sysutils/rex/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                rex
-perl5.branches      5.24 5.26
+perl5.branches      5.26
 perl5.setup         Rex 1.5.0 ../by-authors/id/J/JF/JFRIED
 perl5.link_binaries_suffix
+revision            1
 
 categories          sysutils perl
 platforms           darwin

--- a/sysutils/rpm/Portfile
+++ b/sysutils/rpm/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                rpm
 version             4.4.9
-revision            19
-perl5.branches      5.24
+revision            20
+perl5.branches      5.26
 platforms           darwin freebsd linux
 license             GPL-2 LGPL-2
 categories          sysutils archivers

--- a/sysutils/rpm54/Portfile
+++ b/sysutils/rpm54/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                rpm54
 version             5.4.15
-revision            5
+revision            6
 set date            20140824
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin freebsd linux
@@ -64,8 +64,8 @@ build.type          gnu
 # set default variant to perl5_24 (#52081)
 
 perl5.conflict_variants yes
-perl5.branches          5.24
-perl5.default_branch    5.24
+perl5.branches          5.26
+perl5.default_branch    5.26
 perl5.create_variants   ${perl5.branches}
 
 configure.args      --disable-nls \

--- a/sysutils/rsnapshot/Portfile
+++ b/sysutils/rsnapshot/Portfile
@@ -5,7 +5,8 @@ PortGroup           perl5 1.0
 
 name                rsnapshot
 version             1.4.2
-perl5.branches      5.24
+revision            1
+perl5.branches      5.26
 categories          sysutils net
 platforms           darwin
 maintainers         nomaintainer

--- a/sysutils/sleuthkit/Portfile
+++ b/sysutils/sleuthkit/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                sleuthkit
 version             4.1.3
-revision            5
+revision            6
 categories          sysutils
 maintainers         nomaintainer
 platforms           darwin
@@ -29,7 +29,7 @@ master_sites        sourceforge:project/sleuthkit/sleuthkit/${version}
 checksums           rmd160  223c6ffe22259ca057b6d9634813536e7ccd9dba \
                     sha256  67f9d2a31a8884d58698d6122fc1a1bfa9bf238582bde2b49228ec9b899f0327
 
-perl5.branches      5.24
+perl5.branches      5.26
 depends_build       port:file \
                     port:perl${perl5.major}
 depends_lib         port:libewf \

--- a/sysutils/stow/Portfile
+++ b/sysutils/stow/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                stow
 version             2.2.2
-revision            1
+revision            2
 categories          sysutils
 platforms           darwin
 maintainers         nomaintainer
@@ -26,7 +26,7 @@ master_sites        gnu
 checksums           rmd160  c8f64c35d81dca28030d5a731f3597f262ce33bd \
                     sha256  e2f77649301b215b9adbc2f074523bedebad366812690b9dc94457af5cf273df
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 configure.perl      ${perl5.bin}
 depends_lib         port:perl${perl5.major}

--- a/sysutils/xserve-raid-tools/Portfile
+++ b/sysutils/xserve-raid-tools/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                xserve-raid-tools
 version             1.2
-revision            5
+revision            6
 categories          sysutils net
 license             GPL-2
 maintainers         nomaintainer
@@ -24,7 +24,7 @@ master_sites        ftp://noc.hep.wisc.edu/pub/src/xserve-raid-tools/
 checksums           rmd160  52f6973a8eb86a767e3c11619ce0bbdd53e035e0 \
                     sha256  fb13b345ef253ad6d2de9dcef8572818515ecc7a4bc4552439cfe7e42362b100
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:p${perl5.major}-xml-parser \
                     port:netcat

--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -7,6 +7,7 @@ PortGroup           texlive 1.0
 
 name                LaTeXML
 version             0.8.2
+revision            1
 license             public-domain
 maintainers         nist.gov:bruce.miller
 description         LaTeXML converts TeX to XML/HTML/MathML
@@ -15,7 +16,7 @@ long_description \
 
 # Written in Perl, but it is an application, not just modules
 PortGroup           perl5 1.0
-perl5.branches      5.24
+perl5.branches      5.26
 perl5.setup         ${name} ${version}
 perl5.link_binaries_suffix
 

--- a/textproc/docbook-utils/Portfile
+++ b/textproc/docbook-utils/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                docbook-utils
 version             0.6.14
-revision            4
-perl5.branches      5.24
+revision            5
+perl5.branches      5.26
 categories          textproc
 platforms           darwin
 license             GPL-2+

--- a/textproc/naturaldocs/Portfile
+++ b/textproc/naturaldocs/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                naturaldocs
 version             1.52
-revision            2
+revision            3
 categories          textproc devel
 license             AGPL-3
 maintainers         nomaintainer
@@ -27,7 +27,7 @@ extract.mkdir       yes
 checksums           rmd160  92b6420cd4450f787bb7170e39cfe8e56b27bfb2 \
                     sha256  3f13c99e15778afe6c5555084a083f856e93567b31b08acd1fd81afb10082681
 
-perl5.branches      5.24
+perl5.branches      5.26
 
 depends_lib         port:perl${perl5.major}
 

--- a/www/spidereyeballs/Portfile
+++ b/www/spidereyeballs/Portfile
@@ -5,8 +5,8 @@ PortGroup           perl5 1.0
 
 name                spidereyeballs
 version             0.21
-revision            5
-perl5.branches      5.24
+revision            6
+perl5.branches      5.26
 categories          www
 platforms           darwin
 supported_archs     noarch

--- a/www/wml/Portfile
+++ b/www/wml/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    wml
 version                 2.0.11
-revision                12
+revision                13
 platforms               darwin
 categories              www lang
 maintainers             cfaerber.name:cfaerber \
@@ -22,7 +22,7 @@ master_sites            http://thewml.org/distrib/ \
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.24
+perl5.branches          5.26
 perl5.create_variants   ${perl5.branches}
 
 checksums               rmd160  fead82a35d116447b860d7b1c506c6de187355e8 \


### PR DESCRIPTION
See: https://trac.macports.org/ticket/55208

#### Description

I would like to ask maintainers to test this PR which revbumps ports to switch to Perl5.26. A small number of ports is left out.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

**NOT TESTED**

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
