### PR TITLE
R: Set version normally

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -5,14 +5,9 @@ PortGroup compilers 1.0
 PortGroup active_variants 1.1
 
 name                        R
-
-set major 3
-set minor 4
-set point 3
-
 #Remember to remove revision line when bumping version
-version                     ${major}.${minor}.${point}
-
+version                     3.4.3
+set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
 maintainers                 me.com:kjell.konis
 license                     {GPL-2 GPL-3}
@@ -48,7 +43,7 @@ depends_lib                 port:readline \
 
 universal_variant           no
 
-set resources ${frameworks_dir}/R.framework/Versions/${major}.${minor}/Resources
+set resources               ${frameworks_dir}/R.framework/Versions/${branch}/Resources
 
 post-patch {
     reinplace "s|R_HOME|\"${resources}\"|" "${worksrcpath}/src/unix/Rscript.c"


### PR DESCRIPTION
#### Description

@kjellpk: This PR changes the R port to set the `version` field directly, rather than based on other variables. It removes the port's custom `major`, `minor` and `point` variables and introduces the "[standard](https://trac.macports.org/wiki/PortfileRecipes#branch)" `branch` variable.

This is what other port developers are used to seeing, and it makes it easier for them to update the port. Some people such as myself use automated scripts to update the `version` and `checksums` of a portfile, which don’t work with the nonstandard way this port was setting its version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?