### PR TITLE
gimp-jp2: fix build by updating automake dependency

### DIFF
--- a/graphics/gimp-jp2/files/patch-autogen.sh.diff
+++ b/graphics/gimp-jp2/files/patch-autogen.sh.diff
@@ -5,14 +5,17 @@
  
  AUTOCONF_REQUIRED_VERSION=2.54
 -AUTOMAKE_REQUIRED_VERSION=1.6
-+AUTOMAKE_REQUIRED_VERSION=1.15
++AUTOMAKE_REQUIRED_VERSION=1.16
  GLIB_REQUIRED_VERSION=2.0.0
  INTLTOOL_REQUIRED_VERSION=0.17
  
-@@ -62,6 +62,9 @@
+@@ -62,6 +62,12 @@
  elif (automake-1.9 --version) < /dev/null > /dev/null 2>&1; then
     AUTOMAKE=automake-1.9
     ACLOCAL=aclocal-1.9
++elif (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake-1.16
++   ACLOCAL=aclocal-1.16
 +elif (automake-1.15 --version) < /dev/null > /dev/null 2>&1; then
 +   AUTOMAKE=automake-1.15
 +   ACLOCAL=aclocal-1.15


### PR DESCRIPTION
#### Description

Fix gimp-jp2 build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
