### PR TITLE
py-bpython: Update to 1.17.1; add py35, py36; update dependencies

### DIFF
--- a/python/py-blessings/Portfile
+++ b/python/py-blessings/Portfile
@@ -7,7 +7,7 @@ name                py-blessings
 set real_name       blessings
 version             1.6.1
 maintainers         nomaintainer
-python.versions     27 34
+python.versions     27 34 35 36
 
 description         A thin, practical wrapper around terminal formatting, positioning, and more
 long_description    ${description}

--- a/python/py-blessings/Portfile
+++ b/python/py-blessings/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-blessings
 set real_name       blessings
-version             1.6
+version             1.6.1
 maintainers         nomaintainer
 python.versions     27 34
 
@@ -18,8 +18,9 @@ license             MIT
 homepage            https://github.com/erikrose/blessings
 master_sites        pypi:b/${real_name}/
 distname            ${real_name}-${version}
-checksums           rmd160  00014f95d6c303cb87f02476f9b4c1d3e242293a \
-                    sha256  edc5713061f10966048bf6b40d9a514b381e0ba849c64e034c4ef6c1847d3007
+checksums           rmd160  56381887db40a66014ea3ce6ae2d9490c0669be4 \
+                    sha256  74919575885552e14bc24a68f8b539690bd1b5629180faa830b1a25b8c7fb6ea \
+                    size    20122
 
 if {${name} ne ${subport}} {
     depends_build  port:py${python.version}-setuptools

--- a/python/py-bpython/Portfile
+++ b/python/py-bpython/Portfile
@@ -5,12 +5,7 @@ PortGroup               python 1.0
 PortGroup               select 1.0
 PortGroup               github 1.0
 
-# FIXME: bpython uses a version *suffix* instead of a *prefix*.
-# Add support to github portgroup for version suffix?
-github.setup            bpython bpython 0.16-release
-version                 0.16
-distname                ${name}-${version}
-
+github.setup            bpython bpython 0.17.1 "" -release
 name                    py-${name}
 platforms               darwin
 supported_archs         noarch
@@ -21,8 +16,9 @@ long_description        a fancy interface to the Python interpreter for \
                         Unix-like operating systems
 
 homepage                http://www.bpython-interpreter.org/
-checksums               rmd160  258763b4cfaaf16e8ae10448d0cb7684138de87a \
-                        sha256  858f6a1c90279a41891568787b1c4d6ef1fa703f5a250792bc3746dfaec45de0
+checksums               rmd160  d375318faa9a5a5af7b6a5223aa29e854ab89532 \
+                        sha256  2e2c0d94986aed8b04fc6be652d7a89632d425e77e808e891a59993e48c5a394 \
+                        size    204362
 
 python.versions         27 34
 
@@ -61,7 +57,4 @@ when you execute the commands without a version suffix, e.g. 'bpython', run:
 
 port select --set ${select.group} [file tail ${select.file}]
 "
-} else {
-    livecheck.regex         archive/(\[^"\]+)-release${extract.suffix}
-    livecheck.version       ${version}
 }

--- a/python/py-bpython/Portfile
+++ b/python/py-bpython/Portfile
@@ -20,7 +20,7 @@ checksums               rmd160  d375318faa9a5a5af7b6a5223aa29e854ab89532 \
                         sha256  2e2c0d94986aed8b04fc6be652d7a89632d425e77e808e891a59993e48c5a394 \
                         size    204362
 
-python.versions         27 34
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     livecheck.type          none

--- a/python/py-bpython/Portfile
+++ b/python/py-bpython/Portfile
@@ -15,7 +15,7 @@ description             fancy interface to the Python interpreter
 long_description        a fancy interface to the Python interpreter for \
                         Unix-like operating systems
 
-homepage                http://www.bpython-interpreter.org/
+homepage                https://www.bpython-interpreter.org
 checksums               rmd160  d375318faa9a5a5af7b6a5223aa29e854ab89532 \
                         sha256  2e2c0d94986aed8b04fc6be652d7a89632d425e77e808e891a59993e48c5a394 \
                         size    204362

--- a/python/py-bpython/files/bpython35
+++ b/python/py-bpython/files/bpython35
@@ -1,0 +1,8 @@
+bin/bpdb-3.5
+bin/bpython-3.5
+bin/bpython-curses-3.5
+bin/bpython-urwid-3.5
+${frameworks_dir}/Python.framework/Versions/3.5/share/man/man1/bpython.1
+${frameworks_dir}/Python.framework/Versions/3.5/share/man/man5/bpython-config.5
+${frameworks_dir}/Python.framework/Versions/3.5/share/themes/light.theme
+${frameworks_dir}/Python.framework/Versions/3.5/share/themes/sample.theme

--- a/python/py-bpython/files/bpython36
+++ b/python/py-bpython/files/bpython36
@@ -1,0 +1,8 @@
+bin/bpdb-3.6
+bin/bpython-3.6
+bin/bpython-curses-3.6
+bin/bpython-urwid-3.6
+${frameworks_dir}/Python.framework/Versions/3.6/share/man/man1/bpython.1
+${frameworks_dir}/Python.framework/Versions/3.6/share/man/man5/bpython-config.5
+${frameworks_dir}/Python.framework/Versions/3.6/share/themes/light.theme
+${frameworks_dir}/Python.framework/Versions/3.6/share/themes/sample.theme

--- a/python/py-curtsies/Portfile
+++ b/python/py-curtsies/Portfile
@@ -20,7 +20,7 @@ checksums               md5     20e7295c9592b4101915131a685725f0 \
                         sha256  89c802ec051d01dec6fc983e9856a3706e4ea8265d2940b1f6d504a9e26ed3a9 \
                         size    47120
 
-python.versions         27 34
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     livecheck.type          none

--- a/python/py-curtsies/Portfile
+++ b/python/py-curtsies/Portfile
@@ -12,7 +12,7 @@ license                 MIT
 description             Curses-like terminal wrapper, with colored strings
 long_description        ${description}
 
-homepage                http://curtsies.readthedocs.org/
+homepage                http://curtsies.readthedocs.io
 master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname                ${python.rootname}-${version}
 checksums               md5     05609f5c0dc758fe776bfcc5625f9562 \

--- a/python/py-curtsies/Portfile
+++ b/python/py-curtsies/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-curtsies
-version                 0.2.10
+version                 0.3.0
 platforms               darwin
 supported_archs         noarch
 maintainers             {aronnax @lpsinger} openmaintainer
@@ -15,9 +15,10 @@ long_description        ${description}
 homepage                http://curtsies.readthedocs.io
 master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname                ${python.rootname}-${version}
-checksums               md5     05609f5c0dc758fe776bfcc5625f9562 \
-                        rmd160  f173e1def7d3ab94faf1a844eb20022a75f3c4ec \
-                        sha256  26d5c3356bf318443f57866903dda3c66a10da3b86a79bc3e9b2719bb5272715
+checksums               md5     20e7295c9592b4101915131a685725f0 \
+                        rmd160  39fd8eb76f8e38fec3a7803659e3ae1a7cbfce2a \
+                        sha256  89c802ec051d01dec6fc983e9856a3706e4ea8265d2940b1f6d504a9e26ed3a9 \
+                        size    47120
 
 python.versions         27 34
 


### PR DESCRIPTION
#### Description

Updates py-bpython to 1.17.1 and adds py35 and py36 subports
Updates its dependency py-curtsies to 0.3.0 and adds py35 and py36 subports
Updates its dependency py-blessings to 1.6.1 and adds py35 and py36 subports

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
