### PR TITLE
py-nmrglue: update to 0.6

### DIFF
--- a/python/py-nmrglue/Portfile
+++ b/python/py-nmrglue/Portfile
@@ -4,12 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-nmrglue
-set internal_name   nmrglue
-
-version             0.4
-
+version             0.6
 categories-append   science
-maintainers         gmail.com:michelle.lynn.gill openmaintainer
+maintainers         {@mlgill gmail.com:michelle.lynn.gill} openmaintainer
 platforms           darwin
 license             BSD
 
@@ -19,17 +16,16 @@ long_description    nmrglue is a module for working with NMR data in Python. \
                     nmrglue provides a robust interpreted environment for processing, \
                     analysing, and inspecting NMR data.
 
-homepage            https://code.google.com/p/nmrglue/
-master_sites        googlecode:nmrglue
-
-distname            ${internal_name}-${version}-corrected
-worksrcdir          ${internal_name}-${version}
 supported_archs     noarch
+homepage            https://nmrglue.com
+master_sites        pypi:n/nmrglue/
+distname            nmrglue-${version}
 
-checksums           rmd160  37ce92304515f9d05de4b59c03c69748e453d8cd \
-                    sha256  85c45750aef431f2c1326a9f4856eeac4da8aedbc94c6255de6e08e3ea35f316
+checksums           rmd160  37534eaaee6d72f5301a6e7933594e8db74229ef \
+                    sha256  2392555a8d0e558c7d12eee6f0d1bd71c5571972517bb252bf803484cf3c1300 \
+                    size    150827
 
-python.versions     26 27
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-scipy \
@@ -37,7 +33,5 @@ if {${name} ne ${subport}} {
 
     livecheck.type  none
 } else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     ${internal_name}-(\[0-9\]+\\.\[0-9\]+)\\.tar\\.gz
+    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- update to version 0.6
- switch from googlecode to PyPI
- add size to checksums
- fix livecheck
- update subports
- update homepage
- add maintainer's github handle
 
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.5, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
