### PR TITLE
py-django2: new port (based on py-django)

### DIFF
--- a/python/py-django2/Portfile
+++ b/python/py-django2/Portfile
@@ -4,12 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        django django 1.11.11
-name                py-django
+github.setup        django django 2.0.3
+name                py-django2
 categories-append   www
 platforms           darwin
 license             BSD
-maintainers         {danchr @danchr} openmaintainer
+# feel free to take over this port
+maintainers         {@mojca mojca} openmaintainer
 
 description         Django is a high-level Python Web framework
 long_description    Django is a high-level Python Web framework that \
@@ -18,17 +19,17 @@ long_description    Django is a high-level Python Web framework that \
 
 homepage            http://www.djangoproject.com
 
-checksums           rmd160  aea1595dc97ee2c03291a9298c1cb6f9f5a1f574 \
-                    sha256  908572660e67bfc2d472d847c43307f6a87e144d594463ca6f9b456b31f42ed1
+checksums           rmd160  cdd4fac4aa634be509ef8ee5d1569fc7a7d21c0c \
+                    sha256  d0fe12b6bc6a4ba353d19e192d649e184ab7c6f1b38043e8440875f5eec8d811
 
-python.versions     27 34 35 36
+python.versions     35 36
 supported_archs     noarch
 
 if {${name} ne ${subport}} {
-    conflicts               py${python.version}-django2
+    conflicts               py${python.version}-django
 
     depends_build-append    port:py${python.version}-setuptools
-    depends_run-append      port:py${python.version}-tz
+    depends_run             port:py${python.version}-tz
 
     variant bash_completion {
         depends_run-append  path:etc/bash_completion:bash-completion
@@ -62,6 +63,4 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type  none
-} else {
-    livecheck.regex {archive/(1[.].+?).tar.gz}
 }


### PR DESCRIPTION
#### Description

MacPorts is currently missing the port for Django version 2. I assume that there might be sufficient compatibility problems that this warrants a new port, so that users can still decide which one to install. Based on https://www.djangoproject.com/download/ we might perhaps want to implement a different naming scheme. The `py-django` port also needs a `conflicts` keywoard.

I added @danchr as maintainer, I hope he agrees and is willing to maintain the port.

See also #1432 for an update to 1.11.11.

Not sure if there is a way to bundle two versions as subports in the same file. That would probably be better, but I'm not sure if it is feasible without too much hacking.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?