### PR TITLE
Update patch for python27

### DIFF
--- a/lang/python27/files/patch-configure-universal.diff
+++ b/lang/python27/files/patch-configure-universal.diff
@@ -1,56 +1,52 @@
---- configure.orig	2013-05-20 04:46:39.000000000 +1000
-+++ configure	2013-05-20 04:50:42.000000000 +1000
-@@ -6078,36 +6078,9 @@
- 	    EXPORT_MACOSX_DEPLOYMENT_TARGET=''
+--- configure.orig	2018-05-02 00:03:54.000000000 -0500
++++ configure	2018-05-02 00:04:44.000000000 -0500
+@@ -6121,46 +6121,9 @@
  
- 	    if test "${enable_universalsdk}"; then
--		UNIVERSAL_ARCH_FLAGS=""
--	        if test "$UNIVERSAL_ARCHS" = "32-bit" ; then
--		   UNIVERSAL_ARCH_FLAGS="-arch ppc -arch i386"
--		   ARCH_RUN_32BIT=""
--		   LIPO_32BIT_FLAGS=""
--
--	         elif test "$UNIVERSAL_ARCHS" = "64-bit" ; then
--		   UNIVERSAL_ARCH_FLAGS="-arch ppc64 -arch x86_64"
--		   LIPO_32BIT_FLAGS=""
--		   ARCH_RUN_32BIT="true"
--
--	         elif test "$UNIVERSAL_ARCHS" = "all" ; then
--		   UNIVERSAL_ARCH_FLAGS="-arch i386 -arch ppc -arch ppc64 -arch x86_64"
--		   LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
--		   ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
--
--	         elif test "$UNIVERSAL_ARCHS" = "intel" ; then
--		   UNIVERSAL_ARCH_FLAGS="-arch i386 -arch x86_64"
--		   LIPO_32BIT_FLAGS="-extract i386"
--		   ARCH_RUN_32BIT="/usr/bin/arch -i386"
--
--	         elif test "$UNIVERSAL_ARCHS" = "3-way" ; then
--		   UNIVERSAL_ARCH_FLAGS="-arch i386 -arch ppc -arch x86_64"
--		   LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
--		   ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
--
--		 else
--	           as_fn_error $? "proper usage is --with-universal-arch=32-bit|64-bit|all|intel|3-way" "$LINENO" 5
--
--		 fi
-+	        UNIVERSAL_ARCH_FLAGS="__UNIVERSAL_ARCHFLAGS__"
-+	        ARCH_RUN_32BIT=""
-+	        LIPO_32BIT_FLAGS=""
+         if test "${enable_universalsdk}"
+         then
+-            case "$UNIVERSAL_ARCHS" in
+-            32-bit)
+-               UNIVERSAL_ARCH_FLAGS="-arch ppc -arch i386"
+-               LIPO_32BIT_FLAGS=""
+-               ARCH_RUN_32BIT=""
+-               ;;
+-            64-bit)
+-               UNIVERSAL_ARCH_FLAGS="-arch ppc64 -arch x86_64"
+-               LIPO_32BIT_FLAGS=""
+-               ARCH_RUN_32BIT=""
+-               ;;
+-            all)
+-               UNIVERSAL_ARCH_FLAGS="-arch i386 -arch ppc -arch ppc64 -arch x86_64"
+-               LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
+-               ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
+-               ;;
+-            intel)
+-               UNIVERSAL_ARCH_FLAGS="-arch i386 -arch x86_64"
+-               LIPO_32BIT_FLAGS="-extract i386"
+-               ARCH_RUN_32BIT="/usr/bin/arch -i386"
+-               ;;
+-            intel-32)
+-               UNIVERSAL_ARCH_FLAGS="-arch i386"
+-               LIPO_32BIT_FLAGS=""
+-               ARCH_RUN_32BIT=""
+-               ;;
+-            intel-64)
+-               UNIVERSAL_ARCH_FLAGS="-arch x86_64"
+-               LIPO_32BIT_FLAGS=""
+-               ARCH_RUN_32BIT=""
+-               ;;
+-            3-way)
+-               UNIVERSAL_ARCH_FLAGS="-arch i386 -arch ppc -arch x86_64"
+-               LIPO_32BIT_FLAGS="-extract ppc7400 -extract i386"
+-               ARCH_RUN_32BIT="/usr/bin/arch -i386 -ppc"
+-               ;;
+-            *)
+-               as_fn_error $? "proper usage is --with-universal-arch=32-bit|64-bit|all|intel|3-way" "$LINENO" 5
+-               ;;
+-            esac
++            UNIVERSAL_ARCH_FLAGS="__UNIVERSAL_ARCHFLAGS__"
++            ARCH_RUN_32BIT=""
++            LIPO_32BIT_FLAGS=""
  
- 
- 		CFLAGS="${UNIVERSAL_ARCH_FLAGS} ${CFLAGS}"
-@@ -8605,8 +8605,11 @@ then
- 			fi
- 		else
- 			# building for OS X 10.3 and later
--			if test "${enable_universalsdk}"; then
--				LDFLAGS="${UNIVERSAL_ARCH_FLAGS} -isysroot ${UNIVERSALSDK} ${LDFLAGS}"
-+			if test "${enable_universalsdk}" ; then
-+			    LDFLAGS="${UNIVERSAL_ARCH_FLAGS} ${LDFLAGS}"
-+			    if test "${UNIVERSALSDK}" != "/"; then
-+				LDFLAGS="-isysroot ${UNIVERSALSDK} ${LDFLAGS}"
-+			    fi
- 			fi
- 			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'
- 			LDCXXSHARED='$(CXX) -bundle -undefined dynamic_lookup'
+             if test "${UNIVERSALSDK}" != "/"
+             then


### PR DESCRIPTION
#### Description
patch-configure-universal.diff does not apply cleanly after python27 update in 0003f5433396aa5563d08aab773fe9e1a89f70d0 due to format changes. This updates the patch accordingly.


###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
