### PR TITLE
mypaint-brushes: new port

### DIFF
--- a/graphics/mypaint-brushes/Portfile
+++ b/graphics/mypaint-brushes/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+categories          graphics
+maintainers         {devans @dbevans} {ryandesign @ryandesign} openmaintainer
+platforms           darwin
+
+github.setup        Jehan mypaint-brushes 1.3.0 v
+
+license             GPL-2+
+description         libmypaint brush data for GIMP 2.10+
+long_description    ${description}
+    
+# no release tarballs to be had at the moment
+# github.tarball_from releases
+
+checksums           rmd160  4f57d9a46a4177906ed779034c77ee3b9a6f1a76 \
+                    sha256  53269363448a705936ba8cfa2ad126f71ac2470c42160d93aee547f4189ec331 \
+                    size    2446910
+
+depends_build       port:pkgconfig \
+                    port:intltool \
+                    port:autoconf\
+                    port:automake \
+                    port:libtool
+
+depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2
+
+patchfiles          patch-autogen.sh.diff
+
+configure.cmd       ./autogen.sh && ./configure

--- a/graphics/mypaint-brushes/files/patch-autogen.sh.diff
+++ b/graphics/mypaint-brushes/files/patch-autogen.sh.diff
@@ -1,0 +1,24 @@
+--- autogen.sh.orig	2018-04-16 14:57:58.000000000 -0700
++++ autogen.sh	2018-04-16 15:01:35.000000000 -0700
+@@ -7,9 +7,9 @@
+ # tools and you shouldn't use this script. Just call ./configure
+ # directly.
+ 
+-ACLOCAL=${ACLOCAL-aclocal-1.13}
++ACLOCAL=${ACLOCAL-aclocal-1.16}
+ AUTOCONF=${AUTOCONF-autoconf}
+-AUTOMAKE=${AUTOMAKE-automake-1.13}
++AUTOMAKE=${AUTOMAKE-automake-1.16}
+ 
+ AUTOCONF_REQUIRED_VERSION=2.62
+ AUTOMAKE_REQUIRED_VERSION=1.13
+@@ -90,6 +90,9 @@
+ echo -n "checking for automake >= $AUTOMAKE_REQUIRED_VERSION ... "
+ if ($AUTOMAKE --version) < /dev/null > /dev/null 2>&1; then
+    AUTOMAKE=$AUTOMAKE
++elif (automake-1.16 --version) < /dev/null > /dev/null 2>&1; then
++   AUTOMAKE=automake-1.16
++   ACLOCAL=aclocal-1.16
+ elif (automake-1.15 --version) < /dev/null > /dev/null 2>&1; then
+    AUTOMAKE=automake-1.15
+    ACLOCAL=aclocal-1.15


### PR DESCRIPTION
libmypaint brush data for GIMP 2.10+.

No conflicts with existing MyPaint ports.

#### Description


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
