### PR TITLE
Update Tesseract to 03.05.01

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
-github.setup        tesseract-ocr tesseract 3.04.01
+github.setup        tesseract-ocr tesseract 3.05.01
 categories          textproc graphics pdf
 platforms           darwin
 license             Apache-2
@@ -23,8 +24,8 @@ long_description    The Tesseract OCR engine was one of the top  3  engines in \
 
 github.master_sites ${github.homepage}/archive/${git.branch}
 
-checksums           rmd160  5e754411afa74cfc4e6b601fe2c770ba93a25f23 \
-                    sha256  57f63e1b14ae04c3932a2683e4be4954a2849e17edd638ffe91bc5a2156adc6a
+checksums           rmd160  11fae540fdd0ec4f6f9388fae4bbde790b17ee4d \
+                    sha256  05898f93c5d057fada49b9a116fc86ad9310ff1726a0f499c3e5211b3af47ec1
 
 if {${name} eq ${subport}} {
     depends_lib             port:zlib \
@@ -32,14 +33,13 @@ if {${name} eq ${subport}} {
                             port:leptonica \
                             port:jpeg
 
-    configure.env-append    LIBLEPT_HEADERSDIR=${prefix}/include/leptonica
+    cmake.out_of_source     yes
 
     livecheck.regex         "/tag/(\[\.0-9\]+\[-a-z\]*)"
 } else {
     revision                1
 
     depends_run             port:tesseract
-
     livecheck.type          none
 }
 


### PR DESCRIPTION
#### Description
Update Tesseract to 03.05.01, coverting build to CMake as needed, and makes obsolete old 03.04.01 bugs.

Fixes: https://trac.macports.org/ticket/54006
Closes: https://trac.macports.org/ticket/50128
Closes: https://trac.macports.org/ticket/50118

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E182a
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
