### PR TITLE
openldap: update to version 2.4.46 - not tested against libressl

### DIFF
--- a/databases/openldap/Portfile
+++ b/databases/openldap/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup muniversal 1.0
 
 name            openldap
-version         2.4.45
+version         2.4.46
 categories      databases
 maintainers     nomaintainer
 license         openldap
@@ -19,8 +19,8 @@ master_sites    ftp://ftp.OpenLDAP.org/pub/OpenLDAP/openldap-release/ \
                 ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/
 extract.suffix    .tgz
 
-checksums       rmd160  a2f4483ffb958cc103a2aa0fb13c1f78e7951263 \
-                sha256  cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824
+checksums       rmd160  d7038355b1c13a0b2d5104a0c75735b63e9c4148 \
+                sha256  9a90dcb86b99ae790ccab93b7585a31fbcbeec8c94bf0f7ab0ca0a87ea0c4b2d
 
 depends_lib     path:bin/perl:perl5 \
                 port:tcp_wrappers \

--- a/databases/openldap/files/libressl.patch
+++ b/databases/openldap/files/libressl.patch
@@ -54,6 +54,3 @@
  #define BIO_set_init(b, x)	b->init = x
  #define BIO_set_data(b, x)	b->ptr = x
  #define BIO_clear_flags(b, x)	b->flags &= ~(x)
-@@ -822,7 +822,7 @@ tlso_bio_puts( BIO *b, const char *str )
- 	return tlso_bio_write( b, str, strlen( str ) );
- }

--- a/databases/openldap/files/libressl.patch
+++ b/databases/openldap/files/libressl.patch
@@ -57,9 +57,4 @@
 @@ -822,7 +822,7 @@ tlso_bio_puts( BIO *b, const char *str )
  	return tlso_bio_write( b, str, strlen( str ) );
  }
- 
--#if OPENSSL_VERSION_NUMBER >= 0x10100000
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000) && !defined(LIBRESSL_VERSION_NUMBER)
- struct bio_method_st {
-     int type;
-     const char *name;
+

--- a/databases/openldap/files/libressl.patch
+++ b/databases/openldap/files/libressl.patch
@@ -57,4 +57,3 @@
 @@ -822,7 +822,7 @@ tlso_bio_puts( BIO *b, const char *str )
  	return tlso_bio_write( b, str, strlen( str ) );
  }
-


### PR DESCRIPTION
#### Description
I have built openldap 2.4.46 against openssl. I have had to remove one hunk from libressl.patch, as gstdtlsconnection.c was modified upstream. 
###### Type(s)
- [ x] update

###### Tested on
macOS 10.13.3
Xcode 9.2
