### PR TITLE
gcc6: Fix revision of libgcc6

### DIFF
--- a/lang/gcc45/Portfile
+++ b/lang/gcc45/Portfile
@@ -2,13 +2,12 @@ PortSystem 1.0
 PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
-# Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.5
 name                gcc45
-subport             libgcc45 {}
-
+# Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.5
 epoch               1
 version             4.5.4
 revision            13
+subport             libgcc45 { revision 13 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer

--- a/lang/gcc46/Portfile
+++ b/lang/gcc46/Portfile
@@ -5,9 +5,8 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc46
-epoch               1
-
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.6
+epoch               1
 version             4.6.4
 revision            11
 platforms           darwin

--- a/lang/gcc47/Portfile
+++ b/lang/gcc47/Portfile
@@ -5,9 +5,8 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc47
-epoch               1
-
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.7
+epoch               1
 version             4.7.4
 revision            8
 platforms           darwin

--- a/lang/gcc48/Portfile
+++ b/lang/gcc48/Portfile
@@ -5,7 +5,6 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc48
-
 # Whenever this port is bumped for version/revision, please revbump dragonegg-3.4-gcc-4.8
 epoch               2
 version             4.8.5

--- a/lang/gcc49/Portfile
+++ b/lang/gcc49/Portfile
@@ -5,7 +5,6 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc49
-
 epoch               2
 version             4.9.4
 revision            2

--- a/lang/gcc5/Portfile
+++ b/lang/gcc5/Portfile
@@ -5,7 +5,6 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc5
-
 epoch               2
 version             5.5.0
 revision            1

--- a/lang/gcc6/Portfile
+++ b/lang/gcc6/Portfile
@@ -5,11 +5,10 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc6
-subport             libgcc6 { revision 2 }
-
 epoch               2
 version             6.4.0
 revision            1
+subport             libgcc6 { revision 2 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -5,12 +5,10 @@ PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                gcc7
-subport             libgcc { revision 1 }
-
 epoch               2
 version             7.3.0
 revision            1
-
+subport             libgcc { revision 1 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -6,13 +6,11 @@ PortGroup compiler_blacklist_versions 1.0
 
 epoch               1
 name                gcc8
-revision            2
-subport             libgcc-devel { revision 3 }
-
 # This is the last version that builds; see
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82092
 version             8-20170604
-
+revision            2
+subport             libgcc-devel { revision 3 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

gcc6: Fix revision of libgcc6

gcc*: Ensure subport revision is set after port revision.

This fixes an error introduced in 1f683a75f9aa2423dfb6485f44062b2a97483264.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

