### PR TITLE
doxygen-launcher: install doxygen dependent with correct variant

### DIFF
--- a/aqua/doxygen-launcher/Portfile
+++ b/aqua/doxygen-launcher/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 
 name                doxygen-launcher
 # should match doxygen version
 version             1.8.13
+revision            1
 categories          aqua textproc devel
 platforms           darwin
 license             GPL-2
@@ -62,6 +64,25 @@ build {
 
 destroot {
     copy ${worksrcpath}/Doxygen.app ${destroot}${applications_dir}
+}
+
+variant qt5 conflicts qt4 description {Use doxygen wizard based on Qt5} {
+    require_active_variants doxygen qt5
+}
+
+variant qt4 conflicts qt5 description {Use doxygen wizard based on Qt4} {
+    require_active_variants doxygen qt4
+}
+
+if {![variant_isset qt4] && ![variant_isset qt5]} {
+    default_variants-append +qt5
+}
+
+if {![variant_isset qt4] && ![variant_isset qt5]} {
+    pre-fetch {
+        ui_error "${name} must be installed with either the +qt4 or +qt5 variant"
+        return -code error "Qt variant required"
+    }
 }
 
 livecheck.url       https://github.com/macports/macports-ports/blob/master/textproc/doxygen/Portfile


### PR DESCRIPTION
#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
