### PR TITLE
harfbuzz: Add comment, won't need compiler blacklist on next update

### DIFF
--- a/graphics/harfbuzz/Portfile
+++ b/graphics/harfbuzz/Portfile
@@ -23,6 +23,7 @@ checksums           rmd160  1d18522d979ac4c750e29c13e7b76960311dbf50 \
 
 depends_build       port:pkgconfig
 
+# Remove this on an update to >1.7.6 as https://github.com/harfbuzz/harfbuzz/commit/2a2360
 compiler.blacklist  *llvm-gcc-4.2
 
 configure.args      --disable-silent-rules \


### PR DESCRIPTION
HarfBuzz port won't need the blacklisting on its next release as https://github.com/harfbuzz/harfbuzz/pull/899. The current release (which is not added yet to the macports it seems) don't have that also but the next release, will.