### PR TITLE
libressl-devel: upgrade to 2.7.2

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                libressl-devel
-version             2.6.2
+version             2.7.2
 distname            libressl-${version}
 
 categories          security devel
@@ -24,8 +23,8 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160  4e83f3c89e8b81c5a6565e0e1639e67547e788f6 \
-                    sha256  b029d2492b72a9ba5b5fcd9f3d602c9fd0baa087912f2aaecc28f52f567ec478
+checksums           rmd160 71b2479da15af6800dc0bd18141e3fe211e96828 \
+                    sha256 917a8779c342177ff3751a2bf955d0262d1d8916a4b408930c45cef326700995
 
 patchfiles \
     openssldir-cert.pem.patch
@@ -37,9 +36,6 @@ configure.args \
 post-patch {
     reinplace "s|@OPENSSLDIR@|${prefix}/etc/ssl|" ${worksrcpath}/include/openssl/opensslconf.h
 }
-
-# gcc-4.2 from Xcode 3.2.6 fails to handle some of the asm
-compiler.blacklist *gcc-4.2* {clang < 100}
 
 # HOST_ASM_MACOSX_X86_64 gets set when building i386 on x86_64
 set merger_configure_args(i386)     --disable-asm


### PR DESCRIPTION
* fixes build on macOS 10.11 and older.
* adds support for many OpenSSL 1.0.2 and 1.1 APIs,
  based on observations of real-world usage in applications.
* extensive corrections, improvements, and additions
  to the API documentation, including new public APIs from OpenSSL
  that had no pre-existing documentation.

See also https://github.com/macports/macports-ports/pull/1626
for the benefits which are not happening for now,
as we are upgrading libressl-devel, not libressl.

See also https://trac.macports.org/ticket/55264

While here, stop blacklisting compilers; that was introduced
for a much older version and doesn't seem to be needed any more

- [x] bugfix
- [x] enhancement
- [ ] security fix

Tested on 10.13.4 and 10.6.8

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
