### PR TITLE
py-qtpy: update to 1.4.2, add size

### DIFF
--- a/python/py-qtpy/Portfile
+++ b/python/py-qtpy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        spyder-ide qtpy 1.4.0 v
+github.setup        spyder-ide qtpy 1.4.2 v
 name                py-qtpy
 
 categories-append   devel
@@ -22,9 +22,9 @@ long_description    QtPy (pronounced 'cutie pie') is a small abstraction layer \
                     PyQt5 layout (where the QtGui module has been split into \
                     QtGui and QtWidgets).
 
-checksums \
-    rmd160  d47b6256dd9845b7f687c4dbe7bd9a16f9e8a76a \
-    sha256  80273cdf1e9cd6fe8895902869b42d0c935817ff197be90109afdfd6bd00c24a
+checksums           rmd160  f78a886f80e228954224ff189283a30edc27aa8a \
+                    sha256  51f35b923f4b89824587e030032b0600ac65f825ee4f00085e5ca0e8a5efe5d6 \
+                    size    29520
 
 python.versions     27 34 35 36
 


### PR DESCRIPTION
#### Description
- update to version 1.4.2
- add size to checksums

For me this fixes a crash upon startup of py36-spyder-devel. I must admit that from the upstream Changelog it is not clear to me why this exactly fixes the problem or where it originates from to start with... 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3 9E145
Python 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
