### PR TITLE
py-pymc3: update to 3.4.1

### DIFF
--- a/python/py-pymc3/Portfile
+++ b/python/py-pymc3/Portfile
@@ -4,35 +4,37 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pymc-devs pymc3 3.3 v
+github.setup        pymc-devs pymc3 3.4.1 v
 name                py-pymc3
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@reneeotten gmail.com:ottenr.work} openmaintainer
 license             Apache-2
 supported_archs     noarch
+homepage            https://github.com/pymc-devs/pymc3
 
-description         Bayesian statistical models and fitting algorithms for python
-long_description    PyMC is a python module that implements Bayesian statistical models \
-                    and fitting algorithms, including Markov chain Monte Carlo. \
-                    Its flexibility makes it applicable to a large suite of problems \
-                    as well as easily extensible. Along with core sampling functionality, \
-                    PyMC includes methods for summarizing output, plotting, \
-                    goodness-of-fit and convergence diagnostics.
+description         Bayesian statistical modeling and Probabilistic Machine Learning in Python
+long_description    PyMC3 is a Python package for Bayesian statistical modeling and \
+                    Probabilistic Machine Learning focusing on advanced Markov chain \
+                    Monte Carlo (MCMC) and variational inference (VI) algorithms. \
+                    Its flexibility and extensibility make it applicable to a large \
+                    suite of problems.
 
-python.versions     27 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
-    checksums           rmd160  f78fbfd4f89c453573dd75bb45a1daad00921a7d \
-                        sha256  2b1223e024203f50b3286716b90d57722653abe33b80269745f4fa1767925522
+    checksums           rmd160  caf807fb6dac03b7153f58e2f72437702778a3cc \
+                        sha256  399a0a1c3704b50fcdb7ff7cda240917bf43f0054d2d9349c80b1e349f3943b8 \
+                        size    25753021
 
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-scipy \
-                        port:py${python.version}-matplotlib \
                         port:py${python.version}-theano \
                         port:py${python.version}-pandas \
                         port:py${python.version}-patsy \
                         port:py${python.version}-joblib \
-                        port:py${python.version}-tqdm
+                        port:py${python.version}-tqdm \
+                        port:py${python.version}-six \
+                        port:py${python.version}-h5py
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to version 3.4.1
- add size to checksums
- update dependencies, homepage and description
- assume maintainership

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7, 3.4-3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
