### PR TITLE
py-tqdm: add py34 subport

### DIFF
--- a/python/py-tqdm/Portfile
+++ b/python/py-tqdm/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 


### PR DESCRIPTION
#### Description

While looking into updating the py-pymc3 port I came across the following Trac ticket:
https://trac.macports.org/ticket/54311

If adding the py34-subport for py-tqdm would be acceptable, it would allow for adding the py34-pymc3 again. In a recent commit 3c807a0 the py34-pymc3 subport was removed referencing another Trac ticket: https://trac.macports.org/ticket/56131 Alternatively, I can update the py-pymc3 port while leaving py34 out and just close the first Trac ticket. What is the preference here?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 3.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

