### PR TITLE
py-uncertainties: update to 3.0.2

### DIFF
--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            lebigot uncertainties 2.4.8.1
+github.setup            lebigot uncertainties 3.0.2
 
 name                    py-uncertainties
 categories-append       math
@@ -16,8 +16,9 @@ long_description        The uncertainties package transparently handles\
                         uncertainties.
 platforms               darwin
 
-checksums               rmd160  a8805a0554d7ca6417775f4863e7277f81094a30 \
-                        sha256  2a769626f977b7a76a44292d5fce8e938ba082e7d1f3325199762d5f671a35af
+checksums               rmd160  4954e8e43e56322ad3d8ac888163d9c436e87a95 \
+                        sha256  4d5d7f0035ed13e78a123a04bd17bb8711d887220f0e2ae109274b33c5bb92ae \
+                        size    146359
 
 python.versions         27 34 35 36
 


### PR DESCRIPTION
#### Description
update to version 3.0.2
add size to checksums
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5 and 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
