### PR TITLE
py-typing: update to 3.6.4

### DIFF
--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typing
-version             3.6.2
+version             3.6.4
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -24,9 +24,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 
 master_sites        pypi:t/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           md5     143af0bf3afd1887622771f2f1ffe8e1 \
-                    rmd160  7980d3c187ba68832978f08fc99ebe3b801fedff \
-                    sha256  d514bd84b284dd3e844f0305ac07511f097e325171f6cc4a20878d11ad771849
+checksums           md5     5b2ade08d83be488f17b5fe587c27c74 \
+                    rmd160  0c03e1a2972bc8ed83494ef5a92f06a76d32e7d9 \
+                    sha256  d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2
 
 python.versions     27 33 34
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?