### PR TITLE
 ola: update to 0.10.6 maintainer

### DIFF
--- a/net/ola/Portfile
+++ b/net/ola/Portfile
@@ -3,11 +3,14 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        OpenLightingProject ola 0.10.3
+github.setup        OpenLightingProject ola 0.10.6
 categories          net comms
 platforms           darwin
 license             GPL-2+ LGPL-2.1+
-maintainers         gmail.com:nomis52 p3k.org:interface pjnewman.co.uk:bugs
+maintainers         {gmail.com:nomis52 @nomis52} \
+                    {p3k.org:interface @p3k} \
+                    {pjnewman.co.uk:bugs @peternewman} \
+                    openmaintainer
 
 description         An open framework for DMX512 lighting control
 
@@ -19,14 +22,17 @@ long_description    The Open Lighting Architecture (OLA) provides a plugin \
 
 homepage            http://www.openlighting.org/ola/
 
-checksums           rmd160  c051d1770c67f311752a36eff8e982da78779e7c \
-                    sha256  0196fa6b046b63a16ace0d9e240ab0a33530e3038c2f81e51fc7126393f7c1f9
+checksums           rmd160  b60d96f7c1504e5045ee333c39bef30185f12134 \
+                    sha256  26a8302b5134c370541e59eabff0145dcf7127cda761890df10aa80dfe223af0
 
 github.tarball_from releases
 
 depends_build       port:pkgconfig
 
 depends_test        port:cppunit
+# temporary workaround (else configure fails)
+depends_build-append \
+                    port:cppunit
 
 depends_lib         port:protobuf-cpp
 


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.5 16F73
Xcode 8.2.1 8C1002

Also via Travis CI:
https://travis-ci.org/OpenLightingProject/ola/builds/328739048

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
