### PR TITLE
py-pymc3: remove homepage, already set by GitHub portgroup

### DIFF
--- a/python/py-pymc3/Portfile
+++ b/python/py-pymc3/Portfile
@@ -10,7 +10,6 @@ platforms           darwin
 maintainers         {@reneeotten gmail.com:ottenr.work} openmaintainer
 license             Apache-2
 supported_archs     noarch
-homepage            https://github.com/pymc-devs/pymc3
 
 description         Bayesian statistical modeling and Probabilistic Machine Learning in Python
 long_description    PyMC3 is a Python package for Bayesian statistical modeling and \


### PR DESCRIPTION
#### Description
- remove homepage as requested by @ryandesign on commit bdff39a48b937295b3b222219233ca4c2d3f43f2

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] enhancement



