### PR TITLE
editorconfig-core-c: Update to 0.12.2

### DIFF
--- a/devel/editorconfig-core-c/Portfile
+++ b/devel/editorconfig-core-c/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
-PortGroup           cmake 1.0
 
-github.setup        editorconfig editorconfig-core-c 0.12.1 v
+github.setup        editorconfig editorconfig-core-c 0.12.2 v
 license             BSD
 categories          devel
-maintainers         sean openmaintainer
+maintainers         {sean @seanfarley} openmaintainer
 description         EditorConfig makes it easy to maintain the correct coding style
 long_description \
    This code produces a program that accepts a filename as input and will \
@@ -18,8 +18,9 @@ platforms           darwin
 
 depends_lib         port:pcre
 
-checksums           rmd160  09e6a4843291f54474052a27d7ee1ba3ee514ee4 \
-                    sha256  b467f99a9d94d0b60b70d4cb0ab6db59dc595e8af22efc17e8575943dc0583ab
+checksums           rmd160  14a1e30f0db589c7c37592855aad432c705cef68 \
+                    sha256  ad16136ab410aebf1abbf7f6d457412e7b3cab27a903abc952224e1d4102fd20 \
+                    size    66999
 
 pre-build {
     file mkdir "${worksrcpath}/doc/man"


### PR DESCRIPTION
#### Description

editorconfig-core-c: Update to 0.12.2

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?