### PR TITLE
eiffelstudio: update to version 18.01

### DIFF
--- a/lang/eiffelstudio/Portfile
+++ b/lang/eiffelstudio/Portfile
@@ -1,8 +1,8 @@
 PortSystem        1.0
 
 name              eiffelstudio
-set major_version 17.01
-set minor_version 9.9700
+set major_version 18.01
+set minor_version 10.1424
 version           ${major_version}.${minor_version}
 categories        lang
 license           GPL-2
@@ -38,8 +38,8 @@ extract.only      ${distname}${extract.suffix}
 worksrcdir        PorterPackage
 
 checksums         ${distname}${extract.suffix} \
-                    rmd160  c5ffe1eed294995f69ec375d7f131941416001f6 \
-                    sha256  610344e8e4bbb4b8ccedc22e57b6ffa6b8fd7b9ffee05edad15fc1aa2b1259a1 \
+                    rmd160  9d4ddebf7d4b9307205294e38fc6859ee5657359 \
+                    sha256  2016be2e94bc2f9df6c317118c1b7125f9243e646a1e763641c1dc9243e9cb40 \
                   ${eiffel_launch} \
                     rmd160 f52af5b8b09ecdd21af4b1d89d2716597a9c1340 \
                     sha256 862bce03664b1ef554e3b8f432cdc77284912d606f6ac58dc47dd499c3a3f594


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
