### PR TITLE
pymol: fix -O3 usage on Darwin and clean up broken reinplaces 

### DIFF
--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -7,6 +7,7 @@ PortGroup           compilers 1.0
 
 name                pymol
 version             2.1.0
+revision            1
 categories          science chemistry
 license             PSF
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
@@ -67,7 +68,8 @@ universal_variant   no
 patchfiles          pymol_shell.diff \
                     pmg_tk_platform.patch \
                     apbs-psize.patch  \
-                    pdb2pqr.patch
+                    pdb2pqr.patch \
+                    setup.py.diff
 
 require_active_variants tcl "" corefoundation
 require_active_variants tk "" quartz
@@ -76,7 +78,6 @@ post-patch {
     reinplace  "s|@PREFIX@|${prefix}|g" ${worksrcpath}/setup.py ${worksrcpath}/modules/pmg_tk/startup/apbs_tools.py
     reinplace  "s|@@PYTHON_PKGDIR@@|${python.pkgd}|g" ${worksrcpath}/setup/pymol_macports
     reinplace  "s|@@PYTHON_BINARY@@|${python.bin}|g" ${worksrcpath}/setup/pymol_macports
-    reinplace  "s|\"-O3\",|\"-O3\", \"-g\",|g" ${worksrcpath}/setup.py
     reinplace  "s|cxx + \' \' + cxxflags|\'${configure.cxx} \' + cxxflags|g" ${worksrcpath}/monkeypatch_distutils.py
 }
 

--- a/science/pymol/files/setup.py.diff
+++ b/science/pymol/files/setup.py.diff
@@ -1,0 +1,29 @@
+Index: setup.py
+===================================================================
+--- setup.py	(revision 4187)
++++ setup.py	(working copy)
+@@ -87,7 +87,7 @@
+     X11 = ['/usr/X11'] * (not options.osx_frameworks)
+ 
+     if sys.platform == 'darwin':
+-        for prefix in ['/sw', '/opt/local', '/usr/local']:
++        for prefix in ['@PREFIX@', '/usr/local']:
+             if sys.executable.startswith(prefix):
+                 return [prefix] + X11
+ 
+@@ -392,12 +392,12 @@
+     libs += ["GLEW"]
+     libs += pyogl_libs
+ 
+-    ext_comp_args += ["-ffast-math", "-funroll-loops", "-fcommon"]
++    ext_comp_args += ["-ffast-math", "-funroll-loops", "-fcommon", "-O3"]
+ 
+     # optimization currently causes a clang segfault on OS X 10.9 when
+     # compiling layer2/RepCylBond.cpp
+-    if sys.platform != 'darwin':
+-        ext_comp_args += ["-O3"]
++    if sys.platform == 'darwin':
++        ext_comp_args += ["-fno-strict-aliasing"]
+ 
+ def get_pymol_version():
+     return re.findall(r'_PyMOL_VERSION "(.*)"', open('layer0/Version.h').read())[0]


### PR DESCRIPTION
#### Description

Restore -O3 compiler optimization by appending -fno-strict-aliasing which avoids a compiler ICE.

Note that the clang compiler ICE has been filed upstream with llvm.org as [https://bugs.llvm.org/show_bug.cgi?id=37280](https://bugs.llvm.org/show_bug.cgi?id=37280)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.4 17E202
Xcode 9.3 9E145 


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-poxrts/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?