### PR TITLE
octave: remove references to nonexistent compilers

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -98,8 +98,6 @@ pre-patch {
     set libcxxbug no
     if { ${configure.cc} eq "/usr/bin/clang" && [lindex [split ${xcodeversion} .] 0] eq 6 } {
         set libcxxbug yes
-    } elseif { [variant_exists clang35] && [variant_isset clang35] } {
-        set libcxxbug yes
     }
     if { ${libcxxbug} } {
         patchfiles-append   \
@@ -210,8 +208,6 @@ compilers.setup     \
     -gcc45          \
     -gcc44          \
     -g95            \
-    -clang36        \
-    -clang35        \
     -clang34        \
     -clang33
 


### PR DESCRIPTION
See https://trac.macports.org/ticket/55548
Fixes https://trac.macports.org/ticket/56362

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->