### PR TITLE
libxkbcommon: New port, version 0.8.0

### DIFF
--- a/devel/libxkbcommon/Portfile
+++ b/devel/libxkbcommon/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        xkbcommon libxkbcommon 0.8.0 xkbcommon-
+categories          devel
+platforms           darwin
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             MIT
+
+description         library to handle keyboard descriptions
+
+long_description    ${name} is a ${description}, including loading them from \
+                    disk, parsing them and handling their state. It's mainly \
+                    meant for client toolkits, window systems, and other \
+                    system applications. It is also used by some XCB \
+                    applications for proper keyboard support.
+
+homepage            https://xkbcommon.org
+master_sites        ${homepage}/download/
+use_xz              yes
+
+checksums           rmd160  440bdd2d824bc37481240e60c9122f50e09c644f \
+                    sha256  e829265db04e0aebfb0591b6dc3377b64599558167846c3f5ee5c5e53641fe6d \
+                    size    643456
+
+depends_build       port:bison \
+                    port:pkgconfig \
+                    port:xkeyboard-config \
+                    port:xorg-util-macros
+
+configure.args      --disable-docs \
+                    --disable-silent-rules \
+                    --disable-x11 \
+                    --without-doxygen
+
+#subport ${name}-x11 {
+#    depends_lib     port:${name} \
+#                    port:xorg-libxcb
+#
+#    configure.args-replace \
+#                    --disable-x11 --enable-x11
+#}


### PR DESCRIPTION
#### Description

New port libxkbcommon

<!-- [skip notification] -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
