### PR TITLE
libfdk-aac: update to version 0.1.6

### DIFF
--- a/audio/libfdk-aac/Portfile
+++ b/audio/libfdk-aac/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libfdk-aac
-version             0.1.5
+version             0.1.6
 categories          audio
 license             Restrictive
 platforms           darwin
@@ -16,12 +16,13 @@ long_description    Fraunhofer FDK AAC Codec Library, released as part of Androi
 
 compiler.blacklist  gcc-4.2
 
-homepage            http://sourceforge.net/projects/opencore-amr/
+homepage            https://sourceforge.net/projects/opencore-amr/
 master_sites        sourceforge:project/opencore-amr/fdk-aac
 distname            fdk-aac-${version}
-checksums           rmd160  defcda67213653ad075ddad4d691def362b1182a \
-                    sha256  2164592a67b467e5b20fdcdaf5bd4c50685199067391c6fcad4fa5521c9b4dd7
+checksums           rmd160  cd792eac8339d65b6997c8769c8eda4565fb9201 \
+                    sha256  aab61b42ac6b5953e94924c73c194f08a86172d63d39c5717f526ca016bed3ad \
+                    size    2091618
 
 livecheck.type      regex
-livecheck.url       http://sourceforge.net/projects/opencore-amr/files/fdk-aac/
+livecheck.url       https://sourceforge.net/projects/opencore-amr/files/fdk-aac/
 livecheck.regex     "fdk-aac-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
#### Description

Update to version 0.1.6
Update URLs

###### Tested on

macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
