### PR TITLE
py-gammapy: update to version 0.7

### DIFF
--- a/python/py-gammapy/Portfile
+++ b/python/py-gammapy/Portfile
@@ -7,23 +7,24 @@ set _name           gammapy
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.6
+version             0.7
 categories-append   science
 platforms           darwin
-maintainers         gmail.com:Deil.Christoph openmaintainer
+license             BSD
+maintainers         {@cdeil gmail.com:Deil.Christoph} openmaintainer
 
 description         A Python package for gamma-ray astronomy
 long_description    ${description}
 
-homepage            https://github.com/gammapy/gammapy
+homepage            http://gammapy.org/
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     68679182c52654aeb8e0ad97b9a28f81 \
-                    rmd160  2413dd10219ed9b679b088b3f4d2d3336c8d9f0d \
-                    sha256  50f816a1b13de0bd483b588fc5ca4799849cca65a74102f81b8d972d48903550
+checksums           md5     abda1f58982d8b6d19fff632980e521a \
+                    rmd160  7a5dcb6c93078e80f4308174985eab3a421e30b4 \
+                    sha256  f30eef6efefb2829d55ceb4bab547011ae1e9fa0434cb5ab6042e4156f1ec6da
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
 


### PR DESCRIPTION
#### Description

* Update py-gammapy to version 0.7

###### Tested on

macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Running `sudo port test` doesn't work (installs previous version? tests not defined?)
https://gist.github.com/cdeil/af5acf40e0be9d230a0fed41acf1c5f0
Could you please point out an example of a Python port that defines tests?

Running `sudo port -vst install` fails like this:
https://gist.github.com/cdeil/509b70fd4775c07d38deaf16428a3c19

Help?