### PR TITLE
lowdown: LDFLAGS for universal and snowleopardfixes

### DIFF
--- a/textproc/lowdown/Portfile
+++ b/textproc/lowdown/Portfile
@@ -4,6 +4,7 @@ PortGroup		snowleopard_fixes 1.0
 name			lowdown
 categories		textproc
 version			0.3.1
+revision		1
 license			BSD
 
 description		simple markdown translator
@@ -18,5 +19,8 @@ checksums \
 	rmd160 bb93c94c974d8f68b2912f840829fc05e665a314 \
 	sha256 9e3796c7f819a3d28a8e304eac60da62e98fa996cae4131da971d8deaea44766
 
-configure.pre_args	""
-configure.args		"PREFIX=${prefix}"
+patchfiles		Makefile.patch configure.patch
+
+configure.universal_args
+configure.pre_args	PREFIX=${prefix}
+configure.args		MANDIR=${prefix}/share/man

--- a/textproc/lowdown/files/Makefile.patch
+++ b/textproc/lowdown/files/Makefile.patch
@@ -1,0 +1,12 @@
+Use LDFLAGS when linking lowdown.
+--- Makefile.orig	2017-10-26 04:00:30.000000000 -0500
++++ Makefile	2018-02-22 15:09:45.000000000 -0600
+@@ -62,7 +62,7 @@
+ 	install -m 0444 lowdown.tar.gz.sha512 $(WWWDIR)/snapshots
+ 
+ lowdown: liblowdown.a main.o
+-	$(CC) -o $@ main.o liblowdown.a -lm
++	$(CC) -o $@ main.o liblowdown.a -lm $(LDFLAGS)
+ 
+ lowdown-diff: lowdown
+ 	ln -f lowdown lowdown-diff

--- a/textproc/lowdown/files/configure.patch
+++ b/textproc/lowdown/files/configure.patch
@@ -1,0 +1,21 @@
+Allow LDFLAGS to be passed from the environment.
+--- configure.orig	2017-10-26 04:00:30.000000000 -0500
++++ configure	2018-02-22 15:15:10.000000000 -0600
+@@ -56,7 +56,7 @@
+ 
+ #----------------------------------------------------------------------
+ # Initialize all variables here such that nothing can leak in from the
+-# environment except for CC and CFLAGS, which we might have passed in.
++# environment except for CC, CFLAGS and LDFLAGS, which we might have passed in.
+ #----------------------------------------------------------------------
+ 
+ CC=`printf "all:\\n\\t@echo \\\$(CC)\\n" | make -sf -`
+@@ -65,7 +65,7 @@
+ CFLAGS="${CFLAGS} -Wwrite-strings -Wno-unused-parameter"
+ LDADD=
+ CPPFLAGS=
+-LDFLAGS=
++LDFLAGS=`printf "all:\\n\\t@echo \\\$(LDFLAGS)\\n" | make -sf -`
+ PREFIX="/usr/local"
+ BINDIR=
+ SBINDIR=


### PR DESCRIPTION
Clear lowdown's `configure.universal_args`, as it ony reconizes KEY=VAL.
Make lowdown's build system honor LDFLAGS so that we can pass what's needed
for a `+universal` build, and for `-lsnowleopardfixes` on older releases.

Prepared by Ryan in  https://trac.macports.org/ticket/55878, slightly tweeked by me.
Tested on 10.5.8, 10.6.8 and 10.13.2, with +universal and without.
