### PR TITLE
py-unittest2: revert addition of 35 36 subports

### DIFF
--- a/python/py-unittest2/Portfile
+++ b/python/py-unittest2/Portfile
@@ -8,15 +8,16 @@ version             0.5.1
 revision            1
 license             PSF
 maintainers         {aronnax @lpsinger} openmaintainer
-python.versions     26 27 33 34 35 36
+# do not add subports for python > 3.4
+python.versions     26 27 33 34
 
 description         New features in the unittest library
 
-long_description    \
-    unittest2 is a backport of the new features added to the unittest testing \
-    framework in Python 2.7. It is tested to run on Python 2.4 - 2.7. To use \
-    unittest2 instead of unittest simply replace import unittest with \
-    import unittest2.
+long_description    unittest2 is a backport of the new features added to the unittest \
+                    testing framework in Python 2.7 and onwards. \
+                    It is tested to run on Python 2.6, 2.7, 3.2, 3.3, 3.4 and pypy. \
+                    To use unittest2 instead of unittest simply replace import unittest with \
+                    import unittest2.
 
 platforms           darwin
 supported_archs     noarch


### PR DESCRIPTION
Revert 6c05e9852d0b08b2a8f14e7ee622031196a9d699.
See: https://trac.macports.org/ticket/56357

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
