### PR TITLE
crossgcc-1.0: support version info for newlib

### DIFF
--- a/cross/arm-none-eabi-gcc/Portfile
+++ b/cross/arm-none-eabi-gcc/Portfile
@@ -4,19 +4,11 @@ PortSystem          1.0
 PortGroup           crossgcc 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-crossgcc.setup      arm-none-eabi 5.4.0
-crossgcc.setup_libc newlib 2.5.0
+crossgcc.setup      arm-none-eabi 7.3.0
+crossgcc.setup_libc newlib 3.0.0
 
 revision            3
 maintainers         nomaintainer
-
-checksums           gcc-${version}.tar.bz2 \
-                    rmd160  7ae3413ca7e90bb21e65e637c02ddf2b675b45f4 \
-                    sha256  608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a \
-                    newlib-${crossgcc.libc_version}.tar.gz \
-                    sha1    be1f1960bce564130a0cf9598e388fcc437169dc \
-                    rmd160  fc2beafe309701e02da3d2dff737236f67c0de4d \
-                    sha256  5b76a9b97c9464209772ed25ce55181a7bb144a66e5669aaec945aa64da3189b
 
 patchfiles          patch-enable-with-multilib-list-for-arm.diff
 patch.pre_args      -p1

--- a/cross/arm-none-eabi-gcc/files/patch-enable-with-multilib-list-for-arm.diff
+++ b/cross/arm-none-eabi-gcc/files/patch-enable-with-multilib-list-for-arm.diff
@@ -1,16 +1,16 @@
 Upstream: https://projects.archlinux.org/svntogit/community.git/tree/trunk/enable-with-multilib-list-for-arm.patch?h=packages/arm-none-eabi-gcc
 
-commit 605db6de62e8144a1b8f721c05f40d879f70625b
+commit 71587241301d28b68bbe2f41c5eb2856053c750c
 Author: Anatol Pomozov <anatol.pomozov@gmail.com>
-Date:   Fri Jan 30 06:23:17 2015 -0800
+Date:   Tue May 9 21:19:27 2017 -0700
 
     ARM patch https://gcc.gnu.org/ml/gcc-patches/2012-05/msg00083/enable-with-multilib-list-for-arm.patch
 
 diff --git a/gcc/Makefile.in b/gcc/Makefile.in
-index 4ab7405..6e1ea2c 100644
+index f675e073ecc..cced5329b47 100644
 --- a/gcc/Makefile.in
 +++ b/gcc/Makefile.in
-@@ -535,6 +535,7 @@ lang_opt_files=@lang_opt_files@ $(srcdir)/c-family/c.opt $(srcdir)/common.opt
+@@ -558,6 +558,7 @@ lang_opt_files=@lang_opt_files@ $(srcdir)/c-family/c.opt $(srcdir)/common.opt
  lang_specs_files=@lang_specs_files@
  lang_tree_files=@lang_tree_files@
  target_cpu_default=@target_cpu_default@
@@ -19,10 +19,10 @@ index 4ab7405..6e1ea2c 100644
  extra_modes_file=@extra_modes_file@
  extra_opt_files=@extra_opt_files@
 diff --git a/gcc/config.gcc b/gcc/config.gcc
-index cb08a5c..7bded02 100644
+index b8bb4d65825..713e35b62af 100644
 --- a/gcc/config.gcc
 +++ b/gcc/config.gcc
-@@ -1072,7 +1072,7 @@ arm*-*-eabi* | arm*-*-symbianelf* | arm*-*-rtems*)
+@@ -1140,7 +1140,7 @@ arm*-*-eabi* | arm*-*-symbianelf* | arm*-*-rtems* | arm*-*-fuchsia*)
  	case ${target} in
  	arm*-*-eabi*)
  	  tm_file="$tm_file newlib-stdint.h"
@@ -30,53 +30,67 @@ index cb08a5c..7bded02 100644
 +	  tmake_file="${tmake_file} arm/t-bpabi arm/t-mlibs"
  	  use_gcc_stdint=wrap
  	  ;;
- 	arm*-*-rtems*)
-@@ -3684,42 +3684,6 @@ case "${target}" in
+ 	arm*-*-fuchsia*)
+@@ -3787,56 +3787,6 @@ case "${target}" in
+ 			echo "Switch \"--with-tune\" may not be used with switch \"--with-cpu\""  1>&2
  			exit 1
  		fi
- 
+-
 -		# Add extra multilibs
 -		if test "x$with_multilib_list" != x; then
 -			arm_multilibs=`echo $with_multilib_list | sed -e 's/,/ /g'`
--			for arm_multilib in ${arm_multilibs}; do
--				case ${arm_multilib} in
--				aprofile)
+-			case ${arm_multilibs} in
+-			aprofile)
 -				# Note that arm/t-aprofile is a
 -				# stand-alone make file fragment to be
 -				# used only with itself.  We do not
 -				# specifically use the
 -				# TM_MULTILIB_OPTION framework because
 -				# this shorthand is more
--				# pragmatic. Additionally it is only
--				# designed to work without any
--				# with-cpu, with-arch with-mode
--				# with-fpu or with-float options.
--					if test "x$with_arch" != x \
--					    || test "x$with_cpu" != x \
--					    || test "x$with_float" != x \
--					    || test "x$with_fpu" != x \
--					    || test "x$with_mode" != x ; then
--					    echo "Error: You cannot use any of --with-arch/cpu/fpu/float/mode with --with-multilib-list=aprofile" 1>&2
--					    exit 1
--					fi
--					tmake_file="${tmake_file} arm/t-aprofile"
--					break
--					;;
--				default)
--					;;
--				*)
--					echo "Error: --with-multilib-list=${with_multilib_list} not supported." 1>&2
--					exit 1
--					;;
--				esac
--			done
+-				# pragmatic.
+-				tmake_profile_file="arm/t-aprofile"
+-				;;
+-			rmprofile)
+-				# Note that arm/t-rmprofile is a
+-				# stand-alone make file fragment to be
+-				# used only with itself.  We do not
+-				# specifically use the
+-				# TM_MULTILIB_OPTION framework because
+-				# this shorthand is more
+-				# pragmatic.
+-				tmake_profile_file="arm/t-rmprofile"
+-				;;
+-			default)
+-				;;
+-			*)
+-				echo "Error: --with-multilib-list=${with_multilib_list} not supported." 1>&2
+-				exit 1
+-				;;
+-			esac
+-
+-			if test "x${tmake_profile_file}" != x ; then
+-				# arm/t-aprofile and arm/t-rmprofile are only
+-				# designed to work without any with-cpu,
+-				# with-arch, with-mode, with-fpu or with-float
+-				# options.
+-				if test "x$with_arch" != x \
+-				    || test "x$with_cpu" != x \
+-				    || test "x$with_float" != x \
+-				    || test "x$with_fpu" != x \
+-				    || test "x$with_mode" != x ; then
+-				    echo "Error: You cannot use any of --with-arch/cpu/fpu/float/mode with --with-multilib-list=${with_multilib_list}" 1>&2
+-				    exit 1
+-				fi
+-
+-				tmake_file="${tmake_file} ${tmake_profile_file}"
+-			fi
 -		fi
  		;;
  
  	fr*-*-*linux*)
 diff --git a/gcc/config/arm/t-mlibs b/gcc/config/arm/t-mlibs
 new file mode 100644
-index 0000000..5720cf7
+index 00000000000..5720cf7503d
 --- /dev/null
 +++ b/gcc/config/arm/t-mlibs
 @@ -0,0 +1,89 @@
@@ -170,10 +184,10 @@ index 0000000..5720cf7
 +MULTILIB_REUSE      += mthumb/march.armv7/mfloat-abi.hard/mfpu.vfpv3-d16=marm/march.armv7/mfloat-abi.hard/mfpu.vfpv3-d16
 +endif
 diff --git a/gcc/configure b/gcc/configure
-index 9523773..24952e3 100755
+index ea73b151a4e..c609f25e50c 100755
 --- a/gcc/configure
 +++ b/gcc/configure
-@@ -763,6 +763,7 @@ SET_MAKE
+@@ -772,6 +772,7 @@ SET_MAKE
  accel_dir_suffix
  real_target_noncanonical
  enable_as_accelerator
@@ -181,7 +195,7 @@ index 9523773..24952e3 100755
  REPORT_BUGS_TEXI
  REPORT_BUGS_TO
  PKGVERSION
-@@ -7462,6 +7463,7 @@ else
+@@ -7763,6 +7764,7 @@ else
  fi
  
  
@@ -190,10 +204,10 @@ index 9523773..24952e3 100755
  # Checks for other programs
  # -------------------------
 diff --git a/gcc/configure.ac b/gcc/configure.ac
-index 68b0ee8..f8a1097 100644
+index 9d4c792a33f..abd988eb113 100644
 --- a/gcc/configure.ac
 +++ b/gcc/configure.ac
-@@ -925,6 +925,7 @@ AC_ARG_WITH(multilib-list,
+@@ -1007,6 +1007,7 @@ AC_ARG_WITH(multilib-list,
  [AS_HELP_STRING([--with-multilib-list], [select multilibs (AArch64, SH and x86-64 only)])],
  :,
  with_multilib_list=default)


### PR DESCRIPTION
#### Description

I wanted to support specifying checksums for newlib for crossgcc, but my solution is not the most elegant one as it hardcodes filename which could be generated automatically.

I would be grateful for some feedback before merging this. Tested on `arm-none-eabi-gcc`. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?