### PR TITLE
ccpnmr: repair openmp to fix compilation

### DIFF
--- a/science/ccpnmr/Portfile
+++ b/science/ccpnmr/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 
 name                ccpnmr
 version             2.4.2
-revision            1
+revision            2
 set branch          [join [lrange [split $version .] 0 1] .]
 categories          science python
 maintainers         {gmail.com:howarth.at.macports @jwhowarth}
@@ -29,6 +29,7 @@ use_configure       no
 
 compilers.choose    cc cxx
 compilers.setup     -clang -g95 -gfortran
+compiler.blacklist  cc clang {macports-clang-3.[0-7]}
 
 set python.branch	2.7
 set python.prefix	${frameworks_dir}/Python.framework/Versions/${python.branch}

--- a/science/ccpnmr/files/ccpnmr.patch
+++ b/science/ccpnmr/files/ccpnmr.patch
@@ -128,7 +128,7 @@
 +#Environment file for use with fink to build ccpnmr suite - environment.txt
 +
 +CC = @CC@
-+LINK = $(CC)
++LINK = $(CC) -fopenmp
 +MAKE = make
 +CO_NAME = -c $<
 +OUT_NAME = -o $@
@@ -146,7 +146,7 @@
 +COPY_LIBRARIES = sh copySharedObjs
 +
 +OPENMP_FLAGS = -fopenmp
-+OPENMP_LIB  = -L@GCCLIB@ -lgomp
++OPENMP_LIB  = 
 +
 +GL_FLAG = -DUSE_GL_TRUE
 +


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/56292
closes: https://trac.macports.org/ticket/53953
