### PR TITLE
Remove maintainer me.com:link.dupont

### DIFF
--- a/net/libstrophe/Portfile
+++ b/net/libstrophe/Portfile
@@ -6,7 +6,7 @@ PortGroup github   1.0
 github.setup       strophe libstrophe 0.9.1
 categories         net
 platforms          darwin
-maintainers        me.com:link.dupont openmaintainer
+maintainers        nomaintainer
 description        A simple, lightweight C library for writing XMPP clients
 homepage           http://strophe.im/libstrophe/
 license            {GPL-3 MIT}

--- a/net/profanity/Portfile
+++ b/net/profanity/Portfile
@@ -7,7 +7,7 @@ name               profanity
 version            0.5.1
 categories         net
 platforms          darwin
-maintainers        me.com:link.dupont openmaintainer
+maintainers        nomaintainer
 description        A console-based XMPP client written in C using ncurses
 homepage           http://profanity.im/
 license            {GPL-3+ OpenSSLException}


### PR DESCRIPTION
#### Description

Per private email, maintainer no longer has access to a Mac.
