### PR TITLE
rust: update to 1.26.0

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           active_variants 1.1
 
 name                rust
-version             1.25.0
+version             1.26.0
 categories          lang devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -25,9 +25,9 @@ long_description    Rust is a curly-brace, block-structured expression \
 
 homepage            https://www.rust-lang.org/
 
-set ruststd_version 1.24.0
-set rustc_version   1.24.0
-set cargo_version   0.25.0
+set ruststd_version 1.25.0
+set rustc_version   1.25.0
+set cargo_version   0.26.0
 set llvm_version    6.0
 
 # can use cmake or cmake-devel; default to cmake.
@@ -66,37 +66,37 @@ foreach arch ${architectures} {
 }
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  5176d728e189332e6dc3da389aa9938a0be911d9 \
-                    sha256  eef63a0aeea5147930a366aee78cbde248bb6e5c6868801bdf34849152965d2d \
-                    size    98639156
+                    rmd160  5f7c7180496cdc5dd1c694bba2fa4fce236e708e \
+                    sha256  4fb09bc4e233b71dcbe08a37a3f38cabc32219745ec6a628b18a55a1232281dd \
+                    size    95383826
 
 checksums-append \
                     rust-std-${ruststd_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  7d6d13d80c8ec7764cc1c869b5477d20a0502124 \
-                    sha256  bdce37eefb2183862bed3e3456d35329a6751b3ee660c66c92bb87fbeb296a7e \
-                    size 73787428 \
+                    rmd160  9e6a5e8f4c34ad24c2bd16c045d7090efffb37e9 \
+                    sha256  ef58976acd7d97f3d7d2832553a9b63e29bed6ccb68783e90c8a3de98b1ab6be \
+                    size 48237324 \
                     rustc-${rustc_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  613ab07442dcd8de96eabf3bd3e0635176784a82 \
-                    sha256  9f00040da32975aa7c6a136a4557e7429c71133b5471ee14c5f7ea448a57da66 \
-                    size 51197331 \
+                    rmd160  a6646bf8ad40ec8a79c196d26c06fd58dd3bb8d1 \
+                    sha256  287d2b73d909791faa93e172835bfcdfd6faa3e8b1688dd2f393ffff289eb978 \
+                    size 61033359 \
                     cargo-${cargo_version}-i686-apple-${os.platform}${extract.suffix} \
-                    rmd160  aa221ec6398d3f8a9e84d50753ec90caaff1dac5 \
-                    sha256  9182e535d51e0fd869216f3e6a0a4c5c19bceec6ee816a1fd7abbf16096ee0e2 \
-                    size    3863660
+                    rmd160  cab4400acf6b2df6b9f2efdcba858deb0b92923c \
+                    sha256  4126e65d47cc80c6ddf1d1f525bb312388d23918f62fc73ed85a3754e3ef3529 \
+                    size    3619348
 
 checksums-append \
                     rust-std-${ruststd_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  66ecaff563916f963a95bbba80c8cee394d9714b \
-                    sha256  f51274e3dfb20609dff61433bd723927540fc85681cdf940e27807b535d7d42f \
-                    size 74527364 \
+                    rmd160  7bbdc0a38598f90db874ffad298e2b05ceb0af6c \
+                    sha256  cfaae3e7a1fed1345fef8702380b0090af7d7821b705da3117d9e28ee13310cf \
+                    size 49382071 \
                     rustc-${rustc_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  cf168ff5d15d348c8ce353b72c6eccf86cbc9d95 \
-                    sha256  29099098de7057c8a68ea9a156580533654d9362105592cddd7e2a2a6b5f39f9 \
-                    size 52091244 \
+                    rmd160  86b82b93b46f38fc166a5c73558f7d53ae4e4179 \
+                    sha256  ff8b144aeb4407bb9c405291f96fdce2a7a57fd7e712f8560418239e762a3595 \
+                    size 62274937 \
                     cargo-${cargo_version}-x86_64-apple-${os.platform}${extract.suffix} \
-                    rmd160  b1cb1d07219b9d7070f252fbddf563c11a156a26 \
-                    sha256  5b441397347318697399c034e3c01fcbe1ba8025d243d6d990574cc33f83f6f8 \
-                    size    4142582
+                    rmd160  ab89d35abe25d66f00b3490d6e40cd47c2c8b6cb \
+                    sha256  cab6adf58e9dea7ac217b1882312eff3487005cf32dcde099327669aac6e37de \
+                    size    3941366
 
 pre-fetch {
     if {${os.platform} eq "darwin" && ${os.major} < 11} {


### PR DESCRIPTION
#### Description
~~Will test install tomorrow.~~
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
