### PR TITLE
wget: +ssl and +gnutls

### DIFF
--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    wget
 version                 1.19.4
-revision                1
+revision                2
 categories              net www
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 GPL-3+
@@ -91,12 +91,21 @@ configure.args-append       ac_cv_header_uuid_uuid_h=no
 test.run                yes
 test.target             check
 
-variant ssl description {Build with SSL support using GnuTLS} {
+variant gnutls conflicts ssl description {SSL support via GnuTLS} {
+    configure.args-replace  --without-ssl --with-ssl=gnutls
+    configure.args-append   --with-libgnutls-prefix=${prefix}
     depends_lib-append      port:gnutls
-    configure.args-delete   --without-ssl
 }
 
-default_variants        +ssl
+variant ssl conflicts gnutls description {SSL support via OpenSSL} {
+    configure.args-replace  --without-ssl --with-ssl=openssl
+    configure.args-append   --with-libssl-prefix=${prefix}
+    depends_lib-append      path:lib/libssl.dylib:openssl
+}
+
+if {![variant_isset ssl]} {
+    default_variants +gnutls
+}
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" \


### PR DESCRIPTION
Currently, wget has a +ssl variant, which actually builds with gnutls.
Name that +gnutls, and also have a +ssl variant built with openssl.
(That's how other ports call these variants, see e.g. curl.)
Make +gnutls the default, as that's what upstream does.

Tested on 10.13.2 and 10.5.8
