### PR TITLE
babl: tweak gcc blacklisting

### DIFF
--- a/graphics/babl/Portfile
+++ b/graphics/babl/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  9c6a2fe80ae5d68b40c55ef0ed38d0436edd02c0 \
 
 # In 0.1.12, i386 fails to compile with SL's gcc-4.2:
 #    babl-cpuaccel.c:169: error: ‘asm’ operand has impossible constraints
-compiler.blacklist-append *gcc*
+compiler.blacklist-append *gcc-3.* *gcc-4.*
 
 # additionally blacklist compilers that don't support C11 (typedef redefinition in C)
 # babl-icc.c:1031:25: error: redefinition of typedef 'UTF8' is invalid in C


### PR DESCRIPTION
allows builds with newer gcc versions e.g. on PPC
closes: https://trac.macports.org/ticket/49764

```
$ port -v installed babl
The following ports are currently installed:
  babl @0.1.46_0 (active) platform='darwin 9' archs='ppc' date='2018-04-16T20:42:30-0700'
```