### PR TITLE
leveldb: do not opportunistically use gperftools

### DIFF
--- a/databases/leveldb/Portfile
+++ b/databases/leveldb/Portfile
@@ -15,7 +15,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
 github.setup        google leveldb 1.20 v
-revision            1
+revision            2
 categories          databases
 platforms           darwin
 license             BSD
@@ -30,6 +30,10 @@ checksums           rmd160  dd72b89d356031709df9a41da2c31ea2e093361d \
 depends_lib         port:snappy
 
 patchfiles          install_name.patch
+
+# see https://trac.macports.org/ticket/56164
+# see https://trac.macports.org/ticket/56508
+patchfiles-append   patch-no_gperftools.diff
 
 use_configure       no
 

--- a/databases/leveldb/Portfile
+++ b/databases/leveldb/Portfile
@@ -58,17 +58,11 @@ build.env-append                          \
     CXX="${configure.cxx}"                \
     OPT="-DNDEBUG"
 
-# muniversal build requires Makefile
-post-extract {
-    set makefile [open ${worksrcpath}/Makefile-Install "w"]
-    puts ${makefile} {install:}
-    puts ${makefile} "\t/usr/bin/install -d -m 0755 \$(DESTDIR)${prefix}/include/leveldb"
-    puts ${makefile} "\t/usr/bin/install -d -m 0755 \$(DESTDIR)${prefix}/include/helpers/memenv"
-    puts ${makefile} "\t/usr/bin/install -m 0644 include/leveldb/*.h \$(DESTDIR)${prefix}/include/leveldb"
-    puts ${makefile} "\t/usr/bin/install -m 0644 helpers/memenv/memenv.h \$(DESTDIR)${prefix}/include/helpers/memenv"
-    puts ${makefile} "\t/bin/cp -R out-shared/libleveldb* \$(DESTDIR)${prefix}/lib"
-    puts ${makefile} "\t/usr/bin/install -m 0644 out-static/lib*.a \$(DESTDIR)${prefix}/lib"
-    close ${makefile}
+destroot {
+    xinstall -d -m 0755 ${destroot}${prefix}/include/leveldb
+    xinstall -d -m 0755 ${destroot}${prefix}/include/helpers/memenv
+    xinstall -m 0644 {*}[glob ${worksrcpath}/include/leveldb/*.h] ${destroot}${prefix}/include/leveldb
+    xinstall -m 0644 ${worksrcpath}/helpers/memenv/memenv.h ${destroot}${prefix}/include/helpers/memenv
+    copy {*}[glob ${worksrcpath}/out-shared/libleveldb*.dylib] ${destroot}${prefix}/lib
+    xinstall -m 0644 {*}[glob ${worksrcpath}/out-static/lib*.a] ${destroot}${prefix}/lib
 }
-
-destroot.args-append -f Makefile-Install

--- a/databases/leveldb/files/patch-no_gperftools.diff
+++ b/databases/leveldb/files/patch-no_gperftools.diff
@@ -1,0 +1,19 @@
+--- build_detect_platform.orig	2018-05-20 06:06:16.000000000 -0700
++++ build_detect_platform	2018-05-20 06:25:00.000000000 -0700
+@@ -219,16 +219,6 @@
+         PLATFORM_LIBS="$PLATFORM_LIBS -lsnappy"
+     fi
+ 
+-    # Test whether tcmalloc is available
+-    $CXX $CXXFLAGS -x c++ - -o $CXXOUTPUT -ltcmalloc 2>/dev/null  <<EOF
+-      int main() {}
+-EOF
+-    if [ "$?" = 0 ]; then
+-        PLATFORM_LIBS="$PLATFORM_LIBS -ltcmalloc"
+-    fi
+-
+-    rm -f $CXXOUTPUT 2>/dev/null
+-
+     # Test if gcc SSE 4.2 is supported
+     $CXX $CXXFLAGS -x c++ - -o $CXXOUTPUT -msse4.2 2>/dev/null  <<EOF
+       int main() {}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->