### PR TITLE
muttprint: fix perl 5.26 compatibility

### DIFF
--- a/mail/muttprint/Portfile
+++ b/mail/muttprint/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                muttprint
 version             0.72d
-revision            5
+revision            6
 perl5.branches      5.26
 categories          mail
 license             GPL-2
@@ -24,6 +24,10 @@ checksums           rmd160  cb6f40c892de0142584969e7b0ca60b4f3fed140 \
 
 depends_lib         port:dialog \
                     port:p${perl5.major}-text-iconv
+
+# fix script to work with perl 5.26
+# see https://trac.macports.org/ticket/56075
+patchfiles          muttprintperl5.26fix.patch
 
 use_configure       no
 

--- a/mail/muttprint/files/muttprintperl5.26fix.patch
+++ b/mail/muttprint/files/muttprintperl5.26fix.patch
@@ -1,0 +1,11 @@
+--- muttprint	2018-03-16 08:40:25.000000000 -0700
++++ muttprint	2018-03-16 08:41:09.000000000 -0700
+@@ -1639,7 +1639,7 @@
+ 	open (AUX, "$auxfile") or fatalError "Could not open $auxfile:\n$!";
+ 	
+ 	while (<AUX>) {
+-		($numberOfPages) = /\\newlabel{LastPage}{{}{(\d+)}}/;
++		($numberOfPages) = /\\newlabel\{LastPage\}\{\{\}\{(\d+)\}\}/;
+ 	}
+ 	
+ 	close AUX or fatalError "Could not close $auxfile:\n$!";


### PR DESCRIPTION
by escaping braces
closes: https://trac.macports.org/ticket/56075
patch supplied by lukeodom