### PR TITLE
newsboat: update version and fix dependency

### DIFF
--- a/net/newsboat/Portfile
+++ b/net/newsboat/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           cxx11 1.1
 
 name                newsboat
-version             2.10.1
-revision            1
+version             2.11.1
 categories          net www
 platforms           darwin
 license             MIT
@@ -18,8 +17,8 @@ master_sites        https://newsboat.org/releases/${version}/
 
 use_xz              yes
 
-checksums           rmd160  860d704b04629409596d220d1f87b9c70a53fc62 \
-                    sha256  44d698284246ad82e32fa7cb7f07086fa1ef8406baab09d33321e1252f9cf8f5
+checksums           rmd160  e1f342f3d430c1b496296fa150c7272342e981f0 \
+                    sha256  aab67dcd386a3512812e1af0fddb8e1f4dce08d2a106946fe5ad405210ed37cf
 
 depends_build       port:asciidoc \
                     port:docbook-xsl-nons \
@@ -44,7 +43,8 @@ post-extract {
     }
 }
 
-patchfiles          patch-Makefile.diff
+patchfiles          patch-Makefile.diff \
+                    patch-config.sh.diff
 
 use_configure       no
 

--- a/net/newsboat/files/patch-config.sh.diff
+++ b/net/newsboat/files/patch-config.sh.diff
@@ -1,0 +1,11 @@
+--- config.sh
++++ config.sh
+@@ -105,7 +105,7 @@ check_pkg "stfl" || fail "stfl"
+ ( check_pkg "json" "" 0.11 || check_pkg "json-c" "" 0.11 ) || fail "json-c"
+ 
+ if [ `uname -s` = "Darwin" ]; then
+-	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"
++	check_pkg "ncursesw" || fail "ncursesw"
+ elif [ `uname -s` != "OpenBSD" ]; then
+ 	check_pkg "ncursesw" || \
+ 	check_custom "ncursesw5" "ncursesw5-config" || \


### PR DESCRIPTION
* update version to 2.11.1
* remove hard dependency on ncurses5.4

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
