### PR TITLE
FileZilla: update to 3.32.0

### DIFF
--- a/www/FileZilla/Portfile
+++ b/www/FileZilla/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
 
 name                FileZilla
-version             3.31.0
+version             3.32.0
 categories          www aqua
 platforms           darwin
 maintainers         {@yan12125 gmail.com:yan12125} openmaintainer
@@ -19,10 +19,10 @@ long_description    FileZilla Client is a fast and reliable cross-platform \
                     and an intuitive graphical user interface.
 
 homepage            https://filezilla-project.org/
-master_sites        sourceforge:project/filezilla/FileZilla_Client/${version}
+master_sites        https://dl3.cdn.filezilla-project.org/client
 
-checksums           rmd160  43ceb95ce8239faec8fb9cc4bc7034dd4979ddbd \
-                    sha256  14c568b7e3331b8ae6d2371aeb4f4b43fbf97f057c0af9d75165d0d8d0d2dee5
+checksums           rmd160  bbb82c58b0b02584ea7a8db2f1bfbf77bdaa5850 \
+                    sha256  2d3d28b590c21b7b9cb92209c04833caf4c50f51186ca20747e5d9653f623be9
 
 # wxWidgets-3.0 with support for C++11 on < 10.9
 wxWidgets.use       wxWidgets-3.0-cxx11


### PR DESCRIPTION
#### Description

This version is no longer hosted on SourceForge. The new URL is retrieved from https://filezilla-project.org/download.php?show_all=1

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
macOS 10.13.4 17E199
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (no tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
