### PR TITLE
mpstats: include requested port information

### DIFF
--- a/sysutils/mpstats/Portfile
+++ b/sysutils/mpstats/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                mpstats
-version             0.1.6
+version             0.1.7
 categories          sysutils macports
 license             BSD
 platforms           darwin

--- a/sysutils/mpstats/files/mpstats.tcl
+++ b/sysutils/mpstats/files/mpstats.tcl
@@ -204,7 +204,7 @@ proc json_encode_port {port_info {indent ""}} {
     set first true
 
     set json "\{"
-    foreach name {name version variants} {
+    foreach name {name version requested variants} {
         # Skip empty strings
         if {$port($name) eq ""} {
             continue
@@ -319,8 +319,8 @@ proc split_variants {variants} {
 #        collection of inactive ports
 # @returns
 #        a list of installed ports chosen according to the \a active parameter, where each entry is
-#        the list representation of a Tcl array with the keys name, version and variants. The
-#        variants value is encoded using \c split_variants, the version entry has the form
+#        the list representation of a Tcl array with the keys name, version, requested and variants.
+#        The variants value is encoded using \c split_variants, the version entry has the form
 #        "$version_$revision".
 proc get_installed_ports {active} {
     set ilist {}
@@ -339,8 +339,18 @@ proc get_installed_ports {active} {
             set iname [lindex $i 0]
             set iversion [lindex $i 1]
             set irevision [lindex $i 2]
-            set ivariants [split_variants [lindex $i 3]]
-            lappend results [list name $iname version "${iversion}_${irevision}" variants $ivariants]
+            set ivariants [lindex $i 3]
+            set iepoch [lindex $i 5]
+
+            set regref [registry::open_entry $iname $iversion $irevision $ivariants $iepoch]
+            if {[registry::property_retrieve $regref "requested"]} {
+                set irequested "true"
+            } else {
+                set irequested ""
+            }
+            set ivariantlist [split_variants $ivariants]
+
+            lappend results [list name $iname version "${iversion}_${irevision}" requested $irequested variants $ivariantlist]
         }
     }
 


### PR DESCRIPTION
#### Description

I would like to include the information about whether a port has been requested. I hope this doesn't break the app running on the server, even if it cannot yet read the response.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
