### PR TITLE
libvorbis does not need pkgconfig to find libogg

### DIFF
--- a/audio/libvorbis/Portfile
+++ b/audio/libvorbis/Portfile
@@ -20,8 +20,6 @@ long_description \
 homepage        https://xiph.org/vorbis/
 master_sites    https://downloads.xiph.org/releases/vorbis/
 
-depends_build   port:pkgconfig
-
 depends_lib     port:libogg
 
 checksums       rmd160  ba4efb81513d0f431d4d04f6a7b2590c80778a43 \


### PR DESCRIPTION
libvorbis finds and builds against the installed libogg even without pkgconfig.
This is on MacOS 10.13.4 running MP 2.4.4

Is pkg-config needed somewhere else,
or  can we drop the dependency?
