### PR TITLE
Add GitHub handle randomphrase to maintainers

### DIFF
--- a/python/py-appscript/Portfile
+++ b/python/py-appscript/Portfile
@@ -9,7 +9,7 @@ version             1.0.1
 categories          python
 platforms           darwin
 license             public-domain
-maintainers         internode.on.net:arsptr
+maintainers         {internode.on.net:arsptr @randomphrase}
 description         High-level application scripting package for Python
 long_description    Appscript is a high-level, user-friendly MacPython to \
                     Apple event bridge that allows you to control scriptable \

--- a/python/py-xattr/Portfile
+++ b/python/py-xattr/Portfile
@@ -7,7 +7,7 @@ name                py-xattr
 version             0.8.0
 license             {MIT PSF}
 platforms           darwin linux
-maintainers         optusnet.com.au:arsptr openmaintainer
+maintainers         {internode.on.net:arsptr @randomphrase} openmaintainer
 description         Python wrapper for extended filesystem attributes
 long_description    xattr is a Python wrapper for Darwin, Linux, and FreeBSD \
                     extended filesystem attributes. Extended attributes \

--- a/ruby/rb-flexmock/Portfile
+++ b/ruby/rb-flexmock/Portfile
@@ -7,7 +7,7 @@ ruby.setup			flexmock 0.8.11 basic_install.rb {}
 
 categories-append	devel
 platforms			darwin
-maintainers			internode.on.net:arsptr
+maintainers			{internode.on.net:arsptr @randomphrase}
 
 description			FlexMock is a flexible mocking library for use in unit testing and behavior specification.
 long_description	FlexMock is a flexible mocking library for use in unit testing and behavior specification. \

--- a/ruby/rb-mocha/Portfile
+++ b/ruby/rb-mocha/Portfile
@@ -5,7 +5,7 @@ ruby.setup          mocha 0.9.12 gem {} rubygems
 
 homepage			http://gofreerange.com/mocha/docs
 
-maintainers			internode.on.net:arsptr
+maintainers			{internode.on.net:arsptr @randomphrase}
 platforms			darwin
 categories-append	devel
 

--- a/ruby/rb-ruby-debug-base/Portfile
+++ b/ruby/rb-ruby-debug-base/Portfile
@@ -7,7 +7,7 @@ ruby.setup        ruby-debug-base 0.9.3 gem {} rubygems
 
 platforms         darwin
 categories-append devel
-maintainers       internode.on.net:arsptr
+maintainers       {internode.on.net:arsptr @randomphrase}
 
 description       Ruby debugger base core C API
 

--- a/ruby/rb-ruby-debug/Portfile
+++ b/ruby/rb-ruby-debug/Portfile
@@ -7,7 +7,7 @@ ruby.setup        ruby-debug 0.9.3 gem {} rubygems
 
 platforms         darwin
 categories-append devel
-maintainers       internode.on.net:arsptr
+maintainers       {internode.on.net:arsptr @randomphrase}
 
 depends_lib-append port:rb-ruby-debug-base
 


### PR DESCRIPTION
#### Description

Add GitHub handle @randomphrase to maintainers.

I also updated the email address listed for py-xattr to match [changes made to your other ports](https://trac.macports.org/ticket/9037#comment:2) 12 years ago.

I notice your GitHub profile shows a different email address. If you'd rather use that email address for your ports as well, I'll be happy to update the PR to make that change, just let me know.

If you no longer wish to maintain these ports, let me know and I'll change the ports to `nomaintainer`.

<!-- [skip notification] -->