### PR TITLE
submission: New port libimobiledevice, libusbmuxd

### DIFF
--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        libimobiledevice libimobiledevice 1.2.0
+
+categories          devel
+platforms           darwin
+
+license             LGPL-2.1
+maintainers         {ijackson @iJacksonIsaac} openmaintainer
+
+description         A cross-platform software protocol library \
+    and tools to communicate with iOS devices natively.
+
+long_description    libimobiledevice is a cross-platform software \
+    library that talks the protocols to support iPhone, iPod Touch, \
+    iPad and Apple TV devices. Unlike other projects, it does not \
+    depend on using any existing proprietary libraries and does not \
+    require jailbreaking. It allows other software to easily access \
+    the device's filesystem, retrieve information about the device \
+    and it's internals, backup/restore the device, manage SpringBoard \
+    icons, manage installed applications, retrieve addressbook/calendars \
+    /notes and bookmarks and (using libgpod) synchronize music and video \
+    to the device.
+
+homepage            https://www.libimobiledevice.org/
+
+checksums           rmd160  b0f6873fa9fae1adf888fec967382f1474d780c3 \
+                    sha256  13516ca1c5c79ee89a6cb2aaea5a23fce1b8c7ecd3e6fff3ee2f1658d4d73c5d \
+                    size    223635
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
+
+depends_lib         port:libplist \
+                    port:libusbmuxd
+
+configure.cmd       ./autogen.sh

--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        libimobiledevice libusbmuxd 1.0.10
+
+categories          devel
+platforms           darwin
+
+maintainers         {ijackson @JacksonIsaac} openmaintainer
+
+description         A client library to multiplex connections from and to iOS devices.
+long_description    A client library to multiplex connections from and to iOS devices \
+    by connecting to a socket provided by a usbmuxd daemon.
+
+license             LGPL-2.1
+
+checksums           rmd160  eb232798c31bca6d0259796b87922644a99d00fa \
+                    sha256  f7fe90e3613d20dd16967d8caa1df2edac5dacdaf32f5a826dc8e31d6d8b6b39 \
+                    size    28340
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
+
+depends_lib         port:libplist
+
+configure.cmd       ./autogen.sh


### PR DESCRIPTION
#### Description

New port libimobiledevice. Also contains new port for its dependency i.e., libusbmuxd

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
