### PR TITLE
grpc: fix destroot.target

### DIFF
--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -44,5 +44,3 @@ destroot.args-append \
     DEFAULT_CC="${configure.cc}" CC="${configure.cc}" \
     DEFAULT_CXX="${configure.cxx}" CXX="${configure.cxx}" \
     prefix=${destroot}${prefix}
-
-destroot.target "install install-plugins"


### PR DESCRIPTION
#### Description

Remove destroot.target (fixing bad use of quotes) since it's not needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
