### PR TITLE
KeePassXC: fix building on 10.7-10.9

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 PortGroup               qt5 1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.0
+PortGroup               compiler_blacklist_versions 1.0
 
 github.setup            keepassxreboot keepassxc 2.3.1
 name                    KeePassXC
@@ -42,6 +43,17 @@ depends_lib-append      port:argon2 \
                         port:libsodium \
                         port:zlib
 
+# KeePassXC uses -fstack-protector-strong on Clang [1]. That flag is not
+# available until clang 602 [2] or upstream clang 3.5 [3]
+# [1] https://github.com/keepassxreboot/keepassxc/blob/develop/CMakeLists.txt
+# [2] https://opensource.apple.com/source/clang/clang-600.0.57/src/tools/clang/lib/CodeGen/CodeGenModule.cpp.auto.html
+#     https://opensource.apple.com/source/clang/clang-602.0.53/src/tools/clang/lib/CodeGen/CodeGenModule.cpp.auto.html
+# [3] https://github.com/llvm-project/clang/blob/release_34/lib/CodeGen/CodeGenModule.cpp
+#     https://github.com/llvm-project/clang/blob/release_35/lib/CodeGen/CodeGenModule.cpp
+compiler.blacklist-append {clang < 602} macports-clang-3.4 macports-clang-3.3
+# XXX: the following line shouldn't be necessary - revisit when libc++ becomes the default and default compiler configurations are updated
+compiler.fallback-append macports-clang-5.0 macports-clang-4.0 macports-clang-3.9
+
 cmake.out_of_source     yes
 configure.pre_args-append \
     -DCMAKE_INSTALL_PREFIX=${applications_dir} \
@@ -53,6 +65,11 @@ configure.pre_args-append \
 
 if {${configure.cxx_stdlib} eq "libstdc++"} {
     configure.pre_args-append   -DWITH_CXX11=OFF
+}
+
+if {${os.major} < 12} {
+    # autotype does not compile on 10.7
+    configure.pre_args-append   -DWITH_XC_AUTOTYPE=OFF
 }
 
 variant yubikey description {Enable YubiKey challenge-response support} {


### PR DESCRIPTION
#### Description

**NOTE: I created this patch based on buildbot logs. I didn't actually test it.**

Fixes building issues on older systems.

[10.8](https://build.macports.org/builders/ports-10.8_x86_64_legacy-builder/builds/53301/steps/install-port/logs/stdio) & [10.9](https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/50801/steps/install-port/logs/stdio): clang in older Xcode versions reports error on unsupported option
```
cd /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/build/src && /usr/bin/clang -DQT_NO_CAST_TO_ASCII -DQT_NO_EXCEPTIONS -DQT_STRICT_ITERATORS -DWITH_APP_BUNDLE -I/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/build/src/zxcvbn_autogen/include -isystem /opt/local/include -I/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/keepassxc-2.3.1/src -I/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/build/src -I/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/keepassxc-2.3.1/src/zxcvbn  -pipe -Os -fno-common -Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long -Wformat=2 -Wmissing-format-attribute -fvisibility=hidden -fstack-protector-strong -Wchar-subscripts -Wwrite-strings -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -std=c99 -DNDEBUG -arch x86_64 -mmacosx-version-min=10.8   -o CMakeFiles/zxcvbn.dir/zxcvbn/zxcvbn.c.o   -c /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/keepassxc-2.3.1/src/zxcvbn/zxcvbn.c
make[2]: Entering directory `/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/build'
clang: error: unknown argument: '-fstack-protector-strong' [-Wunused-command-line-argument-hard-error-in-future]
clang: note: this will be a hard error (cannot be downgraded to a warning) in the future
make[2]: *** [src/CMakeFiles/zxcvbn.dir/zxcvbn/zxcvbn.c.o] Error 1
```

[10.7](https://build.macports.org/builders/ports-10.7_x86_64_legacy-builder/builds/59388/steps/install-port/logs/stdio): looks like an Obj-C API not supported on this system?
```
/usr/bin/clang++  -pipe -Os -stdlib=libstdc++ -fno-common -Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long -Wformat=2 -Wmissing-format-attribute -fvisibility=hidden -fvisibility-inlines-hidden -fstack-protector-strong -fno-exceptions -fno-rtti -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Werror=format-security -std=c++11 -stdlib=libc++ -DNDEBUG -arch x86_64 -mmacosx-version-min=10.7 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -L/opt/local/lib -Wl,-headerpad_max_install_names CMakeFiles/testgroup.dir/TestGroup.cpp.o CMakeFiles/testgroup.dir/testgroup_autogen/mocs_compilation.cpp.o  -o testgroup -Wl,-rpath,/opt/local/lib ../src/libkeepassx_core.a /opt/local/libexec/qt5/lib/QtTest.framework/QtTest /opt/local/lib/libgcrypt.dylib /opt/local/lib/libgpg-error.dylib /opt/local/lib/libz.dylib ../src/libautotype.a ../src/http/libkeepasshttp.a ../src/http/qhttp/libqhttp.a ../src/browser/libkeepassxcbrowser.a /opt/local/libexec/qt5/lib/QtConcurrent.framework/QtConcurrent /opt/local/lib/libsodium.dylib ../src/sshagent/libsshagent.a /opt/local/libexec/qt5/lib/QtWidgets.framework/QtWidgets /opt/local/libexec/qt5/lib/QtNetwork.framework/QtNetwork /opt/local/lib/libcurl.dylib ../src/libzxcvbn.a /opt/local/lib/libargon2.dylib /opt/local/lib/libgcrypt.dylib /opt/local/lib/libgpg-error.dylib /opt/local/lib/libz.dylib -framework Foundation /opt/local/libexec/qt5/lib/QtMacExtras.framework/QtMacExtras /opt/local/libexec/qt5/lib/QtGui.framework/QtGui /opt/local/libexec/qt5/lib/QtCore.framework/QtCore 
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_security_KeePassXC/KeePassXC/work/keepassxc-2.3.1/src/autotype/mac/AppKitImpl.mm:46:33: error: expected method to read dictionary element not found on object of type 'NSDictionary *'
    NSRunningApplication *app = userInfo[NSWorkspaceApplicationKey];
                                ^
1 error generated.
make[2]: *** [src/autotype/mac/CMakeFiles/keepassx-autotype-cocoa.dir/AppKitImpl.mm.o] Error 1
```
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`? (on 10.13 only)
- [x] tested basic functionality of all binary files? (on 10.13 only)
