### PR TITLE
mandoc: configure takes no arguments

### DIFF
--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -33,11 +33,6 @@ MANDIR="${prefix}/share/man"
 MANPATH_DEFAULT="${prefix}/share/man:/usr/local/share/man:/usr/share/man"
 MANPATH_BASE="/usr/share/man"
 
-INSTALL_PROGRAM="${configure.install} -m 0755"
-INSTALL_LIB="${configure.install} -m 0644"
-INSTALL_MAN="${configure.install} -m 0644"
-INSTALL_DATA="${configure.install} -m 0644"
-
 INSTALL_LIBMANDOC=0
 BUILD_CGI=0
 BUILD_CATMAN=0
@@ -45,6 +40,7 @@ BUILD_CATMAN=0
 CC="${configure.cc}"
 CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc]"
 LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
+INSTALL="${configure.install}"
 
 } ]
 
@@ -52,3 +48,8 @@ LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
     puts "${fd}" "${content}"
     close "${fd}"
 }
+
+# ./configure takes no args
+configure.universal_args
+configure.pre_args
+configure.args


### PR DESCRIPTION
Clear `configure.*args` as mandoc's configure takes none.
Also, is is enough to set INSTALL; INSTALL_* inherit that.
No functional change.

Tested on 10.13.2, 10.6.8 and 10.5.8