### PR TITLE
py-notebook: update to 5.4.1

### DIFF
--- a/python/py-notebook/Portfile
+++ b/python/py-notebook/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-notebook
-version             5.4.0
+version             5.4.1
 revision            0
 categories-append   devel science
 platforms           darwin
@@ -23,8 +23,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  d364bcdf75a4a2684f376a679fe765a3ac6c0e88 \
-                    sha256  dd431fad9bdd25aa9ff8265da096ef770475e21bf1d327982611a7de5cd904ca
+checksums           rmd160  b13485d07a53f8e5a9f21002457daddf1866c6fa \
+                    sha256  7d6143d10e9b026df888e0b2936ceff1827ef2f2087646b4dd475c8dcef58606
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-jinja2 \


### PR DESCRIPTION
#### Description
Fixes CVE-2018-8768

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
