### PR TITLE
poedit1: revive old Poedit port for old OS

### DIFF
--- a/editors/poedit1/Portfile
+++ b/editors/poedit1/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           wxWidgets 1.0
+
+set my_name         poedit
+name                ${my_name}1
+version             1.5.7
+set branch          [join [lrange [split ${version} .] 0 1] .]
+categories          editors aqua
+platforms           darwin
+license             MIT
+maintainers         nomaintainer
+description         Poedit is a cross-platform gettext catalogs (.po files) editor.
+long_description    Poedit is a cross-platform gettext catalogs (.po files) editor. It aims to \
+                    provide more convenient approach to editing catalogs than editing the file by \
+                    hand. This port installs Poedit.app.
+homepage            https://www.poedit.net/
+master_sites        sourceforge:project/poedit/poedit/${branch}
+distname            ${my_name}-${version}
+
+checksums           md5     f5b53ec66a606f088b0aa388595ea5f9 \
+                    sha1    e83c08ca33997829be946e1dcf1a35149856d184 \
+                    rmd160  46436e98caf2b41b61188fc1b79db62f2f218817 \
+                    sha256  24535cac22c8f7fb4f995710f6638ebc26825056076a04210ee66e19d65c0f78 \
+                    size    2605725
+
+wxWidgets.use       wxWidgets-3.0
+
+depends_build       bin:grep:grep \
+                    port:pkgconfig \
+                    port:boost
+depends_lib         port:gettext \
+                    port:${wxWidgets.port}
+
+depends_skip_archcheck grep pkgconfig boost
+
+patchfiles          patch-src-edframe.cpp.diff
+
+# remove some additional features, especially sparkle because macports handles updates
+configure.args      --disable-spellchecking \
+                    --disable-transmem \
+                    --without-sparkle \
+                    --with-wxdir=${wxWidgets.wxdir}
+
+build.dir           ${build.dir}/src
+build.target        bundle
+build.env-append    GETTEXT_PREFIX=${prefix} \
+                    WX_ROOT=${wxWidgets.prefix}
+
+destroot {
+    # the gettext binaries are copied into Poedit.app during build,
+    # but we rather delete and symlink them to get updates to gettext automatically
+    foreach extra { msgfmt msgmerge msgunfmt xgettext } {
+        file delete ${worksrcpath}/src/Poedit.app/Contents/MacOS/${extra}
+        ln -s ${prefix}/bin/${extra} ${worksrcpath}/src/Poedit.app/Contents/MacOS/${extra}
+    }
+    file delete ${worksrcpath}/src/Poedit.app/Contents/MacOS/gnu_gettext.COPYING
+
+    file copy ${worksrcpath}/src/Poedit.app ${destroot}${applications_dir}/Poedit1.app
+}
+
+variant transmem description {Enables translation memory for often used phrases} {
+    depends_lib-append          port:db48
+    configure.args-delete       --disable-transmem
+    configure.args-append       --enable-transmem
+    configure.cppflags-append   "-I${prefix}/include/db48"
+    configure.ldflags-append    "-L${prefix}/lib/db48"
+}
+
+variant spellcheck description {Enables spellchecking} {
+    depends_lib-append      port:gtkspell2
+    configure.args-delete   --disable-spellchecking
+    configure.args-append   --enable-spellchecking
+}
+
+default_variants    +transmem
+
+if {${os.platform} eq "darwin" && ${os.major} > 14} {
+    notes-append    "${name} @${version} is designed for OS X 10.6 Snow Leopard\
+    and older; for OS X 10.11 El Capitan and newer you may prefer to use the\
+    poedit port."
+}
+
+livecheck.type      none

--- a/editors/poedit1/files/patch-src-edframe.cpp.diff
+++ b/editors/poedit1/files/patch-src-edframe.cpp.diff
@@ -1,0 +1,11 @@
+--- src/edframe.cpp.orig	2013-07-05 17:25:25.000000000 +0000
++++ src/edframe.cpp	2018-05-27 02:08:00.000000000 +0000
+@@ -2317,7 +2317,7 @@
+                 dt.SetAutomatic(true);
+                 dt.SetFuzzy(true);
+                 matches++;
+-                msg.Printf(_("Automatically translated %u strings"), matches);
++                msg.Printf(_("Automatically translated %lu strings"), matches);
+                 pi.UpdateMessage(msg);
+ 
+                 if (m_modified == false)


### PR DESCRIPTION
#### Description
> Mac OS X 10.6 Snow Leopard & PPC Macs — the latest working version is 1.5.7

This partially reverts commit e70cecc5b3e9ffe4fcaf4d61dd781872833bd06d.