### PR TITLE
dmd family: fix makefile variables

### DIFF
--- a/lang/dmd/Portfile
+++ b/lang/dmd/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
 github.setup        dlang dmd 2.080.0 v
+revision            1
 categories          lang
 platforms           darwin
 license             Boost-1
@@ -24,6 +25,8 @@ post-patch {
 
 use_configure       no
 
+patchfiles          patch-posix.mak.diff
+
 depends_build-append          port:dmd-bootstrap
 depends_skip_archcheck-append dmd-bootstrap
 
@@ -39,6 +42,7 @@ post-extract {
 # Another solution would be the use of override directive in posix.mak.
 build.args          -f posix.mak all man \
                     HOST_CXX="${configure.cxx}" \
+                    CC="${configure.cc}" \
                     LDFLAGS="${configure.ldflags} -framework CoreServices" \
                     ENVP="MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}" \
                     SYSCONFDIR=${prefix}/etc/${name} \
@@ -47,17 +51,23 @@ build.args          -f posix.mak all man \
 if { ![variant_isset universal] } {
     if { ${build_arch} eq "x86_64" || ${build_arch} eq "ppc64" } {
         build.args-append MODEL=64
+        destroot.args-append MODEL=64
     } else {
         build.args-append MODEL=32
+        destroot.args-append MODEL=32
     }
 } else {
     lappend merger_build_args(x86_64) MODEL=64
     lappend merger_build_args(i386)   MODEL=32
     lappend merger_build_args(ppc64)  MODEL=64
     lappend merger_build_args(ppc)    MODEL=32
+    lappend merger_destroot_args(x86_64) MODEL=64
+    lappend merger_destroot_args(i386)   MODEL=32
+    lappend merger_destroot_args(ppc64)  MODEL=64
+    lappend merger_destroot_args(ppc)    MODEL=32
 }
 
-destroot.args \
+destroot.args-append \
     -f makefile_macports_install \
     PREFIX=${prefix}
 

--- a/lang/dmd/files/patch-posix.mak.diff
+++ b/lang/dmd/files/patch-posix.mak.diff
@@ -1,0 +1,13 @@
+--- src/posix.mak.orig	2018-05-01 06:42:29.000000000 -0700
++++ src/posix.mak	2018-05-12 12:03:12.000000000 -0700
+@@ -95,10 +95,6 @@
+ G = $(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
+ $(shell mkdir -p $G)
+ 
+-ifeq (osx,$(OS))
+-    export MACOSX_DEPLOYMENT_TARGET=10.9
+-endif
+-
+ HOST_CXX=c++
+ # compatibility with old behavior
+ ifneq ($(HOST_CC),)

--- a/lang/druntime/Portfile
+++ b/lang/druntime/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
 github.setup        dlang druntime 2.080.0 v
+revision            1
 categories          lang
 platforms           darwin
 license             Boost-1
@@ -23,11 +24,13 @@ checksums           rmd160  c37bb020454e0ee641262957dbbd49e825e63365 \
 
 depends_lib         port:dmd
 
+patchfiles          patch-posix.mak.diff
+
 use_configure       no
 
 build.args          -f posix.mak \
                     CC=${configure.cc} \
-                    CFLAGS=\"${configure.cflags}\" \
+                    MACPORTS_CFLAGS=\"${configure.cflags}\" \
                     DMD=${prefix}/bin/dmd \
                     DRUNTIME_BASE=${name} \
                     DMD_DIR=${prefix}/share/dmd

--- a/lang/druntime/files/patch-posix.mak.diff
+++ b/lang/druntime/files/patch-posix.mak.diff
@@ -1,0 +1,24 @@
+--- posix.mak.orig	2018-04-17 02:34:24.000000000 -0700
++++ posix.mak	2018-05-12 11:32:28.000000000 -0700
+@@ -49,7 +49,6 @@
+ ifeq (osx,$(OS))
+ 	DOTDLL:=.dylib
+ 	DOTLIB:=.a
+-	export MACOSX_DEPLOYMENT_TARGET=10.7
+ else
+ 	DOTDLL:=.so
+ 	DOTLIB:=.a
+@@ -66,12 +65,7 @@
+ DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
+ 
+ # Set CFLAGS
+-CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+-ifeq ($(BUILD),debug)
+-	CFLAGS += -g
+-else
+-	CFLAGS += -O3
+-endif
++CFLAGS=$(MACPORTS_CFLAGS) $(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+ ifeq (solaris,$(OS))
+ 	CFLAGS+=-D_REENTRANT  # for thread-safe errno
+ endif

--- a/lang/phobos/Portfile
+++ b/lang/phobos/Portfile
@@ -6,6 +6,7 @@ PortGroup           muniversal 1.0
 PortGroup           active_variants 1.1
 
 github.setup        dlang phobos 2.080.0 v
+revision            1
 categories          lang
 platforms           darwin
 license             Boost-1
@@ -21,7 +22,8 @@ checksums           rmd160  815bd89416b6aa91e65afa5c5108230c551e6718 \
 
 depends_lib         port:druntime
 
-patchfiles          patch-gzlib.c.diff
+patchfiles          patch-gzlib.c.diff \
+                    patch-posix.mak.diff
 
 use_configure       no
 
@@ -54,7 +56,7 @@ build.args          -f posix.mak \
                     DMD_DIR=${prefix}/share/dmd \
                     DRUNTIME_PATH=${prefix}/include/druntime \
                     CC=${configure.cc} \
-                    CFLAGS=\"${configure.cflags}\" \
+                    MACPORTS_CFLAGS=\"${configure.cflags}\" \
                     DMD=${prefix}/bin/dmd
 build.target        ""
 

--- a/lang/phobos/files/patch-posix.mak.diff
+++ b/lang/phobos/files/patch-posix.mak.diff
@@ -1,0 +1,27 @@
+--- posix.mak.orig	2018-04-30 07:38:51.000000000 -0700
++++ posix.mak	2018-05-12 11:48:28.000000000 -0700
+@@ -40,10 +40,6 @@
+ 
+ include $(DMD_DIR)/src/osmodel.mak
+ 
+-ifeq (osx,$(OS))
+-	export MACOSX_DEPLOYMENT_TARGET=10.7
+-endif
+-
+ # Default to a release build, override with BUILD=debug
+ ifeq (,$(BUILD))
+ BUILD_WAS_SPECIFIED=0
+@@ -112,12 +108,7 @@
+ endif
+ 
+ # Set CFLAGS
+-CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+-ifeq ($(BUILD),debug)
+-	CFLAGS += -g
+-else
+-	CFLAGS += -O3
+-endif
++CFLAGS=$(MACPORTS_CFLAGS) $(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H
+ 
+ # Set DFLAGS
+ DFLAGS=-conf= -I$(DRUNTIME_PATH)/import $(DMDEXTRAFLAGS) -w -de -dip25 $(MODEL_FLAG) $(PIC) -transition=complex


### PR DESCRIPTION
Set CC flag (UsingTheRightCompiler).
Do not set MACOSX_DEPLOYMENT_TARGET in makefiles.
Append to CFLAGS instead of replacing.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->