### PR TITLE
Add GitHub handle jjstickel to maintainers

### DIFF
--- a/devel/git-latexdiff/Portfile
+++ b/devel/git-latexdiff/Portfile
@@ -7,7 +7,7 @@ version             1.2.0
 categories          devel tex
 platforms           darwin
 supported_archs     noarch
-maintainers         @jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 license             BSD
 
 description         Tool for using latexdiff on latex documents in git \

--- a/graphics/inkscape-textext/Portfile
+++ b/graphics/inkscape-textext/Portfile
@@ -6,7 +6,7 @@ name                    inkscape-textext
 version                 0.4.4
 revision                2
 categories              graphics tex
-maintainers             gmail.com:jjstickel
+maintainers             {gmail.com:jjstickel @jjstickel}
 license                 BSD
 platforms               darwin
 homepage                http://pav.iki.fi/software/textext/

--- a/math/libqalculate/Portfile
+++ b/math/libqalculate/Portfile
@@ -7,7 +7,7 @@ github.setup        qalculate libqalculate 2.2.0 v
 
 categories          math
 platforms           darwin
-maintainers         gmail.com:jjstickel
+maintainers         {gmail.com:jjstickel @jjstickel}
 license             GPL-2+
 
 description \

--- a/math/minpack/Portfile
+++ b/math/minpack/Portfile
@@ -7,7 +7,7 @@ version             19961126
 categories          math devel
 license             bsd
 platforms           darwin
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Minpack includes software for solving nonlinear equations\
     and nonlinear least squares problems.

--- a/math/qalculate-gtk/Portfile
+++ b/math/qalculate-gtk/Portfile
@@ -8,7 +8,7 @@ github.setup        qalculate qalculate-gtk 2.2.0 v
 categories          math
 platforms           darwin
 license             GPL-2+
-maintainers         gmail.com:jjstickel
+maintainers         {gmail.com:jjstickel @jjstickel}
 
 description         Qalculate! is a multi-purpose desktop calculator
 long_description    Qalculate! is a multi-purpose desktop calculator. \

--- a/python/py-apptools/Portfile
+++ b/python/py-apptools/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought apptools 4.4.0
 name                py-apptools
 categories-append   devel
 license             BSD
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 supported_archs     noarch
 
 description         The Enthought apptools package

--- a/python/py-blockcanvas/Portfile
+++ b/python/py-blockcanvas/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought blockcanvas 4.0.3
 name                py-blockcanvas
 categories-append   devel
 license             BSD
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         The Enthought visual environment for creating simulation experiments
 long_description    The blockcanvas project provides a visual environment for\
                     creating simulation experiments, where function and data\

--- a/python/py-chaco/Portfile
+++ b/python/py-chaco/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought chaco 4.5.0
 name                py-chaco
 categories-append   devel
 license             BSD PSF
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 platforms           darwin
 description         The Enthought chaco package for 2-D plotting
 long_description    Chaco is a Python plotting application toolkit that\

--- a/python/py-codetools/Portfile
+++ b/python/py-codetools/Portfile
@@ -8,7 +8,7 @@ version             4.0.0
 revision            1
 categories-append   devel
 license             BSD
-maintainers         vcn.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Code analysis and execution tools
 

--- a/python/py-cvxopt/Portfile
+++ b/python/py-cvxopt/Portfile
@@ -12,7 +12,7 @@ name                py-cvxopt
 categories-append   math
 platforms           darwin
 license             GPL-3+
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Python module for convex optimization
 long_description    CVXOPT is a free software package for convex \

--- a/python/py-enable/Portfile
+++ b/python/py-enable/Portfile
@@ -8,7 +8,7 @@ github.setup        enthought enable 4.5.0
 
 name                py-enable
 categories-append   devel
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         The Enthought enable package
 long_description    The Enable project provides two related multi-platform\
                     packages for drawing GUI objects.  Enable: An object\

--- a/python/py-enthoughtbase/Portfile
+++ b/python/py-enthoughtbase/Portfile
@@ -7,7 +7,7 @@ name                py-enthoughtbase
 version             3.1.0
 categories-append   devel
 license             BSD
-maintainers         vcn.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 supported_archs     noarch
 
 description         The Enthought base package

--- a/python/py-envisage/Portfile
+++ b/python/py-envisage/Portfile
@@ -8,7 +8,7 @@ github.setup        enthought envisage 4.5.1
 
 name                py-envisage
 categories-append   devel
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         The Enthought envisage package
 long_description    Envisage is a Python-based framework for building\
     extensible applications, that is, applications whose functionality can\

--- a/python/py-etsdevtools/Portfile
+++ b/python/py-etsdevtools/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought etsdevtools 4.0.2
 name                py-etsdevtools
 categories-append   devel
 license             BSD
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         Enthought tools to support Python development
 long_description    The etsdevtools project includes a set of packages that \
                     can be used during the development of a software project,\

--- a/python/py-etsproxy/Portfile
+++ b/python/py-etsproxy/Portfile
@@ -7,7 +7,7 @@ name                py-etsproxy
 version             0.1.1
 categories-append   devel
 license             BSD
-maintainers         vcn.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Proxy modules for backwards compatibility
 

--- a/python/py-fipy/Portfile
+++ b/python/py-fipy/Portfile
@@ -8,7 +8,7 @@ version             3.1
 categories-append   math
 platforms           darwin
 supported_archs     noarch
-maintainers         vcn.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 license             public-domain
 
 description         FiPy: A Finite Volume PDE Solver Using Python

--- a/python/py-gsl/Portfile
+++ b/python/py-gsl/Portfile
@@ -9,7 +9,7 @@ revision                1
 categories-append       science
 license                 GPL-2+
 platforms               darwin
-maintainers             gmail.com:jjstickel openmaintainer
+maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description             Python interface to the GNU Scientific Library
 long_description        Python interface to the GSL, the GNU Scientfic \

--- a/python/py-kiwisolver/Portfile
+++ b/python/py-kiwisolver/Portfile
@@ -8,7 +8,7 @@ github.setup        nucleic kiwi 1.0.1
 
 name                py-kiwisolver
 categories-append   math
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         Kiwi is an efficient C++ implementation of the Cassowary constraint solving algorithm.
 long_description    Kiwi is an implementation of the algorithm based on the\
                     seminal Cassowary paper. It is not a refactoring of the\

--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -7,7 +7,7 @@ name                    py-lmfit
 version                 0.9.5
 categories-append       math
 license                 BSD
-maintainers             gmail.com:jjstickel openmaintainer
+maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 description             Least-Squares Minimization with Bounds and Constraints
 long_description        Built on top of scipy.optimize, lmfit provides a\
                         Parameter object which can be set as fixed or free,\

--- a/python/py-mayavi/Portfile
+++ b/python/py-mayavi/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought mayavi 4.5.0
 
 name                py-mayavi
 categories-append   devel graphics math
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         The Enthought mayavi package
 long_description    3D Scientific Data Visualization and Plotting using VTK as the \
     rendering backend and wxpython or pyqt4 for the (G)UI.

--- a/python/py-pkginfo/Portfile
+++ b/python/py-pkginfo/Portfile
@@ -7,7 +7,7 @@ name                py-pkginfo
 version             1.4.1
 platforms           darwin
 license             MIT
-maintainers         {@jjstickel gmail.com:jjstickel} openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Query metadatdata from sdists and bdists installed packages.
 long_description \

--- a/python/py-pyface/Portfile
+++ b/python/py-pyface/Portfile
@@ -11,7 +11,7 @@ github.setup            enthought pyface 5.1.0
 name                    py-pyface
 categories-append       devel
 license                 BSD
-maintainers             gmail.com:jjstickel openmaintainer
+maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 supported_archs         noarch
 
 description             The Enthought pyface package

--- a/python/py-pysparse/Portfile
+++ b/python/py-pysparse/Portfile
@@ -8,7 +8,7 @@ version             1.1.1
 revision            1
 categories-append   math
 platforms           darwin
-maintainers         vcn.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 license             BSD
 
 description         a fast sparse matrix library for Python

--- a/python/py-requests-toolbelt/Portfile
+++ b/python/py-requests-toolbelt/Portfile
@@ -9,7 +9,7 @@ github.setup        requests toolbelt 0.8.0
 name                py-requests-toolbelt
 platforms           darwin
 license             apache
-maintainers         {@jjstickel gmail.com:jjstickel} openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Collection of utilities for python-requests
 long_description    This is just a collection of utilities for\

--- a/python/py-scikit-umfpack/Portfile
+++ b/python/py-scikit-umfpack/Portfile
@@ -10,7 +10,7 @@ name                py-scikit-umfpack
 categories-append   math
 platforms           darwin
 license             BSD
-maintainers         {@jjstickel gmail.com:jjstickel} openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         scikit-umfpack provides wrapper of UMFPACK sparse direct solver to SciPy.
 long_description    ${description}

--- a/python/py-scimath/Portfile
+++ b/python/py-scimath/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought scimath 4.1.2
 name                py-scimath
 categories-append   devel
 license             BSD
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         The Enthought scimath package
 long_description    The SciMath project includes packages to support\
                     scientific and mathematical calculations,\

--- a/python/py-traits/Portfile
+++ b/python/py-traits/Portfile
@@ -9,7 +9,7 @@ github.setup        enthought traits 4.5.0
 name                py-traits
 categories-append   devel
 license             BSD {PSF ZPL}
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         The Enthought traits package
 long_description    A trait is a type definition that can be used for normal\

--- a/python/py-traitsui/Portfile
+++ b/python/py-traitsui/Portfile
@@ -10,7 +10,7 @@ name                py-traitsui
 categories-append   devel
 # traitsui/wx/editors_gen.py is GPLv2
 license             BSD GPL-2
-maintainers         gmail.com:jjstickel openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         The Enthought traitsui package
 long_description    The traitsui project contains a toolkit-independent GUI\
                     abstraction layer, which is used to support the\

--- a/python/py-twine/Portfile
+++ b/python/py-twine/Portfile
@@ -9,7 +9,7 @@ github.setup        pypa twine 1.9.1
 name                py-twine
 platforms           darwin
 license             apache
-maintainers         {@jjstickel gmail.com:jjstickel} openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 
 description         Twine is a utility for interacting with PyPI.
 long_description    ${description}

--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -9,7 +9,7 @@ github.setup            lebigot uncertainties 2.4.8.1
 name                    py-uncertainties
 categories-append       math
 license                 BSD
-maintainers             gmail.com:jjstickel openmaintainer
+maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 description             The python uncertainties package.
 long_description        The uncertainties package transparently handles\
                         calculations for numbers with\

--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -16,7 +16,7 @@ license             BSD
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
-maintainers         gmail.com:jjstickel {dstrubbe @dstrubbe} openmaintainer
+maintainers         {gmail.com:jjstickel @jjstickel} {dstrubbe @dstrubbe} openmaintainer
 
 description         3D data analysis and visualization application
 

--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    pdfjam
 version                 2.08
 categories              textproc pdf
-maintainers             vcn.com:jjstickel
+maintainers             {gmail.com:jjstickel @jjstickel}
 license                 GPL-2
 platforms               darwin
 homepage                http://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam


### PR DESCRIPTION
#### Description

Add GitHub handle @jjstickel to maintainers

Some ports were using the maintainer's vcn.com email address; I switched them to the gmail.com address for consistency.

<!-- [skip notification] -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
