### PR TITLE
pcre2: Update to 10.31

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                pcre
 version             8.41
 subport pcre2 {
-    version         10.30
+    version         10.31
 }
 categories          devel
 license             BSD
@@ -34,10 +34,13 @@ use_bzip2           yes
 
 set rmd160(pcre)    29342fea75514f96553149b18c44eae0abe86b9d
 set sha256(pcre)    e62c7eac5ae7c0e7286db61ff82912e1c0b7a0c13706616e94a7dd729321b530
-set rmd160(pcre2)   558de9a06531ff6b690abc5b6f587ce2c207f3b5
-set sha256(pcre2)   90bd41c605d30e3745771eb81928d779f158081a51b2f314bbcc1f73de5773db
+set size(pcre)      1561874
+set rmd160(pcre2)   77a851c705eab3745db05da9f7dc59dcce2d70bf
+set sha256(pcre2)   e07d538704aa65e477b6a392b32ff9fc5edf75ab9a40ddfc876186c4ff4d68ac
+set size(pcre2)     1603075
 checksums           rmd160  $rmd160(${subport}) \
-                    sha256  $sha256(${subport})
+                    sha256  $sha256(${subport}) \
+                    size    $size(${subport})
 
 patchfiles          no-darwin-pthread-flag.patch
 


### PR DESCRIPTION
#### Description

Update pcre2 to 10.31 and add `size` to checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
