### PR TITLE
osc2midi: new port @ 0.2.3

### DIFF
--- a/audio/osc2midi/Portfile
+++ b/audio/osc2midi/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+github.setup            ssj71 OSC2MIDI 0.2.3 v
+name                    osc2midi
+
+checksums               rmd160  588963bee79574b7da57a6392323887afe8be8c4 \
+                        sha256  25071213508949b61d801d77dfe680dfd804f62d70533b9488e0498b6a00b073 \
+                        size    50185
+
+maintainers             {ryandesign @ryandesign} \
+                        {gmail.com:aggraef @agraef} \
+                        openmaintainer
+
+categories              audio
+description             OSC to JACK MIDI bridge
+long_description        This is a flexible OSC to JACK MIDI (and back) Bridge \
+                        written in C for Linux. It was designed to be configurable \
+                        so that any combination of MIDI and OSC client or host \
+                        can work perfectly with it.
+
+platforms               darwin
+license                 GPL-3
+
+depends_lib-append      port:jack \
+                        port:liblo


### PR DESCRIPTION
OSC to JACK MIDI bridge
closes: https://trac.macports.org/ticket/47823

Better late than never!
@ryandesign 
@agraef 