### PR TITLE
librsvg: fix patch to be for configure.ac instead of configure

### DIFF
--- a/graphics/librsvg/files/patch-rust_target_subdir.diff
+++ b/graphics/librsvg/files/patch-rust_target_subdir.diff
@@ -1,15 +1,15 @@
---- configure.orig	2018-01-24 09:14:02.000000000 -0700
-+++ configure	2018-03-21 09:01:03.000000000 -0700
-@@ -15371,9 +15371,9 @@
-   CROSS_COMPILING_FALSE=
- fi
+--- configure.ac.orig
++++ configure.ac
+@@ -261,9 +261,9 @@
+ AM_CONDITIONAL([DEBUG_RELEASE], [test "x$debug_release" = "xyes"])
  
+ AM_CONDITIONAL(CROSS_COMPILING, test $cross_compiling = yes)
 -if test "x$cross_compiling" = "xyes" ; then
 -	RUST_TARGET_SUBDIR="$host/$RUST_TARGET_SUBDIR"
 -fi
 +#if test "x$cross_compiling" = "xyes" ; then
 +	RUST_TARGET_SUBDIR="$CARGO_BUILD_TARGET/$RUST_TARGET_SUBDIR"
 +#fi
+ AC_SUBST([RUST_TARGET_SUBDIR])
  
- 
- 
+ dnl ===========================================================================


### PR DESCRIPTION
addresses MacPorts ticket https://trac.macports.org/ticket/56192

The original patch was for 'configure', which was overwritten and hence the patch did nothing. This update patches 'configure.ac'. Tested on 10.12 and 10.9; should work on any usable MacOS.