### PR TITLE
libplist: Update to 2.0.0

### DIFF
--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -1,49 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                libplist
-version             1.12
+github.setup        libimobiledevice libplist 2.0.0
+
 categories          textproc multimedia
-maintainers         nomaintainer
+platforms           darwin
+
+license             LGPL-2.1
+maintainers         {ijackson @JacksonIsaac} openmaintainer
+
 description         Library for working with Apple Binary and XML Property Lists
 long_description    ${description}
-platforms           darwin
-license             GPL-2+ LGPL-2.1+
-homepage            http://libimobiledevice.org/
-master_sites        http://libimobiledevice.org/downloads/
-use_bzip2           yes
 
-checksums           rmd160  c1d6171766329dd809013c9061239636f8cb3998 \
-                    sha256  0effdedcb3de128c4930d8c03a3854c74c426c16728b8ab5f0a5b6bdc0b644be
+homepage            https://www.libimobiledevice.org/
 
-depends_build-append    port:pkgconfig
-depends_lib-append      port:libxml2
+checksums           rmd160  3ed1e778e4bb429b243fc2724e1db1c2ff55c503 \
+                    sha256  47c9024e1f88033d05cf3f447af986b97b53589097b4a301c0d3bbe728cc41ab \
+                    size    161266
 
-configure.args-append   --disable-silent-rules \
-                        --without-cython
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
 
-build.args-append       CC="${configure.cc} ${configure.cflags} [get_canonical_archflags cc]" \
-                        CXX=${configure.cxx} \
-                        CPP=${configure.cpp}
+configure.cmd       ./autogen.sh
 
-use_parallel_build  no
-
-default_variants    +python27
-
-variant python27 description {Use Python 2.7} {
-    depends_build-append    port:gsed \
-                            port:py27-setuptools
-    depends_lib-append      port:py27-cython
-    configure.args-delete   --without-cython
-    configure.env-append    PYTHON=${prefix}/bin/python2.7 \
-                            PYTHON_VERSION=2.7 \
-                            CYTHON=${prefix}/bin/cython-2.7
-}
-
-test.run            yes
-test.target         check
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+configure.args      --disable-silent-rules \
+                    --without-cython


### PR DESCRIPTION
#### Description

libplist: Update to 2.0.0
- Update to github PortGroup
- Update license to 'LGPL-2.1'
- Remove python2.7 variant since it is not required by default
- Update dependencies and use ./autogen.sh
- Add ijackson as maintainer

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
<!-- (delete all below for minor changes) -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
