### PR TITLE
util-linux: Update to 2.31.1

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           snowleopard_fixes 1.0
 
-name                util-linux
-version             2.29.2
+github.setup        karelzak util-linux 2.31.1 v
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          devel
 platforms           darwin
@@ -18,13 +18,12 @@ long_description    ${name} contains miscellaneous utility programs \
                     and messages. This port contains ONLY those parts \
                     of ${name} that run on Darwin.
 
-homepage            http://freecode.com/projects/util-linux
 master_sites        https://www.kernel.org/pub/linux/utils/util-linux/v${branch}/
 use_xz              yes
 
-checksums           rmd160  70bfcbef7210c3a28b067fc064b5619061339fe0 \
-                    sha256  accea4d678209f97f634f40a93b7e9fcad5915d1f4749f6c47bee6bf110fe8e3 \
-                    size    4277668
+checksums           rmd160  5cdcfb431ca74bd34f5f87303c8fb3e596fbb624 \
+                    sha256  1a51b16fa9cd51d26ef9ab52d2f1de12403b810fc8252bf7d478df91b3cddf11 \
+                    size    4510096
 
 depends_lib         port:gettext \
                     port:ncurses


### PR DESCRIPTION

#### Description

@kurthindenburg Updates util-linux to 2.31.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] tried a full install with `sudo port -vst install`?
