### PR TITLE
FreeCAD: Update to 0.16.6712

### DIFF
--- a/cad/freecad/Portfile
+++ b/cad/freecad/Portfile
@@ -6,8 +6,7 @@ PortGroup               compilers 1.0
 PortGroup               github 1.0
 PortGroup               qt4 1.0
 
-github.setup            FreeCAD FreeCAD 0.16
-revision                4
+github.setup            FreeCAD FreeCAD 0.16.6712
 name                    freecad
 categories              cad
 platforms               darwin
@@ -25,10 +24,11 @@ long_description \
     Source (LGPL2+ license) and extremely modular, allowing for very \
     advanced extension and customization.
 
-homepage                http://www.freecadweb.org/
+homepage                https://www.freecadweb.org
 
-checksums               rmd160 21974e87bfa6ea9b1a8ceb4a3cc3dbf1f74c685b \
-                        sha256 6f4ac4b38a32086155506717885d239453131cc64b177b75616f44163276d343
+checksums               rmd160  02eee552016fc0664fdeef030569be082d600bad \
+                        sha256  990aab10320921d14169979b19d349234f7d81de6921c23dbcd6d05be8bfa8a8 \
+                        size    111706057
 
 depends_lib-append      port:python27 \
                         port:boost \
@@ -49,6 +49,7 @@ depends_lib-append      port:python27 \
 depends_run             port:qt4-mac-sqlite3-plugin
 
 patchfiles              cMake-FindCoin3D.cmake.diff \
+                        NULL.diff \
                         src-App-FreeCADInit.py.diff
 
 post-patch {
@@ -88,9 +89,9 @@ pre-configure {
         -DPYTHON_LIBRARY=${python_prefix}/Python \
         -DPYTHON_INCLUDE_DIR=${python_prefix}/Headers \
         -DPYTHON_EXECUTABLE=${python_prefix}/bin/python2.7 \
-        -DShiboken_DIR=${python_prefix}/lib/cmake/Shiboken-1.2.2 \
-        -DPySide_DIR=${python_prefix}/lib/cmake/PySide-1.2.2 \
-        -DOCE_DIR=${frameworks_dir}/OCE.framework/Versions/0.15/Resources
+        -DShiboken_DIR=${python_prefix}/lib/cmake/Shiboken-1.2.4 \
+        -DPySide_DIR=${python_prefix}/lib/cmake/PySide-1.2.4 \
+        -DOCE_DIR=${frameworks_dir}/OCE.framework/Versions/0.17/Resources
 }
 
 post-destroot {

--- a/cad/freecad/Portfile
+++ b/cad/freecad/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               cmake 1.0
+PortGroup               cmake 1.1
 PortGroup               compilers 1.0
 PortGroup               github 1.0
 PortGroup               qt4 1.0
@@ -59,18 +59,17 @@ post-patch {
         ${worksrcpath}/src/Mod/OpenSCAD/OpenSCADUtils.py
 }
 
-cmake.out_of_source     yes
-
 compilers.choose        fc
 compilers.setup         -dragonegg -g95 require_fortran
 
-configure.args-delete   -DCMAKE_INSTALL_RPATH=${prefix}/lib \
-                        -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib
+cmake.install_prefix    ${prefix}/libexec/${name}
+cmake.install_rpath     ${cmake.install_prefix}/lib
 
-configure.args-append   -DCMAKE_INSTALL_RPATH=${prefix}/libexec/${name}/lib \
-                        -DCMAKE_INSTALL_NAME_DIR=${prefix}/libexec/${name}/lib \
-                        -DCMAKE_INSTALL_PREFIX=${prefix}/libexec/${name} \
-                        -DCMAKE_INSTALL_DATADIR=${prefix}/share/${name} \
+configure.pre_args-replace \
+                        -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
+                        -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib
+
+configure.args-append   -DCMAKE_INSTALL_DATADIR=${prefix}/share/${name} \
                         -DCMAKE_INSTALL_DOCDIR=${prefix}/share/doc/${name} \
                         -DCMAKE_FRAMEWORK_PATH=${frameworks_dir} \
                         -DMACPORTS_PREFIX=${prefix} \

--- a/cad/freecad/files/NULL.diff
+++ b/cad/freecad/files/NULL.diff
@@ -1,0 +1,23 @@
+error: ordered comparison between pointer and zero ('FILE *' (aka '__sFILE *') and 'int')
+--- src/3rdParty/salomesmesh/src/DriverDAT/DriverDAT_R_SMDS_Mesh.cpp.orig	2017-07-17 12:27:47.000000000 -0500
++++ src/3rdParty/salomesmesh/src/DriverDAT/DriverDAT_R_SMDS_Mesh.cpp	2018-02-28 23:52:54.000000000 -0600
+@@ -52,7 +52,7 @@
+    ****************************************************************************/
+   char *file2Read = (char *)myFile.c_str();
+   FILE* aFileId = fopen(file2Read, "r");
+-  if (aFileId < 0) {
++  if (aFileId == NULL) {
+     fprintf(stderr, ">> ERREUR : ouverture du fichier %s \n", file2Read);
+     return DRS_FAIL;
+   }
+--- src/3rdParty/salomesmesh/src/DriverDAT/DriverDAT_W_SMDS_Mesh.cpp.orig	2017-07-17 12:27:47.000000000 -0500
++++ src/3rdParty/salomesmesh/src/DriverDAT/DriverDAT_W_SMDS_Mesh.cpp	2018-02-28 23:55:04.000000000 -0600
+@@ -38,7 +38,7 @@
+   
+   char *file2Read = (char *)myFile.c_str();
+   FILE* aFileId = fopen(file2Read, "w+");
+-  if (aFileId < 0) {
++  if (aFileId == NULL) {
+     fprintf(stderr, ">> ERREUR : ouverture du fichier %s \n", file2Read);
+     return DRS_FAIL;
+   }

--- a/cad/freecad/files/src-App-FreeCADInit.py.diff
+++ b/cad/freecad/files/src-App-FreeCADInit.py.diff
@@ -1,10 +1,10 @@
---- src/App/FreeCADInit.py.orig	2014-07-13 10:33:02.000000000 -0500
-+++ src/App/FreeCADInit.py	2014-07-17 20:19:20.000000000 -0500
-@@ -101,6 +101,7 @@
+--- src/App/FreeCADInit.py.orig	2017-07-17 12:27:47.000000000 -0500
++++ src/App/FreeCADInit.py	2018-02-28 23:48:24.000000000 -0600
+@@ -110,6 +110,7 @@
  					Log('Init:      Initializing ' + Dir + '... done\n')
  			else:
  				Log('Init:      Initializing ' + Dir + '(Init.py not found)... ignore\n')
-+        sys.path.insert(0,BinDir)
++	sys.path.insert(0,BinDir)
  	sys.path.insert(0,LibDir)
+ 	sys.path.insert(0,Lib64Dir)
  	sys.path.insert(0,ModDir)
- 	Log("Using "+ModDir+" as module path!\n")


### PR DESCRIPTION
#### Description

* Update FreeCAD to 0.16.6712. Closes https://trac.macports.org/ticket/55847
* Use cmake 1.1 portgroup.
* Use https for homepage since http redirects there.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?