### PR TITLE
py-ligo-common: renamed ligo-common

### DIFF
--- a/python/py-ligo-common/Portfile
+++ b/python/py-ligo-common/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem         1.0
+PortGroup          python 1.0
+
+name               py-ligo-common
+version            1.0.3
+
+categories-append  science
+platforms          darwin
+supported_archs    noarch
+maintainers        {ram @skymoo} {ligo.org:duncan.macleod @duncanmmacleod}
+license            GPL
+
+description        Common package for LIGO Python libraries
+long_description   ${description}
+homepage           https://git.ligo.org/lscsoft/ligo-common
+
+master_sites       http://software.ligo.org/lscsoft/source/
+distname           ligo-common-${version}
+
+checksums  rmd160  ba7b27ac876e1133e852fd9f3f8bb2442bb24638 \
+           sha256  a3e00d79bf3b0474b429f50fb60079da015453afa09658f90efcab8ae158a835 \
+           size    15620
+
+python.versions         27 36
+python.default_version  27
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+}
+
+livecheck.type   regex
+livecheck.url    ${master_sites}
+livecheck.regex  {ligo-common-(\d+(?:\.\d+)*).tar.gz}

--- a/science/ligo-common/Portfile
+++ b/science/ligo-common/Portfile
@@ -1,35 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem    1.0
-PortGroup     python 1.0
+
+replaced_by   py27-ligo-common
+PortGroup     obsolete 1.0
 
 name          ligo-common
 version       1.0.2
+revision      1
 categories    science
 platforms     darwin
 supported_archs noarch
 maintainers   {ram @skymoo}
 license       GPL
-
-# The GPL and OpenSSL licenses conflict with each other, and our build
-# dependency on Python results in an indirect dependency on OpenSSL.
-# However, there is no real conflict in the case of LALSuite because Python
-# is used as a separately installed interpreter.
-license_noconflict openssl
-
-description   Common package for LIGO Python libraries
-long_description ${description}
-
-homepage      https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html
-master_sites  http://software.ligo.org/lscsoft/source/
-
-checksums     rmd160 71dceed13de28e620ed8e08c86ecf96e1bc05413 \
-              sha256 ef0052467457bc20f92045dfb7f6d33c440d9bddde2120a31c54465bbe16ed09
-
-python.default_version  27
-
-depends_build-append port:py${python.version}-setuptools
-
-livecheck.type   regex
-livecheck.url    ${master_sites}
-livecheck.regex  {ligo-common-(\d+(?:\.\d+)*).tar.gz}

--- a/science/ligo-gracedb/Portfile
+++ b/science/ligo-gracedb/Portfile
@@ -32,7 +32,7 @@ checksums     rmd160 13f6352f9459afb647d43933f59e4c27a1e6d6d2 \
 
 python.default_version  27
 
-depends_lib-append port:ligo-common \
+depends_lib-append port:py${python.version}-ligo-common \
                    port:py${python.version}-m2crypto \
                    port:py${python.version}-cjson \
                    port:py${python.version}-setuptools

--- a/science/ligo-lars/Portfile
+++ b/science/ligo-lars/Portfile
@@ -23,7 +23,7 @@ checksums     rmd160 2b6533731c613595d576ace9461912eb0c8a4b37 \
 
 python.default_version  27
 
-depends_lib-append port:ligo-common \
+depends_lib-append port:py${python.version}-ligo-common \
                    port:glue \
                    port:py${python.version}-m2crypto
 

--- a/science/ligo-lvalert-heartbeat/Portfile
+++ b/science/ligo-lvalert-heartbeat/Portfile
@@ -26,7 +26,7 @@ python.default_version  27
 
 depends_build-append port:py${python.version}-setuptools
 
-depends_lib-append port:ligo-common \
+depends_lib-append port:py${python.version}-ligo-common \
                    port:py${python.version}-pyxmpp \
                    port:ligo-lvalert
 

--- a/science/ligo-lvalert/Portfile
+++ b/science/ligo-lvalert/Portfile
@@ -33,7 +33,7 @@ python.default_version  27
 
 depends_build-append port:py${python.version}-setuptools
 
-depends_lib-append port:ligo-common \
+depends_lib-append port:py${python.version}-ligo-common \
                    port:py${python.version}-pyxmpp \
                    port:py${python.version}-libxml2 \
                    port:py${python.version}-m2crypto \


### PR DESCRIPTION
#### Description

This PR renames the `ligo-common` port to `py-ligo-common` to provide multiple python versions, as per convention. This includes an update to the next release 1.0.3 which supports python3.

I have also updated all dependents I could see to reference the new port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
