### PR TITLE
tcpdump: explicit ./configure --options

### DIFF
--- a/net/tcpdump/Portfile
+++ b/net/tcpdump/Portfile
@@ -22,13 +22,19 @@ depends_lib         port:libpcap \
                     port:libsmi \
                     path:lib/libssl.dylib:openssl
 
-configure.args      --disable-smb --disable-universal
+configure.args      --disable-universal \
+                    --disable-smb \
+                    --with-smi \
+                    --without-sandbox-capsicum \
+                    --with-system-libpcap \
+                    --with-crypto=${prefix} \
+                    --with-cap-ng
 
 # ugly: beat ./configure to use $prefix BEFORE /usr
 configure.cflags-append "-I${prefix}/include -L${prefix}/lib"
 
 variant smb description {enable possibly-buggy SMB printer} {
-    configure.args-delete   --disable-smb
+    configure.args-replace --disable-smb --enable-smb
 }
 
 livecheck.type      regex


### PR DESCRIPTION
Explicity state the ooptions in ./configure --help order.
While here, explicitly --enable-smb for the smb variant.

Tested on 10.13.2, 10.6.8 and 10.5.8