### PR TITLE
pidof: Do not force install.user to be root

### DIFF
--- a/sysutils/pidof/files/patch-Makefile.diff
+++ b/sysutils/pidof/files/patch-Makefile.diff
@@ -14,8 +14,8 @@
  install:
 -	install -s -o root -g wheel -m 755 pidof ${DESTDIR}/bin
 -	install -o root -g wheel -m 644 pidof.1 ${DESTDIR}/share/man/man1
-+	install -s -o root -g wheel -m 755 pidof ${DESTDIR}${PREFIX}/bin
-+	install -o root -g wheel -m 644 pidof.1 ${DESTDIR}${PREFIX}/share/man/man1
++	install -s -m 755 pidof ${DESTDIR}${PREFIX}/bin
++	install -m 644 pidof.1 ${DESTDIR}${PREFIX}/share/man/man1
  
 -uninstall:
 -	/bin/rm ${DESTDIR}/bin/pidof


### PR DESCRIPTION
No revbump because port either build correctly or not at all

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->