### PR TITLE
keepassxc: update to 2.3.0

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -5,10 +5,10 @@ PortGroup               qt5 1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.0
 
-github.setup            keepassxreboot keepassxc 2.2.4
+github.setup            keepassxreboot keepassxc 2.3.0
 name                    KeePassXC
 categories              security aqua
-maintainers             @yan12125 openmaintainer
+maintainers             {@yan12125 gmail.com:yan12125} openmaintainer
 
 description             KeePassXC is a cross-platform community-driven port \
                         of the Windows application “Keepass Password Safe”.
@@ -27,19 +27,29 @@ use_xz                  yes
 distname                ${github.project}-${version}-src
 worksrcdir              ${github.project}-${version}
 
-checksums               rmd160  f7c77f3865c2f79f4e0ac86b0ba70eedf12a74c7 \
-                        sha256  e52fa32cb39af3c64ddd651481b7963b1206830687fb7d4c9f20ad5d6ac0d3dd \
-                        size    3258424
+checksums               rmd160  9fcb5e519a100ba21213b9e8517a6cd27794a016 \
+                        sha256  ec5858daeaa05386a614b799d5daf01c634205844647e2f9d25aaf655d2adbec \
+                        size    3803400
 
-depends_lib-append      port:libgcrypt \
+patchfiles              patch-no-deployqt.diff
+
+qt5.depends_component   qtmacextras
+qt5.depends_build_component \
+                        qttools
+
+depends_lib-append      port:argon2 \
+                        port:libgcrypt \
+                        port:libsodium \
                         port:zlib
-depends_build-append    port:qt5-qttools
 
 cmake.out_of_source     yes
 configure.pre_args-append \
     -DCMAKE_INSTALL_PREFIX=${applications_dir} \
+    -DCMAKE_INSTALL_MANDIR=${prefix}/share/man \
     -DWITH_XC_HTTP=ON \
-    -DQT_BINARY_DIR=${prefix}/libexec/qt5/bin
+    -DWITH_XC_BROWSER=ON \
+    -DWITH_XC_SSHAGENT=ON \
+    -DWITH_XC_NETWORKING=ON
 
 if {${configure.cxx_stdlib} eq "libstdc++"} {
     configure.pre_args-append   -DWITH_CXX11=OFF

--- a/security/KeePassXC/files/patch-no-deployqt.diff
+++ b/security/KeePassXC/files/patch-no-deployqt.diff
@@ -1,0 +1,41 @@
+--- CMakeLists.txt	2018-02-28 05:38:05.000000000 +0800
++++ CMakeLists.txt	2018-03-02 16:51:27.000000000 +0800
+@@ -306,12 +306,6 @@
+ 
+ if(APPLE)
+   set(CMAKE_MACOSX_RPATH TRUE)
+-  find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
+-  if(NOT MACDEPLOYQT_EXE)
+-    message(FATAL_ERROR "macdeployqt is required to build in macOS")
+-  else()
+-    message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
+-  endif()
+ endif()
+ 
+ # Debian sets the the build type to None for package builds.
+--- src/CMakeLists.txt	2018-02-28 05:38:05.000000000 +0800
++++ src/CMakeLists.txt	2018-03-02 16:47:48.000000000 +0800
+@@ -319,11 +319,6 @@
+   set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
+   include(CPack)
+ 
+-  add_custom_command(TARGET ${PROGNAME}
+-                     POST_BUILD
+-                     COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app
+-                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+-                     COMMENT "Deploying app bundle")
+ endif()
+ 
+ install(TARGETS ${PROGNAME}
+--- src/autotype/mac/CMakeLists.txt	2018-02-28 05:38:05.000000000 +0800
++++ src/autotype/mac/CMakeLists.txt	2018-03-02 16:48:26.000000000 +0800
+@@ -13,8 +13,8 @@
+ if(WITH_APP_BUNDLE)
+   add_custom_command(TARGET keepassx-autotype-cocoa
+                      POST_BUILD
++                     COMMAND ${CMAKE_COMMAND} -E make_directory ${PLUGIN_INSTALL_DIR}
+                      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}
+-                     COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so -no-plugins
+                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+   COMMENT "Deploying autotype plugin")
+ else()


### PR DESCRIPTION
#### Description

* Enable all KeePassXC features
* Patched to skip macdeployqt steps. It's not necessary for a MacPorts application as dependent libraries are always available, and it significantly reduces the package size. (2.2.4 24M => 2.3.0 4.4M)

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
