### PR TITLE
cppcheck: update to 1.83

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   cxx11 1.0
 
 name                        cppcheck
-version                     1.81
+version                     1.83
 categories                  devel
 license                     GPL-3
 platforms                   darwin
@@ -21,8 +21,9 @@ long_description            Cppcheck is an analysis tool for C and C++ code. Unl
 homepage                    http://cppcheck.sourceforge.net/
 master_sites                sourceforge:project/cppcheck/cppcheck/${version}
 
-checksums                   rmd160  d8b2a54386bd278cd38136c23818b4a89137786b \
-                            sha256  7164a0fc15839957c69f1cf48d714a8ea346005ef6cc413f4f6a41f173ce4c7a
+checksums                   rmd160  e832b14859bac928025c8369b0f53e750853ad63 \
+                            sha256  db297f390af0a09c3cdbb5bd31d2c17852291da71e8af3337586859712909aac \
+                            size    2085396
 
 depends_build               port:libxslt \
                             port:docbook-xsl


### PR DESCRIPTION
#### Description
- update to version 1.83
- add size to checksums

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
