### PR TITLE
ostinato: switch from protobuf-cpp to protobuf3-cpp

### DIFF
--- a/net/ostinato/Portfile
+++ b/net/ostinato/Portfile
@@ -5,6 +5,7 @@ PortGroup           qt4 1.0
 PortGroup           github 1.0
 
 github.setup        pstavirs ostinato 0.8 v
+revision            1
 maintainers         g5pw openmaintainer
 license             GPL-3+
 
@@ -18,7 +19,7 @@ platforms           darwin
 
 depends_lib         port:qt4-mac \
                     port:libpcap \
-                    port:protobuf-cpp
+                    port:protobuf3-cpp
 
 checksums           rmd160  990cd710ccafea3e9ea821073eea35511ba1e2c6 \
                     sha256  c7ea549a20c69969b1d2a3df5349f4a01115c79f07bc25d9e4f2208908cef15b


### PR DESCRIPTION
#### Description

Part of the upgrade path described in: https://trac.macports.org/ticket/56135#comment:2

After everything is using protobuf3-cpp, we'll obsolete that and protobuf-cpp and switch everything over to a new "protobuf" port.

(I tested the build, btw. Not familiar enough to check functionality.)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
