### PR TITLE
kotlin: update to 1.2.40

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.2.31 v
+github.setup        JetBrains kotlin 1.2.40 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,8 +21,8 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  b4a7b4a37495d83c2a0a2d14ece537ec4d399487 \
-                    sha256  da99c6ba77a5222955292eafbfe8459a4696960ef8e5585cbe71cee49cdc8026
+checksums           rmd160  578c9adb8301f03ae8b77fb06ac0cce509c73be9 \
+                    sha256  3498571126c335be0feec24075c359f1954d46bbabccafc729ec49db1a509658
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.2.40.

###### Tested on

macOS 10.13.4 17E199
Xcode 9.3 9E145 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?