### PR TITLE
yubikey-manager: new ports

### DIFF
--- a/python/py-pyscard/Portfile
+++ b/python/py-pyscard/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        LudovicRousseau pyscard 1.9.6 release-
+name                py-pyscard
+platforms           darwin
+license             GPL
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+
+description         Smartcard module for Python.
+long_description    ${description}
+
+homepage            https://pyscard.sourceforge.io/
+
+checksums           rmd160  1c8ed2bf25edfe573b59f0010ceca4f5a3fac25b \
+                    sha256  2ce5b157e77e1ecb70fdf7f6275f1f701f23fa80918d56d54f8b9ea88a8277ff
+
+python.versions     27 35 36
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:swig-python
+}

--- a/security/yubikey-manager/Portfile
+++ b/security/yubikey-manager/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                yubikey-manager
+github.setup        Yubico yubikey-manager 0.6.0 yubikey-manager-
+categories          security python
+platforms           darwin
+license             BSD
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+
+description         Tool ("ykman") for managing your YubiKey configuration.
+long_description    ${description}
+
+homepage            https://developers.yubico.com/yubikey-manager/
+
+checksums           rmd160  f4a621975f73ed2ec22f95e5813c5307b269dd6f \
+                    sha256  2a14d0f648f323bfcf97076908d2cb8d7070effb5ff4c8222c44cd687e9c0262
+
+python.default_version 36
+
+depends_build-append \
+    port:py${python.version}-setuptools
+
+depends_lib-append \
+    port:py${python.version}-six \
+    port:py${python.version}-pyscard \
+    port:py${python.version}-pyusb \
+    port:py${python.version}-click \
+    port:py${python.version}-cryptography \
+    port:py${python.version}-openssl
+
+depends_run-append \
+    port:ykpers \
+    port:libu2f-host \
+    port:swig \
+    port:libusb


### PR DESCRIPTION
#### Description

This is a CLI management tool for Yubikeys. See: https://github.com/Yubico/yubikey-manager

One dependency (`pyscard`) was not already available in MacPorts, so I have included a new port for that.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
