### PR TITLE
protobuf3-cpp: use autoreconf

### DIFF
--- a/devel/protobuf3-cpp/Portfile
+++ b/devel/protobuf3-cpp/Portfile
@@ -42,13 +42,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     }
 }
 
-# see https://trac.macports.org/ticket/56366
-depends_build-append port:libtool
-post-configure {
-    # when linking, libtool does not respect -stdlib
-    delete ${worksrcpath}/libtool
-    xinstall -m 0755 ${prefix}/bin/glibtool ${worksrcpath}/libtool
-}
+# bundled libtool version doesn't recognise -stdlib
+use_autoreconf  yes
 
 checksums       rmd160  21375095e562cfee25ba68d68e481cf608ac9a9a \
                 sha256  c28dba8782da2cfea1e11c61d335958c31a9c1bc553063546af9cbe98f204092


### PR DESCRIPTION
take 2 on this fix for protobuf3-cpp to use the proper stdlib when linking, courtesy of @ryandesign . This approach is a more robust fix to the issue. Works on all tested systems 

10.6 / libc++
10.7 / libstdc++ (and macports-libstdc++)
10.8 / libstdc++ (and macports-libstdc++)
10.13

let's see how Travis likes it.
