### PR TITLE
mythtv.28: use perl5 PortGroup, switch to perl5.26

### DIFF
--- a/multimedia/mythtv.28/Portfile
+++ b/multimedia/mythtv.28/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           qt5 1.0
+PortGroup           perl5 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 PortGroup           conflicts_build 1.0
@@ -11,8 +12,8 @@ set shorthash       0e079696
 set majorversion    .28
 set minorversion    .1
 set lastcommit      20171010
-set corerev         1
-set pluginsrev      0
+set corerev         2
+set pluginsrev      1
 set metarev         0
 github.setup        MythTV mythtv ${shorthash}
 checksums           rmd160  cf7ce3662be5335f3dc0ea0d749389d4e5d4583a \
@@ -43,13 +44,11 @@ set mythverstring   v0${majorversion}${minorversion}-${shorthash}-MacPorts
 set mythbranch      fixes/0${majorversion}
 set applescripts    {Myth_Frontend Myth_Filldatabase Myth_Setup Myth_Stop_Start}
 set mysqlver        mariadb
-set perlver         perl5.24
-set perlbin         ${prefix}/bin/${perlver}
-set perlmodver      p5.24
 set pythonbranch    2.7
 set pythonver       python${pythonbranch}
 set pythonbin       ${prefix}/bin/${pythonver}
 set pymodver        py27
+perl5.branches      5.26
 # change to 1 to print reinplace warnings
 set maintainer_mode 0
 if {!$maintainer_mode} {
@@ -99,12 +98,12 @@ if {$subport eq "mythtv-core${majorversion}"} {
                         port:${pymodver}-lxml \
                         port:${pymodver}-requests-cache \
                         port:${pymodver}-urlgrabber \
-                        port:${perlmodver}-dbd-mysql \
-                        port:${perlmodver}-http-request-ascgi \
-                        port:${perlmodver}-lwp-useragent-determined \
-                        port:${perlmodver}-io-socket-inet6 \
-                        port:${perlmodver}-datemanip \
-                        port:${perlmodver}-net-upnp
+                        port:p${perl5.major}-dbd-mysql \
+                        port:p${perl5.major}-http-request-ascgi \
+                        port:p${perl5.major}-lwp-useragent-determined \
+                        port:p${perl5.major}-io-socket-inet6 \
+                        port:p${perl5.major}-datemanip \
+                        port:p${perl5.major}-net-upnp
     
     depends_build-append \
                         port:yasm
@@ -118,7 +117,7 @@ if {$subport eq "mythtv-core${majorversion}"} {
     require_active_variants \
                         qt5-mysql-plugin mariadb55 mysql56
     require_active_variants \
-                        ${perlmodver}-dbd-mysql mariadb {mariadb10_0 mariadb10_1 mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 percona}
+                        p${perl5.major}-dbd-mysql mariadb {mariadb10_0 mariadb10_1 mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 percona}
     require_active_variants \
                         ${pymodver}-mysql mariadb55 {mysql4 mysql51 mysql55 mysql56 percona55}
     require_active_variants \
@@ -160,14 +159,14 @@ if {$subport eq "mythtv-core${majorversion}"} {
     post-patch {
         set sedPath ${worksrcpath}/mythtv/
         ui_info "Make Myth utils use MacPorts Perl"
-        reinplace -locale C "s|check_cmd perl -e|check_cmd ${perlbin} -e|" \
+        reinplace -locale C "s|check_cmd perl -e|check_cmd ${perl5.bin} -e|" \
             ${sedPath}configure
     
-        reinplace -locale C "s|#!/usr/bin/env perl|#!${perlbin}|" \
+        reinplace -locale C "s|#!/usr/bin/env perl|#!${perl5.bin}|" \
             ${sedPath}programs/scripts/internetcontent/topdocumentaryfilm.pl  \
             ${sedPath}programs/scripts/internetcontent/twit.tv.pl
     
-        reinplace -locale C "s|#!/usr/bin/perl|#!${perlbin}|" \
+        reinplace -locale C "s|#!/usr/bin/perl|#!${perl5.bin}|" \
             ${sedPath}bindings/perl/Makefile.PL  \
             ${sedPath}contrib/maintenance/optimize_mythdb.pl  \
             ${sedPath}contrib/user_jobs/mythlink.pl  \
@@ -533,14 +532,14 @@ if {$subport eq "mythtv-plugins${majorversion}"} {
 
     post-patch {
         set sedPath ${worksrcpath}/mythplugins/
-        reinplace -locale C "s|check_cmd perl -e|check_cmd ${perlbin} -e|" \
+        reinplace -locale C "s|check_cmd perl -e|check_cmd ${perl5.bin} -e|" \
             ${sedPath}configure
         reinplace -locale C "s|python=\"python\"|python=\"${pythonbin}\"|" \
             ${sedPath}configure
         # do fixups regardless of whether variant is selected or not
         foreach fixfile [exec find ${sedPath}/mythweather/mythweather/scripts -name "*.p?"] {
-            reinplace {*}$qflag "s;/usr/bin/perl;${perlbin};g" ${fixfile}
-            reinplace {*}$qflag "s;/usr/share/mythtv;${perlbin};g" ${fixfile}
+            reinplace {*}$qflag "s;/usr/bin/perl;${perl5.bin};g" ${fixfile}
+            reinplace {*}$qflag "s;/usr/share/mythtv;${perl5.bin};g" ${fixfile}
         }
     }
 
@@ -575,7 +574,7 @@ if {$subport eq "mythtv-plugins${majorversion}"} {
 
     if {[variant_isset mythnetvision] || [variant_isset mythweather]} {
     # for both MythNetvision and MythWeather (Canada)
-        depends_lib-append      port:${perlmodver}-perlmagick
+        depends_lib-append      port:p${perl5.major}-perlmagick
     }
 
     # Linking error, see https://code.mythtv.org/trac/ticket/12839
@@ -624,13 +623,13 @@ if {$subport eq "mythtv-plugins${majorversion}"} {
     }
 
     variant mythweather description {Weather information for your chosen locations via Myth plugin.} {
-        depends_lib-append      port:${perlmodver}-datemanip\
-                                port:${perlmodver}-xml-simple \
-                                port:${perlmodver}-xml-xpath \
-                                port:${perlmodver}-image-size \
-                                port:${perlmodver}-datetime-format-iso8601 \
-                                port:${perlmodver}-soap-lite \
-                                port:${perlmodver}-json
+        depends_lib-append      port:p${perl5.major}-datemanip\
+                                port:p${perl5.major}-xml-simple \
+                                port:p${perl5.major}-xml-xpath \
+                                port:p${perl5.major}-image-size \
+                                port:p${perl5.major}-datetime-format-iso8601 \
+                                port:p${perl5.major}-soap-lite \
+                                port:p${perl5.major}-json
         configure.args-delete   --disable-mythweather
     #   configure.args-append   --enable-mythweather
     }


### PR DESCRIPTION
I would like to ask maintainer for review.

See: https://trac.macports.org/ticket/55208

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
