### PR TITLE
hiredis: Update to 0.13.3

### DIFF
--- a/databases/hiredis/Portfile
+++ b/databases/hiredis/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        redis hiredis 0.12.1 v
-revision            1
-set branch          [join [lrange [split ${version} .] 0 1] .]
+github.setup        redis hiredis 0.13.3 v
 categories          databases
 platforms           darwin
 license             BSD
@@ -15,14 +13,24 @@ maintainers         {pixilla @pixilla} openmaintainer
 description         Hiredis is a minimalistic C client library for the Redis database.
 long_description    ${description}
 
-checksums           rmd160  56595fa744ea3855e45943e114d80908c9e85e06 \
-                    sha256  b83303b2adba85b9d384d5db124f89ca02550ee58ecfed2502c75d06068f7406
+checksums           rmd160  f461cba002bbecba9fee6691f45493ef8c3e6460 \
+                    sha256  da93bcb49209b757e8a57cfe7cd9319066ecebe7b6d80d9ce466434cc5995999 \
+                    size    58315
+
+patchfiles          cp.patch \
+                    install_name.patch
 
 use_configure       no
 
+# The Makefile misuses LIBRARY_PATH
+# https://github.com/redis/hiredis/issues/382
+compiler.library_path
+
 variant universal {}
 
-build.args-append   CC="${configure.cc} [get_canonical_archflags cc]" \
-                    LDFLAGS="-Wl,-install_name,${prefix}/lib/lib${name}.${branch}.dylib"
-destroot.args       PREFIX=${prefix} \
-                    LIBRARY_PATH=lib
+build.args-append   CC="${configure.cc}" \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]" \
+                    OPTIMIZATION="${configure.optflags}" \
+                    PREFIX=${prefix}
+destroot.args       PREFIX=${prefix}

--- a/databases/hiredis/files/cp.patch
+++ b/databases/hiredis/files/cp.patch
@@ -1,0 +1,25 @@
+Use cp -pPR instead of cp -a to fix install on Mac OS X Leopard and earlier.
+https://github.com/redis/hiredis/pull/596
+--- Makefile.orig	2015-09-16 05:25:02.000000000 -0500
++++ Makefile	2018-05-14 17:56:18.000000000 -0500
+@@ -58,7 +58,6 @@
+ ifeq ($(uname_S),SunOS)
+   REAL_LDFLAGS+= -ldl -lnsl -lsocket
+   DYLIB_MAKE_CMD=$(CC) -G -o $(DYLIBNAME) -h $(DYLIB_MINOR_NAME) $(LDFLAGS)
+-  INSTALL= cp -r
+ endif
+ ifeq ($(uname_S),Darwin)
+   DYLIBSUFFIX=dylib
+@@ -161,11 +160,7 @@
+ dep:
+ 	$(CC) -MM *.c
+ 
+-ifeq ($(uname_S),SunOS)
+-  INSTALL?= cp -r
+-endif
+-
+-INSTALL?= cp -a
++INSTALL?= cp -pPR
+ 
+ $(PKGCONFNAME): hiredis.h
+ 	@echo "Generating $@ for pkgconfig..."

--- a/databases/hiredis/files/install_name.patch
+++ b/databases/hiredis/files/install_name.patch
@@ -1,0 +1,15 @@
+Fix install_name
+https://github.com/redis/hiredis/issues/437
+https://github.com/redis/hiredis/pull/595/commits/881fcb776d4237168f9ad4b2dd32c6ea902628ac
+Also use -dynamiclib instead of -shared for compatibility with older macOS.
+--- Makefile.orig	2015-09-16 05:25:02.000000000 -0500
++++ Makefile	2018-05-14 14:15:38.000000000 -0500
+@@ -63,7 +63,7 @@
+ ifeq ($(uname_S),Darwin)
+   DYLIBSUFFIX=dylib
+   DYLIB_MINOR_NAME=$(LIBNAME).$(HIREDIS_SONAME).$(DYLIBSUFFIX)
+-  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
++  DYLIB_MAKE_CMD=$(CC) -dynamiclib -Wl,-install_name,$(PREFIX)/$(LIBRARY_PATH)/$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
+ endif
+ 
+ all: $(DYLIBNAME) $(STLIBNAME) hiredis-test $(PKGCONFNAME)

--- a/games/minetest/Portfile
+++ b/games/minetest/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 
 github.setup            minetest minetest 0.4.16
-revision                2
+revision                3
 
 # have to do some shenanigans to add on more files to a github portgroup download
 # cache the preset distfiles delivered by the github PG

--- a/mail/rspamd/Portfile
+++ b/mail/rspamd/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        vstakhov rspamd 0.8.3
 
 version             0.8.3
-revision            1
+revision            2
 categories          mail
 license             BSD
 maintainers         {pixilla @pixilla} openmaintainer

--- a/sysutils/gearmand/Portfile
+++ b/sysutils/gearmand/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
 github.setup        gearman gearmand 1.1.18
-revision            1
+revision            2
 categories          sysutils net devel
 maintainers         nomaintainer
 platforms           darwin


### PR DESCRIPTION
#### Description

Update hiredis to 0.13.3. Fix install failure on Leopard and earlier.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1212
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
