### PR TITLE
libsecret: Fix build with automake 1.16

### DIFF
--- a/gnome/libsecret/Portfile
+++ b/gnome/libsecret/Portfile
@@ -41,9 +41,11 @@ gobject_introspection yes
 
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 
-post-patch {
+pre-patch {
     xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}
 }
+
+patchfiles      automake-1.16.patch
 
 configure.cmd   ./autogen.sh
 

--- a/gnome/libsecret/files/automake-1.16.patch
+++ b/gnome/libsecret/files/automake-1.16.patch
@@ -1,0 +1,12 @@
+Fix build with automake 1.16.
+--- autogen.sh.orig
++++ autogen.sh
+@@ -43,7 +43,7 @@
+ 	DIE=1
+ }
+ 
+-AUTOMAKE_VERSIONS="1.15 1.14 1.13 1.12 1.11 1.10"
++AUTOMAKE_VERSIONS="1.16 1.15 1.14 1.13 1.12 1.11 1.10"
+ for version in $AUTOMAKE_VERSIONS; do
+ 	if automake-$version --version < /dev/null > /dev/null 2>&1 ; then
+ 		AUTOMAKE=automake-$version


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/56116

#### Description

Fixes build with automake 1.16

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] tried a full install with `sudo port -vst install`?
