### PR TITLE
salt: update to version 2017.7.4

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -3,10 +3,10 @@
 PortSystem        1.0
 
 name               salt
-version            2017.7.3
+version            2017.7.4
 categories         sysutils python
 platforms          darwin
-maintainers        {@aphor gmail.com:jeremy.mcmillan}
+maintainers        {@aphor gmail.com:jeremy.mcmillan} openmaintainer
 license            Apache-2
 supported_archs    noarch
 description        Salt is a Python-based remote execution, automation, \
@@ -25,8 +25,8 @@ if {$subport eq $name} {
     python.versions         27 34 35 36
     categories              sysutils python
 
-    checksums           rmd160  a50e20349ac6feea60a122f1b01aaa2f2224fb9d \
-                        sha256  249cfbd895c9cfb5283812d6e2ca047c643244cd9b02d030d3e20b8dd0ec2c8e
+    checksums           rmd160  ddb1cbf6f26890360cc06592bb4ba17decf4b772 \
+                        sha256  2698745b572541ccf2e2b1cec48c0c1646b6cad5f56d372a29c4a2a93655e592
 
     notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
 
@@ -34,7 +34,7 @@ if {$subport eq $name} {
         default_variants +python27
     }
 
-    variant python27 conflicts python34 python35 python36 description {experimental python-2.7 support} {
+    variant python27 conflicts python34 python35 python36 description {python-2.7 support} {
         python.default_version 27
         depends_build       port:py${python.version}-setuptools
 
@@ -49,7 +49,7 @@ if {$subport eq $name} {
         notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
     }
 
-    variant python34 conflicts python27 python35 python36 description {experimental python-3.4 support} {
+    variant python34 conflicts python27 python35 python36 description {python-3.4 support} {
         python.default_version 34
         depends_build       port:py${python.version}-setuptools
 
@@ -60,12 +60,9 @@ if {$subport eq $name} {
               port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
-
-        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
-                "Support for Python 3 versions is experimental."
     }
 
-    variant python35 conflicts python27 python34 python36 description {experimental python-3.5 support} {
+    variant python35 conflicts python27 python34 python36 description {python-3.5 support} {
         python.default_version 35
         depends_build       port:py${python.version}-setuptools
 
@@ -76,12 +73,9 @@ if {$subport eq $name} {
               port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
-
-        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
-                "Support for Python 3 versions is experimental."
     }
 
-    variant python36 conflicts python27 python34 python35 description {experimental python-3.6 support} {
+    variant python36 conflicts python27 python34 python35 description {python-3.6 support} {
         python.default_version 36
         depends_build       port:py${python.version}-setuptools
 
@@ -92,9 +86,6 @@ if {$subport eq $name} {
               port:py${python.version}-zmq
 
         destroot.cmd-append --with-salt-version=${version}
-
-        notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api. " \
-                "Support for Python 3 versions is experimental."
     }
 
     patchfiles patch-macports_syspaths.diff


### PR DESCRIPTION
#### Description
 - remove "experimental" notes re: python3x variants
 - Version 2017.7.4 is a (minor) bugfix release for 2017.7
- release notes https://docs.saltstack.com/en/latest/topics/releases/2017.7.4.html
[skip notification]

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 9.2 (9C40b)
Python 2.7.14
Python 3.6.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
