### PR TITLE
py-pygit2: Add py-six to depends_lib

### DIFF
--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        libgit2 pygit2 0.26.3 v
+revision            1
 name                py-pygit2
 
 categories-append   devel
@@ -26,7 +27,8 @@ python.versions     27 34 35 36
 if {${name} ne ${subport}} {
     depends_lib-append  port:libgit2 \
                         port:py${python.version}-cffi \
-                        port:py${python.version}-setuptools
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-six
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description

Installed `gitless`, `gl` failed with the following message:
```
Traceback (most recent call last):
  File "/opt/local/bin/gl", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3088, in <module>
    @_call_aside
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3072, in _call_aside
    f(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3101, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py", line 574, in _build_master
    ws.require(__requires__)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py", line 892, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pkg_resources/__init__.py", line 778, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'six' distribution was not found and is required by pygit2
```

I am assuming, from the message above, that `py-pygit2` should be amended to depend on `py-six`. After doing that `gitless` is working as expected.

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
