### PR TITLE
remove jabber

### DIFF
--- a/net/jabber/Portfile
+++ b/net/jabber/Portfile
@@ -1,5 +1,9 @@
 PortSystem 1.0
 
+# Remove in April 2019.
+replaced_by     jabberd
+PortGroup       obsolete 1.0
+
 name		jabber
 version		1.4.2
 revision	5
@@ -7,58 +11,3 @@ categories	net
 license		GPL-2+ MPL-1.1 Apache-1 Restrictive
 maintainers	nomaintainer
 homepage	http://jabberd.org/
-description	Online presence and instant messaging server
-long_description	The Jabber server (jabberd) is a daemon for Jabber clients to connect and communicate with.
-platforms	darwin
-master_sites	http://download.jabberd.org/jabberd14/ \
-		http://download.jabberd.org/jabberd14/old/ \
-		http://download.jabberd.org/jabberd14/old/discontinued/ \
-		netbsd:packages/distfiles/
-checksums	md5 10780dbdb93926ea5bb360e1186b939c
-depends_lib	port:libiconv port:expat port:gettext lib:libpth.a:pth
-build.type  gnu
-
-platform darwin {
-	configure.cflags-append	"-DBIND_8_COMPAT=1"
-}
-
-configure.cflags-append -std=gnu89
-
-destroot {
-	file mkdir ${destroot}${prefix}/etc
-	file mkdir ${destroot}${prefix}/lib
-	file mkdir ${destroot}${prefix}/sbin
-	file mkdir ${destroot}${prefix}/share/man
-	xinstall -o root -m 755 ${worksrcpath}/jabberd/jabberd ${destroot}${prefix}/sbin
-		
-	xinstall -o root -m 755 -d ${destroot}${prefix}/lib/jabber/pthsock
-	xinstall -o root -m 755 ${worksrcpath}/pthsock/pthsock_client.so ${destroot}${prefix}/lib/jabber/pthsock
-	
-	xinstall -o root -m 755 -d ${destroot}${prefix}/lib/jabber/dialback
-	xinstall -o root -m 755 ${worksrcpath}/dialback/dialback.so ${destroot}${prefix}/lib/jabber/dialback
-	
-	xinstall -o root -m 755 -d ${destroot}${prefix}/lib/jabber/dnsrv
-	xinstall -o root -m 755 ${worksrcpath}/dnsrv/dnsrv.so ${destroot}${prefix}/lib/jabber/dnsrv
-	
-	xinstall -o root -m 755 -d ${destroot}${prefix}/lib/jabber/xdb_file
-	xinstall -o root -m 755 ${worksrcpath}/xdb_file/xdb_file.so ${destroot}${prefix}/lib/jabber/xdb_file
-	
-	xinstall -o root -m 755 -d ${destroot}${prefix}/lib/jabber/jsm
-	xinstall -o root -m 755 ${worksrcpath}/jsm/jsm.so ${destroot}${prefix}/lib/jabber/jsm
-		
-	xinstall -o root -m 755 -d ${destroot}${prefix}/etc/jabber/
-	xinstall -o root -m 755 ${worksrcpath}/jabber.xml ${destroot}${prefix}/etc/jabber
-	
-	destroot.keepdirs \
-		${destroot}${prefix}/var/lib/jabber \
-		${destroot}${prefix}/var/run/jabber \
-		${destroot}${prefix}/var/log/jabber \
-		${destroot}${prefix}/var/spool/jabber
-
-	file copy -force ${destroot}${prefix}/etc/jabber/jabber.xml ${destroot}${prefix}/etc/jabber/jabber.xml.default
-}
-
-variant ssl description {Enable SSL} {
-	depends_lib-append	lib:libssl.0.9:openssl
-	configure.args	--enable-ssl
-}


### PR DESCRIPTION
Jabber 1.4.2 is more than a decade old, has no maintainer,
asks for OpenSSL 0.9, the homepage is dead,
and nobody's using it (right)?

