### PR TITLE
Qt57 fixes

### DIFF
--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -1068,6 +1068,14 @@ foreach {module module_info} [array get modules] {
             # unless overridden, configure script uses gmake if it can find it
             configure.env-append MAKE=${build.cmd}
 
+            post-configure {
+                # remove any QMAKE_* entries from mkspecs/qmodule.pri
+                # This file is created by the configure script, and
+                # will overwrite these variables when set in earlier
+                # mkspecs scripts, which is not what it should be doing.
+                reinplace "/^QMAKE/d" ${worksrcpath}/mkspecs/qmodule.pri
+            }
+
             if { [variant_isset universal] } {
 
                 post-destroot {


### PR DESCRIPTION
2 fixes: (1) explicitly use c++11 for building, which some older OSs / compiler combinations require; (2) remove QMAKE_* variables from the configure-generated mkspecs/qmodule.pri file, such that they do not overwrite those variables set in other mkspecs files.

Tested on MacOS X 10.8 and 10.12.

We should consider porting these changes to the other qt5 ports for Qt 5.8+ that are similar in Portfile structure.