### PR TITLE
libfilezilla: fix errors reported by `port lint`

### DIFF
--- a/devel/libfilezilla/Portfile
+++ b/devel/libfilezilla/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                libfilezilla
 version             0.12.2


### PR DESCRIPTION
#### Description

Fix lint errors reported in https://github.com/macports/macports-ports/pull/1754#issuecomment-387153908

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?