### PR TITLE
py-autopep8: update to 1.3.5

### DIFF
--- a/python/py-autopep8/Portfile
+++ b/python/py-autopep8/Portfile
@@ -6,26 +6,31 @@ PortGroup           select 1.0
 
 name                py-autopep8
 set realname        autopep8
-version             1.2.1
+version             1.3.5
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             MIT
-maintainers         nomaintainer
+maintainers         {@reneeotten gmail.com:ottenr.work} openmaintainer
 
 description         A tool that automatically formats Python code to \
                     conform to the PEP 8 style guide
-long_description    autopep8 formats Python code based on the output \
-                    of the pep8_ utility.
+long_description    autopep8 automatically formats Python code to \
+                    conform to the PEP 8 style guide. It uses the \
+                    pycodestyle utility to determine what parts of \
+                    the code needs to be formatted. autopep8 is \
+                    capable of fixing most of the formatting issues \
+                    that can be reported by pycodestyle.
 
 homepage            https://pypi.python.org/pypi/${realname}
 
 master_sites        pypi:a/${realname}
 distname            ${realname}-${version}
 
-checksums           md5     4167555f521ddd69b66f13819604f3db \
-                    rmd160  175a0f1fc4a79073bca99ab3a87f87f07aa54af9 \
-                    sha256  d0a7cdc397e46be0d91a968acb3f561cc1b9244f5df94a2514cf32acfc8a2e94
+checksums           md5     9d0dfe251d003edb8f6a95dc4929b7b7 \
+                    rmd160  98c2eeb12ae464628d0b1e2ae5ba090be11ee94b \
+                    sha256  2284d4ae2052fedb9f466c09728e30d2e231cfded5ffd7b1a20c34123fdc4ba4 \
+                    size    109415
 
 python.versions     27 34 35 36
 
@@ -33,7 +38,7 @@ if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools
     depends_run-append      \
         port:${realname}_select \
-        path:${python.pkgd}/pep8:py${python.version}-pep8
+        path:${python.pkgd}/pycodestyle:py${python.version}-codestyle
 
     select.group            ${realname}
     select.file             ${filespath}/${realname}-${python.version}
@@ -41,12 +46,10 @@ if {${name} ne ${subport}} {
 To make the Python ${python.branch} version of autopep8 the one that is run\
 when you execute the commands without a version suffix, e.g. 'autopep8', run:
 
-    port select --set ${select.group} [file tail ${select.file}]
+    sudo port select --set ${select.group} [file tail ${select.file}]
 "
 
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${realname}/json
-    livecheck.regex "\"${realname}-(\[.\\d\]+)\\${extract.suffix}\""
+    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- update to version 1.3.5
- add size to cheksums
- switch to using pycodestyle that replaced pep8
- update livecheck and description
- assume maintainership
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.4-3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?