### PR TITLE
libressl-devel: update to 2.7.3

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libressl-devel
-version             2.7.2
+version             2.7.3
 distname            libressl-${version}
 
 categories          security devel
@@ -23,8 +23,8 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160 71b2479da15af6800dc0bd18141e3fe211e96828 \
-                    sha256 917a8779c342177ff3751a2bf955d0262d1d8916a4b408930c45cef326700995
+checksums           rmd160 54394d02692a63ec51445a7ea7eab37dabe931f5 \
+                    sha256 16c70d8fe1de6e9bedea0d67804b55f3894717693a05ed45e15e0e2f939c2795
 
 patchfiles \
     openssldir-cert.pem.patch


### PR DESCRIPTION
This is a bugfix release following 2.7.2
https://github.com/libressl-portable/portable/blob/master/ChangeLog

- [x] bugfix
- [ ] enhancement
- [x] security fix

Tested on MacOS 10.13.4

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
