### PR TITLE
dash: Update to 0.5.10

### DIFF
--- a/shells/dash/Portfile
+++ b/shells/dash/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                dash
-version             0.5.9.1
+version             0.5.10
 categories          shells
 license             GPL-2+
 platforms           darwin
@@ -16,8 +16,9 @@ long_description    DASH is a direct descendant of the NetBSD version of ash \
 homepage            http://gondor.apana.org.au/~herbert/dash
 
 master_sites        ${homepage}/files/
-checksums           rmd160  c03b72e99a5e285e47b9b72678d0a4fdb124306d \
-                    sha256  5ecd5bea72a93ed10eb15a1be9951dd51b52e5da1d4a7ae020efd9826b49e659
+checksums           rmd160  5d87a0f48efa8743a28c0a2a6f93a0d09e445269 \
+                    sha256  ad70e0cc3116b424931c392912b3ebdb8053b21f3fd968c782f0b19fd8ae31ab \
+                    size    225242
 
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\\d+(\\.\\d+)+)${extract.suffix}


### PR DESCRIPTION
#### Description

Update dash to 0.5.10.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
