### PR TITLE
py-dill: update to 0.2.7.1

### DIFF
--- a/python/py-dill/Portfile
+++ b/python/py-dill/Portfile
@@ -25,7 +25,7 @@ long_description    \
     provides the ability to save the state of an interpreter session in a \
     single command.
 
-homepage            http://www.cacr.caltech.edu/~mmckerns/dill.htm
+homepage            https://github.com/uqfoundation/dill
 
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/

--- a/python/py-dill/Portfile
+++ b/python/py-dill/Portfile
@@ -7,7 +7,7 @@ set _name           dill
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.2.6
+version             0.2.7.1
 
 platforms           darwin
 supported_archs     noarch
@@ -27,13 +27,13 @@ long_description    \
 
 homepage            http://www.cacr.caltech.edu/~mmckerns/dill.htm
 
-use_zip             yes
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-checksums           md5     f8b98b15223d23431024349f2102b4f9 \
-                    rmd160  b3e9915f8ba32f6140dd04e61b409b5830fc1c73 \
-                    sha256  6c1ccca68be483fa8c66e85a89ffc850206c26373aa77a97b83d8d0994e7f1fd
+checksums           md5     e58b860720a9bf47195e117636fe3c6a \
+                    rmd160  a37a53f39a163251a30fb0cd2339077021d6a917 \
+                    sha256  97fd758f5fe742d42b11ec8318ecfcff8776bccacbfcec05dfd6276f5d450f73 \
+                    size    64485
 
 python.versions     27 34 35 36
 

--- a/python/py-dill/Portfile
+++ b/python/py-dill/Portfile
@@ -42,7 +42,5 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
+    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- update to version 0.2.7.1
- add size to checksums
- fix livecheck
- update homepage

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5 and 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?