### PR TITLE
mediainfo: revbump after wxWidgets-3.2 update

### DIFF
--- a/multimedia/mediainfo/Portfile
+++ b/multimedia/mediainfo/Portfile
@@ -35,17 +35,20 @@ configure.env-append    PKG_CONFIG_SYSTEM_INCLUDE_PATH=${prefix}/include
 
 subport MediaInfo-gui {
     PortGroup           app 1.0
-    description         Identifies audio and video codecs in a media file. GUI
+    PortGroup           wxWidgets 1.0
+    wxWidgets.use       wxWidgets-3.2
+    revision            1
 
+    description         Identifies audio and video codecs in a media file. GUI
     long_description    MediaInfo supplies technical and tag information about a \
                         video or audio file via graphical utility
 
-    depends_lib-append  port:wxWidgets-3.2
+    depends_lib-append  port:${wxWidgets.port}
 
     set worksrcpath     ${workpath}/${worksrcdir}/Project/GNU/GUI
 
-    configure.args      --with-wx-config=${prefix}/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.1/bin/wx-config \
-                        --with-wx-prefix=${prefix}/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.1
+    configure.args      --with-wx-config=${wxWidgets.wxconfig} \
+                        --with-wx-prefix=${wxWidgets.prefix}
 
     app.executable      mediainfo-gui
     app.name            MediaInfo


### PR DESCRIPTION
Thanks to @RJVB for reminding me that ports depending on wxWidgets-3.2 need a revbump.

I also simplified code with wxWidgets PortGroup

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
