### PR TITLE
py-*: add missing subports for python 3.5 and 3.6

### DIFF
--- a/python/py-DAWG/Portfile
+++ b/python/py-DAWG/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-PyRSS2Gen/Portfile
+++ b/python/py-PyRSS2Gen/Portfile
@@ -20,7 +20,7 @@ distname            PyRSS2Gen-${version}
 checksums           rmd160  0dea97364066f78189b99a512015e851601aa2fa \
                     sha256  2a9a3ee7c8e30cb40434ef3a295f9a60166f7d8c3eaefac9f46f7ed4b27c2269
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${subport} ne ${name}} {
     post-destroot {

--- a/python/py-XlsxWriter/Portfile
+++ b/python/py-XlsxWriter/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 github.setup        jmcnamara XlsxWriter 0.9.6 RELEASE_
 name                py-XlsxWriter
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 python.default_version 27
 platforms           darwin
 license             BSD

--- a/python/py-acor/Portfile
+++ b/python/py-acor/Portfile
@@ -23,7 +23,7 @@ checksums           md5     8681b949f50e0f9a02bfbd15f7a3d56c \
                     rmd160  d6e0c55e4db74b45e2ed632a0a553851ef6fe017 \
                     sha256  4c647d30326004cfcfbcf630e97586ce574954e36bebf75b657d33d5d79e94e3
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  pypi

--- a/python/py-actdiag/Portfile
+++ b/python/py-actdiag/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-appscript/Portfile
+++ b/python/py-appscript/Portfile
@@ -24,7 +24,7 @@ distname            ${real_name}-${version}
 checksums           rmd160  d5bc7581a0149500b6bed18c47711ddc31024658 \
                     sha256  24eae98bb50bd6788be9e7ce03cea1187788d63e70712eedcf186dc1b9fb6578
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-apptools/Portfile
+++ b/python/py-apptools/Portfile
@@ -22,7 +22,7 @@ platforms           darwin
 checksums           rmd160  004958cc00d28caf83045497c813880cdbf7f1ee \
                     sha256  eb80e3ba421de2c3665a7f83bd3e3588d291013b3dd1d46e816124d62a53e163
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-apsw/Portfile
+++ b/python/py-apsw/Portfile
@@ -26,7 +26,7 @@ checksums           md5     ae32e46df985b5fbbdbdd17640367711 \
                     sha1    735f1b1e236055e4f0de286e17e400d7db1f87e7 \
                     rmd160  91df80878469dbed49c35f5d2704bdcb9cfbe549
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:sqlite3

--- a/python/py-asciitable/Portfile
+++ b/python/py-asciitable/Portfile
@@ -8,7 +8,7 @@ name                py-asciitable
 version             0.8.0
 revision            2
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     replaced_by     py${python.version}-astropy

--- a/python/py-asdf-devel/Portfile
+++ b/python/py-asdf-devel/Portfile
@@ -19,7 +19,7 @@ license             LGPL-3
 
 maintainers         nomaintainer
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib

--- a/python/py-astlib/Portfile
+++ b/python/py-astlib/Portfile
@@ -23,7 +23,7 @@ checksums               md5     50871e614a04cded84bcfcc555dc9121 \
                         sha1    cbd999f87773002e471bd165927c2ee124a5515f \
                         rmd160  e4a82b9e86c9e5ea7f8f8bf9b3b1a35d4183a86e
 
-python.versions         27 34 35
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-atpy/Portfile
+++ b/python/py-atpy/Portfile
@@ -26,7 +26,7 @@ checksums           md5     2306195fcefff7c1e4d36ae92a894ff2 \
                     sha1    93525db0a36770b7cbbafefa6041fc80aac51c61 \
                     rmd160  a2c76ef4ac595d0f9cbfb0a21d3bf1bf98b088cf
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-backports-ssl_match_hostname/Portfile
+++ b/python/py-backports-ssl_match_hostname/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-backports/Portfile
+++ b/python/py-backports/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-backports_abc/Portfile
+++ b/python/py-backports_abc/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-bcdoc/Portfile
+++ b/python/py-bcdoc/Portfile
@@ -19,7 +19,7 @@ distname            bcdoc-${version}
 checksums           rmd160  c82c8aa2033ccdcc29cd75c8ae21ee2381e963ed \
                     sha256  f568c182e06883becf7196f227052435cffd45604700c82362ca77d3427b6202
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-bdist_mpkg/Portfile
+++ b/python/py-bdist_mpkg/Portfile
@@ -27,7 +27,7 @@ checksums           md5 81f5f8601331acda2926efeb97a0804d \
                     rmd160 a5550e7d420fde8b7425a273286c5f02b056c8cf \
                     sha256 1b460cc4ea834f0be9e787759fac542cb2414463a1f7f1aedb5870e90f6beb9d
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-setuptools

--- a/python/py-bitarray/Portfile
+++ b/python/py-bitarray/Portfile
@@ -34,7 +34,7 @@ checksums           md5     3825184f54f4d93508a28031b4c65d3b \
                     rmd160  58c2a2665c2759f23bf1ab096de8c34bf7fcfcbb \
                     sha256  7da501356e48a83c61f479393681c1bc4b94e5a34ace7e08cb29e7dd9290ab18
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 livecheck.type      none
 

--- a/python/py-bitstring/Portfile
+++ b/python/py-bitstring/Portfile
@@ -32,4 +32,4 @@ if {${name} ne ${subport}} {
    }
 }
 
-python.versions     27 34
+python.versions     27 34 35 36

--- a/python/py-blessed/Portfile
+++ b/python/py-blessed/Portfile
@@ -20,7 +20,7 @@ distname            ${python.rootname}-${version}
 checksums           rmd160  5c2faf81f6fa6305e1acf74518677f5b792de5bb \
                     sha256  58a289d833299944dc2f7b02aae522e3ed53ec0d43fbbfca5d9eeb9486b2c073
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-blist/Portfile
+++ b/python/py-blist/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-blockdiag/Portfile
+++ b/python/py-blockdiag/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-bob-ap/Portfile
+++ b/python/py-bob-ap/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ap 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  caa97ff581775f6e2654a7a64cd4d2c2310be3f8 \

--- a/python/py-bob-blitz/Portfile
+++ b/python/py-bob-blitz/Portfile
@@ -27,7 +27,7 @@ long_description             This package contains a set of Pythonic bindings to
 github.setup                 bioidiap bob.blitz 2.0.8 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 

--- a/python/py-bob-core/Portfile
+++ b/python/py-bob-core/Portfile
@@ -30,7 +30,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.core 2.1.0 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 

--- a/python/py-bob-db-atnt/Portfile
+++ b/python/py-bob-db-atnt/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.db.atnt 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  2eea3680e535fd69981969685ea7dbeb16f4f906 \

--- a/python/py-bob-db-base/Portfile
+++ b/python/py-bob-db-base/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.db.base 2.0.5 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  a31d1e89841ae1cc35fc11b721802f8a6c59a572 \

--- a/python/py-bob-db-iris/Portfile
+++ b/python/py-bob-db-iris/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.db.iris 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  b262d9d14a5f6395c54152c10db256b4a8458231 \

--- a/python/py-bob-db-mnist/Portfile
+++ b/python/py-bob-db-mnist/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.db.mnist 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  e01c456e1b3b54ce3685ff413c5c6fbf64c9bd4b \

--- a/python/py-bob-db-verification-utils/Portfile
+++ b/python/py-bob-db-verification-utils/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.db.verification.utils 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  686cee02180b4ece796761595653ad6db0bb1442 \

--- a/python/py-bob-db-wine/Portfile
+++ b/python/py-bob-db-wine/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.db.wine 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  92fdbec48799a939a981785e323bfa458fa4ef99 \

--- a/python/py-bob-extension/Portfile
+++ b/python/py-bob-extension/Portfile
@@ -29,7 +29,7 @@ long_description             This package is part of the signal-processing and m
 github.setup                 bioidiap bob.extension 2.0.11 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 

--- a/python/py-bob-io-audio/Portfile
+++ b/python/py-bob-io-audio/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.io.audio 2.0.0 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  427c3e439f19bcad72471d86acda6d1de3bf55f7 \

--- a/python/py-bob-io-base/Portfile
+++ b/python/py-bob-io-base/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.io.base 2.0.7 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  16d0b8c865880df1af80d54311cbbe5ec2de7756 \

--- a/python/py-bob-io-image/Portfile
+++ b/python/py-bob-io-image/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.io.image 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  2b357d7ea827bfc2e1b842ea87b85659022cfe3c \

--- a/python/py-bob-io-matlab/Portfile
+++ b/python/py-bob-io-matlab/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.io.matlab 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  c9fe85df2b9d255dd81d7652c9d703dafc506ee6 \

--- a/python/py-bob-io-video/Portfile
+++ b/python/py-bob-io-video/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.io.video 2.0.5 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  fc269ae3e4d19327b401617bf73f2e7a95f570a3 \

--- a/python/py-bob-ip-base/Portfile
+++ b/python/py-bob-ip-base/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.base 2.0.7 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  651d49a23439ed65586280031d4870aac1a9b5f5 \

--- a/python/py-bob-ip-color/Portfile
+++ b/python/py-bob-ip-color/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.color 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  00d27bc6f15f2ccb26b184b3d4cf21037cdc63ad \

--- a/python/py-bob-ip-draw/Portfile
+++ b/python/py-bob-ip-draw/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.draw 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  cded496c918b73afd91403487a02ac1078ee85b1 \

--- a/python/py-bob-ip-facedetect/Portfile
+++ b/python/py-bob-ip-facedetect/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.facedetect 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  f7a6e71731c18f085d566212e250ee8e4370fafe \

--- a/python/py-bob-ip-gabor/Portfile
+++ b/python/py-bob-ip-gabor/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.gabor 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  9f4a5785e86cf9f863282ef15726b9e09f95ced6 \

--- a/python/py-bob-ip-optflow-hornschunck/Portfile
+++ b/python/py-bob-ip-optflow-hornschunck/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.optflow.hornschunck 2.0.6 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  64b5db989230bd6c6fc02008a4589fcf57c8d634 \

--- a/python/py-bob-ip-optflow-liu/Portfile
+++ b/python/py-bob-ip-optflow-liu/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.ip.optflow.liu 2.0.5 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  29b29cdb657b6cc003a5aa945aa47cd8fcc38805 \

--- a/python/py-bob-learn-activation/Portfile
+++ b/python/py-bob-learn-activation/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.learn.activation 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  f5f15307fb71fc0cd9aeb813963fa3243555fa06 \

--- a/python/py-bob-learn-boosting/Portfile
+++ b/python/py-bob-learn-boosting/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.learn.boosting 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  527c4cde056088a5d352ec718a2d9f585489294b \

--- a/python/py-bob-learn-em/Portfile
+++ b/python/py-bob-learn-em/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.learn.em 2.0.7 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  49b46b0157602073d528076842df97528e069a4e \

--- a/python/py-bob-learn-libsvm/Portfile
+++ b/python/py-bob-learn-libsvm/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.learn.libsvm 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  28a09c8066d699d98e52dc76bd16f684b2dee068 \

--- a/python/py-bob-learn-linear/Portfile
+++ b/python/py-bob-learn-linear/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.learn.linear 2.0.7 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  254aec3787ca2f3c6ae1d5cb157fc3ff726318c3 \

--- a/python/py-bob-learn-mlp/Portfile
+++ b/python/py-bob-learn-mlp/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.learn.mlp 2.0.6 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  bcd2cdfa1d49d1dbcb50deff8462d22bf67ffa2b \

--- a/python/py-bob-math/Portfile
+++ b/python/py-bob-math/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.math 2.0.3 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  52b04f5b4d6c5ce910b898843904dae57eaad049 \

--- a/python/py-bob-measure/Portfile
+++ b/python/py-bob-measure/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.measure 2.1.0 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  6d8fa0b38a517bcc46a2dbb715c88a6000eb2ebb \

--- a/python/py-bob-sp/Portfile
+++ b/python/py-bob-sp/Portfile
@@ -31,7 +31,7 @@ long_description             Bob is a signal-processing and machine learning too
 github.setup                 bioidiap bob.sp 2.0.4 v
 
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 checksums                    rmd160  f5c107635e36a199661dff16038fbfef8479b28c \

--- a/python/py-bob/Portfile
+++ b/python/py-bob/Portfile
@@ -29,7 +29,7 @@ long_description             Bob is a signal-processing and machine learning too
 
 github.setup                idiap bob 2.1.0 v
 
-python.versions              27 34
+python.versions              27 34 35 36
 python.default_version       27
 
 

--- a/python/py-breadability/Portfile
+++ b/python/py-breadability/Portfile
@@ -23,7 +23,7 @@ distname            ${real_name}-${version}
 checksums           rmd160  8d862c9606f2bee49df7eb8007ba6878006c8963 \
                     sha256  f1a7fdad1e58e295df80954879143824c706bbfb1826cdf4b1d15de1a86afe99
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-bson/Portfile
+++ b/python/py-bson/Portfile
@@ -29,7 +29,7 @@ checksums           md5     be14a8e89f86970e873f9b64822412e3 \
                     rmd160  f86ad4349e4b465bdc6a7e9bdf3f98534653309b \
                     sha256  b3fe82fb5cd4ac5958b5839d211ae35d2a29418a588a63fa054f9916173324a4
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     conflicts               py${python.version}-pymongo

--- a/python/py-cached-property/Portfile
+++ b/python/py-cached-property/Portfile
@@ -16,7 +16,7 @@ long_description    ${description}
 checksums           rmd160  3ec81facf050c0fe5e43deddb1fc5acc94d97817 \
                     sha256  afb2bf7637ee3fab7351262b9d3f9fc4c51608a8fb0beff6294f669f0cb0389a
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-cairocffi/Portfile
+++ b/python/py-cairocffi/Portfile
@@ -23,7 +23,7 @@ homepage                http://cairocffi.readthedocs.io/en/latest/
 checksums               rmd160  e30a400c154754f6eb2c61454bd729e43dc228c8 \
                         sha256  b4325b2d0de14c69a714bb9b66749214f4e70929c5968d10c7cc71b431d4f77a
 
-python.versions         27 34 35
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cairosvg/Portfile
+++ b/python/py-cairosvg/Portfile
@@ -23,7 +23,7 @@ long_description    CairoSVG is a SVG converter based on Cairo. It can export SV
 checksums           rmd160  9a79721e8504236fc8514ed06b005f5212071570 \
                     sha256  8288ea5a1cdacd2ce3b79c7a17d39851bd7f34e756185d384f8fe981329f1a02
 
-python.versions     34 35
+python.versions     34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-cssselect \

--- a/python/py-cchardet/Portfile
+++ b/python/py-cchardet/Portfile
@@ -22,7 +22,7 @@ distname            ${realname}-${version}
 checksums           rmd160  008854344e638db961b2eedc08d427c4ba722b5c \
                     sha256  98e6dc7ca225abfa7e559a6450404aeb2f5bea0713afd6dd492c1a51cec57e63
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-chainer/Portfile
+++ b/python/py-chainer/Portfile
@@ -16,7 +16,7 @@ long_description    ${description}
 homepage            https://chainer.org/
 platforms           darwin
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     checksums           rmd160  d09dcb82a97bffeb14fd53ab271679c891eb95cb \

--- a/python/py-chronic/Portfile
+++ b/python/py-chronic/Portfile
@@ -16,7 +16,7 @@ long_description    ${description}  Add decorators or wrap code in with \
 platforms           darwin
 license             MIT
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 if { $subport ne $name } {
     checksums           rmd160  4320705a0656fad02dfa4a73bdc044bbb1c593f2 \

--- a/python/py-ckanapi/Portfile
+++ b/python/py-ckanapi/Portfile
@@ -28,7 +28,7 @@ checksums           md5     2ab2508df730b0e7d84e13be74adc314 \
                     rmd160  98f6682c1ef512d3120833e0e7087ec26500ce44 \
                     sha256  47009c49cce783595c8c7bd089a7205b1b3c55d250eb049229a655fb07ca69ac
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-cog/Portfile
+++ b/python/py-cog/Portfile
@@ -25,7 +25,7 @@ distname            ${realname}-${version}
 checksums           rmd160  15e5bea87f033ceb603c95ac00b37dc7ef8fe8ad \
                     sha256  5b71a8cfd8dcfd7c408d2ab0f25a4cd546a2d03f8cd99475f775ba79a75a7ba3
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     post-destroot {

--- a/python/py-control/Portfile
+++ b/python/py-control/Portfile
@@ -11,7 +11,7 @@ license             BSD
 platforms           darwin
 
 # other versions untested
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         nomaintainer
 

--- a/python/py-cookies/Portfile
+++ b/python/py-cookies/Portfile
@@ -32,7 +32,7 @@ checksums           md5     6f4c53aba3ed03e4e7b50812c2c2579a \
                     rmd160  a942793a1d643cb30ddf5d161e4c4b1e5c8dcf31 \
                     sha256  d6b698788cae4cfa4e62ef8643a9ca332b79bd96cb314294b864ae8d7eb3ee8e
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-crcmod/Portfile
+++ b/python/py-crcmod/Portfile
@@ -20,7 +20,7 @@ checksums           md5     2d5b92117d958dcead94f9e17f54cd32 \
                     sha1    61d9fea169099b87c2e36ce572d2d25e0fd2de59 \
                     rmd160  503b415394d7c833b22e5a999454c0d67598cd54
 
-python.versions     34
+python.versions     34 35 36
 
 if {${name} ne ${subport}} {
     build.args-append -f

--- a/python/py-cubes/Portfile
+++ b/python/py-cubes/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-datrie/Portfile
+++ b/python/py-datrie/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             LGPL
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-des/Portfile
+++ b/python/py-des/Portfile
@@ -4,7 +4,7 @@ PortGroup           python 1.0
 name                py-des
 set realname        pyDes
 version             2.0.1
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   devel
 platforms           darwin
 license             public-domain

--- a/python/py-distutils-extra/Portfile
+++ b/python/py-distutils-extra/Portfile
@@ -29,7 +29,7 @@ distname                ${my_name}-${version}
 checksums               rmd160  ec5fcffc0ac6258bc86a68c2108af2f5b2dda419 \
                         sha256  723f24f4d65fc8d99b33a002fbbb3771d4cc9d664c97085bf37f3997ae8063af
 
-python.versions         27 33 34 35
+python.versions         27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-django-htmlmin/Portfile
+++ b/python/py-django-htmlmin/Portfile
@@ -22,7 +22,7 @@ long_description \
 checksums           rmd160  6b0a90fdb8d3591f0273d56211c2d04d1337c145 \
                     sha256  7f00773ecadb73161f74e12a1ab57d029fbb3ef631a9c62c9655949c84a549b3
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-django-nose/Portfile
+++ b/python/py-django-nose/Portfile
@@ -23,7 +23,7 @@ checksums           md5     199d5358317a804b39fe05d806cab427 \
                     rmd160  bdd535ec8bbd042eab00c47b605848ad67b14fdd \
                     sha256  9aae16b562866a4ddaa5e8978729abadbbed544728d88e0b9c9af7b31dd072ed
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib     port:py${python.version}-django \

--- a/python/py-djvubind/Portfile
+++ b/python/py-djvubind/Portfile
@@ -6,7 +6,7 @@ PortGroup                       python 1.0
 name                            py-djvubind
 version                         1.2.1
 revision                        1
-python.versions                 33 34
+python.versions                 33 34 35 36
 platforms                       darwin
 supported_archs                 noarch
 maintainers                     {raphael @raphael-st} openmaintainer

--- a/python/py-dnspython/Portfile
+++ b/python/py-dnspython/Portfile
@@ -21,7 +21,7 @@ homepage           http://www.dnspython.org/
 master_sites       ${homepage}kits/${version}
 distname           dnspython-${version}
 
-python.versions    26 27 33 34 35
+python.versions    26 27 33 34 35 36
 
 checksums          rmd160 b3bf88a627850d29b5da6e67d5f2e9643283bc65 \
                    sha256 11598ae5735746e63921f8eebdfdee4a2e7d0ba842ebd57ba02682d4aed8244b

--- a/python/py-dockerpty/Portfile
+++ b/python/py-dockerpty/Portfile
@@ -18,7 +18,7 @@ long_description    Provides the functionality needed to operate the \
 checksums           rmd160  6d0604c549d301b92b98c2b25825ff04881e48cd \
                     sha256  9603174148835398767ee75ac763333321bf84f764de93891a5decd07aa58d08
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-docopt/Portfile
+++ b/python/py-docopt/Portfile
@@ -23,7 +23,7 @@ distname            ${real_name}-${version}
 checksums           rmd160  c2e76c031e12096906b9c6b1f7dc62a9b30336f1 \
                     sha256  49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-dynd/Portfile
+++ b/python/py-dynd/Portfile
@@ -13,7 +13,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-ecdsa/Portfile
+++ b/python/py-ecdsa/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-envisage/Portfile
+++ b/python/py-envisage/Portfile
@@ -22,7 +22,7 @@ supported_archs     noarch
 checksums           rmd160  aacd17f0d3904cf815ac577ff3b900e647a25f37 \
                     sha256  b89ca690b4a357a93f179fc7501e6272cbe595285c625fc5d4ab8d3c533449c9
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-epc/Portfile
+++ b/python/py-epc/Portfile
@@ -22,7 +22,7 @@ long_description    \
 checksums           rmd160  d25f8c858c86493589843c65db40813f25c5feb1 \
                     sha256  76ef4061e5ff94fb87879188d6a85e958e2a32363124a1ce6027b5c1cc5c4f46
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append   port:py${python.version}-sexpdata

--- a/python/py-ephem/Portfile
+++ b/python/py-ephem/Portfile
@@ -26,7 +26,7 @@ checksums           md5     405a109f3017251ecd8c2890d850f649 \
                     rmd160  32e5fcb0e74936706b68bd811a9dcdf55b97b1f8 \
                     sha256  7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  regex

--- a/python/py-expressions/Portfile
+++ b/python/py-expressions/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     35
+python.versions     35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-ez_setup/Portfile
+++ b/python/py-ez_setup/Portfile
@@ -20,7 +20,7 @@ distname            ez_setup-${version}
 checksums           rmd160  796b5364e8e64455468b76b4f8a2fd10f0389d1b \
                     sha256  303c5b17d552d1e3fb0505d80549f8579f557e13d8dc90e5ecef3c07d7f58642
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-ezodf/Portfile
+++ b/python/py-ezodf/Portfile
@@ -6,7 +6,7 @@ PortGroup           bitbucket 1.0
 
 bitbucket.setup     mozman ezodf 0.2.5
 name                py-ezodf
-python.versions     27 34
+python.versions     27 34 35 36
 platforms           darwin
 maintainers         gmail.com:Mathias.Laurin openmaintainer
 license             MIT

--- a/python/py-fabio/Portfile
+++ b/python/py-fabio/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  346d9401c75ff63d71f606ba2938d444c5aa8c2a \
 
 universal_variant   no
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy

--- a/python/py-figleaf/Portfile
+++ b/python/py-figleaf/Portfile
@@ -4,7 +4,7 @@ PortGroup           python 1.0
 name                py-figleaf
 set real_name       figleaf
 version             0.6.1
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   devel
 platforms           darwin
 license             BSD

--- a/python/py-filechunkio/Portfile
+++ b/python/py-filechunkio/Portfile
@@ -24,7 +24,7 @@ checksums           md5     c168a11ad94cd2ec42a219f0f8869a7b \
                     rmd160  79d8362d9eb5c0762f2468056d8be8375d0750a1 \
                     sha256  163948052cd274daddfcde9cec9cb5e04ac19d7bb91606cdc6a305b0428a0e70
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-fortranformat/Portfile
+++ b/python/py-fortranformat/Portfile
@@ -17,7 +17,7 @@ long_description    Generates text from a Python list of variables or will \
 checksums           md5 d78c5a320fedcbdf21f823cd18e28ac0 \
                     rmd160 212edf59a6da06b8127322f30806e6559353ea79 \
                     sha256 ec76c1c7bc07972aa98e01ff2303bb0aefe77306be8ff2723bc40b7c7775292c
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 bitbucket.tarball_from downloads
 distname            fortranformat-${version}

--- a/python/py-funcparserlib/Portfile
+++ b/python/py-funcparserlib/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-fuzzywuzzy/Portfile
+++ b/python/py-fuzzywuzzy/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc
 platforms           darwin freebsd
 license             GPL-2+
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         nomaintainer
 

--- a/python/py-generator/Portfile
+++ b/python/py-generator/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  5ce5ba93b7f512bcbd7a04eb4a8471bd72dd93d1 \
 
 use_configure       no
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     build {}

--- a/python/py-genshi/Portfile
+++ b/python/py-genshi/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc www
 platforms           darwin
 license             BSD
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-geohash/Portfile
+++ b/python/py-geohash/Portfile
@@ -10,7 +10,7 @@ categories-append   devel math
 platforms           darwin
 license             Apache MIT BSD
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-geojson/Portfile
+++ b/python/py-geojson/Portfile
@@ -32,7 +32,7 @@ checksums           md5     2131dfaf4546db43f64d9c98d443b48c \
                     rmd160  e7a6622856f9418bced6ef0602e90a7d7a819ae2 \
                     sha256  72541ca29b4b6bf93deb61b4719499c3c346f1a82c1c3edb31c6ae2fde1dec8e
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-gflags/Portfile
+++ b/python/py-gflags/Portfile
@@ -27,7 +27,7 @@ checksums           sha1    db309e6964b102ff36de319ce551db512a78281e \
                     rmd160  b54a08bbb4dfb79cea17aef60e65f0847aab0a26 \
                     sha256  311066217acb8cd8519a4c872cb3fe64f02bcf105802bb761ab0de55c2386cd6
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-hat-trie/Portfile
+++ b/python/py-hat-trie/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-hdfs/Portfile
+++ b/python/py-hdfs/Portfile
@@ -27,7 +27,7 @@ checksums           md5     c48b86a0fb05d22b5f4eb4cb84fc6452 \
                     rmd160  442f119b819afecb20ab3f13096c3a8a8827542f \
                     sha256  c62038dec3d2a7d5344ceb3aa2a721dfaf35e46a311676d74f91d3cb2a866055
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-hieroglyph/Portfile
+++ b/python/py-hieroglyph/Portfile
@@ -20,7 +20,7 @@ supported_archs     noarch
 checksums           rmd160  73f12f2e864945c13aadeed3fa50b463fc18335a \
                     sha256  ba4ec61a5bc931f9bfcc9562ab6d7dbbdc36da4d84ef11daef30ac081a44e2f1
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-sphinx

--- a/python/py-hiredis/Portfile
+++ b/python/py-hiredis/Portfile
@@ -10,7 +10,7 @@ categories-append   devel databases
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-http-parser/Portfile
+++ b/python/py-http-parser/Portfile
@@ -27,7 +27,7 @@ checksums           md5 751967e2785c829dffebdc9a511e0eec \
                     sha1 de2509e6b62d6beb191e0953d3b098ffac27fedd \
                     rmd160 5953b6a238917e14b1bf6c1e4f995fbac03463b5
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-icalendar/Portfile
+++ b/python/py-icalendar/Portfile
@@ -24,7 +24,7 @@ homepage            http://icalendar.readthedocs.org/
 checksums           rmd160  4dfd631b54acebd0943cb2d4b10e6d423c9b8c0d \
                     sha256  1e9fbef0c823477a600cb5656c060775b190f121a80cfc30ea4627740ec56334
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-idlsave/Portfile
+++ b/python/py-idlsave/Portfile
@@ -27,7 +27,7 @@ checksums           md5  2b2d4d0cc69d12d327bff2a78bcb737d \
                     sha1  345a4f25b208c57be5996f4096061e86b8968284 \
                     rmd160  78e648439ca2eaab8a4e8529efca88e21dd25623
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_run-append  port:py${python.version}-numpy

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -9,7 +9,7 @@ categories-append   math
 platforms           darwin
 license             GPL-2+
 
-python.versions     26 27 34 35
+python.versions     26 27 34 35 36
 
 maintainers         {snc @nerdling} openmaintainer
 

--- a/python/py-import_relative/Portfile
+++ b/python/py-import_relative/Portfile
@@ -26,7 +26,7 @@ distname            import_relative-${version}
 checksums           rmd160  ab53ebfdbbdf7f5c6f06849f0f7913a1e169a5cd \
                     sha256  3ed62f11ec8fc525686135d55a117e317b62ee8a612b4415436b6fb03d9724ea
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-importmagic/Portfile
+++ b/python/py-importmagic/Portfile
@@ -18,7 +18,7 @@ long_description    ${description}
 checksums           rmd160  ce9c4594f18821d36f5b67f3f9bff2f646dd901a \
                     sha256  c95e46fe7b506b7d3613dd8303e36fd13e6ffcfde009e7461e9384a9a2074688
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_build-append    port:py${python.version}-nose \

--- a/python/py-ioflo/Portfile
+++ b/python/py-ioflo/Portfile
@@ -33,7 +33,7 @@ long_description    IoFlo is a magically powerful open interoperable software \
 homepage            http://ioflo.com
 
 
-python.versions 27 34
+python.versions 27 34 35 36
 python.default_version 27
 
 checksums           rmd160 bb99fc946fd6f1b3ffd81cc9ac5508918fc86213 \

--- a/python/py-ipwhois/Portfile
+++ b/python/py-ipwhois/Portfile
@@ -20,7 +20,7 @@ long_description    ${description}
 checksums           rmd160   06f14990dfc2ba792fef02c36d7b909a7cc46fac \
                     sha256   258c6925aa5b85428db5b4f8c6af3e1f61f2e4f04a51552b4e59aacbe9203e06
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-ipy/Portfile
+++ b/python/py-ipy/Portfile
@@ -30,7 +30,7 @@ distname            ${_name}-${version}
 checksums           rmd160  9d059c6949134ac0f74ae768a8d6dbac5cdb9b54 \
                     sha256  61da5a532b159b387176f6eabf11946e7458b6df8fb8b91ff1d345ca7a6edab8
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     post-destroot {

--- a/python/py-jmespath-terminal/Portfile
+++ b/python/py-jmespath-terminal/Portfile
@@ -19,7 +19,7 @@ distname            jmespath-terminal-${version}
 checksums           rmd160  a3d5fc3c05fe2e9e71fab9c6d9f6acfeac7ce39f \
                     sha256  df26ac6fa774676b4c0eff155bdb2f9ddf0c78c013b5b4824b597f44793903f0
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-langid/Portfile
+++ b/python/py-langid/Portfile
@@ -17,7 +17,7 @@ description         Stand-alone language identification system
 
 long_description    ${description}
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     checksums           rmd160  bc1c7c0039d4defd0801492cd4472001b9d3f7d8 \

--- a/python/py-lepl/Portfile
+++ b/python/py-lepl/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  dc5bb15465e38d7748a440e644adbc3a2984a929 \
                     sha256  a8715c709308350ce4afed5d525682656886d38141387ec87d44421da8d41397
 
 python.default_version  27
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-levenshtein/Portfile
+++ b/python/py-levenshtein/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc
 platforms           darwin freebsd
 license             GPL-2+
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-libcloud/Portfile
+++ b/python/py-libcloud/Portfile
@@ -32,7 +32,7 @@ checksums           md5     d12ef4f96878a940321c73f4e0821237 \
                     rmd160  047ca8213ae50c4a46d20a3a8eff4f3a4749c6dc \
                     sha256  f36dcf8e6a4270c86b521ab4868fd762a7ec217195e126a8ccb028a82cf55466
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-libnacl/Portfile
+++ b/python/py-libnacl/Portfile
@@ -21,7 +21,7 @@ long_description    Libnacl is a Python binding for the libsodium NaCl crypto \
 
 homepage            https://github.com/saltstack/libnacl
 
-python.versions 27 34
+python.versions 27 34 35 36
 
 checksums           rmd160 573c6d621926268a478518c0c03080d58cccf8ae \
                     sha256 50bf608a23ec10040f9a8e4666b89b8bebac40f3bee91c528e5356162433452e

--- a/python/py-llfuse/Portfile
+++ b/python/py-llfuse/Portfile
@@ -23,7 +23,7 @@ master_sites        pypi:l/llfuse
 checksums           rmd160  96c560c5710bc5dd12c41ac64588a7b1a163cd26 \
                     sha256  1b84b1152ae461e66ecc526d0de71eaec086c587e97d1dda93d620b16a92db6c
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:pkgconfig \

--- a/python/py-llvmmath/Portfile
+++ b/python/py-llvmmath/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-llvmpy/Portfile
+++ b/python/py-llvmpy/Portfile
@@ -15,7 +15,7 @@ license             BSD
 # Stealth update
 dist_subdir         ${name}/${version}_1
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -21,7 +21,7 @@ distname                lmfit-${version}
 checksums               rmd160  3e9c32c8fe88987e35211e4d7ed694eff292dc7d \
                         sha256  eebc3c34ed9f3e51bdd927559a5482548c423ad5a0690c6fdcc414bfb5be6667
 
-python.versions         27 34 35
+python.versions         27 34 35 36
 
 if {$subport ne $name} {
     depends_build-append       port:py${python.version}-setuptools

--- a/python/py-local-pipelines/Portfile
+++ b/python/py-local-pipelines/Portfile
@@ -20,7 +20,7 @@ supported_archs     noarch
 checksums           rmd160  2d78e8998a4feb3f9654b92f67a5d517f26c2393 \
                     sha256  c599dd9d22a3aa44da3b9088ae5a20c54f2e9e7c8145ea965f7c69702600f864
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 depends_run-append  port:local-pipelines_select
 if {${name} ne ${subport}} {

--- a/python/py-logilab-constraint/Portfile
+++ b/python/py-logilab-constraint/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             GPL-2+
 supported_archs     noarch
 
-python.versions     27 35
+python.versions     27 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-lz4/Portfile
+++ b/python/py-lz4/Portfile
@@ -18,7 +18,7 @@ distname            lz4-${version}
 checksums           rmd160  77fde62ba95eb293912a389d7af85b92e9f98898 \
                     sha256  6bf49061d73d69c453e892ace4586b99ccffc7de558f921d18b9418235692ac7
 
-python.versions     26 27 34 35
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append        port:py${python.version}-setuptools

--- a/python/py-macfsevents/Portfile
+++ b/python/py-macfsevents/Portfile
@@ -9,7 +9,7 @@ revision            0
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-markdown2/Portfile
+++ b/python/py-markdown2/Portfile
@@ -4,7 +4,7 @@ PortGroup           github 1.0
 
 github.setup        trentm python-markdown2 2.1.0
 name                py-markdown2
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   textproc
 maintainers         nomaintainer
 description         Python implementation of Markdown

--- a/python/py-mayavi/Portfile
+++ b/python/py-mayavi/Portfile
@@ -20,7 +20,7 @@ platforms           darwin
 checksums           rmd160  ea9281e86e594796e867d279ff7b7fcfdf237a78 \
                     sha256  31889891b1545069ffce8c77b6ca7757bdd300d314b10e1df9d492359843aaf2
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-mdp-toolkit/Portfile
+++ b/python/py-mdp-toolkit/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-medusa/Portfile
+++ b/python/py-medusa/Portfile
@@ -22,7 +22,7 @@ distname            ${real_name}-${version}
 checksums           rmd160  84da6140aaf3e677e86014a4e87c83ada39776ec \
                     sha256  ab7fc4c9afd28b3aaf575aca5bb07005d228a0cad5b1787a521ffca63cfe4317
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-meld3/Portfile
+++ b/python/py-meld3/Portfile
@@ -22,7 +22,7 @@ distname            ${real_name}-${version}
 checksums           rmd160  079742bd8829507272c75a78c90e26dd05dc811b \
                     sha256  57b41eebbb5a82d4a928608962616442e239ec6d611fe6f46343e765e36f0b2b
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-memprof/Portfile
+++ b/python/py-memprof/Portfile
@@ -19,7 +19,7 @@ long_description    ${description} It logs and plots the memory usage of all\
                     the variables during the execution of the decorated methods.
 
 homepage            https://jmdana.github.io/memprof/
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-cython

--- a/python/py-meta-devel/Portfile
+++ b/python/py-meta-devel/Portfile
@@ -13,7 +13,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-mimeparse/Portfile
+++ b/python/py-mimeparse/Portfile
@@ -5,7 +5,7 @@ PortGroup python 1.0
 
 name                py-mimeparse
 version             0.1.3
-python.versions     27 34 35
+python.versions     27 34 35 36
 categories-append   www
 license             MIT
 platforms           darwin

--- a/python/py-misaka/Portfile
+++ b/python/py-misaka/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        FSX misaka 1.0.2 v
 name                py-misaka
-python.versions     27 34
+python.versions     27 34 35 36
 license             MIT
 platforms           darwin
 

--- a/python/py-mlpy/Portfile
+++ b/python/py-mlpy/Portfile
@@ -31,7 +31,7 @@ distname            mlpy-${version}
 
 checksums           sha1    32f986f7f0f7cce5c773d2909d34705eab39df16
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-mmh3/Portfile
+++ b/python/py-mmh3/Portfile
@@ -20,7 +20,7 @@ master_sites        pypi:m/${real_name}/
 
 distname            ${real_name}-${version}
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     checksums           rmd160  108cd84049528834dc857e2119d2427946b028f3 \

--- a/python/py-mongoengine/Portfile
+++ b/python/py-mongoengine/Portfile
@@ -21,7 +21,7 @@ long_description    \
 
 homepage            http://mongoengine.org/
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-montage/Portfile
+++ b/python/py-montage/Portfile
@@ -25,7 +25,7 @@ checksums           md5     f309653b9858e5cab5b1bdce3f152978 \
                     sha1    4ad4e086adb11313f7675ad39c24c2131c2ccd3b \
                     rmd160  7e1065df27b996df0e2773aca0fb59dd6d036ddc
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_run-append  port:py${python.version}-numpy \

--- a/python/py-mrjob/Portfile
+++ b/python/py-mrjob/Portfile
@@ -26,7 +26,7 @@ checksums           md5     3d2e484d389f049a6e328d5ec7601be8 \
                     rmd160  4c2b46f67e4b54ba03253069b1164282d4fff576 \
                     sha256  4c694c1f6f83f0d52b779843927e4dff6ace07213f994d1eb58e8cc98a36655d
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-mssql/Portfile
+++ b/python/py-mssql/Portfile
@@ -24,7 +24,7 @@ checksums           md5     e955442a8cd43456cdf5c28b75147afb \
                     rmd160  4a66ad05af080684b5aa9f4096819a0523c13556 \
                     sha256  7dbfcf8de21be1f34164a7f26f1d573b0e4c0bad5804a62f8997b99fe91ece5d
 
-python.versions	    27 34
+python.versions	    27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-mustache/Portfile
+++ b/python/py-mustache/Portfile
@@ -19,7 +19,7 @@ long_description    \
 checksums           rmd160  07b303af8cb3841fb1afb1bf73c625cf54b6fe94 \
                     sha256  f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append   port:py${python.version}-setuptools

--- a/python/py-natsort/Portfile
+++ b/python/py-natsort/Portfile
@@ -27,7 +27,7 @@ distname            $realName-${version}
 checksums           rmd160  7f7ef1bab57862009369c1e97f8b171f8bb17f3f \
                     sha256  c76ba3e85fba78f276ac06e4d47f2230d1070f9c19413b2a0bfe7de6af311839
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-netlib/Portfile
+++ b/python/py-netlib/Portfile
@@ -33,7 +33,7 @@ checksums           md5     7c8622364947ae11c9dc39e1bf00a38d \
                     rmd160  77b0605f59143e6591a7d17e0ecaee88c4beb768 \
                     sha256  c70ed1915a5662c9ffce4dc97d143209e009cf0035a2f692031a6c47e87e6002
 
-python.versions         27 34 35
+python.versions         27 34 35 36
 python.default_version  35
 
 if {${name} ne ${subport}} {

--- a/python/py-nibabel/Portfile
+++ b/python/py-nibabel/Portfile
@@ -24,7 +24,7 @@ distname                nibabel-${version}
 checksums               rmd160  b4d284328e2e9cb8f177bbfb73db45f4cfb76405 \
                         sha256  a2a4baedb490c6d0878b1950b569650cfa2ce65c24da4741817ca4069771103c
 
-python.versions         27 34
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib         port:py${python.version}-numpy

--- a/python/py-nose-exclude/Portfile
+++ b/python/py-nose-exclude/Portfile
@@ -4,7 +4,7 @@ PortGroup           python 1.0
 name                py-nose-exclude
 set real_name       nose-exclude
 version             0.1.7
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   devel
 platforms           darwin
 license             GNU LGPL

--- a/python/py-novas/Portfile
+++ b/python/py-novas/Portfile
@@ -22,7 +22,7 @@ homepage                https://pypi.python.org/pypi/novas/
 checksums               rmd160  7eda716bb72102f2a4d7e39fc7e52313af53482a \
                         sha256  c0e55db139f7e33ed9cb213bf2c803aed6c0cbc582f491f69144a8edd9f900ed
 
-python.versions         27 33 34
+python.versions         27 33 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-novas_de405/Portfile
+++ b/python/py-novas_de405/Portfile
@@ -19,7 +19,7 @@ master_sites            http://jplephem.s3.amazonaws.com/
 distname                novas_de405-${version}
 checksums               sha256  b63583a7cf7711e5ffb02a09c4ff840f0424cc9a374214f5c6dc2d5d70f6dd7a
 
-python.versions         26 27 33 34
+python.versions         26 27 33 34 35 36
 
 livecheck.url           http://jplephem.s3.amazonaws.com/packages.html
 livecheck.regex         novas_de405-((\[0-9\]+)(\.\[0-9\]+)\*)[quotemeta ${extract.suffix}]

--- a/python/py-nwdiag/Portfile
+++ b/python/py-nwdiag/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-obspy-devel/Portfile
+++ b/python/py-obspy-devel/Portfile
@@ -26,7 +26,7 @@ long_description    \
 
 homepage            http://www.obspy.org/
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     replaced_by     py${python.version}-obspy

--- a/python/py-oursql/Portfile
+++ b/python/py-oursql/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-oursql
-python.versions     27 34
+python.versions     27 34 35 36
 # TODO: It would be very nice to resolve this bizarre dual-version situation.
 version             [expr {${name} eq ${subport} || ${python.version} < 30
                         ? {0.9.3.1}

--- a/python/py-pandasql/Portfile
+++ b/python/py-pandasql/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-parsimonious/Portfile
+++ b/python/py-parsimonious/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         nomaintainer
 

--- a/python/py-pinocchio/Portfile
+++ b/python/py-pinocchio/Portfile
@@ -4,7 +4,7 @@ PortGroup           python 1.0
 name                py-pinocchio
 set real_name       pinocchio
 version             0.3.1
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   devel
 platforms           darwin
 license             MIT

--- a/python/py-pint/Portfile
+++ b/python/py-pint/Portfile
@@ -22,7 +22,7 @@ long_description    Pint is Python module/package to define, operate and \
 
 homepage            https://pint.readthedocs.org/
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_run-append      port:py${python.version}-setuptools

--- a/python/py-plumbum/Portfile
+++ b/python/py-plumbum/Portfile
@@ -23,7 +23,7 @@ platforms           darwin
 
 homepage            http://plumbum.readthedocs.org
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if { ${subport} ne ${name} } {
     depends_lib         port:py${python.version}-six

--- a/python/py-polygon/Portfile
+++ b/python/py-polygon/Portfile
@@ -10,7 +10,7 @@ categories-append   devel math
 platforms           darwin
 license             LGPL Noncommercial
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-postgresql/Portfile
+++ b/python/py-postgresql/Portfile
@@ -30,7 +30,7 @@ if {${name} ne ${subport}} {
    }
 }
 
-python.versions     34
+python.versions     34 35 36
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]

--- a/python/py-powerline/Portfile
+++ b/python/py-powerline/Portfile
@@ -20,7 +20,7 @@ long_description    ${description}
 checksums           rmd160  90c33fffc03fcc4e631d13bc98722edd23adced3 \
                     sha256  3d30d0064e08fc8cc397ae52f5a48729dada3c3002d1eb99dd6869ccc065b57b
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-pptx/Portfile
+++ b/python/py-pptx/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 github.setup        scanny python-pptx 0.6.7 v
 name                py-pptx
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 python.default_version 27
 platforms           darwin
 license             MIT

--- a/python/py-pss/Portfile
+++ b/python/py-pss/Portfile
@@ -21,7 +21,7 @@ long_description    ${description}
 checksums           rmd160  873b1682efcc6905c74f64ba696469f06d9e0b82 \
                     sha256  bbd3804dfca1249b0cf3e5b81e67360c6bfd8544a93cb52b86089a0b80b95a44
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-pudb/Portfile
+++ b/python/py-pudb/Portfile
@@ -30,7 +30,7 @@ distname            ${_name}-${version}
 checksums           rmd160  b7ff56ff14b6ee7871d7068820d0ab4e2ccfb530 \
                     sha256  d6c453f553d414c0b656242a12df2d0410db548588ed46f7219237927b157786
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib     port:py${python.version}-urwid \

--- a/python/py-pycallgraph/Portfile
+++ b/python/py-pycallgraph/Portfile
@@ -22,7 +22,7 @@ checksums           md5     41d2108eedbf3a2f19cae8d4959e6265 \
                     sha1    0eb1d0d2e4fd18ce47722a1898f6fba9edcdaa31 \
                     rmd160  c7504663783e7e72d3a64cac77f8f8d523e50a2a
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_run-append  path:bin/dot:graphviz

--- a/python/py-pyface/Portfile
+++ b/python/py-pyface/Portfile
@@ -23,7 +23,7 @@ platforms               darwin
 checksums               rmd160  b8f32c8c7606977fc2aa3c8201769048182ebcba \
                         sha256  ba3af8605c4fcafdd0713955f7a752e6a6444cd7456a3604ede2e842768025de
 
-python.versions         27 35
+python.versions         27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-pyficache/Portfile
+++ b/python/py-pyficache/Portfile
@@ -23,7 +23,7 @@ long_description    The pyficache module allows one to get any line \
 checksums           rmd160  b09c67d7b94c891cf077f7ed9e87f7247c015923 \
                     sha256  d508736331fc559e15f922f7850fcb10c67c5a17869241f90d947f5ab9058ab5
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_lib-append  port:py${python.version}-coverage \

--- a/python/py-pyfits/Portfile
+++ b/python/py-pyfits/Portfile
@@ -9,7 +9,7 @@ name                py-pyfits
 version             3.3
 revision            5
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 if {${name} ne ${subport}} {
     replaced_by     py${python.version}-astropy

--- a/python/py-pyglet/Portfile
+++ b/python/py-pyglet/Portfile
@@ -10,7 +10,7 @@ categories-append   devel graphics
 platforms           darwin
 license             BSD
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-pyinstaller/Portfile
+++ b/python/py-pyinstaller/Portfile
@@ -21,7 +21,7 @@ license             GPL
 
 homepage            http://www.pyinstaller.org/
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-pyke/Portfile
+++ b/python/py-pyke/Portfile
@@ -29,7 +29,7 @@ checksums           md5     b0f9daa278d9996bc742277126831001 \
                     rmd160  4552fa7f20de373426b9adb27f758efb4536fcf6 \
                     sha256  b0b294f435c6e6d2d4a80badf57d92cb66814dfe21e644a521901209e6a3f8ae
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-pylibmc/Portfile
+++ b/python/py-pylibmc/Portfile
@@ -22,7 +22,7 @@ distname            pylibmc-${version}
 checksums           rmd160  24ff2977e97eef5446dbc491ada668baa02c5ff3 \
                     sha256  ecba261859c3e1ba3365389cb4f4dfffb7e02120a9f57a288cacf2f42c45cdd6
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:libmemcached

--- a/python/py-pylzma/Portfile
+++ b/python/py-pylzma/Portfile
@@ -10,7 +10,7 @@ categories-append   archivers
 platforms           darwin
 license             LGPL-2.1+
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-pymc/Portfile
+++ b/python/py-pymc/Portfile
@@ -20,7 +20,7 @@ long_description    PyMC is a python module that implements Bayesian statistical
 
 platforms           darwin
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy

--- a/python/py-pympler/Portfile
+++ b/python/py-pympler/Portfile
@@ -7,7 +7,7 @@ name                py-pympler
 set real_name       Pympler
 version             0.2.1
 revision            1
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   devel
 license             Apache-2 BSD MIT
 maintainers         nomaintainer

--- a/python/py-pymunk/Portfile
+++ b/python/py-pymunk/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     i386 x86_64
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-pyne/Portfile
+++ b/python/py-pyne/Portfile
@@ -12,7 +12,7 @@ categories-append   science
 platforms           darwin
 license             BSD
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         nomaintainer
 

--- a/python/py-pyobjc-fsevents/Portfile
+++ b/python/py-pyobjc-fsevents/Portfile
@@ -18,7 +18,7 @@ distname            pyobjc-framework-FSEvents-${version}
 checksums           rmd160  3221afb058d70b8751d6a1c663bfbc37d25828b3 \
                     sha256  1a41d9ff4fc1597c8ca482076306cf8c7519a536281563cbadf7fc097376db34
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 # since there is replication of code all these pyObjc related framework should probably all be merged
 # as subports of py-pyobj

--- a/python/py-pyobjc-qtkit/Portfile
+++ b/python/py-pyobjc-qtkit/Portfile
@@ -24,7 +24,7 @@ distname            pyobjc-framework-QTKit-${version}
 checksums           rmd160  d032d56b1007fc45ca5c36b29d90717f3075508a \
                     sha256  4dccc8bcf29c474de437a68907a6e6ff6eafe2530885fcaddcca05675f7649d6
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib         port:py${python.version}-pyobjc-quartz

--- a/python/py-pyorick/Portfile
+++ b/python/py-pyorick/Portfile
@@ -30,7 +30,7 @@ distname            pyorick-${version}
 checksums           rmd160  563ca3a68e452a48e0f1a1dd7290dfda04f01647 \
                     sha256  a03167e874a45201ce479b7153fd9447981418c53d175931e01cf874cdcf4f72
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pypdf2/Portfile
+++ b/python/py-pypdf2/Portfile
@@ -24,7 +24,7 @@ long_description        A Pure-Python PDF toolkit. It is capable of \
 checksums               rmd160  15953f4bc160a060ec5e9772dec4e802c7e22415 \
                         sha256  f007889cbaa19f9fd4c69b37eb2f28a8ddc995ad29a1c906546529b9a80f6373
 
-python.versions         26 27 34 35
+python.versions         26 27 34 35 36
 
 if {${name} ne ${subport}} {
     post-destroot {

--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -28,7 +28,7 @@ distname            ${real_name}-${version}
 checksums           rmd160  45d5f581afd5ee68f25bf1fabb8f9b89dd97516b \
                     sha256  4c0589774e3c8b0c374931397cf6356b9cc99a790215d1917bb7f015c6f0729a
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_lib-append      port:py${python.version}-scipy

--- a/python/py-pyquery/Portfile
+++ b/python/py-pyquery/Portfile
@@ -21,7 +21,7 @@ distname                    pyquery-${version}
 checksums                   rmd160  bce4fef874ecdefcb98b1af3d15e4972e613e068 \
                             sha256  1c39f786c42430279eadf787f1ef06873f15c9acba2698c23dfd925ac7b169d7
 
-python.versions             27 34
+python.versions             27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-pyro/Portfile
+++ b/python/py-pyro/Portfile
@@ -25,7 +25,7 @@ maintainers         fusion.gat.com:smithsp openmaintainer
 checksums           rmd160  91f221b6f24b4707d94b3bd95e6e72830ff6e706 \
                     sha256  b194e71f2d830d747015cd47b9fc79776e4933406894645f6c7fc76f45738753
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-pyrxp/Portfile
+++ b/python/py-pyrxp/Portfile
@@ -17,7 +17,7 @@ homepage          https://pypi.python.org/pypi/pyRXP
 master_sites      pypi:p/pyRXP/
 distname          pyRXP-${version}
 
-python.versions   27 33 34
+python.versions   27 33 34 35 36
 
 checksums         md5     945b6586a0bc16e1735bca1244e824c6 \
                   rmd160  62140c9da21066772582d5e0908c28e5971255ac \

--- a/python/py-pysal/Portfile
+++ b/python/py-pysal/Portfile
@@ -18,7 +18,7 @@ distname                pysal-${version}
 checksums               rmd160  a6136c7eef8eb0796b9af10da5e7bdb570b74b6d \
                         sha256  f055a39ca8c159e3384a1a34e56b6e1f8b56ea7acd507c6867fdb64d11ae6f9d
 
-python.versions         27 34 35 
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib             port:py${python.version}-numpy \

--- a/python/py-pystache/Portfile
+++ b/python/py-pystache/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 33 34 35
+python.versions     27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-python-augeas/Portfile
+++ b/python/py-python-augeas/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-python-augeas
 set real_name       python-augeas
 version             1.0.3
-python.versions     27 34 35
+python.versions     27 34 35 36
 maintainers         nomaintainer
 license             LGPL-2.1+
 description         Python bindings for Augeas

--- a/python/py-python-augeas05/Portfile
+++ b/python/py-python-augeas05/Portfile
@@ -7,7 +7,7 @@ name                py-python-augeas05
 set real_name       python-augeas
 epoch               1
 version             0.5.0
-python.versions     27 34 35
+python.versions     27 34 35 36
 maintainers         nomaintainer
 license             LGPL-2.1+
 description         Python bindings for Augeas

--- a/python/py-pyviennacl/Portfile
+++ b/python/py-pyviennacl/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-pywcs/Portfile
+++ b/python/py-pywcs/Portfile
@@ -8,7 +8,7 @@ name                py-pywcs
 version             1.11-4.8.2
 revision            2
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     replaced_by     py${python.version}-astropy

--- a/python/py-pyx/Portfile
+++ b/python/py-pyx/Portfile
@@ -25,7 +25,7 @@ distname            PyX-${version}
 checksums           rmd160  1beb789478f6b93fdec25b101158a65a455f778c \
                     sha256  05d1b7fc813379d2c12fcb5bd0195cab522b5aabafac88f72913f1d47becd912
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  bin:tex:texlive

--- a/python/py-pyxb/Portfile
+++ b/python/py-pyxb/Portfile
@@ -22,7 +22,7 @@ long_description \
 checksums       rmd160  d46433cde04a0396e2f6fb7bbaaf16473d88abee \
                 sha256  fbde9edc292010904c5adefa1fc553babaaa0b16c8afa7f41fd20408991f3cb8
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
 

--- a/python/py-qdarkstyle/Portfile
+++ b/python/py-qdarkstyle/Portfile
@@ -29,7 +29,7 @@ checksums           md5     0f50dd5f1c7ed07e3547115a5e614ea6 \
                     rmd160  f845a22dd31936b51ecfb7a184ff411d458ff0cf \
                     sha256  137eb8f707ddc954224ec28bfa03d1e2d5db8fbde0ad2f622294dfed36f9d6ea
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-quantities/Portfile
+++ b/python/py-quantities/Portfile
@@ -25,7 +25,7 @@ long_description    \
 
 checksums           rmd160  a9be07abc6ceb746e3648cafa11e5762778a25c6 \
                     sha256  d31e55a150a207c68c999611d459b93fc8b501863de993ef7efa47766c84eabd
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-requests-unixsocket/Portfile
+++ b/python/py-requests-unixsocket/Portfile
@@ -20,7 +20,7 @@ long_description    This module uses py-requests to talk HTTP \
 checksums           rmd160  b93fe67f600cf4ab628240c6bea87a215b220988 \
                     sha256  0d017aa6bfa00b15b96a7aa8f9b719c4f146b5ae621d405518ebe67af22aff21
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-responses/Portfile
+++ b/python/py-responses/Portfile
@@ -28,7 +28,7 @@ checksums           md5     f1962b295b18128c522e83901556deac \
                     rmd160  381e17e5ffc7675f27c366cb7537e0436157d8d6 \
                     sha256  8cad64c45959a651ceaf0023484bd26180c927fea64a81e63d334ddf6377ecea
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-robotremoteserver/Portfile
+++ b/python/py-robotremoteserver/Portfile
@@ -18,7 +18,7 @@ long_description    Allows hosting test libraries on different processes \
 homepage            https://github.com/robotframework/PythonRemoteServer
 
 platforms           darwin
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 python.default_version  27
 
 universal_variant   yes

--- a/python/py-rtm/Portfile
+++ b/python/py-rtm/Portfile
@@ -18,7 +18,7 @@ master_sites    pypi:p/pyrtm/
 distname        pyrtm-${version}
 use_bzip2       yes
 
-python.versions 27 34
+python.versions 27 34 35 36
 
 if {${name} ne ${subport}} {
   depends_lib-append port:py${python.version}-setuptools

--- a/python/py-rtree/Portfile
+++ b/python/py-rtree/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             LGPL
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-scikits-module/Portfile
+++ b/python/py-scikits-module/Portfile
@@ -17,7 +17,7 @@ homepage            http://scikits.appspot.com
 
 supported_archs     noarch
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     # Nothing to see here, move along

--- a/python/py-scoop/Portfile
+++ b/python/py-scoop/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             LGPL
 supported_archs     noarch
 
-python.versions     27 33 35
+python.versions     27 33 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-scruffington/Portfile
+++ b/python/py-scruffington/Portfile
@@ -21,7 +21,7 @@ long_description    Scruffy is a framework for taking care of a bunch of \
 checksums           rmd160  bf0c12c3d3203cb9831a57d98039e88a07b78b69 \
                     sha256  a56cc14e0fa97155548012c42151e53afa2b0e28fec651eb3e6113d0bd9ba8f5
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-seqdiag/Portfile
+++ b/python/py-seqdiag/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-serial/Portfile
+++ b/python/py-serial/Portfile
@@ -22,7 +22,7 @@ long_description    This module incapsulates the access for the serial port. \
 checksums           rmd160  6e5466e785a61d42ff9d1de2e4bfa0cf059eb02d \
                     sha256  1e4043a9b02849c3bea778c7a3c53aec17e3465643f199732f2febbf2d01b5a9
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-serpent/Portfile
+++ b/python/py-serpent/Portfile
@@ -23,7 +23,7 @@ long_description    \
 checksums           rmd160  3e05a73e07f07a3cace5b27a5b418725d49cf45f \
                     sha256  d3d3cdb601a81b5693e8462948795a93234f64fbc8d060044eb2c9d199930e5e
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-sexpdata/Portfile
+++ b/python/py-sexpdata/Portfile
@@ -17,7 +17,7 @@ It has simple load and dump functions like pickle, json or PyYAML module.
 checksums           rmd160  e0efa95d961e29cbae9076b6392b589a0655bc2f \
                     sha256  c18876855ae71d1881435c30dbad0c8c5eb6bd6c63b56bc4ee171211374e7511
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     livecheck.type       none

--- a/python/py-sgp4/Portfile
+++ b/python/py-sgp4/Portfile
@@ -23,7 +23,7 @@ long_description    \
 checksums           rmd160  623726d5b4af3784ddf08eeb33fa6f6451be5adf \
                     sha256  15338b568bf07bc0f8471513b1aee140ced3420104e1c65927aecb20629e1a85
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 	depends_lib-append  port:py${python.version}-setuptools

--- a/python/py-sh/Portfile
+++ b/python/py-sh/Portfile
@@ -21,7 +21,7 @@ long_description    ${description} \
 checksums           rmd160  1f5a81d714cf0085f812d26f7cc42706b1ca21a5 \
                     sha256  ebe7e50fd1c28e41aa438bc9447daffd972ddbcbb473ea864781478d6ae5e077
 
-python.versions     26 27 33 34 35
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-shove/Portfile
+++ b/python/py-shove/Portfile
@@ -27,7 +27,7 @@ distname            shove-${version}
 checksums           rmd160  768c3ece5c561ac46039506c4959c482e22c0a1b \
                     sha256  f132c2d22749e9c30421dcc59fa2edb63bea2acd29b7fdc61f37dca984dc5498
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools

--- a/python/py-simpy/Portfile
+++ b/python/py-simpy/Portfile
@@ -17,7 +17,7 @@ long_description \
 
 homepage        http://simpy.readthedocs.org
 
-python.versions 27 33 34
+python.versions 27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append       port:py${python.version}-setuptools

--- a/python/py-slepc4py/Portfile
+++ b/python/py-slepc4py/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  4eb11e30d5ab1b415977f7fb73e729f945ef7c78 \
 
 mpi.setup           require
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 build.env-append    PETSC_DIR=${prefix}/lib/petsc SLEPC_DIR=${prefix}/lib/slepc
 destroot.env-append PETSC_DIR=${prefix}/lib/petsc SLEPC_DIR=${prefix}/lib/slepc

--- a/python/py-snmp/Portfile
+++ b/python/py-snmp/Portfile
@@ -21,7 +21,7 @@ distname		pysnmp-${version}
 checksums       rmd160  e2d0dafa6edf9b2940244adec4719dfe393b7a9b \
                 sha256  c46e65d99a604f690b3d5800e2f6e26e1ed9a3c7f7e17e7b4b4d897150f7077f
 
-python.versions 27 34
+python.versions 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-asn1 \

--- a/python/py-socketpool/Portfile
+++ b/python/py-socketpool/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-speaklater/Portfile
+++ b/python/py-speaklater/Portfile
@@ -24,7 +24,7 @@ distname            ${_name}-${version}
 checksums           rmd160  70c03aa32233a9f4a6dd352c4dca1fe0d1888ffe \
                     sha256  59fea336d0eed38c1f0bf3181ee1222d0ef45f3a9dd34ebe65e6bfffdd6a65a9
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  regex

--- a/python/py-suds-jurko/Portfile
+++ b/python/py-suds-jurko/Portfile
@@ -27,7 +27,7 @@ use_bzip2           yes
 checksums           rmd160  34329d93f0e784671539d08764959a18721752bb \
                     sha256  29edb72fd21e3044093d86f33c66cf847c5aaab26d64cb90e69e528ef014e57f
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 python.default_version  27
 
 if {${name} ne ${subport}} {

--- a/python/py-sumy/Portfile
+++ b/python/py-sumy/Portfile
@@ -24,7 +24,7 @@ use_zip             yes
 checksums           rmd160  081d45a1d5aca397667aeabcc0e6d65d375fc345 \
                     sha256  f0755f044118fe95a7c5e01dae973a2a894b1a5975b7bb7a7e73e63faad8ab9c
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-docopt \

--- a/python/py-svipc/Portfile
+++ b/python/py-svipc/Portfile
@@ -21,7 +21,7 @@ homepage            https://github.com/mdcb/yp-svipc
 checksums           rmd160  5faa9b3943e638bdae084018316ddfe50d1c9aa4 \
                     sha256  9f879670ecb4df71f1851cd3ac0250fdd2317baeb25e200f924037cc120dd1e3
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-swap/Portfile
+++ b/python/py-swap/Portfile
@@ -13,7 +13,7 @@ long_description    ${description}
 
 homepage            http://www.panstamp.com/
 
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-taskw/Portfile
+++ b/python/py-taskw/Portfile
@@ -19,7 +19,7 @@ long_description    ${description} It contains two implementations: \
 platforms           darwin
 license             GPL-3
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-tc/Portfile
+++ b/python/py-tc/Portfile
@@ -17,7 +17,7 @@ distname            tc-${version}
 checksums           md5  4405e1464caf0a0b1e1bc30f0874cd9f \
                     sha1 cf95b3c67ab632b551042b9b75d29036cdece0d8
 
-python.versions     26 27 34
+python.versions     26 27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:tokyocabinet

--- a/python/py-textile/Portfile
+++ b/python/py-textile/Portfile
@@ -19,7 +19,7 @@ homepage            https://pypi.python.org/pypi/textile
 master_sites        pypi:t/textile/
 distname            textile-${version}
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 checksums           rmd160  ca2870e180fe3764b0273bcad7847c818fdab6d3 \
                     sha256  4899f06c63bfdc32a204d4c1c1e9302ddf17f26c20328419747d109348e23afd

--- a/python/py-texttable/Portfile
+++ b/python/py-texttable/Portfile
@@ -20,4 +20,4 @@ distname            texttable-${version}
 checksums           rmd160  e612f66d2327ee99b97353eca445d0eeeb3513fe \
                     sha256  f333ac915e7c5daddc7d4877b096beafe74ea88b4b746f82a4b110f84e348701
 
-python.versions     27 34
+python.versions     27 34 35 36

--- a/python/py-threadpool/Portfile
+++ b/python/py-threadpool/Portfile
@@ -35,7 +35,7 @@ checksums           md5     343bd94fa32effcc9367d382323b4cb3 \
                     rmd160  ede7bc376bd2eec52c5798e13e93881434e6aaa2 \
                     sha256  cce4ef898b7eda686a6086facf33c9ac006d1809281db0030673d1647bfeefa4
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-tinycss/Portfile
+++ b/python/py-tinycss/Portfile
@@ -24,7 +24,7 @@ homepage                https://tinycss.readthedocs.io/en/latest/
 checksums               rmd160  bbfe212d317350f8e877ce898805ae4509f738c5 \
                         sha256  fd4828775c8711c159c60323bbd8bdbe3c38a1ea95f615c5158294a8923080f4
 
-python.versions         27 34 35
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-traits/Portfile
+++ b/python/py-traits/Portfile
@@ -20,7 +20,7 @@ platforms           darwin
 checksums           rmd160  7bfc711e951867ed112d798f4d204f5ace39c335 \
                     sha256  e87de459f1ec7c57813b84b6e395a98afed5660a0920b2829b2af7699a35c5e0
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-traitsui/Portfile
+++ b/python/py-traitsui/Portfile
@@ -20,7 +20,7 @@ platforms           darwin
 checksums           rmd160  2135fd90e51f3470f1dbfbe01303de24d7a99e48 \
                     sha256  93fe84a9cfe04eb3a3169083de71b68f7292be3498f378feafd5caa2c776c26a
 
-python.versions     27 35
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-transaction/Portfile
+++ b/python/py-transaction/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-transaction
 set real_name       transaction
 version             1.2.0
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   databases
 maintainers         nomaintainer
 license             ZPL-2.1

--- a/python/py-triangle/Portfile
+++ b/python/py-triangle/Portfile
@@ -25,7 +25,7 @@ checksums           md5     ef7e121d51a8dc2bd5163a0db11b2b16 \
                     rmd160  4aa893ccaf47db733d11bb87b2bd5793e2e8a987 \
                     sha256  419fb6d773e6c187a3b850cfd74970dfd31804a5c9281207fd4198384fb1b27a
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_lib-append   port:triangle

--- a/python/py-trollius/Portfile
+++ b/python/py-trollius/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-tstables/Portfile
+++ b/python/py-tstables/Portfile
@@ -10,7 +10,7 @@ categories-append   science
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-tweepy/Portfile
+++ b/python/py-tweepy/Portfile
@@ -20,7 +20,7 @@ homepage            http://www.tweepy.org/
 checksums           rmd160  f846d121b6aa28ef9027403f1aac94ad97b6579a \
                     sha256  37eb7230f90a7ad2ac1cae198acc98941c5089bd16c4a12256009a7231edb333
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -28,7 +28,7 @@ checksums           md5     5b2ade08d83be488f17b5fe587c27c74 \
                     rmd160  0c03e1a2972bc8ed83494ef5a92f06a76d32e7d9 \
                     sha256  d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2
 
-python.versions     27 33 34
+python.versions     27 33 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-tz-gae/Portfile
+++ b/python/py-tz-gae/Portfile
@@ -18,7 +18,7 @@ homepage        https://code.google.com/p/gae-pytz/
 master_sites    pypi:g/${real_name}
 distname        ${real_name}-${version}
 
-python.versions 27 34
+python.versions 27 34 35 36
 
 checksums       rmd160  f704e2c99016d115d27f03fd47c5cb89721fc9d4 \
                 sha256  d6e214fdc071c9a22234aed92ea763889501d0c000ee202b8a5493ef4390843b

--- a/python/py-unittest2/Portfile
+++ b/python/py-unittest2/Portfile
@@ -8,7 +8,7 @@ version             0.5.1
 revision            1
 license             PSF
 maintainers         {aronnax @lpsinger} openmaintainer
-python.versions     26 27 33 34
+python.versions     26 27 33 34 35 36
 
 description         New features in the unittest library
 

--- a/python/py-urlwatch/Portfile
+++ b/python/py-urlwatch/Portfile
@@ -30,7 +30,7 @@ livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     "Current version: (\\d+(?:\\.\\d+)*)"
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools

--- a/python/py-virtualfish/Portfile
+++ b/python/py-virtualfish/Portfile
@@ -29,7 +29,7 @@ checksums               rmd160  e1c2936e459aa21c7461090639fc5cfe60e9de44 \
 patchfiles              patch-setup.py.diff
 
 # Possibly other versions works as well, please test and patch
-python.versions         27 35
+python.versions         27 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-virtualenv \

--- a/python/py-visa/Portfile
+++ b/python/py-visa/Portfile
@@ -31,7 +31,7 @@ long_description    PyVISA allows dialog between a computer and\
 checksums           rmd160  6bc43d1aed4f8f9823ec164ecc510bdb224164fe \
                     sha256  42711646de0b77b8c6d786da7fdda1b4dc3a47453c55880dc9391fc049e82136
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools\

--- a/python/py-vobject/Portfile
+++ b/python/py-vobject/Portfile
@@ -24,7 +24,7 @@ homepage            https://eventable.github.io/vobject/
 checksums           rmd160  04c5dcb5fed4a2b3bd3ba69526fab7403ac13712 \
                     sha256  e43e4fe03f8a0077f8d0d9ab3cb66273b3fda0d7e1de19c0316f95bd5e9ba02f
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-dateutil \

--- a/python/py-wand/Portfile
+++ b/python/py-wand/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-whoosh/Portfile
+++ b/python/py-whoosh/Portfile
@@ -28,7 +28,7 @@ checksums           md5     9d35a7498d5c7af8fe162f63719f4eeb \
                     rmd160  e5bd168af8cc5cd601af9d3aff6c6cb85c38d61c \
                     sha256  450d3b76c45dd26ceda101ebafee181c7ab377e8ea37ff5aaca1be79227f73fa
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-word2vec/Portfile
+++ b/python/py-word2vec/Portfile
@@ -19,7 +19,7 @@ master_sites        pypi:w/${real_name}/
 
 distname            ${real_name}-${version}
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     checksums           rmd160  d2157e7f525468fd325d2f88eb93da06030c7857 \

--- a/python/py-wtforms/Portfile
+++ b/python/py-wtforms/Portfile
@@ -26,7 +26,7 @@ use_zip             yes
 checksums           rmd160  f509df447f3cc6a55bdc0bd40ee1f9e4715e0023 \
                     sha256  62859c74be4683601b5265ba83b9babd8a8f1cdd0ba31600fa1e70d295cd4ed2
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  regex

--- a/python/py-x2go/Portfile
+++ b/python/py-x2go/Portfile
@@ -24,7 +24,7 @@ supported_archs     noarch
 master_sites        http://code.x2go.org/releases/source/python-x2go/
 distname            python-x2go-${version}
 
-python.versions     27 34
+python.versions     27 34 35 36
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-xattr/Portfile
+++ b/python/py-xattr/Portfile
@@ -25,7 +25,7 @@ distname            xattr-${version}
 checksums           rmd160  15a8cb415077e3b66af6c7eafe4bd3f10b964294 \
                     sha256  71d08712f78ed543215e4145779a336e42acb4003b97e16d493a680cf08f1d01
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-yappi/Portfile
+++ b/python/py-yappi/Portfile
@@ -13,7 +13,7 @@ platforms           darwin
 maintainers         openmaintainer {adfernandes @adfernandes}
 
 supported_archs     noarch
-python.versions     27 34
+python.versions     27 34 35 36
 
 description         Yet Another Python Profiler.
 long_description    \

--- a/python/py-yapsy/Portfile
+++ b/python/py-yapsy/Portfile
@@ -24,7 +24,7 @@ distname            $realName-${version}
 checksums           rmd160  e5d0ce20047d339856ade3345be63fae0c5d41bd \
                     sha256  9ba7767f63ab591c0ad3fc8b2bd11ac19a0fabb7259bcb1733858eab5bd9b1e1
 
-python.versions     27 34
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-yt/Portfile
+++ b/python/py-yt/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  34e493fed435b837ca9c1934110c74b11a40d589 \
                     sha256  de52057d1677473a83961d8a1119a9beae3121ec69a4a5469c65348a75096d4c \
                     md5     4e3df6a98d6199a942a67a701bffb406
 
-python.versions     27 34 35
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_run-append  port:py${python.version}-numpy \

--- a/python/py-zen/Portfile
+++ b/python/py-zen/Portfile
@@ -5,7 +5,7 @@ name                py-zen
 set real_name       PyZen
 version             0.3.2
 revision            1
-python.versions     27 34
+python.versions     27 34 35 36
 categories-append   devel
 platforms           darwin
 supported_archs     noarch


### PR DESCRIPTION
Untested addition of python 3.5 and 3.6 subports.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
