### PR TITLE
new ports: libsass, sassc

### DIFF
--- a/www/libsass/Portfile
+++ b/www/libsass/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        sass libsass 3.5.2
+checksums           rmd160  63e7a4306ca5cabea8b551c2f26853642d21d497 \
+                    sha256  3c856095b9156d28ac21771ddeb6a6f0bd283f4f8924ff6afdb33365d2ea9266 \
+                    size    326854
+
+maintainers         {cal @neverpanic} openmaintainer
+categories          www textproc
+platforms           darwin
+
+license             MIT
+homepage            http://sass-lang.com/libsass
+description         A C/C++ implementation of a Sass compiler
+long_description    LibSass is a C/C++ port of the Sass engine. The point is to \
+    be simple, faster, and easy to integrate.
+
+use_autoreconf      yes

--- a/www/sassc/Portfile
+++ b/www/sassc/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        sass sassc 3.5.0
+checksums           rmd160  b30303d80bdaf36598a3acec73da9c33bc78df00 \
+                    sha256  850fd57285e15089366c7a7f4b29a55e082d2bbb90746b887248a4e327a56f2c \
+                    size    25836
+
+maintainers         {cal @neverpanic} openmaintainer
+categories          www textproc
+platforms           darwin
+
+license             MIT
+description         sassc is the libsass command line driver and compiles Sass to CSS
+long_description    ${description}
+
+depends_lib         port:libsass
+
+use_autoreconf      yes


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?