### PR TITLE
Clear distfiles/patchfiles

### DIFF
--- a/databases/postgresql80-server/Portfile
+++ b/databases/postgresql80-server/Portfile
@@ -14,9 +14,7 @@ master_sites	postgresql
 
 depends_run		port:postgresql80
 
-fetch	{}
-checksum	{}
-extract	{}
+distfiles
 use_configure	no
 build	{}
 

--- a/databases/postgresql81-server/Portfile
+++ b/databases/postgresql81-server/Portfile
@@ -14,9 +14,7 @@ master_sites	postgresql
 
 depends_run		port:postgresql81
 
-fetch	{}
-checksum	{}
-extract	{}
+distfiles
 use_configure	no
 build	{}
 

--- a/databases/postgresql82-server/Portfile
+++ b/databases/postgresql82-server/Portfile
@@ -16,9 +16,7 @@ master_sites		postgresql
 
 depends_run		port:postgresql82
 
-fetch	{}
-checksum	{}
-extract	{}
+distfiles
 use_configure	no
 build	{}
 

--- a/databases/postgresql83-server/Portfile
+++ b/databases/postgresql83-server/Portfile
@@ -16,9 +16,7 @@ master_sites		postgresql
 
 depends_run		port:postgresql83
 
-fetch	{}
-checksum	{}
-extract	{}
+distfiles
 use_configure	no
 build	{}
 

--- a/devel/dbus-python/Portfile
+++ b/devel/dbus-python/Portfile
@@ -24,11 +24,11 @@ homepage        https://www.freedesktop.org/wiki/Software/dbus/
 if {${name} eq ${subport}} {
     # set up dbus-python as a stub port that depends on the default dbus-pythonXY
     distfiles
+    patchfiles
     supported_archs noarch
 
     depends_lib port:${name}${python_default_version}
 
-    patch {}
     use_configure no
     build {}
     destroot {

--- a/devel/haskell-platform/Portfile
+++ b/devel/haskell-platform/Portfile
@@ -27,9 +27,7 @@ if {$subport == $name} {
 
     depends_run     port:ghc
 
-    fetch {}
-    checksum {}
-    extract {}
+    distfiles
     use_configure   no
     build {}
     destroot {

--- a/devel/qscintilla/Portfile
+++ b/devel/qscintilla/Portfile
@@ -94,12 +94,10 @@ foreach qt_major {4 5} {
     subport py-${name}-qt${qt_major} {
         categories-append python
         use_configure no
-        fetch {}
-        checksum {}
-        extract {}
+        distfiles
+        patchfiles
         supported_archs noarch
         depends_lib port:py27-qscintilla-qt${qt_major}
-        patch {}
         build {}
         destroot {
             xinstall -d -m 755 ${destroot}${prefix}/share/doc/${subport}
@@ -178,12 +176,10 @@ foreach qt_major {4 5} {
 if {${subport} eq ${name}} {
     revision 1
 
+    distfiles
+    patchfiles
     use_configure no
-    fetch {}
-    checksum {}
-    extract {}
     supported_archs noarch
-    patch {}
     build {}
     destroot {
         xinstall -d -m 755 ${destroot}${prefix}/share/doc/${subport}

--- a/editors/abiword/Portfile
+++ b/editors/abiword/Portfile
@@ -39,7 +39,7 @@ variant use_binary conflicts use_source {
 		file mkdir /tmp/${name}-${version}
 		system "hdiutil attach ${workpath}/${distname}.dmg -private -nobrowse -mountpoint /tmp/${name}-${version}"
 	}
-	patch {}
+	patchfiles
 	use_configure	no
 	build {}
 	destroot {

--- a/kde/qtcurve/Portfile
+++ b/kde/qtcurve/Portfile
@@ -99,9 +99,8 @@ subport ${name}-extra {
     installs_libs           no
     supported_archs         noarch
     depends_run-append      port:ciment-icons
-    fetch {}
-    checksum {}
-    extract {}
+    fetch.type              standard
+    distfiles
     build {}
     destroot {
         xinstall -m 755 -d ${destroot}/${prefix}/share/apps/kstyle/themes

--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -163,7 +163,6 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
     }
 } else {
     distfiles
-    fetch {}
     build {}
     destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${name}

--- a/multimedia/mythtv-pkg.27/Portfile
+++ b/multimedia/mythtv-pkg.27/Portfile
@@ -26,9 +26,7 @@ depends_run         port:mariadb-server port:mythtv-core.27 port:mythweb.27 \
 
 universal_variant   no
 
-fetch {}
-checksum {}
-extract {}
+distfiles
 use_configure no
 build {}
 

--- a/science/geant4/Portfile
+++ b/science/geant4/Portfile
@@ -419,10 +419,8 @@ if {$subport eq $name} {
     # other users should install geant4.10.x directly
     depends_lib   port:geant${version}
 
-    fetch         {}
-    checksum      {}
-    extract       {}
-    patch         {}
+    distfiles
+    patchfiles
     use_configure no
     build         {}
     destroot {

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -389,9 +389,9 @@ pre-built packages for ${subport} by running:
 } else {
     depends_lib-append      port:$name-default
     distfiles
+    patchfiles
     supported_archs         noarch
     use_configure           no
-    patch {}
     build {}
     destroot {
         set docdir          ${destroot}${prefix}/share/doc/${name}

--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -320,9 +320,9 @@ you execute 'mpicc' etc.) please run:
 } else {
     depends_lib-append      port:$name-default
     distfiles
+    patchfiles
     supported_archs         noarch
     use_configure           no
-    patch {}
     build {}
     destroot {
         set docdir          ${destroot}${prefix}/share/doc/${name}

--- a/security/qtkeychain/Portfile
+++ b/security/qtkeychain/Portfile
@@ -44,12 +44,10 @@ foreach qt_major {4 5} {
 
 if {${subport} eq ${name}} {
     revision 2
+    distfiles
+    patchfiles
     use_configure no
-    fetch {}
-    checksum {}
-    extract {}
     supported_archs noarch
-    patch {}
     build {}
     destroot {
         xinstall -d -m 755 ${destroot}${prefix}/share/doc/${subport}

--- a/sysutils/MacPorts_daemondo/Portfile
+++ b/sysutils/MacPorts_daemondo/Portfile
@@ -21,9 +21,7 @@ master_sites
 
 universal_variant   no
 
-fetch {}
-checksum {}
-extract {}
+distfiles
 use_configure no
 build {}
 


### PR DESCRIPTION
#### Description

Clear `distfiles`/`patchfiles` rather than overriding phases.

This should fix [fetch failures of our buildbot distfile mirroring job](https://build.macports.org/builders/jobs-mirror/builds/15624).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
