### PR TITLE
bzflag: update to version 2.4.14

### DIFF
--- a/games/bzflag/Portfile
+++ b/games/bzflag/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           app 1.0
 
 name                bzflag
-version             2.4.12
+version             2.4.14
 categories          games
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {allejo.io:me @allejo} openmaintainer
 license             {LGPL-2.1 MPL-2}
 
 description         3D tank game, multiplayer and internet gaming available
@@ -18,8 +18,9 @@ homepage            https://www.bzflag.org/
 master_sites        https://download.bzflag.org/bzflag/source/${version}/
 use_bzip2           yes
 
-checksums           rmd160 6ea084cdcded82cc63dc9a0455bb631ad6454c56 \
-                    sha256 a8a13a58648798a6f6f969a2911cf21377fe45964f2edf46a327d1370ff1000d
+checksums           rmd160  4831f3915256fcb8c762acbd47bcc19afdaeb02c \
+                    sha256  09a46ec14cf956cb69fd069cee978de4dec321cb563036b16367ea8aae529bdc \
+                    size    14066129
 
 depends_build       port:pkgconfig
 depends_lib         port:c-ares \


### PR DESCRIPTION
#### Description

Hi, macports team! I'm gonna need your help on this one since I've never contributed on here. I'm one of the developers for BZFlag and saw that there wasn't a maintainer for the macports version of BZFlag so I figured I'd take a stab at it.

Let me know what I did wrong and/or need to do correctly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10.4 14E46
Xcode 6.4 6E35b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
