### PR TITLE
libcaer: new port

### DIFF
--- a/devel/libcaer/Portfile
+++ b/devel/libcaer/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1   
+
+github.setup        inilabs libcaer 2.4.0
+categories          devel
+platforms           darwin
+license             BSD-2-Clause
+maintainers         {@ierofant gmail.com:aw.kornilov} openmaintainer
+
+description         Minimal C library to access, configure and get/send AER data
+long_description    Minimal C library to access, configure and get/send AER data from sensors \
+                    or to/from neuromorphic processors. Supported devices are the Dynamic Vision Sensor (DVS), \
+                    all the DAVIS cameras, and the Dynap-se neuromorphic processor.
+
+depends_lib-append  port:libusb
+
+checksums           rmd160  67b5c16b8da39a193249dcdd055d90a9930cd9e4 \
+                    sha256  431b606934b40de498a7d0f50876745b92b95d64b5ea81da0a52d055a2b89cd7


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
