### PR TITLE
github-1.0.tcl: always verify TLS certificate

### DIFF
--- a/_resources/port1.0/group/github-1.0.tcl
+++ b/_resources/port1.0/group/github-1.0.tcl
@@ -143,7 +143,7 @@ proc handle_tarball_from {option action args} {
 }
 
 proc github.setup {gh_author gh_project gh_version {gh_tag_prefix ""}} {
-    global extract.suffix os.platform os.major github.author github.project github.version github.tag_prefix github.homepage github.master_sites PortInfo
+    global extract.suffix github.author github.project github.version github.tag_prefix github.homepage github.master_sites PortInfo
 
     github.author           ${gh_author}
     github.project          ${gh_project}
@@ -159,9 +159,6 @@ proc github.setup {gh_author gh_project gh_version {gh_tag_prefix ""}} {
     git.url                 ${github.homepage}.git
     git.branch              [join ${github.tag_prefix}]${github.version}
     distname                ${github.project}-${github.version}
-    if {${os.platform} eq "darwin" && ${os.major} <= 9} {
-        fetch.ignore_sslcert yes
-    }
 
     post-extract {
         # When fetching from a tag, the extracted directory name will contain a


### PR DESCRIPTION
#### Description
Now that GitHub disabled TLS 1/1.1, and OS X < 10.9 doesn't support TLS 1.2, we should remove this hack and rely on distfile mirroring or custom `--with-curlprefix` (which should have recent CA certs, e.g. from `curl-ca-bundle`).

See: https://githubengineering.com/crypto-deprecation-notice/
and https://github.com/dotnet/announcements/issues/58
>As of 22 Feb 2018, GitHub has disabled support for weak encryption.


cc @ryandesign