### PR TITLE
mercurial: point master_sites to official download location

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           bitbucket 1.0
 
+name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-bitbucket.setup     seanfarley mercurial 4.5
+version             4.5
 categories          devel python
 license             GPL-2+
 maintainers         sean openmaintainer
@@ -27,8 +28,10 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 
 homepage            http://www.mercurial-scm.org
 platforms           darwin
-checksums           rmd160  5dbe7f98426d71e8ce60c5d026a71e28686f43da \
-                    sha256  e14e42cc72f1650501784b9f3c571cb862b5f3f5825dd398e1349b1c709531dc
+master_sites        https://www.mercurial-scm.org/release/
+checksums           rmd160  646b6f06a793320db6a84d53749fc53906c3db38 \
+                    sha256  4d9338d9f9d88dc90b836d1227a3677e3347efaf2a118cc97d7fd1f605f1f265 \
+                    size    5876130
 
 depends_build       port:py27-docutils
 
@@ -50,6 +53,7 @@ subport mercurial-devel {
     revision            0
 
     conflicts           mercurial
+    master_sites        ${bitbucket.master_sites}
     checksums           rmd160  6035b11e2e037b824b61231a49e8a53f1a69d3a9 \
                         sha256  0812e74014fdc15b4f0b61e1528c30461bd6efc2f64e40059d047139faffe838
 }


### PR DESCRIPTION
@seanfarley I noticed that livecheck for Mercurial was not detecting recent releases, then I noticed that the port is pointing to a mirror in BitBucket maintained by you (which has not been updated in a while) and not the official upstream location. I wonder why this was done? Could you clarify? I thought this was frowned upon.

My understanding is that ports should always download from official distribution sites, so I propose that the `Portfile` should be changed to point to the canonical download location: https://www.mercurial-scm.org/release/. To save you the trouble, I am submitting the change here, and updated the hashes to match the official tarball. This change also fixes the livecheck.
