### PR TITLE
MacVim: update to snapshot 145

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -3,7 +3,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 set vim_version     8.0
-set snapshot        144
+set snapshot        145
 github.setup        macvim-dev macvim ${snapshot} snapshot-
 name                MacVim
 version             ${vim_version}.snapshot${snapshot}
@@ -18,9 +18,9 @@ long_description \
 
 homepage            https://macvim-dev.github.io/macvim/
  
-checksums           rmd160  8639911c46c35d0fc18b6975fe07132afc0f2bfc \
-                    sha256  676203d9f28039d4399ad18627aafd275e1a76c46f9d40098b58d046ad34fa18 \
-                    size    19756349
+checksums           rmd160  1e67df25f101d84b494222fbd0f66df06193828e \
+                    sha256  07571dd6cf9e96f6c18238e070577e932baa743b2906ded49b2c4dc3097ff9da \
+                    size    19783527
 
 depends_build       bin:grep:grep
 depends_lib         port:ncurses \


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/55971
