### PR TITLE
groovy: update to 2.4.14

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.4.13
+version         2.4.14
 
 categories      lang java
 maintainers     breun.nl:nils openmaintainer
@@ -37,8 +37,8 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  9374551a29abb2034e4e3d7fa8e2506e7c55680d \
-                sha256  b9e4ad752affe37867a28e186dccddc8b541ea82ad3d86e4172a0fd9084c146f
+checksums       rmd160  27fcfb19a4977e5f9610536d7a96c150c2335439 \
+                sha256  f9c846e21d9220bac464ffc00eae8f4146f4c26777b61f62e3123da95c6bc52a
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.4.14.

###### Tested on

macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?