### PR TITLE
ninja: fix build on Tiger

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -74,4 +74,9 @@ platform darwin {
         depends_build-append    port:python27
         configure.python        ${prefix}/bin/python2.7
     }
+    
+    if {${os.major} == 8} {
+        patchfiles-append patch-tiger-no-posix-spawn.diff
+        patchfiles-append patch-tiger-sysconf.diff
+    }
 }

--- a/devel/ninja/files/patch-tiger-no-posix-spawn.diff
+++ b/devel/ninja/files/patch-tiger-no-posix-spawn.diff
@@ -1,0 +1,146 @@
+diff --git src/subprocess-posix.cc src/subprocess-posix.cc
+index 1de22c3..75ef0b2 100644
+--- src/subprocess-posix.cc
++++ src/subprocess-posix.cc
+@@ -22,9 +22,6 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/wait.h>
+-#include <spawn.h>
+-
+-extern char** environ;
+ 
+ #include "util.h"
+ 
+@@ -53,63 +50,62 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
+ #endif  // !USE_PPOLL
+   SetCloseOnExec(fd_);
+ 
+-  posix_spawn_file_actions_t action;
+-  if (posix_spawn_file_actions_init(&action) != 0)
+-    Fatal("posix_spawn_file_actions_init: %s", strerror(errno));
+-
+-  if (posix_spawn_file_actions_addclose(&action, output_pipe[0]) != 0)
+-    Fatal("posix_spawn_file_actions_addclose: %s", strerror(errno));
+-
+-  posix_spawnattr_t attr;
+-  if (posix_spawnattr_init(&attr) != 0)
+-    Fatal("posix_spawnattr_init: %s", strerror(errno));
+-
+-  short flags = 0;
+-
+-  flags |= POSIX_SPAWN_SETSIGMASK;
+-  if (posix_spawnattr_setsigmask(&attr, &set->old_mask_) != 0)
+-    Fatal("posix_spawnattr_setsigmask: %s", strerror(errno));
+-  // Signals which are set to be caught in the calling process image are set to
+-  // default action in the new process image, so no explicit
+-  // POSIX_SPAWN_SETSIGDEF parameter is needed.
+-
+-  if (!use_console_) {
+-    // Put the child in its own process group, so ctrl-c won't reach it.
+-    flags |= POSIX_SPAWN_SETPGROUP;
+-    // No need to posix_spawnattr_setpgroup(&attr, 0), it's the default.
+-
+-    // Open /dev/null over stdin.
+-    if (posix_spawn_file_actions_addopen(&action, 0, "/dev/null", O_RDONLY,
+-                                         0) != 0) {
+-      Fatal("posix_spawn_file_actions_addopen: %s", strerror(errno));
++   pid_ = fork();
++   if (pid_ < 0)
++     Fatal("fork: %s", strerror(errno));
++ 
++   if (pid_ == 0) {
++     close(output_pipe[0]);
++ 
++     // Track which fd we use to report errors on.
++     int error_pipe = output_pipe[1];
++     do {
++       if (sigaction(SIGINT, &set->old_int_act_, 0) < 0)
++         break;
++       if (sigaction(SIGTERM, &set->old_term_act_, 0) < 0)
++         break;
++       if (sigaction(SIGHUP, &set->old_hup_act_, 0) < 0)
++         break;
++       if (sigprocmask(SIG_SETMASK, &set->old_mask_, 0) < 0)
++         break;
++ 
++       if (!use_console_) {
++         // Put the child in its own process group, so ctrl-c won't reach it.
++         if (setpgid(0, 0) < 0)
++           break;
++ 
++         // Open /dev/null over stdin.
++         int devnull = open("/dev/null", O_RDONLY);
++         if (devnull < 0)
++           break;
++         if (dup2(devnull, 0) < 0)
++           break;
++         close(devnull);
++ 
++         if (dup2(output_pipe[1], 1) < 0 ||
++             dup2(output_pipe[1], 2) < 0)
++           break;
++ 
++         // Now can use stderr for errors.
++         error_pipe = 2;
++         close(output_pipe[1]);
++       }
++       // In the console case, output_pipe is still inherited by the child and
++       // closed when the subprocess finishes, which then notifies ninja.
++ 
++       execl("/bin/sh", "/bin/sh", "-c", command.c_str(), (char *) NULL);
++     } while (false);
++ 
++     // If we get here, something went wrong; the execl should have
++     // replaced us.
++     char* err = strerror(errno);
++     if (write(error_pipe, err, strlen(err)) < 0) {
++       // If the write fails, there's nothing we can do.
++       // But this block seems necessary to silence the warning.
++      }
++     _exit(1);
+     }
+ 
+-    if (posix_spawn_file_actions_adddup2(&action, output_pipe[1], 1) != 0)
+-      Fatal("posix_spawn_file_actions_adddup2: %s", strerror(errno));
+-    if (posix_spawn_file_actions_adddup2(&action, output_pipe[1], 2) != 0)
+-      Fatal("posix_spawn_file_actions_adddup2: %s", strerror(errno));
+-    if (posix_spawn_file_actions_addclose(&action, output_pipe[1]) != 0)
+-      Fatal("posix_spawn_file_actions_addclose: %s", strerror(errno));
+-    // In the console case, output_pipe is still inherited by the child and
+-    // closed when the subprocess finishes, which then notifies ninja.
+-  }
+-#ifdef POSIX_SPAWN_USEVFORK
+-  flags |= POSIX_SPAWN_USEVFORK;
+-#endif
+-
+-  if (posix_spawnattr_setflags(&attr, flags) != 0)
+-    Fatal("posix_spawnattr_setflags: %s", strerror(errno));
+-
+-  const char* spawned_args[] = { "/bin/sh", "-c", command.c_str(), NULL };
+-  if (posix_spawn(&pid_, "/bin/sh", &action, &attr,
+-                  const_cast<char**>(spawned_args), environ) != 0)
+-    Fatal("posix_spawn: %s", strerror(errno));
+-
+-  if (posix_spawnattr_destroy(&attr) != 0)
+-    Fatal("posix_spawnattr_destroy: %s", strerror(errno));
+-  if (posix_spawn_file_actions_destroy(&action) != 0)
+-    Fatal("posix_spawn_file_actions_destroy: %s", strerror(errno));
+-
+   close(output_pipe[1]);
+   return true;
+ }
+diff --git src/subprocess_test.cc src/subprocess_test.cc
+index 0a8c206..672a2f1 100644
+--- src/subprocess_test.cc
++++ src/subprocess_test.cc
+@@ -224,8 +224,7 @@ TEST_F(SubprocessTest, SetWithLots) {
+   rlimit rlim;
+   ASSERT_EQ(0, getrlimit(RLIMIT_NOFILE, &rlim));
+   if (rlim.rlim_cur < kNumProcs) {
+-    printf("Raise [ulimit -n] above %u (currently %lu) to make this test go\n",
+-           kNumProcs, rlim.rlim_cur);
++    printf("Raise [ulimit -n] well above %u (currently %lu) to make this test go\n", kNumProcs, rlim.rlim_cur);
+     return;
+   }
+ 

--- a/devel/ninja/files/patch-tiger-sysconf.diff
+++ b/devel/ninja/files/patch-tiger-sysconf.diff
@@ -1,0 +1,65 @@
+--- src/util.cc.old	2018-04-23 22:08:41.000000000 -0700
++++ src/util.cc	2018-04-23 22:13:09.000000000 -0700
+@@ -54,6 +54,47 @@
+ #include "edit_distance.h"
+ #include "metrics.h"
+ 
++#ifdef __APPLE__
++#ifndef __MAC_OS_X_VERSION_MIN_REQUIRED
++#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
++#include <Availability.h>
++#else
++#include <AvailabilityMacros.h>
++#endif
++#endif //#ifndef __MAC_OS_X_VERSION_MIN_REQUIRED
++
++
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++//#include <sys/types.h>
++//#include <sys/sysctl.h>
++#define _SC_NPROCESSORS_ONLN 58
++
++long tigersysconf(int name){
++
++    if (name == _SC_NPROCESSORS_ONLN) {
++		int nm[2];
++		size_t len = 4;
++		uint32_t count;
++		
++		nm[0] = CTL_HW; nm[1] = HW_AVAILCPU;
++		sysctl(nm, 2, &count, &len, NULL, 0);
++		
++		if (count < 1) {
++			nm[1] = HW_NCPU;
++			sysctl(nm, 2, &count, &len, NULL, 0);
++			if (count < 1) { count = 1; }
++			}
++			
++		return (long)count;
++    }
++    return -1;
++}
++#endif //#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++#endif //#ifdef __APPLE__
++
++
++
++
+ void Fatal(const char* msg, ...) {
+   va_list ap;
+   fprintf(stderr, "ninja: fatal: ");
+@@ -476,8 +517,14 @@
+   GetNativeSystemInfo(&info);
+   return info.dwNumberOfProcessors;
+ #else
++
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++  return tigersysconf(_SC_NPROCESSORS_ONLN);
++#else
+   return sysconf(_SC_NPROCESSORS_ONLN);
+ #endif
++
++#endif
+ }
+ 
+ #if defined(_WIN32) || defined(__CYGWIN__)


### PR DESCRIPTION
adds replacement for sysconf() call
replaces posix_spawn calls with fork()/exec()
(essentially reverts <https://github.com/ninja-build/ninja/commit/89587196>)

```
$ port -v installed ninja
The following ports are currently installed:
  ninja @1.8.2_1 (active) platform='darwin 8' archs='ppc' date='2018-04-23T22:03:13-0700'

$ ninja --version
1.8.2

$ ninja --help
usage: ninja [options] [targets...]

if targets are unspecified, builds the 'default' target (see manual).

options:
  --version  print ninja version ("1.8.2")

  -C DIR   change to DIR before doing anything else
  -f FILE  specify input build file [default=build.ninja]

  -j N     run N jobs in parallel [default=3, derived from CPUs available]
  -k N     keep going until N jobs fail [default=1]
  -l N     do not start new jobs if the load average is greater than N
  -n       dry run (don't run commands but act like they succeeded)
  -v       show all command lines while building

  -d MODE  enable debugging (use -d list to list modes)
  -t TOOL  run a subtool (use -t list to list subtools)
    terminates toplevel options; further flags are passed to the tool
  -w FLAG  adjust warnings (use -w list to list warnings)
```