### PR TITLE
plumed: added optimization flags

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -12,6 +12,8 @@ PortGroup           debug 1.0
 github.setup        plumed plumed2 2.4.1 v
 name                plumed
 
+revision            1
+
 categories          science
 
 # Most of the PLUMED code is L-GPL3. However, PLUMED containts
@@ -66,6 +68,11 @@ if {[mpi_variant_isset]} {
     }
 }
 
+# Optimization flags.
+# Notice that plumed is computationally heavy and that
+# this change has a significant impact in plumed performances
+configure.cxxflags-replace -Os -O3
+
 # Libraries.
 # Library names are specified here to make sure that
 # only requested packages are linked.
@@ -103,6 +110,7 @@ pre-configure {
 subport plumed-devel {
     github.setup        plumed plumed2 f0eab70af62be7797ed007565d42a2ab88c6303b
     version             2.5-20180302
+    revision            1
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed


### PR DESCRIPTION
#### Description

I replaced -Os with -O3 since this has a significant impact in plumed performances.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G19009
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
