### PR TITLE
devel/automake: update to 1.16.1

### DIFF
--- a/devel/automake/Portfile
+++ b/devel/automake/Portfile
@@ -9,7 +9,7 @@ name                automake
 # Otherwise glibtoolize will provide an incompatible version of aclocal.m4
 # from the older version of automake.
 # cf: ${prefix}/share/libtool/aclocal.m4
-version             1.15.1
+version             1.16.1
 
 categories          devel
 platforms           darwin freebsd
@@ -30,8 +30,9 @@ depends_build       port:autoconf
 installs_libs       no
 
 master_sites        gnu
-checksums           rmd160  3dfd5d5aa037db5aae281829539eef328694cd75 \
-                    sha256  988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260
+use_xz              yes
+checksums           rmd160  8c2a91e8fc0595dbf4854be3cef4d14bb8c5e756 \
+                    sha256  5d05bb38a23fd3312b10aea93840feec685bdf4a41146e78882848165d3ae921
 
 patchfiles          test-glibtool.patch
 

--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libtool
 version             2.4.6
-revision            4
+revision            5
 categories          devel sysutils
 platforms           darwin freebsd
 # Scripts are GPL-2+, libltdl is LGPL-2+, but all parts that tend to be


### PR DESCRIPTION
This updates `automake` to 1.16.1.

Larry, as you're the maintainer of `libtool` and updating `automake` requires a revbump of `libtool` I wanted to run this past you.

Any objections?