### PR TITLE
grafx2: new port, version 2.5  (new Portfile)

### DIFF
--- a/graphics/grafx2/Portfile
+++ b/graphics/grafx2/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                grafx2
 version             2.5
 categories          graphics
-maintainers         @miniupnp
+maintainers         {@miniupnp free.fr:miniupnp} openmaintainer
 platforms           darwin
 license             GPL-2
 
@@ -26,6 +26,7 @@ use_bzip2           yes
 checksums           ${distname}.tar.bz2 \
                     sha256 cf634e0f1d94bc5131a4de4490d4bf07e2965d774687add2487a9fa0240aeb10 \
                     rmd160 692e8c871ade535db741bfff730cb74bc3398327 \
+                    size   1611643 \
                     recoil-4.2.0.tar.gz \
                     rmd160  84b3452624717ede3d001986129d65e94e099692 \
                     sha256  4e8c8e3048b143654da49cc1187a0b26679c9f97f841edc0ba9e0b2e2e7f18e5 \

--- a/graphics/grafx2/Portfile
+++ b/graphics/grafx2/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                grafx2
+version             2.5
+categories          graphics
+maintainers         @miniupnp
+platforms           darwin
+license             GPL-2
+
+description         The ultimate 256-color painting program
+long_description    GrafX2 is a bitmap paint program inspired by the Amiga programs \
+                    Deluxe Paint and Brilliance. Specialized in 256-color drawing, \
+                    it includes a very large number of tools and effects that make \
+                    it particularly suitable for pixel art, game graphics, and generally \
+                    any detailed graphics painted with a mouse.
+
+homepage            http://grafx2.chez.com/
+distname            ${name}-v${version}
+master_sites        https://gitlab.com/GrafX2/grafX2/-/archive/v${version}/::gfx2 \
+                    sourceforge:project/recoil/recoil/4.2.0:recoil
+distfiles           ${distname}.tar.bz2:gfx2 \
+                    recoil-4.2.0.tar.gz:recoil
+use_bzip2           yes
+checksums           ${distname}.tar.bz2 \
+                    sha256 cf634e0f1d94bc5131a4de4490d4bf07e2965d774687add2487a9fa0240aeb10 \
+                    rmd160 692e8c871ade535db741bfff730cb74bc3398327 \
+                    recoil-4.2.0.tar.gz \
+                    rmd160  84b3452624717ede3d001986129d65e94e099692 \
+                    sha256  4e8c8e3048b143654da49cc1187a0b26679c9f97f841edc0ba9e0b2e2e7f18e5 \
+                    size    431422
+fetch.ignore_sslcert    yes
+
+worksrcdir          grafX2-v${version}-60b5e5fd50acb01cbdc59f50e2c8f4b8786635c0
+
+depends_lib         port:libsdl \
+                    port:libsdl_ttf \
+                    port:libsdl_image \
+                    port:libpng \
+                    port:lua
+
+use_configure       no
+
+pre-build {
+    file mkdir ${worksrcpath}/3rdparty/archives
+    copy ${distpath}/recoil-4.2.0.tar.gz ${worksrcpath}/3rdparty/archives
+}
+
+destroot {
+    xinstall -d ${destroot}${applications_dir}
+    copy ${worksrcpath}/src/GrafX2.app ${destroot}${applications_dir}
+}

--- a/graphics/grafx2/Portfile
+++ b/graphics/grafx2/Portfile
@@ -43,10 +43,15 @@ depends_lib         port:libsdl \
 
 use_configure       no
 
+patch.pre_args      -p1
+patchfiles-append   grafx2_cc.patch
+
 pre-build {
     file mkdir ${worksrcpath}/3rdparty/archives
     copy ${distpath}/recoil-4.2.0.tar.gz ${worksrcpath}/3rdparty/archives
 }
+
+build.args-append   CC=${configure.cc} CXX=${configure.cxx} CPP=${configure.cpp}
 
 destroot {
     xinstall -d ${destroot}${applications_dir}

--- a/graphics/grafx2/files/grafx2_cc.patch
+++ b/graphics/grafx2/files/grafx2_cc.patch
@@ -1,0 +1,123 @@
+commit a016e21abcff0d554789b4f11587bad05465b051
+Author: Thomas BERNARD <miniupnp@free.fr>
+Date:   Mon May 14 22:47:36 2018 +0200
+
+    Default to CC=gcc but allow to define other values
+    
+    so it is possible to
+    > CC=clang make        (environment)
+    or
+    > make CC=gcc-5        (command-line)
+
+diff --git a/src/Makefile b/src/Makefile
+index 022200f..afdd108 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -64,6 +64,11 @@ TAR = tar
+ # Note : --transform option was added in GNU tar version 1.15.91
+ TARTRANSFORM = --strip=1 --transform 's,^,grafx2/,g'
+ 
++# default to gcc compiler
++ifeq (default,$(origin CC))
++  CC = gcc
++endif
++
+ # There is no uname under windows, but we can guess we are there with the COMSPEC env.var
+ # Windows specific
+ ifdef COMSPEC
+@@ -75,7 +80,6 @@ ifdef COMSPEC
+   COPT = -W -Wall -Wdeclaration-after-statement -O$(OPTIM) -g -ggdb `sdl-config --cflags` $(TTFCOPT) $(JOYCOPT) $(LUACOPT)
+   LOPT = `sdl-config --libs` -lSDL_image $(TTFLOPT) -lpng -lz $(LUALOPT)
+   LUALOPT = -llua
+-  CC = gcc
+   OBJDIR = ../obj/win32
+   # Resources (icon)
+   WINDRES = windres.exe
+@@ -98,7 +102,6 @@ else
+     BIN = ../bin/grafx2
+     COPT = -Wall -gstabs $(shell sdl-config --cflags) $(TTFCOPT)
+     LOPT = $(shell sdl-config --libs) -lSDL_image -lpng -ljpeg -lz $(TTFLOPT) -lft2
+-    CC = gcc
+     OBJDIR = ../obj/amiga
+     ZIP = lha
+     ZIPOPT = a
+@@ -198,7 +201,6 @@ endif
+     COPT += -DENABLE_FILENAMES_ICONV
+     LOPT += -liconv
+     # Use gcc for compiling. Use ncc to build a callgraph and analyze the code.
+-    CC = gcc
+     #CC = nccgen -ncgcc -ncld -ncfabs
+     OBJDIR = ../obj/macosx
+     PLATFORMOBJ = SDLMain.o
+@@ -215,7 +217,6 @@ endif
+     BIN = ../bin/grafx2
+     COPT = -Wall -g $(shell sdl-config --cflags) $(TTFCOPT)
+     LOPT = -lSDL_image $(shell sdl-config --libs) -lpng -ljpeg -lz $(TTFLOPT) -lfreetype2shared
+-    CC = gcc
+     OBJDIR = ../obj/aros
+     STRIP = strip --strip-unneeded --remove-section .comment
+     ZIP = lha
+@@ -231,7 +232,6 @@ endif
+     BIN = ../bin/grafx2
+     COPT = -Wall -gstabs $(shell sdl-config --cflags) $(TTFCOPT)
+     LOPT = -lSDL_image $(shell sdl-config --libs) -lpng -ljpeg -lz $(TTFLOPT)
+-    CC = gcc
+     OBJDIR = ../obj/morphos
+     ZIP = lha
+     ZIPOPT = a
+@@ -247,7 +247,6 @@ endif
+     BIN = ../bin/grafx2
+     COPT = -W -Wall -g $(shell sdl-config --cflags) $(TTFCOPT) -I/boot/home/config/include
+     LOPT = $(shell sdl-config --libs) -lSDL_image -lpng -ljpeg -lz $(TTFLOPT)
+-    CC = gcc
+     OBJDIR = ../obj/beos
+     ZIP = zip
+ 
+@@ -271,7 +270,6 @@ endif
+     COPT = -W -Wall -g $(shell sdl-config --cflags) $(TTFCOPT) -I/boot/common/include $(LUACOPT)
+     COPT += -DENABLE_FILENAMES_ICONV
+     LOPT = $(shell sdl-config --libs) -lSDL_image -lpng -ljpeg -lz $(TTFLOPT) -lfreetype -lbe $(LUALOPT) -liconv
+-    CC = gcc
+     #Append the gcc kind to the objdir (gcc2 or gcc4) to avoid conflicts when switching from one to other.
+     OBJKIND = $(shell gcc -dumpversion)
+     OBJDIR = ../obj/haiku/$(OBJKIND)
+@@ -287,7 +285,6 @@ endif
+     BIN = ../bin/grafx2
+     COPT = -W -Wall -Wdeclaration-after-statement -g $(shell sdl-config --cflags) $(TTFCOPT)
+     LOPT = $(shell sdl-config --libs) -lSDL_image -lpng -ljpeg -lz $(TTFLOPT)
+-    CC = gcc
+     OBJDIR = ../obj/skyos
+     ZIP = zip
+ 
+@@ -306,7 +303,6 @@ endif
+     OBJDIR = ../obj/unix
+     FCLOPT = -lfontconfig
+     COPT += -DUSE_FC
+-    CC = gcc
+   else
+   ifeq ($(PLATFORM),FreeMiNT) #10
+     #Atari FreeMiNT/TOS specific
+@@ -316,7 +312,6 @@ endif
+     CP = cp
+     ZIP = zip
+     PLATFORMFILES = ../share/grafx2/gfx2.png
+-    CC = gcc
+     BIN = ../bin/grafx2.ttp
+     LUALOPT = -llua
+     OBJDIR = ../obj/m68k-atari-mint
+@@ -341,7 +336,6 @@ endif
+     BIN = ../bin/grafx2
+     COPT = -W -Wall -Wdeclaration-after-statement -std=c99 -g `sdl-config --cflags` -I/resources/indexes/include/SDL $(TTFCOPT) $(LUACOPT) $(JOYCOPT) -O$(OPTIM)
+     LOPT = `sdl-config --libs` -lSDL_image $(TTFLOPT) -lpng -lz $(LUALOPT) -lm
+-    CC = gcc
+     OBJDIR = ../obj/syllable
+     FCLOPT = 
+   else
+@@ -460,7 +454,6 @@ endif
+         LOPT = $(shell sdl-config --libs) -lSDL_image $(TTFLOPT)
+         LOPT += $(shell pkg-config --libs libpng)
+         LOPT += $(LUALOPT) -lm
+-        CC = gcc
+         OBJDIR = ../obj/unix
+         FCLOPT = -lfontconfig
+         COPT += -DUSE_FC


### PR DESCRIPTION
Signed-off-by: Thomas Bernard <miniupnp@free.fr>

#### Description

new port for GrafX2 a 256 color painting program
http://grafx2.chez.com/

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.4
Xcode 2.5

###### Verification 
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
