### PR TITLE
remove sylpheed-devel

### DIFF
--- a/mail/sylpheed-devel/Portfile
+++ b/mail/sylpheed-devel/Portfile
@@ -1,5 +1,9 @@
 PortSystem 1.0
 
+# Remove in April 2019
+replaced_by         sylpheed
+PortGroup           obsolete 1.0
+
 name			sylpheed-devel
 version			2.2.0beta7
 revision		1
@@ -8,59 +12,3 @@ license			{GPL-2 LGPL-2.1}
 maintainers		nomaintainer
 description		Fast, lightweight GTK+ mail client
 homepage		http://sylpheed.good-day.net/
-platforms		darwin
-
-long_description	Sylpheed is a fast, lightweight email client written \
-			in GTK+.  The appearance and interface are similar to \
-			popular Windows clients, such as Outlook Express, \
-			Becky!, and Datula. This is the development version.
-
-master_sites    	http://sylpheed.good-day.net/sylpheed/v2.2beta/
-
-checksums		md5 927ac3cfe9e28a8155aee0acbfb4ae54 \
-			sha1 fe0292aeeb414dec8c89fdab56e79901589bd8f7 \
-			rmd160 a42ccfef89b0a2fcb7d75eee5840d918c0c911d7
-
-use_bzip2		yes
-
-distname		sylpheed-${version}
-
-depends_build	port:pkgconfig
-depends_lib		lib:libgtk.2:gtk2
-
-pre-configure {		reinplace "s|-traditional-cpp|-no-cpp-precomp|g" \
-				${worksrcpath}/configure
-			}
-
-configure.cflags	"-O3 -fstrict-aliasing -funroll-loops -pipe -bind_at_load"
-
-configure.args		--disable-compface \
-			--disable-jpilot \
-			--disable-gdk-pixbuf \
-			--disable-ssl \
-			--enable-ipv6
-
-variant ssl {		depends_lib-append	lib:libssl.0.9:openssl
-			configure.args-append 	--enable-ssl
-			}
-
-variant gpg {		depends_lib-append	lib:libgpgme:gpgme
-			configure.args-append	--enable-gpgme \
-						--with-gpgme-prefix=${prefix}
-			}
-
-variant gdk {		depends_lib-append	lib:libgdk-pixbuf:gdk-pixbuf
-			configure.args-delete	--disable-gdk-pixbuf
-			configure.args-append	--enable-gdk-pixbuf
-			}
-
-variant ldap		{ configure.args-append	--enable-ldap }
-
-variant gtkspell {	depends_lib-append	lib:libgtkspell:gtkspell2
-			configure.args-append	--enable-gtkspell
-			}
-			
-variant compface {	depends_lib-append	port:compface
-			configure.args-delete	--disable-compface
-			configure.args-append	--enable-compface
-			}


### PR DESCRIPTION
sylpheed 2.2.0beta7 is more than a decade old, has no maintainer,
asks for OpenSSL 0.9, and the homepage is dead. Also, we have
sylpheed 3.5.1, which is still active, unlike this.
