### PR TITLE
gnome-internet-radio-locator: update to 1.3.0

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             1.2.0
+version             1.3.0
 set branch          [join [lrange [split $version .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -12,14 +12,14 @@ maintainers         {gnome.org:ole @oleaamot} \
                     openmaintainer
 description         GNOME Internet Radio Locator
 long_description    Locate Internet Radio Stations
-homepage            https://people.gnome.org/~ole/gnome-internet-radio-locator
+homepage            https://www.gnome.org/~ole/gnome-internet-radio-locator
 master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  e666fb5770cfcfbe1aa9f6b020eac2d800443fe2 \
-                    sha256  77b0758bdcca865a22558ca3c2fef9ce59140a8231776f69e7b9c25e1defe503 \
-                    size    540240
+checksums           rmd160  4e8ac0c666b134bc9212f6509f297c86304a5a78 \
+                    sha256  0613024d38540c7d995227d137a8c60bdfd02a2aa381d6b36c410a00b130a221 \
+                    size    540516
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

Update to version 1.3.0 of gnome-internet-radio-locator

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->