### PR TITLE
Submit for review the Portfiles for the Linux ABI implementation, aka Linux Execution Flavour for OSX

### DIFF
--- a/emulators/noah/Portfile
+++ b/emulators/noah/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               GitHub 1.0
+
+github.setup            linux-noah noah 0.5.1
+
+PortGroup               cmake 1.0
+
+cmake.out_of_source     yes
+
+categories              emulators
+maintainers             nomaintainer
+platforms               darwin
+# others do not make sense at this point
+supported_archs         x86_64
+
+description             Linux ABI implementation for OSX
+
+homepage                http://github.com/linux-noah/noah
+
+long_description        Noah is a Darwin subsystem for Linux, or \"Bash on Ubuntu on Mac OS X\". Noah is implemented as a hypervisor that traps linux system calls and translates them into Darwin's system calls. Noah also has an interpreter of ELF files so that binary executables of Linux run directly and flawlessly without any modifications. \
+\
+                        I.e. it's effectively an OSX Linux Execution Flavour, similar to that of FreeBSD Linuxolator, aka Linux Emulation, aka Linux ABI. \
+\
+                        In other words, it's the exact reverse of the Linux Darling project: https://github.com/darlinghq.
+
+license                 Dual MIT/GPL
+
+checksums               rmd160  acfb387976bd21a0b2a02a1490a4ef1891d73103 \
+                        sha256  6a2ecba330aa6b3aacc7a2799f4d4a2fbdb5413dd3a8aa9553d3bcd1a81424c0

--- a/emulators/noahstrap/Portfile
+++ b/emulators/noahstrap/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               GitHub 1.0
+
+github.setup            linux-noah noahstrap 2.0.0
+
+categories              emulators
+maintainers             nomaintainer
+platforms               darwin
+# others do not make sense at this point
+supported_archs         x86_64
+
+description             Bootstrap a Linux ABI implementation for OSX
+
+homepage                http://github.com/linux-noah/noahstrap
+
+long_description        Noah is a Darwin subsystem for Linux, or \"Bash on Ubuntu on Mac OS X\". Noah is implemented as a hypervisor that traps linux system calls and translates them into Darwin's system calls. Noah also has an interpreter of ELF files so that binary executables of Linux run directly and flawlessly without any modifications. \
+\
+                        I.e. it's effectively an OSX Linux Execution Flavour, similar to that of FreeBSD Linuxolator, aka Linux Emulation, aka Linux ABI. \
+\
+                        In other words, it's the exact reverse of the Linux Darling project: https://github.com/darlinghq.
+
+license                 Dual MIT/GPL
+
+checksums               rmd160 7eb7168d4211255e3ff6e603b68d36a1746ecda8 \
+                        sha256  616a05c9eb3c12bfcfe12933652a27663c56c46fe91b5d799061742e0973f3fe
+
+use_configure           no
+
+build                   {
+                               reinplace "s|gtar|gnutar|g" ${worksrcpath}/noahstrap
+                        }
+
+destroot                {
+                                xinstall -m 555 ${worksrcpath}/noahstrap ${destroot}${prefix}/bin/noahstrap
+                        }
+
+depends_lib             port:pv \
+                        port:gnutar


### PR DESCRIPTION
Noah is the 'emulator' proper, noahstrap is Virtual Filesystem Package
retrieval and processing utility for it.

#### Description

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
