### PR TITLE
py-mdtraj: update to 1.9.1

### DIFF
--- a/python/py-mdtraj/Portfile
+++ b/python/py-mdtraj/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        mdtraj mdtraj 1.9.0
+github.setup        mdtraj mdtraj 1.9.1
 name                py-mdtraj
 homepage            http://www.mdtraj.org
 platforms           darwin
@@ -18,8 +18,8 @@ long_description    Read, write and analyze MD trajectories with only a few line
 
 supported_archs     i386 x86_64
 
-checksums           rmd160  58a3684fdf7a81813699aa281c411c04b130b91b \
-                    sha256  e93db244035b7551488cea24d96dd813e67ce655461fc50f53c4d8a9cd8bd7ca
+checksums           rmd160  1860a73278dc30932c0556e0bfb0c2d16a94546c \
+                    sha256  2f0ed62155b75d6ed1d55da0fe52aef37b7f5cf3707f2582ec5137e66002d0df
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
#### Description

Notice that this version is identical to 1.9.0, except for the version number (see [this comment](https://github.com/mdtraj/mdtraj/releases/tag/1.9.1)). I would merge this change so that `port livecheck py36-mdtraj` stops complaining.


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G19009
Xcode 8.1 8B62 
