### PR TITLE
osmocore: Add talloc dependency

### DIFF
--- a/science/osmocore/Portfile
+++ b/science/osmocore/Portfile
@@ -62,4 +62,7 @@ pre-configure		{
 
 configure.ldflags-delete -L${prefix}/lib
 
-configure.args-append --disable-pcsc --disable-pseudotalloc
+configure.args-append \
+                    --disable-pcsc \
+                    --disable-pseudotalloc \
+                    --disable-silent-rules

--- a/science/osmocore/Portfile
+++ b/science/osmocore/Portfile
@@ -14,6 +14,7 @@ platforms           darwin macosx
 
 github.setup        osmocom libosmocore 6950b191e84c73687f9dc77462ff66cbeaec5686
 version             20180226
+revision            1
 checksums           rmd160 bc35cd00b469cd029b4894942f29ad16cdffdc5b \
                     sha256 56f63e1d5de27998331f826b2a5f6404c4d750b410736465901f96892e1b6c2c
 
@@ -26,7 +27,8 @@ depends_build-append \
 
 depends_lib-append \
     port:gnutls \
-    port:python27
+    port:python27 \
+    port:talloc
 
 # fix use of Python2
 


### PR DESCRIPTION
#### Description

This adds the [required talloc dependency](https://trac.macports.org/ticket/55990), and disables silent rules so that we can see the build commands that are run.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?