### PR TITLE
rust: Downgrade to llvm-4.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                rust
 version             1.24.1
-revision            1
+revision            2
 categories          lang devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -29,7 +29,9 @@ homepage            https://www.rust-lang.org/
 depends_build       path:bin/cmake:cmake \
                     bin:python2.7:python27
 
-depends_lib         port:llvm-5.0
+# Currently LLVM 4.0 is required, see this issue for LLVM 5.0 support:
+# https://github.com/rust-lang/rust/issues/43370 .
+depends_lib         port:llvm-4.0
 
 master_sites        https://static.rust-lang.org/dist
 
@@ -119,7 +121,7 @@ configure.args      --enable-vendor \
                     --default-linker=${configure.cc} \
                     --disable-codegen-tests \
                     --disable-docs \
-                    --llvm-root=${prefix}/libexec/llvm-5.0 \
+                    --llvm-root=${prefix}/libexec/llvm-4.0 \
                     --release-channel=stable
 
 if {![variant_isset universal]} {


### PR DESCRIPTION
The update to 1.24.0 in 4b2c24ca erroneously switched to LLVM 5.0, which
is still not supported by this rust version. Compiling with rustc will
produce "invalid expression" messages.

See: https://github.com/rust-lang/rust/issues/43370
See: https://github.com/rust-lang/rust/issues/47464

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

I did not test to build it.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
