### PR TITLE
libmypaint: new port

### DIFF
--- a/graphics/libmypaint/Portfile
+++ b/graphics/libmypaint/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                libmypaint
+categories          graphics
+maintainers         {ryandesign @ryandesign} {devans @dbevans} openmaintainer
+platforms           darwin
+
+conflicts           MyPaint MyPaint-devel
+github.setup        mypaint libmypaint 1.3.0 v
+
+license             Permissive
+description         The MyPaint Brush Library
+
+long_description    libmypaint, a.k.a. \"brushlib\", is a library for making brushstrokes \
+                    which is used by MyPaint and other projects.
+    
+github.tarball_from releases
+
+use_xz              yes
+
+checksums           rmd160  b70855b627d29a5150e8e89c5c49be17f2f10c9e \
+                    sha256  6a07d9d57fea60f68d218a953ce91b168975a003db24de6ac01ad69dcc94a671 \
+                    size    438160
+
+depends_build       port:pkgconfig \
+                    port:intltool
+
+depends_lib         port:json-c


### PR DESCRIPTION
Previously known as brushlib, now split off as a separate
project in mypaint github repo.  Necessary to build gimp2 2.10.0.

Currently conflicts with both MyPaint and MyPaint-devel.
Presumably will be a dependency of MyPaint in a future 1.3.0 stable release.

Closes https://trac.macports.org/ticket/48278

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
