### PR TITLE
Missing depends py-game and py-Pillow

### DIFF
--- a/python/py-kivy/Portfile
+++ b/python/py-kivy/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-kivy
 version             1.10.0
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -39,6 +39,9 @@ if {${name} ne ${subport}} {
                         port:libsdl2_ttf \
                         port:py${python.version}-docutils \
                         port:py${python.version}-pygments
+
+    depends_run-append  port:py${python.version}-Pillow \
+                        port:py${python.version}-game
 
     patchfiles          patch-setup.py.diff
 


### PR DESCRIPTION
#### Description

When execute the [minimal application](https://kivy.org/docs/guide/basic.html#create-an-application) in the Kivy documentation,
Example failed to import PIL and pygame

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
