### PR TITLE
gdal: fix build on 10.7 and earlier

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -111,6 +111,13 @@ patchfiles          patch-gdalwarpkernel_opencl_h.diff \
                     patch-ogr_api_cpp.diff \
                     patch-scripts-GNUmakefile.diff
 
+# see https://trac.macports.org/ticket/55752
+platform darwin {
+    if {${os.major} < 12} {
+        patchfiles  MacTypes.diff
+    }
+}
+
 # for all platforms without C++11 support
 # this is just a suboptimal approximation (doesn't hold for gcc)
 if {${configure.cxx_stdlib} != "libc++"} {

--- a/gis/gdal/files/MacTypes.diff
+++ b/gis/gdal/files/MacTypes.diff
@@ -1,0 +1,13 @@
+diff --git ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
+index 58b759a..2c34f41 100644
+--- ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
++++ ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
+@@ -52,7 +52,7 @@ template <typename T> std::string to_string(T val)
+ #endif
+ 
+ #ifdef __APPLE__
+-    #include <MacTypes.h>
++    #include <CoreServices/../Frameworks/CarbonCore.framework/Headers/MacTypes.h>
+ #endif
+ 
+ #define UNKNOWN1 CADHeader::MAX_HEADER_CONSTANT + 1


### PR DESCRIPTION
MacTypes.h moved in 10.8+ to /usr/include
closes: https://trac.macports.org/ticket/55752

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
