### PR TITLE
gimp2: Use CC_FOR_BUILD

### DIFF
--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -122,6 +122,7 @@ configure.args      --build=${configure.build_arch}-apple-${os.platform}${os.ver
                     --without-gudev \
                     --without-webkit \
                     ac_cv_path_INTLTOOL_PERL=${configure.perl}
+configure.env       CC_FOR_BUILD=${configure.cc}
 
 variant python27 description {Build with python plugin support using python 2.7} {
     configure.args-delete     --disable-python
@@ -129,7 +130,7 @@ variant python27 description {Build with python plugin support using python 2.7}
     depends_lib-append        port:py27-pygtk
     set python_framework      ${frameworks_dir}/Python.framework/Versions/2.7
     configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env             PATH=${python_framework}/bin:$env(PATH)
+    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
 }
 
 


### PR DESCRIPTION
#### Description

gimp2: Use `CC_FOR_BUILD`. Ensures the right compiler is used when building tools.

Prior to this change, the error was:

```
gcc -fPIC -o invert-svg invert-svg.c -L/opt/local/lib -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lintl -Wl,-framework -Wl,CoreFoundation -I/opt/local/include -g -O2 -L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64 -D_REENTRANT -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include
gcc: Error: You should be using ${configure.cc}
See https://trac.macports.org/wiki/UsingTheRightCompiler
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?