### PR TITLE
py-kombine @0.8.3: new port

### DIFF
--- a/python/py-kombine/Portfile
+++ b/python/py-kombine/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-kombine
+version             0.8.3
+
+categories-append   science
+maintainers         {uoregon.edu:bfarr @bfarr} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+
+platforms           darwin
+license             GPL-3
+
+description         An embarrassingly parallel, kernel-density-based \
+                    ensemble sampler
+long_description    kombine is an ensemble sampler that uses a clustered \
+                    kernel-density-estimate proposal density, allowing for \
+                    massive parallelization and efficient sampling.
+homepage            https://github.com/bfarr/kombine
+
+master_sites        pypi:k/kombine
+distname            kombine-${version}
+checksums   rmd160  74c1ba9d7f4f1866f79f4628c868943afb9fabec \
+            sha256  da7a9542600c81df4b2ede2772b730dacef61ea3bc19b495f4fa445ff2b92f75 \
+            size    17495
+
+python.versions     27 36
+python.default_version 27
+
+if {${name} ne ${subport}} {
+
+    depends_lib-append  port:py${python.version}-numpy \
+                        port:py${python.version}-scipy
+
+    depends_build-append port:py${python.version}-setuptools
+
+}


### PR DESCRIPTION
#### Description

[kombine](bfarr/kombine) is a kernel-density-based, embarrassingly parallel ensemble sampler, written by @bfarr.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D47
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
