### PR TITLE
libressl builds fine with gcc 4.2 from xcode 3.2.6

### DIFF
--- a/security/libressl/Portfile
+++ b/security/libressl/Portfile
@@ -36,9 +36,6 @@ post-patch {
     reinplace "s|@OPENSSLDIR@|${prefix}/etc/ssl|" ${worksrcpath}/include/openssl/opensslconf.h
 }
 
-# gcc-4.2 from Xcode 3.2.6 fails to handle some of the asm
-compiler.blacklist *gcc-4.2* {clang < 100}
-
 # HOST_ASM_MACOSX_X86_64 gets set when building i386 on x86_64
 set merger_configure_args(i386)     --disable-asm
 


### PR DESCRIPTION
Currently, libressl bans gcc-4.2 from Xcode 3.2.6
because it "fails to handle some of the asm".

I am on 10.6.8 with exactly that: xcode 3.2.6 and gcc 4.2. It builds just fine.
Perhaps this was needed for some previous version of libressl?

The main benefit of this change is that libressl has zero dependences.
With the needless restriction, a compiler gets pulled in, producing a long list of deps,
containing, ironicaly, openssl which is in conflict with libressl.
