### PR TITLE
toxiproxy: new port

### DIFF
--- a/net/toxiproxy/Portfile
+++ b/net/toxiproxy/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        Shopify toxiproxy 2.1.3 v
+categories          net
+platforms           darwin
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+license             MIT
+
+description         Toxiproxy is a framework for simulating network conditions.
+
+long_description    Toxiproxy is a framework for simulating network conditions. \
+    It's made specifically to work in testing, CI and development environments, \
+    supporting deterministic tampering with connections, but with support for \
+    randomized chaos and customization. Toxiproxy is the tool you need to prove \
+    with tests that your application doesn't have single points of failure.
+
+depends_build       port:go
+use_configure       no
+
+checksums           rmd160  3b77a1fa1ca0b922140155b222ece12075f9a375 \
+                    sha256  a56767e7209bd97675800c91c5b4d51c39992fe0811cf2a6cbfa7f1313ebde34
+
+post-extract {
+    xinstall -d ${worksrcpath}/src/github.com/${github.author}/
+    ln -sf ${worksrcpath} ${worksrcpath}/src/github.com/${github.author}/${github.project}
+    # `go build` wants deps in /vendor/src but they are in /vendor for some reason
+    ln -sf ${worksrcpath} ${worksrcpath}/vendor/src
+}
+
+build.cmd           make
+build.target        darwin
+build.env           GOPATH=${worksrcpath} \
+                    CC=${configure.cc}
+
+destroot {
+    set arch darwin-amd64
+    xinstall -m 755 ${worksrcpath}/tmp/build/${name}-server-${arch} \
+        ${destroot}${prefix}/bin/${name}-server
+    xinstall -m 755 ${worksrcpath}/tmp/build/${name}-cli-${arch} \
+        ${destroot}${prefix}/bin/${name}-cli
+}


### PR DESCRIPTION
#### Description

[toxiproxy](https://github.com/Shopify/toxiproxy) is a proxy that lets you simulate network problems.

###### Tested on
macOS 10.13.3 17D102
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
