### PR TITLE
spring-boot-cli: update to 2.0.1.RELEASE

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.0.0
+version         2.0.1
 
 categories      java
 platforms       darwin
@@ -28,8 +28,8 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  2d89c0aef9fb05ecc49b0d32986e6cd82a7161d5 \
-                sha256  729714a91e63cd30fc0fe59db1c8de28125fb20b92da8c13bcd004233603f83f
+checksums       rmd160  a003a291cdf724be841067885f00e26b127e83b8 \
+                sha256  230c33a954b50b64b22e8337c2d2e802c2d9d507fddc9484a5839ecc8998b1a8
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot 2.0.1.RELEASE.

###### Tested on

macOS 10.13.4 17E199
Xcode 9.3 9E145 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?