### PR TITLE
libvirt: Update to 4.1.0

### DIFF
--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-libvirt
-version             3.4.0
+version             4.1.0
 platforms           darwin
 license             MIT
 maintainers         {danchr @danchr} openmaintainer
@@ -20,8 +20,9 @@ homepage            http://www.libvirt.org/
 distname            libvirt-python-${version}
 master_sites        ${homepage}sources/python
 
-checksums           rmd160  894dbdb9d3fcb1259287639156c1eed192672800 \
-                    sha256  afa77781f518988f164dd5f99d1844034ca807a8e731e07cbae18474d250b511
+checksums           rmd160  e42219ddd3b9127657d9519511f5181097e9a152 \
+                    sha256  dec2a33d68779672b4688b296d6de18c9c41b89d8c74c9d3dc887e366587b8c7 \
+                    size    186312
 
 python.default_version  27
 python.versions     27 34 35 36

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -57,6 +57,7 @@ configure.args      --disable-silent-rules \
                     --without-udev \
                     --without-uml \
                     --without-virtualport \
+                    --without-wireshark-dissector \
                     --without-xen \
                     --without-xenapi \
                     --without-xen-inotify \

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -58,7 +58,7 @@ configure.args      --disable-silent-rules \
                     --with-esx \
                     --without-fuse \
                     --without-glusterfs \
-                    --with-gnutls \
+                    --without-gnutls \
                     --without-hal \
                     --without-hyperv \
                     --with-init-script=none \
@@ -98,6 +98,20 @@ configure.args      --disable-silent-rules \
                     --without-xen-inotify \
                     --with-xml-catalog-file=${prefix}/etc/xml/catalog \
                     --with-yajl
+
+if {![variant_isset openssl]} {
+    default_variants +gnutls
+}
+
+variant gnutls description {Use GnuTLS} conflicts openssl {
+    depends_lib-append     port:gnutls
+    configure.args-replace  --without-gnutls --with-gnutls
+}
+
+variant openssl description {Use OpenSSL} conflicts gnutls {
+    depends_lib-append     path:lib/libssl.dylib:openssl
+    configure.args-replace  --without-openssl --with-openssl
+}
 
 variant avahi description {Use Avahi to advertise remote daemon} {
     depends_lib-append      port:avahi

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                libvirt
-version             1.3.5
-revision            1
+version             4.1.0
 categories          sysutils
 license             LGPL-2.1+
 platforms           darwin
@@ -17,56 +16,86 @@ long_description    A toolkit to interact with the virtualization \
 
 homepage            https://libvirt.org
 master_sites        ${homepage}/sources/
+use_xz              yes
 
-checksums           rmd160  6a2e0b288dcafaab0440c35523c6658ef9d3ea8d \
-                    sha256  93a23c44eb431da46c9458f95a66e29c9b98e37515d44b6be09e75b35ec94ac8 \
-                    size    35109092
+checksums           rmd160  06526a4c49e761a1bb8d2a78da248a957c914a07 \
+                    sha256  8a2fa4826f311a936be8b7d4c8d76516c29417a593b1d1bb8641a8caaa316439 \
+                    size    15046956
 
 depends_build       port:pkgconfig \
-                    port:xhtml1
+                    port:xhtml1 \
+                    port:bash-completion \
+                    port:python27 \
+                    port:perl5
 
 depends_lib         port:curl \
                     port:gnutls \
                     port:libiconv \
-                    port:libssh2 \
                     port:libxml2 \
                     port:readline \
                     port:yajl \
                     port:zlib
 
+# libvirt build scripts work with python 2.x only
+configure.python    ${prefix}/bin/python2.7
+configure.perl      ${prefix}/bin/perl5
+
 configure.args      --disable-silent-rules \
+                    --enable-debug \
                     --without-apparmor \
+                    --without-attr \
                     --without-audit \
                     --without-avahi \
+                    --with-bash-completion \
+                    --with-bash-completions-dir=${prefix}/share/bash-completion/completions \
+                    --without-bhyve \
+                    --without-blkid \
                     --without-capng \
+                    --with-curl \
+                    --without-dbus \
+                    --with-driver-modules \
                     --without-dtrace \
+                    --with-esx \
+                    --without-fuse \
+                    --without-glusterfs \
+                    --with-gnutls \
                     --without-hal \
+                    --without-hyperv \
                     --with-init-script=none \
                     --without-libpcap \
+                    --without-libssh \
+                    --with-libvirtd \
                     --without-lxc \
                     --without-macvtap \
                     --without-netcf \
                     --without-network \
                     --without-numactl \
+                    --without-openssl \
                     --without-openvz \
-                    --without-phyp \
+                    --without-openwsman \
+                    --with-phyp \
+                    --without-pm-utils \
                     --without-polkit \
                     --without-qemu \
+                    --with-readline \
+                    --with-remote \
+                    --without-sanlock \
                     --without-sasl \
+                    --with-secrets \
                     --without-selinux \
+                    --without-ssh2 \
+                    --without-sysctl \
+                    --with-test \
                     --without-udev \
                     --without-uml \
+                    --with-vbox \
                     --without-virtualport \
+                    --with-vmware \
+                    --without-vz \
                     --without-wireshark-dissector \
                     --without-xen \
                     --without-xenapi \
                     --without-xen-inotify \
-                    --with-esx \
-                    --with-libvirtd \
-                    --with-remote \
-                    --with-test \
-                    --with-vbox=check \
-                    --with-vmware \
                     --with-xml-catalog-file=${prefix}/etc/xml/catalog \
                     --with-yajl
 
@@ -75,10 +104,28 @@ variant avahi description {Use Avahi to advertise remote daemon} {
     configure.args-replace  --without-avahi --with-avahi
 }
 
+variant fuse description {FUSE support} {
+    depends_lib-append      port:osxfuse
+    configure.args-replace  --without-fuse --with-fuse
+}
+
+variant libssh2 description {Enable the libssh2 transport} {
+    depends_lib-append      port:libssh2
+    configure.args-replace  --without-ssh2 --with-ssh2
+}
+
 variant sasl description {Use Cyrus SASL for authentication} {
     depends_lib-append      port:cyrus-sasl2
     configure.args-replace  --without-sasl --with-sasl
 }
+
+notes "
+    The default socket path for the libvirt client is ${prefix}/var/run/libvirt/libvirt-sock,\
+    which might cause problems when you want to attach to a remote libvirtd instance.\
+    In this case, remember to also specify the socket path for the remote side, which is\
+    usually /var/run/libvirt/libvirt-sock. For example to connect to a remote host with virsh:
+      $ virsh -c qemu+ssh://user@host/system?socket=/var/run/libvirt/libvirt-sock
+"
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]


### PR DESCRIPTION
#### Description

Update libvirt and py-libvirt to 4.1.0.

Closes: https://trac.macports.org/ticket/52968

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
