### PR TITLE
Update libre librem baresip restund

### DIFF
--- a/net/baresip/Portfile
+++ b/net/baresip/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                baresip
-version             0.4.19
-revision            1
+version             0.5.8
 categories          net
 platforms           darwin
-maintainers         db.org:aeh
+maintainers         {db.org:aeh @alfredh}
 license             BSD
 
 description         portable and modular SIP User-Agent \
@@ -19,8 +18,9 @@ long_description    ${name} is a ${description}.
 homepage            http://www.creytiv.com/
 master_sites        ${homepage}pub/
 
-checksums           rmd160  55fffe69c2497042ab5869ecfb65a6fa772374d9 \
-                    sha256 bb8c62da225d7ee30ad371e6e0cd0f4bb663635e73b8c09cd43b054b981eb0d1
+checksums           rmd160  42da362bfe81d5ea8b1b6055d4271ab51b619cf1 \
+                    sha256  d9f11da50fd6c9359ab478618b5d3c132474a838fe9f668c249f9d5a07f26662 \
+                    size    584406
 
 depends_lib         port:libre \
                     port:librem \

--- a/net/libre/Portfile
+++ b/net/libre/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libre
-version             0.4.17
+version             0.5.7
 categories          net
 platforms           darwin
-maintainers         db.org:aeh
+maintainers         {db.org:aeh @alfredh}
 license             BSD
 
 description         Protocol library for real-time communications with async \
@@ -20,8 +20,9 @@ master_sites        ${homepage}pub/
 
 distname            re-${version}
 
-checksums           rmd160  7c732c27b6ca813d87f1b5c09375dec4878cf92e \
-                    sha256  2ce089b64909dc2aaa71421245e3a76dfe8a3279478f3eebd2aaead591106098
+checksums           rmd160  8f3ffabd75a30d5971c2cfd4a9ebbb3c9e233a27 \
+                    sha256  5dcc15610c28ff1df147d28266b29b934adcff43bfc3fdac58767fd789101039 \
+                    size    299678
 
 depends_lib         port:zlib \
                     path:lib/libssl.dylib:openssl

--- a/net/librem/Portfile
+++ b/net/librem/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                librem
-version             0.4.7
+version             0.5.2
 categories          net
 platforms           darwin
-maintainers         db.org:aeh
+maintainers         {db.org:aeh @alfredh}
 license             BSD
 
 description         portable audio and video processing media library
@@ -19,8 +19,9 @@ master_sites        ${homepage}pub/
 
 distname            rem-${version}
 
-checksums           rmd160  a0d01c46975a8e1e7cc5de892d8145b355f29619 \
-                    sha256  5d084f5ee17b839680ab6b978357c095c2a85d04bdf61fa03192019e3435954e
+checksums           rmd160  2e78ec96b3147ddb8158b80e310cd781f605a567 \
+                    sha256  fbc54e81ed4fd28a11d525f4384d06bee4c11e10975395668e8260ef0d4a64eb \
+                    size    40251
 
 depends_lib         port:libre
 

--- a/net/restund/Portfile
+++ b/net/restund/Portfile
@@ -42,15 +42,15 @@ if {[tbool configure.ccache]} {
     build.env-append CCACHE=ccache
 }
 
-#if {[variant_isset universal]} {
-#    foreach arch ${configure.universal_archs} {
-#        lappend merger_build_env(${arch})    CC='${configure.cc} -arch ${arch}'
-#        lappend merger_destroot_env(${arch}) CC='${configure.cc} -arch ${arch}'
-#    }
-#} else {
+if {[variant_isset universal]} {
+    foreach arch ${configure.universal_archs} {
+        lappend merger_build_env(${arch})    CC='${configure.cc} -arch ${arch}'
+        lappend merger_destroot_env(${arch}) CC='${configure.cc} -arch ${arch}'
+    }
+} else {
     build.env-append    CC='${configure.cc} ${configure.cc_archflags}'
     destroot.env-append CC='${configure.cc} ${configure.cc_archflags}'
-#}
+}
 
 post-destroot {
     reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/etc/restund.conf

--- a/net/restund/Portfile
+++ b/net/restund/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                restund
-version             0.4.11
+version             0.4.12
 categories          net
 platforms           darwin
-maintainers         db.org:aeh
+maintainers         {db.org:aeh @alfredh}
 license             BSD
 
 description         modular STUN/TURN server
@@ -17,8 +17,9 @@ long_description    ${name} is a ${description}.
 homepage            http://www.creytiv.com/
 master_sites        ${homepage}pub/
 
-checksums           rmd160  f4168287a76177b99b75cde8625ac7fb9676b604 \
-                    sha256  d4630dfb8777f12cc48ed118da0ea6445bc60e94ff916ab0ca5d436c74bdc2d7
+checksums           rmd160  84dace7d3bf9ec256e38c24fa9130b5635a58e32 \
+                    sha256  3170441dc882352ab0275556b6fc889b38b14203d936071b5fa12f39a5c86d47 \
+                    size    183127
 
 depends_lib         port:libre
 


### PR DESCRIPTION
#### Description

@alfredh: Updates libre to 0.5.7, librem to 0.5.2, baresip to 0.5.8, and restund to 0.4.12; adds GitHub maintainer handle to all ports; adds `size` to checksums; and fixes restund's universal variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
