### PR TITLE
py-wheel: add Python 3.4 subport

### DIFF
--- a/python/py-wheel/Portfile
+++ b/python/py-wheel/Portfile
@@ -20,7 +20,7 @@ distname            wheel-${version}
 checksums           rmd160  d20aec3dccbe9c8994466cd677c0fec125f956ab \
                     sha256  9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8
 
-python.versions     27 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
This patch adds a Python 3.4 subport for `py-wheel`.

Was there a significant reason why the port did not include Python 3.4? It's listed in the list trove classifiers in [wheel's PyPI page](https://pypi.python.org/pypi/wheel/0.30.0).