### PR TITLE
py-django: update to 1.11.11

### DIFF
--- a/python/py-django/Portfile
+++ b/python/py-django/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           python 1.0
 
+github.setup        django django 1.11.11
 name                py-django
-version             1.11.7
 categories-append   www
 platforms           darwin
 license             BSD
@@ -16,21 +17,19 @@ long_description    Django is a high-level Python Web framework that \
                     design.
 
 homepage            http://www.djangoproject.com
-set branch          [join [lrange [split ${version} .] 0 1] .]
-master_sites        https://www.djangoproject.com/m/releases/${branch}/
-distname            Django-${version}
 
-checksums           rmd160  a7a64a93e56ba5e425f61752801c8083f9b2bff4 \
-                    sha256  8918e392530d8fc6965a56af6504229e7924c27265893f3949aa0529cd1d4b99
+checksums           rmd160  aea1595dc97ee2c03291a9298c1cb6f9f5a1f574 \
+                    sha256  908572660e67bfc2d472d847c43307f6a87e144d594463ca6f9b456b31f42ed1
 
 python.versions     27 34 35 36
 supported_archs     noarch
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-tz
 
     variant bash_completion {
-        depends_run-append path:etc/bash_completion:bash-completion
+        depends_run-append  path:etc/bash_completion:bash-completion
 
         post-patch {
             reinplace "s|django-admin.py|django-admin-${python.branch}.py|g" \
@@ -62,7 +61,5 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   http://www.djangoproject.com/download/
-    livecheck.regex "The latest official version is (1\.\[0-9\]+\.\[0-9\]*)"
+    livecheck.regex {archive/(1[.].+?).tar.gz}
 }


### PR DESCRIPTION
#### Description

This update includes a security fix, see https://trac.macports.org/ticket/55975

See also #1429 for Django version 2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?