### PR TITLE
Use use_configure no

### DIFF
--- a/audio/etree-scripts/Portfile
+++ b/audio/etree-scripts/Portfile
@@ -16,6 +16,6 @@ worksrcdir	${name}
 depends_lib	bin:shorten:shorten bin:shntool:shntool bin:flac:flac \
 		bin:lame:lame
 
-configure	{}
+use_configure	no
 build		{}
 destroot.destdir	prefix=${destroot}${prefix}

--- a/devel/haskell-platform/Portfile
+++ b/devel/haskell-platform/Portfile
@@ -30,15 +30,12 @@ if {$subport == $name} {
     fetch {}
     checksum {}
     extract {}
-    configure {}
+    use_configure   no
     build {}
     destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${name}
         system "echo ${long_description} > ${destroot}${prefix}/share/doc/${name}/README.txt"
     }
-
-    use_configure       no
-    universal_variant   no
 
     livecheck.type      regex
     livecheck.url       ${homepage}

--- a/devel/opendx-java40/Portfile
+++ b/devel/opendx-java40/Portfile
@@ -22,7 +22,7 @@ checksums	md5 7b7601d1339f852de69a87a2028448d2
 
 distname	netscape-java40
 
-configure	{ }
+use_configure	no
 build		{ }
 destroot	{
 		  set java_share_dir ${destroot}${prefix}/share/java

--- a/net/ttcp/Portfile
+++ b/net/ttcp/Portfile
@@ -25,7 +25,7 @@ extract.cmd		cp
 extract.pre_args	{}
 extract.post_args	${worksrcdir}
 
-configure	{}
+use_configure	no
 build {
 	system "cd \"${worksrcpath}\" && cc -o ttcp ttcp.c"
 }

--- a/news/nnap/Portfile
+++ b/news/nnap/Portfile
@@ -14,7 +14,7 @@ distname	${name}
 extract.suffix	.c
 checksums	md5 ea48d42df822cdcc566549638681f4e4
 extract	{	system "cp ${distpath}/${name}.c ${workpath}/nnap.c" }
-configure	{}
+use_configure	no
 build	{	system "cd ${workpath} && \
 			cc -o ${name} ${name}.c" }
 destroot {	system "cd ${workpath} && \

--- a/science/hdf5-lz4-plugin/Portfile
+++ b/science/hdf5-lz4-plugin/Portfile
@@ -45,8 +45,7 @@ post-patch {
     reinplace "s^%%PREFIX%%^${prefix}^" Makefile
 }
 
-configure {
-}
+use_configure       no
 
 build.target        lib
 build.env-append    CC="${configure.cc}"

--- a/security/logsentry/Portfile
+++ b/security/logsentry/Portfile
@@ -22,7 +22,7 @@ master_sites        sourceforge:sentrytools
 platforms           darwin
 checksums           md5 e97c2f096e219e20310c1b80e9e1bc29
 
-configure {}
+use_configure       no
 build.target        build
 
 patchfiles          patch-Makefile

--- a/security/portsentry/Portfile
+++ b/security/portsentry/Portfile
@@ -20,7 +20,8 @@ master_sites      \
                   sourceforge:sentrytools
 platforms         darwin 
 checksums         md5 782839446b7eca554bb1880ef0882670
-configure { }
+
+use_configure     no
 build.target      generic
 
 ## 1.2 beta from sf.net doesn't compile

--- a/textproc/html/Portfile
+++ b/textproc/html/Portfile
@@ -21,7 +21,7 @@ checksums	md5 57a45bf82f0a3694d59d889b0d0ad71c \
 
 depends_run	bin:mkcatalog:mkcatalog
 
-configure	{}
+use_configure	no
 build		{}
 
 set instdir	share/sgml/html

--- a/textproc/rfksay/Portfile
+++ b/textproc/rfksay/Portfile
@@ -10,7 +10,7 @@ long_description    ${description}
 homepage    	http://freebsdcluster.org/~mich/software/
 master_sites	http://freebsdcluster.org/~mich/software/
 checksums	md5 df98afcc309dd8e590b830dec51b36c1
-configure	{}
+use_configure	no
 build		{}
 destroot	{ file mkdir ${destroot}${prefix}/bin
 		  system "cd $workpath && 

--- a/x11/mplus-fonts/Portfile
+++ b/x11/mplus-fonts/Portfile
@@ -20,7 +20,7 @@ depends_lib		bin:mkfontdir:mkfontdir
 patchfiles 		patch-install_mplus_fonts.diff
 set fontsdir	/share/fonts
 set docs		{LICENSE_E LICENSE_J README_E README_J}
-configure		{}
+use_configure		no
 build.cmd		${worksrcpath}/install_mplus_fonts
 build.target
 destroot		{xinstall -d -m 755 \


### PR DESCRIPTION
#### Description

Use `use_configure no` rather than overriding the configure phase.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
