### PR TITLE
ldas-tools-al: fix depends_lib

### DIFF
--- a/science/ldas-tools-al/Portfile
+++ b/science/ldas-tools-al/Portfile
@@ -19,7 +19,7 @@ checksums     rmd160 182f0fc8715508fa44e3564f3b3bbed008d78bfe \
               sha256 72fcc57378b45f96ecb573656e36e4ac45b52b847811c83c872dce1ea0f0fb8d
 
 depends_build  port:pkgconfig
-depends_lib    port:lib/libssl.dylib:openssl \
+depends_lib    path:lib/libssl.dylib:openssl \
                port:zlib \
                port:bzip2
 


### PR DESCRIPTION
"port:lib/libssl.dylib:openssl" makes no sense.
