### PR TITLE
aspell-dict-*: add modeline and fix livecheck

### DIFF
--- a/textproc/aspell-dict-af/Portfile
+++ b/textproc/aspell-dict-af/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        af

--- a/textproc/aspell-dict-af/Portfile
+++ b/textproc/aspell-dict-af/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-ar/Portfile
+++ b/textproc/aspell-dict-ar/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-ar/Portfile
+++ b/textproc/aspell-dict-ar/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        ar

--- a/textproc/aspell-dict-az/Portfile
+++ b/textproc/aspell-dict-az/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        az

--- a/textproc/aspell-dict-az/Portfile
+++ b/textproc/aspell-dict-az/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-be/Portfile
+++ b/textproc/aspell-dict-be/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        be

--- a/textproc/aspell-dict-be/Portfile
+++ b/textproc/aspell-dict-be/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell5?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-bn/Portfile
+++ b/textproc/aspell-dict-bn/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-bn/Portfile
+++ b/textproc/aspell-dict-bn/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        bn

--- a/textproc/aspell-dict-ca/Portfile
+++ b/textproc/aspell-dict-ca/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*\\..*?)\\.tar\\.

--- a/textproc/aspell-dict-ca/Portfile
+++ b/textproc/aspell-dict-ca/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        ca

--- a/textproc/aspell-dict-cs/Portfile
+++ b/textproc/aspell-dict-cs/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-cs/Portfile
+++ b/textproc/aspell-dict-cs/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        cs

--- a/textproc/aspell-dict-da/Portfile
+++ b/textproc/aspell-dict-da/Portfile
@@ -30,4 +30,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-da/Portfile
+++ b/textproc/aspell-dict-da/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        da

--- a/textproc/aspell-dict-de-alt/Portfile
+++ b/textproc/aspell-dict-de-alt/Portfile
@@ -31,4 +31,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-de-alt/Portfile
+++ b/textproc/aspell-dict-de-alt/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        de-alt

--- a/textproc/aspell-dict-de/Portfile
+++ b/textproc/aspell-dict-de/Portfile
@@ -31,4 +31,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-el/Portfile
+++ b/textproc/aspell-dict-el/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        el

--- a/textproc/aspell-dict-el/Portfile
+++ b/textproc/aspell-dict-el/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6\?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-eo/Portfile
+++ b/textproc/aspell-dict-eo/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-eo/Portfile
+++ b/textproc/aspell-dict-eo/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        eo

--- a/textproc/aspell-dict-es/Portfile
+++ b/textproc/aspell-dict-es/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-es/Portfile
+++ b/textproc/aspell-dict-es/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        es

--- a/textproc/aspell-dict-et/Portfile
+++ b/textproc/aspell-dict-et/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        et

--- a/textproc/aspell-dict-et/Portfile
+++ b/textproc/aspell-dict-et/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-fa/Portfile
+++ b/textproc/aspell-dict-fa/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        fa

--- a/textproc/aspell-dict-fa/Portfile
+++ b/textproc/aspell-dict-fa/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-fi/Portfile
+++ b/textproc/aspell-dict-fi/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        fi

--- a/textproc/aspell-dict-fi/Portfile
+++ b/textproc/aspell-dict-fi/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-fr/Portfile
+++ b/textproc/aspell-dict-fr/Portfile
@@ -1,31 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
 
-name		aspell-dict-fr
-set my_name aspell-fr
-version		0.50
-categories	textproc
-license		GPL-2
-maintainers	nomaintainer
-description	French dictionary for aspell
-homepage	http://aspell.net/
-platforms	darwin
-supported_archs   noarch
+name                aspell-dict-fr
+set my_name         aspell-fr
+version             0.50
+categories          textproc
+license             GPL-2
+maintainers         nomaintainer
+description         French dictionary for aspell
+homepage            http://aspell.net/
+platforms           darwin
+supported_archs     noarch
 
-long_description Aspell with French dictionary.
+long_description    Aspell with French dictionary.
 
-master_sites	gnu:aspell/dict/fr
+master_sites        gnu:aspell/dict/fr
 
-distname	$my_name-${version}-3
-checksums	md5 53a2d05c4e8f7fabd3cefe24db977be7
+distname            $my_name-${version}-3
+checksums           md5 53a2d05c4e8f7fabd3cefe24db977be7
 
-use_bzip2	yes
+use_bzip2           yes
 
-depends_build	bin:aspell:aspell
+depends_build       bin:aspell:aspell
 
-configure	{ system "cd ${worksrcpath} && ./configure \
-		    --vars ASPELL=${prefix}/bin/aspell \
-		    WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress" }
+configure           { system "cd ${worksrcpath} && ./configure \
+                        --vars ASPELL=${prefix}/bin/aspell \
+                        WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress" }
 
 livecheck.distname  $my_name

--- a/textproc/aspell-dict-fr/Portfile
+++ b/textproc/aspell-dict-fr/Portfile
@@ -2,9 +2,9 @@
 
 PortSystem          1.0
 
-name                aspell-dict-fr
-set my_name         aspell-fr
-version             0.50
+set langcode        fr
+name                aspell-dict-${langcode}
+version             0.50-3
 categories          textproc
 license             GPL-2
 maintainers         nomaintainer
@@ -15,17 +15,21 @@ supported_archs     noarch
 
 long_description    Aspell with French dictionary.
 
-master_sites        gnu:aspell/dict/fr
-
-distname            $my_name-${version}-3
-checksums           md5 53a2d05c4e8f7fabd3cefe24db977be7
+master_sites        gnu:aspell/dict/${langcode}
+distname            aspell-${langcode}-${version}
+checksums           size    283086 \
+                    rmd160  4072f990bc56871e6aaa842f7636969a4cd60960 \
+                    sha256  f9421047519d2af9a7a466e4336f6e6ea55206b356cd33c8bd18cb626bf2ce91
 
 use_bzip2           yes
 
 depends_build       bin:aspell:aspell
 
-configure           { system "cd ${worksrcpath} && ./configure \
-                        --vars ASPELL=${prefix}/bin/aspell \
-                        WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress" }
+configure.pre_args  {}
+configure.args      --vars \
+                    ASPELL=${prefix}/bin/aspell \
+                    WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
-livecheck.distname  $my_name
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
+livecheck.regex     >aspell-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-fr/Portfile
+++ b/textproc/aspell-dict-fr/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 name		aspell-dict-fr

--- a/textproc/aspell-dict-he/Portfile
+++ b/textproc/aspell-dict-he/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-he/Portfile
+++ b/textproc/aspell-dict-he/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        he

--- a/textproc/aspell-dict-hi/Portfile
+++ b/textproc/aspell-dict-hi/Portfile
@@ -35,4 +35,6 @@ post-destroot {
     file delete ${destroot}${prefix}/lib/aspell-0.60/u-deva.cset
 }
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-hi/Portfile
+++ b/textproc/aspell-dict-hi/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        hi

--- a/textproc/aspell-dict-hr/Portfile
+++ b/textproc/aspell-dict-hr/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        hr

--- a/textproc/aspell-dict-hr/Portfile
+++ b/textproc/aspell-dict-hr/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-hu/Portfile
+++ b/textproc/aspell-dict-hu/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        hu

--- a/textproc/aspell-dict-hu/Portfile
+++ b/textproc/aspell-dict-hu/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-id/Portfile
+++ b/textproc/aspell-dict-id/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        id

--- a/textproc/aspell-dict-id/Portfile
+++ b/textproc/aspell-dict-id/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-is/Portfile
+++ b/textproc/aspell-dict-is/Portfile
@@ -35,4 +35,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-is/Portfile
+++ b/textproc/aspell-dict-is/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        is

--- a/textproc/aspell-dict-it/Portfile
+++ b/textproc/aspell-dict-it/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-it/Portfile
+++ b/textproc/aspell-dict-it/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        it

--- a/textproc/aspell-dict-lt/Portfile
+++ b/textproc/aspell-dict-lt/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        lt

--- a/textproc/aspell-dict-lt/Portfile
+++ b/textproc/aspell-dict-lt/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-lv/Portfile
+++ b/textproc/aspell-dict-lv/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        lv

--- a/textproc/aspell-dict-lv/Portfile
+++ b/textproc/aspell-dict-lv/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-mg/Portfile
+++ b/textproc/aspell-dict-mg/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        mg

--- a/textproc/aspell-dict-mg/Portfile
+++ b/textproc/aspell-dict-mg/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell5?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-mk/Portfile
+++ b/textproc/aspell-dict-mk/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        mk

--- a/textproc/aspell-dict-mk/Portfile
+++ b/textproc/aspell-dict-mk/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-mr/Portfile
+++ b/textproc/aspell-dict-mr/Portfile
@@ -34,4 +34,6 @@ post-destroot {
     file delete ${destroot}${prefix}/lib/aspell-0.60/u-deva.cset
 }
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-mr/Portfile
+++ b/textproc/aspell-dict-mr/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        mr

--- a/textproc/aspell-dict-ms/Portfile
+++ b/textproc/aspell-dict-ms/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-ms/Portfile
+++ b/textproc/aspell-dict-ms/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        ms

--- a/textproc/aspell-dict-nb/Portfile
+++ b/textproc/aspell-dict-nb/Portfile
@@ -35,4 +35,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-nb/Portfile
+++ b/textproc/aspell-dict-nb/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        nb

--- a/textproc/aspell-dict-nl/Portfile
+++ b/textproc/aspell-dict-nl/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        nl

--- a/textproc/aspell-dict-nl/Portfile
+++ b/textproc/aspell-dict-nl/Portfile
@@ -27,4 +27,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-pl/Portfile
+++ b/textproc/aspell-dict-pl/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-pl/Portfile
+++ b/textproc/aspell-dict-pl/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        pl

--- a/textproc/aspell-dict-pt_BR/Portfile
+++ b/textproc/aspell-dict-pt_BR/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        pt_BR

--- a/textproc/aspell-dict-pt_BR/Portfile
+++ b/textproc/aspell-dict-pt_BR/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-pt_PT/Portfile
+++ b/textproc/aspell-dict-pt_PT/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-pt_PT/Portfile
+++ b/textproc/aspell-dict-pt_PT/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        pt_PT

--- a/textproc/aspell-dict-ro/Portfile
+++ b/textproc/aspell-dict-ro/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-ro/Portfile
+++ b/textproc/aspell-dict-ro/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        ro

--- a/textproc/aspell-dict-ru/Portfile
+++ b/textproc/aspell-dict-ru/Portfile
@@ -28,4 +28,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-ru/Portfile
+++ b/textproc/aspell-dict-ru/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        ru

--- a/textproc/aspell-dict-rw/Portfile
+++ b/textproc/aspell-dict-rw/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-rw/Portfile
+++ b/textproc/aspell-dict-rw/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        rw

--- a/textproc/aspell-dict-sk/Portfile
+++ b/textproc/aspell-dict-sk/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-sk/Portfile
+++ b/textproc/aspell-dict-sk/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        sk

--- a/textproc/aspell-dict-sr/Portfile
+++ b/textproc/aspell-dict-sr/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-sr/Portfile
+++ b/textproc/aspell-dict-sr/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        sr

--- a/textproc/aspell-dict-sw/Portfile
+++ b/textproc/aspell-dict-sw/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        sw

--- a/textproc/aspell-dict-sw/Portfile
+++ b/textproc/aspell-dict-sw/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-ta/Portfile
+++ b/textproc/aspell-dict-ta/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        ta

--- a/textproc/aspell-dict-ta/Portfile
+++ b/textproc/aspell-dict-ta/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-tl/Portfile
+++ b/textproc/aspell-dict-tl/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-tl/Portfile
+++ b/textproc/aspell-dict-tl/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        tl

--- a/textproc/aspell-dict-tr/Portfile
+++ b/textproc/aspell-dict-tr/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell(?:5|6)?-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-tr/Portfile
+++ b/textproc/aspell-dict-tr/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        tr

--- a/textproc/aspell-dict-uk/Portfile
+++ b/textproc/aspell-dict-uk/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        uk

--- a/textproc/aspell-dict-uk/Portfile
+++ b/textproc/aspell-dict-uk/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-uz/Portfile
+++ b/textproc/aspell-dict-uz/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        uz

--- a/textproc/aspell-dict-uz/Portfile
+++ b/textproc/aspell-dict-uz/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.

--- a/textproc/aspell-dict-vi/Portfile
+++ b/textproc/aspell-dict-vi/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 set langcode        vi

--- a/textproc/aspell-dict-vi/Portfile
+++ b/textproc/aspell-dict-vi/Portfile
@@ -29,4 +29,6 @@ configure.args      --vars \
                     ASPELL=${prefix}/bin/aspell \
                     WORD_LIST_COMPRESS=${prefix}/bin/word-list-compress
 
+livecheck.type      regex
+livecheck.url       http://ftp.gnu.org/gnu/aspell/dict/0index.html
 livecheck.regex     >aspell6-${langcode}-(.*?)\\.tar\\.


### PR DESCRIPTION
#### Description

I went through the `aspell-dict-*` ports with `nomaintainer` and added the modeline and fixed livecheck following `aspell-dict-en`. I also fixed the whitespace on `aspell-dict-fr` and updated it to use the full version string from upstream.

Other than `aspell-dict-fr`, I did not install any of the dictionaries as my changes would not impact users. Due to the version change, `aspell-dict-fr` would trigger an update and I verified it successfully installed on my system.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?