### PR TITLE
gildas: add -openmp variant

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -6,6 +6,7 @@ PortGroup           active_variants 1.1
 
 name                gildas
 version             201803b
+revision            1
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
@@ -49,6 +50,9 @@ depends_build       port:cfitsio \
                     port:pkgconfig \
                     port:slatec
 
+set my_build_opts   ""
+variant openmp description {Add OpenMP support} {set my_build_opts "-o openmp"}
+
 # need x11 and cannot be used with quartz; see ticket #42886
 require_active_variants gtk2 x11 quartz
 
@@ -84,7 +88,7 @@ configure {
 }
 
 build {
-    system -W ${worksrcpath} "source admin/gildas-env.sh -c ${configure.fc} -s ${prefix}/include:${prefix}/lib:/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/Current/ && export GAG_SLDFLAGS='-shared -o ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@) -install_name ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@)' && export DYLD_LIBRARY_PATH=${worksrcpath}/integ/x86_64-darwin-gfortran/lib && export GAG_ADDONS=yes && make -w depend && make -w install"
+    system -W ${worksrcpath} "source admin/gildas-env.sh -c ${configure.fc} ${my_build_opts} -s ${prefix}/include:${prefix}/lib:/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/Current/ && export GAG_SLDFLAGS='-shared -o ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@) -install_name ${prefix}/lib/gildas/x86_64-darwin-gfortran/lib/\$(notdir \$@)' && export DYLD_LIBRARY_PATH=${worksrcpath}/integ/x86_64-darwin-gfortran/lib && export GAG_ADDONS=yes && make -w depend && make -w install"
 }
 
 destroot {

--- a/science/gildas/files/patch-admin-define-system.sh.diff
+++ b/science/gildas/files/patch-admin-define-system.sh.diff
@@ -44,7 +44,7 @@
      #  source admin/gildas-env.sh -c ifort14  (i.e. use namely non default ifort 14)
      # does not build their binaries in the same integration branch.
 -    GAG_EXEC_SYSTEM=$GAG_MACHINE-$GAG_TARGET_VERS-$GAG_COMPILER_FEXE$GAG_CONFIG
-+    GAG_EXEC_SYSTEM=$GAG_MACHINE-$GAG_TARGET_VERS-$GAG_COMPILER_FKIND$GAG_CONFIG
++    GAG_EXEC_SYSTEM=$GAG_MACHINE-$GAG_TARGET_VERS-$GAG_COMPILER_FKIND
      export GAG_COMP_SYSTEM GAG_EXEC_SYSTEM
      export GAG_MACHINE GAG_CONFIG
      export GAG_ENV_KIND GAG_ENV_VERS


### PR DESCRIPTION
#### Description

Add OpenMP support to Gildas, as discussed in #1246 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.3 17D102
Xcode 9.2 9C40b 
