### PR TITLE
audio/chuck: Update to version 1.4.0.

### DIFF
--- a/audio/chuck/Portfile
+++ b/audio/chuck/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 
 name                chuck
-version             1.3.5.2
+version             1.4.0.0
+revision            0
 categories          audio
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {gmail.com:slewsys @slewsys} openmaintainer
 license             GPL-2+
 
 description         Chuck is a strongly-timed, concurrent, and on-the-fly \
@@ -26,8 +27,9 @@ homepage            http://chuck.cs.princeton.edu/
 master_sites        ${homepage}release/files/
 extract.suffix      .tgz
 
-checksums           rmd160  733ea2c6963edad668972d6c9a8c976bcf04f1c5 \
-                    sha256  e900b8545ffcb69c6d49354b18c43a9f9b8f789d3ae822f34b408eaee8d3e70b
+checksums           rmd160  95a3f401a8cef6cfaa80cbe6690dec0d8586c927 \
+                    sha256  2caee332b8d48e2fddad0f8a0a1811b6cf4c5afab73ae8a17b85ec759cce27ac \
+                    size    14664130
 
 depends_build       port:bison \
                     port:flex
@@ -41,8 +43,8 @@ use_configure       no
 variant universal {}
 
 build.dir           ${worksrcpath}/src
-build.type          gnu
-build.args-append   ARCHS="[get_canonical_archs]" \
+build.args-append   osx \
+                    ARCHS="[get_canonical_archs]" \
                     CC="${configure.cc}" \
                     CXX="${configure.cxx}" \
                     LD="${configure.cxx}"
@@ -52,7 +54,7 @@ destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name} ${destroot}${prefix}/share/examples
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS COPYING DEVELOPER PROGRAMMER QUICKSTART \
-        README THANKS TODO VERSIONS doc/GOTO \
+        README THANKS TODO VERSIONS \
         ${destroot}${prefix}/share/doc/${name}
     copy ${worksrcpath}/examples ${destroot}${prefix}/share/examples/${name}
 }

--- a/audio/chuck/files/patch-makefile.osx.diff
+++ b/audio/chuck/files/patch-makefile.osx.diff
@@ -1,5 +1,5 @@
---- src/makefile.osx.orig	2014-12-22 17:14:58.000000000 -0500
-+++ src/makefile.osx	2015-03-03 01:54:09.000000000 -0500
+--- src/core/makefile.x/makefile.osx.orig	2014-12-22 17:14:58.000000000 -0500
++++ src/core/makefile.x/makefile.osx	2015-03-03 01:54:09.000000000 -0500
 @@ -37,7 +37,7 @@
  # by default, ChucK uses a pre-configured libsndfile...
  # uncomment the next 3 lines to use libsndfile on your system


### PR DESCRIPTION
#### Description

audio/chuck: Update to version 1.4.0.
Add maintainer/openmainter.

###### Tested on


macOS 10.13.4 17E199
Xcode 9.3 9E145 

macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

