### PR TITLE
Change over from protobuf-cpp to protobuf3-cpp

### DIFF
--- a/databases/rethinkdb/Portfile
+++ b/databases/rethinkdb/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                rethinkdb
 version             1.11.1
-revision            3
+revision            4
 categories          databases
 platforms           darwin
 maintainers         nomaintainer

--- a/databases/rethinkdb/Portfile
+++ b/databases/rethinkdb/Portfile
@@ -29,7 +29,7 @@ depends_build       port:coffee-script
 depends_lib         port:boost \
                     port:v8 \
                     path:bin/node:nodejs4 \
-                    port:protobuf-cpp
+                    port:protobuf3-cpp
 
 # nodejs only supports Intel processors and is not universal
 supported_archs     i386 x86_64
@@ -43,7 +43,7 @@ compiler.blacklist-append {clang < 137}
 
 platform darwin {
     if {${configure.cxx_stdlib} eq "libstdc++"} {
-        # When protobuf-cpp and v8 are compiled against libstdc++, don't use
+        # When protobuf3-cpp and v8 are compiled against libstdc++, don't use
         # clang, which only supports C++11 (required by rethinkdb) when using
         # libc++.
         compiler.blacklist-append   *clang*

--- a/devel/protobuf-c/Portfile
+++ b/devel/protobuf-c/Portfile
@@ -3,6 +3,7 @@ PortGroup       github 1.0
 
 name		protobuf-c
 version		1.1.0
+revision        1
 categories	devel
 license		Apache-2
 maintainers	nomaintainer

--- a/devel/protobuf-c/Portfile
+++ b/devel/protobuf-c/Portfile
@@ -26,7 +26,7 @@ checksums       sha1    20bfcf3663ae56b125a5bfc3b4dca8c7f0ef1e48 \
 
 platforms	darwin
 
-depends_lib	port:protobuf-cpp
+depends_lib	port:protobuf3-cpp
 depends_build   port:pkgconfig
 
 test.run	yes

--- a/finance/bitcoin/Portfile
+++ b/finance/bitcoin/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  e06b58ef2a0272a3049e6edf8a3a44e09d0a5059 \
 
 depends_build           port:libtool		\
                         port:pkgconfig		\
-                        port:protobuf-cpp	\
+                        port:protobuf3-cpp	\
                         port:python36
 
 depends_lib             port:boost	\

--- a/finance/bitcoin/Portfile
+++ b/finance/bitcoin/Portfile
@@ -6,7 +6,7 @@ PortGroup               cxx11 1.1
 name                    bitcoin
 categories              finance crypto
 version                 0.16.0
-revision                0
+revision                1
 platforms               darwin
 license                 MIT
 maintainers             {easieste @easye} yopmail.com:sami.laine openmaintainer

--- a/games/Cockatrice/Portfile
+++ b/games/Cockatrice/Portfile
@@ -23,7 +23,7 @@ homepage            http://www.woogerworks.com/
 checksums           rmd160  f590177c0e2252e9905c8c5bd7d50d070348b916 \
                     sha256  03751fd5283bfa0cd38071c2de295093dcace9c6ef9ad2a5ca3eba6d95e45cf9
 
-depends_lib-append  port:protobuf-cpp
+depends_lib-append  port:protobuf3-cpp
 
 configure.args-append -DWITH_QT4:BOOL=ON
 

--- a/games/Cockatrice/Portfile
+++ b/games/Cockatrice/Portfile
@@ -10,6 +10,7 @@ PortGroup           qt4    1.0
 github.setup        Cockatrice Cockatrice 2016-05-06-Release
 
 epoch               1
+revision            1
 categories          games
 maintainers         nomaintainer
 description         A board for playing trading card games like MTG online

--- a/games/raceintospace/Portfile
+++ b/games/raceintospace/Portfile
@@ -30,7 +30,7 @@ depends_lib-append  port:jsoncpp \
                     port:libtheora \
                     port:libvorbis \
                     port:physfs \
-                    port:protobuf-cpp \
+                    port:protobuf3-cpp \
                     port:zlib
 
 patchfiles          CMakeLists.txt.patch \

--- a/games/raceintospace/Portfile
+++ b/games/raceintospace/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 
 github.setup        raceintospace raceintospace e0d423d40747a06094b7ea441b0d63ca345c9a27
 version             1.1-20170605
+revision            1
 categories          games
 platforms           darwin
 maintainers         nomaintainer

--- a/graphics/MyPaint/Portfile
+++ b/graphics/MyPaint/Portfile
@@ -9,7 +9,7 @@ name                        MyPaint
 if {${name} eq ${subport}} {
     conflicts               ${name}-devel
     github.setup            mypaint mypaint 1.2.1 v
-    revision                1
+    revision                2
 
     github.tarball_from     releases
     use_xz                  yes
@@ -22,7 +22,7 @@ subport ${name}-devel {
     conflicts               ${name}
     github.setup            mypaint mypaint 1fc6f4ccab6e421ef38004d481ceae95960c9f02
     version                 1.3.0-alpha.20160514+git.[string range ${git.branch} 0 7]
-    revision                1
+    revision                2
     set libmypaint_branch   65ffae19bc152749d30e78593b7f78749b294718
 
     master_sites-append     https://github.com/${github.author}/libmypaint/tarball/${libmypaint_branch}:libmypaint

--- a/graphics/MyPaint/Portfile
+++ b/graphics/MyPaint/Portfile
@@ -69,7 +69,7 @@ depends_lib-append          path:lib/pkgconfig/glib-2.0.pc:glib2 \
                             port:py27-cairo \
                             port:py27-gobject3 \
                             port:py27-numpy \
-                            port:py27-protobuf \
+                            port:py27-protobuf3 \
                             port:py27-pyobjc-cocoa
 
 depends_run-append          port:hicolor-icon-theme

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 name                caffe
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
-revision            5
+revision            6
 categories          math science
 maintainers         nomaintainer
 

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  fbf514385ccfb2e7c0ef3ccd85c15ffbbd52ec88 \
 
 depends_lib-append  port:google-glog \
                     port:gflags \
-                    port:protobuf-cpp \
+                    port:protobuf3-cpp \
                     port:leveldb \
                     port:snappy \
                     port:lmdb \
@@ -124,7 +124,7 @@ variant python27 description {Install Python 2.7 interface} {
                     port:py27-networkx \
                     port:py27-nose \
                     port:py27-pandas \
-                    port:py27-protobuf \
+                    port:py27-protobuf3 \
                     port:py27-gflags \
                     port:py27-leveldb \
                     port:py27-dateutil \

--- a/math/shogun-devel/Portfile
+++ b/math/shogun-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.0
 name                shogun-devel
 version             4.0.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            9
+revision            10
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/math/shogun-devel/Portfile
+++ b/math/shogun-devel/Portfile
@@ -84,7 +84,7 @@ depends_lib-append  port:hdf5 \
                     port:gzip \
                     port:bzip2 \
                     port:xz \
-                    port:protobuf-cpp
+                    port:protobuf3-cpp
 
 variant python27 description {Build the Python 2.7 API}  {
     depends_lib-append  port:swig-python \

--- a/net/et/Portfile
+++ b/net/et/Portfile
@@ -20,4 +20,4 @@ checksums           rmd160  539faf1aae76e9f7115e7561ec4cfaba159d2dc8 \
 depends_lib         port:gflags \
                     port:google-glog \
                     port:libsodium \
-                    port:protobuf-cpp
+                    port:protobuf3-cpp

--- a/net/et/Portfile
+++ b/net/et/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
 github.setup        MisterTea EternalTerminal 4.2.1 et-v
+revision            1
 name                et
 categories          net
 license             Apache-2

--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -28,7 +28,7 @@ perl5.create_variants   ${perl5.branches}
 depends_build           port:pkgconfig
 
 depends_lib             port:ncurses \
-                        port:protobuf-cpp \
+                        port:protobuf3-cpp \
                         port:zlib \
                         port:p${perl5.major}-getopt-long \
                         port:p${perl5.major}-io-socket-ip

--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -5,6 +5,7 @@ PortGroup               perl5 1.0
 
 name                    mosh
 version                 1.3.2
+revision                1
 categories              net
 license                 {GPL-3+ OpenSSLException}
 platforms               darwin

--- a/net/ola/Portfile
+++ b/net/ola/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        OpenLightingProject ola 0.10.6
+revision            1
 categories          net comms
 platforms           darwin
 license             GPL-2+ LGPL-2.1+

--- a/net/ola/Portfile
+++ b/net/ola/Portfile
@@ -34,7 +34,7 @@ depends_test        port:cppunit
 depends_build-append \
                     port:cppunit
 
-depends_lib         port:protobuf-cpp
+depends_lib         port:protobuf3-cpp
 
 configure.args      --disable-fatal-warnings  \
                     --disable-http \
@@ -48,7 +48,7 @@ variant python26 conflicts python27 description {Enable the Python 2.6 API} {
 }
 
 variant python27 conflicts python26 description {Enable the Python 2.7 API} {
-    depends_lib-append      port:py27-protobuf
+    depends_lib-append      port:py27-protobuf3
     configure.args-append   --enable-python-libs
     configure.python        ${prefix}/bin/python2.7
 }

--- a/net/ostinato/Portfile
+++ b/net/ostinato/Portfile
@@ -5,6 +5,7 @@ PortGroup           qt4 1.0
 PortGroup           github 1.0
 
 github.setup        pstavirs ostinato 0.8 v
+revision            1
 maintainers         g5pw openmaintainer
 license             GPL-3+
 

--- a/net/ostinato/Portfile
+++ b/net/ostinato/Portfile
@@ -18,7 +18,7 @@ platforms           darwin
 
 depends_lib         port:qt4-mac \
                     port:libpcap \
-                    port:protobuf-cpp
+                    port:protobuf3-cpp
 
 checksums           rmd160  990cd710ccafea3e9ea821073eea35511ba1e2c6 \
                     sha256  c7ea549a20c69969b1d2a3df5349f4a01115c79f07bc25d9e4f2208908cef15b

--- a/science/sumo/Portfile
+++ b/science/sumo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                sumo
 version             0.32.0
-revision            2
+revision            3
 categories          science devel
 platforms           darwin
 maintainers         {gmail.com:tlockhart1976 @lockhart} openmaintainer

--- a/science/sumo/Portfile
+++ b/science/sumo/Portfile
@@ -41,7 +41,7 @@ depends_lib-append \
 depends_lib-append \
     port:python27 \
     port:py27-matplotlib \
-    port:py27-protobuf
+    port:py27-protobuf3
 
 set bindir            ${prefix}/bin
 set libdir            ${prefix}/lib


### PR DESCRIPTION
Also from py27-protobuf to py27-protobuf3.

This is intended as a replacement for #690 

Note these changes have been performed quite mechanically, and are not tested. We need to discuss this before it gets merged.

As requested by @mojca 

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
