### PR TITLE
mingw-w64 binutils: apply upstream patch for broken static constructors in linked PE files

### DIFF
--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -8,8 +8,11 @@ set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.30
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
+
+patchfiles          patch-upstream-fix-pe-static-constructors.diff
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/i686-w64-mingw32-binutils/files/patch-upstream-fix-pe-static-constructors.diff
+++ b/cross/i686-w64-mingw32-binutils/files/patch-upstream-fix-pe-static-constructors.diff
@@ -1,0 +1,110 @@
+https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=a985e9b9deabd81e16754584f4397a638e9d3f36
+
+From: Nick Clifton <nickc@redhat.com>
+Date: Mon, 5 Feb 2018 09:12:42 +0000
+Subject: [PATCH] Import patch from mainline to remove PROVODE qualifiers
+ around definitions of __CTOR_LIST__ and __DTOR_LIST__ in PE linker scripts.
+
+	PR 22762
+	* scripttempl/pe.sc: Remove PROVIDE()s from __CTOR_LIST__ and
+	__DTOR_LIST__ symbols.  Add a comment explaining why this is
+	necessary.
+	* scripttemp/pep.sc: Likewise.
+	* ld.texinfo (PROVIDE): Add a note about the effect of common
+	symbols.
+---
+--- ld/ld.texinfo.orig
++++ ld/ld.texinfo
+@@ -4001,6 +4001,12 @@ underscore), the linker will silently use the definition in the program.
+ If the program references @samp{etext} but does not define it, the
+ linker will use the definition in the linker script.
+ 
++Note - the @code{PROVIDE} directive considers a common symbol to be
++defined, even though such a symbol could be combined with the symbol
++that the @code{PROVIDE} would create.  This is particularly important
++when considering constructor and destructor list symbols such as
++@samp{__CTOR_LIST__} as these are often defined as common symbols.
++
+ @node PROVIDE_HIDDEN
+ @subsection PROVIDE_HIDDEN
+ @cindex PROVIDE_HIDDEN
+--- ld/scripttempl/pe.sc.orig
++++ ld/scripttempl/pe.sc
+@@ -98,8 +98,22 @@ SECTIONS
+     ${RELOCATING+*(.glue_7t)}
+     ${RELOCATING+*(.glue_7)}
+     ${CONSTRUCTING+
+-       PROVIDE(___CTOR_LIST__ = .);
+-       PROVIDE(__CTOR_LIST__ = .);
++       /* Note: we always define __CTOR_LIST__ and ___CTOR_LIST__ here,
++          we do not PROVIDE them.  This is because the ctors.o startup
++	  code in libgcc defines them as common symbols, with the 
++          expectation that they will be overridden by the definitions
++	  here.  If we PROVIDE the symbols then they will not be
++	  overridden and global constructors will not be run.
++	  
++	  This does mean that it is not possible for a user to define
++	  their own __CTOR_LIST__ and __DTOR_LIST__ symbols.  If that
++	  ability is needed a custom linker script will have to be
++	  used.  (The custom script can just be a copy of this script
++	  with the PROVIDE() qualifiers added).
++
++	  See PR 22762 for more details.  */
++       ___CTOR_LIST__ = .;
++       __CTOR_LIST__ = .;
+        LONG (-1);
+        KEEP(*(.ctors));
+        KEEP(*(.ctor));
+@@ -107,8 +121,10 @@ SECTIONS
+        LONG (0);
+      }
+     ${CONSTRUCTING+
+-       PROVIDE(___DTOR_LIST__ = .);
+-       PROVIDE(__DTOR_LIST__ = .);
++       /* See comment about __CTOR_LIST__ above.  The same reasoning
++          applies here too.  */
++       ___DTOR_LIST__ = .;
++       __DTOR_LIST__ = .;
+        LONG (-1);
+        KEEP(*(.dtors));
+        KEEP(*(.dtor));
+--- ld/scripttempl/pep.sc.orig
++++ ld/scripttempl/pep.sc
+@@ -99,8 +99,22 @@ SECTIONS
+     ${RELOCATING+*(.glue_7)}
+     ${CONSTRUCTING+. = ALIGN(8);}
+     ${CONSTRUCTING+
+-       PROVIDE(___CTOR_LIST__ = .);
+-       PROVIDE(__CTOR_LIST__ = .);
++       /* Note: we always define __CTOR_LIST__ and ___CTOR_LIST__ here,
++          we do not PROVIDE them.  This is because the ctors.o startup
++	  code in libgcc defines them as common symbols, with the 
++          expectation that they will be overridden by the definitions
++	  here.  If we PROVIDE the symbols then they will not be
++	  overridden and global constructors will not be run.
++	  
++	  This does mean that it is not possible for a user to define
++	  their own __CTOR_LIST__ and __DTOR_LIST__ symbols.  If that
++	  ability is needed a custom linker script will have to be
++	  used.  (The custom script can just be a copy of this script
++	  with the PROVIDE() qualifiers added).
++
++	  See PR 22762 for more details.  */
++       ___CTOR_LIST__ = .;
++       __CTOR_LIST__ = .;
+        LONG (-1); LONG (-1);
+        KEEP (*(.ctors));
+        KEEP (*(.ctor));
+@@ -108,8 +122,10 @@ SECTIONS
+        LONG (0); LONG (0);
+      }
+     ${CONSTRUCTING+
+-       PROVIDE(___DTOR_LIST__ = .);
+-       PROVIDE(__DTOR_LIST__ = .);
++       /* See comment about __CTOR_LIST__ above.  The same reasoning
++    	  applies here too.  */
++       ___DTOR_LIST__ = .;
++       __DTOR_LIST__ = .;
+        LONG (-1); LONG (-1);
+        KEEP (*(.dtors));
+        KEEP (*(.dtor));

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -8,8 +8,11 @@ set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.30
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
+
+patchfiles          patch-upstream-fix-pe-static-constructors.diff
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/x86_64-w64-mingw32-binutils/files/patch-upstream-fix-pe-static-constructors.diff
+++ b/cross/x86_64-w64-mingw32-binutils/files/patch-upstream-fix-pe-static-constructors.diff
@@ -1,0 +1,110 @@
+https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=a985e9b9deabd81e16754584f4397a638e9d3f36
+
+From: Nick Clifton <nickc@redhat.com>
+Date: Mon, 5 Feb 2018 09:12:42 +0000
+Subject: [PATCH] Import patch from mainline to remove PROVODE qualifiers
+ around definitions of __CTOR_LIST__ and __DTOR_LIST__ in PE linker scripts.
+
+	PR 22762
+	* scripttempl/pe.sc: Remove PROVIDE()s from __CTOR_LIST__ and
+	__DTOR_LIST__ symbols.  Add a comment explaining why this is
+	necessary.
+	* scripttemp/pep.sc: Likewise.
+	* ld.texinfo (PROVIDE): Add a note about the effect of common
+	symbols.
+---
+--- ld/ld.texinfo.orig
++++ ld/ld.texinfo
+@@ -4001,6 +4001,12 @@ underscore), the linker will silently use the definition in the program.
+ If the program references @samp{etext} but does not define it, the
+ linker will use the definition in the linker script.
+ 
++Note - the @code{PROVIDE} directive considers a common symbol to be
++defined, even though such a symbol could be combined with the symbol
++that the @code{PROVIDE} would create.  This is particularly important
++when considering constructor and destructor list symbols such as
++@samp{__CTOR_LIST__} as these are often defined as common symbols.
++
+ @node PROVIDE_HIDDEN
+ @subsection PROVIDE_HIDDEN
+ @cindex PROVIDE_HIDDEN
+--- ld/scripttempl/pe.sc.orig
++++ ld/scripttempl/pe.sc
+@@ -98,8 +98,22 @@ SECTIONS
+     ${RELOCATING+*(.glue_7t)}
+     ${RELOCATING+*(.glue_7)}
+     ${CONSTRUCTING+
+-       PROVIDE(___CTOR_LIST__ = .);
+-       PROVIDE(__CTOR_LIST__ = .);
++       /* Note: we always define __CTOR_LIST__ and ___CTOR_LIST__ here,
++          we do not PROVIDE them.  This is because the ctors.o startup
++	  code in libgcc defines them as common symbols, with the 
++          expectation that they will be overridden by the definitions
++	  here.  If we PROVIDE the symbols then they will not be
++	  overridden and global constructors will not be run.
++	  
++	  This does mean that it is not possible for a user to define
++	  their own __CTOR_LIST__ and __DTOR_LIST__ symbols.  If that
++	  ability is needed a custom linker script will have to be
++	  used.  (The custom script can just be a copy of this script
++	  with the PROVIDE() qualifiers added).
++
++	  See PR 22762 for more details.  */
++       ___CTOR_LIST__ = .;
++       __CTOR_LIST__ = .;
+        LONG (-1);
+        KEEP(*(.ctors));
+        KEEP(*(.ctor));
+@@ -107,8 +121,10 @@ SECTIONS
+        LONG (0);
+      }
+     ${CONSTRUCTING+
+-       PROVIDE(___DTOR_LIST__ = .);
+-       PROVIDE(__DTOR_LIST__ = .);
++       /* See comment about __CTOR_LIST__ above.  The same reasoning
++          applies here too.  */
++       ___DTOR_LIST__ = .;
++       __DTOR_LIST__ = .;
+        LONG (-1);
+        KEEP(*(.dtors));
+        KEEP(*(.dtor));
+--- ld/scripttempl/pep.sc.orig
++++ ld/scripttempl/pep.sc
+@@ -99,8 +99,22 @@ SECTIONS
+     ${RELOCATING+*(.glue_7)}
+     ${CONSTRUCTING+. = ALIGN(8);}
+     ${CONSTRUCTING+
+-       PROVIDE(___CTOR_LIST__ = .);
+-       PROVIDE(__CTOR_LIST__ = .);
++       /* Note: we always define __CTOR_LIST__ and ___CTOR_LIST__ here,
++          we do not PROVIDE them.  This is because the ctors.o startup
++	  code in libgcc defines them as common symbols, with the 
++          expectation that they will be overridden by the definitions
++	  here.  If we PROVIDE the symbols then they will not be
++	  overridden and global constructors will not be run.
++	  
++	  This does mean that it is not possible for a user to define
++	  their own __CTOR_LIST__ and __DTOR_LIST__ symbols.  If that
++	  ability is needed a custom linker script will have to be
++	  used.  (The custom script can just be a copy of this script
++	  with the PROVIDE() qualifiers added).
++
++	  See PR 22762 for more details.  */
++       ___CTOR_LIST__ = .;
++       __CTOR_LIST__ = .;
+        LONG (-1); LONG (-1);
+        KEEP (*(.ctors));
+        KEEP (*(.ctor));
+@@ -108,8 +122,10 @@ SECTIONS
+        LONG (0); LONG (0);
+      }
+     ${CONSTRUCTING+
+-       PROVIDE(___DTOR_LIST__ = .);
+-       PROVIDE(__DTOR_LIST__ = .);
++       /* See comment about __CTOR_LIST__ above.  The same reasoning
++    	  applies here too.  */
++       ___DTOR_LIST__ = .;
++       __DTOR_LIST__ = .;
+        LONG (-1); LONG (-1);
+        KEEP (*(.dtors));
+        KEEP (*(.dtor));


### PR DESCRIPTION
#### Description

In binutils 2.30, PE files linked by ld no longer call functions marked with `__attribute__((constructor))`. Applying the [upstream patch](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=a985e9b9deabd81e16754584f4397a638e9d3f36) fixes the problem. 
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.9.5
Xcode 6.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
