### PR TITLE
meld: upgrade to new app PG features, and update to 3.18.1

### DIFF
--- a/textproc/meld/Portfile
+++ b/textproc/meld/Portfile
@@ -6,9 +6,7 @@ PortGroup               app 1.0
 PortGroup               active_variants 1.1
 
 name                    meld
-version                 3.18.0
-# FIXME: remember to remove revision at next updade!
-revision                1
+version                 3.18.1
 categories              textproc devel
 license                 GPL-2+
 platforms               darwin
@@ -26,8 +24,9 @@ long_description        Meld is a visual diff and merge tool. You can compare \
 master_sites            gnome:sources/${name}/[join [lrange [split $version .] 0 1] .]
 use_xz                  yes
 
-checksums               rmd160  04a24763fd112b787824145cd18eff48faeb63bc \
-                        sha256  848158b1e5c7473b9da3ddc16e057aad8951ec82979beb5914b8b4acdf97223e
+checksums               rmd160  92e0d17b0b60843a8f7de72d4923a5287e76489e \
+                        sha256  3af68caeab5f38e82de66567346722db47ed6a6fa6d9d595de4ae7e15c88e879 \
+                        size    563516
 
 python.versions         36
 python.default_version  36

--- a/textproc/meld/Portfile
+++ b/textproc/meld/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               app 1.0
+PortGroup               active_variants 1.1
 
 name                    meld
 version                 3.18.0
@@ -65,5 +66,17 @@ variant help description {Meld user manual (requires yelp)} {
 }
 
 app.icon                data/icons/hicolor/scalable/apps/meld.svg
+app.use_launch_script   yes
 
-app.executable          "${prefix}/bin/meld"
+variant x11 conflicts quartz {
+   require_active_variants gtk3 x11 quartz
+   app.hide_dock_icon      yes
+}
+
+variant quartz conflicts x11 {
+   require_active_variants gtk3 quartz x11
+}
+
+if {![variant_isset quartz]} {
+    default_variants-append +x11
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->


This is the first port I'll try updating to the new app PG features. I added a separate commit to upgrade the port as well, to force a rebuild / reinstall.

It fixes the app launch on some systems that error out with the "-p" flag sent (like mine), by using the launch script option.

It hides the dock icon with the x11 build to prevent it bouncing forever. 

It defaults to x11 because that's what gtk2 and gtk3 do. That might cause some issue if the user previously had `meld` installed without any variants (as there were none before), and wants `+quartz`. Any way around this?

Looking for opinions on this style, what errors might there there be in this logic, and the usual eyeballs on the process, esp @ryandesign .

I don't see how to make this much simpler. I had wondered if some of this might be put into the app PG itself, but I guess not.

If this one works out, I'd like to do pan2, and then others if everyone likes this...