### PR TITLE
qpid-proton: update to version 0.22.0

### DIFF
--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -19,12 +19,12 @@ homepage            https://qpid.apache.org
 
 PortGroup           github 1.0
 
-github.setup        apache qpid-proton 0.21.0
+github.setup        apache qpid-proton 0.22.0
 
 PortGroup           cmake 1.0
 
-checksums           rmd160  8828d18e9c3f664e38012f496e80e20a2aee8cb1 \
-                    sha256  26524227525c7bcec0817cdc5ce83aeb0729412aec0408431ebafc103c23572b
+checksums           rmd160  97f8f1920286d6841c1ee6ecc9fd6ab512b67eff \
+                    sha256  6d4683e17078361e91bc33e18d99b4c047593ab75269833aca110893910df17b
 
 cmake.out_of_source yes
 configure.args-append \
@@ -41,7 +41,7 @@ default_variants    +openssl
 variant openssl description {With built-in support for OpenSSL} {
     configure.args-replace -DSSL_IMPL=none -DSSL_IMPL=openssl
 
-    depends_lib-append      path:lib/libssl.dylib:openssl
+    depends_lib-append      port:openssl
 }
 
 variant swig description {With built-in support for SWIG so the bindings can be built} {


### PR DESCRIPTION
* update to version 0.22.0

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G1611
Xcode 7.3.1 7D1014 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
