### PR TITLE
gdal-grass: Fix build with grass7 @7.4.0 and when postgresql variants are used

### DIFF
--- a/gis/gdal-grass/Portfile
+++ b/gis/gdal-grass/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 name                gdal-grass
 categories          gis
 version             2.2.0
+revision            1
 maintainers         vince
 description         This plugin allows GDAL to read GRASS files
 long_description    This plugin allows GDAL to read GRASS files
@@ -25,7 +26,7 @@ checksums           md5     c8f2c9f0243ce651404f68d16fa9b499 \
 use_configure       yes
 
 configure.args-append   --with-gdal=${prefix}/bin/gdal-config
-configure.args-append   --with-grass=${prefix}/share/grass-7.2.2
+configure.args-append   --with-grass=${prefix}/share/grass-7.4.0
 
 variant postgresql96 conflicts postgresql95 {
   depends_build-append  port:postgresql95

--- a/gis/gdal-grass/Portfile
+++ b/gis/gdal-grass/Portfile
@@ -28,10 +28,12 @@ configure.args-append   --with-gdal=${prefix}/bin/gdal-config
 configure.args-append   --with-grass=${prefix}/share/grass-7.2.2
 
 variant postgresql96 conflicts postgresql95 {
+  depends_build-append  port:postgresql95
   configure.args-append  --with-postgres-includes=${prefix}/include/postgresql96
 }
 
 variant postgresql95 conflicts postgresql96 {
+  depends_build-append  port:postgresql96
   configure.args-append  --with-postgres-includes=${prefix}/include/postgresql95
 }
 


### PR DESCRIPTION
#### Description

Fixes build with grass7 @7.4.0. Increases revision because this changes what libraries the program links to. Closes https://trac.macports.org/ticket/56012.

Fixes build when postgresql variants are used but postgresql ports are not installed. Closes https://trac.macports.org/ticket/56014.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?