### PR TITLE
py-stevedore: update to 1.28.0

### DIFF
--- a/python/py-stevedore/Portfile
+++ b/python/py-stevedore/Portfile
@@ -7,7 +7,7 @@ set _name           stevedore
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             1.12.0
+version             1.28.0
 categories-append   devel
 platforms           darwin
 maintainers         nomaintainer
@@ -22,18 +22,17 @@ homepage            https://pypi.python.org/pypi/${_name}/${version}
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           rmd160  76199a29dca21e383c717ad0ba4418a3d885458c \
-                    sha256  1bdeb2562d8f2c1e3047c2f17134a38b37a6e53e16ca1d9f79ff2ac5d5fe2925
+checksums           rmd160  a17cd13695020b58b7259262a1c0e5eab442a015 \
+                    sha256  f1c7518e7b160336040fee272174f1f7b29a46febb3632502a8f2055f973d60b \
+                    size    504872
 
 python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
-    # uses pkg_resources for extensions
     depends_lib-append  port:py${python.version}-setuptools \
                         port:py${python.version}-pbr \
                         port:py${python.version}-six
 
-    # Adding documentation
     post-destroot {
         set dest_doc ${destroot}${prefix}/share/doc/${subport}
         xinstall -d  ${dest_doc}


### PR DESCRIPTION
#### Description
- update to version 1.28.0
- add size to checksums

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
