### PR TITLE
auto-multiple-choice: update to version git201805011238

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               bitbucket 1.0
 PortGroup               perl5 1.0
 PortGroup               texlive 1.0
 
@@ -23,25 +22,30 @@ homepage                http://www.auto-multiple-choice.net/
 
 subport auto-multiple-choice-devel {}
 
+set gitlab.home https://gitlab.com
+set gitlab.author jojo_boulix
+set gitlab.project ${name}
+
 if {${subport} eq ${name}} {
     # release
-    set bitbucket_commit    "ac9013f9ddd7"
-    set amc_revision        "2141"
-    set amc_date            "201712262328"
-    checksums               rmd160  f39c23b3311bb03994d0f6d77c67c108ae3da123 \
-                            sha256  47fa3d7291e4703d2302526ee3a2df0ab83bc93501805f2a697ad7fa9ec1641f
+    set gitlab.commit       "a488cdbc7f8d6d1d6b7fde48b6ce92e9d972d62a"
+    set amc_revision        "git201805011238"
+    set amc_date            "201805011238"
+    checksums               rmd160  fe210d0320577e27d09ee1975f6452cfccdd3606 \
+                            sha256  4303691433ebea2e9420517d6a1c89b3ea2e1746f37753ea08109f44cdd8f2b7
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set bitbucket_commit    "9592fa9f3258"
-    set amc_revision        "2162"
-    set amc_date            "201802050752"
-    checksums               rmd160  3df52b76f01120fb2ea3ae3702afbaf3cc9c91e7 \
-                            sha256  c3b9d7c76c69a9fd2c26f246c36d47c7050f37cc47ea616c753b91b45830321f
+    set gitlab.commit       "3e19f40ce6e72f0d454a068b03d1bf6d02398d40"
+    set amc_revision        "git201805020726"
+    set amc_date            "201805020726"
+    checksums               rmd160  87006ab2e9923a58fa6eeb756f25e59fcc9fcb86 \
+                            sha256  edf1d4919a90c8481a5c915317cf211fdcfc53eba80922a7cec2375429bacb00
     conflicts               auto-multiple-choice
 }
 
-bitbucket.setup         auto-multiple-choice auto-multiple-choice ${bitbucket_commit}
+master_sites            https://gitlab.com/jojo_boulix/auto-multiple-choice/repository/archive.tar.gz?ref=${gitlab.commit}&dummy=
+distname                ${gitlab.project}-${gitlab.commit}
 version                 1.3.0.${amc_revision}
 
 depends_build-append    \
@@ -72,10 +76,11 @@ depends_run             \
                         port:p${perl5.major}-text-csv \
                         port:p${perl5.major}-xml-simple \
                         port:p${perl5.major}-xml-writer \
-                        port:pdftk \
                         port:poppler \
+                        port:qpdf \
                         port:sqlite3 \
                         port:texlive \
+                        port:texlive-fonts-extra \
                         port:texlive-lang-japanese \
                         port:texlive-latex-extra
 
@@ -128,6 +133,7 @@ instead of Macports texlive tools. To install the mactex variant \
 
     depends_run-delete      \
                             port:texlive \
+                            port:texlive-fonts-extra \
                             port:texlive-lang-japanese \
                             port:texlive-latex-extra
 


### PR DESCRIPTION
auto-multiple-choice: update to version git201805011238

* switch from Bitbucket to Gitlab
* update release to version git201805011238
* update devel to version git201805020726
* replace dependancy on pdftk by qpdf
* add texlive-fonts-extra dependancy

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
