### PR TITLE
libtorrent-rasterbar: Use frameworks_dir

### DIFF
--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -58,7 +58,7 @@ variant python27 description {Build bindings for Python 2.7} {
         depends_lib-append port:python27
         configure.python ${prefix}/bin/python2.7
         configure.env-append \
-                "PYTHON_INSTALL_PARAMS=--prefix=${destroot}${prefix}/Library/Frameworks/Python.framework/Versions/2.7" \
+                "PYTHON_INSTALL_PARAMS=--prefix=${destroot}${frameworks_dir}/Python.framework/Versions/2.7" \
                 PYTHON_EXTRA_LIBS=' '
 }
 


### PR DESCRIPTION
#### Description

Use `frameworks_dir`