### PR TITLE
py-lmfit: update to 0.9.10

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -32,6 +32,12 @@ if {$subport ne $name} {
                                port:py${python.version}-six \
                                port:py${python.version}-asteval
 
+    depends_test-append        port:py${python.version}-pytest
+    test.run                   yes
+    test.cmd                   py.test-${python.branch}
+    test.target
+    test.env                   PYTHONPATH=${worksrcpath}/build/lib
+
     notes-append "If py${python.version}-uncertainties is also installed, propagation of uncertainties to constrained parameters will be enabled."
     notes-append "If upgrading from 0.8.x, any scripts using lmfit must be changed https://lmfit.github.io/lmfit-py/whatsnew.html#whatsnew-090-label"
     livecheck.type      none

--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -41,6 +41,14 @@ if {$subport ne $name} {
     notes-append "If py${python.version}-uncertainties is also installed, propagation of uncertainties to constrained parameters will be enabled."
     notes-append "If upgrading from 0.8.x, any scripts using lmfit must be changed https://lmfit.github.io/lmfit-py/whatsnew.html#whatsnew-090-label"
     livecheck.type      none
+
+    post-destroot {
+       xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}
+       xinstall -m 644 -W ${worksrcpath} README.rst LICENSE THANKS.txt \
+          ${destroot}${prefix}/share/doc/${subport}
+       xinstall -m 644 {*}[glob ${worksrcpath}/examples/*] \
+          ${destroot}${prefix}/share/doc/${subport}/examples
+       }
 } else {
     livecheck.type      pypi
 }

--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-lmfit
-version                 0.9.9
+version                 0.9.10
 categories-append       math
 license                 BSD
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
@@ -18,9 +18,9 @@ homepage                https://lmfit.github.io/lmfit-py/
 master_sites            pypi:l/lmfit/
 distname                lmfit-${version}
 
-checksums               rmd160  b2891fa6b125ea11e88769dc31704e681cde91a8 \
-                        sha256  eee9fa534dc3c494a4d7dd3e0cd243792bbc6cb409805440282a4b5fdab50ea1 \
-                        size    1574912
+checksums               rmd160  d6280d2da50a2ada0f44e1d4715e526383320c7c \
+                        sha256  72ff4abdeb7b97ad8434ed3796783425750ce6286e032a265ae44ade05d92eae \
+                        size    1590006
 
 python.versions         27 34 35 36
 
@@ -34,6 +34,7 @@ if {$subport ne $name} {
 
     notes-append "If py${python.version}-uncertainties is also installed, propagation of uncertainties to constrained parameters will be enabled."
     notes-append "If upgrading from 0.8.x, any scripts using lmfit must be changed https://lmfit.github.io/lmfit-py/whatsnew.html#whatsnew-090-label"
+    livecheck.type      none
 } else {
     livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- update to version 0.9.10
- remove livecheck from subports
- enable tests
<!-- Note: it is best make pull requests from a branch rather than from master -->
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
