### PR TITLE
neovim: Restore mouse support to neovim 0.2.2

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -5,6 +5,7 @@ PortGroup github 1.0
 PortGroup cmake 1.0
 
 github.setup            neovim neovim 0.2.2 v
+revision                1
 categories              editors
 platforms               darwin
 maintainers             {raimue @raimue} \
@@ -22,6 +23,8 @@ homepage                https://neovim.io
 checksums               rmd160  2fc734ffef7db15fe06f6ff06fc4f3bd9d720916 \
                         sha256  80c6c2b7c624d1b56c88bb2cb46b33b244f8991e7221c5ce265c2fe884e9213d \
                         size    8327883
+
+patchfiles              patch-mouse-ncurses.diff
 
 depends_build-append    port:pkgconfig
 

--- a/editors/neovim/files/patch-mouse-ncurses.diff
+++ b/editors/neovim/files/patch-mouse-ncurses.diff
@@ -1,0 +1,16 @@
+Upstream: https://github.com/neovim/neovim/commit/3a5721e91ba890718319213154ba6964c9dca4d2
+--- src/nvim/tui/tui.c
++++ src/nvim/tui/tui.c
+@@ -1722,6 +1722,12 @@ static const char *tui_tk_ti_getstr(const char *name, const char *value,
+     if (value != NULL && strequal(stty_erase, value)) {
+       return stty_erase[0] == DEL ? CTRL_H_STR : DEL_STR;
+     }
++  } else if (strequal(name, "key_mouse")) {
++    DLOG("libtermkey:kmous=%s", value);
++    // If key_mouse is found, libtermkey uses its terminfo driver (driver-ti.c)
++    // for mouse input, which by accident only supports X10 protocol.
++    // Force libtermkey to fallback to its CSI driver (driver-csi.c). #7948
++    return NULL;
+   }
+ 
+   return value;


### PR DESCRIPTION
#### Description

Neovim's mouse support was broken by an update to ncurses. Apply the
upstream patch to fix it.

- https://github.com/neovim/neovim/commit/3a5721e91ba890718319213154ba6964c9dca4d2

Closes: https://trac.macports.org/ticket/55775

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
