### PR TITLE
ntpsec: Fixes build when default Python is old.

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -27,7 +27,8 @@ checksums           rmd160  65e6f3a2339b98ffa0b0cdf7310dd850cd3082a6 \
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}
 
-patchfiles          patch-PreHighSierra.diff
+patchfiles          patch-PreHighSierra.diff \
+                    patch-OldPython.diff
 
 post-patch {
     foreach f {ntpdig ntpkeygen ntploggps ntplogtemp ntpmon ntpq ntpsnmpd ntpsweep ntptrace ntpviz ntpwait} {

--- a/sysutils/ntpsec/files/patch-OldPython.diff
+++ b/sysutils/ntpsec/files/patch-OldPython.diff
@@ -1,0 +1,20 @@
+--- pylib/wscript.orig	2018-03-14 20:28:15.000000000 -0700
++++ pylib/wscript	2018-03-30 16:01:44.000000000 -0700
+@@ -36,7 +36,7 @@
+     ctx(
+         before=['pyc', 'pyo'],
+         cwd=srcnode,
+-        rule='${SRC} >${TGT}',
++        rule='${PYTHON} ${SRC} >${TGT}',
+         source=["../wafhelpers/pythonize-header", "../include/ntp_control.h"],
+         target=target1,
+     )
+@@ -44,7 +44,7 @@
+     ctx(
+         before=['pyc', 'pyo'],
+         cwd=srcnode,
+-        rule='${SRC} >${TGT}',
++        rule='${PYTHON} ${SRC} >${TGT}',
+         source=["../wafhelpers/pythonize-header", "../include/ntp.h"],
+         target=target2,
+     )


### PR DESCRIPTION
A Python program used as a build helper was being run with the
system default Python, and failing when that was too old.  This
fix (possibly acceptable upstream) causes it to use the same
Python as is being used to run waf, which is already forced to
be the MacPorts Python 2.7.

TESTED:
On both MacPro/10.9 and PowerBook/10.5, with python_select set to
python25-apple, verified that the build failed without this fix
and succeeded with it.  Also tested with the usual python27.

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
