### PR TITLE
enchant2: Use release download

### DIFF
--- a/textproc/enchant2/Portfile
+++ b/textproc/enchant2/Portfile
@@ -15,20 +15,19 @@ long_description    Enchant aims to provide a simple but comprehensive abstracti
                     with different spell checking libraries in a consistent way. Installs in \
                     parallel with legacy Enchant 1.x versions without conflict.
 
-checksums           rmd160  63c735cbefa3acde3739e69c3dfa23aba7a60119 \
-                    sha256  526382df483ed7e01e2715ad3b9e892c3befc3936a5f99579983058ba69db01c \
-                    size    150710
+github.tarball_from releases
+
+# Remove dist_subdir when updating to the next version.
+dist_subdir         ${name}/${version}_1
+
+checksums           rmd160  87ac76b00ed54d47d246b0938d493d2a82180de6 \
+                    sha256  abd8e915675cff54c0d4da5029d95c528362266557c61c7149d53fa069b8076d \
+                    size    957451
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2
 
 depends_build       port:pkgconfig \
-                    port:git \
-                    port:gnupg2 \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool
-
-configure.cmd       ./bootstrap && ./configure
+                    port:gnupg2
 
 configure.args      --without-hunspell \
                     --without-applespell \


### PR DESCRIPTION
#### Description

Use a release download for enchant2. Avoids the need to use autoconf, automake, libtool, and a git clone of gnulib at build time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
