### PR TITLE
remove links1

### DIFF
--- a/www/links1/Portfile
+++ b/www/links1/Portfile
@@ -1,30 +1,12 @@
-PortSystem 1.0
+PortSystem       1.0
+
+# This port can be removed on April 18, 2019.
+replaced_by      links
+PortGroup        obsolete 1.0
 
 name             links1
 version          1.00pre14
-distname         links-${version}
+homepage         http://artax.karlin.mff.cuni.cz/~mikulas/links/
 categories       www
 license          GPL-2+
 maintainers      nomaintainer
-description      text WWW browser with tables
-long_description \
-    Links is a text-based browser with support for HTML tables and frames.
-homepage         http://artax.karlin.mff.cuni.cz/~mikulas/links/
-platforms        darwin
-master_sites     ${homepage}download/
-checksums        md5 87713eaab818c73503807fc13340fe5f
-configure.args   --without-ssl
-
-destroot.destdir-append mandir=${prefix}/share/man
-
-post-destroot {
-    set bindir ${destroot}${prefix}/bin
-    file rename ${bindir}/links ${bindir}/links1
-    set man1dir ${destroot}${prefix}/share/man/man1
-    file rename ${man1dir}/links.1 ${man1dir}/links1.1
-}
-
-variant ssl {
-    configure.args-delete --without-ssl
-    depends_lib-append lib:libssl.0.9:openssl
-}


### PR DESCRIPTION
Links 1.00pre14 is 13 years old, has no maintainer,
and asks for OpenSSL 0.9. Also, the current distribution
warns to not use releases < 2.6
