### PR TITLE
gimp-lqr-plugin: fix by updating automake dependency

### DIFF
--- a/graphics/gimp-lqr-plugin/files/patch-autogen.sh.diff
+++ b/graphics/gimp-lqr-plugin/files/patch-autogen.sh.diff
@@ -9,7 +9,7 @@
  GLIB_REQUIRED_VERSION=2.0.0
  INTLTOOL_REQUIRED_VERSION=0.17
  
-@@ -53,7 +53,10 @@
+@@ -53,7 +53,13 @@
  fi
  
  echo -n "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
@@ -17,6 +17,9 @@
 +if (automake-1.15 --version) < /dev/null > /dev/null 2>&1; then
 +   AUTOMAKE=automake-1.15
 +   ACLOCAL=aclocal-1.15
++elif (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake-1.16
++   ACLOCAL=aclocal-1.16
 +elif (automake-1.7 --version) < /dev/null > /dev/null 2>&1; then
     AUTOMAKE=automake-1.7
     ACLOCAL=aclocal-1.7


### PR DESCRIPTION
#### Description

Fix gimp-lqr-plugin

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?