### PR TITLE
gcr: add variants for x11 and quartz

### DIFF
--- a/gnome/gcr/Portfile
+++ b/gnome/gcr/Portfile
@@ -6,13 +6,15 @@ PortGroup           gobject_introspection 1.0
 
 name                gcr
 version             3.28.0
+revision            1
 license             LGPL-2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         GCR is a library for displaying certificates, and crypto UI, accessing \
                     key stores.
 long_description    ${description} \
                     It also provides the viewer for crypto files on the GNOME \
-                    desktop and a library for accessing PKCS#11 modules like smart cards, in a \
+                    desktop (if the +x11 variant is installed) and a library for \
+                    accessing PKCS#11 modules like smart cards, in a \
                     (G)object oriented way.
 
 maintainers         {devans @dbevans} openmaintainer
@@ -46,12 +48,6 @@ gobject_introspection yes
 patchfiles          patch-egg-egg-armor.c.diff \
                     patch-ui-gcr.pc.in.diff
 
-# gcr uses X11 specific code in UI (#41839)
-# https://bugzilla.gnome.org/show_bug.cgi?id=734366
-# https://bugzilla.gnome.org/show_bug.cgi?id=688678
-
-require_active_variants port:gtk3 x11
-
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 
 post-patch {
@@ -65,6 +61,28 @@ configure.args      --enable-vala=yes \
                     --disable-update-mime \
                     --disable-update-icon-cache \
                     --disable-silent-rules
+                    
+
+# gcr uses X11 specific code in UI (#41839)
+# https://bugzilla.gnome.org/show_bug.cgi?id=734366
+# https://bugzilla.gnome.org/show_bug.cgi?id=688678
+
+variant x11 conflicts quartz {
+    require_active_variants gtk2 x11 quartz
+    require_active_variants gtk3 x11 quartz
+}
+
+variant quartz conflicts x11 {
+    require_active_variants gtk2 quartz x11
+    require_active_variants gtk3 quartz x11
+    
+    configure.args-append --without-gtk
+}
+
+if {![variant_isset quartz]} {
+    default_variants-append +x11
+}
+
 
 pre-activate {
     if {![catch {set installed [lindex [registry_active gnome-keyring] 0]}]} {


### PR DESCRIPTION
until now, gcr required gtk2 or gtk3 to be
installed +x11 (for UI code). This prevented
any ports requiring gcr from being installed
with gtk2 or 3 +quartz active.

This commit adds a +quartz variant to gcr
that disables the UI, and therefore no need for
the +x11 code. This allows ports that use gcr
to be installed +quartz.

A default +x11 variant is also added to mimic
existing behaviour.

closes: https://trac.macports.org/ticket/41839


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
