### PR TITLE
Fetch from SourceForge SVN using https

### DIFF
--- a/aqua/PsyncX/Portfile
+++ b/aqua/PsyncX/Portfile
@@ -19,7 +19,7 @@ long_description    ${name} is a ${description}. That means that PsyncX \
                     allow you to schedule backups whenever you want.
 
 fetch.type          svn
-svn.url             http://svn.code.sf.net/p/psyncx/code/trunk/
+svn.url             https://svn.code.sf.net/p/psyncx/code/trunk/
 svn.revision        29
 worksrcdir          trunk
 

--- a/aqua/cotvnc/Portfile
+++ b/aqua/cotvnc/Portfile
@@ -20,7 +20,7 @@ long_description    Chicken is a Cocoa based VNC client for \
 homepage            https://sourceforge.net/projects/chicken/
 
 fetch.type          svn
-svn.url             http://svn.code.sf.net/p/chicken/code/trunk
+svn.url             https://svn.code.sf.net/p/chicken/code/trunk
 svn.revision        797
 
 depends_build-append \

--- a/audio/cmuclmtk/Portfile
+++ b/audio/cmuclmtk/Portfile
@@ -16,7 +16,7 @@ long_description    \
 homepage            http://cmusphinx.sourceforge.net/
 master_sites        sourceforge:cmusphinx
 fetch.type          svn
-svn.url             http://svn.code.sf.net/p/cmusphinx/code/trunk/cmuclmtk/
+svn.url             https://svn.code.sf.net/p/cmusphinx/code/trunk/cmuclmtk/
 svn.revision        10092
 worksrcdir          ${name}
 

--- a/devel/codeblocks/Portfile
+++ b/devel/codeblocks/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           wxWidgets 1.0
 
 fetch.type          svn
-svn.url             svn://svn.code.sf.net/p/codeblocks/code/trunk
+svn.url             https://svn.code.sf.net/p/codeblocks/code/trunk
 svn.revision        11098
 # Get the svn last changed date by running the following command:
-# svn info http://svn.code.sf.net/p/codeblocks/code/trunk| grep "^Last Changed Date:" | cut -d" " -f4,5
+# svn info https://svn.code.sf.net/p/codeblocks/code/trunk| grep "^Last Changed Date:" | cut -d" " -f4,5
 set LCD             "2017-06-21 13:35:48"
 
 name                codeblocks
@@ -17,7 +17,6 @@ platforms           darwin freebsd
 categories          devel aqua x11
 license             GPL-3+
 license_noconflict  boost
-# I'm looking for a volunteer to take the port over
 maintainers         nomaintainer
 description         Open Source, Cross-platform, Free C/C++/D IDE
 long_description    Code::Blocks is a free C++ IDE built specifically \

--- a/emulators/spim/Portfile
+++ b/emulators/spim/Portfile
@@ -24,7 +24,7 @@ platforms       darwin
 
 fetch.type      svn
 svn.revision    643
-svn.url         http://svn.code.sf.net/p/spimsimulator/code
+svn.url         https://svn.code.sf.net/p/spimsimulator/code
 
 depends_build   port:rman port:flex port:bison
 

--- a/graphics/wxLua/Portfile
+++ b/graphics/wxLua/Portfile
@@ -23,7 +23,7 @@ distname            ${name}-${version}-src
 
 ## SVN repository
 # fetch.type        svn
-# svn.url           http://svn.code.sf.net/p/wxlua/svn/trunk/${name}
+# svn.url           https://svn.code.sf.net/p/wxlua/svn/trunk/${name}
 # worksrcdir        ${name}
 
 checksums           rmd160  c09c3e64b0abde69e1d3ecc62a703b225c78e278 \

--- a/multimedia/AtomicParsley-devel/Portfile
+++ b/multimedia/AtomicParsley-devel/Portfile
@@ -19,7 +19,7 @@ depends_lib     port:zlib
 conflicts       AtomicParsley
 
 fetch.type      svn
-svn.url         http://svn.code.sf.net/p/atomicparsley/code/trunk/atomicparsley
+svn.url         https://svn.code.sf.net/p/atomicparsley/code/trunk/atomicparsley
 svn.revision    ${svn_rev}
 
 post-patch {

--- a/multimedia/despotify/Portfile
+++ b/multimedia/despotify/Portfile
@@ -21,7 +21,7 @@ depends_lib         port:ncurses \
                     port:expat
 
 fetch.type          svn
-svn.url             http://svn.code.sf.net/p/despotify/code/src/
+svn.url             https://svn.code.sf.net/p/despotify/code/src/
 svn.revision        515
 
 worksrcdir          src

--- a/science/flashdot/Portfile
+++ b/science/flashdot/Portfile
@@ -15,7 +15,7 @@ homepage          http://www.flashdot.info/
 platforms         darwin
 fetch.type        svn
 worksrcdir        src
-svn.url           http://svn.code.sf.net/p/flashdot/code/trunk/src/
+svn.url           https://svn.code.sf.net/p/flashdot/code/trunk/src/
 svn.revision      78
 # Use checkout as the version calculation makes certain assumptions
 svn.method        checkout

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -22,7 +22,7 @@ homepage            http://www.pymol.org/
 
 master_sites        sourceforge
 fetch.type          svn
-svn.url             http://svn.code.sf.net/p/pymol/code/trunk/pymol
+svn.url             https://svn.code.sf.net/p/pymol/code/trunk/pymol
 svn.revision        4187
 worksrcdir          pymol
 


### PR DESCRIPTION
#### Description

Fetch from SourceForge SVN using https

Reverts 23a487d670a45f85bf17635d5bdabc5caddfc134

Closes: https://trac.macports.org/ticket/56501

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
