### PR TITLE
Clear extract.only

### DIFF
--- a/devel/cl-ppcre/Portfile
+++ b/devel/cl-ppcre/Portfile
@@ -32,8 +32,7 @@ variant sbcl description {Compile using Steel Bank Common Lisp} {
         depends_build port:sbcl
 }
 
-
-extract   {}
+extract.only
 use_configure       no
 build     {}
 

--- a/java/lucene-gosen2/Portfile
+++ b/java/lucene-gosen2/Portfile
@@ -27,7 +27,7 @@ variant naist description {Use naist chasen dictionary instead of ipadic} {
                     sha256  4a235bde351a6eb7148f26e5f0c8df5dee94b649383c7246f4b47376a1bf0431
 }
 
-extract {}
+extract.only
 
 use_configure       no
 supported_archs     noarch

--- a/java/lucene-gosen4/Portfile
+++ b/java/lucene-gosen4/Portfile
@@ -27,7 +27,7 @@ variant naist description {Use naist chasen dictionary instead of ipadic} {
                     sha256  6478117cfdc1aecde6ea7683ee75191fb375b36db24f1811aed654ee8500ed25
 }
 
-extract {}
+extract.only
 
 use_configure       no
 supported_archs     noarch

--- a/python/py-tensorboard/Portfile
+++ b/python/py-tensorboard/Portfile
@@ -33,9 +33,7 @@ if {${python.version} < 30} {
 }
 
 extract.suffix      .whl
-
-extract {
-}
+extract.only
 
 python.versions     27 35 36
 

--- a/python/py-tensorflow-tensorboard/Portfile
+++ b/python/py-tensorflow-tensorboard/Portfile
@@ -33,9 +33,7 @@ if {${python.version} < 30} {
 }
 
 extract.suffix      .whl
-
-extract {
-}
+extract.only
 
 python.versions     27 35 36
 

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -38,9 +38,7 @@ if {${python.version} eq 27} {
 distname            tensorflow-1.4.1-cp${python.version}-cp${python.version}m-macosx_10_11_x86_64
 
 extract.suffix      .whl
-
-extract {
-}
+extract.only
 
 python.versions     27 35 36
 

--- a/sysutils/ccal/Portfile
+++ b/sysutils/ccal/Portfile
@@ -18,7 +18,7 @@ master_sites        http://web.archive.org/web/20050926034036/www.jamiehillman.c
 checksums           md5 d7318e1383ac4856f1294e6de0954e3f
 use_configure       no
 
-extract     {}
+extract.only
 build       {}
 destroot    {
         xinstall -m 755 -c ${distpath}/${distname}${extract.suffix} \


### PR DESCRIPTION
#### Description

Clear `extract.only` rather than overriding the extract phase.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
