### PR TITLE
Use port:pkgconfig for pkgconfig dependencies

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -38,7 +38,7 @@ autoreconf.cmd   "build/autogen.sh"
 autoreconf.args  -fvi
 
 depends_build    port:autoconf port:automake port:libtool \
-                 path:bin/pkg-config:pkgconfig
+                 port:pkgconfig
 
 configure.args   --enable-bsdtar=shared --enable-bsdcpio=shared \
                  --disable-silent-rules --without-nettle \

--- a/audio/cmus/Portfile
+++ b/audio/cmus/Portfile
@@ -17,7 +17,7 @@ platforms           darwin
 checksums           rmd160  3a9ff85f3279ff74af5d46cca2d8bf5b79671c6b \
                     sha256  56bbdb487cf15285dea630a71e31b094276e143cb4c15c411b1b3549ec6f23b3
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 depends_lib         port:libao \
                     port:libmad \
                     port:libogg \

--- a/audio/herrie/Portfile
+++ b/audio/herrie/Portfile
@@ -29,8 +29,8 @@ checksums	md5 88832b10298ab89473730eb0c93b6ddf \
 		sha1 ae5c39be11aeb19898cd3f968580eafc623830b7
 use_bzip2	yes
 
+depends_build	port:gettext port:pkgconfig
 depends_lib	path:lib/pkgconfig/glib-2.0.pc:glib2 port:ncurses
-depends_build	port:gettext bin:pkg-config:pkgconfig
 
 configure.pre_args
 configure.env-append PREFIX=${prefix}

--- a/audio/uade2/Portfile
+++ b/audio/uade2/Portfile
@@ -18,7 +18,7 @@ checksums           md5     29bb1018b7fa58f93b246264c160bdc6 \
                     sha1    61c5ce9dfecc37addf233de06be196c9b15a91d8 \
                     rmd160  10034302e848ea7c974429ae302ca52403909ded
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 depends_lib         port:libao
 
 configure.args      --without-uadefs --without-xmms --without-audacious --package-prefix=${destroot}

--- a/cross/usbprog/Portfile
+++ b/cross/usbprog/Portfile
@@ -21,7 +21,7 @@ wxWidgets.use       wxWidgets-3.0
 depends_build       port:autoconf \
                     port:automake \
                     port:libtool \
-                    path:bin/pkg-config:pkgconfig
+                    port:pkgconfig
 
 depends_lib-append  port:curl \
                     port:libusb-compat \

--- a/databases/libpqxx/Portfile
+++ b/databases/libpqxx/Portfile
@@ -62,7 +62,7 @@ if {[variant_isset postgresql83]} {
 }
 
 platforms       darwin
-depends_build   path:bin/pkg-config:pkgconfig
+depends_build   port:pkgconfig
 depends_lib     port:${server}
 
 patchfiles      patch-tools-maketemporary.diff

--- a/databases/libpqxx26/Portfile
+++ b/databases/libpqxx26/Portfile
@@ -40,7 +40,7 @@ checksums \
 set server      postgresql83
 
 platforms       darwin
-depends_build   path:bin/pkg-config:pkgconfig
+depends_build   port:pkgconfig
 depends_lib     port:${server}
 
 # postgresql83 is not universal

--- a/devel/libofx/Portfile
+++ b/devel/libofx/Portfile
@@ -25,7 +25,7 @@ checksums               md5     2ea3adcec51e6dc90555a52a7ab621c9 \
                         sha1    b8ea875cee16953166449de8ddd1b69fb181f61b \
                         rmd160  c3df97d1004e3218ddac45f049e29c890c5bafd2
 
-depends_build           path:bin/pkg-config:pkgconfig
+depends_build           port:pkgconfig
 depends_lib             port:opensp
 
 configure.args          --with-opensp-includes=${prefix}/include/OpenSP \

--- a/devel/lua-luasocket/Portfile
+++ b/devel/lua-luasocket/Portfile
@@ -23,8 +23,8 @@ homepage            http://w3.impa.br/~diego/software/luasocket/
 checksums           rmd160  56ea9c789fcac0c8bc1665f0f7258d7ea9dfa98e \
                     sha256  caee7e37107df53e917105c7e6b73438e9337ab2b309a3790edfc022d881748f
 
+depends_build       port:pkgconfig
 depends_lib         port:lua
-depends_build       path:bin/pkg-config:pkgconfig
 
 # Old luaforge livecheck. For now, use github-livecheck, but maybe luaforge
 # will be more up to date some day or other.

--- a/fuse/py-fuse/Portfile
+++ b/fuse/py-fuse/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c0acad069284e3adba7db8aaf957c7d228c488fc \
 python.versions     26 27
 
 if {${name} ne ${subport}} {
-    depends_build-append    path:bin/pkg-config:pkgconfig
+    depends_build-append    port:pkgconfig
     depends_lib-append      port:osxfuse
 
     # osxfuse is not universal

--- a/fuse/s3fs/Portfile
+++ b/fuse/s3fs/Portfile
@@ -22,7 +22,7 @@ license             GPL-2
 checksums           rmd160  582c193888466341ecf0cc6472dd2a2b5e3eb803 \
                     sha256  47e6700c9ec65f85cc1eeb004dcf33b4533b3415466107f310fe167f49f35ec5
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 depends_lib         port:curl \
                     port:libxml2 \
                     path:lib/pkgconfig/fuse.pc:fuse4x \

--- a/fuse/sshfs/Portfile
+++ b/fuse/sshfs/Portfile
@@ -22,7 +22,7 @@ license             GPL-2
 checksums           rmd160  9c940d816480a6ffba9d43d257f7fcc2484d06f3 \
                     sha256  640096693c8bf7dfebebb40bb05bb363ef4b5515105262c8c35b823a8c3f9c14
                     
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 depends_lib         port:gettext \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/fuse.pc:osxfuse \

--- a/games/blobwars/Portfile
+++ b/games/blobwars/Portfile
@@ -24,7 +24,7 @@ master_sites            sourceforge:project/blobwars
 checksums               rmd160  c4a54ce0f64db2fc6038590eb22d1b2241b0917f \
                         sha256  c406279f6cdf2aed3c6edb8d8be16efeda0217494acd525f39ee2bd3e77e4a99
 
-depends_build-append    path:bin/pkg-config:pkgconfig
+depends_build-append    port:pkgconfig
 
 depends_lib-append      port:gettext \
                         port:libsdl2 \

--- a/games/lincity-ng/Portfile
+++ b/games/lincity-ng/Portfile
@@ -38,7 +38,7 @@ depends_lib				port:libxml2 \
 					lib:libsdl_gfx:libsdl_gfx \
 					lib:libphysfs:physfs \
 					port:libiconv
-depends_build		path:bin/pkg-config:pkgconfig \
+depends_build		port:pkgconfig \
 					bin:jam:jam
 
 configure.cxxflags-append -I${prefix}/include

--- a/graphics/ipe/Portfile
+++ b/graphics/ipe/Portfile
@@ -26,7 +26,7 @@ checksums           sha1    58410e29c04e7a7c3978bd9afe6d25a7924bd30d \
                     rmd160  6d68ad7831923d04ba07086f3dde2be9830d756a \
                     sha256  d66d3f2619e3e6ff617f42c2e3695c3db6e2a64adcc3d7613214e5fd14c49f22
 
-depends_build-append    path:bin/pkg-config:pkgconfig
+depends_build-append    port:pkgconfig
 
 depends_lib-append      port:freetype \
                         path:lib/pkgconfig/cairo.pc:cairo \

--- a/graphics/wxsvg/Portfile
+++ b/graphics/wxsvg/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  2b8327a18c78fa97b73047f6773a6fc374c886ac \
 
 wxWidgets.use       wxWidgets-3.0
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:expat \

--- a/irc/lostirc/Portfile
+++ b/irc/lostirc/Portfile
@@ -20,5 +20,5 @@ checksums	md5 501cd56bc0740d599540fb415718b939 \
 patchfiles	patch-src__libirc__DCC.cpp
 configure.args	--mandir=${prefix}/share/man
 
-depends_build	bin:pkg-config:pkgconfig
+depends_build	port:pkgconfig
 depends_lib	lib:libgtkmm.2:gtkmm

--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  063eaa8d94d2995fe5857f3eb9292974173d5aea \
                     sha256  feb58c9358d9d129e00507f3b34d4b13c4caea3f004325c587f8caafe5dbe724 \
                     size    5289416
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 
 depends_lib         port:expat \
                     port:fontconfig \

--- a/multimedia/audacious-core/Portfile
+++ b/multimedia/audacious-core/Portfile
@@ -58,7 +58,7 @@ use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
 autoreconf.args
 
-depends_build       path:bin/pkg-config:pkgconfig \
+depends_build       port:pkgconfig \
                     path:bin/aclocal:automake \
                     path:bin/autom4te:autoconf
 

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -106,7 +106,7 @@ use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
 autoreconf.args
 
-depends_build       path:bin/pkg-config:pkgconfig \
+depends_build       port:pkgconfig \
                     path:bin/aclocal:automake \
                     path:bin/autom4te:autoconf
 

--- a/multimedia/libcec/Portfile
+++ b/multimedia/libcec/Portfile
@@ -22,7 +22,7 @@ checksums           md5     a1a314b9451a381107d9921ab0ba429b \
                     sha256  6a67dac0345e125011cc708070fbe6c018d68de94a9726ead34c0c2ab94e943e
 
 depends_build-append \
-                    path:bin/pkg-config:pkgconfig \
+                    port:pkgconfig \
                     port:swig-python
 
 depends_lib         port:ncurses \

--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -38,7 +38,7 @@ checksums               ${mpv_distfile} \
 
 installs_libs           no
 
-depends_build           path:bin/pkg-config:pkgconfig
+depends_build           port:pkgconfig
 depends_lib             path:lib/libavcodec.dylib:ffmpeg \
                         path:bin/perl:perl5 \
                         port:libiconv \

--- a/multimedia/p8-platform/Portfile
+++ b/multimedia/p8-platform/Portfile
@@ -20,7 +20,7 @@ checksums           md5     0d655ee34b30ac1887c8168a9743dd04 \
                     sha256  56074379574a1148c570d9794ef34932f06acb4d79395e9f1d175e53ff5acef3
 
 depends_build-append \
-                    path:bin/pkg-config:pkgconfig
+                    port:pkgconfig
 
 cmake.out_of_source yes
 

--- a/net/ushare/Portfile
+++ b/net/ushare/Portfile
@@ -17,7 +17,7 @@ long_description \
     multimedia files. uShare uses the built-in http server of libupnp to \
     stream the files to clients.
 
-depends_build       path:bin/pkg-config:pkgconfig
+depends_build       port:pkgconfig
 depends_lib         port:gettext \
                     port:libupnp \
                     port:libdlna

--- a/science/freehdl/Portfile
+++ b/science/freehdl/Portfile
@@ -13,12 +13,13 @@ platforms           darwin
 description         A free VHDL simulator used for digital simulations by qucs
 long_description    A project to develop a free, open source, GPL'ed VHDL simulator \
                     for Linux!
-depends_build       path:bin/pkg-config:pkgconfig
 homepage            http://www.freehdl.seul.org
 master_sites        http://freehdl.seul.org/~enaroska/
 checksums           md5     6d702aa188fb2c62f8cfca5a2f66d956 \
                     sha1    eca7ad3ac58e56b72842e83a0a702c05b8f86aa4 \
                     rmd160  d00e14d6b1cd97154b221717124c6e20b0d4f776
+
+depends_build       port:pkgconfig
 
 patchfiles          std-vhdl-types.hh.patch kernel-sig-info.hh.patch \
                     driver_info.cc.patch

--- a/security/lastpass-cli/Portfile
+++ b/security/lastpass-cli/Portfile
@@ -15,7 +15,7 @@ supported_archs     noarch
 description         command line interface to LastPass.com
 long_description    ${description}
 
-depends_build-append    path:bin/pkg-config:pkgconfig
+depends_build-append    port:pkgconfig
 depends_lib-append  port:curl \
                     port:libxml2 \
                     path:lib/libssl.dylib:openssl

--- a/security/openvas-client/Portfile
+++ b/security/openvas-client/Portfile
@@ -26,7 +26,7 @@ long_description \
     the client component.
 
 depends_build \
-    path:bin/pkg-config:pkgconfig \
+    port:pkgconfig \
     bin:grep:grep
 
 depends_lib \

--- a/security/openvas-libnasl/Portfile
+++ b/security/openvas-libnasl/Portfile
@@ -26,7 +26,7 @@ long_description \
     by the server component.
 
 depends_build \
-    path:bin/pkg-config:pkgconfig \
+    port:pkgconfig \
     path:bin/bison:bison \
     path:bin/gsed:gsed
 

--- a/security/openvas-libraries/Portfile
+++ b/security/openvas-libraries/Portfile
@@ -26,7 +26,7 @@ long_description \
     contains the libraries used by the server component.
 
 depends_build \
-    path:bin/pkg-config:pkgconfig \
+    port:pkgconfig \
     bin:grep:grep
 
 depends_lib             port:gettext \

--- a/security/openvas-plugins/Portfile
+++ b/security/openvas-plugins/Portfile
@@ -25,7 +25,7 @@ long_description \
     contains the plugins used by the server component.
 
 depends_build \
-    path:bin/pkg-config:pkgconfig \
+    port:pkgconfig \
     bin:grep:grep \
     path:bin/gsed:gsed
 

--- a/sysutils/syslog-ng/Portfile
+++ b/sysutils/syslog-ng/Portfile
@@ -22,7 +22,7 @@ checksums			md5 7107f5758dec4b774136f0f827b35258
 distfiles			${name}_${version}${extract.suffix}
 patchfiles			patch-src-Makefile.in.diff
 
-depends_build			path:bin/pkg-config:pkgconfig
+depends_build			port:pkgconfig
 depends_lib			port:eventlog \
 				port:libnet11 \
 				path:lib/pkgconfig/glib-2.0.pc:glib2

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -77,7 +77,7 @@ depends_run     port:ghostscript
 
 depends_build-append \
                 path:bin/perl:perl5 \
-                path:bin/pkg-config:pkgconfig
+                port:pkgconfig
 
 # patches related to changes in install paths
 patchfiles-append  patch-texk_chktex_Makefile.in.diff \

--- a/textproc/hyperestraier/Portfile
+++ b/textproc/hyperestraier/Portfile
@@ -27,7 +27,7 @@ checksums       md5 847aefb9e23266545280378d797f3981 \
 				sha1 21c3f325f42019fef096172105c2fc16f3e72fc0 \
 				rmd160 8af0af25df6d5bd45a09e9abfbb26300339b5a2c
 
-depends_build	bin:pkg-config:pkgconfig
+depends_build	port:pkgconfig
 depends_lib		port:qdbm port:libiconv port:zlib 
 
 configure.args  --mandir=${prefix}/share/man \

--- a/textproc/wv2/Portfile
+++ b/textproc/wv2/Portfile
@@ -18,7 +18,7 @@ use_bzip2       yes
 checksums       rmd160  9e64fb57178daca5e917201e591845227ea75de9 \
                 sha256  896ff8ec59e280e8cb1ef9a953b364845dd65de1cdf8e4ed8a7e045a3f81c546
 
-depends_build   path:bin/pkg-config:pkgconfig
+depends_build   port:pkgconfig
 depends_lib     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                 port:libgsf \
                 port:libxml2

--- a/x11/gcin/Portfile
+++ b/x11/gcin/Portfile
@@ -16,7 +16,8 @@ checksums	md5 aa028e3c136f1b80e38ef6fd33024385
 distfiles	${name}-${version}.tar.bz2
 platforms	darwin
 use_bzip2	yes
+depends_build	port:pkgconfig
 depends_lib	lib:libglib.2:glib2 lib:libgtk.2:gtk2 lib:libpango:pango \
 		lib:libexpat:expat lib:libfontconfig:fontconfig lib:libpng:libpng \
-		bin:pkg-config:pkgconfig port:xorg-libXtst
+		port:xorg-libXtst
 patchfiles	patch-Makefile patch-configure

--- a/x11/nabi/Portfile
+++ b/x11/nabi/Portfile
@@ -16,7 +16,7 @@ homepage		http://nabi.kldp.net
 master_sites		http://kldp.net/frs/download.php/3742/
 distname		nabi-${version}
 
-depends_build		path:bin/pkg-config:pkgconfig
+depends_build		port:pkgconfig
 depends_lib		port:gtk2 port:libhangul
 checksums		md5 8746890ea666ac1b7ae6db77993c6592
 

--- a/x11/xarchiver/Portfile
+++ b/x11/xarchiver/Portfile
@@ -15,5 +15,5 @@ checksums	md5 9700305deef4e2b6878697bd18bd2dd9 \
 		sha1 db80abdebf3396ded3cf8d2224e88c987a2d9c32 \
 		rmd160 73e951ef9dd1cd6eb347eb0bb96ef8cb7eede602
 
-depends_build	path:bin/pkg-config:pkgconfig
+depends_build	port:pkgconfig
 depends_lib	port:gtk2

--- a/x11/xcircuit-devel/Portfile
+++ b/x11/xcircuit-devel/Portfile
@@ -34,9 +34,10 @@ checksums           rmd160  7b3a3a956249aa7006549f24f46dded2b17fa656 \
                     sha256  57b9a324e8365c3dc2f160e2879aec1fdb63d5fc247cb01d8a09a9c5ac87473d \
                     size    1612065
 
-depends_build       path:bin/pkg-config:pkgconfig \
-                    port:autoconf \
-                    port:automake
+depends_build       port:autoconf \
+                    port:automake \
+                    port:pkgconfig
+
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:ghostscript \
                     port:tk \

--- a/x11/xcircuit/Portfile
+++ b/x11/xcircuit/Portfile
@@ -33,9 +33,10 @@ checksums           rmd160  0fa28f4689dbb2d53ae29c478428a776da411a5e \
                     sha256  4f0e7c9630775a9624568ccd6e312941e2d6fa46a44f6012a99fde1bbd8249ce \
                     size    1620922
 
-depends_build       path:bin/pkg-config:pkgconfig \
-                    port:autoconf \
-                    port:automake
+depends_build       port:autoconf \
+                    port:automake \
+                    port:pkgconfig
+
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:ghostscript \
                     port:tk \

--- a/xfce/garcon/Portfile
+++ b/xfce/garcon/Portfile
@@ -20,5 +20,5 @@ checksums       md5 aba62b80787aac295083bf7afd419ffb \
 
 configure.args  --mandir=${prefix}/share/man
 
-depends_build   path:bin/pkg-config:pkgconfig port:intltool
+depends_build   port:intltool port:pkgconfig
 depends_lib     port:libxfce4util port:gtk2

--- a/xfce/libxfce4util/Portfile
+++ b/xfce/libxfce4util/Portfile
@@ -18,7 +18,7 @@ checksums       md5 4eb012b6c1292ceedb3a83ebfc1ff08d \
                 sha1 fbea10b13db55c1f7756ec36ea7c8e84ca781492 \
                 sha256 876bdefa2e13cbf68b626b2158892fb93e824e1ef59cf951123a96cefbc8881d
 
-depends_build   path:bin/pkg-config:pkgconfig port:intltool
+depends_build   port:intltool port:pkgconfig
 depends_lib     port:gettext path:lib/pkgconfig/glib-2.0.pc:glib2 \
                 port:libiconv
 

--- a/xfce/squeeze/Portfile
+++ b/xfce/squeeze/Portfile
@@ -20,7 +20,7 @@ checksums       md5 bd3cb0648b49be1f146fc4f675606176 \
                 sha1 218f0e61e1d105f1f9aa898a56837f78ce65aaac \
                 sha256 7b8dc13e0adf72c67bba12e1ed1285ec820946e65d0eec247f7bd159a2cfac2d
 
-depends_build   path:bin/pkg-config:pkgconfig
+depends_build   port:pkgconfig
 depends_lib     port:gtk2 port:libxfce4util port:dbus-glib port:Thunar
 
 patchfiles      patch-internals.diff


### PR DESCRIPTION
#### Description

Use `port:pkgconfig` not `path:bin/pkg-config:pkgconfig` nor `bin:pkg-config:pkgconfig` for pkgconfig dependencies.

pkgconfig is the only port that provides the pkg-config program, we're not planning on adding a pkgconfig-devel port anytime soon, and `path:` dependencies confuse newcomers.

`bin:` dependencies would allow a program installed outside of MacPorts to satisfy the dependency, which we don't want.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
