### PR TITLE
dhcptest: new port, version 0.7.0

### DIFF
--- a/net/dhcptest/Portfile
+++ b/net/dhcptest/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        CyberShadow dhcptest 0.7
+
+categories          net
+license             Boost-1
+platforms           darwin
+maintainers         {gmail.com:yan12125 @yan12125} openmaintainer
+
+description         Cross-platform DHCP test client
+long_description    This is a DHCP test tool. It can send DHCP discover \
+                    packets, and listen for DHCP replies.
+
+checksums           rmd160  4b3ab0bb209ed449e22ac3779346de402edb58e2 \
+                    sha256  1da188de642b47a31b3516caf27f820aa0298ec2bf91c1a2c01fc06dcc8a4bc5 \
+                    size    10422
+
+depends_build       port:dmd \
+                    port:druntime \
+                    port:phobos
+
+use_configure       no
+
+build {
+    system -W ${worksrcpath} "dmd dhcptest.d"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/dhcptest ${destroot}${prefix}/bin/dhcptest
+}


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
