### PR TITLE
py-pypdf2: update to 1.26.0

### DIFF
--- a/python/py-pypdf2/Portfile
+++ b/python/py-pypdf2/Portfile
@@ -33,9 +33,4 @@ if {${name} ne ${subport}} {
             ${destroot}${prefix}/share/doc/${subport}
     }
     livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       ${github.raw}/master/CHANGELOG
-    livecheck.version   ${version}
-    livecheck.regex     {Version (\d+\.\d+)}
 }

--- a/python/py-pypdf2/Portfile
+++ b/python/py-pypdf2/Portfile
@@ -4,9 +4,8 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            mstamy2 PyPDF2 2f499c55d575be976c0984a5e1047f99a6f7667f
+github.setup            mstamy2 PyPDF2 1.26.0
 name                    py-pypdf2
-version                 1.25.1
 categories-append       devel
 platforms               darwin
 supported_archs         noarch
@@ -21,10 +20,11 @@ long_description        A Pure-Python PDF toolkit. It is capable of \
                         into a single page, and encrypting and \
                         decrypting PDF files.
 
-checksums               rmd160  15953f4bc160a060ec5e9772dec4e802c7e22415 \
-                        sha256  f007889cbaa19f9fd4c69b37eb2f28a8ddc995ad29a1c906546529b9a80f6373
+checksums               rmd160  04256188413724d3bdbaeaecb923966145014958 \
+                        sha256  3d5531d5bb456fdb1881356352035059a878dea4a5548c4a57e01d82075870df \
+                        size    199567
 
-python.versions         26 27 34 35 36
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     post-destroot {

--- a/python/py-pypdf2/Portfile
+++ b/python/py-pypdf2/Portfile
@@ -10,7 +10,7 @@ categories-append       devel
 platforms               darwin
 supported_archs         noarch
 license                 BSD
-maintainers             nomaintainer
+maintainers             {@reneeotten gmail.com:ottenr.work} openmaintainer
 
 description             A utility to read and write pdfs with Python
 long_description        A Pure-Python PDF toolkit. It is capable of \


### PR DESCRIPTION
#### Description
- update to version 1.26.0
- add size to checksums
- fix livecheck
- drop py26
- take maintainership

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?