### PR TITLE
gdal-grass: add MIT license, postgresql10 variant

### DIFF
--- a/gis/gdal-grass/Portfile
+++ b/gis/gdal-grass/Portfile
@@ -11,6 +11,7 @@ description         This plugin allows GDAL to read GRASS files
 long_description    This plugin allows GDAL to read GRASS files
 
 homepage            http://grass.osgeo.org/
+license             MIT
 
 platforms           darwin
 
@@ -20,22 +21,28 @@ depends_lib         port:gdal \
 master_sites        http://download.osgeo.org/gdal/${version}
 
 checksums           md5     c8f2c9f0243ce651404f68d16fa9b499 \
+                    rmd160  733e8918561d3d5aead3ce2d98a41c9b636e32f5 \
                     sha256  0eb2b541e87db4c0d1b3cdc61512b88631e6f7d39db5986eeb773aada0a7995f \
-                    rmd160  733e8918561d3d5aead3ce2d98a41c9b636e32f5
+                    size    54973
 
 use_configure       yes
 
 configure.args-append   --with-gdal=${prefix}/bin/gdal-config
 configure.args-append   --with-grass=${prefix}/share/grass-7.4.0
 
-variant postgresql96 conflicts postgresql95 {
-  depends_build-append  port:postgresql96
-  configure.args-append  --with-postgres-includes=${prefix}/include/postgresql96
+variant postgresql10 conflicts postgresql96 postgresql95 description {Enable PostgreSQL 10 support} {
+  depends_build-append  port:postgresql10
+  configure.args-append --with-postgres-includes=${prefix}/include/postgresql10
 }
 
-variant postgresql95 conflicts postgresql96 {
+variant postgresql96 conflicts postgresql10 postgresql95 description {Enable PostgreSQL 9.6 support} {
+  depends_build-append  port:postgresql96
+  configure.args-append --with-postgres-includes=${prefix}/include/postgresql96
+}
+
+variant postgresql95 conflicts postgresql10 postgresql96 description {Enable PostgreSQL 9.5 support} {
   depends_build-append  port:postgresql95
-  configure.args-append  --with-postgres-includes=${prefix}/include/postgresql95
+  configure.args-append --with-postgres-includes=${prefix}/include/postgresql95
 }
 
 post-configure {
@@ -46,7 +53,7 @@ post-configure {
         reinplace -E "s|^(LD_SHARED.*)|\\1 ${configure.universal_cxxflags}|" \
             ${worksrcpath}/Makefile
     }
-            
+
     # Fixes destroot issues
     reinplace -E "s|^(GRASSTABLES_DIR\[^/]*)(.*)|\\1${destroot}\\2|" \
         ${worksrcpath}/Makefile
@@ -55,4 +62,4 @@ post-configure {
     reinplace "s|mkdir|mkdir -p|" ${worksrcpath}/Makefile
 }
 
-build.target    
+build.target


### PR DESCRIPTION
Here's some nitpicking after #1416

* Add MIT license
* Add postgresql10 variant
* Add variant descriptions
* Minor whitespace changes

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?