### PR TITLE
py-lmfit: update to 0.9.9

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-lmfit
-version                 0.9.5
+version                 0.9.9
 categories-append       math
 license                 BSD
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
@@ -18,14 +18,19 @@ homepage                https://lmfit.github.io/lmfit-py/
 master_sites            pypi:l/lmfit/
 distname                lmfit-${version}
 
-checksums               rmd160  3e9c32c8fe88987e35211e4d7ed694eff292dc7d \
-                        sha256  eebc3c34ed9f3e51bdd927559a5482548c423ad5a0690c6fdcc414bfb5be6667
+checksums               rmd160  b2891fa6b125ea11e88769dc31704e681cde91a8 \
+                        sha256  eee9fa534dc3c494a4d7dd3e0cd243792bbc6cb409805440282a4b5fdab50ea1 \
+                        size    1574912
 
 python.versions         27 34 35 36
 
 if {$subport ne $name} {
     depends_build-append       port:py${python.version}-setuptools
-    depends_lib-append         port:py${python.version}-scipy
+
+    depends_lib-append         port:py${python.version}-scipy \
+                               port:py${python.version}-numpy \
+                               port:py${python.version}-six \
+                               port:py${python.version}-asteval
 
     notes-append "If py${python.version}-uncertainties is also installed, propagation of uncertainties to constrained parameters will be enabled."
     notes-append "If upgrading from 0.8.x, any scripts using lmfit must be changed https://lmfit.github.io/lmfit-py/whatsnew.html#whatsnew-090-label"


### PR DESCRIPTION
#### Description
- update to version 0.9.9
- add size to checksums
- update dependencies

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
