### PR TITLE
Add puregh portgroup

### DIFF
--- a/_resources/port1.0/group/puregh-1.0.tcl
+++ b/_resources/port1.0/group/puregh-1.0.tcl
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# Copyright (c) 2009-2018 The MacPorts Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of The MacPorts Project nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# This PortGroup automatically sets up the standard environment for building
+# a module for the Pure language (Github version).
+#
+# Usage:
+#
+#   PortGroup               puregh 1.0
+#   pure.setup              module module_version
+#
+# where module is the name of the module (e.g. pure-gsl) and module_version is
+# its version.
+
+
+PortGroup                       github 1.0
+
+proc pure.setup {module module_version} {
+    global name homepage
+
+    github.setup                agraef pure-lang ${module_version} ${module}-
+    name                        ${module}
+    categories-append           pure
+    homepage                    https://github.com/agraef/pure-lang/wiki/Addons#${name}
+    github.tarball_from         releases
+    distname                    ${name}-${module_version}
+
+    depends_lib-append          port:pure
+
+    use_configure               no
+
+    build.args-append           PUREC_FLAGS=-mcpu=generic
+
+    pre-build {
+        if {${configure.cxx_stdlib} ne "" && [string match "*clang*" [option configure.cxx]]} {
+            configure.cxxflags-append -stdlib=${configure.cxx_stdlib}
+        }
+        build.args-append       CC="${configure.cc}" \
+                                CFLAGS="${configure.cflags} ${configure.cc_archflags}" \
+                                CPPFLAGS="${configure.cppflags}" \
+                                CXX="${configure.cxx}" \
+                                CXXFLAGS="${configure.cxxflags} ${configure.cxx_archflags}" \
+                                LDFLAGS="${configure.ldflags} ${configure.ld_archflags}"
+    }
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/doc/${name}
+        foreach f {COPYING README} {
+            if {[file exists ${worksrcpath}/${f}]} {
+                xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/doc/${name}
+            }
+        }
+        if {[file exists ${worksrcpath}/examples]} {
+            xinstall -d ${destroot}${prefix}/share/examples
+            copy ${worksrcpath}/examples ${destroot}${prefix}/share/examples/${name}
+        }
+    }
+}

--- a/pure/faust2pd/Portfile
+++ b/pure/faust2pd/Portfile
@@ -1,15 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       github 1.0
+PortGroup                       puregh 1.0
 
-name                            faust2pd
-github.setup                    agraef pure-lang 2.16 ${name}-
-github.tarball_from             releases
-distname                        ${name}-${version}
-homepage                        https://github.com/agraef/pure-lang/wiki/Addons#${name}
-
-categories                      pure audio devel
+pure.setup                      faust2pd 2.16
+categories-append               audio devel
 platforms                       darwin
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license                         GPL-3+
@@ -21,38 +16,7 @@ long_description                ${name} is ${description}.
 checksums                       rmd160  cddc64a42ed718dbdeddef4c7ec196294e20e8ef \
                                 sha256  6538f85f913d11441a6746d2f352b3e14ea2012ab3c77658a5500ffc641c20e6
 
-use_configure                   no
-
-# copied from pure-1.0.tcl
-build.args-append               PUREC_FLAGS=-mcpu=generic
-
-pre-build {
-    if {${configure.cxx_stdlib} ne "" && [string match "*clang*" [option configure.cxx]]} {
-        configure.cxxflags-append -stdlib=${configure.cxx_stdlib}
-    }
-    build.args-append           CC="${configure.cc}" \
-                                CFLAGS="${configure.cflags} ${configure.cc_archflags}" \
-                                CPPFLAGS="${configure.cppflags}" \
-                                CXX="${configure.cxx}" \
-                                CXXFLAGS="${configure.cxxflags} ${configure.cxx_archflags}" \
-                                LDFLAGS="${configure.ldflags} ${configure.ld_archflags}"
-}
-
-post-destroot {
-    xinstall -d ${destroot}${prefix}/share/doc/${name}
-    foreach f {COPYING README} {
-        if {[file exists ${worksrcpath}/${f}]} {
-            xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/doc/${name}
-        }
-    }
-    if {[file exists ${worksrcpath}/examples]} {
-        xinstall -d ${destroot}${prefix}/share/examples
-        copy ${worksrcpath}/examples ${destroot}${prefix}/share/examples/${name}
-    }
-}
-
-depends_lib-append              port:pure \
-                                port:pure-xml
+depends_lib-append              port:pure-xml
 
 build.args-append               LIBRARY_PATH=${prefix}/lib \
                                 prefix=${prefix} \

--- a/pure/pd-faust/Portfile
+++ b/pure/pd-faust/Portfile
@@ -1,15 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       github 1.0
+PortGroup                       puregh 1.0
 
-name                            pd-faust
-github.setup                    agraef pure-lang 0.15 ${name}-
-github.tarball_from             releases
-distname                        ${name}-${version}
-homepage                        https://github.com/agraef/pure-lang/wiki/Addons#${name}
-
-categories                      pure audio devel
+pure.setup                      pd-faust 0.15
+categories-append               audio devel
 platforms                       darwin
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license                         LGPL-3+ MIT
@@ -23,41 +18,10 @@ long_description                ${name} provides ${description}.
 checksums                       rmd160  65aa3cbe2ddc70d5cdbce9379c32e001f7c0ea1b \
                                 sha256  e3286dfd1ccdc93fa81bc45ed593b7c466badf7e8b989b1aaf2a38cdbd417dc2
 
-use_configure                   no
-
-# copied from pure-1.0.tcl
-build.args-append               PUREC_FLAGS=-mcpu=generic
-
-pre-build {
-    if {${configure.cxx_stdlib} ne "" && [string match "*clang*" [option configure.cxx]]} {
-        configure.cxxflags-append -stdlib=${configure.cxx_stdlib}
-    }
-    build.args-append           CC="${configure.cc}" \
-                                CFLAGS="${configure.cflags} ${configure.cc_archflags}" \
-                                CPPFLAGS="${configure.cppflags}" \
-                                CXX="${configure.cxx}" \
-                                CXXFLAGS="${configure.cxxflags} ${configure.cxx_archflags}" \
-                                LDFLAGS="${configure.ldflags} ${configure.ld_archflags}"
-}
-
-post-destroot {
-    xinstall -d ${destroot}${prefix}/share/doc/${name}
-    foreach f {COPYING README} {
-        if {[file exists ${worksrcpath}/${f}]} {
-            xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/doc/${name}
-        }
-    }
-    if {[file exists ${worksrcpath}/examples]} {
-        xinstall -d ${destroot}${prefix}/share/examples
-        copy ${worksrcpath}/examples ${destroot}${prefix}/share/examples/${name}
-    }
-}
-
 depends_build-append            path:bin/faust:faust \
                                 port:pkgconfig
 
-depends_lib-append              port:pure \
-                                port:pure-faust \
+depends_lib-append              port:pure-faust \
                                 port:pure-midi \
                                 port:pure-stldict
 

--- a/pure/pure-faust/Portfile
+++ b/pure/pure-faust/Portfile
@@ -1,15 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       github 1.0
+PortGroup                       puregh 1.0
 
-name                            pure-faust
-github.setup                    agraef pure-lang 0.13 ${name}-
-github.tarball_from             releases
-distname                        ${name}-${version}
-homepage                        https://github.com/agraef/pure-lang/wiki/Addons#${name}
-
-categories                      pure audio lang
+pure.setup                      pure-faust 0.13
+categories-append               audio lang
 platforms                       darwin
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
 license                         LGPL-3+
@@ -23,37 +18,6 @@ long_description                ${name} provides ${description}.
 checksums                       rmd160  3e0709960ddd749693fb459cfc2e01cbf520ee55 \
                                 sha256  5947f8c41e166c9998bd42d90a4a4119a1c7b6962bbf813df5a9839f5f30694a
 
-use_configure                   no
-
-# copied from pure-1.0.tcl
-build.args-append               PUREC_FLAGS=-mcpu=generic
-
-pre-build {
-    if {${configure.cxx_stdlib} ne "" && [string match "*clang*" [option configure.cxx]]} {
-        configure.cxxflags-append -stdlib=${configure.cxx_stdlib}
-    }
-    build.args-append           CC="${configure.cc}" \
-                                CFLAGS="${configure.cflags} ${configure.cc_archflags}" \
-                                CPPFLAGS="${configure.cppflags}" \
-                                CXX="${configure.cxx}" \
-                                CXXFLAGS="${configure.cxxflags} ${configure.cxx_archflags}" \
-                                LDFLAGS="${configure.ldflags} ${configure.ld_archflags}"
-}
-
-post-destroot {
-    xinstall -d ${destroot}${prefix}/share/doc/${name}
-    foreach f {COPYING README} {
-        if {[file exists ${worksrcpath}/${f}]} {
-            xinstall -m 644 ${worksrcpath}/${f} ${destroot}${prefix}/share/doc/${name}
-        }
-    }
-    if {[file exists ${worksrcpath}/examples]} {
-        xinstall -d ${destroot}${prefix}/share/examples
-        copy ${worksrcpath}/examples ${destroot}${prefix}/share/examples/${name}
-    }
-}
-
 depends_build-append            port:pkgconfig
 
-depends_lib-append              port:pure \
-                                port:libtool
+depends_lib-append              port:libtool


### PR DESCRIPTION
#### Description

This adds a new puregh port group which works pretty much like the existing pure port group but handles Pure modules released on Github rather than Bitbucket, now that Pure moved to Github. The three existing portfiles of Pure modules already on Github (faust2pd, pure-faust and pd-faust, recently updated in #1272, #1273 and #1274) are changed so that they use the new port group.

More updates of Pure modules on Github are to be submitted soon, so it made sense to add a special port group for them now (see the comments in the cited PRs). For the time being, the pure port group is still required for the older module releases on Bitbucket. (Once all modules have releases on Github, the old pure port group can then be removed and the new puregh port group renamed to pure, but that is still some time in the future.)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1314
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
