### PR TITLE
libphonenumber-cpp: switch from protobuf-cpp to protobuf3-cpp

### DIFF
--- a/devel/libphonenumber-cpp/Portfile
+++ b/devel/libphonenumber-cpp/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 
 github.setup        googlei18n libphonenumber 8.9.4 v
 name                libphonenumber-cpp
+revision            1
 license             Apache-2
 description         Google's C++ library for parsing, formatting, storing \
                     and validating international phone numbers.
@@ -40,7 +41,7 @@ depends_lib-append  port:boost \
                     port:icu
 
 # enable build with either protobuf-cpp or protobuf3-cpp
-depends_lib-append  path:${prefix}/lib/libprotobuf.dylib:protobuf-cpp
+depends_lib-append  path:${prefix}/lib/libprotobuf.dylib:protobuf3-cpp
 
 configure.args-append \
                     -DGTEST_SOURCE_DIR=${gtest_srcdir} \


### PR DESCRIPTION
#### Description

Part of the cleanup associated with:
https://trac.macports.org/ticket/56135#comment:2

Note that strictly speaking, this one might not be necessary since the port was already built to work with either version. There's one downstream dependent which I don't think needs to be bumped at this time as a result (evolution-data-server).

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
