### PR TITLE
New port: RESTinio

### DIFF
--- a/devel/asio/Portfile
+++ b/devel/asio/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem                  1.0
 PortGroup                   cxx11 1.1
-PortGroup                   github 1.0
 
-github.setup                chriskohlhoff asio 1-12-0 asio-
-version                     [string map {- .} ${github.version}]
+name                        asio
+version                     1.12.1
 license                     Boost-1
 description                 Asio C++ Library.
 long_description            Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a \
@@ -15,22 +14,27 @@ maintainers                 {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
 categories                  devel
 platforms                   darwin
 
-checksums                   rmd160  08cb85fcc1d7c26fa2805d1b6a0f718d8fefb090 \
-                            sha256  657bf83c883d429259d02a5efe010b63cbb571dc344fd13560151fc2a6b5292c \
-                            size    1195583
+master_sites                https://sourceforge.net/projects/${name}/files/
+dist_subdir                 ${name}/${version}%20(Stable)/
+distpath                    ${portdbpath}/distfiles/${name}/${version}/
+use_bzip2                   yes
+checksums                   rmd160  e526185e4183560e1880add3a9e944fa4afc68e1 \
+                            sha256  a9091b4de847539fa5b2259bf76a5355339c7eaaa5e33d7d4ae74d614c21965a \
+                            size    1444246
 
-worksrcdir                  ${worksrcdir}/${name}
-
-use_autoconf                yes
-autoconf.cmd                ./autogen.sh
+use_configure               yes
+configure.args              --with-boost=no
 
 depends_build               port:autoconf \
                             port:automake
-depends_lib                 port:boost
 
 configure.cxxflags-append   -std=gnu++14
-configure.env-append        ASIO_STANDALONE=1 \
-                            ASIO_HAS_STD_CHRONO=1 \
+configure.env-append        ASIO_HAS_STD_CHRONO=1 \
                             ASIO_DISABLE_STD_STRING_VIEW=1
 
 build.post_args-delete      VERBOSE=ON
+
+variant ssl {
+    configure.args-append   --with-openssl=${prefix}/
+    depends_lib-append      port:openssl
+}

--- a/devel/asio/Portfile
+++ b/devel/asio/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   cxx11 1.1
+PortGroup                   github 1.0
+
+github.setup                chriskohlhoff asio 1-12-0 asio-
+version                     [string map {- .} ${github.version}]
+license                     Boost-1
+description                 Asio C++ Library.
+long_description            Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a \
+                            consistent asynchronous model using a modern C++ approach.
+homepage                    http://www.think-async.com
+maintainers                 {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
+categories                  devel
+platforms                   darwin
+
+checksums                   rmd160  08cb85fcc1d7c26fa2805d1b6a0f718d8fefb090 \
+                            sha256  657bf83c883d429259d02a5efe010b63cbb571dc344fd13560151fc2a6b5292c \
+                            size    1195583
+
+worksrcdir                  ${worksrcdir}/${name}
+
+use_autoconf                yes
+autoconf.cmd                ./autogen.sh
+
+depends_build               port:autoconf \
+                            port:automake
+depends_lib                 port:boost
+
+configure.cxxflags-append   -std=gnu++14
+configure.env-append        ASIO_STANDALONE=1 \
+                            ASIO_HAS_STD_CHRONO=1 \
+                            ASIO_DISABLE_STD_STRING_VIEW=1
+
+build.post_args-delete      VERBOSE=ON

--- a/www/http-parser/Portfile
+++ b/www/http-parser/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+
+github.setup                nodejs http-parser 2.8.1 v
+categories                  www devel
+platforms                   darwin
+license                     MIT
+maintainers                 {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
+
+description                 http request/response parser for C.
+long_description            This is a parser for HTTP messages written in C. It parses both requests and responses. \
+                            The parser is designed to be used in performance HTTP applications. \
+                            It does not make any syscalls nor allocations, it does not buffer data, it can be interrupted at anytime. \
+                            Depending on your architecture, it only requires about 40 bytes of data per message stream (in a web server that is per connection).
+
+checksums                   rmd160  8ebe6c4b7ea28b40c31b1ef1abbfd7a89f57f7fb \
+                            sha256  6d6a66251dd4236c6e15565849777230f5bc78a92e16eb2d40cec1f7c0f5bbe3 \
+                            size    50744
+
+patchfiles                  patch-Makefile.diff
+
+use_configure               no
+
+build.target                ""
+build.args                  CFLAGS="-DHTTP_PARSER_STRICT=0"
+build.post_args-delete      VERBOSE=ON
+build.env-append            PREFIX=${prefix}
+destroot.env-append         PREFIX=${prefix}

--- a/www/http-parser/files/patch-Makefile.diff
+++ b/www/http-parser/files/patch-Makefile.diff
@@ -1,0 +1,21 @@
+--- Makefile
++++ Makefile
+@@ -131,14 +131,14 @@
+ 	ctags $^
+ 
+ install: library
+-	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
++	$(INSTALL) -c  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
++	$(INSTALL) -c $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+ 
+ install-strip: library
+-	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
++	$(INSTALL) -c  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
++	$(INSTALL) -c -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+ 

--- a/www/restinio/Portfile
+++ b/www/restinio/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+
+PortGroup                   github 1.0
+PortGroup                   cmake 1.1
+PortGroup                   cxx11 1.1
+PortGroup                   compiler_blacklist_versions 1.0
+
+github.setup                Stiffstream restinio 0.4.8 v.
+categories                  www devel
+platforms                   darwin
+license                     BSD
+maintainers                 {gmail.com:g.litenstein @Lord-Kamina} openmaintainer
+homepage                    https://stiffstream.com/en/products/restinio.html
+description                 Header-only C++14 library that gives you an embedded HTTP/Websocket server.
+long_description            RESTinio is a header-only C++14 library that gives you an embedded \
+                            HTTP/Websocket server. It is based on standalone version of ASIO and targeted \
+                            primarily for asynchronous processing of HTTP-requests.
+checksums                   rmd160  15b3c324ca28abd62bb4877dd2ce315461d062aa \
+                            sha256  454352bde5f01de5f903322ed55bb39c67616312bffeb1cf7c8f1c85bee502b3 \
+                            size    459870
+
+depends_build-append        port:boost \
+                            port:openssl \
+                            port:pcre \
+                            port:zlib \
+                            port:doxygen
+depends_lib-append          port:asio \
+                            port:http-parser \
+                            port:libfmt
+
+patchfiles                  patch-CMakeLists.txt.diff
+
+cmake.source_dir            ${worksrcpath}/dev
+cmake.build_type            Release
+cmake.generator             Unix Makefiles
+
+configure.env-append        ASIO_STANDALONE=1 \
+                            ASIO_HAS_STD_CHRONO=1 \
+                            ASIO_DISABLE_STD_STRING_VIEW=1 \
+                            FMT_HEADER_ONLY=1 \
+configure.pre_args-delete   -DCMAKE_POLICY_DEFAULT_CMP0025=NEW
+configure.optflags-delete   -Os
+compiler.blacklist-append   *gcc-3.* *gcc-4.* {*gcc-5.[0-3]} \
+                            {clang < 800} macports-clang-3.4 macports-clang-3.5 macports-clang-3.6 macports-clang-3.7
+
+build.post_args-delete      VERBOSE=ON
+
+destroot {
+    set components { . impl path2regex router third_party/optional-lite third_party/string-view-lite transforms utils utils/impl websocket websocket/impl }
+    set files { }
+    set instdir "${destroot}${prefix}/include/${github.project}"
+
+    foreach i ${components} {
+        lappend files {*}[glob -tails -directory ${worksrcpath}/dev/${github.project}/ ${i}/*{.hpp,.inl}]
+        xinstall -m 755 -d ${instdir}/${i}
+    }
+    foreach x ${files} {
+        xinstall -m 644 "${worksrcpath}/dev/${github.project}/${x}" "${instdir}/${x}"
+    }
+    set docdir "${destroot}${prefix}/share/doc/${github.project}"
+    xinstall -m 755 -d "${docdir}/html/search"
+    system -W ${worksrcpath}/dev "${prefix}/bin/doxygen ${worksrcpath}/dev/Doxyfile"
+    xinstall -m 644 "${worksrcpath}/README.md" "${docdir}"
+    xinstall -m 644 "${worksrcpath}/LICENSE" "${docdir}"
+    xinstall -m 644 {*}[glob "${worksrcpath}/dev/doc/html/*.*" "${docdir}/html"]
+    xinstall -m 644 {*}[glob "${worksrcpath}/dev/doc/html/search/*.*" "${docdir}/html/search"]
+}

--- a/www/restinio/files/patch-CMakeLists.txt.diff
+++ b/www/restinio/files/patch-CMakeLists.txt.diff
@@ -1,0 +1,99 @@
+--- dev/CMakeLists.txt.orig
++++ dev/CMakeLists.txt
+@@ -11,12 +11,7 @@
+ ENDIF ()
+ 
+ option(RESTINIO_INSTALL "Generate the install target." ${RESTINIO_MASTER_PROJECT})
+-option(RESTINIO_TEST "Build the tests." ${RESTINIO_MASTER_PROJECT})
+-option(RESTINIO_SAMPLE "Build samples." ${RESTINIO_MASTER_PROJECT})
+-option(RESTINIO_INSTALL_SAMPLES "Build install samples." ${RESTINIO_MASTER_PROJECT})
+-option(RESTINIO_BENCH "Build the test target." ${RESTINIO_MASTER_PROJECT})
+-option(RESTINIO_INSTALL_BENCHES "Build install samples." ${RESTINIO_MASTER_PROJECT})
+-option(RESTINIO_FIND_DEPS "Use `find_package()` for including RESTinio dependencies." OFF)
++option(RESTINIO_FIND_DEPS "Use `find_package()` for including RESTinio dependencies." ON)
+ 
+ SET(RESTINIO_USE_BOOST_ASIO "none" CACHE STRING "Use boost version of ASIO")
+ SET(RESTINIO_USE_BOOST_ASIO_VALUES "none;static;shared")
+@@ -71,82 +66,7 @@
+ 		# fmtlib
+ 		add_subdirectory(fmt)
+ 	ENDIF ()
+-
+-	# ------------------------------------------------------------------------------
+-
+-	# ------------------------------------------------------------------------------
+-	# Tests, samples and benchmark dependencies:
+-	# OpenSSL
+-	find_package(OpenSSL)
+-	IF ( OPENSSL_FOUND )
+-		message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+-		message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+-	ENDIF ( OPENSSL_FOUND )
+-
+-	# PCRE
+-	find_package(PCRE)
+-	IF (PCRE_FOUND)
+-		message( STATUS "PCRE_LIBRARIES='" ${PCRE_LIBRARIES} "'" )
+-		message( STATUS "PCRE_INCLUDE_DIRS='" ${PCRE_INCLUDE_DIRS} "'" )
+-	ENDIF ()
+-
+-	# PCRE2
+-	find_package(PCRE2)
+-	IF (PCRE2_FOUND)
+-		message( STATUS "PCRE2_LIBRARIES='" ${PCRE2_LIBRARIES} "'" )
+-		message( STATUS "PCRE2_INCLUDE_DIRS='" ${PCRE2_INCLUDE_DIRS} "'" )
+-	ENDIF ()
+-
+-	# PCRE2
+-	find_package(PCRE2)
+-	IF (PCRE2_FOUND)
+-		message( STATUS "PCRE2_LIBRARIES='" ${PCRE2_LIBRARIES} "'" )
+-		message( STATUS "PCRE2_INCLUDE_DIRS='" ${PCRE2_INCLUDE_DIRS} "'" )
+-	ENDIF ()
+-
+-	# ------------------------------------------------------------------------------
+-	# SObjectizer
+-	SET(SOBJECTIZER_BUILD_STATIC ON)
+-	SET(SOBJECTIZER_LIBS sobjectizer::StaticLib)
+-	add_subdirectory(so_5)
+-
+-	# ------------------------------------------------------------------------------
+-	# Zlib
+-	find_package(ZLIB)
+-
+-	IF (NOT ZLIB_FOUND)
+-		add_subdirectory(restinio/third_party/zlib)
+-		message( STATUS "USE OWN ZLIB SOURCES")
+-		SET(ZLIB_LIBRARIES zlibstatic)
+-		SET(ZLIB_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/restinio/third_party/zlib)
+-	ENDIF ()
+-
+-	message( STATUS "ZLIB_LIBRARIES='" ${ZLIB_LIBRARIES} "'" )
+-	message( STATUS "ZLIB_INCLUDE_DIRS='" ${ZLIB_INCLUDE_DIRS} "'" )
+ ENDIF (RESTINIO_MASTER_PROJECT)
+ 
+ # RESTinio itself.
+ add_subdirectory(restinio)
+-
+-# ------------------------------------------------------------------------------
+-# Tests
+-IF (RESTINIO_TEST)
+-	enable_testing()
+-	add_subdirectory(test)
+-
+-	IF (WIN32)
+-		configure_file(${CMAKE_SOURCE_DIR}/cmake/run_tests.bat ${CMAKE_BINARY_DIR} NEWLINE_STYLE WIN32)
+-	ENDIF ()
+-ENDIF ()
+-
+-# ------------------------------------------------------------------------------
+-# Samples
+-IF (RESTINIO_SAMPLE)
+-	add_subdirectory(sample)
+-ENDIF ()
+-
+-# ------------------------------------------------------------------------------
+-# Benches
+-IF (RESTINIO_BENCH)
+-	add_subdirectory(benches)
+-ENDIF ()


### PR DESCRIPTION
Refactored the Portfile and fixed various bugs that were present in my first attempt. Tried the port with the basic example copy-pasted straight from README.md and it's working as expected.

Commented/disabled tests, samples and benchmarks because they have way too many dependencies that aren't needed for the actual port.

#### Description

RESTinio is a header-only C++14 library that gives you an embedded
HTTP/Websocket server. It is based on standalone version of ASIO and targeted
primarily for asynchronous processing of HTTP-requests.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
