### PR TITLE
py-typing: reverse py35/py36 subports added by 6c05e98

### DIFF
--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -28,7 +28,7 @@ checksums           md5     5b2ade08d83be488f17b5fe587c27c74 \
                     rmd160  0c03e1a2972bc8ed83494ef5a92f06a76d32e7d9 \
                     sha256  d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2
 
-python.versions     27 33 34 35 36
+python.versions     27 33 34
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
This is one of the ports listed under [ticket #56357](https://trac.macports.org/ticket/56357).

@mojca, I was not sure from the ticket whether I am supposed to submit the PR, or you were planning to.