### PR TITLE
cdf-to-fits: Update to 1.0-20180227

### DIFF
--- a/science/cdf-to-fits/Portfile
+++ b/science/cdf-to-fits/Portfile
@@ -1,44 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
 
 name                    cdf-to-fits
-version                 1.0
-revision                1
+version                 1.0-20180227
 maintainers             {aronnax @lpsinger}
 categories              science
 description             CDF to FITS converter
 long_description        Tool for converting CDF files to FITS files
-homepage                http://cdf.gsfc.nasa.gov/html/dtws.html
 platforms               darwin
-fetch.use_epsv          no
-master_sites            ftp://cdaweb.gsfc.nasa.gov/pub/cdf/conversion_tools/source/
+
+homepage                https://cdf.gsfc.nasa.gov/html/dttools.html
+master_sites            https://spdf.gsfc.nasa.gov/pub/software/cdf/conversion_tools/source/
 distname                ${name}
 dist_subdir             ${name}/${version}
-extract.suffix          .tar
-extract.cmd             tar
-extract.pre_args        -xf
-extract.post_args
+
+checksums               rmd160  817d1f3fefb59b44cf601f8b1ffe17146e9137d6 \
+                        sha256  603fd9d3d3c18ff5e8ad8bfb59a95196434737782f15caa50ba42222bae1adb8 \
+                        size    89676
 
 # cdf is not universal
 universal_variant       no
 
-checksums               md5 d805504740ec92c40a85b712fe57b168 \
-                        sha1 c2a6802b4819f4f39a6f24ecd940c9841e19fa16 \
-                        rmd160 091fa81c6bc92a875134e041aa2da6152dfb754b
-
 depends_lib             port:cfitsio \
                         port:cdf
+
+extract.mkdir           yes
+post-extract {
+    file attributes ${configure.dir}/configure -permissions a+x
+}
 
 patchfiles              patch-Makefile.in.diff
 
 configure.args          --with-cfitsio-prefix=${prefix} \
                         --with-cdf-prefix=${prefix}
 
-destroot.post_args      INSTDIR=${destroot}${prefix}/bin
+build.target            cdf-to-fits
+
+destroot.post_args      INSTALL_DIR=${destroot}${prefix}/bin
 
 post-destroot {
-    set docdir ${destroot}${prefix}/share/doc/${name}
-    xinstall -d ${docdir}
-    xinstall -m 644 -W ${worksrcpath} \
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
         README \
-        ${docdir}
+        ${destroot}${docdir}
 }
+
+livecheck.type          none


### PR DESCRIPTION
#### Description

Updates cdf-to-fits to the current version available upstream, which was last modified 20180227. It still advertises itself as being version "1.0".

See https://trac.macports.org/ticket/54133

Fixes build failure of the version currently in the ports tree.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] tried a full install with `sudo port -vst install`?
