### PR TITLE
mandoc: rename files to not conflict with groff

### DIFF
--- a/sysutils/groff/Portfile
+++ b/sysutils/groff/Portfile
@@ -6,7 +6,6 @@ name                groff
 version             1.22.3
 revision            4
 categories          sysutils textproc
-conflicts           mandoc
 platforms           darwin
 maintainers         nomaintainer
 license             GPL-3+

--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 
 name                mandoc
 version             1.14.3
-revision            5
+revision            6
 description         UNIX manpage compiler
 homepage            https://mandoc.bsd.lv/
 categories          textproc
-conflicts           man groff
+conflicts           man
 license             ISC
 maintainers         {grimreaper @grimreaper} stare.cz:hans openmaintainer
 platforms           openbsd freebsd netbsd darwin
@@ -32,6 +32,12 @@ MANDIR="${prefix}/share/man"
 
 MANPATH_DEFAULT="${prefix}/share/man:/usr/local/share/man:/usr/share/man"
 MANPATH_BASE="/usr/share/man"
+
+# The following files are in conflict with groff:
+# bin/soelim, share/man/man1/soelim.1.gz, share/man/man7/roff.7.gz
+# Rename them so that mandoc and groff can coexist
+BINM_SOELIM="msoelim"
+MANM_ROFF="mandoc_roff"
 
 INSTALL_LIBMANDOC=0
 BUILD_CGI=0


### PR DESCRIPTION
The following files from `mandoc` are in a name conflict with `groff`:

*  /opt/local/bin/soelim
* /opt/local/share/man/man1/soelim.1.gz
* /opt/local/share/man/man7/roff.7.gz 

Rename them so that mandoc and groff can coexist.
Closes https://trac.macports.org/ticket/56313
