### PR TITLE
harfbuzz: build with coretext

### DIFF
--- a/graphics/harfbuzz/Portfile
+++ b/graphics/harfbuzz/Portfile
@@ -24,7 +24,8 @@ checksums           rmd160  bfd237407c3b8eea5a59f1c6bbab4a467549c767 \
 
 depends_build       port:pkgconfig
 
-patchfiles-append   32bit.patch
+patchfiles-append   32bit.patch \
+                    coretext.patch
 
 # Remove this on an update to >1.7.6 as https://github.com/harfbuzz/harfbuzz/commit/2a2360
 compiler.blacklist  *llvm-gcc-4.2
@@ -35,7 +36,7 @@ configure.args      --disable-silent-rules \
                     ac_cv_prog_AWK=/usr/bin/awk
 
 if {${name} eq ${subport}} {
-    revision        0
+    revision        1
     
     depends_lib-append \
                     path:lib/pkgconfig/cairo.pc:cairo \
@@ -67,6 +68,14 @@ if {${name} eq ${subport}} {
                     ${destroot}${docdir}
     }
     
+    if {${os.platform} eq "darwin" && ${os.major} >= 9} {
+        configure.args-append \
+                    --with-coretext
+    } else {
+        configure.args-append \
+                    --without-coretext
+    }
+
     if {${os.platform} eq "darwin" && ${os.major} < 10} {
         depends_test-append \
                     port:python27

--- a/graphics/harfbuzz/files/coretext.patch
+++ b/graphics/harfbuzz/files/coretext.patch
@@ -1,0 +1,62 @@
+Fix build with CoreText on OS X 10.7 and earlier.
+https://github.com/harfbuzz/harfbuzz/pull/952
+--- src/hb-coretext.cc.orig	2018-02-18 13:36:12.000000000 -0600
++++ src/hb-coretext.cc	2018-04-04 02:57:53.000000000 -0500
+@@ -168,6 +168,10 @@
+   if (CFStringHasPrefix (cg_postscript_name, CFSTR (".SFNSText")) ||
+       CFStringHasPrefix (cg_postscript_name, CFSTR (".SFNSDisplay")))
+   {
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
++# define kCTFontUIFontSystem kCTFontSystemFontType
++# define kCTFontUIFontEmphasizedSystem kCTFontEmphasizedSystemFontType
++#endif
+     CTFontUIFontType font_type = kCTFontUIFontSystem;
+     if (CFStringHasSuffix (cg_postscript_name, CFSTR ("-Bold")))
+       font_type = kCTFontUIFontEmphasizedSystem;
+@@ -206,7 +210,18 @@
+       return ct_font;
+   }
+ 
+-  CFURLRef original_url = (CFURLRef)CTFontCopyAttribute(ct_font, kCTFontURLAttribute);
++  CFURLRef original_url = NULL;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++  ATSFontRef atsFont;
++  FSRef fsref;
++  OSStatus status;
++  atsFont = CTFontGetPlatformFont (ct_font, NULL);
++  status = ATSFontGetFileReference (atsFont, &fsref);
++  if (status == noErr)
++    original_url = CFURLCreateFromFSRef (NULL, &fsref);
++#else
++  original_url = (CFURLRef) CTFontCopyAttribute (ct_font, kCTFontURLAttribute);
++#endif
+ 
+   /* Create font copy with cascade list that has LastResort first; this speeds up CoreText
+    * font fallback which we don't need anyway. */
+@@ -225,7 +240,15 @@
+        * system locations that we cannot access from the sandboxed renderer
+        * process in Blink. This can be detected by the new file URL location
+        * that the newly found font points to. */
+-      CFURLRef new_url = (CFURLRef) CTFontCopyAttribute (new_ct_font, kCTFontURLAttribute);
++      CFURLRef new_url = NULL;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++      atsFont = CTFontGetPlatformFont (new_ct_font, NULL);
++      status = ATSFontGetFileReference (atsFont, &fsref);
++      if (status == noErr)
++        new_url = CFURLCreateFromFSRef (NULL, &fsref);
++#else
++      new_url = (CFURLRef) CTFontCopyAttribute (new_ct_font, kCTFontURLAttribute);
++#endif
+       // Keep reconfigured font if URL cannot be retrieved (seems to be the case
+       // on Mac OS 10.12 Sierra), speculative fix for crbug.com/625606
+       if (!original_url || !new_url || CFEqual (original_url, new_url)) {
+@@ -944,6 +967,9 @@
+ 
+       int level = HB_DIRECTION_IS_FORWARD (buffer->props.direction) ? 0 : 1;
+       CFNumberRef level_number = CFNumberCreate (kCFAllocatorDefault, kCFNumberIntType, &level);
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++      extern const CFStringRef kCTTypesetterOptionForcedEmbeddingLevel;
++#endif
+       CFDictionaryRef options = CFDictionaryCreate (kCFAllocatorDefault,
+ 						    (const void **) &kCTTypesetterOptionForcedEmbeddingLevel,
+ 						    (const void **) &level_number,


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

Just a WIP branch to ask @ryandesign if there is a reason for this option not being in `./configure`
