### PR TITLE
libwebsockets: Update to version 3.0.0.

### DIFF
--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        warmcat libwebsockets 2.4.2 v
+github.setup        warmcat libwebsockets 3.0.0 v
 categories          devel net
 platforms           darwin
 license             LGPL-2.1
@@ -18,9 +18,9 @@ long_description    \
     CPU and memory resources, and provide fast throughput in both directions \
     as client or server.
 
-checksums           rmd160  79089070ba8cede8e125a214ddd41f2f0cf5e170 \
-                    sha256  52904d4be01a659cef886bf42fa740743f50b45b896eed55d39e9137b25b7ea6 \
-                    size    3777268
+checksums           rmd160  9fced325670a8aec052d15a6c2f8cb23c6191f92 \
+                    sha256  33ab15c3807a4dab8b05b28f7052c37cf9e38acf0f55f87a38dcce0000d3a3d3 \
+                    size    7482525
 
 depends_lib-append  path:lib/libssl.dylib:openssl \
                     port:zlib

--- a/net/mosquitto/Portfile
+++ b/net/mosquitto/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 
 name                mosquitto
 version             1.4.15
-revision            0
+revision            1
 
 categories          net devel
 platforms           darwin
@@ -34,6 +34,22 @@ depends_lib         port:c-ares \
 
 configure.args-append \
                     -DWITH_WEBSOCKETS=ON -DUSE_LIBWRAP=ON
+
+test.run            yes
+test.target         -C ${workpath}/build/test test
+
+pre-test {
+    if {![file exist ${workpath}/build/test]} {
+        foreach f [list config.mk test] {
+            copy -force ${worksrcpath}/${f} ${workpath}/build
+        }
+        fs-traverse dir ${workpath}/build/test {
+            if {[file tail ${dir}] eq "Makefile"} {
+                reinplace -E "s|\\.so\\.\[^\[:space:\]\]+|.dylib|g" $dir
+            }
+        }
+    }
+}
 
 set mosquitto_user  mosquitto
 set mosquitto_group mosquitto


### PR DESCRIPTION
libwebsockets: Update to version 3.0.0.
mosquitto:  Bump revsion and add test suite.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b
and
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->

<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->