### PR TITLE
netcdf: Rev bump to catch hdf5 v1.10.2

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -8,7 +8,7 @@ PortGroup                   muniversal 1.0
 
 
 github.setup                Unidata netcdf-c 4.4.1.1 v
-revision                    1
+revision                    2
 epoch                       3
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer


### PR DESCRIPTION
#### Description

Rev bump netcdf, force it to rebuild to current hdf5 version 1.10.2.
Should fix reported version mismatch errors:
See: https://trac.macports.org/ticket/56312
See: https://trac.macports.org/ticket/56445
See: https://trac.macports.org/ticket/56446
Etc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
__Untested__

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->