### PR TITLE
biblatex-biber: remove perl variants

### DIFF
--- a/tex/biblatex-biber/Portfile
+++ b/tex/biblatex-biber/Portfile
@@ -10,15 +10,11 @@ PortGroup texlive 1.0
 name            biblatex-biber
 epoch           2
 
-perl5.require_variant   yes
-perl5.conflict_variants yes
-perl5.branches          5.24 5.26
-perl5.create_variants   ${perl5.branches}
-perl5.default_branch    5.26
+perl5.branches  5.26
 
 perl5.setup     Biber 2.7
 version         ${perl5.moduleversion}
-revision        2
+revision        3
 
 categories      tex
 license         {Artistic-2 GPL}


### PR DESCRIPTION
I would like confirmation from the maintainer. There's probably no reason to actually keep the variants around, just make sure that the port is built with a consistent set of dependencies.

See: https://trac.macports.org/ticket/55208

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
