### PR TITLE
texlive: update to 2018 release

### DIFF
--- a/tex/biblatex-biber/Portfile
+++ b/tex/biblatex-biber/Portfile
@@ -12,9 +12,8 @@ epoch           2
 
 perl5.branches  5.26
 
-perl5.setup     Biber 2.7
+perl5.setup     Biber 2.11
 version         ${perl5.moduleversion}
-revision        3
 
 categories      tex
 license         {Artistic-2 GPL}
@@ -36,10 +35,10 @@ master_sites    https://github.com/plk/biber/archive/
 distname        v${version}
 worksrcdir      biber-${version}
 
-checksums       rmd160  50f689a15bde19959ed261cea1c105fa815ab5a7 \
-                sha256  a0afc4cd97d56f4f433e476de1d4bd9bf9740eb29191bf616b1ea3f424408d9f
+checksums       rmd160  38505d7ab6e3776acae69f6b4293ec931a37d20e \
+                sha256  4839cc5b73cf4d960ef751636f2d29df7212c722ddb5073885df404b785f0cd2
 
-patchfiles      patch-use-encode.pm
+#patchfiles      patch-use-encode.pm
 
 depends_build-append    port:p${perl5.major}-config-autoconf \
                         port:p${perl5.major}-extutils-libbuilder \
@@ -59,7 +58,7 @@ depends_lib-append      port:p${perl5.major}-autovivification \
                         port:p${perl5.major}-encode-eucjpascii \
                         port:p${perl5.major}-encode-hanextra \
                         port:p${perl5.major}-encode-jis2k \
-                        port:p${perl5.major}-file-slurp \
+                        port:p${perl5.major}-file-slurper \
                         port:p${perl5.major}-file-which \
                         port:p${perl5.major}-ipc-cmd \
                         port:p${perl5.major}-ipc-run3 \
@@ -69,6 +68,7 @@ depends_lib-append      port:p${perl5.major}-autovivification \
                         port:p${perl5.major}-list-moreutils \
                         port:p${perl5.major}-log-log4perl \
                         port:p${perl5.major}-mozilla-ca \
+                        port:p${perl5.major}-perlio-utf8_strict \
                         port:p${perl5.major}-readonly \
                         port:p${perl5.major}-readonly-xs \
                         port:p${perl5.major}-regexp-common \

--- a/tex/latexmk/Portfile
+++ b/tex/latexmk/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 
 name                latexmk
-version             4.52c
-checksums           rmd160  760a912d1d8627c8263e8678f1ce75db86922a00 \
-                    sha256  7a8fd50e0bd46c8705aa4e0fcbc36d01d528cc92a96d71e1c00e1fb2e6484db2
+version             4.55
+checksums           rmd160  c4370e8f75c7745ad9f79ee7029b8140b73a3568 \
+                    sha256  aa400d3c5860fffc925efe5d832c575f3bee1d3770e4c6db96e2add518c38d2b
 
 categories          tex print
 platforms           darwin

--- a/tex/texlive-basic/Portfile
+++ b/tex/texlive-basic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-basic
-version             44435
+version             47434
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Essential programs and files
 long_description    These files are regarded as basic for any TeX system, covering plain TeX macros, Computer Modern fonts, and configuration for common drivers\; no LaTeX.
 
-checksums           texlive-basic-44435-run.tar.xz \
-                    rmd160  d559ff32322d346375078a953124e3500d30d8d3 \
-                    sha256  47ec78ffc398ab98728a224218457c41f44482dcbd99d00d2a87a16f650c8a17 \
-                    texlive-basic-44435-doc.tar.xz \
-                    rmd160  28a376169c8999e332eca0d42e083e2c5d36bb48 \
-                    sha256  497fd18272015da1002e2833fffa989e9bb4d494cc7675e6e2f8c927fb27f816 \
-                    texlive-basic-44435-src.tar.xz \
-                    rmd160  dcd0ae5fe4c861ab2e6a4fd536ab272e36d745c2 \
-                    sha256  bb8e6c4dfb03497865c542201372243d323fc811b452e248aac94d0e8da4ad4d
+checksums           texlive-basic-47434-run.tar.xz \
+                    rmd160  db9269a12e1efcf9606b92cedb1eb675bc3c2017 \
+                    sha256  24e7db599421c175f31526370e3c98886d422eeb305d774b3ab221783d95e6e4 \
+                    texlive-basic-47434-doc.tar.xz \
+                    rmd160  432242993facb78e2286f7eef10e70855d69f382 \
+                    sha256  c860614acadbe0409d9a7000de6d7604d30cb098a09112b070feb23370583cab \
+                    texlive-basic-47434-src.tar.xz \
+                    rmd160  908d10d2a0e750eff9e02b917be85c9d8d055259 \
+                    sha256  6ec3d03346618eca9e50ce078108ae65380eedb5f7270064804823cb0da50791
 
 texlive.formats      \
     {1 luatex luatex language.def,language.dat.lua {luatex.ini}} \
@@ -44,7 +44,7 @@ texlive.maps      \
     {Map dummy-space.map} \
     {Map mathpple.map}
 
-texlive.binaries    afm2tfm allcm allec allneeded bibtex dvi2fax dviluatex dvipdfm dvipdfmx dvipdft dvips dvired ebb etex extractbb fmtutil fmtutil-sys fmtutil-user gftodvi gftopk gftype gsftopk inimf initex kpseaccess kpsepath kpsereadlink kpsestat kpsetool kpsewhere kpsewhich kpsexpand luajittex luatex makeindex mf mf-nowin mft mkindex mkocp mkofm mktexfmt mktexlsr mktexmf mktexpk mktextfm pdfetex pdftex pktogf pktype simpdftex tex texconfig texconfig-dialog texconfig-sys texhash texlinks texlua texluac texluajit texluajitc updmap updmap-sys updmap-user xdvi
+texlive.binaries    afm2tfm allcm allec allneeded bibtex dvi2fax dviluatex dvipdfm dvipdfmx dvipdft dvips dvired ebb etex extractbb fmtutil fmtutil-sys fmtutil-user gftodvi gftopk gftype gsftopk inimf initex kpseaccess kpsepath kpsereadlink kpsestat kpsetool kpsewhere kpsewhich kpsexpand luajittex luatex luatex53 makeindex mf mf-nowin mft mkindex mkocp mkofm mktexfmt mktexlsr mktexmf mktexpk mktextfm pdfetex pdftex pktogf pktype simpdftex tex texconfig texconfig-dialog texconfig-sys texhash texlinks texlua texlua53 texluac texluajit texluajitc updmap updmap-sys updmap-user xdvi
 
 texlive.exclude     texmf-dist/web2c/fmtutil.cnf \
                     texmf-dist/web2c/texmf.cnf \

--- a/tex/texlive-bibtex-extra/Portfile
+++ b/tex/texlive-bibtex-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-bibtex-extra
-version             44385
+version             47418
 revision            0
 
 categories          tex
@@ -13,19 +13,19 @@ license             Copyleft Permissive
 description         TeX Live: BibTeX additional styles
 long_description    Additional BibTeX styles and bibliography data(bases), notably including BibLaTeX.
 
-checksums           texlive-bibtex-extra-44385-run.tar.xz \
-                    rmd160  a217eede0d8377f61009c100fbabf8e606655273 \
-                    sha256  8ce8a88bed7da520cc87bd7fa537c439989efa4b002e0825b6706be4b0ab57f1 \
-                    texlive-bibtex-extra-44385-doc.tar.xz \
-                    rmd160  097b8559b9224d873f424a8d52d6eaad2aec52d7 \
-                    sha256  e00b4856f983db3e14b93c46b4c73ab92eaefb02927d1209ab26938f0649bdb2 \
-                    texlive-bibtex-extra-44385-src.tar.xz \
-                    rmd160  0e1b18e768548c2e4bba5888ba1bca963d97c51c \
-                    sha256  1441db7b639316b7f09b9c21ed557416e031b42ab37774c75c0276dbcb63eb4f
+checksums           texlive-bibtex-extra-47418-run.tar.xz \
+                    rmd160  f1632190d3d24455a1ed5d5a6affd11d381fe537 \
+                    sha256  9c8fc7eb20cfe8364ab3ab247c3323e485c3fb980e3846fe502a9e8606ff9c78 \
+                    texlive-bibtex-extra-47418-doc.tar.xz \
+                    rmd160  d79593200fb6b62f7053a91825b45babdf37eda0 \
+                    sha256  828afc56354f76e0aea6e89143fe9ff13fc906a8d12097e412e06addf6e3b920 \
+                    texlive-bibtex-extra-47418-src.tar.xz \
+                    rmd160  d95aa3642457a501aa2d7ad1791fb3610ba1d93a \
+                    sha256  4ce079e79ae7c660bb7e3e374a4f03da038176b055dc410cdefa0798ea5f2c81
 
 depends_lib         port:texlive-latex
 
-texlive.binaries    bbl2bib bibdoiadd bibexport bibmradd bibzbladd listbib ltx2crossrefxml multibibliography urlbst
+texlive.binaries    bbl2bib bib2gls bibdoiadd bibexport bibmradd biburl2doi bibzbladd convertgls2bib listbib ltx2crossrefxml multibibliography urlbst
 
 
 texlive.texmfport

--- a/tex/texlive-bin-extra/Portfile
+++ b/tex/texlive-bin-extra/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-bin-extra
-version             44432
-revision            1
+version             47446
+revision            0
 
 categories          tex
 maintainers         {dports @drkp}
@@ -13,31 +13,27 @@ license             Copyleft Permissive
 description         TeX Live: TeX auxiliary programs
 long_description    Various useful, but non-essential, support programs. Includes programs and macros for DVI file manipulation, literate programming, patgen, and the TeX Works Editor.
 
-checksums           texlive-bin-extra-44432-run.tar.xz \
-                    rmd160  65af35dd9c8273fd30b2363e3a754d6783f68809 \
-                    sha256  5a1b31ba13bb52b9fc298d62711afc32133ac09af8a88a6bd2099e9e057310d7 \
-                    texlive-bin-extra-44432-doc.tar.xz \
-                    rmd160  c0580c7ff09cc509c74e9c05dbaec6924faa5dbd \
-                    sha256  2f0c0cf572a09bfdc5fb21f3aded330a8a33b1129e20ac9f936bca755e593304 \
-                    texlive-bin-extra-44432-src.tar.xz \
-                    rmd160  0fc7d00f4244b20191b40f72a1024cccd6db31e4 \
-                    sha256  0efa7f9a101f63c4780cbb92dfd600973b0fd48cadaf0be1e8ef82c6d929c627
+checksums           texlive-bin-extra-47446-run.tar.xz \
+                    rmd160  465d16566d0bb2545117d761e419cd72c9591767 \
+                    sha256  5834c7734dc4985b3c821757af02b8a6a0cd7e487ed1a303f217a434d0070866 \
+                    texlive-bin-extra-47446-doc.tar.xz \
+                    rmd160  0a9cd67461e8b3fea14467f22a7ae44518d3f16f \
+                    sha256  c1b813f6dfab8fd9700ca3f97949d1221226c30d1ba282917080732ea2955a40 \
+                    texlive-bin-extra-47446-src.tar.xz \
+                    rmd160  d1fdf8dc75551a3e9c4ca9e74eaaa94692fe213a \
+                    sha256  872036e0009c46de9d1c24da73d0eba42dd6f1f35e1aee29bd4afbf7f063f8df
 
 depends_lib         port:texlive-basic
 
 texlive.formats      \
     {0 mflua mflua-nowin - {mf.ini}}
 
-texlive.binaries    a2ping a5toa4 adhocfilelist arara arlatex bibtex8 bibtexu bundledoc checklistings chktex chkweb ctangle ctanify ctanupload ctie cweave de-macro depythontex deweb dt2dv dtxgen dv2dt dviasm dvibook dviconcat dvicopy dvidvi dvihp dvilj dvilj2p dvilj4 dvilj4l dvilj6 dvipos dviselect dvisvgm dvitodvi dvitype e2pall findhyph fragmaster installfont-tl lacheck latex-git-log latex-papersize latex2man latex2nemeth latexfileversion latexindent latexpand listings-ext.sh ltxfileinfo ltximg make4ht match_parens mflua mflua-nowin mfluajit mfluajit-nowin mkjobtexmf patgen pdfatfi pdfbook2 pdfclose pdfcrop pdflatexpicscale pdfopen pdftosrc pdfxup pfarrei pkfix pkfix-helper pooltype purifyeps pythontex rpdfcrop srcredact sty2dtx synctex tangle tex4ebook texcount texdef texdiff texdirflatten texdoc texdoctk texfot texliveonfly texloganalyser texosquery texosquery-jre5 texosquery-jre8 tie tpic2pdftex typeoutfileinfo weave
+texlive.binaries    a2ping a5toa4 adhocfilelist arara arlatex bibtex8 bibtexu bundledoc checklistings chktex chkweb ctan-o-mat ctangle ctanify ctanupload ctie cweave de-macro depythontex deweb dt2dv dtxgen dv2dt dviasm dvibook dviconcat dvicopy dvidvi dvihp dviinfox dvilj dvilj2p dvilj4 dvilj4l dvilj6 dvipos dviselect dvisvgm dvitodvi dvitype e2pall findhyph fragmaster installfont-tl ketcindy lacheck latex-git-log latex-papersize latex2man latex2nemeth latexdef latexfileversion latexindent latexpand listings-ext.sh ltxfileinfo ltximg make4ht match_parens mflua mflua-nowin mfluajit mfluajit-nowin mkjobtexmf patgen pdfatfi pdfbook2 pdfclose pdfcrop pdflatexpicscale pdfopen pdftosrc pdfxup pfarrei pkfix pkfix-helper pooltype purifyeps pythontex rpdfcrop srcredact sty2dtx synctex tangle tex4ebook texcount texdef texdiff texdirflatten texdoc texdoctk texfot texliveonfly texloganalyser texosquery texosquery-jre5 texosquery-jre8 tie tlcockpit tlshell tpic2pdftex typeoutfileinfo weave
 
 depends_run         port:latexmk \
                     port:detex \
                     port:latexdiff \
                     port:pdfjam \
                     port:dvipng
-
-#   fix FTBFS: Unescaped left brace in regex is illegal here in regex
-#   See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=871159
-patchfiles          871159.diff
 
 texlive.texmfport

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -9,10 +9,8 @@ PortGroup       cxx11 1.1
 # scripts) to build universal
 PortGroup       muniversal 1.0
 
-
 name            texlive-bin
-version         2017
-revision        4
+version         2018.47642
 
 categories      tex
 maintainers     {dports @drkp}
@@ -39,20 +37,21 @@ license         Copyleft Permissive LGPL-2.1+ BSD
 master_sites    https://giraffe.cs.washington.edu/texlive/ \
                 https://alpaca.cs.washington.edu/texlive/ \
                 https://www.ambulatoryclam.net/texlive/
-set distversion 20170604
 use_xz          yes
-distname        texlive-source-${distversion}-stripped
+distname        texlive-source-${version}-stripped
 worksrcdir      ${distname}
 
-set tlpkgdistname   tlpkg-TeXLive-${distversion}
+set tlpkgdistname   tlpkg-TeXLive-${version}
 distfiles-append    ${tlpkgdistname}${extract.suffix}
 
-checksums           texlive-source-20170604-stripped.tar.xz \
-                    rmd160  7d52410ec667323dc4681f49cba3667d09dc0607 \
-                    sha256  0d406c581a48fe9227992ceed09f90a7fb75bfe68568e9478a19da8e6e544217 \
-                    tlpkg-TeXLive-20170604.tar.xz \
-                    rmd160  23b7e5841cf94994c87b95bb3adf09ffa53a0087 \
-                    sha256  b574ae43f707a8529f9c5280b63dfbd2445c29da702ae5f4b4acc71684867654
+checksums           texlive-source-2018.47642-stripped.tar.xz \
+                    rmd160  5cacb77580def95071a797c73e620f3f59558fb6 \
+                    sha256  3d96e6993d52c373c78291c70c8d668968bad2e9e0da2249da4f6138434f3118 \
+                    size    18994796 \
+                    tlpkg-TeXLive-2018.47642.tar.xz \
+                    rmd160  c14c04444af0ee2ed739c7c6776b6afac39cf766 \
+                    sha256  54505501198b171af862ca17c2da4388242b1a1b6e724aabb048ce5125517c8f \
+                    size    103320
 
 depends_lib     port:fontconfig \
                 port:freetype \
@@ -77,7 +76,7 @@ depends_run     port:ghostscript
 
 depends_build-append \
                 path:bin/perl:perl5 \
-                port:pkgconfig
+                path:bin/pkg-config:pkgconfig
 
 # patches related to changes in install paths
 patchfiles-append  patch-texk_chktex_Makefile.in.diff \
@@ -92,12 +91,9 @@ patchfiles-append  patch-texk_chktex_Makefile.in.diff \
 patchfiles-append  patch-libs_luajit_configure.diff \
                    patch-texk_web2c_configure.diff
 
-# fix dvips crash; see https://trac.macports.org/ticket/53974
-patchfiles-append  patch-53974.diff
-
-# upstream patch for luatex: see
-# http://tug.org/pipermail/tlbuild/2017q2/003847.html
-patchfiles-append  patch-r44590.diff
+# patches for compatibility with latest poppler 
+patchfiles-append  patch-pdftosrc-const.diff \
+                   patch-r47470.diff
 
 post-patch {
     reinplace "s|@@TEXMFDIST@@|${texlive_texmfdist}|" ${worksrcpath}/texk/texlive/linked_scripts/Makefile.in
@@ -120,6 +116,10 @@ post-patch {
     file copy ${filespath}/texk_kpathsea_paths.h ${worksrcpath}/texk/kpathsea/paths.h
     reinplace "s|@@PREFIX@@|${prefix}|" ${worksrcpath}/texk/kpathsea/paths.h
     reinplace "s|@@TEXMFSYSCONFIG@@|${texlive_texmfsysconfig}|" ${worksrcpath}/texk/kpathsea/paths.h
+
+    # Required to support poppler >0.59
+    file rename -force ${worksrcpath}/texk/web2c/pdftexdir/pdftoepdf-newpoppler.cc ${worksrcpath}/texk/web2c/pdftexdir/pdftoepdf.cc 
+    file rename -force ${worksrcpath}/texk/web2c/pdftexdir/pdftosrc-newpoppler.cc ${worksrcpath}/texk/web2c/pdftexdir/pdftosrc.cc 
 }
 
 # We use MacPorts-provided libraries instead of the ones included in
@@ -133,6 +133,7 @@ post-patch {
 # Many of the --with-system-* and --disable-* flags are actually
 # redundant because we've removed those components from the distfile,
 # but we leave them here for compatibility with the stock distfile.
+
 configure.args  --bindir=${texlive_bindir} \
                 --mandir=${texlive_bindir} \
                 --infodir=${prefix}/share/info \

--- a/tex/texlive-bin/files/patch-pdftosrc-const.diff
+++ b/tex/texlive-bin/files/patch-pdftosrc-const.diff
@@ -1,0 +1,12 @@
+reverted:
+--- texk/web2c/pdftexdir/pdftosrc-newpoppler.cc.orig	2018-06-16 15:37:11.000000000 -0700
++++ texk/web2c/pdftexdir/pdftosrc-newpoppler.cc	2018-06-16 15:37:18.000000000 -0700
+@@ -68,7 +68,7 @@
+     Stream *s;
+     Object srcStream, srcName, catalogDict;
+     FILE *outfile;
++    const char *outname;
+-    char *outname;
+     int objnum = 0, objgen = 0;
+     bool extract_xref_table = false;
+     int c;

--- a/tex/texlive-bin/files/patch-r47470.diff
+++ b/tex/texlive-bin/files/patch-r47470.diff
@@ -1,0 +1,132 @@
+Index: texk/web2c/luatexdir/image/pdftoepdf.w
+===================================================================
+--- texk/web2c/luatexdir/image/pdftoepdf.w	(revision 47469)
++++ texk/web2c/luatexdir/image/pdftoepdf.w	(revision 47470)
+@@ -472,10 +472,10 @@
+         break;
+     */
+     case objString:
+-        copyString(pdf, obj->getString());
++        copyString(pdf, (GooString *)obj->getString());
+         break;
+     case objName:
+-        copyName(pdf, obj->getName());
++        copyName(pdf, (char *)obj->getName());
+         break;
+     case objNull:
+         pdf_add_null(pdf);
+Index: texk/web2c/luatexdir/lua/lepdflib.cc
+===================================================================
+--- texk/web2c/luatexdir/lua/lepdflib.cc	(revision 47469)
++++ texk/web2c/luatexdir/lua/lepdflib.cc	(revision 47470)
+@@ -674,7 +674,7 @@
+     uin = (udstruct *) luaL_checkudata(L, 1, M_##in);          \
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)             \
+         pdfdoc_changed_error(L);                               \
+-    gs = ((in *) uin->d)->function();                          \
++    gs = (GooString *)((in *) uin->d)->function();             \
+     if (gs != NULL)                                            \
+         lua_pushlstring(L, gs->getCString(), gs->getLength()); \
+     else                                                       \
+@@ -1813,7 +1813,7 @@
+     if (uin->pd != NULL && uin->pd->pc != uin->pc)
+         pdfdoc_changed_error(L);
+     if (((Object *) uin->d)->isString()) {
+-        gs = ((Object *) uin->d)->getString();
++        gs = (GooString *)((Object *) uin->d)->getString();
+         lua_pushlstring(L, gs->getCString(), gs->getLength());
+     } else
+         lua_pushnil(L);
+Index: texk/web2c/pdftexdir/ChangeLog
+===================================================================
+--- texk/web2c/pdftexdir/ChangeLog	(revision 47469)
++++ texk/web2c/pdftexdir/ChangeLog	(revision 47470)
+@@ -1,3 +1,8 @@
++2018-04-28  Akira Kakuto  <kakuto@fuk.kindai.ac.jp>
++
++	* pdftoepdf-newpoppler.cc, pdftosrc-newpoppler.cc:
++	Support poppler 0.64.0.
++
+ 2018-04-14  Karl Berry  <karl@tug.org>
+ 
+ 	* TeX Live 2018 release, pdftex 1.40.19.
+Index: texk/web2c/pdftexdir/pdftoepdf-newpoppler.cc
+===================================================================
+--- texk/web2c/pdftexdir/pdftoepdf-newpoppler.cc	(revision 47469)
++++ texk/web2c/pdftexdir/pdftoepdf-newpoppler.cc	(revision 47470)
+@@ -290,7 +290,7 @@
+ static void copyDictEntry(Object * obj, int i)
+ {
+     Object obj1;
+-    copyName(obj->dictGetKey(i));
++    copyName((char *)obj->dictGetKey(i));
+     pdf_puts(" ");
+     obj1 = obj->dictGetValNF(i);
+     copyObject(&obj1);
+@@ -355,7 +355,7 @@
+         if (!procset.isName())
+             pdftex_fail("PDF inclusion: invalid ProcSet entry type <%s>",
+                         procset.getTypeName());
+-        copyName(procset.getName());
++        copyName((char *)procset.getName());
+         pdf_puts(" ");
+     }
+     pdf_puts("]\n");
+@@ -418,7 +418,7 @@
+         && fontdescRef.isRef()
+         && fontdesc.isDict()
+         && embeddableFont(&fontdesc)
+-        && (fontmap = lookup_fontmap(basefont.getName())) != NULL) {
++        && (fontmap = lookup_fontmap((char *)basefont.getName())) != NULL) {
+         // round /StemV value, since the PDF input is a float
+         // (see Font Descriptors in PDF reference), but we only store an
+         // integer, since we don't want to change the struct.
+@@ -427,7 +427,7 @@
+         charset = fontdesc.dictLookup("CharSet");
+         if (!charset.isNull() &&
+             charset.isString() && is_subsetable(fontmap))
+-            epdf_mark_glyphs(fd, charset.getString()->getCString());
++            epdf_mark_glyphs(fd, (char *)charset.getString()->getCString());
+         else
+             embed_whole_font(fd);
+         addFontDesc(fontdescRef.getRef(), fd);
+@@ -456,7 +456,7 @@
+         if (fontRef.isRef())
+             copyFont(obj->dictGetKey(i), &fontRef);
+         else if (fontRef.isDict()) {   // some programs generate pdf with embedded font object
+-            copyName(obj->dictGetKey(i));
++            copyName((char *)obj->dictGetKey(i));
+             pdf_puts(" ");
+             copyObject(&fontRef);
+         }
+@@ -565,7 +565,7 @@
+     } else if (obj->isNum()) {
+         pdf_printf("%s", convertNumToPDF(obj->getNum()));
+     } else if (obj->isString()) {
+-        s = obj->getString();
++        s = (GooString *)obj->getString();
+         p = s->getCString();
+         l = s->getLength();
+         if (strlen(p) == (unsigned int) l) {
+@@ -589,7 +589,7 @@
+             pdf_puts(">");
+         }
+     } else if (obj->isName()) {
+-        copyName(obj->getName());
++        copyName((char *)obj->getName());
+     } else if (obj->isNull()) {
+         pdf_puts("null");
+     } else if (obj->isArray()) {
+Index: texk/web2c/pdftexdir/pdftosrc-newpoppler.cc
+===================================================================
+--- texk/web2c/pdftexdir/pdftosrc-newpoppler.cc	(revision 47469)
++++ texk/web2c/pdftexdir/pdftosrc-newpoppler.cc	(revision 47470)
+@@ -109,7 +109,7 @@
+             fprintf(stderr, "No SourceName found\n");
+             exit(1);
+         }
+-        outname = srcName.getString()->getCString();
++        outname = (char *)srcName.getString()->getCString();
+         // We cannot free srcName, as objname shares its string.
+         // srcName.free();
+     } else if (objnum > 0) {

--- a/tex/texlive-common/Portfile
+++ b/tex/texlive-common/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-common
-version             2017.1
+version             2018
 
 categories          tex
 maintainers         {dports @drkp}
@@ -24,8 +24,8 @@ master_sites        https://giraffe.cs.washington.edu/texlive/ \
 worksrcdir          ${distname}
 use_xz              yes
 
-checksums           rmd160  6fb366c4bddd6b98840d1e852af123ad25ffeafa \
-                    sha256  feef1314f09f5a13db4cb84803e7f879bb31a8ae50fdd8a89fd92ac1e37cb028
+checksums           rmd160  97e28b6ecf08033a84cc5bdfca131405047546f8 \
+                    sha256  1d3916547138032d47060b17e44c6699d14d67173c26dd909390b92d728c06a1
 
 livecheck.type  regex
 livecheck.url   [lindex ${master_sites} 0]

--- a/tex/texlive-context/Portfile
+++ b/tex/texlive-context/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-context
-version             44436
+version             47403
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: ConTeXt and packages
 long_description    Hans Hagen's powerful ConTeXt system, http://pragma-ade.com. Also includes third-party ConTeXt packages.
 
-checksums           texlive-context-44436-run.tar.xz \
-                    rmd160  99839754874bf71a2e4ed5a255c988ee3aa0073d \
-                    sha256  1456e63298d6146c13b6e74a1353f158dddf03a654e72f29028d7d893ddaa362 \
-                    texlive-context-44436-doc.tar.xz \
-                    rmd160  8c7f3c19601d1597adadd6b1ba51b1def305a791 \
-                    sha256  9b1d78bc79b0603f3c6b5c0f0e722c78817b5f3833ee6aed66e51307354c1c6d \
-                    texlive-context-44436-src.tar.xz \
-                    rmd160  9ec6e1d86deeb09a00a3a25e6e140a11c2f94d2e \
-                    sha256  bd202dfc45566029ab302708a1c382cd90cd1a5708939eb8213f3b25e110e43d
+checksums           texlive-context-47403-run.tar.xz \
+                    rmd160  bdd71787979acb182a0263b23378d66ef90f73bc \
+                    sha256  ee1525d11f7317a62934770ef0074263d830b2643861b3973b9046ce97797026 \
+                    texlive-context-47403-doc.tar.xz \
+                    rmd160  9019d1097d5f77dfe5ee0418085e0b255afa3fdb \
+                    sha256  b1fba1d65534234faf2d1cd71a874834235758caa166dcf0df68098a672d4e8b \
+                    texlive-context-47403-src.tar.xz \
+                    rmd160  927d5fa1d7e1e38ff2c113f0c7076a1fae3ffba7 \
+                    sha256  4bb91deb31c220127f1d14abd221383f78df7f033baeaa359fe5f3410ba7c258
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-fonts-extra/Portfile
+++ b/tex/texlive-fonts-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-fonts-extra
-version             44409
+version             47288
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Additional fonts
 long_description    Additional fonts
 
-checksums           texlive-fonts-extra-44409-run.tar.xz \
-                    rmd160  eece87e7b97e32f818be3bb9d4008272fa2d5e65 \
-                    sha256  88a9365e349895cc2ce4cd9396c0b6daf3d6cb419c5568e20d6cc124c5a28729 \
-                    texlive-fonts-extra-44409-doc.tar.xz \
-                    rmd160  bf348e56685d4c443c28da23f8d74453f5fe935c \
-                    sha256  37a6bf3607783d2bd9f26c566fac1239fccb247bfc82e37602f57efb12c02e89 \
-                    texlive-fonts-extra-44409-src.tar.xz \
-                    rmd160  f76ad674292bed9fa7ef96fea81d0f01ad9ddafa \
-                    sha256  ac327934850136d1fa70d6ab1510c2fa5773e8f29cebe27e4bfa033f6485bf98
+checksums           texlive-fonts-extra-47288-run.tar.xz \
+                    rmd160  40e95b0f6e09ab971d38282781401fdaaed608cd \
+                    sha256  775ce49626dcab444dd9915517b3b95cde5559b81b04f0a86a6afb486135ec1b \
+                    texlive-fonts-extra-47288-doc.tar.xz \
+                    rmd160  0966fa64e7251b5d5453e50898fc90457e97f9eb \
+                    sha256  9c245f71166b6830abc9b41adb7c71d8a8fa73bf0791871361d86c7b51c29637 \
+                    texlive-fonts-extra-47288-src.tar.xz \
+                    rmd160  9f98e39311a05a65ddc2e678e34cccf371e26be8 \
+                    sha256  504c0e7df22c9ada485c41a5db5829191060fe43bbd68ff0499758287c7e6cce
 
 depends_lib         port:texlive-basic
 
@@ -31,6 +31,7 @@ texlive.maps      \
     {Map ArrowsADF.map} \
     {Map BulletsADF.map} \
     {Map Alegreya.map} \
+    {Map algolrevived.map} \
     {MixedMap allrunes.map} \
     {Map AnonymousPro.map} \
     {Map uaq.map} \
@@ -45,7 +46,7 @@ texlive.maps      \
     {Map aurical.map} \
     {Map ybv.map} \
     {Map baskervaldx.map} \
-    {Map baskervillef.map} \
+    {Map BaskervilleF.map} \
     {MixedMap bbold.map} \
     {Map belleek.map} \
     {Map bera.map} \
@@ -69,7 +70,9 @@ texlive.maps      \
     {Map cm-lgc.map} \
     {Map cmexb.map} \
     {MixedMap cmll.map} \
+    {Map cmsrb.map} \
     {Map Cochineal.map} \
+    {Map Coelacanth.map} \
     {Map comfortaa.map} \
     {Map ComicNeue.map} \
     {Map ComicNeueAngular.map} \
@@ -173,6 +176,7 @@ texlive.maps      \
     {Map newtx.map} \
     {Map newtxsf.map} \
     {Map newtxtt.map} \
+    {Map niceframe.map} \
     {Map nimbus15.map} \
     {Map noto.map} \
     {Map cherokee.map} \
@@ -186,6 +190,7 @@ texlive.maps      \
     {Map phaistos.map} \
     {MixedMap pigpen.map} \
     {Map PlayfairDisplay.map} \
+    {Map plex.map} \
     {Map ap.map} \
     {Map prodint.map} \
     {Map pxtx.map} \

--- a/tex/texlive-fonts-recommended/Portfile
+++ b/tex/texlive-fonts-recommended/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-fonts-recommended
-version             42428
+version             45777
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Recommended fonts
 long_description    Recommended fonts, including the base 35 PostScript fonts, Latin Modern, TeX Gyre, and T1 and other encoding support for Computer Modern, in outline form.
 
-checksums           texlive-fonts-recommended-42428-run.tar.xz \
-                    rmd160  614e9d9c4875d5120b6ba1de7166aa1adfd79f5d \
-                    sha256  aebf0781a320eb2e31c9416bee9984f841dc091c377149a43d27161631a5836e \
-                    texlive-fonts-recommended-42428-doc.tar.xz \
-                    rmd160  889d89d71046bbcb5f3516312e3db810a6c42bf9 \
-                    sha256  6994516b24cb897fcc430444d7ae4918e1aa5ee4d83caa934995bd7a85f36edc \
-                    texlive-fonts-recommended-42428-src.tar.xz \
-                    rmd160  ad8ffcc5aeb98629fd627e9c5d16a5055a0084e4 \
-                    sha256  65008cc49810a1a603baa33a16dfd155b31103d9a5c53fa85ad25b993e2a8b0e
+checksums           texlive-fonts-recommended-45777-run.tar.xz \
+                    rmd160  d7989568c2fbbc1a1c3cf39fc499d7aac8b7fd99 \
+                    sha256  e81ae26f9fa23c9d7a48d76285574a620df98ce9f34b55b67ef2a1158ec1e9d6 \
+                    texlive-fonts-recommended-45777-doc.tar.xz \
+                    rmd160  a98e1848a210c3f68e57e09e2d47c5b286046f47 \
+                    sha256  c1c70da9489562ad671c54dcf33e28454c8e55abe183576c213ea9ab623555bd \
+                    texlive-fonts-recommended-45777-src.tar.xz \
+                    rmd160  16a3ef8bd5e45680b0c7cb60c7c54c0df2cb2e0f \
+                    sha256  caaf16af733468998d8a9c277f3739f1e8ca77d316e919060dea8deb142de3ad
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-fontutils/Portfile
+++ b/tex/texlive-fontutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-fontutils
-version             44166
+version             47198
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Graphics and font utilities
 long_description    Programs for conversion between font formats, testing fonts, virtual fonts, .gf and .pk manipulation, mft, fontinst, etc. Manipulating OpenType, TrueType, Type 1,and for manipulation of PostScript and other image formats.
 
-checksums           texlive-fontutils-44166-run.tar.xz \
-                    rmd160  74951f832e22c7f06eaf30b509455cb2abcc7dc5 \
-                    sha256  0ac93b02883a87a657d912342f0a7f452d8553216e16505cab60b957ca77a6be \
-                    texlive-fontutils-44166-doc.tar.xz \
-                    rmd160  c115a2c736136fb34b651b525e1674bd5f7e400a \
-                    sha256  412beacb487256db4b55f0af83fecc86ea537387e32b230e878d1538963d1d04 \
-                    texlive-fontutils-44166-src.tar.xz \
-                    rmd160  f00195796a32e0c713bae8b421bdbddb45081ca0 \
-                    sha256  80bb6d72e63222eb3b1956ce5b7ec13a86480401b344ff603cbb23b356aeb6aa
+checksums           texlive-fontutils-47198-run.tar.xz \
+                    rmd160  609195da77826c736848d245fd73a7701f38a641 \
+                    sha256  439237e14abfaf44fc9aae788366b062cd4b055c87d8630d4ee7b89a71b896f9 \
+                    texlive-fontutils-47198-doc.tar.xz \
+                    rmd160  51f06b7e8a01326f31dd28282ea815a731d6b325 \
+                    sha256  e151f829b768b3153d65455ebf86576da1aa95c84fcfed03eef172eb1a47bef4 \
+                    texlive-fontutils-47198-src.tar.xz \
+                    rmd160  7915d5cbf5d6b5b9478fa4bf3703980635d673a3 \
+                    sha256  f019a6b19799f547bace44938b5aa2a4c894b89c8083dec79122ffd43b06bc3c
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-formats-extra/Portfile
+++ b/tex/texlive-formats-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-formats-extra
-version             44177
+version             47198
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Additional formats
 long_description    Collected TeX `formats', i.e., large-scale macro packages designed to be dumped into .fmt files -- excluding the most common ones, such as latex and context, which have their own package(s). It also includes the Aleph engine and related Omega formats and packages.
 
-checksums           texlive-formats-extra-44177-run.tar.xz \
-                    rmd160  5f93bef99ab2a21686125b030b13a0c5b7e2d671 \
-                    sha256  898fddaed614f9f1961cfe4d20be1aee3556906979af6fbc83e0893f3e5d2769 \
-                    texlive-formats-extra-44177-doc.tar.xz \
-                    rmd160  809495235a5c2e54f6f0f032dfbcb54f32bf7521 \
-                    sha256  1a028f98dbe0b2e8d2661de628cc8f437fd8228bee4a15f1e43e45b64005d59c \
-                    texlive-formats-extra-44177-src.tar.xz \
-                    rmd160  ef38f680d5e8544f4437ab1a8b0579cad10b1a8d \
-                    sha256  e23a2a079895d3baa1faa925df040ac53e533812fd83f1feeb812c8feee9db43
+checksums           texlive-formats-extra-47198-run.tar.xz \
+                    rmd160  94a3c20c7b2ba644215ea6f26e1ec7345fd7d804 \
+                    sha256  51dce1e0ff70b7cfd339d2fb44755035e036e215d483f0741a41fc95be3722d5 \
+                    texlive-formats-extra-47198-doc.tar.xz \
+                    rmd160  721bf70308fd344396b46e056fddf655e90ff571 \
+                    sha256  abba006b3f51f47fdf1051cee4364992482f36ffb472eea1b9f8236154f330c5 \
+                    texlive-formats-extra-47198-src.tar.xz \
+                    rmd160  8e813326e805f94cf1250a9eb604a317a4fadce2 \
+                    sha256  b5b49b32222e347db22356d37e727393b0066a16bb52bb0cbd5a60cdbc75d0b0
 
 depends_lib         port:texlive-basic port:texlive-latex
 
@@ -44,6 +44,5 @@ texlive.maps      \
 
 texlive.binaries    aleph eplain jadetex lamed lollipop mllatex mltex odvicopy odvitype ofm2opl omfonts opl2ofm otangle otp2ocp outocp ovf2ovp ovp2ovf pdfjadetex pdfxmltex texsis wofm2opl wopl2ofm wovf2ovp xmltex
 
-depends_lib-append  port:texlive-latex
 
 texlive.texmfport

--- a/tex/texlive-games/Portfile
+++ b/tex/texlive-games/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-games
-version             44131
+version             46791
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Games typesetting
 long_description    Setups for typesetting various games, including chess.
 
-checksums           texlive-games-44131-run.tar.xz \
-                    rmd160  1295941ec3d28373d9245696b187033705ee8afb \
-                    sha256  1aa46b25d0498c53bd7728ec7b59f8c2817473f3468640ea2db40791109677ab \
-                    texlive-games-44131-doc.tar.xz \
-                    rmd160  10746aa5583d62e2b0534bfe310cef7e0bc75482 \
-                    sha256  eab64a7bca8b41d1d18c4738635dcf923e4f5d82a3f28b4b4c34459a19099dac \
-                    texlive-games-44131-src.tar.xz \
-                    rmd160  c3c77b4d97628b7c14ffd55b7c29b2ca98f93ead \
-                    sha256  8aa0439f5da17f60f82e934d7596ba71e8ec43b0f713a91328ad46b6f096482f
+checksums           texlive-games-46791-run.tar.xz \
+                    rmd160  4f19b3f1bf544a620f24c3922c97092e7d713ca1 \
+                    sha256  39a44409b5669e13e29a55244bd17cf08bc6db1ea8e3ae438b6f2f3f8827ed5c \
+                    texlive-games-46791-doc.tar.xz \
+                    rmd160  9b85afe97786750cbf2bdae5159525a77d0da05e \
+                    sha256  e9c2e6d75e67edf9ab388af090c6c817604ebcdf767018c541878d5768d13b84 \
+                    texlive-games-46791-src.tar.xz \
+                    rmd160  80c33f2c68a79ac0f3f5a7cff3fa43e60a632086 \
+                    sha256  9e60e52bb276b9bbc6ecc8377b26ac62cd94c54336f8fe5010c502c402e015e8
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-humanities/Portfile
+++ b/tex/texlive-humanities/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-humanities
-version             44196
+version             47359
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Humanities packages
 long_description    Packages for law, linguistics, social sciences, humanities, etc.
 
-checksums           texlive-humanities-44196-run.tar.xz \
-                    rmd160  8953c6c2c6a64f1ac3a2e221a727cf5852ad16ff \
-                    sha256  e30ba355152191e457599389115bc79b430e4928fabc1f95c1f2003f3248c4e0 \
-                    texlive-humanities-44196-doc.tar.xz \
-                    rmd160  f70ea5a0363cbf2cb40132508dafc54a09bc3208 \
-                    sha256  ed99e19ea66ba12170cf19c03275ac652568f0fa314fb0c721bf0653ff511f0d \
-                    texlive-humanities-44196-src.tar.xz \
-                    rmd160  55ebddcfd18efa9466231c9dbad570381d3934e4 \
-                    sha256  a7902e48a86937a0093d101f656bef6a135891d4bbd450dbcf78d4fbf4ac32f3
+checksums           texlive-humanities-47359-run.tar.xz \
+                    rmd160  859411323f53aee4bda51a6eb9c30d316fb1c730 \
+                    sha256  5ed3ad68e566ee9712bba3490cb50ef0c4197f81b4fd18d43e05fb8df3dd26eb \
+                    texlive-humanities-47359-doc.tar.xz \
+                    rmd160  5b3d244fb3666228859bae65664e294d726f65fa \
+                    sha256  c50922d7eeaafcc687d0d5b171a2785abe1f93ef24977609a28d0988d9cbcf96 \
+                    texlive-humanities-47359-src.tar.xz \
+                    rmd160  17252de01c20979baa6023b8af734a1a485d77f3 \
+                    sha256  d992e2e59d2955bae8d197191d56adf6508062b6fcf55f3578574ae77d9236cd
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-lang-arabic/Portfile
+++ b/tex/texlive-lang-arabic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-arabic
-version             44413
+version             47226
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Arabic
 long_description    Support for Arabic and Persian.
 
-checksums           texlive-lang-arabic-44413-run.tar.xz \
-                    rmd160  64a140230f449ae5f8ac3765e3550f3a361516d5 \
-                    sha256  3cddbaf484a51467fd880c05bf1480993dd78af1a5d1c0697ba606df2fdeda60 \
-                    texlive-lang-arabic-44413-doc.tar.xz \
-                    rmd160  cd6a87da0161a4938be2660aa2acf0ac61af17fd \
-                    sha256  b655a707e5e1eee5de64a9a6b0de9f93fef84fec49a19134c2ce497d480c05ba \
-                    texlive-lang-arabic-44413-src.tar.xz \
-                    rmd160  0d28b58e875116643be6be3dfcd4e95ffabb392c \
-                    sha256  c96ed9f70a92dc7d2037392bb099fbc31cdacf3680450e5991204f9da9f1ba36
+checksums           texlive-lang-arabic-47226-run.tar.xz \
+                    rmd160  40a963cd0c8b0fd66731234e3ad8db486d957f03 \
+                    sha256  2ed47dbbabedfa7bf445a5faa2beb770f100c3faf7149f2d4e94df9cf19755dc \
+                    texlive-lang-arabic-47226-doc.tar.xz \
+                    rmd160  3caa5c2965cf9164d48be6555608cc51e951cc43 \
+                    sha256  5dbf2b6d4afc4a4814c1ca0b92034be91f60e26f1cb73f74c6d75aa4b399250b \
+                    texlive-lang-arabic-47226-src.tar.xz \
+                    rmd160  db51f118c5f409a1b43f386170c8d89f3498633a \
+                    sha256  d1ed66f529554d7dbed4ded1c55becdb140f0c2c1afd6fc63d13ebbca66eb937
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-chinese/Portfile
+++ b/tex/texlive-lang-chinese/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-chinese
-version             44333
+version             47408
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Chinese
 long_description    Support for Chinese\; additional packages in collection-langcjk.
 
-checksums           texlive-lang-chinese-44333-run.tar.xz \
-                    rmd160  5bb658f85ea91cbeb7612b140bb5b80dc1dc01ec \
-                    sha256  ec6fd45e3440fa4746dde92539232a309189e59cd656c18f1882d60daab8268d \
-                    texlive-lang-chinese-44333-doc.tar.xz \
-                    rmd160  d556b85ded750ab49985b9cb57c21b8766b44744 \
-                    sha256  3bbbde18d2eb5b67c8d30f301cd4f740bde267bb190fdac7d5b9b90875330105 \
-                    texlive-lang-chinese-44333-src.tar.xz \
-                    rmd160  3db435d7b2df1d4fd3357975e7f3b06c6242c535 \
-                    sha256  82ba6ebcbfe7e2a5d33c087d71d733d7a33dab943072576bffe957f82a135605
+checksums           texlive-lang-chinese-47408-run.tar.xz \
+                    rmd160  9d088075cf4ffeadc77c37a77d6ab50c44fa8602 \
+                    sha256  32917b5e8df21528362e86cf347aaf5e81ac3c893dcda34286ae18cb36df22a5 \
+                    texlive-lang-chinese-47408-doc.tar.xz \
+                    rmd160  33a5283ee64f40e7a729dfbc9d42e515c86c207a \
+                    sha256  c2432a5ce123c4239febd4070911fce0460b456ecb8cf6240b29e61b5c32e10b \
+                    texlive-lang-chinese-47408-src.tar.xz \
+                    rmd160  32169cd6b1e6dbcb24953ae77b814d0495947f0d \
+                    sha256  b2f965ee103baa3db68f66100837430779e2c4262e7a30d0893bcfc8cf316d77
 
 depends_lib         port:texlive-lang-cjk
 

--- a/tex/texlive-lang-cjk/Portfile
+++ b/tex/texlive-lang-cjk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-cjk
-version             44207
+version             47198
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Chinese/Japanese/Korean (base)
 long_description    Packages supporting a combination of Chinese, Japanese, Korean, including macros, fonts, documentation.  Also Thai in the c90 encoding, since there is some overlap in those fonts\; standard Thai support is in collection-langother.  Additional packages for CJK are in their individual language collections.
 
-checksums           texlive-lang-cjk-44207-run.tar.xz \
-                    rmd160  4bd9740a8caa863a4bd8944c806efdf0c60cf6a1 \
-                    sha256  f5e87948c5d7e695b3b2eeec9dcb4ad2ec6b43c28d48f4d75d48d9f8a5f5df52 \
-                    texlive-lang-cjk-44207-doc.tar.xz \
-                    rmd160  c36426fa1773d118a7726c1618239d55138adc43 \
-                    sha256  d47a44aabfa66c70658fba2436ea7ea59852da4eaf71a8e607629b56acb73545 \
-                    texlive-lang-cjk-44207-src.tar.xz \
-                    rmd160  13ee1eb54c850e8f1a499c43f4abbf03a4406cde \
-                    sha256  a13d4a930f7d123a3d2ed3784d03bd575cc606778032557e454166ed374a8119
+checksums           texlive-lang-cjk-47198-run.tar.xz \
+                    rmd160  afabb475a7f41ff591d16efd0e1ea075f95590b3 \
+                    sha256  68630c930b93c3974e48ed2d40593fc4255d59500b52b62cf6a72906d0fb249b \
+                    texlive-lang-cjk-47198-doc.tar.xz \
+                    rmd160  a5aeb0698db0830ae7c1f7ccfc18fa9ece4e6c06 \
+                    sha256  46229af5e654facde2ef9e290fed4724e5109a420b434402d21cfb88bb3a1b91 \
+                    texlive-lang-cjk-47198-src.tar.xz \
+                    rmd160  c665f911aa5f1d1e88d3eb4a2e816f35dd300156 \
+                    sha256  8a0bac900f66e231398476fbc5bf93174d237e8d897439cf73d4cc73c00f4198
 
 depends_lib         port:texlive-basic
 
@@ -29,7 +29,7 @@ texlive.maps      \
     {Map garuda-c90.map} \
     {Map norasi-c90.map}
 
-texlive.binaries    bg5+latex bg5+pdflatex bg5conv bg5latex bg5pdflatex cef5conv cef5latex cef5pdflatex cefconv ceflatex cefpdflatex cefsconv cefslatex cefspdflatex cjk-gs-integrate extconv gbklatex gbkpdflatex hbf2gf sjisconv sjislatex sjispdflatex
+texlive.binaries    bg5+latex bg5+pdflatex bg5conv bg5latex bg5pdflatex cef5conv cef5latex cef5pdflatex cefconv ceflatex cefpdflatex cefsconv cefslatex cefspdflatex cjk-gs-integrate extconv gbklatex gbkpdflatex hbf2gf jfmutil sjisconv sjislatex sjispdflatex
 
 depends_lib-append port:texlive-latex
 

--- a/tex/texlive-lang-cyrillic/Portfile
+++ b/tex/texlive-lang-cyrillic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-cyrillic
-version             44401
+version             47458
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Cyrillic
 long_description    Support for Cyrillic scripts (Bulgarian, Russian, Serbian, Ukrainian), even if Latin alphabets may also be used.
 
-checksums           texlive-lang-cyrillic-44401-run.tar.xz \
-                    rmd160  925dfd5937f2ffe78646884b0c40c323e22f0b95 \
-                    sha256  7e0dede12deabeb96ac6dbc624c9de7d8126054c9f58147ae4d295bdfdf882d3 \
-                    texlive-lang-cyrillic-44401-doc.tar.xz \
-                    rmd160  bd3ca48aab70e27bf57450002099c3d3f9caf5f8 \
-                    sha256  c484eb5f5444c32b42f167bba0c94dc96fe94a00ea67f3151028684f06ad793c \
-                    texlive-lang-cyrillic-44401-src.tar.xz \
-                    rmd160  c13c8b1230af53371c1d7984dda223a22b2fc1f4 \
-                    sha256  ccc0d5e08a1a15a7de9cb566ac9fd96397dc9c1f2ce77ed3290a86681024f62f
+checksums           texlive-lang-cyrillic-47458-run.tar.xz \
+                    rmd160  8601dd04673ec2a9465840972bd784185da26e30 \
+                    sha256  8ec422c710cafe993a7545c77a5d3dc2250224ecce14ea867651bed831055720 \
+                    texlive-lang-cyrillic-47458-doc.tar.xz \
+                    rmd160  f4730fc368e40ee1f3e32c0ce6ca1f5a1e4faba9 \
+                    sha256  db37ba0a57bb0a8a5712638eb1eb857ec095d94d2864e83c8a168de1516260e6 \
+                    texlive-lang-cyrillic-47458-src.tar.xz \
+                    rmd160  9ad47404363b607b3197258903dbeaeb80a25c61 \
+                    sha256  017890f9fc9a2791682cf70cc1ea0be1c6c531d8e672ad50b03937506a36fb50
 
 depends_lib         port:texlive-basic port:texlive-latex
 

--- a/tex/texlive-lang-czechslovak/Portfile
+++ b/tex/texlive-lang-czechslovak/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-czechslovak
-version             44347
+version             47441
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Czech/Slovak
 long_description    Support for Czech/Slovak.
 
-checksums           texlive-lang-czechslovak-44347-run.tar.xz \
-                    rmd160  c1c883e60910b0ee3784083c94b3957547c37489 \
-                    sha256  3846b2949be385cd06e6f186a0db345356933a1fff9b29199b7d265916743e09 \
-                    texlive-lang-czechslovak-44347-doc.tar.xz \
-                    rmd160  712130f5dc024462b2e5afa95ee5e49c0b190d25 \
-                    sha256  c635784821fb6f74a5a293d55237eba08b4bde63dd9b915380e0a88135d05f08 \
-                    texlive-lang-czechslovak-44347-src.tar.xz \
-                    rmd160  216feb9ece16c5d7139282dfbabe83f3b4c748f4 \
-                    sha256  310ed2656c40bbd36b9a98cbb6428b3ed33726cb78e7351db28551d616b14851
+checksums           texlive-lang-czechslovak-47441-run.tar.xz \
+                    rmd160  d51aa179456def724803193d0fcedf14aec4b150 \
+                    sha256  ad5bfaa8beab658f17ebbd7e9c6fa367683415247730ace1d32fc0a644a1de7f \
+                    texlive-lang-czechslovak-47441-doc.tar.xz \
+                    rmd160  a18c89febf8f825a16463580223356cc64b58efc \
+                    sha256  d635a415f5403c4403e5c9cc0ece515d0bf7f92306bc2188b2f62476063181a3 \
+                    texlive-lang-czechslovak-47441-src.tar.xz \
+                    rmd160  1c4ffbce79bbc3b3884c6b14cf08b42e8cd86d08 \
+                    sha256  7c0b211c13673e31027a14e70d2c5e42c14f8198e3727a60e31ea98caa6dca8a
 
 depends_lib         port:texlive-basic port:texlive-latex
 

--- a/tex/texlive-lang-english/Portfile
+++ b/tex/texlive-lang-english/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-english
-version             44131
+version             47419
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: US and UK English
 long_description    Support for, and documentation in, English.
 
-checksums           texlive-lang-english-44131-run.tar.xz \
-                    rmd160  a543681e9c794aca5fd94ffe32e7acaaee187771 \
-                    sha256  24a2979a457a04c1bf282c43494eaea11cb8332945995346eb8d4c8c3940e117 \
-                    texlive-lang-english-44131-doc.tar.xz \
-                    rmd160  30d9f2d0a60a5a26b58fa84f479a16255add6c65 \
-                    sha256  50d532221ce12d8e5e8d384a6868abdbb7d17ab0c99569bfb447c005306978be \
-                    texlive-lang-english-44131-src.tar.xz \
-                    rmd160  67bfad41079239d870d977c030c38b0f4485d493 \
-                    sha256  990d4bc58e69a5be7f66be5431b2c66aa8a2cac58a3f28844afddc5ad41026b9
+checksums           texlive-lang-english-47419-run.tar.xz \
+                    rmd160  642e24d7dfc522f9620db5e827fa7808e6228396 \
+                    sha256  553e7791d6db494636438dbf96384fb5a73e857f53ebd7f7eec59a3f3bcb040c \
+                    texlive-lang-english-47419-doc.tar.xz \
+                    rmd160  87b620ac6cd8b7d67609bde56b7d07e53e47a9c5 \
+                    sha256  dc0cf3c1684b0bb3f6c9c5e94c62fbeab9d1a624d02ee32085751168bd19df39 \
+                    texlive-lang-english-47419-src.tar.xz \
+                    rmd160  e7c6842d2ea74c722dee43c00adcbf033d7acccd \
+                    sha256  5c2fcd64701d0c019dcdddab0b86c11c4b3624369c6a9c1bd73c99b22b2dbf13
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-european/Portfile
+++ b/tex/texlive-lang-european/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-european
-version             44414
+version             47375
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Other European languages
 long_description    Support for a number of European languages\; others (Greek, German, French, ...) have their own collections, depending simply on the size of the support.
 
-checksums           texlive-lang-european-44414-run.tar.xz \
-                    rmd160  21c7d694e08b5678c80ca51da15fb8983731141b \
-                    sha256  662f7b0daa7a737822c8e2df1876d06b34a4d4a226c035fd940ee0b9414caa64 \
-                    texlive-lang-european-44414-doc.tar.xz \
-                    rmd160  8fd066319e2708446289c26aefa581d072bb53de \
-                    sha256  8740ca491e6801e4881826acb52b63d1d995bd55fdec0329de4c89f5061506b5 \
-                    texlive-lang-european-44414-src.tar.xz \
-                    rmd160  b83d97a354b81e9c83bd64bb7a1e2f761478c981 \
-                    sha256  0e305ac4cd32f8b66fb35aafb4d7fab57f43c6c7279a9ec75845e5a9553781f5
+checksums           texlive-lang-european-47375-run.tar.xz \
+                    rmd160  262df179c99ab738a9792f5ca4b83c1a9a62774b \
+                    sha256  b6ce1a3295dc691008e6e6d0873d152c88a335fdf3d4718057806c912b9e0e0d \
+                    texlive-lang-european-47375-doc.tar.xz \
+                    rmd160  99c654b4d455e952e3b38abb371d41b283bb7d95 \
+                    sha256  37c00faf9bee7a7806b13d4801eda82e6e2697521026ed8a029b8764cccf07ce \
+                    texlive-lang-european-47375-src.tar.xz \
+                    rmd160  256be63f571272163ac2ceea27f40d7e4b8a1b0b \
+                    sha256  1443b0cce47656ef52c4839dd920a5098bd6445630b013cb68797b05feb97dc9
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-french/Portfile
+++ b/tex/texlive-lang-french/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-french
-version             44342
+version             47463
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: French
 long_description    Support for French and Basque.
 
-checksums           texlive-lang-french-44342-run.tar.xz \
-                    rmd160  a898bab52e379535f8df5d086c1ddb435d64e5f7 \
-                    sha256  1e7c0cc3977f7414da9049d49ce7d3bacf74c684d1f1116ac2f0db0aac79cbc6 \
-                    texlive-lang-french-44342-doc.tar.xz \
-                    rmd160  0f5c19de4f49b5125c92d4b175eec3347d03c3dc \
-                    sha256  146ed0323dd6d5fba56ba273ded1fc574476b1d6c8fa529498734786d447dce3 \
-                    texlive-lang-french-44342-src.tar.xz \
-                    rmd160  0d4142b1c48979d27617f1483cd941d49519bf2b \
-                    sha256  a9d1a0cc66843e6a24e6fdb722ecc2d15b07a2913974567114a5d8ca1e77e808
+checksums           texlive-lang-french-47463-run.tar.xz \
+                    rmd160  f8359c3791ae4355390a66e474c03cf4c10d0946 \
+                    sha256  19e1ce44a98a797e40ef1957740719bbc39711424d5d900f1266b06b81ac0b15 \
+                    texlive-lang-french-47463-doc.tar.xz \
+                    rmd160  1ed6a32744a97487a1823917a472e53ec0ace649 \
+                    sha256  611887031c731117a1d86f58f31f88ba4618244a4c90344bab168278af4c35ad \
+                    texlive-lang-french-47463-src.tar.xz \
+                    rmd160  5a450fd89cc0f9160bca86c6b1c1527a04cfcc7d \
+                    sha256  ef8797a578104ce33fd73cc2f60afb5221a05c5fc372d5bd70fc0094739d5375
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-german/Portfile
+++ b/tex/texlive-lang-german/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-german
-version             44401
+version             47442
 revision            0
 
 categories          tex
@@ -13,21 +13,21 @@ license             Copyleft Permissive
 description         TeX Live: German
 long_description    Support for German.
 
-checksums           texlive-lang-german-44401-run.tar.xz \
-                    rmd160  2494e76bca577d2616828d4cc18b7a5c2fa91454 \
-                    sha256  b85cff369b4a70a26b3e5de234879fcbc977d10e45bcc5a714e8f3356d26f382 \
-                    texlive-lang-german-44401-doc.tar.xz \
-                    rmd160  d766399fc17f8c14f02115c75a9f1d29dd018a6c \
-                    sha256  6331f6f973e8b9357aed2b520f619975da20252fcd35e2979c55b41d9036685d \
-                    texlive-lang-german-44401-src.tar.xz \
-                    rmd160  5ee155c57d4ea01ea44d2f39275e24c1274924c8 \
-                    sha256  a28c574c8874fb49200e98efe4b7730f6164ea558218c3fd4379b67b2919c21d
+checksums           texlive-lang-german-47442-run.tar.xz \
+                    rmd160  0d372444a175595fab0770268e2705a7186b4bbb \
+                    sha256  02aaad3a4248a878ffb0a6c65cff6bdece196c49070bf9092a7e65030571e11d \
+                    texlive-lang-german-47442-doc.tar.xz \
+                    rmd160  89e23880bdba64de1c955c133f3181ab6ca2fe49 \
+                    sha256  e75bf1786765a7a49320c797f706bcd9b30a87950148905cae81135dd2776681 \
+                    texlive-lang-german-47442-src.tar.xz \
+                    rmd160  362428c370301b9ee0aa711004b575bba93a8374 \
+                    sha256  aed84e9d57e521b9dc12c0c75c5bd9bc5c1167d555903414531e183e1bab98e0
 
 depends_lib         port:texlive-basic
 
 texlive.languages      \
-    {german-x-2017-03-31 dehypht-x-2017-03-31.tex 2 2 {german-x-latest} {hyph-de-1901.pat.txt} {hyph-de-1901.hyp.txt} {} } \
-    {ngerman-x-2017-03-31 dehyphn-x-2017-03-31.tex 2 2 {ngerman-x-latest} {hyph-de-1996.pat.txt} {hyph-de-1996.hyp.txt} {} } \
+    {german-x-2018-03-31 dehypht-x-2018-03-31.tex 2 2 {german-x-latest} {hyph-de-1901.pat.txt} {hyph-de-1901.hyp.txt} {} } \
+    {ngerman-x-2018-03-31 dehyphn-x-2018-03-31.tex 2 2 {ngerman-x-latest} {hyph-de-1996.pat.txt} {hyph-de-1996.hyp.txt} {} } \
     {german loadhyph-de-1901.tex 2 2 {} {hyph-de-1901.pat.txt} {} {} } \
     {ngerman loadhyph-de-1996.tex 2 2 {} {hyph-de-1996.pat.txt} {} {} } \
     {swissgerman loadhyph-de-ch-1901.tex 2 2 {} {hyph-de-ch-1901.pat.txt} {} {} }

--- a/tex/texlive-lang-greek/Portfile
+++ b/tex/texlive-lang-greek/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-greek
-version             44192
+version             46662
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Greek
 long_description    Support for Greek.
 
-checksums           texlive-lang-greek-44192-run.tar.xz \
-                    rmd160  bd849f08b9e28ca24dfc9b900e84b2ea22e35f16 \
-                    sha256  6cc39185a62947c929d3cb6e6f72b708a78c68aeea1c60e87a8f99d2fb14b50f \
-                    texlive-lang-greek-44192-doc.tar.xz \
-                    rmd160  6cba6976ce013de56f68433273696bf56683083f \
-                    sha256  60162fb0e026132cca2213c5b65f79bc091db45d9cf0e2c831aa13e8862509cd \
-                    texlive-lang-greek-44192-src.tar.xz \
-                    rmd160  cc6b3aec516ae154b003b06f98acf66d9e9a0bb9 \
-                    sha256  c478adda2700a1cd5cef1f14d83c89e350a33dd595de0be16b168e2b557a2bc1
+checksums           texlive-lang-greek-46662-run.tar.xz \
+                    rmd160  75391d508118b1833a54a398b0c02d31ef9392f7 \
+                    sha256  4e580e006fa7979e64000cb23802ea71f6cdefb10699e928bc972637665227b3 \
+                    texlive-lang-greek-46662-doc.tar.xz \
+                    rmd160  5474a0cd5f4a0113456327fbfd274f1aa4de3322 \
+                    sha256  0a5671293a9dd0e468c385c5af29c2a90865665a87edef32ff60208cafba6516 \
+                    texlive-lang-greek-46662-src.tar.xz \
+                    rmd160  7c159d99e368ca1ca17a547a3617cdb2ab97bbd3 \
+                    sha256  05461c14ef26b1db3259c3b36840520e526a0c6ae0a171f246f6442121d6bb7f
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-italian/Portfile
+++ b/tex/texlive-lang-italian/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-italian
-version             44357
+version             47434
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Italian
 long_description    Support for Italian.
 
-checksums           texlive-lang-italian-44357-run.tar.xz \
-                    rmd160  d4f60a3546dccd8c220d950fc969daaa95f775bd \
-                    sha256  97b36539921940507047bde49ac1c08c48e1f26dbc78996d18950c5e05061df8 \
-                    texlive-lang-italian-44357-doc.tar.xz \
-                    rmd160  6cce5b37e960e5633bb082fdd10bb41dcff5bcd0 \
-                    sha256  5791998aebf607c291eb457d3f185119faa028f7190861dbb144ce26bd9c3140 \
-                    texlive-lang-italian-44357-src.tar.xz \
-                    rmd160  2ef1ff45d06db59ebff103e0d054efe3546c4b59 \
-                    sha256  e7fb0fa843ac5437ca9be62e044174c766e0fe33c5e05572ef1ca52347cf1251
+checksums           texlive-lang-italian-47434-run.tar.xz \
+                    rmd160  1fb4910a6db33a4044be59f3726fa02b67b169e2 \
+                    sha256  1591a0748950c688f009add650a3096ba9f4e1864e34a4b0ca62a7540e5573cd \
+                    texlive-lang-italian-47434-doc.tar.xz \
+                    rmd160  baee3bc0463f470d06cb7b773a1643a585d22274 \
+                    sha256  1f30912a94aad8e67be7e34e4e84dd0899ec50007421201dc048c7ad607fcd0b \
+                    texlive-lang-italian-47434-src.tar.xz \
+                    rmd160  fe91aaef0a146a06a422a9a84af3887a5743801f \
+                    sha256  5cebb679b6cb8412991c8ba1f55d0a0f5d850daa7471ec6e8fa4ddd27a686d9a
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-japanese/Portfile
+++ b/tex/texlive-lang-japanese/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-japanese
-version             44377
+version             47402
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Japanese
 long_description    Support for Japanese\; additional packages in collection-langcjk.
 
-checksums           texlive-lang-japanese-44377-run.tar.xz \
-                    rmd160  838db53edf879e3155373030baf017c30736b2fb \
-                    sha256  c1807cf9242694193ca006bf43c2e92cae185831efa998dbf6e6c8414d10a607 \
-                    texlive-lang-japanese-44377-doc.tar.xz \
-                    rmd160  15ec375364d0705445e1abeb37cfec797e5ade5c \
-                    sha256  4a4caafbd2f8a0af22b97ea218559c7ec2e95732fa4c240b6183c0cd544e888c \
-                    texlive-lang-japanese-44377-src.tar.xz \
-                    rmd160  e93daedb0bcc4269fd51acf82176e44749a5135a \
-                    sha256  91212218f6c1ca59307e52e012a2b4eb2841a27eddf79d530de51a9e24e03e87
+checksums           texlive-lang-japanese-47402-run.tar.xz \
+                    rmd160  3150330aec748ff2968f4be53f935cd499847511 \
+                    sha256  4c3aa71c82ac4c9ff7cb47e89ef54127bdca26d869f9703e5d0950dea1e1e13f \
+                    texlive-lang-japanese-47402-doc.tar.xz \
+                    rmd160  dd2bea8d8b799cf5605a1f6c68e1a21f7b3760f6 \
+                    sha256  da17a12b09cdc97c646f2a5e453d9eeda3c938667a5ead6d8abeafd9cdbae893 \
+                    texlive-lang-japanese-47402-src.tar.xz \
+                    rmd160  d62df8eb21a7ef7be5c8295512f7e292a32f1b15 \
+                    sha256  21a137223b61b49018e6c582d18b221b730cde75f50c8281f482eb0c8dcf56a3
 
 depends_lib         port:texlive-lang-cjk
 
@@ -39,8 +39,8 @@ texlive.maps      \
     {KanjiMap otf-tc-@tcEmbed@.map} \
     {KanjiMap otf-ko-@koEmbed@.map} \
     {KanjiMap otf-up-@jaEmbed@.map} \
+    {KanjiMap morisawa5.map} \
     {KanjiMap ptex-@jaEmbed@@jaVariant@.map} \
-    {KanjiMap morisawa.map} \
     {KanjiMap uptex-@jaEmbed@@jaVariant@.map} \
     {KanjiMap uptex-sc-@scEmbed@.map} \
     {KanjiMap uptex-tc-@tcEmbed@.map} \

--- a/tex/texlive-lang-korean/Portfile
+++ b/tex/texlive-lang-korean/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-korean
-version             43130
+version             44467
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Korean
 long_description    Support for Korean\; additional packages in collection-langcjk.
 
-checksums           texlive-lang-korean-43130-run.tar.xz \
-                    rmd160  001e7f37cd4bf64fe1119a268176d3fbcdf6de5b \
-                    sha256  7c40921a135dc90a0e0badd121939ddfb0ef70c0c778aee33171c6fe1b0d967f \
-                    texlive-lang-korean-43130-doc.tar.xz \
-                    rmd160  066095e41aaf48dbfed98121cd9ea5d8901b7c54 \
-                    sha256  175650faa0b0335ee7218ddd1d97dd44b6594d78952b46ed989f57ad486ba9b4 \
-                    texlive-lang-korean-43130-src.tar.xz \
-                    rmd160  becff107b91248db6fce3a02546d4b26c1ed9201 \
-                    sha256  28e155f52acfbf8feba6051b12c3ecaa39575a33b6e195184b1b7454373a3790
+checksums           texlive-lang-korean-44467-run.tar.xz \
+                    rmd160  d91cdfca062feb1b0b76e1bf88d1a5ed9e694169 \
+                    sha256  c602180a88fa02676d32a54322843371502ffe1042ff5aad7eb84f08515211f5 \
+                    texlive-lang-korean-44467-doc.tar.xz \
+                    rmd160  0bf1e3f590b8083e96c9c7be2e0765adb3007224 \
+                    sha256  a53fd9d83e3389d57e6311322bf17d891ae1bd168f155b098ead450cf0b599e7 \
+                    texlive-lang-korean-44467-src.tar.xz \
+                    rmd160  4c992c37a20bc23a9631989b913cbb315d17e0dd \
+                    sha256  943ef2bda37c2849eab223717801ada007d5976990fc7942a52358f2b939d1f0
 
 depends_lib         port:texlive-lang-cjk
 

--- a/tex/texlive-lang-other/Portfile
+++ b/tex/texlive-lang-other/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-other
-version             44414
+version             47375
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Other languages
 long_description    Support for languages not otherwise listed, including Indic, Thai, Vietnamese, Hebrew, Indonesian, African languages, and plenty more.  The split is made simply on the basis of the size of the support, to keep both collection sizes and the number of collections reasonable.
 
-checksums           texlive-lang-other-44414-run.tar.xz \
-                    rmd160  09283622c0bf7ae4195f515f536de9fb8e8066e0 \
-                    sha256  ec3154746d15e7123243c0157c7424e33e48c8647a20f782b7e152d77ab063d1 \
-                    texlive-lang-other-44414-doc.tar.xz \
-                    rmd160  059abb7060effd4c1c997c38bb4c840c4c664d38 \
-                    sha256  7bd8c6e60333e95966da70ac20e55bb8397bac60ae65c9e3c225a6d59a608116 \
-                    texlive-lang-other-44414-src.tar.xz \
-                    rmd160  df86097a7a364be234fdf8dc5d0cda2d7373e94b \
-                    sha256  84889c920a6e3dbb189dc3555fb62ef0c754851a9665d164aa277534e9faca69
+checksums           texlive-lang-other-47375-run.tar.xz \
+                    rmd160  1d7bede381b4159577a793ddedf068766fb356e0 \
+                    sha256  3846053316ebebe3ba2d01c7bd17d40874ad19bd35fe09d892a1a3f18439ec0c \
+                    texlive-lang-other-47375-doc.tar.xz \
+                    rmd160  8388ae69b201adb6ac2e3a3bdce77856a47e6b3f \
+                    sha256  0602bec34412d00579efe22259659339168fc8157beb6b3e61be72d63258addb \
+                    texlive-lang-other-47375-src.tar.xz \
+                    rmd160  fc2fa8005af0c2dd5e447d3b6e5f00e8b1e40e78 \
+                    sha256  7920e1a053ea0817ff4d7db74a9c75d4a3357943b28dfa16a0e81dbe27843f27
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-polish/Portfile
+++ b/tex/texlive-lang-polish/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-polish
-version             44371
+version             47447
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Polish
 long_description    Support for Polish.
 
-checksums           texlive-lang-polish-44371-run.tar.xz \
-                    rmd160  b5ab79e99d69364f6662456c91b817b50ba442ea \
-                    sha256  926824fa6011652d84c52c64386eb3be379e3d1c8ed6c104140fb3e6ce3b6bef \
-                    texlive-lang-polish-44371-doc.tar.xz \
-                    rmd160  93aa59608096939c2cd2a3d1eab668c8fab4e92e \
-                    sha256  7778c0946610802f16af3d454577b6f49e67f759c7f3f8e98b146ef72f054760 \
-                    texlive-lang-polish-44371-src.tar.xz \
-                    rmd160  fe9e9784fcc0c16f407fc882df42f23fa6976a74 \
-                    sha256  721618dd5b3f64b97d23c259f2403ae67a8050607d2718df97ce0f6cfae9ecdc
+checksums           texlive-lang-polish-47447-run.tar.xz \
+                    rmd160  a91d0220e8e8c559e3214f753f9261d86d450e7b \
+                    sha256  0103822c4e4441693b55ce344b79e55970b2e1feae789a35de204df5e70c7e80 \
+                    texlive-lang-polish-47447-doc.tar.xz \
+                    rmd160  c2cf7b6d89a7ba8ebc4db8f4262251ad2bf72093 \
+                    sha256  53533dcc58ee3afc3d799db9e5733254cf20a0712fc80718360475177a0a8e74 \
+                    texlive-lang-polish-47447-src.tar.xz \
+                    rmd160  2fbe7fec33683dd71edc1482bd49a5873b3295c6 \
+                    sha256  0f5730eed4280e6956b39db45b4fe774e995baaefe038bb825b08bf6332e7738
 
 depends_lib         port:texlive-latex port:texlive-basic
 

--- a/tex/texlive-lang-portuguese/Portfile
+++ b/tex/texlive-lang-portuguese/Portfile
@@ -5,7 +5,7 @@ PortGroup           texlive 1.0
 
 name                texlive-lang-portuguese
 version             40340
-revision            1
+revision            0
 
 categories          tex
 maintainers         {dports @drkp}
@@ -14,14 +14,14 @@ description         TeX Live: Portuguese
 long_description    Support for Portuguese.
 
 checksums           texlive-lang-portuguese-40340-run.tar.xz \
-                    rmd160  9c78bea82c43c2d65d0abac66d20a19c4ad40a5c \
-                    sha256  46266e63a944fb2dbce79cc9b602682d1b33b548802ffa204ade2dc05b0b0464 \
+                    rmd160  00873ae33817e534925c1b4ef581d059a94d1b73 \
+                    sha256  bcb76c5b9f4d986cf6884679b9cc64ec4806ffff22abcf00c5a0b1f66d2633f3 \
                     texlive-lang-portuguese-40340-doc.tar.xz \
-                    rmd160  17d0aaea1c5a1894f09c8996ed0172c75111a013 \
-                    sha256  7b447c7994c274666fe513ebe0d573ee7671e50e3ba804171b8fe59d3ce2512f \
+                    rmd160  0da122ca82c0139a0ba1a9ceebc57b3f9fc840c0 \
+                    sha256  8db208320a359ded3948807860868ef20a9f1b90ab1deaa0f8e2adad8c722a85 \
                     texlive-lang-portuguese-40340-src.tar.xz \
-                    rmd160  8377c82bf807e34340420c74efd6a3a244ddfe18 \
-                    sha256  68657bddd90339ac0ab76e39809be40f026c1573623ed024996c16e7ef27b9d3
+                    rmd160  c3bf98a5a9e7e387a2ba64545067f850b69eaecf \
+                    sha256  af8026011ee360cd124d33726c3ecd86dc699e9c10f4184914528df1a0c5552e
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-spanish/Portfile
+++ b/tex/texlive-lang-spanish/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-spanish
-version             44356
+version             47443
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Spanish
 long_description    Support for Spanish.
 
-checksums           texlive-lang-spanish-44356-run.tar.xz \
-                    rmd160  58450ea49f8f76bf6bfac931b6b3e5472bb0232f \
-                    sha256  faeda8169ff1f45d0a4ad059fa1c6a41623f6235d193eee9bdad23e51d0fc4e2 \
-                    texlive-lang-spanish-44356-doc.tar.xz \
-                    rmd160  d48b3b7706dc06a254f79212601ba0c3353374ec \
-                    sha256  63dc130d9c664a3241bb50ef9c22e729ea0f11a637fb7b73cdd9e6e91e89b7b0 \
-                    texlive-lang-spanish-44356-src.tar.xz \
-                    rmd160  f57c0ce872caf5e23be97563f9f05ddbcd69b6c9 \
-                    sha256  8576a4895017e6645874c3e7965502d5e14a465b93cbbf51aad4596450a55fc2
+checksums           texlive-lang-spanish-47443-run.tar.xz \
+                    rmd160  f3229d49df02790badc0101862c48938b211c5ae \
+                    sha256  05fb3fad40768bde944a1aed27ec6cae1c013d5f83a051603455da5431d46b92 \
+                    texlive-lang-spanish-47443-doc.tar.xz \
+                    rmd160  108f52ddb2818d9801806abcc0d9012e599bda0f \
+                    sha256  eb4320e2818349adb694ad1480a37076f9b2f7591b19f4525e4f362d726c7c03 \
+                    texlive-lang-spanish-47443-src.tar.xz \
+                    rmd160  c6dbcf5b38e61722fd5ec2b472c5416cfb0315b0 \
+                    sha256  b35c60ac6b866e79e8ca9c149ce824c4bb3228fc5a376ad4f4ded2d922412dcc
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-latex-extra/Portfile
+++ b/tex/texlive-latex-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-latex-extra
-version             44430
+version             47410
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: LaTeX additional packages
 long_description    A very large collection of add-on packages for LaTeX.
 
-checksums           texlive-latex-extra-44430-run.tar.xz \
-                    rmd160  594e93d40fd72550ee609a929b8b3d491b2d6808 \
-                    sha256  7c675227d1150ddb767e413e32b796834619045485cac54e033c0f340b96cb06 \
-                    texlive-latex-extra-44430-doc.tar.xz \
-                    rmd160  0efb9132b04455b3add1d360e8b7f911701cf6a9 \
-                    sha256  4b205b61815db6f2a33ab0b53605da6a6a159fcc9e0e5d04be197cbab0a1ddec \
-                    texlive-latex-extra-44430-src.tar.xz \
-                    rmd160  5678b6fa373b299e3fd261ee8e9c8c82a758398c \
-                    sha256  cf4e575cc6ff0ce19a95fd5dab2515b64e42736e01b421847e0f176da3333625
+checksums           texlive-latex-extra-47410-run.tar.xz \
+                    rmd160  44efb4a85c4e8fce195fc01c3bc1967b737f02f6 \
+                    sha256  c12b3c2d4c16a81931dade769d11ec8e0dbd657dc2435791c6232d40795a6d4b \
+                    texlive-latex-extra-47410-doc.tar.xz \
+                    rmd160  b472e500d0de7bcb3a0de2930759c2fd77ad978b \
+                    sha256  d0e802eb422b1dd2373443990b6ccf5913804799a4941790f49f0d339bb889be \
+                    texlive-latex-extra-47410-src.tar.xz \
+                    rmd160  964df8fceb4921b87a516684ddbe2f82de96e89d \
+                    sha256  21c4c8cebefe69e0b71383760035db71458bf0d04c482c5bdd337350d91f1651
 
 depends_lib         port:texlive-latex-recommended port:texlive-pictures
 
@@ -30,7 +30,7 @@ texlive.maps      \
     {MixedMap esint.map} \
     {Map scanpages.map}
 
-texlive.binaries    authorindex exceltex makedtx makeglossaries makeglossaries-lite pdfannotextractor perltex ps4pdf splitindex svn-multi vpe yplan
+texlive.binaries    authorindex exceltex l3build makedtx makeglossaries makeglossaries-lite pdfannotextractor perltex pygmentex splitindex svn-multi vpe wordcount yplan
 
 pre-activate {
     # Handle conflicts for TL2017 upgrade

--- a/tex/texlive-latex-recommended/Portfile
+++ b/tex/texlive-latex-recommended/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-latex-recommended
-version             44369
+version             47392
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: LaTeX recommended packages
 long_description    A collection of recommended add-on packages for LaTeX which have widespread use.
 
-checksums           texlive-latex-recommended-44369-run.tar.xz \
-                    rmd160  73017bb87029f72b832ab118710dc3666691f3b8 \
-                    sha256  aaad6f30466731f8c1bfc0e42c285f99be62b1b4faddfb98f78508a0e47a6346 \
-                    texlive-latex-recommended-44369-doc.tar.xz \
-                    rmd160  1078dc9cd1a4a4adc27411c0d12f917cc8ca0afe \
-                    sha256  d699a8d0faaa88ff34db6153724033a097a3a6e41fb808e4d9f61e1d5a36882d \
-                    texlive-latex-recommended-44369-src.tar.xz \
-                    rmd160  2f09f22400870e06a3238dad2ce23ff304462ab2 \
-                    sha256  9abf98b5fe8dcb77ffac69b1bcc87106d89efef3d0bfa01fb327ed143de9cd4c
+checksums           texlive-latex-recommended-47392-run.tar.xz \
+                    rmd160  c001dd46556ed0b9a9354d96cc87c39cb804f90e \
+                    sha256  2956d6845ab8d9c9732f879c9f3dfa9164f5c16a4c0a580dc43656601205c567 \
+                    texlive-latex-recommended-47392-doc.tar.xz \
+                    rmd160  f97511fd4319cb3382be1001ae29edfb32419142 \
+                    sha256  27d978b9d15215c2ffeafc378a3461ce317904691300c5fb11adb0edfdac007a \
+                    texlive-latex-recommended-47392-src.tar.xz \
+                    rmd160  1e89d497a9de61ee3d84b737dbc7dced25247cf0 \
+                    sha256  8d098cf8ed6c419c944ad71448dbb04ea53e45dc9455e3e8ea8fbce03821143d
 
 depends_lib         port:texlive-latex
 
@@ -31,6 +31,16 @@ texlive.binaries    lwarpmk thumbpdf
 depends_lib-append port:pgf
 
 pre-activate {
+    # Handle conflicts for TL2018 upgrade
+    if { ![catch {set vers [lindex [registry_active texlive-latex-extra] 0]}]
+         && ([vercmp [lindex $vers 1] 47410] < 0) } {
+        registry_deactivate_composite texlive-latex-extra "" [list ports_nodepcheck 1]
+    }
+    if { ![catch {set vers [lindex [registry_active texlive-xetex] 0]}]
+         && ([vercmp [lindex $vers 1] 47444] < 0) } {
+        registry_deactivate_composite texlive-luatex "" [list ports_nodepcheck 1]
+    }
+
     # Handle conflicts for TL2017 upgrade
     # no version check on the first two; the ports are obsolete
     if { ![catch {set vers [lindex [registry_active texlive-htmlxml] 0]}] } {
@@ -49,11 +59,6 @@ pre-activate {
         registry_deactivate_composite texlive-latex-extra "" [list ports_nodepcheck 1]
     }
 
-    # Handle conflicts for TL2015 upgrade
-    if { ![catch {set vers [lindex [registry_active texlive-humanities] 0]}]
-         && ([vercmp [lindex $vers 1] 37330] < 0) } {
-        registry_deactivate_composite texlive-humanities "" [list ports_nodepcheck 1]
-    }
 }
 
 

--- a/tex/texlive-latex/Portfile
+++ b/tex/texlive-latex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-latex
-version             44427
+version             47377
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: LaTeX fundamental packages
 long_description    These packages are either mandated by the core LaTeX team, or very widely used and strongly recommended in practice.
 
-checksums           texlive-latex-44427-run.tar.xz \
-                    rmd160  534433311e8a0cc9da3cf39ae50df1195e1bcc96 \
-                    sha256  a3dc336b899222445a05ae8b5897b5711427ef59fa267c68d18b772ac1ad2a98 \
-                    texlive-latex-44427-doc.tar.xz \
-                    rmd160  c05fe03343453245e3714d23029924f5cac7175d \
-                    sha256  fdfe13688e97d613d70bbab273603c92ae20ac6f9db19f9ed43975cb6b93932a \
-                    texlive-latex-44427-src.tar.xz \
-                    rmd160  5e5ee44f5c54715935877bddea1816dbc227997e \
-                    sha256  3ce856dac18ace9920e66b39082ccd370dc67ffb8c47e4b8fd42c36a513fcd6b
+checksums           texlive-latex-47377-run.tar.xz \
+                    rmd160  1531cbc3aa60bc90e3c49c2b98506874d981f347 \
+                    sha256  6ca9ae5d09d5c0507cc888271f68d76c6117d408e9609dd4ee4d58720062b303 \
+                    texlive-latex-47377-doc.tar.xz \
+                    rmd160  195939443c373cabcf96d5660fd12eeeaf3f8d17 \
+                    sha256  7cc7a2649e655c9764c40aa41c24bb9b248cbfb25cf9ddd7da1aaebda4d58990 \
+                    texlive-latex-47377-src.tar.xz \
+                    rmd160  7af692c52f4a5378a1bd130c76e2808c14d0ec8f \
+                    sha256  5bff840fca8f2dd784e8ed8f447426844aaa21a8dc743f99f03c0a2493655577
 
 depends_lib         port:texlive-basic
 
@@ -40,16 +40,6 @@ texlive.maps      \
     {Map utopia.map}
 
 texlive.binaries    dvilualatex latex lualatex mptopdf pdflatex
-
-# TL 2014: miscdoc moved from texlive-latex-recommended to texlive-latex
-pre-activate {
-    if { ![catch {set vers [lindex [registry_active texlive-latex-recommended] 0]}]
-         && ([vercmp [lindex $vers 1] 32420] < 0
-             || [vercmp [lindex $vers 1] 32420] == 0
-             && [lindex $vers 2] < 1)} {
-        registry_deactivate_composite texlive-latex-recommended "" [list ports_nodepcheck 1]
-    }
-}
 
 
 texlive.texmfport

--- a/tex/texlive-luatex/Portfile
+++ b/tex/texlive-luatex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-luatex
-version             44141
+version             47444
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: LuaTeX packages
 long_description    Packages for LuaTeX, a Unicode-aware extension of pdfTeX, using Lua as an embedded scripting and extension language. http://luatex.org/
 
-checksums           texlive-luatex-44141-run.tar.xz \
-                    rmd160  8a21bd25bc5a5719bb7da6fe005252bd3c1d53b0 \
-                    sha256  7c3e6f16f0be887ae1dea8182842356160a7239271c0656d6d652d4b269919a5 \
-                    texlive-luatex-44141-doc.tar.xz \
-                    rmd160  e1adeb8bc7f6be5a461fcd8174cc4b0a7209ce0a \
-                    sha256  dbb6b7818c5c4b1c1932be958734dd8ea6d9232c424b1fc4050741317bed59a6 \
-                    texlive-luatex-44141-src.tar.xz \
-                    rmd160  dea95d3d3265f2dd4f9649f1bbb1e59e9482a3d3 \
-                    sha256  34881a22332bf20d74b6fa81165cfb7fbaa1867eb9a96a2bb8594291ee97dca4
+checksums           texlive-luatex-47444-run.tar.xz \
+                    rmd160  c4eaae273d1f0b83b76b1e5293b518ea55793f49 \
+                    sha256  ceee09f8f16dc363482d73ee569a7a54215163cc5870273913bf7dbdb3ed2841 \
+                    texlive-luatex-47444-doc.tar.xz \
+                    rmd160  4933eff85f3a78429ce0b88388cf10bac43a4e6d \
+                    sha256  778035d812d37dc54fac9b26266b64186fd9fe68511c15ab64055dc71a2eb7a5 \
+                    texlive-luatex-47444-src.tar.xz \
+                    rmd160  e8d64bc058987123b8c114fb51d15f8ee5823486 \
+                    sha256  0d2b415d311f62ce73432922fe94632ca198bd4b618351b70dac2c606e80baf0
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-math-science/Portfile
+++ b/tex/texlive-math-science/Portfile
@@ -4,24 +4,24 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-math-science
-version             44428
+version             47412
 revision            0
 
 categories          tex
 maintainers         {dports @drkp}
 license             Copyleft Permissive
-description         TeX Live: Mathematics and science packages
-long_description    Mathematics and science packages
+description         TeX Live: Mathematics, natural sciences, computer science packages
+long_description    Mathematics, natural sciences, computer science packages
 
-checksums           texlive-math-science-44428-run.tar.xz \
-                    rmd160  bd0b81415793c278141238004cb846e03f42dbc5 \
-                    sha256  6469afe870364ba6eff4667c74dde2828bf8ae88935f4aefdb11156d9a1adfd2 \
-                    texlive-math-science-44428-doc.tar.xz \
-                    rmd160  f6fc034d3b7c2b6748f00a1e6430bf2d576a7cd0 \
-                    sha256  2240a69357a16563f5c6869cd1113e3580c96dd2fb9e1c48cf2238a1c0d64589 \
-                    texlive-math-science-44428-src.tar.xz \
-                    rmd160  d74eac463222b1b2f3828e5bac2fac684a5ec99e \
-                    sha256  b86b182bf04164db45b73e83da829b5ed9839dcffb8eef0273835980f1868b44
+checksums           texlive-math-science-47412-run.tar.xz \
+                    rmd160  8fa30ba888c45e0bfa3d570174764a24eabee5d9 \
+                    sha256  2f46a44d545a616255952edcb67316a0621bed7a9c280c45ed8166659f5b41a0 \
+                    texlive-math-science-47412-doc.tar.xz \
+                    rmd160  c478bbb049b3459e2aba67361d6f734238cad2f9 \
+                    sha256  886ab030e253cc6ba81684cb5890f9b29373142e8e6b19237f11f9a6e5d08e4a \
+                    texlive-math-science-47412-src.tar.xz \
+                    rmd160  2d76f508015df1792a98ab8a58231bbfb3248dba \
+                    sha256  ca21e6d246a5bb97aa04e989c48c64f3b861ffa739e80e7e0a10646cbca2950d
 
 depends_lib         port:texlive-fonts-recommended port:texlive-latex
 
@@ -33,7 +33,7 @@ texlive.maps      \
     {MixedMap stmaryrd.map} \
     {MixedMap yhmath.map}
 
-texlive.binaries    amstex pygmentex ulqda
+texlive.binaries    amstex axohelp ulqda
 
 pre-activate {
     # Handle conflicts for TL2017 upgrade

--- a/tex/texlive-metapost/Portfile
+++ b/tex/texlive-metapost/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-metapost
-version             44298
+version             47198
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: MetaPost and Metafont packages
 long_description    MetaPost and Metafont packages
 
-checksums           texlive-metapost-44298-run.tar.xz \
-                    rmd160  4bc471335d9ac88a8c94fb8926533e51d5415d95 \
-                    sha256  25163ce2f3ae40027a5887a41304bd1a2656d4d0ccdfc7629004b56499930d77 \
-                    texlive-metapost-44298-doc.tar.xz \
-                    rmd160  ad32b03ca646a052bb67d42dfcb179ed602cad97 \
-                    sha256  a33e3424744f837e5e93453b088dd0707e006a94fa3e7273da40107c147bcc5e \
-                    texlive-metapost-44298-src.tar.xz \
-                    rmd160  66b6e97fa92952ad7dc6bcd3a1f5f37118c78aba \
-                    sha256  948bb48e64ee96fc2853d5064539b8610c358a5c6c0b504ec6af96ca69605dfd
+checksums           texlive-metapost-47198-run.tar.xz \
+                    rmd160  329ca3dc2c7c9b1e40a98f8d8ad2b255d9803d2b \
+                    sha256  16cdd6e8e50a7aa21832214b6c9adeffe4da70985730b51c6a52c1f2991be60e \
+                    texlive-metapost-47198-doc.tar.xz \
+                    rmd160  ed10e9997e1a8580abaef9a8fad12f7394079bdb \
+                    sha256  a0c7932f2868c5dd7af688ea8a9c5975be3729a7e7c472f405087aa2063bf646 \
+                    texlive-metapost-47198-src.tar.xz \
+                    rmd160  cce70eeb2dcdadc626cc12607d6b9cd906323851 \
+                    sha256  8c4af5c4c4beeb8a5425e40e057bcdb71f326645db585f1ecd0bc68ef33668e9
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-music/Portfile
+++ b/tex/texlive-music/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-music
-version             44166
+version             47198
 revision            0
 
 categories          tex
@@ -13,22 +13,22 @@ license             Copyleft Permissive
 description         TeX Live: Music packages
 long_description    Music-related fonts and packages.
 
-checksums           texlive-music-44166-run.tar.xz \
-                    rmd160  356e7bb20763c2c27873ffba04c8d4f6b2eaf9e2 \
-                    sha256  0320da5d7773758cd32e0935f0ac46c5f627a1716956c700ab99dfcd012405a7 \
-                    texlive-music-44166-doc.tar.xz \
-                    rmd160  82c8585777f2e3e550783b64f76fc2f830ccb89c \
-                    sha256  1cacae80584020d45ff2e21579ec62e51add533a86b684855b4a456f008d07c2 \
-                    texlive-music-44166-src.tar.xz \
-                    rmd160  226b35099bdb017f1b01dbdbf6ede1dc3718a2b4 \
-                    sha256  5edce8a43e6a4c72d05f14b2f80aa5a446f978426e64346a664e2aaa72a6a084
+checksums           texlive-music-47198-run.tar.xz \
+                    rmd160  753ddcf87ae4c3d62ada6ea8f354e0ae277e11c7 \
+                    sha256  8a64f1581de7ac25bda0107faac8c27736883745da14310193a0cf51f3396146 \
+                    texlive-music-47198-doc.tar.xz \
+                    rmd160  94b6ba94b2eb5d7f2b418c83402dff56a6c5147e \
+                    sha256  f565c165ca1078b94754e1ba0057e93ef2f181581e33f934e2351d2f724004d3 \
+                    texlive-music-47198-src.tar.xz \
+                    rmd160  4cd2ef0dd11e3d81a552290146d92eaa52175157 \
+                    sha256  61e59424758c823ff466debd4938a1aa634a567733368608adb6b946e05c94f5
 
 depends_lib         port:texlive-latex
 
 texlive.maps      \
     {MixedMap musix.map}
 
-texlive.binaries    autosp gregorio lily-glyph-commands lily-image-commands lily-rebuild-pdfs m-tx msxlint musixflx musixtex pmxab pmxchords prepmx scor2prt
+texlive.binaries    autosp gregorio lily-glyph-commands lily-image-commands lily-rebuild-pdfs m-tx msxlint musixflx musixtex pmxab pmxchords prepmx scor2prt tex2aspc
 
 
 texlive.texmfport

--- a/tex/texlive-pictures/Portfile
+++ b/tex/texlive-pictures/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-pictures
-version             44395
+version             47373
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Graphics, pictures, diagrams
 long_description    Including TikZ, pict, etc., but MetaPost and PStricks are separate.
 
-checksums           texlive-pictures-44395-run.tar.xz \
-                    rmd160  b03788505299df758111d936aeb10bcf7d986204 \
-                    sha256  85b6b92ba9c4568ad4b226afc878a080d967339e9f5b413a014c3b1454a489b1 \
-                    texlive-pictures-44395-doc.tar.xz \
-                    rmd160  cc2fd4b7b8439e7ff39d40f48d6c68f2b1f2e371 \
-                    sha256  2e83ebda57fe360260050bb633c8aeacf86aee3f3f73024d4f8774261ffd5440 \
-                    texlive-pictures-44395-src.tar.xz \
-                    rmd160  d067e75e865c38c9bb1fe0c988c7ee31d3497dc3 \
-                    sha256  e12ed081e42385146f41b194285324ba47ac6e922c00facf5fde8ed5f6565b93
+checksums           texlive-pictures-47373-run.tar.xz \
+                    rmd160  11fb34655b43cfaac077f4280f29dd21ea96f6cf \
+                    sha256  f3808b7defe9d8fcc7a7906e2315672bf589ebd0f790f1e811e9524d5e398773 \
+                    texlive-pictures-47373-doc.tar.xz \
+                    rmd160  b1a037b9cface02ae5d29276b2ebca623e720cfa \
+                    sha256  24be57a39ee3646bc6fe40faae552598379d7156633a036d45ece91ea846e661 \
+                    texlive-pictures-47373-src.tar.xz \
+                    rmd160  ed1cd723ea400e21c1e7f83782a098f89f920086 \
+                    sha256  05ba0d961c394b4e2444db02a9bf9141b09c82301876bd04fea00b4f08c22019
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-plain-generic/Portfile
+++ b/tex/texlive-plain-generic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-plain-generic
-version             44379
+version             47437
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Plain (La)TeX packages
 long_description    Add-on packages and macros that work with plain TeX, often LaTeX, and occasionally other formats.
 
-checksums           texlive-plain-generic-44379-run.tar.xz \
-                    rmd160  a11aa4ca51e9ec65f6651e5cecb07268f6595ff1 \
-                    sha256  8a7a7c20323bf539df076df493a1b8ca611e3be3f348891636d8c348bd51f709 \
-                    texlive-plain-generic-44379-doc.tar.xz \
-                    rmd160  dc8b467befcb71b8f628f1fcadd26ee8e7603249 \
-                    sha256  79442849803ee662cd25f7cc62c0e23c4ba40f16a0a339a5562344ba65ed1b05 \
-                    texlive-plain-generic-44379-src.tar.xz \
-                    rmd160  e941553b158e5d7550032c49cb7b14bf23a24d8d \
-                    sha256  9c88504107a1dfbb3d54381f42c74ed5642bf2cbe7a7358f2aabe11b5a626e80
+checksums           texlive-plain-generic-47437-run.tar.xz \
+                    rmd160  6ddaae318aeaaf29b1b0fb3ee7b40a80411fd3af \
+                    sha256  4dceb8eb1ed72ff4a69ee15bd761cfe6e14f3ab76fc5112f9aac3c46f9a41320 \
+                    texlive-plain-generic-47437-doc.tar.xz \
+                    rmd160  b32fe9383e28ee3c01d3fadb4b2013f5d9f8e37a \
+                    sha256  8742dcc728bfc0a6f0c13fd212c5cf9aad54003c066d9a6be572f6cb8bd20525 \
+                    texlive-plain-generic-47437-src.tar.xz \
+                    rmd160  fbc490e1e7040df177da9bb2136578c2bd84ca71 \
+                    sha256  eb0ef2fca71ac578ca9821b000067e2eee43e5f4db6f7e31699801e06f2041a6
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-pstricks/Portfile
+++ b/tex/texlive-pstricks/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-pstricks
-version             44408
+version             47400
 revision            0
 
 categories          tex
@@ -13,19 +13,19 @@ license             Copyleft Permissive
 description         TeX Live: PSTricks
 long_description    PSTricks core and all add-on packages.
 
-checksums           texlive-pstricks-44408-run.tar.xz \
-                    rmd160  c650cbdf600b5127a43e0fefbf68dd4c026c933f \
-                    sha256  f86bceba3f24e374ae1f5555d4ec09b62040ddb36ca9f8ad2f745df6446f12a7 \
-                    texlive-pstricks-44408-doc.tar.xz \
-                    rmd160  e38143714b43a5673a5be3fbca2ac0d6155c6cd9 \
-                    sha256  b4e57011e41f3279558106f17db280194735d4962ad021c29afad7104d0230c6 \
-                    texlive-pstricks-44408-src.tar.xz \
-                    rmd160  957bcea5c73e14c10afe1b2e2a3bd6e055245479 \
-                    sha256  18fe2435a98f754f6dd28a4f42ab72b50e9a50c12cbb5eadfed6f544dd841281
+checksums           texlive-pstricks-47400-run.tar.xz \
+                    rmd160  4498508de9e184428a5ba06425fda3ffa60e7d63 \
+                    sha256  66a6c72507ab266572af4f08458cbf76b4294406f4ddba244a6870c979f29697 \
+                    texlive-pstricks-47400-doc.tar.xz \
+                    rmd160  c6478c9ecf5b7eef4fa309140e252f7664c53399 \
+                    sha256  3c98c284c5e388845f8519d9c9cf11620a3549f88c7f1655de04b33b36e2cd13 \
+                    texlive-pstricks-47400-src.tar.xz \
+                    rmd160  0c9307409d73a096fd2e80c21404d96ef6f23560 \
+                    sha256  cb3bd23802f9c6fb6a7fdcb29d584a841c74dae1e62610c77ebadc00c3b5a33a
 
 depends_lib         port:texlive-basic port:texlive-plain-generic
 
-texlive.binaries    pedigree pst2pdf
+texlive.binaries    pedigree ps4pdf pst2pdf
 
 
 texlive.texmfport

--- a/tex/texlive-publishers/Portfile
+++ b/tex/texlive-publishers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-publishers
-version             44368
+version             47411
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: Publisher styles, theses, etc.
 long_description    Publisher styles, theses, etc.
 
-checksums           texlive-publishers-44368-run.tar.xz \
-                    rmd160  d2b70bc2c4f10e8bc3aabc4e2d78b13a4bbe5b1d \
-                    sha256  23180efc09fae33b3c2a816ebac1bb1bf2a6adf64405bc1fb8f6c491ca979e49 \
-                    texlive-publishers-44368-doc.tar.xz \
-                    rmd160  b91c20fea305a154c8037bcaf75bc13c078954ec \
-                    sha256  c8a1555a5cd9f78cac1e48de4efcdbd304730d99138988b86b248bd7c388d272 \
-                    texlive-publishers-44368-src.tar.xz \
-                    rmd160  2698eed24dfbe306c3e17a919099545e26c3e893 \
-                    sha256  a1fc98a27976c227790fdbc2cecd0c3184992476cd06dcf0c8985bc836a7cd77
+checksums           texlive-publishers-47411-run.tar.xz \
+                    rmd160  2b10ed7bb0c05c959dfe24074234df46dfcbfb7a \
+                    sha256  c02978a2b9b66a2b95fadc3c0b2217c383a4f5814d60066a49a1e1e5f1c36344 \
+                    texlive-publishers-47411-doc.tar.xz \
+                    rmd160  068aeb31acdc76994d3a332a05c67b08ec32f17b \
+                    sha256  7c1d86601a7edca8c633be93c427c1b1c0b091b7c7a8ffcefd33922bb24fb046 \
+                    texlive-publishers-47411-src.tar.xz \
+                    rmd160  501d75709ebe084c55a697c0b1a722143414c852 \
+                    sha256  707d69f04b9bcd8c7bb590f9c2d6d3befcae7107eacfc62a907001a24d42b8d6
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-xetex/Portfile
+++ b/tex/texlive-xetex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-xetex
-version             44370
+version             47362
 revision            0
 
 categories          tex
@@ -13,15 +13,15 @@ license             Copyleft Permissive
 description         TeX Live: XeTeX and packages
 long_description    Packages for XeTeX, the Unicode/OpenType-enabled TeX by Jonathan Kew, http://tug.org/xetex.
 
-checksums           texlive-xetex-44370-run.tar.xz \
-                    rmd160  9f899efe6bc6115f065a3f075dc9e4c5b8422350 \
-                    sha256  fe8a0a91f25af826ee6617b79d3b7ae6bd0fd268e04c47f824e15fafd85a339b \
-                    texlive-xetex-44370-doc.tar.xz \
-                    rmd160  baa6c4c8cd2ca8d2a3f701a7232d8c4ba4c41623 \
-                    sha256  bde0928faa7cbf502a90ebfdf5f289f3e64c289c509bf783bd24421a0d4afb62 \
-                    texlive-xetex-44370-src.tar.xz \
-                    rmd160  d07241afa7f2019280ba6e4b9c7d0398e8f5cdc3 \
-                    sha256  92a422fd36a10c97e7294e60d2ed4aaea522f4f56a7846620f96af596d426447
+checksums           texlive-xetex-47362-run.tar.xz \
+                    rmd160  304e2711577e80b9f4fb5b0d593c907b53552066 \
+                    sha256  6eb91de236c39fc8efddc7c535979548988bba35f96f9b45b00ddf64d3593395 \
+                    texlive-xetex-47362-doc.tar.xz \
+                    rmd160  a62b48569fd74eef930427e04292e6be581abf9d \
+                    sha256  84d571bc50574599c42b39741f1dc152bf7e184bb7e4d8f4f0b0b47cdd5b93d5 \
+                    texlive-xetex-47362-src.tar.xz \
+                    rmd160  29c55b87de93cd667e89d6702640104b5f34934f \
+                    sha256  ee072d604fd22038d36c497623d12aeffe892e59a26d62fdb3f87b9f1e8b0eed
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive/Portfile
+++ b/tex/texlive/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       texlive 1.0
 
 name            texlive
-version         2017
+version         2018
 
 categories      tex
 maintainers     {dports @drkp}


### PR DESCRIPTION
#### Description

This PR is to track the update to the 2018 release of TeX Live. See also https://trac.macports.org/ticket/56386

WIP, but I am posting the PR in case anyone wants to test or comment on it. 

Known issues at the moment:
 - Does not build with MacPorts poppler, so texlive-bin is currently using its own newer in-tree version of poppler. See https://trac.macports.org/ticket/54808
 - registry_deactivate hacks still need to be added for a conflict-free upgrade
