### PR TITLE
gnome-internet-radio-locator: update to version 1.1.3

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             1.1.2
+version             1.1.3
 set branch          [join [lrange [split $version .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -17,9 +17,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  fcb2eb63b6215507756f8229d87395e6d3915eac \
-                    sha256  5249feb18f01ae7cd2e7c06a3eb76f41d6aada4c46fdda8d61a59d45efa53816 \
-                    size    538992
+checksums           rmd160  cfebd90b6d6734967d39228d7ba5d7603d90556a \
+                    sha256  6a83ff9830f36ac1f57d64c6d7ed9fedb33afb2856a5afec2c813ed3ffa56474 \
+                    size    539788
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

gnome-internet-radio-locator: update to version 1.1.3