### PR TITLE
gtk3: tweak gcc blacklisting to fix build on PPC

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -58,9 +58,9 @@ patchfiles          O_CLOEXEC-10.6-and-earlier.patch
 # (redefinition of typedef ‘GdkX11Monitor’ at gdkscreen-x11.h:33)
 
 if {[variant_isset quartz]} {
-    compiler.blacklist  *gcc* {clang < 425}
+    compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 425}
 } else {
-    compiler.blacklist  *gcc* {clang < 300}
+    compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 300}
 }
 
 # gobject-introspection uses g-ir-scanner, which uses $CC from env


### PR DESCRIPTION
with the improved compiler defaulting on PPC, this tweak
now allows gtk3 to build on PPC. x11 tested. 
quartz not likely to build or work extensively on PPC due to ancient SDK
the style of the gcc blacklisting suggested by Ryan
closes innumerable tickets to be searched out and closed individually