### PR TITLE
Use new use_tar command when available

### DIFF
--- a/devel/jam/Portfile
+++ b/devel/jam/Portfile
@@ -24,7 +24,15 @@ long_description    Jam is a software build tool (like make) from \
 homepage            http://www.perforce.com/jam/jam.html
 master_sites        ftp://ftp.perforce.com/jam/
 
-distfiles           ${name}-${version}.tar
+# use_tar is new in MacPorts 2.5.0.
+if {[info command use_tar] eq "use_tar"} {
+use_tar             yes
+} else {
+extract.suffix      .tar
+extract.cmd         tar
+extract.pre_args    -xf
+extract.post_args
+}
 dist_subdir         ${name}/${version}
 
 checksums           md5 c7eb7719d8523c0f819116479492d367 \
@@ -33,11 +41,6 @@ checksums           md5 c7eb7719d8523c0f819116479492d367 \
 platforms           darwin
 
 universal_variant   yes
-
-# This is a .tar file.
-extract.cmd         tar -xf 
-extract.pre_args
-extract.post_args
 
 # Enables post-patch options & Matt Armstrong memory leak patch.
 patchfiles          patch-Makefile.diff \

--- a/lang/eiffelstudio/Portfile
+++ b/lang/eiffelstudio/Portfile
@@ -26,11 +26,15 @@ depends_lib       port:gtk2 \
 depends_build     bin:bzip2:bzip2 \
                   port:pkgconfig
 
+# use_tar is new in MacPorts 2.5.0.
+if {[info command use_tar] eq "use_tar"} {
+use_tar           yes
+} else {
 extract.suffix    .tar
 extract.cmd       tar
 extract.post_args
 extract.pre_args  -xf
-distname          eiffelstudio-${version}
+}
 set eiffel_launch eiffel_launcher_20091003.tar.bz2
 distfiles         ${distname}${extract.suffix}:source \
                   ${eiffel_launch}:launcher

--- a/net/tcpdstat/Portfile
+++ b/net/tcpdstat/Portfile
@@ -19,9 +19,15 @@ master_sites        http://staff.washington.edu/dittrich/talks/core02/tools/
 
 dist_subdir         ${name}/${version}
 distname            ${name}-uw
+# use_tar is new in MacPorts 2.5.0.
+if {[info command use_tar] eq "use_tar"} {
+use_tar             yes
+} else {
 extract.suffix      .tar
 extract.cmd         tar
 extract.pre_args    -xf
+extract.post_args
+}
 
 checksums           md5     64b246fb0a4ee47ae37e83d721b205df \
                     sha1    3f0d95499bd33118bbcf86752a2d524eb2802fa7 \

--- a/science/setiathome/Portfile
+++ b/science/setiathome/Portfile
@@ -19,9 +19,15 @@ master_sites		http://master.us.finkmirrors.net/distfiles/md5/[lindex ${checksums
 
 distname		${name}-${version}.powerpc-apple-darwin1.2
 
+# use_tar is new in MacPorts 2.5.0.
+if {[info command use_tar] eq "use_tar"} {
+use_tar			yes
+} else {
 extract.suffix		.tar
 extract.cmd		tar
 extract.pre_args	-xf
+extract.post_args
+}
 
 patchfiles		patch-README.diff
 

--- a/tex/detex/Portfile
+++ b/tex/detex/Portfile
@@ -11,10 +11,15 @@ license                 NCSA
 homepage                http://www.cs.purdue.edu/homes/trinkle/detex/
 master_sites            ${homepage}
 platforms               darwin
+# use_tar is new in MacPorts 2.5.0.
+if {[info command use_tar] eq "use_tar"} {
+use_tar                 yes
+} else {
 extract.suffix          .tar
 extract.cmd             tar
 extract.pre_args        -xf
 extract.post_args
+}
 use_configure           no
 use_parallel_build      yes
 


### PR DESCRIPTION
#### Description

Updates ports to use the new `use_tar` option (introduced in https://github.com/macports/macports-base/pull/74) when available. Will be in MacPorts 2.5.0.

Unifies how ports handle uncompressed tar files. For pre-`use_tar` installations, adds necessary clearing of `extract.post_args`.

Removes unnecessary setting of `distname`/`distfiles`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?