### PR TITLE
virt-manager: Update to version 1.5.1

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        virt-manager virt-manager 1.4.1 v
+revision            1
 categories          gnome emulators
 supported_archs     noarch
 maintainers         {danchr @danchr} openmaintainer
@@ -37,18 +38,21 @@ post-patch {
         virt-clone virt-convert virt-install virt-manager virt-xml
 }
 
-depends_build       port:intltool
-depends_lib \
+depends_build \
+    port:intltool \
+    port:python${python.version} \
+    bin:podman:perl5 \
+    port:glib2
+depends_run \
     port:py${python.version}-gobject3 \
     port:py${python.version}-libvirt \
     port:py${python.version}-libxml2 \
     port:py${python.version}-ipaddr \
     port:py${python.version}-requests \
     port:libvirt-glib \
-    port:vte-gtk2-compat \
+    port:vte \
     port:gtk-vnc \
     port:spice-gtk \
-    port:gtk2 \
     port:libosinfo
 
 variant quartz {

--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        virt-manager virt-manager 1.4.1 v
-revision            1
+github.setup        virt-manager virt-manager 1.5.1 v
 categories          gnome emulators
 supported_archs     noarch
 maintainers         {danchr @danchr} openmaintainer
@@ -28,8 +27,9 @@ long_description \
     \
     The primary use on macOS is for remote administration of Linux boxes.
 
-checksums           rmd160  49eb78ddc7b7b23e7b7357270b195b884961d429 \
-                    sha256  e6c549999f14fbda210c07821910bfa35c086542e166f8b00d7c83717e9f3944
+checksums           rmd160  720822cf863071b646a02fc487ea0082e5959097 \
+                    sha256  ee889d59110986391a394077f004f68125e01e216a5e7cfc29adb6ae49ab2dab \
+                    size    2796831
 
 python.default_version  27
 


### PR DESCRIPTION
#### Description

Update virt-manager to version 1.5.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
