### PR TITLE
protobuf-c: update to 1.3.0

### DIFF
--- a/devel/protobuf-c/Portfile
+++ b/devel/protobuf-c/Portfile
@@ -1,33 +1,32 @@
-PortSystem 1.0
-PortGroup       github 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name		protobuf-c
-version		1.1.0
-categories	devel
-license		Apache-2
-maintainers	nomaintainer
-description	Pure C code generator and runtime libraries for Protocol Buffers
+PortSystem      1.0
+
+PortGroup       github 1.0
+github.setup    protobuf-c protobuf-c 1.3.0 v
+categories      devel
+license         BSD
+maintainers     nomaintainer
+platforms       darwin
+description     Pure C code generator and runtime libraries for Protocol Buffers
 
 long_description \
-        This package provides a code generator and runtime libraries \
-        to use Protocol Buffers from pure C (not C++). \
-        \
-        Library ABI and API compatibility changes are expected until \
-        version 1.0 is released.
+                protobuf-c is a C implementation of the Google \
+                Protocol Buffers data serialization format. It \
+                includes libprotobuf-c, a pure C library that \
+                implements protobuf encoding and decoding, and \
+                protoc-c, a code generator that converts Protocol \
+                Buffer .proto files to C descriptor code, based on the \
+                original protoc.
+
+checksums       sha256  3ee7b49b67cf721185e92280a8496ca588ae0bdabbd0d1ab14fb2a8c1658f811 \
+                rmd160  6e655d39991822a35d85a3718fcde5cf24c0bcde \
+                size    123177
 
 
-github.setup    protobuf-c protobuf-c ${version} v
-github.tarball_from releases
-homepage        https://github.com/protobuf-c/protobuf-c
-master_sites    https://github.com/protobuf-c/protobuf-c/releases/download/v${version}
+use_autoreconf  yes
+depends_lib     port:protobuf3-cpp
+depends_build-append port:pkgconfig
 
-checksums       sha1    20bfcf3663ae56b125a5bfc3b4dca8c7f0ef1e48 \
-                sha256  9a973fc04aac003f9cf2b5a90ac4b8fa294cacb4e3f0796d3b5a789a5ad46c07
-
-platforms	darwin
-
-depends_lib	port:protobuf-cpp
-depends_build   port:pkgconfig
-
-test.run	yes
-test.target	check
+test.run        yes
+test.target     check


### PR DESCRIPTION
Now depends (for the moment) on protobuf3-cpp.

The Portfile was quite old and this is nearly a complete rewrite.

There's only one variant in MacPorts (and it's non-default) that depends on protobuf-c, so I think even though this changes from protobuf-cpp to protobuf3-cpp, it's safe to integrate as is. It will make the anticipated across the board change to protobuf v3 feasible as this is currently something in the way.

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
