### PR TITLE
libcxx: Handle macosx_version more correctly

### DIFF
--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -59,7 +59,7 @@ platform darwin {
         post-activate {
             set dirs /
             if {${os.subplatform} eq "macosx"} {
-                lappend dirs ${developer_dir}/SDKs/MacOSX${macosx_version}.sdk
+                lappend dirs ${developer_dir}/SDKs/MacOSX[join [lrange [split ${macosx_version} .] 0 1] .].sdk
             }
             foreach d ${dirs} {
                 system -W ${d} "tar xzf ${roots_path}/${root_name}.tgz"


### PR DESCRIPTION
#### Description

Base currently sets `macosx_version` to the major macOS version. This change will ensure the port continues to work correctly if base sets `macosx_version` to the full macOS version.

Recall 94e87f11199ca14c8b8a554d84e675eaa9db917c and the [ensuing discussion](https://lists.macports.org/pipermail/macports-dev/2013-October/024660.html).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?