### PR TITLE
bali-phy: Update to 3.0.3

### DIFF
--- a/science/bali-phy/Portfile
+++ b/science/bali-phy/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
-github.setup        bredelings BAli-Phy 1ed068ee00
+github.setup        bredelings BAli-Phy 3.0.3
 name                bali-phy
-version             3.0-release
 revision            0
 description         Estimation of phylogeny and multiple alignment via MCMC
 long_description    Estimation of phylogeny and multiple alignment via MCMC \
@@ -21,17 +22,13 @@ long_description    Estimation of phylogeny and multiple alignment via MCMC \
                     relative rates for each gene.
 categories          science
 platforms           darwin
-license             GPL-2
+license             GPL-2+
 maintainers         {gmail.com:benjamin.redelings @bredelings} openmaintainer
 homepage            http://www.bali-phy.org/
 
-patchfiles          scripts.patch
-checksums           scripts.patch \
-                    rmd160  7a1538fa6e0f92c3d64aecde29d4bf6193fae0c4 \
-                    sha256  2577479293668711fac962243cc7f3b28469e7660bbb243751890576a79c4aeb \
-                    BAli-Phy-1ed068ee00.tar.gz \
-                    rmd160  7a1538fa6e0f92c3d64aecde29d4bf6193fae0c4 \
-                    sha256  2577479293668711fac962243cc7f3b28469e7660bbb243751890576a79c4aeb
+checksums           rmd160  60c6b2da4f196f68b958e3360f9415fb689729bc \
+                    sha256  4cdfb16b50c4a06e1cf6691d22cc3a5401e0cdb55dbb0ff379c779eb660e060d \
+                    size    12455696
 
 depends_build-append \
                     port:pkgconfig \
@@ -43,8 +40,11 @@ depends_build-append \
 depends_lib         port:boost \
                     path:lib/pkgconfig/cairo.pc:cairo
 
+patchfiles          scripts.patch
+
 # Needs support for -std=c++14.
-compiler.blacklist  {clang < 602}
+compiler.blacklist-append \
+                    {clang < 602}
 
 # build in source directory until we switch to meson
 pre-configure       { system -W ${worksrcpath} "./bootstrap.sh"}


### PR DESCRIPTION
#### Description

Updates the port to 3.0.3 and fixes various problems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
