### PR TITLE
kotlin: update to 1.2.30

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.2.21 v
+github.setup        JetBrains kotlin 1.2.30 v
 github.tarball_from releases
-revision            1
 distname            ${name}-compiler-${version}
 categories          lang java
 platforms           darwin
@@ -22,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  ff46907dacdaeb0808ccaff3357ab75c6a87527d \
-                    sha256  c5f2cbd35daa6c5c394e92e6c06b8eb41d85ad8da64762733874166b6807af22
+checksums           rmd160  38fac15462d8e599b11192153dce3f00ba9e1846 \
+                    sha256  4d6965877301d44241ca6de36480140992dc8a6b1c1884baeb5239ce2c43e071
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.2.30.

###### Tested on

macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?