### PR TITLE
paraview: fix python36 conflict

### DIFF
--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -111,7 +111,7 @@ variant python27 conflicts python36 description {Add Python 2.7 support.} {
         -DPYTHON_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/2.7/Headers/ \
         -DPYTHON_LIBRARY=${prefix}/lib/libpython2.7.dylib
 }
-variant python36 description {Add Python 3.6 support.} {
+variant python36 conflicts python27 description {Add Python 3.6 support.} {
     depends_lib-append  port:py36-matplotlib
     configure.args-append \
         -DPARAVIEW_ENABLE_PYTHON:BOOL=ON \


### PR DESCRIPTION
#### Description

Fix a previously missed conflict between python36 and python27 variants

- [x] bugfix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
