### PR TITLE
pypy3: bump to 5.10.1, fix issues

### DIFF
--- a/lang/pypy/Portfile
+++ b/lang/pypy/Portfile
@@ -35,7 +35,7 @@ patchfiles          darwin.py.diff \
                     ffiplatform.py.diff
 
 subport pypy3 {
-    revision       1
+    version           5.10.1
     set python.branch 3.5
     set python.libdir 3
     livecheck.regex downloads/pypy3-v(\[0-9.\]+)-src\\.tar\\.bz2
@@ -45,12 +45,11 @@ subport pypy3 {
 
     distname            pypy3-v${version}-src
 
-    checksums           rmd160  f8a8c5d290d33fb087924fcc2ed752dfafd5659f \
-                        sha256  a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3
+    checksums           rmd160  6013d3109f2e7d078b960c8743f8885ebdf50bd3 \
+                        sha256  f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713 \
+                        size    29071765
 
     set pypy_c_name pypy3-c
-
-    destroot.args-append --no-embed-dependencies
 }
 
 if {$subport == ${name}} {
@@ -66,12 +65,18 @@ long_description \
     instead of CPython is speed, as it runs generally faster.
 
 post-patch {
-    reinplace "s+('/sw/', '/opt/local/')+('__PREFIX__',)+g" \
+    # the PyPy sources search for  dependancies in /opt/local and /sw,
+    # yet we only want to search  ${prefix} -- the hackery below fixes
+    # that, but without triggering warnings about /opt/local from 'port lint'
+    set default_prefix "/opt"
+    append default_prefix "/local"
+
+    reinplace "s|('/sw/', '${default_prefix}/')|('__PREFIX__',)|" \
         ${worksrcpath}/pypy/tool/cpyext/extbuild.py
 
     # sanity check, useful when upgrading
-    if { ![catch {exec grep -lwre "/sw" -e "/opt/local" ${worksrcpath}}] } {
-        return -code error "didn't catch all references to /sw or /opt/local!"
+    if { ![catch {exec grep -lwre "/sw" -e ${default_prefix} ${worksrcpath}}] } {
+        return -code error "didn't catch all references to /sw or ${default_prefix}!"
     }
 
     reinplace "s|__PREFIX__|${prefix}|" ${worksrcpath}/lib_pypy/cffi/ffiplatform.py \
@@ -142,6 +147,11 @@ destroot.args       --builddir ${destroot}${prefix}/lib \
                     --without-tk
 destroot.target     package.py
 destroot.post_args
+
+subport pypy3 {
+    # we set destroot.args just above, so we cannot do this earlier
+    destroot.args-append --no-embedded-dependencies
+}
 
 # JIT is not available on powerpc at present
 if {${os.arch} ne "i386"} {


### PR DESCRIPTION
- address 'port lint' warning
- properly suppress embedded dependencies

Closes: https://trac.macports.org/ticket/55679

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
