### PR TITLE
rtptools: update to 1.22

### DIFF
--- a/audio/rtptools/Portfile
+++ b/audio/rtptools/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                rtptools
-version             1.21
+version             1.22
 categories          audio net
-license             Noncommercial BSD
-platforms           darwin
+license             BSD
+platforms           darwin freebsd netbsd sunos linux
 maintainers         {stare.cz:hans @janstary}
 
 description		A set of tools for processing RTP data.
@@ -20,5 +20,5 @@ homepage	http://www.cs.columbia.edu/irt/software/rtptools/
 master_sites	http://www.cs.columbia.edu/irt/software/rtptools/download/
 
 checksums \
-	rmd160 ce64f3c1d2299c1f4d4dadd3f57e0f99a75ffdfd \
-	sha256 2ddbf6d3a4dbdef26ca85e860f6795264a359d30e24fd63f14a8c4f7ca331830
+	rmd160 9fd771df2b98231a194370b2685cb2beaf6de77b \
+	sha256 2c76b2a423fb943820c91194372133a44cbdc456ebf69c51616ec50eeb068c28


### PR DESCRIPTION
This updates RTP tools to the latest release.
Two main changes: BSD license and manpages.

Tested on 10.13