### PR TITLE
Add GitHub handle emaros to maintainers

### DIFF
--- a/science/gds/Portfile
+++ b/science/gds/Portfile
@@ -10,7 +10,7 @@ version       2.18.7
 revision      1
 categories    science
 platforms     darwin
-maintainers   {@emaros ligo.org:ed.maros} openmaintainer
+maintainers   {ligo.org:ed.maros @emaros} openmaintainer
 license       GPL
 
 description   LSC Algorithm Library

--- a/science/ldas-tools-al/Portfile
+++ b/science/ldas-tools-al/Portfile
@@ -7,7 +7,7 @@ name          ldas-tools-al
 version       2.5.7
 categories    science
 platforms     darwin
-maintainers   {@emaros ligo.org:ed.maros}
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   LDAS Tools Abstraction library
 long_description ${description}

--- a/science/ldas-tools-diskcacheAPI/Portfile
+++ b/science/ldas-tools-diskcacheAPI/Portfile
@@ -7,7 +7,7 @@ name          ldas-tools-diskcacheAPI
 version       2.5.6
 categories    science
 platforms     darwin
-maintainers   ligo.org:ed.maros
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   Filters library used by ldas-tools
 long_description ${description}

--- a/science/ldas-tools-filters/Portfile
+++ b/science/ldas-tools-filters/Portfile
@@ -7,7 +7,7 @@ name          ldas-tools-filters
 version       2.5.2
 categories    science
 platforms     darwin
-maintainers   ligo.org:ed.maros
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   Filters library used by ldas-tools
 long_description ${description}

--- a/science/ldas-tools-frameAPI/Portfile
+++ b/science/ldas-tools-frameAPI/Portfile
@@ -8,7 +8,7 @@ version       2.5.2
 revision      1
 categories    science
 platforms     darwin
-maintainers   ligo.org:ed.maros
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   Filters library used by ldas-tools
 long_description ${description}

--- a/science/ldas-tools-framecpp/Portfile
+++ b/science/ldas-tools-framecpp/Portfile
@@ -7,7 +7,7 @@ name          ldas-tools-framecpp
 version       2.5.8
 categories    science
 platforms     darwin
-maintainers   ligo.org:ed.maros
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   Suite of LDAS tools
 long_description ${description}

--- a/science/ldas-tools-ldasgen/Portfile
+++ b/science/ldas-tools-ldasgen/Portfile
@@ -7,7 +7,7 @@ name          ldas-tools-ldasgen
 version       2.5.5
 categories    science
 platforms     darwin
-maintainers   ligo.org:ed.maros
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   Filters library used by ldas-tools
 long_description ${description}

--- a/science/ldas-tools-utilities/Portfile
+++ b/science/ldas-tools-utilities/Portfile
@@ -7,7 +7,7 @@ name          ldas-tools-utilities
 version       2.5.1
 categories    science
 platforms     darwin
-maintainers   ligo.org:ed.maros
+maintainers   {ligo.org:ed.maros @emaros}
 
 description   Utilities built upon various ldas-tools components.
 long_description ${description}

--- a/science/ldas-tools/Portfile
+++ b/science/ldas-tools/Portfile
@@ -6,7 +6,7 @@ name            ldas-tools
 version         20161022
 categories      science
 platforms       darwin
-maintainers     ligo.org:ed.maros
+maintainers     {ligo.org:ed.maros @emaros}
 supported_archs noarch
 
 description   Suite of LDAS tools meta-port

--- a/science/ligotools/Portfile
+++ b/science/ligotools/Portfile
@@ -7,7 +7,7 @@ name                ligotools
 version             1.2.0
 categories          science
 platforms           darwin
-maintainers         ligo.org:ed.maros
+maintainers         {ligo.org:ed.maros @emaros}
 license             GPL-3+
 supported_archs     noarch
 

--- a/science/lscsoft-deps/Portfile
+++ b/science/lscsoft-deps/Portfile
@@ -6,7 +6,7 @@ name            lscsoft-deps
 version         20170511
 revision        2
 categories      science
-maintainers     {ram @skymoo} {aronnax @lpsinger} ligo.org:ed.maros
+maintainers     {ram @skymoo} {aronnax @lpsinger} {ligo.org:ed.maros @emaros}
 platforms       darwin
 supported_archs noarch
 

--- a/science/nds2-client/Portfile
+++ b/science/nds2-client/Portfile
@@ -9,7 +9,7 @@ revision          0
 categories        science
 platforms         darwin
 license           GPL-2
-maintainers       ligo.org:ed.maros openmaintainer
+maintainers       {ligo.org:ed.maros @emaros} openmaintainer
 
 description       Network Data Server Client
 long_description \


### PR DESCRIPTION
#### Description

Add GitHub handle @emaros to maintainers

It would be nice if the email address you use for MacPorts (at ligo.org) were registered with your GitHub account, so that when someone types that address into our Trac issue tracker, it gets replaced with your GitHub account name. You can [add email addresses to your GitHub account](https://github.com/settings/emails). After doing so, you should log out of Trac and log back in.

Alternately, we could switch the email address listed with your ports to one that's already registered with your GitHub account. If you want to do that, let me know and I'll modify this PR.

<!-- [skip notification] -->

