### PR TITLE
pipsi: new port submission

### DIFF
--- a/python/pipsi/Portfile
+++ b/python/pipsi/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+# Note: do not update to commits in the range 95060fa..6256bcb. They're buggy.
+github.setup        mitsuhiko pipsi 6a890c8a0ccd1450a4fdb4d00dc1eb3c3a32d8fe
+version             20171126
+categories          python sysutils
+license             MIT
+maintainers         {lbschenkel @lbschenkel} openmaintainer
+supported_archs     noarch
+platforms           darwin
+
+description         pip script installer
+long_description    Wrapper around virtualenv and pip which installs scripts \
+                    provided by Python packages into separate virtualenvs to \
+                    shield them from your system and each other.
+
+checksums           rmd160  45a945d2d518cf3e6a6d5a24362921fb8c86c19b \
+                    sha256  36850d2379855742ac86158ce915586dd27fbb274776618bd54df7b85a3e9830 \
+                    size    9282
+
+python.default_version 36
+depends_lib         port:py${python.version}-click \
+                    port:py${python.version}-virtualenv
+


### PR DESCRIPTION
Although `pipsi` is tagged, last tag is `0.9` from 2015 and there have been
considerable changes since then. The project own installation
instructions direct the user to install the latest version from master.
For this reason this port will track the master branch until upstream
starts tagging releases again.

While testing I found out that the latest code in master is buggy
(2018-01-10), so I am building the code from 2017-11-26 instead.