### PR TITLE
plumed: update to 2.4.1

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -9,8 +9,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.4.0 v
-revision            2
+github.setup        plumed plumed2 2.4.1 v
 name                plumed
 
 categories          science
@@ -29,8 +28,8 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  e3c5df528c00cdd5bc54a8d7ce2eaa5e8c5a8b04 \
-                    sha256  11f8c5a6bf7e2f6c133f9355924bbb5fa5f0cef0dc861d36726fa83a687ead44
+checksums           rmd160  8762d5c2f28c5281da0410691b0ede4575b73c82 \
+                    sha256  1cf9a2fda224b1c12c64b966c81c9a0e52c1468cf35dfbbe7dad51f3e976b102
 
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
@@ -102,13 +101,13 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 d9be97c7bba3d165e130562033286537c23819d0
-    version             2.5-20180129
+    github.setup        plumed plumed2 f0eab70af62be7797ed007565d42a2ab88c6303b
+    version             2.5-20180302
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  e54b52d0c51ca92f3045c619c45f5cdf7358ce8e \
-                        sha256  24cf68700aaf5321415898e7cee934ff5b4993677e3ac362c0a397a8cd9da196
+    checksums           rmd160  ae098ee9a8c2aee503d6c174f9d21bd30cc9c4e5 \
+                        sha256  7f28caafbae93fb81ec3cf17c1a2929313f5b5d79adf9adee6c443cf3826e16d
     configure.ldflags-delete -lmatheval
     depends_lib-delete       port:libmatheval
 # plumed 2.5 supports python. However, I disable it here since it is


### PR DESCRIPTION
Notice that this commit also updated plumed-devel to March 2, 2018 snapshot.

Also notice that there is no change in patches, so there is no need to revbump the dependent port gromacs-plumed.