### PR TITLE
git-sizer @1.0.0: new port

### DIFF
--- a/devel/git-sizer/Portfile
+++ b/devel/git-sizer/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            github git-sizer 1.1.0 v
+categories              devel
+platforms               darwin
+supported_archs         noarch
+maintainers             {@gerardsoleca gmail.com:g.sole.ca} openmaintainer
+license                 MIT
+
+description             Compute various size metrics for a Git repository, \
+                        flagging those that might cause problems
+long_description        Compute various size metrics for a Git repository, \
+                        flagging those that might cause problems like having \
+                        repositories too big (> 5GB), keep many branches or \
+                        tags, including giantic blob files, storing large text \
+                        files with many changes, repeated files across paths, \
+                        detect long path names inside the repository, ...
+
+github.tarball_from     tags
+
+checksums           rmd160  1280b3cc17db70f79851dfb36c854cbbb7a43b0d \
+                    sha256  39fd8cdf799c4ccd0d636574e3879fa618ccfe6753e9df24c745331052a47c4d \
+                    size    101963
+
+depends_build       port:go
+use_configure       no
+use_parallel_build  no
+build.cmd           go
+build.target        build -a -tags production github.com/${github.author}/${name}
+build.env           GOPATH="${workpath}" DYLD_INSERT_LIBRARIES=''
+
+worksrcdir          ${workpath}/src/github.com/github/${name}
+
+post-extract {
+    file mkdir [file dirname ${worksrcdir}]
+    move [glob ${workpath}/${name}-*] ${worksrcdir}
+}
+
+destroot {
+    xinstall ${worksrcpath}/${name} ${destroot}${prefix}/bin
+}
+
+livecheck.regex     archive/[join ${github.tag_prefix} ""](\[^"rw\]+)${extract.suffix}


### PR DESCRIPTION
#### Description
Compute various size metrics for a Git repository, flagging those that might cause problems

https://github.com/github/git-sizer
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1036
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
