### PR TITLE
PR macports/macports-base#55 updates

### DIFF
--- a/audio/libao/Portfile
+++ b/audio/libao/Portfile
@@ -22,8 +22,12 @@ checksums           rmd160  9983f2435a45ad1fc97a2b7f2d60e8f2e6172bfa \
 
 use_bzip2           yes
 
+# This block can be removed once backward compatibility with MacPorts
+# base versions prior to PR macports/macports-base#55 is not needed.
 post-extract {
-    move [glob ${workpath}/libao-${version}-*] ${worksrcpath}
+    if {![file exists ${worksrcpath}]} {
+        move [glob ${workpath}/libao-${version}-*] ${worksrcpath}
+    }
 }
 
 # fix build on Leopard and earlier


### PR DESCRIPTION
Patches and updates for ports that conflict with macports/macports-base#55.

Updates verified as noted below:
FScript - Updated pmougin-F-Script-v2.1-0-g25c850c.zip checksums. Verify to patch stage only.
QMK-Groundstation - Requires QT 4.2.  Verify to patch stage only.
huevos - Source no longer distributed by author?  Verify to patch stage only.
libao - Verify to patch stage only.
daaplib - No longer distributed by author?  Build errors on macOS 13
git-sizer - Update to version 1.2.0 v. Installs and runs okay. 
play - Update to version 1.5. Installs okay.
starfighter - No longer distributed? Verify to patch stage only.
InsightToolkit* - InsightToolkit-devel (current version) has no conflicts.  
graphviz-oldgui - graphviz (current version) has no conflicts.
qmail-spamcontrol - Mark for removal.  Should be replaced by s/qmail.
MobileDevice - Installs okay.
ID3 - Installs okay.

macOS 10.13.4 17E202
Xcode 9.3 9E145 

