### PR TITLE
libglademm: fix compilation failure

### DIFF
--- a/gnome/libglademm/Portfile
+++ b/gnome/libglademm/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            libglademm
 version         2.6.7
-revision        4
+revision        5
 set branch      [join [lrange [split ${version} .] 0 1] .]
 description     C++ wrapper for libglade2.
 long_description ${description}
@@ -27,3 +27,5 @@ depends_lib     port:gtkmm \
                 port:libglade2
 
 livecheck.type  gnome
+
+configure.cxxflags-append -std=c++11


### PR DESCRIPTION
Compiler states code is using C++11 extensions.  Appended -std=c++11 to
CXXFLAGS.
