### PR TITLE
php-mcrypt: New port, version 1.0.1

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -809,6 +809,8 @@ subport ${php}-mbstring {
 }
 
 if {[vercmp ${branch} 7.2] < 0} {
+# mcrypt was evicted from PHP core in version 7.2; php72-mcrypt and later
+# subports are found in the separate php-mcrypt Portfile.
 subport ${php}-mcrypt {
     categories-append       security
     

--- a/php/php-mcrypt/Portfile
+++ b/php/php-mcrypt/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           php 1.1
+
+name                php-mcrypt
+version             1.0.1
+categories-append   security
+platforms           darwin
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             PHP-3.01
+
+# php71-mcrypt and earlier subports are in the php Portfile.
+php.branches        7.2
+php.pecl            yes
+
+description         a PHP interface to the mcrypt library, which offers \
+                    a wide variety of algorithms
+
+long_description    ${description}
+
+checksums           rmd160  5887bb08d105d8a82d4c5360d1811103947f163e \
+                    sha256  a3b0e5493b5cd209ab780ee54733667293d369e6b7052b4a7dab9dd0def46ac6 \
+                    size    33782
+
+if {${name} ne ${subport}} {
+    depends_lib-append      port:libmcrypt
+
+    # The mcrypt extension may be using libtool unnecessarily; monitor
+    # https://bugs.php.net/bug.php?id=54500
+    depends_lib-append      port:libtool
+
+    configure.args-append   --with-mcrypt=${prefix}
+}


### PR DESCRIPTION
#### Description

New php-mcrypt port.

<!-- [skip notification] -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
