### PR TITLE
remove qpopper

### DIFF
--- a/mail/qpopper/Portfile
+++ b/mail/qpopper/Portfile
@@ -1,113 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+
 PortSystem          1.0
+
+# Remove in April 2019
+PortGroup           obsolete 1.0
 
 name                qpopper
 version             4.1.0
 categories          mail
 platforms           darwin
 maintainers         nomaintainer
-license             BSD
-
 description         Eudora POP3 mail server
-
-long_description    popper is Eudora's POP3 mail server. It does not include a mail \
-                    transfer agent or an SMTP server, it just let you get your mail stored \
-                    on the machine via POP3.
-
-homepage            http://www.eudora.com/products/unsupported/qpopper/
-master_sites        http://www.ring.gr.jp/archives/net/mail/qpopper/ \
-                    ftp://ftp.nctu.edu.tw/network/mail/qpopper/ \
-                    ftp://ftp.qualcomm.com/eudora/servers/unix/popper/
-
-distname            ${name}${version}
-
-checksums           rmd160  5254dd252739b2465795a0161bc2fed82adffbcc \
-                    sha256  1bc21f83cda47e9b2d5d8ceecc49f169e10fdb9b99ddddcd543218fad269b0de
-
-patchfiles          patch-Makefile.in patch-popper-Makefile.in
-
-post-patch {
-    reinplace "s|@@INSTALL.USER@@|${install.user}|g" \
-        ${worksrcpath}/Makefile.in \
-        ${worksrcpath}/popper/Makefile.in
-}
-
-configure.args      --mandir=${prefix}/share/man \
-                    --without-pam
-
-destroot.destdir    prefix=${destroot}${prefix} \
-                    mandir=${destroot}${prefix}/share/man
-
-pre-destroot {
-    xinstall -d ${destroot}${prefix}/etc/xinetd.d
-    xinstall -o ${install.user} -m 755 -c ${portpath}/files/qpopper-dist \
-        ${destroot}${prefix}/etc/xinetd.d/
-    reinplace "s|@@PREFIX@@|${prefix}|g" \
-        ${destroot}${prefix}/etc/xinetd.d/qpopper-dist
-}
-
-notes "
-To use qpopper, you'll need to add it to inetd.conf/xinetd.d/launchd depending on\
-what you use on your system.
-
-For inetd, something like:
-pop3  stream  tcp  nowait  root  /usr/libexec/tcpd  ${prefix}/sbin/popper
-should do it.
-
-For xinetd, you'll find in ${prefix}/etc/xinetd.d/\
-a file called qpopper-dist that you should edit and copy to /etc/xinetd.d/
-
-In both cases, don't forget to tell (x)inetd to reload their configuration.
-"
-
-platform darwin {
-    configure.args-append   --enable-specialauth
-    configure.ldflags   "-framework DirectoryService"
-    patchfiles-append       patch-pop_pass.c
-
-    pre-destroot {
-        xinstall -d ${destroot}${prefix}/Library/LaunchDaemons/
-        xinstall -o ${install.user} -m 755 -c ${portpath}/files/org.macports.mail.qpopper.plist-dist \
-            ${destroot}${prefix}/Library/LaunchDaemons/
-        reinplace "s|@@PREFIX@@|${prefix}|g" \
-            ${destroot}${prefix}/Library/LaunchDaemons/org.macports.mail.qpopper.plist-dist
-    }
-
-    notes-append "
-    For launchd, you'll find in ${prefix}/Library/LaunchDaemons/\
-    a file called org.macports.mail.qpopper.plist-dist that you should edit and copy to /Library/LaunchDaemons/
-    "
-}
-
-variant ssl {
-    depends_lib-append      lib:libssl.0:openssl
-
-    configure.args-append   --with-openssl=${prefix}
-
-    notes-append "
-    To get TLS/SSL working, you need to set up certificates.\
-    Cf: http://www.eudora.com/qpopper/faq.html#tls
-    "
-}
-
-variant pam {
-    post-extract {
-        system "mkdir -p ${workpath}/paminclude"
-        system "ln -s /usr/include/pam ${workpath}/paminclude/security"
-    }
-
-    configure.cppflags      -I${workpath}/paminclude
-    configure.cflags        -I${workpath}/paminclude
-    configure.args-delete   --without-pam
-    configure.args-append   --with-pam=pop3
-
-    notes-append "
-    Additionally, for PAM, you need to copy /etc/pam.d/sshd to\
-    /etc/pam.d/pop3, or use another config with pam_securityserver.so.
-    "
-}
-
-livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     ${name}(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
qpopper 4.1.0 is more than a decade old, has no maintainer,
asks for OpenSSL 0.x, the homepage is dead, and is a POP3 server.
