### PR TITLE
python27: Use valid compiler in _sysconfigdata.py

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -7,6 +7,7 @@ name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
 version             2.7.15
+revision            1
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -113,6 +114,10 @@ platform darwin {
         file rename -force ${buildlibdir}/_sysconfigdata.py.new \
             ${buildlibdir}/_sysconfigdata.py
 
+        # replace the compilers used at build time with placeholders
+        reinplace -E "s|(': ')[quotemeta ${configure.cxx}]|\\1@CXX@|g" ${buildlibdir}/_sysconfigdata.py
+        reinplace -E "s|(': ')[quotemeta ${configure.cc}]|\\1@CC@|g" ${buildlibdir}/_sysconfigdata.py
+
         # remove -arch flags from the config
         reinplace -E {s|-arch [a-z0-9_]+||g} \
             ${buildlibdir}/_sysconfigdata.py
@@ -138,6 +143,22 @@ platform darwin {
         # remove -arch flags from the config
         reinplace -E {s|-arch [a-z0-9_]+||g} \
             ${destroot}${framewdir}/lib/python${branch}/config/Makefile
+    }
+
+    post-activate {
+        # replace the placeholders with compilers available at install time
+        set cxx ${configure.cxx}
+        set cc ${configure.cc}
+        if {${os.major} == 10} {
+            if {${cxx} eq "/usr/bin/clang++"} {
+                set cxx /usr/bin/llvm-g++-4.2
+            }
+            if {${cc} eq "/usr/bin/clang"} {
+                set cc /usr/bin/llvm-gcc-4.2
+            }
+        }
+        reinplace "s|@CXX@|${cxx}|g" ${framewdir}/lib/python${branch}/_sysconfigdata.py
+        reinplace "s|@CC@|${cc}|g" ${framewdir}/lib/python${branch}/_sysconfigdata.py
     }
 }
 


### PR DESCRIPTION
#### Description

See https://trac.macports.org/ticket/56458. If this fix is acceptable, I'll update the PR with this fix for the other affected python versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- [skip notification] -->