### PR TITLE
laszip: Update to 3.2.2

### DIFF
--- a/gis/laszip/Portfile
+++ b/gis/laszip/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           cmake   1.1
-PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11   1.1
 PortGroup           github  1.0
 
@@ -22,8 +21,6 @@ homepage            https://www.laszip.org
 checksums           rmd160  8202240f2924ee863fe6236a4def7823e417d095 \
                     sha256  76a7eae65f8a397c3f8f709ad26476c84588aa531102d69af8eb4fd7c1bc3143 \
                     size    222623
-
-compiler.blacklist      {clang < 500}
 
 worksrcdir          LASzip-LASzip-0a71b19
 

--- a/gis/laszip/Portfile
+++ b/gis/laszip/Portfile
@@ -17,7 +17,7 @@ long_description    $description
 platforms           darwin
 license             GPL-2+
 
-homepage            http://www.laszip.org/
+homepage            https://www.laszip.org
 
 checksums           rmd160  8202240f2924ee863fe6236a4def7823e417d095 \
                     sha256  76a7eae65f8a397c3f8f709ad26476c84588aa531102d69af8eb4fd7c1bc3143 \

--- a/gis/laszip/Portfile
+++ b/gis/laszip/Portfile
@@ -5,8 +5,7 @@ PortGroup           cmake   1.1
 PortGroup           cxx11   1.1
 PortGroup           github  1.0
 
-github.setup        LASZip LASzip 3.2.0
-revision            1
+github.setup        LASzip LASzip 3.2.2
 name                laszip
 categories          gis
 maintainers         {vince @Veence}
@@ -17,17 +16,12 @@ platforms           darwin
 license             GPL-2+
 
 homepage            https://www.laszip.org
+github.tarball_from releases
+distname            laszip-src-${version}
+use_bzip2           yes
 
-checksums           rmd160  8202240f2924ee863fe6236a4def7823e417d095 \
-                    sha256  76a7eae65f8a397c3f8f709ad26476c84588aa531102d69af8eb4fd7c1bc3143 \
-                    size    222623
+checksums           rmd160  68213e4397082af113f319333d3441875f705991 \
+                    sha256  815b682ac4470cd4b546a3af105702f5fe161dd3926ea8c6df7dd9f13715153a \
+                    size    151927
 
-worksrcdir          LASzip-LASzip-0a71b19
-
-post-destroot   {
-    exec install_name_tool  -id ${prefix}/lib/liblaszip.3.dylib \
-                            ${destroot}${prefix}/lib/liblaszip.3.2.0.dylib
-    exec install_name_tool  -id ${prefix}/lib/liblaszip_api.3.dylib \
-                            ${destroot}${prefix}/lib/liblaszip_api.3.2.0.dylib
-
-}
+patchfiles          install_name.patch

--- a/gis/laszip/files/install_name.patch
+++ b/gis/laszip/files/install_name.patch
@@ -1,0 +1,14 @@
+Do not override the MacPorts install_name defaults.
+--- cmake/macros.cmake.orig	2018-03-27 07:17:46.000000000 -0500
++++ cmake/macros.cmake	2018-03-27 07:37:39.000000000 -0500
+@@ -70,10 +70,6 @@
+         RUNTIME DESTINATION ${LASZIP_BIN_INSTALL_DIR}
+         LIBRARY DESTINATION ${LASZIP_LIB_INSTALL_DIR}
+         ARCHIVE DESTINATION ${LASZIP_LIB_INSTALL_DIR})
+-    if (APPLE)
+-        set_target_properties(${_name} PROPERTIES INSTALL_NAME_DIR
+-            "@executable_path/../lib")
+-    endif()
+ endmacro(LASZIP_ADD_LIBRARY)
+ 
+ ###############################################################################

--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -20,7 +20,7 @@ long_description    PDAL is a C++ BSD library for translating and\
                     like the GDAL library which handles raster and\
                     vector data.
 
-homepage            http://www.pdal.io/
+homepage            https://www.pdal.io
 master_sites        http://download.osgeo.org/pdal
 distname            PDAL-${version}-src
 

--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -6,7 +6,7 @@ PortGroup           cxx11       1.1
 
 name                pdal
 version             1.6.0
-revision            1
+revision            2
 categories          gis
 license             BSD
 platforms           darwin

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -42,12 +42,16 @@ depends_lib         port:geos \
 
 depends_lib-append      port:${wxWidgets.port}
 
-post-patch  {
-    reinplace -E "s|wx-config|${wxWidgets.wxconfig}|" ${worksrcpath}/configure
-
-    set mkfiles [exec find ${worksrcpath} -type f -name Makefile.in]
-    foreach makefile ${mkfiles} {
-        reinplace -E -q "s|wx-config|${wxWidgets.wxconfig}|" ${makefile}
+post-patch {
+    fs-traverse f ${worksrcpath} {
+        if {[file isfile ${f}]} {
+            switch [file tail ${f}] {
+                configure -
+                Makefile.in {
+                    reinplace -E -q "s|wx-config|${wxWidgets.wxconfig}|" ${f}
+                }
+            }
+        }
     }
 }
 

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -20,10 +20,7 @@ long_description    SAGA is yet another open source GIS targeted towards\
                     a GUI.
 
 homepage            http://www.saga-gis.org/en/index.html
-
 master_sites        sourceforge:project/saga-gis/SAGA%20-%206/SAGA%20-%20${version}
-distname            saga-${version}
-worksrcdir          saga-${version}
 
 checksums           rmd160  4fd7f91c0c6511f5356528a8b148b714d7d4c542 \
                     sha256  bb4b99406e3a25cdaa12559904ce3272c449acb542bc0883b2755ce6508dd243

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -47,7 +47,7 @@ post-patch  {
 
     set mkfiles [exec find ${worksrcpath} -type f -name Makefile.in]
     foreach makefile ${mkfiles} {
-        reinplace -E "s|wx-config|${wxWidgets.wxconfig}|" ${makefile}
+        reinplace -E -q "s|wx-config|${wxWidgets.wxconfig}|" ${makefile}
     }
 }
 

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -8,7 +8,7 @@ name                saga
 categories          gis
 license             GPL
 version             6.3.0
-revision            1
+revision            2
 #set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 maintainers         vince openmaintainer


### PR DESCRIPTION
#### Description

Updates laszip to 3.2.2 using release download. This fixes the library version number. Added a patch to fix the library install name. ~~Added long description.~~ Revbumped saga and pdal to link with the updated laszip library. Switched to https homepages where those are canonical. Removed unnecessary directives and improved ports in other ways; see commit messages.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
