### PR TITLE
py-backports[-ssl_match_hostname]: revert subports

### DIFF
--- a/python/py-backports-ssl_match_hostname/Portfile
+++ b/python/py-backports-ssl_match_hostname/Portfile
@@ -11,7 +11,8 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 33 34 35 36
+# do not add subports for python > 3.4
+python.versions     27 33 34
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-backports/Portfile
+++ b/python/py-backports/Portfile
@@ -10,7 +10,8 @@ platforms           darwin
 license             PSF
 supported_archs     noarch
 
-python.versions     27 33 34 35 36
+# do not add subports for python > 3.4
+python.versions     27 33 34
 
 maintainers         stromnov openmaintainer
 


### PR DESCRIPTION
Revert 6c05e9852d0b08b2a8f14e7ee622031196a9d699.
Remove subports for python 3.5 and 3.6 for py-backports and py-backports-ssl_match_hostname.
See: https://trac.macports.org/ticket/56357

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
