### PR TITLE
ninja: allow universal build on older systems

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -2,6 +2,8 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+# see https://trac.macports.org/ticket/56494
+PortGroup           muniversal 1.0
 
 epoch               1
 github.setup        ninja-build ninja 1.8.2 v
@@ -35,8 +37,6 @@ checksums           rmd160  4565c35672b5cddfde05fb679c80c9eef41935ef \
 
 patchfiles          patch-configure.py-CXXFLAGS.diff \
                     patch-configure.py-bootstrap-only.diff
-
-variant universal {}
 
 depends_build-append \
                     port:re2c


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/56494

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->