### PR TITLE
Pangolin: fix build with ffmpeg 4.0

### DIFF
--- a/graphics/Pangolin/Portfile
+++ b/graphics/Pangolin/Portfile
@@ -6,7 +6,7 @@ PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        stevenlovegrove Pangolin 0.5 v
-revision            2
+revision            3
 categories          graphics
 platforms           darwin
 license             MIT
@@ -35,6 +35,7 @@ depends_lib-append  port:glew \
 checksums           rmd160  5b31d14e8cb1d78cde3f48b9f2576e77e8a5f717 \
                     sha256  7d9ac216ae4ef86150a3ced1cfb0bb23572493aae4f7403b1552be4314b766df
 
-patchfiles-append   CMakeLists.txt.patch
+patchfiles-append   CMakeLists.txt.patch \
+                    ffmpeg-4.0.patch
 
 configure.args      -DBUILD_PANGOLIN_GUI=OFF

--- a/graphics/Pangolin/files/ffmpeg-4.0.patch
+++ b/graphics/Pangolin/files/ffmpeg-4.0.patch
@@ -1,0 +1,87 @@
+commit b56a041ca1586ebaac0659892e5ba381e0a4288d
+Author: ericb <eric.bachard@free.fr>
+Date:   Wed Jan 3 18:46:31 2018 +0100
+
+    Proposed fix for the Linux (maybe other OSs)  issue, because of deprecated CONSTANTS
+
+diff --git a/CMakeModules/FindFFMPEG.cmake b/CMakeModules/FindFFMPEG.cmake
+index 4f77e5a..0f3b6cb 100644
+--- CMakeModules/FindFFMPEG.cmake
++++ CMakeModules/FindFFMPEG.cmake
+@@ -60,8 +60,8 @@ IF(AVCODEC_INCLUDE_DIR AND AVFORMAT_INCLUDE_DIR AND AVUTIL_INCLUDE_DIR AND SWSCA
+    CHECK_CXX_SOURCE_COMPILES(
+      "#include \"${AVCODEC_INCLUDE_DIR}/libavformat/avformat.h\"
+       int main() {
+-        sizeof(AVFormatContext::max_analyze_duration2);
+-      }" HAVE_FFMPEG_MAX_ANALYZE_DURATION2
++        sizeof(AVFormatContext::max_analyze_duration);
++      }" HAVE_FFMPEG_MAX_ANALYZE_DURATION
+    )
+    CHECK_CXX_SOURCE_COMPILES(
+      "#include \"${AVCODEC_INCLUDE_DIR}/libavformat/avformat.h\"
+diff --git a/src/video/drivers/ffmpeg.cpp b/src/video/drivers/ffmpeg.cpp
+index f0aa6ad..efd48dd 100644
+--- src/video/drivers/ffmpeg.cpp
++++ src/video/drivers/ffmpeg.cpp
+@@ -34,6 +34,8 @@
+ #include <libavutil/mathematics.h>
+ }
+ 
++#define CODEC_FLAG_GLOBAL_HEADER AV_CODEC_FLAG_GLOBAL_HEADER
++
+ namespace pangolin
+ {
+ 
+@@ -74,8 +76,10 @@
+     TEST_PIX_FMT_RETURN(YUVJ420P);
+     TEST_PIX_FMT_RETURN(YUVJ422P);
+     TEST_PIX_FMT_RETURN(YUVJ444P);
++#ifdef FF_API_XVMC
+     TEST_PIX_FMT_RETURN(XVMC_MPEG2_MC);
+     TEST_PIX_FMT_RETURN(XVMC_MPEG2_IDCT);
++#endif
+     TEST_PIX_FMT_RETURN(UYVY422);
+     TEST_PIX_FMT_RETURN(UYYVYY411);
+     TEST_PIX_FMT_RETURN(BGR8);
+@@ -95,11 +99,13 @@
+     TEST_PIX_FMT_RETURN(YUV440P);
+     TEST_PIX_FMT_RETURN(YUVJ440P);
+     TEST_PIX_FMT_RETURN(YUVA420P);
++#ifdef FF_API_VDPAU
+     TEST_PIX_FMT_RETURN(VDPAU_H264);
+     TEST_PIX_FMT_RETURN(VDPAU_MPEG1);
+     TEST_PIX_FMT_RETURN(VDPAU_MPEG2);
+     TEST_PIX_FMT_RETURN(VDPAU_WMV3);
+     TEST_PIX_FMT_RETURN(VDPAU_VC1);
++#endif
+     TEST_PIX_FMT_RETURN(RGB48BE );
+     TEST_PIX_FMT_RETURN(RGB48LE );
+     TEST_PIX_FMT_RETURN(RGB565BE);
+@@ -119,7 +125,9 @@
+     TEST_PIX_FMT_RETURN(YUV422P16BE);
+     TEST_PIX_FMT_RETURN(YUV444P16LE);
+     TEST_PIX_FMT_RETURN(YUV444P16BE);
++#ifdef FF_API_VDPAU
+     TEST_PIX_FMT_RETURN(VDPAU_MPEG4);
++#endif
+     TEST_PIX_FMT_RETURN(DXVA2_VLD);
+     TEST_PIX_FMT_RETURN(RGB444BE);
+     TEST_PIX_FMT_RETURN(RGB444LE);
+@@ -560,6 +568,7 @@
+     int ret;
+     int got_packet = 1;
+ 
++#if FF_API_LAVF_FMT_RAWPICTURE
+     // Setup AVPacket
+     if (recorder.oc->oformat->flags & AVFMT_RAWPICTURE) {
+         /* Raw video case - directly store the picture in the packet */
+@@ -569,6 +578,9 @@
+         pkt.pts           = frame->pts;
+         ret = 0;
+     } else {
++#else
++    {
++#endif
+         /* encode the image */
+ #if (LIBAVFORMAT_VERSION_MAJOR >= 54)
+         ret = avcodec_encode_video2(stream->codec, &pkt, frame, &got_packet);


### PR DESCRIPTION
Based on upstream PR.

See https://github.com/stevenlovegrove/Pangolin/pull/318

#### Description

Fixes build failure due to removal of deprecated symbols in ffmpeg 4.0.

Not yet merged upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F70a
Xcode 9.3.1 9E501 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
