### PR TITLE
caffe: switch from protobuf-cpp to protobuf3-cpp

### DIFF
--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 name                caffe
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
-revision            5
+revision            6
 categories          math science
 maintainers         nomaintainer
 
@@ -22,7 +22,7 @@ checksums           rmd160  fbf514385ccfb2e7c0ef3ccd85c15ffbbd52ec88 \
 
 depends_lib-append  port:google-glog \
                     port:gflags \
-                    port:protobuf-cpp \
+                    port:protobuf3-cpp \
                     port:leveldb \
                     port:snappy \
                     port:lmdb \
@@ -124,7 +124,7 @@ variant python27 description {Install Python 2.7 interface} {
                     port:py27-networkx \
                     port:py27-nose \
                     port:py27-pandas \
-                    port:py27-protobuf \
+                    port:py27-protobuf3 \
                     port:py27-gflags \
                     port:py27-leveldb \
                     port:py27-dateutil \


### PR DESCRIPTION
#### Description

As part of https://trac.macports.org/ticket/56135#comment:2 update this for now to protobuf3-cpp. A switch to a new "protobuf" port after protobuf-cpp and protobuf3-cpp are obsoleted will happen in a few days.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
