### PR TITLE
py-pbr: update to 4.0.3

### DIFF
--- a/python/py-pbr/Portfile
+++ b/python/py-pbr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pbr
-version             3.0.0
+version             4.0.3
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -20,13 +20,14 @@ long_description    A library for managing setuptools packaging needs \
                     arguments to a call to setup.py - so the heavy \
                     lifting of handling python packaging needs is \
                     still being done by setuptools.
-homepage            http://docs.openstack.org/developer/pbr
+homepage            https://docs.openstack.org/developer/pbr
 
 master_sites        pypi:p/pbr
 distname            pbr-${version}
 
-checksums           rmd160  775a794b5f5d9a8011875a677409f8c442b519dc \
-                    sha256  568f988af109114fbfa0525dcb6836b069838360d11732736ecc82e4c15d5c12
+checksums           rmd160  6d6c44225e0a40d0bba01d2be114969a68351ffb \
+                    sha256  6874feb22334a1e9a515193cba797664e940b763440c88115009ec323a7f2df5 \
+                    size    108684
 
 python.versions     27 34 35 36
 
@@ -34,7 +35,5 @@ if {${subport} ne ${name}} {
     depends_lib-append  port:py${python.version}-setuptools
     livecheck.type      none
 } else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi?:action=doap&name=pbr
-    livecheck.regex     {<revision>(\d+(\.\d+)+)</revision>}
+    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- fix livecheck
- add size to checksums
- use https for homepage

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
