### PR TITLE
mod_qos: use standard depends_lib style

### DIFF
--- a/www/mod_qos/Portfile
+++ b/www/mod_qos/Portfile
@@ -23,7 +23,7 @@ depends_build       port:autoconf \
 depends_lib         port:apache2 \
                     port:db46 \
                     port:libpng \
-                    path:${prefix}lib/libssl.dylib:openssl \
+                    path:lib/libssl.dylib:openssl \
                     port:pcre
 
 patchfiles          patch-tools-Makefile.in.diff


### PR DESCRIPTION
"path:" already implies "relative to $prefix";
almost all other ports just say "path:lib/libssl.dylib:openssl"
