### PR TITLE
pbzx: New port, version 20180319

### DIFF
--- a/archivers/pbzx/Portfile
+++ b/archivers/pbzx/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                pbzx
+version             20180319
+set 02_decompress_version   20180319
+categories          archivers
+platforms           darwin
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             Permissive
+
+description         utility to decode pbzx streams in xip files
+
+long_description    ${name} is a ${description}.
+
+homepage            http://newosxbook.com/articles/OTA5.html
+master_sites        http://newosxbook.com/code/listings/pbzx.c?dummy=:pbzx \
+                    http://newosxbook.com/code/listings/02_decompress.c?dummy=:decompress
+
+set pbzx.c          pbzx-${version}.c
+set 02_decompress.c 02_decompress-${02_decompress_version}.c
+
+distfiles           ${pbzx.c}:pbzx \
+                    ${02_decompress.c}:decompress
+
+checksums           ${pbzx.c} \
+                    rmd160  19731be9fc5e99257a3ebdddc7e0999543f48442 \
+                    sha256  44a780291ec8565123c1a5b064c3e01e9a18f8882e18d2278f995d2479759f9f \
+                    size    3506 \
+                    ${02_decompress.c} \
+                    rmd160  e698abf6f3054b198d1f1c6acd1126bdaec8b943 \
+                    sha256  244f2503675e1c14e35df5851d04db0cf067e9f8cd4c9b423ce917445740ae8e \
+                    size    13188
+
+depends_lib         port:xz
+
+extract.mkdir       yes
+extract {
+    copy ${distpath}/${pbzx.c} ${worksrcpath}/pbzx.c
+    copy ${distpath}/${02_decompress.c} ${worksrcpath}/02_decompress.c
+}
+
+use_configure       no
+
+variant universal {}
+
+build {
+    system -W ${worksrcpath} "${configure.cc} ${configure.cflags} ${configure.cppflags} ${configure.ldflags} [get_canonical_archflags] pbzx.c 02_decompress.c -llzma -o pbzx"
+}
+
+destroot {
+    xinstall ${worksrcpath}/pbzx ${destroot}${prefix}/bin
+}
+
+livecheck.type      moddate
+livecheck.url       [lindex [split ${master_sites} ?] 0]


### PR DESCRIPTION
#### Description

pbzx: New port, version 20180319

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?