### PR TITLE
New port: RapidJSON

### DIFF
--- a/lang/rapidjson/Portfile
+++ b/lang/rapidjson/Portfile
@@ -3,6 +3,7 @@ PortSystem                      1.0
 PortGroup                       github 1.0
 PortGroup                       cmake 1.1
 
+name                            rapidjson-devel
 github.setup                    Tencent rapidjson b32cd9421c5e3cbe183a99b6537ce11441e50656
 version                         20180424
 license                         MIT

--- a/lang/rapidjson/Portfile
+++ b/lang/rapidjson/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem                      1.0
+PortGroup                       github 1.0
+PortGroup                       cmake 1.1
+
+github.setup                    Tencent rapidjson b32cd9421c5e3cbe183a99b6537ce11441e50656
+version                         20180424
+license                         MIT
+categories                      lang devel
+platforms                       darwin
+maintainers                     {@Lord-Kamina gmail.com:g.litenstein}
+description                     A fast JSON parser/generator for C++ with both SAX/DOM style API.
+long_description                RapidJSON is a fast, unicode-friendly, self-contained \
+                                and header-only library without any dependencies for parsing JSON.
+checksums                       rmd160  a0211ac1dc84270169b59c584894a0f49d0030a8 \
+                                sha256  4133516f8fd578053f478f3b6211ebcfb03056bdd59d6c6d0312c393f467cf37
+homepage                        http://rapidjson.org/
+depends_build-append            bin:doxygen:doxygen
+
+# Disbled Valgrind because it's apparently failing not due to issues with RapidJSON but rather macOS itself.
+patchfiles                      patch-test-CmakeLists.txt.diff \
+                                patch-test-unittest.diff \
+                                patch-test-unittest-CmakeLists.txt.diff
+
+configure.pre_args-delete       -DCMAKE_POLICY_DEFAULT_CMP0025=NEW
+configure.post_args-append      -DRAPIDJSON_HAS_STDSTRING=ON -DRAPIDJSON_HAS_CXX11_RVALUE_REFS=ON -DRAPIDJSON_BUILD_TESTS=OFF
+configure.optflags-delete       -Os
+cmake.generator                 Unix Makefiles
+
+variant tests description {Build and run unit tests.} {
+    depends_build-append        port:gtest
+    configure.post_args-delete  -DRAPIDJSON_BUILD_TESTS=OFF
+    test.run                    yes
+}
+
+default_variants +tests

--- a/lang/rapidjson/files/patch-test-CmakeLists.txt.diff
+++ b/lang/rapidjson/files/patch-test-CmakeLists.txt.diff
@@ -1,0 +1,27 @@
+--- test/CMakeLists.txt.orig	2018-05-03 19:17:38.000000000 -0300
++++ test/CMakeLists.txt	2018-05-03 19:19:01.000000000 -0300
+@@ -1,20 +1,17 @@
+-find_package(GTestSrc)
++find_package(GTest REQUIRED)
+ 
+-IF(GTESTSRC_FOUND)
++IF(GTEST_FOUND)
+     enable_testing()
+ 
+     if (WIN32 AND (NOT CYGWIN) AND (NOT MINGW))
+         set(gtest_disable_pthreads ON)
+         set(gtest_force_shared_crt ON)
+     endif()
+-
+-    add_subdirectory(${GTEST_SOURCE_DIR} ${CMAKE_BINARY_DIR}/googletest)
+-    include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
+-
++    
+     set(TEST_LIBRARIES gtest gtest_main)
+ 
+     add_custom_target(tests ALL)
+     add_subdirectory(perftest)
+     add_subdirectory(unittest)
+ 
+-ENDIF(GTESTSRC_FOUND)
++ENDIF(GTEST_FOUND)

--- a/lang/rapidjson/files/patch-test-unittest-CmakeLists.txt.diff
+++ b/lang/rapidjson/files/patch-test-unittest-CmakeLists.txt.diff
@@ -1,0 +1,16 @@
+// Remove Valgrind from unittests as it is currently failing (apparently) mostly to issues not related to RapidJSON.
+
+--- test/unittest/CMakeLists.txt.orig	2018-05-05 17:09:28.000000000 -0300
++++ test/unittest/CMakeLists.txt	2018-05-05 17:09:47.000000000 -0300
+@@ -78,11 +78,6 @@
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+ 
+ if(NOT MSVC)
+-    # Not running SIMD.* unit test cases for Valgrind
+-    add_test(NAME valgrind_unittest
+-        COMMAND valgrind --suppressions=${CMAKE_SOURCE_DIR}/test/valgrind.supp --leak-check=full --error-exitcode=1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest --gtest_filter=-SIMD.*
+-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+-
+     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+         add_test(NAME symbol_check
+         COMMAND sh -c "objdump -t -C libnamespacetest.a | grep rapidjson ; test $? -ne 0"

--- a/lang/rapidjson/files/patch-test-unittest.diff
+++ b/lang/rapidjson/files/patch-test-unittest.diff
@@ -1,0 +1,489 @@
+diff -ur test/unittest/cursorstreamwrappertest.cpp.orig test/unittest/cursorstreamwrappertest.cpp
+--- test/unittest/cursorstreamwrappertest.cpp.orig	2018-04-24 23:13:00.000000000 -0300
++++ test/unittest/cursorstreamwrappertest.cpp	2018-05-05 01:37:31.000000000 -0300
+@@ -38,8 +38,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 3);
+-    EXPECT_EQ(col, 0);
++    EXPECT_EQ(static_cast<long>(line), 3);
++    EXPECT_EQ(static_cast<long>(col), 0);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingQuotes) {
+@@ -47,8 +47,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 1);
+-    EXPECT_EQ(col, 8);
++    EXPECT_EQ(static_cast<long>(line), 1);
++    EXPECT_EQ(static_cast<long>(col), 8);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingColon) {
+@@ -56,8 +56,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 3);
+-    EXPECT_EQ(col, 0);
++    EXPECT_EQ(static_cast<long>(line), 3);
++    EXPECT_EQ(static_cast<long>(col), 0);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingSecondQuotes) {
+@@ -65,8 +65,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 3);
+-    EXPECT_EQ(col, 1);
++    EXPECT_EQ(static_cast<long>(line), 3);
++    EXPECT_EQ(static_cast<long>(col), 1);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingComma) {
+@@ -74,8 +74,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 3);
+-    EXPECT_EQ(col, 12);
++    EXPECT_EQ(static_cast<long>(line), 3);
++    EXPECT_EQ(static_cast<long>(col), 12);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingArrayBracket) {
+@@ -83,8 +83,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 4);
+-    EXPECT_EQ(col, 9);
++    EXPECT_EQ(static_cast<long>(line), 4);
++    EXPECT_EQ(static_cast<long>(col), 9);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingArrayComma) {
+@@ -92,8 +92,8 @@
+     size_t col, line;
+     bool ret = testJson(json, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 4);
+-    EXPECT_EQ(col, 6);
++    EXPECT_EQ(static_cast<long>(line), 4);
++    EXPECT_EQ(static_cast<long>(col), 6);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingLastArrayBracket) {
+@@ -101,8 +101,8 @@
+     size_t col, line;
+     bool ret = testJson(json8, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 4);
+-    EXPECT_EQ(col, 15);
++    EXPECT_EQ(static_cast<long>(line), 4);
++    EXPECT_EQ(static_cast<long>(col), 15);
+ }
+ 
+ TEST(CursorStreamWrapper, MissingLastBracket) {
+@@ -110,6 +110,6 @@
+     size_t col, line;
+     bool ret = testJson(json9, line, col);
+     EXPECT_TRUE(ret);
+-    EXPECT_EQ(line, 4);
+-    EXPECT_EQ(col, 16);
++    EXPECT_EQ(static_cast<long>(line), 4);
++    EXPECT_EQ(static_cast<long>(col), 16);
+ }
+diff -ur test/unittest/istreamwrappertest.cpp.orig test/unittest/istreamwrappertest.cpp
+--- test/unittest/istreamwrappertest.cpp.orig	2018-04-24 23:13:00.000000000 -0300
++++ test/unittest/istreamwrappertest.cpp	2018-05-05 01:36:02.000000000 -0300
+@@ -35,22 +35,22 @@
+     {
+         StringStreamType iss;
+         BasicIStreamWrapper<StringStreamType> is(iss);
+-        EXPECT_EQ(0, is.Tell());
+-        if (sizeof(Ch) == 1) {
++        EXPECT_EQ(0, static_cast<long>(is.Tell()));
++        if (static_cast<int>(sizeof(Ch)) == 1) {
+             EXPECT_EQ(0, is.Peek4());
+-            EXPECT_EQ(0, is.Tell());
++            EXPECT_EQ(0, static_cast<long>(is.Tell()));
+         }
+         EXPECT_EQ(0, is.Peek());
+         EXPECT_EQ(0, is.Take());
+-        EXPECT_EQ(0, is.Tell());
++        EXPECT_EQ(0, static_cast<long>(is.Tell()));
+     }
+ 
+     {
+         Ch s[] = { 'A', 'B', 'C', '\0' };
+         StringStreamType iss(s);
+         BasicIStreamWrapper<StringStreamType> is(iss);
+-        EXPECT_EQ(0, is.Tell());
+-        if (sizeof(Ch) == 1) {
++        EXPECT_EQ(0, static_cast<long>(is.Tell()));
++        if (static_cast<int>(sizeof(Ch)) == 1) {
+             EXPECT_EQ(0, is.Peek4()); // less than 4 bytes
+         }
+         for (int i = 0; i < 3; i++) {
+@@ -59,7 +59,7 @@
+             EXPECT_EQ('A' + i, is.Peek());
+             EXPECT_EQ('A' + i, is.Take());
+         }
+-        EXPECT_EQ(3, is.Tell());
++        EXPECT_EQ(3, static_cast<long>(is.Tell()));
+         EXPECT_EQ(0, is.Peek());
+         EXPECT_EQ(0, is.Take());
+     }
+@@ -68,11 +68,11 @@
+         Ch s[] = { 'A', 'B', 'C', 'D', 'E', '\0' };
+         StringStreamType iss(s);
+         BasicIStreamWrapper<StringStreamType> is(iss);
+-        if (sizeof(Ch) == 1) {
++        if (static_cast<int>(sizeof(Ch)) == 1) {
+             const Ch* c = is.Peek4();
+             for (int i = 0; i < 4; i++)
+                 EXPECT_EQ('A' + i, c[i]);
+-            EXPECT_EQ(0, is.Tell());
++            EXPECT_EQ(0, static_cast<long>(is.Tell()));
+         }
+         for (int i = 0; i < 5; i++) {
+             EXPECT_EQ(static_cast<size_t>(i), is.Tell());
+@@ -80,7 +80,7 @@
+             EXPECT_EQ('A' + i, is.Peek());
+             EXPECT_EQ('A' + i, is.Take());
+         }
+-        EXPECT_EQ(5, is.Tell());
++        EXPECT_EQ(5, static_cast<long>(is.Tell()));
+         EXPECT_EQ(0, is.Peek());
+         EXPECT_EQ(0, is.Take());
+     }
+@@ -129,7 +129,7 @@
+     Document d;
+     EXPECT_TRUE(!d.ParseStream(eis).HasParseError());
+     EXPECT_TRUE(d.IsObject());
+-    EXPECT_EQ(5, d.MemberCount());
++    EXPECT_EQ(5, static_cast<int>(d.MemberCount()));
+ }
+ 
+ TEST(IStreamWrapper, fstream) {
+@@ -140,7 +140,7 @@
+     Document d;
+     EXPECT_TRUE(!d.ParseStream(eis).HasParseError());
+     EXPECT_TRUE(d.IsObject());
+-    EXPECT_EQ(5, d.MemberCount());
++    EXPECT_EQ(5, static_cast<int>(d.MemberCount()));
+ }
+ 
+ // wifstream/wfstream only works on C++11 with codecvt_utf16
+@@ -158,7 +158,7 @@
+     d.ParseStream<kParseDefaultFlags, UTF16<>, WIStreamWrapper>(isw);
+     EXPECT_TRUE(!d.HasParseError());
+     EXPECT_TRUE(d.IsObject());
+-    EXPECT_EQ(5, d.MemberCount());
++    EXPECT_EQ(5, static_cast<int>(d.MemberCount()));
+ }
+ 
+ TEST(IStreamWrapper, wfstream) {
+@@ -171,7 +171,7 @@
+     d.ParseStream<kParseDefaultFlags, UTF16<>, WIStreamWrapper>(isw);
+     EXPECT_TRUE(!d.HasParseError());
+     EXPECT_TRUE(d.IsObject());
+-    EXPECT_EQ(5, d.MemberCount());
++    EXPECT_EQ(5, static_cast<int>(d.MemberCount()));
+ }
+ 
+ #endif
+diff -ur test/unittest/pointertest.cpp.orig test/unittest/pointertest.cpp
+--- test/unittest/pointertest.cpp.orig	2018-04-24 23:13:00.000000000 -0300
++++ test/unittest/pointertest.cpp	2018-05-05 01:30:13.000000000 -0300
+@@ -153,7 +153,7 @@
+         EXPECT_EQ(kPointerInvalidIndex, p.GetTokens()[0].index);
+     }
+ 
+-    if (sizeof(SizeType) == 4) {
++    if (static_cast<int>(sizeof(SizeType)) == 4) {
+         // Invalid index (overflow)
+         Pointer p("/4294967296");
+         EXPECT_TRUE(p.IsValid());
+@@ -290,7 +290,7 @@
+         EXPECT_EQ(kPointerInvalidIndex, p.GetTokens()[0].index);
+     }
+ 
+-    if (sizeof(SizeType) == 4) {
++    if (static_cast<int>(sizeof(SizeType)) == 4) {
+         // Invalid index (overflow)
+         Pointer p("#/4294967296");
+         EXPECT_TRUE(p.IsValid());
+@@ -634,13 +634,13 @@
+     EXPECT_TRUE(Pointer("/abc").Get(d) == 0);
+     size_t unresolvedTokenIndex;
+     EXPECT_TRUE(Pointer("/foo/2").Get(d, &unresolvedTokenIndex) == 0); // Out of boundary
+-    EXPECT_EQ(1, unresolvedTokenIndex);
++    EXPECT_EQ(1, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(Pointer("/foo/a").Get(d, &unresolvedTokenIndex) == 0); // "/foo" is an array, cannot query by "a"
+-    EXPECT_EQ(1, unresolvedTokenIndex);
++    EXPECT_EQ(1, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(Pointer("/foo/0/0").Get(d, &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
+-    EXPECT_EQ(2, unresolvedTokenIndex);
++    EXPECT_EQ(2, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(Pointer("/foo/0/a").Get(d, &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
+-    EXPECT_EQ(2, unresolvedTokenIndex);
++    EXPECT_EQ(2, static_cast<int>(unresolvedTokenIndex));
+ }
+ 
+ TEST(Pointer, GetWithDefault) {
+@@ -959,13 +959,13 @@
+ 
+     size_t unresolvedTokenIndex;
+     EXPECT_TRUE(GetValueByPointer(d, "/foo/2", &unresolvedTokenIndex) == 0); // Out of boundary
+-    EXPECT_EQ(1, unresolvedTokenIndex);
++    EXPECT_EQ(1, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(GetValueByPointer(d, "/foo/a", &unresolvedTokenIndex) == 0); // "/foo" is an array, cannot query by "a"
+-    EXPECT_EQ(1, unresolvedTokenIndex);
++    EXPECT_EQ(1, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(GetValueByPointer(d, "/foo/0/0", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
+-    EXPECT_EQ(2, unresolvedTokenIndex);
++    EXPECT_EQ(2, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(GetValueByPointer(d, "/foo/0/a", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
+-    EXPECT_EQ(2, unresolvedTokenIndex);
++    EXPECT_EQ(2, static_cast<int>(unresolvedTokenIndex));
+ 
+     // const version
+     const Value& v = d;
+@@ -973,13 +973,13 @@
+     EXPECT_EQ(&d["foo"][0], GetValueByPointer(v, "/foo/0"));
+ 
+     EXPECT_TRUE(GetValueByPointer(v, "/foo/2", &unresolvedTokenIndex) == 0); // Out of boundary
+-    EXPECT_EQ(1, unresolvedTokenIndex);
++    EXPECT_EQ(1, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(GetValueByPointer(v, "/foo/a", &unresolvedTokenIndex) == 0); // "/foo" is an array, cannot query by "a"
+-    EXPECT_EQ(1, unresolvedTokenIndex);
++    EXPECT_EQ(1, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(GetValueByPointer(v, "/foo/0/0", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
+-    EXPECT_EQ(2, unresolvedTokenIndex);
++    EXPECT_EQ(2, static_cast<int>(unresolvedTokenIndex));
+     EXPECT_TRUE(GetValueByPointer(v, "/foo/0/a", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
+-    EXPECT_EQ(2, unresolvedTokenIndex);
++    EXPECT_EQ(2, static_cast<int>(unresolvedTokenIndex));
+ 
+ }
+ 
+diff -ur test/unittest/readertest.cpp.orig test/unittest/readertest.cpp
+--- test/unittest/readertest.cpp.orig	2018-04-24 23:13:00.000000000 -0300
++++ test/unittest/readertest.cpp	2018-05-05 01:42:43.000000000 -0300
+@@ -431,8 +431,8 @@
+         Reader reader; \
+         EXPECT_FALSE(reader.Parse(s, h)); \
+         EXPECT_EQ(errorCode, reader.GetParseErrorCode());\
+-        EXPECT_EQ(errorOffset, reader.GetErrorOffset());\
+-        EXPECT_EQ(streamPos, s.Tell());\
++        EXPECT_EQ(errorOffset, static_cast<long>(reader.GetErrorOffset()));\
++        EXPECT_EQ(streamPos, static_cast<long>(s.Tell()));\
+     }
+ 
+     // Number too big to be stored in double.
+@@ -617,8 +617,8 @@
+     GenericReader<UTF8<> , UTF8<> > reader;\
+     reader.Parse<kParseValidateEncodingFlag>(s, h);\
+     EXPECT_EQ(errorCode, reader.GetParseErrorCode());\
+-    EXPECT_EQ(errorOffset, reader.GetErrorOffset());\
+-    EXPECT_EQ(streamPos, s.Tell());\
++    EXPECT_EQ(errorOffset, static_cast<long>(reader.GetErrorOffset()));\
++    EXPECT_EQ(streamPos, static_cast<long>(s.Tell()));\
+ }
+ 
+ #define ARRAY(...) { __VA_ARGS__ }
+@@ -775,8 +775,8 @@
+         GenericReader<UTF8<>, UTF8<>, CrtAllocator> reader; \
+         EXPECT_FALSE(reader.Parse(s, h)); \
+         EXPECT_EQ(errorCode, reader.GetParseErrorCode());\
+-        EXPECT_EQ(errorOffset, reader.GetErrorOffset());\
+-        EXPECT_EQ(streamPos, s.Tell());\
++        EXPECT_EQ(errorOffset, static_cast<long>(reader.GetErrorOffset()));\
++        EXPECT_EQ(streamPos, static_cast<long>(s.Tell()));\
+     }
+ 
+     // Missing a comma or ']' after an array element.
+@@ -943,8 +943,8 @@
+         Reader reader; \
+         EXPECT_FALSE(reader.Parse(s, h)); \
+         EXPECT_EQ(errorCode, reader.GetParseErrorCode());\
+-        EXPECT_EQ(errorOffset, reader.GetErrorOffset());\
+-        EXPECT_EQ(streamPos, s.Tell());\
++        EXPECT_EQ(errorOffset, static_cast<long>(reader.GetErrorOffset()));\
++        EXPECT_EQ(streamPos, static_cast<long>(s.Tell()));\
+     }
+ 
+ TEST(Reader, ParseDocument_Error) {
+@@ -1117,8 +1117,8 @@
+     reader.Parse<kParseIterativeFlag>(json, handler); \
+     EXPECT_TRUE(reader.HasParseError()); \
+     EXPECT_EQ(errorCode, reader.GetParseErrorCode()); \
+-    EXPECT_EQ(offset, reader.GetErrorOffset()); \
+-    EXPECT_EQ(streamPos, json.Tell()); \
++    EXPECT_EQ(offset, static_cast<long>(reader.GetErrorOffset())); \
++    EXPECT_EQ(streamPos, static_cast<long>(json.Tell())); \
+ }
+ 
+ TEST(Reader, IterativeParsing_ErrorHandling) {
+@@ -1866,8 +1866,8 @@
+         Reader reader; \
+         EXPECT_FALSE(reader.Parse<kParseNanAndInfFlag>(s, h)); \
+         EXPECT_EQ(errorCode, reader.GetParseErrorCode());\
+-        EXPECT_EQ(errorOffset, reader.GetErrorOffset());\
+-        EXPECT_EQ(streamPos, s.Tell());\
++        EXPECT_EQ(errorOffset, static_cast<long>(reader.GetErrorOffset()));\
++        EXPECT_EQ(streamPos, static_cast<long>(s.Tell()));\
+     }
+ 
+     double nan = std::numeric_limits<double>::quiet_NaN();
+diff -ur test/unittest/stringbuffertest.cpp.orig test/unittest/stringbuffertest.cpp
+--- test/unittest/stringbuffertest.cpp.orig	2018-04-24 23:13:00.000000000 -0300
++++ test/unittest/stringbuffertest.cpp	2018-05-05 01:44:42.000000000 -0300
+@@ -41,11 +41,11 @@
+ 
+ TEST(StringBuffer, PutN_Issue672) {
+     GenericStringBuffer<UTF8<>, MemoryPoolAllocator<> > buffer;
+-    EXPECT_EQ(0, buffer.GetSize());
+-    EXPECT_EQ(0, buffer.GetLength());
++    EXPECT_EQ(0, static_cast<long>(buffer.GetSize()));
++    EXPECT_EQ(0, static_cast<long>(buffer.GetLength()));
+     rapidjson::PutN(buffer, ' ', 1);
+-    EXPECT_EQ(1, buffer.GetSize());
+-    EXPECT_EQ(1, buffer.GetLength());
++    EXPECT_EQ(1, static_cast<long>(buffer.GetSize()));
++    EXPECT_EQ(1, static_cast<long>(buffer.GetLength()));
+ }
+ 
+ TEST(StringBuffer, Clear) {
+@@ -81,7 +81,7 @@
+     buffer.Put('E');
+     buffer.Pop(3);
+ 
+-    EXPECT_EQ(2u, buffer.GetSize());
++    EXPECT_EQ(2u, static_cast<long>(buffer.GetSize()));
+     EXPECT_EQ(2u, buffer.GetLength());
+     EXPECT_STREQ("AB", buffer.GetString());
+ }
+diff -ur test/unittest/valuetest.cpp.orig test/unittest/valuetest.cpp
+--- test/unittest/valuetest.cpp.orig	2018-04-24 23:13:00.000000000 -0300
++++ test/unittest/valuetest.cpp	2018-05-05 02:20:08.000000000 -0300
+@@ -24,13 +24,13 @@
+ using namespace rapidjson;
+ 
+ TEST(Value, Size) {
+-    if (sizeof(SizeType) == 4) {
++    if (static_cast<int>(sizeof(SizeType)) == 4) {
+ #if RAPIDJSON_48BITPOINTER_OPTIMIZATION
+-        EXPECT_EQ(16, sizeof(Value));
++        EXPECT_EQ(16, static_cast<long>(sizeof(Value)));
+ #elif RAPIDJSON_64BIT
+-        EXPECT_EQ(24, sizeof(Value));
++        EXPECT_EQ(24, static_cast<long>(sizeof(Value)));
+ #else
+-        EXPECT_EQ(16, sizeof(Value));
++        EXPECT_EQ(16, static_cast<long>(sizeof(Value)));
+ #endif
+     }
+ }
+@@ -652,9 +652,9 @@
+ 
+     // Templated functions
+     EXPECT_TRUE(z.Is<double>());
+-    EXPECT_EQ(56.78, z.Get<double>());
+-    EXPECT_EQ(57.78, z.Set(57.78).Get<double>());
+-    EXPECT_EQ(58.78, z.Set<double>(58.78).Get<double>());
++    EXPECT_DOUBLE_EQ(56.78, z.Get<double>());
++    EXPECT_DOUBLE_EQ(57.78, z.Set(57.78).Get<double>());
++    EXPECT_DOUBLE_EQ(58.78, z.Set<double>(58.78).Get<double>());
+ }
+ 
+ TEST(Value, Float) {
+@@ -682,16 +682,16 @@
+ 
+     // Issue 573
+     z.SetInt(0);
+-    EXPECT_EQ(0.0f, z.GetFloat());
++    EXPECT_FLOAT_EQ(0.0f, z.GetFloat());
+ 
+     z = 56.78f;
+     EXPECT_NEAR(56.78f, z.GetFloat(), 0.0f);
+ 
+     // Templated functions
+     EXPECT_TRUE(z.Is<float>());
+-    EXPECT_EQ(56.78f, z.Get<float>());
+-    EXPECT_EQ(57.78f, z.Set(57.78f).Get<float>());
+-    EXPECT_EQ(58.78f, z.Set<float>(58.78f).Get<float>());
++    EXPECT_FLOAT_EQ(56.78f, z.Get<float>());
++    EXPECT_FLOAT_EQ(57.78f, z.Set(57.78f).Get<float>());
++    EXPECT_FLOAT_EQ(58.78f, z.Set<float>(58.78f).Get<float>());
+ }
+ 
+ TEST(Value, IsLosslessDouble) {
+@@ -1135,10 +1135,10 @@
+         a.PushBack(1, allocator);
+ 
+         Value::Array a2(a); // copy constructor
+-        EXPECT_EQ(1, a2.Size());
++        EXPECT_EQ(1, static_cast<int>(a2.Size()));
+ 
+         Value::Array a3 = a;
+-        EXPECT_EQ(1, a3.Size());
++        EXPECT_EQ(1, static_cast<int>(a3.Size()));
+ 
+         Value::ConstArray y = static_cast<const Value&>(x).GetArray();
+         (void)y;
+@@ -1175,7 +1175,7 @@
+         y.PushBack(123, allocator);
+         x.PushBack(y.GetArray(), allocator);    // Implicit constructor to convert Array to GenericValue
+ 
+-        EXPECT_EQ(1, x.Size());
++        EXPECT_EQ(1, static_cast<int>(x.Size()));
+         EXPECT_EQ(123, x[0][0].GetInt());
+         EXPECT_TRUE(y.IsArray());
+         EXPECT_TRUE(y.Empty());
+@@ -1424,7 +1424,7 @@
+     for (; itr != x.MemberEnd(); ++itr) {
+         size_t i = static_cast<size_t>((itr - x.MemberBegin())) + 1;
+         EXPECT_STREQ(itr->name.GetString(), keys[i]);
+-        EXPECT_EQ(i, itr->value[0].GetInt());
++        EXPECT_EQ(static_cast<long>(i), itr->value[0].GetInt());
+     }
+ 
+     // Erase the last
+@@ -1435,7 +1435,7 @@
+     for (; itr != x.MemberEnd(); ++itr) {
+         size_t i = static_cast<size_t>(itr - x.MemberBegin()) + 1;
+         EXPECT_STREQ(itr->name.GetString(), keys[i]);
+-        EXPECT_EQ(i, itr->value[0].GetInt());
++        EXPECT_EQ(static_cast<long>(i), itr->value[0].GetInt());
+     }
+ 
+     // Erase the middle
+@@ -1447,7 +1447,7 @@
+         size_t i = static_cast<size_t>(itr - x.MemberBegin());
+         i += (i < 4) ? 1 : 2;
+         EXPECT_STREQ(itr->name.GetString(), keys[i]);
+-        EXPECT_EQ(i, itr->value[0].GetInt());
++        EXPECT_EQ(static_cast<long>(i), itr->value[0].GetInt());
+     }
+ 
+     // EraseMember(ConstMemberIterator, ConstMemberIterator)
+@@ -1516,10 +1516,10 @@
+         o.AddMember("1", 1, allocator);
+ 
+         Value::Object o2(o); // copy constructor
+-        EXPECT_EQ(1, o2.MemberCount());
++        EXPECT_EQ(1, static_cast<int>(o2.MemberCount()));
+ 
+         Value::Object o3 = o;
+-        EXPECT_EQ(1, o3.MemberCount());
++        EXPECT_EQ(1, static_cast<int>(o3.MemberCount()));
+ 
+         Value::ConstObject y = static_cast<const Value&>(x).GetObject();
+         (void)y;


### PR DESCRIPTION
#### Description

RapidJSON is a fast, unicode-friendly, self-contained and header-only library without any dependencies for parsing JSON.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
