### PR TITLE
Changed the ca-bundle for wolfssl, gnutls and darwinssl variants

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -137,16 +137,21 @@ if {${name} eq ${subport}} {
 
     variant darwinssl conflicts ssl gnutls wolfssl description {Allow secure connections using Apple OS native TLS} {
         configure.args-replace  --without-darwinssl --with-darwinssl
+        configure.args-append   --without-ca-bundle
     }
 
     variant gnutls conflicts ssl wolfssl darwinssl description {Allow secure connections using GNU TLS} {
-        depends_lib-append      port:gnutls
+        depends_lib-append      port:gnutls \
+                                path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-gnutls --with-gnutls
+        configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
     variant wolfssl conflicts ssl gnutls darwinssl description {Allow secure connections using wolfSSL, formerly CyaSSL} {
-        depends_lib-append      port:wolfssl
+        depends_lib-append      port:wolfssl \
+                                path:share/curl/curl-ca-bundle.crt:curl-ca-bundle
         configure.args-replace  --without-cyassl --with-cyassl
+        configure.args-append   --with-ca-bundle=${prefix}/share/curl/curl-ca-bundle.crt
     }
 
     variant gss description {Support the Generic Security Service API} {


### PR DESCRIPTION
#### Description

Solves https://trac.macports.org/ticket/56404
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (1 test failed among 922, test 1119)
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?