### PR TITLE
py-neovim: update to 0.2.4

### DIFF
--- a/python/py-neovim/Portfile
+++ b/python/py-neovim/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        neovim python-client 0.2.3
+github.setup        neovim python-client 0.2.4
 name                py-neovim
 revision            1
 maintainers         g5pw openmaintainer
@@ -30,8 +30,8 @@ if { ${name} ne ${subport} } {
         depends_lib-append  port:py${python.version}-trollius
     }
 
-    checksums			rmd160  2d213d675dca35c44a9e4a38a1cea68d5a9f2ff0 \
-                        sha256  9542180e2b053c82e56a21baa87feb3dfaf517756333cc01aeeddcf6610f184a
+    checksums           rmd160  de9fcf0868ce1eb5fa1a83c5563484febf2e4724 \
+                        sha256  ddf7c6753a75d7388d178331a07c81f1accdd5b374deccef98b641798c6496ab
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

Update py-neovim to 0.2.4.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?