### PR TITLE
Dbcli related ports updates

### DIFF
--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli mycli 1.10.0 v
+github.setup        dbcli mycli 1.16.0 v
 
 categories          databases python
 maintainers         gmail.com:xeron.oskom openmaintainer
@@ -16,8 +16,8 @@ long_description    ${description}
 
 homepage            http://mycli.net
 
-checksums           rmd160  b74171b91014ab750e5eaf43566814912452f6e6 \
-                    sha256  2181153817a3097c6319d61ec616162d04b4f56ebd2673d9bbd1828929592ee6
+checksums           rmd160  baed20c0ef502c73b66e436c3f5d7604666949c3 \
+                    sha256  76e1ba3bca1bcda5c958c89a5e35e587f69fefab7ada00fbccdcdd5d7c5424af
 
 variant python27 conflicts python34 python35 python36 description "Use Python 2.7" {}
 variant python34 conflicts python27 python35 python36 description "Use Python 3.4" {}
@@ -36,10 +36,11 @@ if {[variant_isset python34]} {
 }
 
 depends_build       port:py${python.version}-setuptools
-depends_lib-append  port:py${python.version}-click \
-                    port:py${python.version}-pycryptodome \
-                    port:py${python.version}-pygments \
+depends_lib-append  port:py${python.version}-cli-helpers \
+                    port:py${python.version}-click \
+                    port:py${python.version}-configobj \
+                    port:py${python.version}-cryptography \
                     port:py${python.version}-prompt_toolkit \
+                    port:py${python.version}-pygments \
                     port:py${python.version}-pymysql \
-                    port:py${python.version}-sqlparse \
-                    port:py${python.version}-configobj
+                    port:py${python.version}-sqlparse

--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli pgcli 1.6.0 v
+github.setup        dbcli pgcli 1.9.1 v
 
 categories          databases python
 maintainers         g5pw gmail.com:xeron.oskom openmaintainer
@@ -16,8 +16,8 @@ long_description    ${description}
 
 homepage            http://pgcli.com
 
-checksums           rmd160  ca04ff2ee199d1ca40758bb589eed158626a2dab \
-                    sha256  01d41d9079b0021038001a8f01981f765a6907096ef9457a77b75eefa544a985
+checksums           rmd160  922f2cf729ab173edef221f39005d9e2d4d1c81c \
+                    sha256  e42291b45e762176218e2e937e7d1603f6f8eb32d17fd97907bb625d003e93dd
 
 variant python27 conflicts python34 python35 python36 description "Use Python 2.7" {}
 variant python34 conflicts python27 python35 python36 description "Use Python 3.4" {}
@@ -36,7 +36,8 @@ if {[variant_isset python34]} {
 }
 
 depends_build       port:py${python.version}-setuptools
-depends_lib-append  port:py${python.version}-click \
+depends_lib-append  port:py${python.version}-cli-helpers \
+                    port:py${python.version}-click \
                     port:py${python.version}-configobj \
                     port:py${python.version}-humanize \
                     port:py${python.version}-pgspecial \
@@ -44,5 +45,4 @@ depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-psycopg2 \
                     port:py${python.version}-pygments \
                     port:py${python.version}-setproctitle \
-                    port:py${python.version}-sqlparse \
-                    port:py${python.version}-wcwidth
+                    port:py${python.version}-sqlparse

--- a/python/py-backports.csv/Portfile
+++ b/python/py-backports.csv/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-backports.csv
+version             1.0.5
+license             PSF
+platforms           darwin
+supported_archs     noarch
+maintainers         gmail.com:xeron.oskom openmaintainer
+description         Backport of Python 3 csv module
+long_description    ${description}
+
+python.versions     27
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  11a1fd6073140587e811a7536fd3553b0c63b31b \
+                    sha256  8c421385cbc6042ba90c68c871c5afc13672acaf91e1508546d6cda6725ebfc6
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    livecheck.type  none
+} else {
+    livecheck.type  pypi
+}

--- a/python/py-cli-helpers/Portfile
+++ b/python/py-cli-helpers/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cli-helpers
+version             1.0.1
+license             BSD
+platforms           darwin
+supported_archs     noarch
+maintainers         gmail.com:xeron.oskom openmaintainer
+description         Helpers for building command-line apps
+long_description    CLI Helpers is a Python package that makes it easy \
+                    to perform common tasks when building command-line apps. \
+                    It’s a helper library for command-line interfaces.
+
+python.versions     27 34 35 36
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            cli_helpers-${version}
+
+checksums           rmd160  d9a431a99f9a605bab1837d385c5cf7d41549d0a \
+                    sha256  55353117960700dfbe000a71cda0bad1ac865e3a9999f1fa81047fa9e1322d42
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-pygments \
+                            port:py${python.version}-tabulate \
+                            port:py${python.version}-terminaltables
+    if {${python.version} eq 27} {
+        depends_lib-append      port:py${python.version}-backports.csv \
+    }
+    livecheck.type  none
+} else {
+    livecheck.type  pypi
+}

--- a/python/py-pgspecial/Portfile
+++ b/python/py-pgspecial/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pgspecial
-version             1.8.0
+version             1.10.0
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -19,9 +19,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     0d1ef54c1f950d5c211f31bdf74398dc \
-                    rmd160  50fd1b93720b9fe330a2ea182255c87a8e2500e1 \
-                    sha256  89f524909e97554bb3eeceb186a834e86cb71e34afef3a95fe645049ead894b7
+checksums           md5     6e617cb1915f414d6ecdc075d77d5f87 \
+                    rmd160  ba666f257b7f54c1bb2be05b91e9c41f10fc1c5b \
+                    sha256  eadb0108cdbcf8b38a69bcc9e403b352dbd6d30622e417f48e659180150ee1b6
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pymysql/Portfile
+++ b/python/py-pymysql/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pymysql
-version             0.7.9
+version             0.8.0
 license             MIT
 platforms           darwin
 supported_archs     noarch
@@ -18,8 +18,8 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            PyMySQL-${version}
 
-checksums           rmd160  b93a86549ac54b2dd6069512beb8c1da37ec449a \
-                    sha256  2331f82b7b85d407c8d9d7a8d7901a6abbeb420533e5d5d64ded5009b5c6dcc3
+checksums           rmd160  6bb48cc4b0028666b94bfedb36f3841bb9f34a10 \
+                    sha256  32da4a66397077d42908e449688f2ec71c2b18892a6cd04f03ab2aa828a70f40
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-terminaltables/Portfile
+++ b/python/py-terminaltables/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-terminaltables
+version             3.1.0
+license             MIT
+platforms           darwin
+supported_archs     noarch
+maintainers         gmail.com:xeron.oskom openmaintainer
+description         Generate simple tables in terminals from a nested list of strings
+long_description    Easily draw tables in terminal/console applications from \
+                    a list of lists of strings. Supports multi-line rows.
+
+python.versions     27 34 35 36
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  3978da76ff2bc1fec403cc29f36427834151305b \
+                    sha256  f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    livecheck.type  none
+} else {
+    livecheck.type  pypi
+}


### PR DESCRIPTION
#### Description

Added new ports:
* `py-terminaltables`
* `py-backports.csv`
* `py-cli-helpers`

Updated ports:
* `py-pymysql` to `0.8.0` (https://trac.macports.org/ticket/56203)
* `py-pgspecial` to `1.10.0`
* `mycli` to `1.16.0`
* `pgcli` to `1.9.0`

###### Type(s)

- [x] update
- [x] submission

###### Tested on

macOS 10.13.4 17E199
Xcode 9.3 9E145 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?