### PR TITLE
serf1: Update to 1.3.9

### DIFF
--- a/www/serf1/Portfile
+++ b/www/serf1/Portfile
@@ -1,9 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 name            serf1
-version         1.3.8
+version         1.3.9
 categories      www
-maintainers     blair
+maintainers     {blair @blair}
 license         Apache-2
 description     C-based HTTP client library
 
@@ -18,8 +20,10 @@ homepage        https://serf.apache.org
 master_sites    https://archive.apache.org/dist/serf/
 distname        serf-${version}
 use_bzip2       yes
-checksums       sha1   1d45425ca324336ce2f4ae7d7b4cfbc5567c5446 \
-                sha256 e0500be065dbbce490449837bb2ab624e46d64fc0b090474d9acaa87c82b2590
+
+checksums       rmd160  4bbc773841eb2bd83a7c12170937b403201dd83b \
+                sha256  549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc \
+                size    145132
 
 patchfiles      patch-SConstruct.diff
 

--- a/www/serf1/files/patch-SConstruct.diff
+++ b/www/serf1/files/patch-SConstruct.diff
@@ -1,7 +1,6 @@
-diff -ru ../serf-1.3.2.orig/SConstruct ./SConstruct
---- ../serf-1.3.2.orig/SConstruct	2013-10-04 08:11:04.000000000 -0700
-+++ ./SConstruct	2013-10-04 23:09:57.000000000 -0700
-@@ -146,7 +146,8 @@ if sys.platform == 'win32':
+--- SConstruct.orig	2015-09-17 07:46:24.000000000 -0500
++++ SConstruct	2017-09-27 14:56:41.000000000 -0500
+@@ -152,7 +152,8 @@
                   True),
      )
  
@@ -11,27 +10,26 @@ diff -ru ../serf-1.3.2.orig/SConstruct ./SConstruct
                    tools=('default', 'textfile',),
                    CPPPATH=['.', ],
                    )
-@@ -210,7 +210,9 @@
- # Unfortunately we can't set the .dylib compatibility_version option separately
+@@ -216,7 +217,8 @@
  # from current_version, so don't use the PATCH level to avoid that build and
  # runtime patch levels have to be identical.
--env['SHLIBVERSION'] = '%d.%d.%d' % (MAJOR, MINOR, 0)
-+
-+# MacPorts: change PATCH to 0 when MINOR goes from 3 to 4.
-+env['SHLIBVERSION'] = '%d.%d.%d' % (MAJOR, MINOR, PATCH)
+ if sys.platform != 'sunos5':
+-  env['SHLIBVERSION'] = '%d.%d.%d' % (MAJOR, MINOR, 0)
++  # MacPorts: change PATCH to 0 when MINOR goes from 3 to 4.
++  env['SHLIBVERSION'] = '%d.%d.%d' % (MAJOR, MINOR, PATCH)
  
  LIBNAME = 'libserf-%d' % (MAJOR,)
  if sys.platform != 'win32':
-@@ -225,7 +225,7 @@ env.Append(RPATH=libdir,
+@@ -229,7 +231,7 @@
  
  if sys.platform == 'darwin':
  #  linkflags.append('-Wl,-install_name,@executable_path/%s.dylib' % (LIBNAME,))
--  env.Append(LINKFLAGS='-Wl,-install_name,%s/%s.dylib' % (thisdir, LIBNAME,))
-+  env.Append(LINKFLAGS='-Wl,-install_name,%s/%s.dylib' % (libdir, LIBNAME,))
+-  env.Append(LINKFLAGS=['-Wl,-install_name,%s/%s.dylib' % (thisdir, LIBNAME,)])
++  env.Append(LINKFLAGS=['-Wl,-install_name,%s/%s.dylib' % (libdir, LIBNAME,)])
  
  if sys.platform != 'win32':
-   ### gcc only. figure out appropriate test / better way to check these
-@@ -402,21 +402,6 @@ if CALLOUT_OKAY:
+   def CheckGnuCC(context):
+@@ -419,21 +421,6 @@
  install_static = env.Install(libdir, lib_static)
  install_shared = env.InstallVersionedLib(libdir, lib_shared)
  


### PR DESCRIPTION
#### Description

Update serf1 to 1.3.9.

<!-- [skip notification] -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] tried a full install with `sudo port -vst install`?
