### PR TITLE
PULL_REQUEST_TEMPLATE: Remove 'port lint'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,6 @@ Have you
 - [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
 - [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
 <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
-- [ ] checked your Portfile with `port lint`?
 - [ ] tried existing tests with `sudo port test`?
 - [ ] tried a full install with `sudo port -vst install`?
 - [ ] tested basic functionality of all binary files?


### PR DESCRIPTION
Now that the 'port lint' output from Travis CI is automatically posted
as a comment each pull request, I feel like we no longer need to ask
users to run this before submitting. If 'port lint' produces output, we
will always notice it now.