### PR TITLE
app PortGroup : change default executable to launch script

### DIFF
--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -218,18 +218,18 @@ platform macosx {
                 return -code error "app.executable ${app.executable} should not start with \${destroot}"
             }
 
-            # If app.executable is in the destroot, link to it.
+            # If app.executable is in the destroot, write a script to launch it.
             if {[file exists ${destroot}[app._resolve_symlink ${executable} ${destroot}]]} {
-                ln -s ${executable} ${destroot}${applications_dir}/${app.name}.app/Contents/MacOS/${app.name}
+                app._write_launch_script ${executable} ${destroot}${applications_dir}/${app.name}.app/Contents/MacOS/${app.name}
             } elseif {[file exists ${executable}]} {
                 # If app.executable starts with ${workpath} or ${filespath}, copy it.
                 if {[string first ${workpath} ${executable}] == 0 || [string first ${filespath} ${executable}] == 0} {
                     xinstall ${executable} ${destroot}${applications_dir}/${app.name}.app/Contents/MacOS/${app.name}
                 
                 # app.executable refers to a file that exists but does not belong to this port.
-                # Assume it belongs to a dependency and symlink it.
+                # Assume it belongs to a dependency and write a script to launch it.
                 } else {
-                    ln -s ${executable} ${destroot}${applications_dir}/${app.name}.app/Contents/MacOS/${app.name}
+                    app._write_launch_script ${executable} ${destroot}${applications_dir}/${app.name}.app/Contents/MacOS/${app.name}
                 }
             } else {
                 return -code error "app.executable ${app.executable} does not exist"
@@ -303,4 +303,19 @@ proc app._resolve_symlink {path destroot} {
     }
 #    ui_debug "In ${destroot}, ${path} is a symlink to ${resolved_path}"
     return [app._resolve_symlink ${resolved_path} ${destroot}]
+}
+
+
+# Write a default launch script for the executable into the bundle, 
+# setting the default PATH as would be expected by the binary
+proc app._write_launch_script  {executable app_destination} {
+    global prefix
+    set launch_script [open ${app_destination} w]
+
+    puts ${launch_script} "#!/bin/bash
+export PATH=\"${prefix}/bin:${prefix}/sbin:\$PATH\"
+eval ${executable}
+"
+    close ${launch_script}
+    file attributes ${app_destination} -permissions 0755
 }


### PR DESCRIPTION
by default the app PortGroup places a symlink to
the executable in the MacOS bundle. However, this
symlink fails to launch in many cases, because
the -psn parameter passed by default by MacOS is
rejected by the executable. Change the default
behaviour to making a simple bash launch script
instead, that does not pass -psn.
