### PR TITLE
Pure 0.67 update

### DIFF
--- a/lang/pure/Portfile
+++ b/lang/pure/Portfile
@@ -1,17 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               bitbucket 1.0
+PortGroup               github 1.0
 
 # Keep the versions of pure and pure-docs in sync.
-bitbucket.setup         purelang pure-lang 0.66 pure-
 name                    pure
+github.setup            agraef pure-lang 0.67 ${name}-
 categories              lang
 platforms               darwin
 maintainers             {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license                 LGPL-3+ GPL-3+ BSD
 use_parallel_build      yes
-homepage                http://purelang.bitbucket.org/
+homepage                https://agraef.github.io/pure-lang/
 
 description             functional programming language based on term rewriting
 
@@ -28,18 +28,19 @@ long_description        Pure is a functional programming language based on \
                         are licensed under LGPL-3+, the interpreter is GPL-3+, \
                         and the examples are BSD-licensed.
 
-bitbucket.tarball_from  downloads
+github.tarball_from     releases
 distname                ${name}-${version}
 
-checksums               rmd160  a3ad0dccdb71eab3aa8ee15d3a04f5e3111208a1 \
-                        sha256  42df6832476e8bee3a7ca179671284c1edd7bc82b71062fa0de62fd2117ee676
+checksums               rmd160  68f52aafe4b378fbafe7bb43fdee5612f1acd666 \
+                        sha256  442de3ccc98f55e7c04a7470771bd8d92e49a43f897964cc5b191c6b7a2b9dc2 \
+                        size    1516318
 
 set llvm_version        3.4
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
 configure.env           PATH=${llvm_prefix}/bin:$env(PATH)
 
 if {${name} eq ${subport}} {
-    revision                    1
+    revision                    0
     
     depends_lib                 port:gmp \
                                 port:libiconv \
@@ -126,6 +127,6 @@ subport pure-mode.el {
     destroot {
         set lispdir ${destroot}${prefix}/share/emacs/site-lisp
         xinstall -d ${lispdir}
-        xinstall -m 644 -W ${destroot.dir} pure-mode.el pure-mode.elc ${lispdir}
+        xinstall -m 644 -W ${destroot.dir} pure-mode.el pure-mode.elc flycheck-pure.el ${lispdir}
     }
 }

--- a/pure/pure-docs/Portfile
+++ b/pure/pure-docs/Portfile
@@ -1,24 +1,34 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       pure 1.0
+PortGroup                       github 1.0
 
 # Keep the versions of pure and pure-docs in sync.
-pure.setup                      docs 0.66
-categories-append               lang
+name                            pure-docs
+github.setup                    agraef pure-lang 0.67 pure-
+github.tarball_from             releases
+distname                        ${name}-${version}
+categories                      pure lang
 platforms                       darwin
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 supported_archs                 noarch
 license                         GFDL-1.3+
-homepage                        http://puredocs.bitbucket.org/
+homepage                        https://agraef.github.io/pure-docs/
 
 description                     documentation for the Pure programming language
 
 long_description                ${name} is an offline copy of the ${description}.
 
-checksums                       rmd160  8a118a8469096aaff246861f294d1bfe2178ea06 \
-                                sha256  83c6f9cf8ccb7d697116479663102cddd45610c03b30ce6276828e52a1a98145
+checksums                       rmd160  45862f6fd67ab5210edc820bb57528e03f9be218 \
+                                sha256  a1340f662224d3cd092fba4c737e0508a9ea71084b8a5b30e8f39db7f5fad3ac \
+                                size    4849200
 
 variant tmdocs description {Also install the TeXmacs-formatted documentation} {
     destroot.target-append  install-tm
 }
+
+# copied from pure-1.0.tcl
+use_configure                   no
+depends_lib-append              port:pure
+build.args-append               prefix=${prefix}
+destroot.args-append            prefix=${prefix}


### PR DESCRIPTION
Update pure to the latest release (cf. https://github.com/agraef/pure-lang/releases/tag/pure-0.67), including pure-docs 0.67 which was released along with it. Tested all functionality and included documentation, ran `make check` on the interpreter, all fine. Pure runtime library is still the same (no API or ABI changes), so all addon modules in the pure group continue to work.

Please note that Pure is hosted on Github now, which called for some changes in the Portfiles. Almost all addon releases are still on Bitbucket, though, hence the pure port group must remain as is for now.

One important new feature in this release is on-the-fly syntax checking of Pure scripts in Emacs. Thus flycheck-pure.el was added to the pure-mode.el subport, but this elisp package isn't byte-compiled right now, because this would require the Emacs flycheck package which isn't available in MacPorts. (Emacs users will typically install flycheck from MELPA anyway, and then flycheck-pure.el can be used, which is why it's included.)

###### Tested on

macOS 10.12.6 16G1212
Xcode 9.2 9C40b