### PR TITLE
mosquitto: Update to revision 1.4.15.

### DIFF
--- a/net/mosquitto/Portfile
+++ b/net/mosquitto/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                mosquitto
-version             1.4.14
+version             1.4.15
+revision            0
 
 categories          net devel
 platforms           darwin
@@ -19,16 +20,16 @@ long_description    \
     Mosquito provides an open-source MQTT v3.1.1 broker (i.e., server) and \
     both  C and C++ client libraries.
 
-
 homepage            https://mosquitto.org
 master_sites        http://mosquitto.org/files/source/
 
-checksums           rmd160 e3066723255dfffbf2f86fc4d37625c866072477 \
-                    sha256 156b1fa731d12baad4b8b22f7b6a8af50ba881fc711b81e9919ec103cf2942d1
+checksums           rmd160  d2438c8c3b2005265def411826961f94c9413b52 \
+                    sha256  7d3b3e245a3b4ec94b05678c8199c806359737949f4cfe0bf936184f6ca89a83 \
+                    size    368961
 
 depends_lib         port:c-ares \
-                    port:tcp_wrappers \
                     port:libwebsockets \
+                    port:tcp_wrappers \
                     path:lib/libssl.dylib:openssl
 
 configure.args-append \


### PR DESCRIPTION
#### Description

net/mosquitto: Update to revision 1.4.15.

A fairly comprehensive pair of test suites can be run something like:
```
cp -a ${worksrcdir}/test ${workpath}/build
edit $(find ${workpath}/build/test/ -type f -name Makefile)
```
and substitute  ".so.1" with ".1.dylib", and
append to CFLAGS  -I options "../mosquitto-1.4.15/" - i.e., ${wrksrcdir}, and
prefix included config.mk likewise.

Both tests suites, broker and lib, pass without error - skipping two requiring certificates.

###### Type(s)


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145 

macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?