### PR TITLE
digital_rf: new port

### DIFF
--- a/science/digital_rf/Portfile
+++ b/science/digital_rf/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           cxx11 1.1
+
+github.setup        MITHaystack digital_rf 2.6.0
+maintainers         {mit.edu:rvolz @ryanvolz} {mit.edu:swoboj @jswoboda} openmaintainer
+description         Read, write, and interact with data in the Digital RF and Digital Metadata formats.
+long_description    ${description} The Digital RF project encompasses a standardized HDF5 format\
+                    for reading and writing of radio frequency data and the software \
+                    for doing so. The format is designed to be self-documenting \
+                    for data archive and to allow rapid random access for data \
+                    processing. For details on the format, refer to the 'documents' \
+                    directory in the source tree.
+categories          science
+license             BSD
+platforms           darwin
+dist_subdir         digital_rf
+
+checksums           rmd160  f095ff1a80f7175f57a45048c826fe68b6dd56e9 \
+                    sha256  6468418a06c269964c9a5c5f145f7bfebf951226e3a85977226c7967fa50e691 \
+                    size    4528350
+
+configure.ldflags-delete -L${prefix}/lib
+
+depends_build-append  port:py27-pkgconfig
+
+depends_lib-append port:hdf5 \
+                   port:py27-mako \
+                   port:py27-numpy
+
+depends_run-append port:boost \
+                   port:gnutls \
+                   port:py27-dateutil \
+                   port:py27-h5py \
+                   port:py27-matplotlib \
+                   port:py27-packaging \
+                   port:py27-pandas \
+                   port:py27-scipy \
+                   port:py27-six \
+                   port:py27-tz \
+                   port:py27-watchdog
+
+depends_run-append path:lib/libgnuradio-runtime.dylib:gnuradio \
+                   path:lib/libuhd.dylib:uhd
+
+# CMAKE configuration
+configure.args-append \
+    -DDRF_INSTALL_PREFIX_PYTHON=${frameworks_dir}/Python.framework/Versions/2.7\
+    -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/2.7/bin/python2.7\
+    -DDRF_DATA_PREFIX_PYTHON=${prefix} \
+    -DDRF_SCRIPT_PREFIX_PYTHON=${prefix}/bin


### PR DESCRIPTION
#### Description

Adding Portfile for Digital RF. Read, write, and interact with data in the Digital RF and Digital Metadata formats. Update from PR #1776.

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
