### PR TITLE
aff4: Update to 1.0-20180212

### DIFF
--- a/security/aff4/Portfile
+++ b/security/aff4/Portfile
@@ -1,11 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
-github.setup        google aff4 2cbfe9d18ae3c244a889c393577b3f5108af6c2e
-revision            2
+github.setup        Velocidex c-aff4 fd984ea3cddc034740d5d03ba510a407a2e451a3
 name                aff4
+epoch               1
+version             1.0-20180212
 categories          security
 platforms           darwin
 license             Apache-2
@@ -14,19 +16,17 @@ description         AFF4 -The Advanced Forensics File Format
 long_description    The Advanced Forensics File Format 4 (AFF4) is an open source \
                     format used for the storage of digital evidence and data.
 
-fetch.type          git
+checksums           rmd160  08295532a5abaa4634e40913af5cf8ed0786f3bf \
+                    sha256  9cf9eebd7146191d59feeac182cc00133921d074702d2d5683895ff0ce0c79bf \
+                    size    667085
 
-post-fetch {
-    system -W ${worksrcpath} "git submodule update --init third_party/gtest"
-}
-
-depends_lib-append  port:google-glog \
-                    port:libuuid \
+depends_lib-append  port:ossp-uuid \
                     port:pcrexx \
                     port:raptor2 \
                     port:snappy \
                     port:tclap \
                     port:uriparser \
+                    port:yaml-cpp \
                     port:zlib
 
 use_autoreconf      yes
@@ -36,9 +36,10 @@ autoreconf.args     --verbose
 depends_build-append port:autoconf \
                     port:automake \
                     port:libtool \
-                    port:pkgconfig
+                    port:pkgconfig \
+                    port:spdlog
 
-use_parallel_build no
+patchfiles          nobundle.patch
 
 test.run            yes
 test.target         check

--- a/security/aff4/files/nobundle.patch
+++ b/security/aff4/files/nobundle.patch
@@ -1,0 +1,22 @@
+Don't try to make the app bundle. It fails if the port isn't already installed,
+and the resulting app bundle isn't installed anywhere.
+https://github.com/Velocidex/c-aff4/issues/17
+--- tools/pmem/Makefile.am.orig	2018-02-12 16:11:48.000000000 -0600
++++ tools/pmem/Makefile.am	2018-03-28 10:44:16.000000000 -0500
+@@ -63,16 +63,4 @@
+ osxpmem_SOURCES = pmem_imager.cc osxpmem.cc
+ osxpmem_LDADD = $(top_srcdir)/aff4/libaff4.la -lyaml-cpp
+ 
+-# In order to build a deployable bundle we must have all the libraries
+-# installed on the system first.
+-install-exec-hook:
+-	@echo Creating deployable bundle.
+-	rm -rf osxpmem.app osxpmem.zip
+-	mkdir osxpmem.app/
+-	cp README.md $(bindir)/osxpmem osxpmem.app/  || echo You must run make install before building a bundle.
+-	dylibbundler -x osxpmem.app/osxpmem -b -d osxpmem.app/libs/ -p @executable_path/libs/ -of -od -cd
+-	cp -a resources/MacPmem.kext osxpmem.app/
+-	chmod -R o-wx osxpmem.app/
+-	zip -r osxpmem.zip osxpmem.app/
+-
+ endif


### PR DESCRIPTION
#### Description

Updates aff4 to 1.0-20180212.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
