### PR TITLE
py-backports.weakref: add size to checksums and reformat

### DIFF
--- a/python/py-backports.weakref/Portfile
+++ b/python/py-backports.weakref/Portfile
@@ -17,8 +17,9 @@ homepage            https://github.com/pjdelport/backports.weakref
 master_sites        pypi:b/backports.weakref
 distname            backports.weakref-${version}
 
-checksums           rmd160  348aceddeb8e58622ffffe3983fae82101bc39c6 \
-                    sha256  bc4170a29915f8b22c9e7c4939701859650f2eb84184aee80da329ac0b9825c2
+checksums           rmd160 348aceddeb8e58622ffffe3983fae82101bc39c6 \
+                    sha256 bc4170a29915f8b22c9e7c4939701859650f2eb84184aee80da329ac0b9825c2 \
+                    size   10574
 
 python.versions     27 35 36
 


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?