### PR TITLE
py-nltk:  add py35 and py36

### DIFF
--- a/python/py-nltk/Portfile
+++ b/python/py-nltk/Portfile
@@ -16,7 +16,7 @@ description         Natural Language Toolkit
 long_description    NLTK is Python modules for research and development in natural language processing
 homepage            http://www.nltk.org/
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     checksums       rmd160  5c4f00776485b189d5d58f4ad01e50beead2cb73 \


### PR DESCRIPTION
Closes:  https://trac.macports.org/ticket/56220

#### Description
In ticket #56220 a request was made for py34-kiwisolver, but the user really just wants a python environment that includes py-nltk. This PR adds py36-nltk to accomplish this.

###### Type(s)
- [x] update

###### Tested on
macOS 10.12.6 16G1212
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
