### PR TITLE
py-astropy: update to 3.0.1

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             2.0.3
+version             3.0.1
 maintainers         robitaille {gmail.com:Deil.Christoph @cdeil}
 
 dist_subdir         ${name}/${version}
@@ -19,9 +19,9 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     f7754aff4a4b9bbaa08a0913c6a03464 \
-                    rmd160  f70a3856af8d173e011a8d51b90cc12858820306 \
-                    sha256  fdfc0248f6250798ed6d1327be609cb901db89ae01fc768cfbc9e263bdf56f4f
+checksums           md5     d54c2571fdb82642fcce27f5a88f33d3 \
+                    rmd160  0fc1b310f3bafbf2f75f22a9b4d6a32706cd2e0e \
+                    sha256  c35f4433c14ddfcaf2407cc815385f3d85396727e9a1e660cf66a7c4f5dd1067
 
 python.versions     27 33 34 35 36
 
@@ -31,6 +31,16 @@ build.args-append   --use-system-cfitsio \
                     --use-system-erfa
 
 if {${name} ne ${subport}} {
+
+    if {${python.version} < 35} {
+        version             2.0.5
+        dist_subdir         ${name}/${version}
+        distname            astropy-${version}
+
+        checksums           md5     37b215f8ab47c188e8abd3f61c9a6987 \
+                            rmd160  0de0d9c30caa6d341c7cbf078ec8335c517f2b1a \
+                            sha256  55b8e2888da512cc7d80aed98e0bcfe87f2d0490024430531a435591161adf35
+    }
 
     depends_lib-append  port:cfitsio \
                         port:expat \


### PR DESCRIPTION
#### Description

And fall back to 2.0.5 for Python < 3.5.

###### Type(s)

- [X] enhancement

###### Tested on

macOS 10.13.4 17E199
Xcode 9.3 9E145 