### PR TITLE
root6: remove variants for python 2.6, 3.3, 3.4

### DIFF
--- a/science/root6/Portfile
+++ b/science/root6/Portfile
@@ -404,7 +404,7 @@ variant opengl description {Build with opengl support} {
 # ========================================================================================
 
 # List of possible python versions
-set python_versions { 2.6 2.7 3.3 3.4 3.5 3.6 }
+set python_versions { 2.7 3.5 3.6 }
 # Enable python variant by default on OSX 10.9 and newer.
 # Disabled on older systems due to an issue fetching the source for
 # the various python dependencies due to these systems having out of


### PR DESCRIPTION
#### Description

Untested removal of old python variants.

I noticed an old requent to add python 3.5 subport and then noticed that root6 includes way too old variants. Maybe this requires a revbump. If so, it makes sense to do this change at another occasion because it's stupid to rebuild the port just for the sake of this tiny change.

Maybe a similar change is needed in root5 as well.

Potentially worth checking: https://trac.macports.org/ticket/50066

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
