### PR TITLE
spring-boot-cli: update to 2.0.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         1.5.10
+version         2.0.0
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  bf4f27645dee361cca58ff8dd73787dca7684aa0 \
-                sha256  1d0a6a6660a2e2245c2d5f65d193f8a96115dc7ed1df36634c30e749825742f5
+checksums       rmd160  2d89c0aef9fb05ecc49b0d32986e6cd82a7161d5 \
+                sha256  729714a91e63cd30fc0fe59db1c8de28125fb20b92da8c13bcd004233603f83f
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.0.0.RELEASE.

###### Tested on

macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?