### PR TITLE
perl5.2[46]: update to 5.24.4 and 5.26.2, add size

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -22,21 +22,21 @@ master_sites        http://www.cpan.org/src/5.0/
 # - revision
 # - rmd160 sha256
 set perl5.versions_info {
-    5.16 3 5 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8
-    5.18 4 4 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5
-    5.20 3 3 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b
-    5.22 4 1 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71
-    5.24 3 1 61e7a9786f1e0f26da7de51c3d1e350d132e2a6c  c1af071e7bc133cedff9dd2278d6d92aa78f3514f195ab201c476382c130854e
-    5.26 1 1 fff5bf2e6ad6488b8866bf300c32707972b8ffc6  2812a01dd4d4cd7650cb70abfe259ee572bf6a0f1ee95763422ba7e54c68d12d
+    5.16 3 5 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8  13724906
+    5.18 4 4 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5  14059430
+    5.20 3 3 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b  13743405
+    5.22 4 1 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
+    5.24 4 0 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
+    5.26 2 0 e4a1c7f5f7611a8aa9625940066559a58691a2be  3f6a6b5bbd43016e5211e24b6631ea84216dd300216a2293b41c9195032f3e81  14495883
 }
 
-foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256} ${perl5.versions_info} {
+foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5.size} ${perl5.versions_info} {
     subport perl${perl5.v} {
         set perl5.major     ${perl5.v}
         version             ${perl5.major}.[string range ${perl5.subversion} 0 0]
         set minor           [lrange [split ${version} .] 1 1]
         revision            ${perl5.revision}
-        checksums           rmd160 ${perl5.rmd160} sha256 ${perl5.sha256}
+        checksums           rmd160 ${perl5.rmd160} sha256 ${perl5.sha256} size ${perl5.size}
 
         description         Perl ${version} - Practical Extraction and Report Language
         long_description    Perl is a general-purpose programming language \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/56339

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
