### PR TITLE
mlt: fix depency on KDE for qt(4) module

### DIFF
--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -8,6 +8,7 @@ github.setup        mltframework mlt 6.8.0 v
 github.tarball_from releases
 
 epoch               3
+revision            1
 categories          multimedia
 maintainers         {dennedy.org:dan @ddennedy} {gmail.com:rjvbertin @RJVB} openmaintainer
 license             GPL-2+
@@ -100,7 +101,8 @@ configure.args-append \
                     --disable-gtk2 \
                     --disable-swfdec \
                     --disable-opencv \
-                    --disable-sdl
+                    --disable-sdl \
+                    --without-kde
 
 platform darwin 10 {
     if {${build_arch} eq "x86_64"} {


### PR DESCRIPTION
#### Description

Fixes ticket https://trac.macports.org/ticket/56510

> mlt uses kde without declaring a dependency on it... Which results in, among other things, building mlt universal failing when kde is not installed universal

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
