### PR TITLE
py-barnaba: submission

### DIFF
--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+version             0.1.4
+
+homepage            https://github.com/srnas/barnaba
+
+master_sites        pypi:b/barnaba
+distname            barnaba-${version}
+
+name                py-barnaba
+platforms           darwin
+categories-append   science
+license             GPL-3
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+
+description         BaRNAba is a tool for analyzing RNA three-dimensional structures and simulations.
+long_description    ${description} \
+                    BaRNAba uses MDtraj to read/write topology and trajectory files, as such it \
+                    supports several formats including pdb, xtc, trr, dcd, binpos, netcdf, mdcrd, \
+                    prmtop, and more. See ${homepage} for more information.
+
+supported_archs     noarch
+
+checksums           rmd160  052f054bae9c4fd8cdb4297b0ab9487425838c8e \
+                    sha256  09846b1a18e61343181e75fc8bedb091e016873829e297281c7beb08fbb62d60
+
+python.versions     27 34 35 36
+
+if {${name} ne ${subport}} {
+
+    depends_build-append port:py${python.version}-setuptools_scm
+
+    depends_lib-append  port:py${python.version}-mdtraj \
+                        port:py${python.version}-scipy \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-pandas \
+                        port:py${python.version}-scikit-learn \
+                        port:py${python.version}-future
+
+    depends_test-append port:py${python.version}-nose
+    test.run            yes
+}
+
+


### PR DESCRIPTION
#### Description

New port submission. Python package for analysis of RNA structures and trajectories.

**Before merging I need some advise.**

1. The barnaba package can be obtained from github (https://github.com/srnas/barnaba). It is still in a pre-release stage, so I would use the date and hashtag in order to indicate the version. Is this ok? Should I tag the version with something like 0.20180312 so that when 1.0 will be out it will be seen as an upgrade?

2. (this requires someone with python+MacPorts experience) Unfortunately, barnaba setup.py uses `setuptools_scm`, that does not allow installing from a git archive. There are two possible solutions:
a. Install from a git fetch (this is the one I implemented in the Portfile included in this pull request). In this manner, MacPorts uses `git clone` every time and `setuptools_scm` seems to work correctly. The negative side is that it does not allow caching the source and verifying the checksums.
b. Use the [setuptools_scm_git_archive](https://github.com/Changaco/setuptools_scm_git_archive) package as well. This would require modifying the setup.py upstream and add a dependency on an additional python package that, by the way, is not currently available on MacPorts.
Are there better alternatives?

Many thanks in advance!!

Giovanni

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G19009
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
