### PR TITLE
libwebsockets: Update to 2.4.2

### DIFF
--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        warmcat libwebsockets 2.4.1 v
+github.setup        warmcat libwebsockets 2.4.2 v
 categories          devel net
 platforms           darwin
 license             LGPL-2.1
@@ -18,8 +18,12 @@ long_description    \
     CPU and memory resources, and provide fast throughput in both directions \
     as client or server.
 
-checksums           rmd160 ec770bb7dd8f98fa239cd7b76bb8d1a26195770d \
-                    sha256 664113e09e76d807023e19be6323a5a453b303fea5061efb9ba797b316272fb3
+checksums           rmd160  79089070ba8cede8e125a214ddd41f2f0cf5e170 \
+                    sha256  52904d4be01a659cef886bf42fa740743f50b45b896eed55d39e9137b25b7ea6 \
+                    size    3777268
+
+depends_lib-append  path:lib/libssl.dylib:openssl \
+                    port:zlib
 
 configure.args-append \
                     -DLWS_WITHOUT_TESTAPPS=ON \
@@ -28,5 +32,5 @@ configure.args-append \
                     -DLWS_WITH_HTTP2=1
 
 post-destroot {
-    delete ${workpath}/destroot/${prefix}/share/${name}-test-server
+    delete ${destroot}${prefix}/share/${name}-test-server
 }


### PR DESCRIPTION
#### Description

Updates libwebsockets to 2.4.2.
Adds zlib and openssl dependencies, because they are used.
Corrects variable usage in post-destroot block.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
