### PR TITLE
libgcc: default to ABI 4 mode on older systems

### DIFF
--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc7
-subport             libgcc { revision 0 }
+subport             libgcc { revision 1 }
 
 epoch               2
 version             7.3.0
@@ -177,6 +177,15 @@ if {${subport} eq "libgcc"} {
     configure.args-replace \
         --with-gxx-include-dir=${prefix}/include/${name}/c++/ \
         --with-gxx-include-dir=${prefix}/include/gcc/c++/
+
+
+    # darwin versions < 13 build c++ software by default against /usr/lib/libstdc++.6.dylib
+    # which is built with ABI version 4. To allow software built against
+    # newer versions of libstdc++ to be compatible with the system libstdc++, have libstdc++
+    # default to ABI version 4 compatible mode on older systems
+    if {${os.platform} eq "darwin" && ${os.major} < 13 } {
+        configure.args-append --with-default-libstdcxx-abi=gcc4-compatible
+    }
 
     # TODO: Possibly disable bootstrap with appropriate configure flags.
     #       the problem is that libstdc++'s configure script tests for tls support


### PR DESCRIPTION
darwin versions < 13 build c++ software by default
against /usr/lib/libstdc++.6.dylib which is built with ABI version 4
To allow software built against newer versions of libstdc++ to
be compatible with the system libstdc++, have libstdc++
default to ABI version 4 compatible mode on older systems
