### PR TITLE
openscad: fix Resource directory discovery

### DIFF
--- a/science/openscad/Portfile
+++ b/science/openscad/Portfile
@@ -5,7 +5,7 @@ PortGroup           qmake 1.0
 
 name                openscad
 version             2015.03-3
-revision            4
+revision            5
 license             GPL-2
 categories          science cad
 maintainers         {dstrubbe @dstrubbe} openmaintainer
@@ -84,8 +84,17 @@ post-destroot {
     # Application
     move ${destroot}${prefix}/bin/OpenSCAD.app ${destroot}${applications_dir}
 
+    # color-schemes -- openscad identifies resource directory by the presence of this folder, so it is required
+    move ${destroot}${prefix}/share/openscad/color-schemes ${destroot}${applications_dir}/OpenSCAD.app/Contents/Resources/color-schemes
+
     # Examples
     move ${destroot}${prefix}/share/openscad/examples ${destroot}${applications_dir}/OpenSCAD.app/Contents/Resources/examples
+
+    # fonts
+    move ${destroot}${prefix}/share/openscad/fonts ${destroot}${applications_dir}/OpenSCAD.app/Contents/Resources/fonts
+
+    # locale
+    move ${destroot}${prefix}/share/openscad/locale ${destroot}${applications_dir}/OpenSCAD.app/Contents/Resources/locale
 
     # Library bitmaps
     file mkdir ${destroot}${applications_dir}/OpenSCAD.app/Contents/Resources/libraries/MCAD/bitmap


### PR DESCRIPTION
openscad finds the resource directory by searching a preset
path list looking for a folder "color-schemes" so this needs
to be in the resource directory.

Fixes missing examples from splash window and allows other items
in the resource directory to be discovered.

Finally, move the fonts and locales folder into the resource directory
as well so that all will be in the same location.

Here's the search algorithm from [src/PlatformUtils.cc](https://github.com/openscad/openscad/blob/0904a3b3a5b56b16bb423b177972468eeca775a9/src/PlatformUtils.cc)

```
	for (int a = 0;searchpath[a] != nullptr;a++) {
	    tmpdir = resourcedir / searchpath[a];
	    
			// The resource folder is the folder which contains "color-schemes" (as well as 
			// "examples" and "locale", and optionally "libraries" and "fonts")
	    const fs::path checkdir = tmpdir / "color-schemes";
	    PRINTDB("Checking '%s'", checkdir.generic_string().c_str());

	    if (is_directory(checkdir)) {
		resourcedir = tmpdir;
		PRINTDB("Found resource folder '%s'", tmpdir.generic_string().c_str());
		break;
	    }
	}
```