### PR TITLE
git: fix SHA1 calculation for older compilers

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -48,7 +48,7 @@ depends_run-append  port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-cgi \
                     port:rsync
 
-patchfiles          patch-Makefile.diff git-subtree.1.diff
+patchfiles          patch-Makefile.diff git-subtree.1.diff patch-sha1dc-older-apple-gcc-versions.diff
 patch.pre_args      -p1
 
 extract.only        git-${version}${extract.suffix} \

--- a/devel/git/files/patch-sha1dc-older-apple-gcc-versions.diff
+++ b/devel/git/files/patch-sha1dc-older-apple-gcc-versions.diff
@@ -1,0 +1,15 @@
+diff --git a/sha1dc/sha1.c b/sha1dc/sha1.c
+index 25eded1..5faf5a5 100644
+--- a/sha1dc/sha1.c
++++ b/sha1dc/sha1.c
+@@ -92,6 +92,10 @@
+  */
+ #define SHA1DC_BIGENDIAN
+ 
++#elif (defined(__APPLE__) && defined(__BIG_ENDIAN__) && !defined(SHA1DC_BIGENDIAN))
++/* older gcc compilers which are the default  on Apple PPC do not define __BYTE_ORDER__ */
++#define SHA1DC_BIGENDIAN
++
+ /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
+ #elif defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
+ /*


### PR DESCRIPTION
fixes stock Apple compilers on older PPC machines
by correcting endianness checks
closes: https://trac.macports.org/ticket/54602

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4 PPC, 10.13 Intel
Xcode 2.5, Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
