### PR TITLE
iperf3 and iperf3-devel update

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        esnet iperf 3.3
+github.setup        esnet iperf 3.5
 name                iperf3
 categories          net
 platforms           darwin
@@ -18,8 +18,8 @@ long_description    ${name} is a tool for active measurements of the maximum \
 
 conflicts           ${name}-devel
 
-checksums           rmd160  10cf69fe9adea1481449ad0ee4cbbd59fa19b639 \
-                    sha256  95f2b274e22e604d14e974f848017b3bd543e9f66c87ed43a880b3c86d10fe04
+checksums           rmd160  f2e3512c38dd508f92dfc35d59a6c9d58d0c8c3d \
+                    sha256  2f7b2fe2bf7ea2212ef11b3d58cb02aa8b325429124db5956452c9bff8d43046
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 
@@ -31,11 +31,6 @@ post-destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} LICENSE RELEASE_NOTES README.md \
         ${destroot}${prefix}/share/doc/${name}
-}
-
-# iperf3-devel includes getline fix
-if {${name} eq ${subport}} {
-    PortGroup           snowleopard_fixes 1.0
 }
 
 subport ${name}-devel {

--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -34,11 +34,11 @@ post-destroot {
 }
 
 subport ${name}-devel {
-    github.setup        esnet iperf 46cb4b4b904e45c2652006ca339c7cf99c995268
-    version             20180103
+    github.setup        esnet iperf 3e58489a5823126fd1d51fcfb74994f9e8fe4e86
+    version             20180323
 
-    checksums           rmd160  0e3227d9ccb9e0098f65520e3154b9e5a77d26aa \
-                        sha256  86e321a802576a5286857476c6e114c10ce1857746ad303566c3906023a7dbd2
+    checksums           rmd160  ccd1246fa2cff704f3b71f667e30fed336622891 \
+                        sha256  48fa6d02db5e82da71e5cecf61c9a3ff45d055a7328b5173a374963befe7e75c
 
     conflicts           ${name}
 


### PR DESCRIPTION
#### Description
iperf3: update to version 3.5
iperf3-devel: update to version 20180323

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?