### PR TITLE
submission: New port ideviceinstaller

### DIFF
--- a/devel/ideviceinstaller/Portfile
+++ b/devel/ideviceinstaller/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        libimobiledevice ideviceinstaller 1.1.0
+
+categories          devel
+platforms           darwin
+
+license             GPL-2+
+maintainers         {ijackson @iJacksonIsaac} openmaintainer
+
+description         Manage apps of iOS devices.
+
+long_description    ideviceinstaller is a tool to interact with the installation_proxy \
+    of an iOS device allowing to install, upgrade, uninstall, archive, restore \
+    and enumerate installed or archived apps. \
+    It makes use of the libimobiledevice library that allows communication \
+    with iOS devices.
+
+homepage            https://www.libimobiledevice.org/
+
+checksums           rmd160  dfa44e79fe90fdbe3a5ab044fdb51c98769761fd \
+                    sha256  2d4bcd46070aba5dc74e6c9b3704f799fb3507c850535018c71cfed97fa1b410 \
+                    size    19931
+
+patchfiles          patch-no-Werror.diff
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
+
+depends_lib         port:libplist \
+                    port:libzip \
+                    port:libimobiledevice
+
+configure.cmd       ./autogen.sh

--- a/devel/ideviceinstaller/files/patch-no-Werror.diff
+++ b/devel/ideviceinstaller/files/patch-no-Werror.diff
@@ -1,0 +1,11 @@
+--- configure.ac.orig	2018-05-06 19:42:49.000000000 +0530
++++ configure.ac	2018-05-06 19:43:00.000000000 +0530
+@@ -55,7 +55,7 @@
+   AC_DEFINE([HAVE_LSTAT], 1, [Define if lstat syscall is supported])
+ fi
+ 
+-AS_COMPILER_FLAGS(GLOBAL_CFLAGS, "-Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith  -Wwrite-strings -Wswitch-default -Wno-unused-parameter -Werror -g")
++AS_COMPILER_FLAGS(GLOBAL_CFLAGS, "-Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith  -Wwrite-strings -Wswitch-default -Wno-unused-parameter -g")
+ AC_SUBST(GLOBAL_CFLAGS)
+ 
+ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])


### PR DESCRIPTION
#### Description

ideviceinstaller: New port, version 1.1.0

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
