### PR TITLE
emacs: Add autoconf/automake build dependencies to gtk variant

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -160,6 +160,7 @@ if {${subport} eq "emacs" || ${subport} eq "emacs-devel"} {
                                 path:lib/pkgconfig/glib-2.0.pc:glib2 \
                                 port:gconf \
                                 port:librsvg
+        depends_build-append port:autoconf port:automake 
 
         # see #21917
         require_active_variants gtk2 x11


### PR DESCRIPTION
The emacs gtk variant fails to build if autoconf/automake are not installed, but the port does not declare a build dependency on them. This MR fixes this..