### PR TITLE
py-pymc: use same compiler variants as in py-numpy

### DIFF
--- a/python/py-pymc/Portfile
+++ b/python/py-pymc/Portfile
@@ -29,9 +29,11 @@ checksums           rmd160  756e3692f1ae14ab2545f194c4db8a17855c9075 \
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy
     compilers.enforce_fortran  port:py${python.version}-numpy
+    compilers.enforce_c  port:py${python.version}-numpy
 
-    compilers.choose   fc f77 f90
-    compilers.setup    require_fortran
+    # keep compilers.setup the same as in the py-numpy port
+    compilers.setup    require_fortran -clang -gcc44 -gcc45 \
+                       -gcc46 -gcc47 -gcc48 -g95 clang37
 
     if {[gcc_variant_isset]} {
         build.cmd "${build.cmd} config_fc --fcompiler gfortran"


### PR DESCRIPTION
#### Description
- use the same ```compilers.setup``` as in py-numpy Portfile
- add ```compilers.enforce_c``` to make sure py-numpy and py-pymc have the same C variant

Closes: https://trac.macports.org/ticket/50453

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

