### PR TITLE
gromacs: update to 2016.5

### DIFF
--- a/science/gromacs/Portfile
+++ b/science/gromacs/Portfile
@@ -11,7 +11,7 @@ PortGroup           linear_algebra 1.0
 
 name                gromacs
 # not all versions have patches available for plumed; subport's patch will fail if not there
-version             2016.4
+version             2016.5
 revision            1
 categories          science math
 license             LGPL-2.1
@@ -31,9 +31,9 @@ homepage            http://www.gromacs.org/
 master_sites        http://ftp.gromacs.org/pub/gromacs
 
 # md5 published at http://www.gromacs.org/Downloads
-checksums           rmd160  76d85579ae322ef61e7382984e66f48f63d1cba9 \
-                    sha256  4be9d3bfda0bdf3b5c53041e0b8344f7d22b75128759d9bfa9442fe65c289264 \
-                    md5     19c8b5c85f3ec62df79d2249a3c272f8
+checksums           rmd160  10d8808e8c5b04702d83f385f78c0d9effdfa266 \
+                    sha256  57db26c6d9af84710a1e0c47a1f5bf63a22641456448dcd2eeb556ebd14e0b7c \
+                    md5     f41807e5b2911ccb547a3fd11f105d47
 
 depends_build-append \
                     port:pkgconfig
@@ -113,7 +113,7 @@ subport gromacs-plumed {
 # override the choice setting the PLUMED_KERNEL environment variable.
 # Also notice that gromacs version is hardcoded here. Plumed patch is not always
 # updated when gromacs is.
-        exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-${version} --runtime -p
+        exec ${prefix}/bin/plumed patch --mdroot=${worksrcpath} -e gromacs-2016.4 --runtime -p
     }
     notes "
 PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\


### PR DESCRIPTION
This is just an update of the gromacs version.

Notice that gromacs-plumed patch was prepare based on gromacs 2016.4. However, the two patches are compatible, so that `plumed patch -e gromacs-2016.4` can be used to patch gromacs 2016.5. 
