### PR TITLE
py-pymc: update to 2.3.7

### DIFF
--- a/python/py-pymc/Portfile
+++ b/python/py-pymc/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 PortGroup           compilers 1.0
 
-github.setup        pymc-devs pymc 2.3.6 v
+github.setup        pymc-devs pymc 2.3.7 v
 name                py-pymc
 maintainers         nomaintainer
 license             {AFL-3 BSD}
@@ -22,12 +22,13 @@ platforms           darwin
 
 python.versions     27 34 35 36
 
+checksums           rmd160  756e3692f1ae14ab2545f194c4db8a17855c9075 \
+                    sha256  511f382a0e4b5c0befdfbf33e75c4730bcc62402ad19c6a845e8c08e326439da \
+                    size    13104435
+
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy
     compilers.enforce_fortran  port:py${python.version}-numpy
-
-    checksums       rmd160  b4eac13ae502bb3e8ec3f314deb73750edcb6a8a \
-                    sha256  9c33a3430e8d55dbe0beaa79394e866f9115c4ec84615e24dabc154334538a6a
 
     compilers.choose   fc f77 f90
     compilers.setup    require_fortran


### PR DESCRIPTION
#### Description
- update to version 2.3.7
- add size to checksums

See: https://trac.macports.org/ticket/50453
I suppose one could close 2-years old abovementioned ticket; right now it seems to build.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145
Python 2.7 and 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

