### PR TITLE
Osxfuse workaround

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -25,3 +25,6 @@ sudo tar -xpf "getopt-v1.1.6.tar.bz2" -C /
 export PATH="/opt/mports/bin:$PATH" && hash -r
 curl -fsSLO "https://github.com/macports/mpbot-github/releases/download/v0.0.1/runner"
 chmod 0755 runner
+
+# Workaround for an Xcode issue. See https://trac.macports.org/ticket/54939
+[ "$OS_MAJOR" = 17 ] && $(cd $(xcode-select -p)/Toolchains && sudo ln -s XcodeDefault.xctoolchain OSX10.13.xctoolchain) || true

--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -119,6 +119,15 @@ post-extract {
             move ${workpath}/osxfuse-${mp.comp}-${mp.rev} ${workpath}/${worksrcdir}/${mp.comp}
         }
     }
+
+    if {${os.major} == 17} {
+        ui_msg "If building this port fails, consider applying the following workaround:"
+        ui_msg ""
+        ui_msg "    cd \$(xcode-select -p)/Toolchains"
+        ui_msg "    sudo ln -s XcodeDefault.xctoolchain OSX10.13.xctoolchain"
+        ui_msg ""
+        ui_msg "See https://trac.macports.org/ticket/54939 for more information."
+    }
 }
 
 if { ! $use_signed_kext } {

--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -120,7 +120,7 @@ post-extract {
         }
     }
 
-    if {${os.major} == 17} {
+    if {${os.major} == 17 && [catch {system "/usr/bin/gen_bridge_metadata --version > /dev/null 2>&1"}]} {
         ui_msg "If building this port fails, consider applying the following workaround:"
         ui_msg ""
         ui_msg "    cd \$(xcode-select -p)/Toolchains"


### PR DESCRIPTION
#### Description

Add notes for the workaround for building OSXFUSE on High Sierra and apply it on Travis CI.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
