### PR TITLE
update py-scipy to 1.1.0 release

### DIFF
--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -6,10 +6,10 @@ PortGroup               active_variants 1.1
 PortGroup               github 1.0
 PortGroup               compilers 1.0
 
-github.setup            scipy scipy 1.0.1 v
-checksums               rmd160 40e2058b0ef22a35be3f7115247d4f06371c2247 \
-                        sha256 68b03a94d05d398cc6aed60da467c9b34936db8a4180b9a8ab2609dfd6a9d886 \
-                        size   18716746
+github.setup            scipy scipy 1.1.0 v
+checksums               rmd160 af116f12c34c57cccbf16cd846fe3b6e3f08391d \
+                        sha256 a731c05d8bffb56edc7f6d09a2e39b79fb094a7d61dc012b3f8b025bb5f5c1e4 \
+                        size   17978853
 
 name                    py-scipy
 platforms               darwin


### PR DESCRIPTION
#### Description

Update py-scipy to the 1.1.0 release

###### Type(s)

- [ ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.4 17E202
Xcode 9.3 9E145 

Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x ] checked your Portfile with `port lint`?
- [x ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?