### PR TITLE
gnome-internet-radio-locator version 1.1.2

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             1.1.1
+version             1.1.2
 set branch          [join [lrange [split $version .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -17,9 +17,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  cc7957a06b8c8edbf5e36ec484ded74ab7d663bf \
-                    sha256  4e16137b4de2091b0f3b8bfa648483c62c2b253f972ae6bea6fd030aac2dc917 \
-                    size    538088
+checksums           rmd160  fcb2eb63b6215507756f8229d87395e6d3915eac \
+                    sha256  5249feb18f01ae7cd2e7c06a3eb76f41d6aada4c46fdda8d61a59d45efa53816 \
+                    size    538992
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
gnome-internet-radio-locator: update to version 1.1.2

* update to version 1.1.2

Closes: https://trac.macports.org/ticket/56368
