### PR TITLE
pdf2json: update to 0.96

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -11,7 +11,7 @@ PortGroup           muniversal 1.0
 # hold off on update until this is sorted out
 
 name                poppler
-conflicts           pdf2json xpdf-tools
+conflicts           xpdf-tools
 version             0.57.0
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer

--- a/graphics/xpdf-tools/Portfile
+++ b/graphics/xpdf-tools/Portfile
@@ -13,7 +13,7 @@ homepage        http://www.foolabs.com/xpdf/
 
 ## conflicts with poppler until poppler renames its CLI tools
 ##  (then conflicts w/ poppler-tools if it gets created)
-conflicts       pdf2json poppler
+conflicts       poppler
 
 supported_archs noarch
 

--- a/graphics/xpdf/Portfile
+++ b/graphics/xpdf/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 
 name                xpdf
-conflicts           pdf2json
 version             3.04
 description         Xpdf is a viewer for PDF files.
 long_description    Xpdf is a viewer for Portable Document Format \

--- a/textproc/pdf2json/Portfile
+++ b/textproc/pdf2json/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                pdf2json
-conflicts           poppler xpdf xpdf-tools
-version             0.61
+github.setup        flexpaper pdf2json 0.69 v
 categories          textproc pdf
 platforms           darwin
-maintainers         devaldi.com:pdf2json
+maintainers         {@flexpaper devaldi.com:pdf2json}
 license             GPL-2
 
 description         PDF to JSON conversion utility
@@ -16,11 +15,11 @@ long_description    PDF2JSON is a conversion library based on XPDF (3.02) \
                     which can be used for high performance PDF page by page \
                     conversion to JSON and XML format.
 
-homepage            https://code.google.com/p/pdf2json/
-master_sites        googlecode
+github.tarball_from releases
 
-checksums           rmd160  44b9d9fb61113193a58db25aaa71d040067761f7 \
-                    sha256  36faf337361768f3108ef4e8d9eacb16b5c6ac84623299b3c8d74d5166f21bd7
+checksums           rmd160  f86436c47973bbd1c7c297f8047019c385602b08 \
+                    sha256  69394ef5d5d5504f7106e8b55e15bf491c48d906d611e6bc2e5952005a85b593 \
+                    size    1156853
 
 extract.mkdir       yes
 
@@ -35,4 +34,13 @@ post-patch {
     reinplace "s|/usr/local|${prefix}|g" \
         ${worksrcpath}/doc/sample-xpdfrc \
         ${worksrcpath}/xpdf/GlobalParams.cc
+}
+
+# remove files already provided by poppler and xpdf
+post-destroot {
+    file delete -force -- ${destroot}${prefix}/share
+    file delete -force -- ${destroot}${prefix}/etc
+    foreach f {pdfinfo pdftotext pdfimages pdffonts pdftops} {
+        file delete ${destroot}${prefix}/bin/$f
+    }
 }

--- a/textproc/pdf2json/files/patch-Makefiles.diff
+++ b/textproc/pdf2json/files/patch-Makefiles.diff
@@ -59,14 +59,13 @@
  CXX = @CXX@
 --- splash/Makefile.in.orig	2012-01-01 22:04:49.000000000 -0600
 +++ splash/Makefile.in	2013-02-01 23:30:10.000000000 -0600
-@@ -16,9 +16,9 @@
+@@ -16,8 +16,9 @@
  FOFISRCDIR = $(srcdir)/../fofi
  FOFILIBDIR = ../fofi
  
 -CXXFLAGS = -I/usr/local/include @CXXFLAGS@ @DEFS@ -I.. -I$(GOOSRCDIR) -I$(FOFISRCDIR) -I$(srcdir)
 +CXXFLAGS = @CXXFLAGS@ @DEFS@ -I.. -I$(GOOSRCDIR) -I$(FOFISRCDIR) -I$(srcdir)
  
--CXX = g++
 +CXX = @CXX@
  AR = ar rc
  RANLIB = ranlib


### PR DESCRIPTION
Please note: I only guessed the maintainer's GitHub handle, this needs to be double-checked before it gets merged.

In theory the build might want `xorg-libX11`, but the resulting binary does not depend on that.

Changes:
* Switched from googlecode to GitHub.
* Remove conflict with popplen and xpdf[-tools]
  by remove the binaries provided by those two.
  Users would likely want to install the port for pdf2json itself
  rather than for all the others which they can get from poppler.
* Add maintainer's github handle.

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?