### PR TITLE
py-asteval: new port submission

### DIFF
--- a/python/py-asteval/Portfile
+++ b/python/py-asteval/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    py-asteval
+version                 0.9.12
+categories-append       math
+license                 BSD
+maintainers             {@reneeotten gmail.com:ottenr.work} openmaintainer
+description             Minimalistic evaluator of python expression using ast module
+long_description        ASTEVAL is a safe(ish) evaluator of Python expressions and \
+                        statements, using Python's ast module. The idea is to provide \
+                        a simple, safe, and robust miniature mathematical language that \
+                        can handle user-input. The emphasis here is on mathematical \
+                        expressions, and so many functions from numpy are imported and \
+                        used if available.
+platforms               darwin
+homepage                https://github.com/newville/asteval
+master_sites            pypi:a/asteval/
+distname                asteval-${version}
+
+checksums               rmd160  68782a598a9532d5384151796883fb42f1138b8a \
+                        sha256  38f3b0592cae7e7f65adc687e37aad1824a8e518245603a29ec33258277e779b \
+                        size    50686
+
+python.versions         27 34 35 36
+
+if {$subport ne $name} {
+    depends_build-append       port:py${python.version}-setuptools
+
+    depends_lib-append         port:py${python.version}-numpy \
+                               port:py${python.version}-six
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description
- submission of new port py-asteval; required for updating py-lmfit

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5 and 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?