### PR TITLE
haproxy: Update to 1.8.8

### DIFF
--- a/net/haproxy/Portfile
+++ b/net/haproxy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                haproxy
-version             1.8.3
+version             1.8.8
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          net
 platforms           darwin
@@ -21,13 +21,16 @@ long_description    HAproxy is a high-performance and highly-robust TCP/HTTP \
                     to achieve up to ten thousands hits per second on modern \
                     hardware, even with thousands simultaneous connections.
 
-homepage            http://www.haproxy.org/
+homepage            https://www.haproxy.org/
 master_sites        ${homepage}download/${branch}/src/
 
-checksums           rmd160  79c2483955d7ce46dbbcdf98cc4d5f72bca8fd95 \
-                    sha256  3dc7f65c4ed6ac1420dfd01896833e0f765f72471fbfa316a195793272e58b4a
+checksums           rmd160  7ae74f2b9113f9de64959470b25080834d784fc6 \
+                    sha256  bcc05ab824bd2f89b8b21ac05459c0a0a0e02247b57ffe441d52cfe771daea92 \
+                    size    2054534
 
-depends_lib         port:pcre
+depends_lib         path:lib/libssl.dylib:openssl \
+                    port:pcre \
+                    port:zlib
 
 patchfiles          patch-Makefile.diff
 
@@ -39,7 +42,9 @@ build.target        TARGET=osx
 
 build.args          CC="${configure.cc} [get_canonical_archflags]" \
                     USE_LIBCRYPT=1 \
-                    USE_PCRE=1
+                    USE_OPENSSL=1 \
+                    USE_PCRE=1 \
+                    USE_ZLIB=1
 
 destroot.args       DOCDIR=${prefix}/share/doc/${name} \
                     PREFIX=${prefix}

--- a/net/haproxy/files/patch-Makefile.diff
+++ b/net/haproxy/files/patch-Makefile.diff
@@ -1,6 +1,6 @@
---- Makefile.orig	2012-08-14 02:09:31.000000000 -0500
-+++ Makefile	2012-09-21 04:18:37.000000000 -0500
-@@ -450,7 +450,9 @@
+--- Makefile.orig	2018-04-19 15:20:31.000000000 +0000
++++ Makefile	2018-05-06 12:00:00.000000000 +0000
+@@ -473,8 +473,10 @@
  ifneq ($(USE_LIBCRYPT),)
  OPTIONS_CFLAGS  += -DCONFIG_HAP_CRYPT
  BUILD_OPTIONS   += $(call ignore_implicit,USE_LIBCRYPT)
@@ -10,3 +10,4 @@
  endif
  
  ifneq ($(USE_CRYPT_H),)
+ OPTIONS_CFLAGS  += -DNEED_CRYPT_H


### PR DESCRIPTION
#### Description
* Use https
* Add dependency on and enable use of openssl, which the Makefile says is recommended

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
