### PR TITLE
newsboat: Configure in the configure phase

### DIFF
--- a/net/newsboat/Portfile
+++ b/net/newsboat/Portfile
@@ -46,7 +46,7 @@ post-extract {
 
 patchfiles          patch-Makefile.diff
 
-use_configure       no
+configure.cmd       ./config.sh
 
 # universal variant needs to be defined for [get_canonical_archflags] to work
 variant universal {}


### PR DESCRIPTION
#### Description

Run the config.sh script in the configure phase, rather than automatically as part of the build phase. This allows the configure phase to be run separately for debugging (with `sudo port configure newsboat`), and avoids the error message `Makefile:30: config.mk: No such file or directory` appearing in the log.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
