### PR TITLE
py-isort: update to 4.3.4

### DIFF
--- a/python/py-isort/Portfile
+++ b/python/py-isort/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-isort
-version             4.2.5
+version             4.3.4
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -27,8 +27,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            isort-${version}
 
-checksums           rmd160  bd8e921d3694dc258d36eb226ba6d575dcb4e55e \
-                    sha256  56b20044f43cf6e6783fe95d054e754acca52dd43fbe9277c1bdff835537ea5c
+checksums           rmd160  48e3caab73e2830bd3ac2c6ebe139e5527018057 \
+                    sha256  b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8 \
+                    size    56070
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-isort/Portfile
+++ b/python/py-isort/Portfile
@@ -12,7 +12,7 @@ supported_archs     noarch
 
 python.versions     27 34 35 36
 
-maintainers         nomaintainer
+maintainers         {@reneeotten gmail.com:ottenr.work} openmaintainer
 
 description         A Python utility / library to sort Python imports.
 


### PR DESCRIPTION
#### Description
- update to version 4.3.4
- add size to checksums
- take maintainership

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5 and 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?