### PR TITLE
android-file-transfer-linux: new port, version 3.3

### DIFF
--- a/aqua/android-file-transfer-linux/Portfile
+++ b/aqua/android-file-transfer-linux/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+PortGroup               qt5 1.0
+
+github.setup            whoozle android-file-transfer-linux 3.3 v
+categories              aqua fuse sysutils
+platforms               darwin
+maintainers             {gmail.com:yan12125 @yan12125} openmaintainer
+license                 LGPL-2.1
+
+description             Reliable MTP client with minimalistic UI
+
+long_description        ${description}
+
+homepage                https://whoozle.github.io/android-file-transfer-linux/
+
+checksums               rmd160  c0de09bad3e4572a27f54b21700395cadf4a3adb \
+                        sha256  0383405d7557c16033cfa325eed402b492d53680d0ad610ccecc6967418fa9c9 \
+                        size    551339
+
+depends_lib             port:osxfuse \
+                        port:libmagic
+
+depends_build-append    port:git
+
+patchfiles              patch-app-location.diff
+
+post-patch {
+    reinplace "s|@APPLICATIONS_DIR@|${applications_dir}|" ${worksrcpath}/qt/CMakeLists.txt
+}
+
+configure.args-append   -DBUILD_FUSE=ON

--- a/aqua/android-file-transfer-linux/files/patch-app-location.diff
+++ b/aqua/android-file-transfer-linux/files/patch-app-location.diff
@@ -1,0 +1,11 @@
+--- qt/CMakeLists.txt.orig	2018-05-06 22:32:50.000000000 +0800
++++ qt/CMakeLists.txt	2018-05-06 22:33:04.000000000 +0800
+@@ -87,7 +87,7 @@
+ 
+   install(TARGETS ${APP_NAME}
+           RUNTIME DESTINATION bin
+-          BUNDLE DESTINATION .)
++          BUNDLE DESTINATION @APPLICATIONS_DIR@)
+ 
+   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+     if (Qt5Widgets_FOUND)


### PR DESCRIPTION
#### Description

PS. The word 'linux' is part of the project name. This tool works fine on macOS.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
