### PR TITLE
npm5: depend on nodejs8 by default

### DIFF
--- a/devel/npm5/Portfile
+++ b/devel/npm5/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                npm5
 version             5.8.0
+revision            1
 
 categories          devel
 platforms           darwin
@@ -33,11 +34,13 @@ checksums           sha1    5e4bfb8c2e7ada01dd41ec0555d13dd0f446ddb2 \
 
 worksrcdir          "package"
 
-depends_lib         path:bin/node:nodejs6
+depends_lib         path:bin/node:nodejs8
 
 platform darwin {
     if {${os.major} < 11} {
-        depends_lib-replace path:bin/node:nodejs6 path:bin/node:nodejs4
+        depends_lib-replace path:bin/node:nodejs8 path:bin/node:nodejs4
+    } elseif {${os.major} < 13} {
+        depends_lib-replace path:bin/node:nodejs8 path:bin/node:nodejs6
     }
 }
 


### PR DESCRIPTION
#### Description
Node.js 6.x bundles npm 3.10.x, and Node.js 8.x is LTS now.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
