### PR TITLE
qalculate-gtk: add MacOS application bundle

### DIFF
--- a/math/qalculate-gtk/Portfile
+++ b/math/qalculate-gtk/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           app 1.0
 
 github.setup        qalculate qalculate-gtk 2.2.0 v
+revision            1
 
 categories          math
 platforms           darwin
@@ -34,5 +36,15 @@ depends_build-append \
 depends_lib-append \
                     port:libqalculate \
                     port:gtk3
+
+app.icon            data/qalculate.png
+# generate simple generic launch script that doesn't pass -psn
+post-extract {
+    set exe [open ${worksrcpath}/${app.name} w]
+    puts ${exe} "#!/bin/bash\n${prefix}/bin/${name}\n"
+    close ${exe}
+    system "chmod 755 ${worksrcpath}/${app.name}"
+}
+app.executable      ${worksrcpath}/${app.name}
 
 notes-append "Graphical plotting is enabled by installing gnuplot.\n"


### PR DESCRIPTION
using PortGroup app 1.0

I like this software, but the name is tedious to type, esp for my kids. 
So make a standard MacOS app bundle to launch it like a normal MacOS app.