### PR TITLE
libsdl_sound: Fix building with physfs 3.0+

### DIFF
--- a/audio/libsdl_sound/Portfile
+++ b/audio/libsdl_sound/Portfile
@@ -34,6 +34,8 @@ depends_lib     port:libsdl \
                 path:lib/libspeex.dylib:speex \
                 port:physfs
 
+patchfiles      patch-playsound-physfsrwops.h.diff
+
 configure.args  --disable-sdltest \
                 --disable-smpegtest \
                 --disable-mikmod

--- a/audio/libsdl_sound/files/patch-playsound-physfsrwops.h.diff
+++ b/audio/libsdl_sound/files/patch-playsound-physfsrwops.h.diff
@@ -1,0 +1,28 @@
+https://github.com/Alexpux/MINGW-packages/blob/914e6aa137efa9cf8d388354f4a21462bb29050e/mingw-w64-SDL2_sound-hg/physfs-renamed-export.patch
+
+--- playsound/physfsrwops.h.orig
++++ playsound/physfsrwops.h
+@@ -29,6 +29,11 @@
+ extern "C" {
+ #endif
+ 
++/* renamed in physfs dev, add alias */
++#ifdef PHYSFS_DECL
++#define __EXPORT__ PHYSFS_DECL
++#endif
++
+ /**
+  * Open a platform-independent filename for reading, and make it accessible
+  *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+@@ -77,6 +82,11 @@
+  */
+ __EXPORT__ SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_file *handle);
+ 
++/* renamed in physfs dev, remove alias */
++#ifdef PHYSFS_DECL
++#undef __EXPORT__
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif


### PR DESCRIPTION
physfs 3.0+ renamed `__EXPORT__` to `PHYSFS_DECL` breaking libsdl_sound 1.0.3 build. Use the patch floating on the Internet, the origins of which can be traced to https://github.com/Alexpux/MINGW-packages/raw/master/mingw-w64-SDL2_sound-hg/physfs-renamed-export.patch

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.9.5
Xcode 6.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
