### PR TITLE
py-autopep8: fix dependency and enable test

### DIFF
--- a/python/py-autopep8/Portfile
+++ b/python/py-autopep8/Portfile
@@ -35,10 +35,12 @@ checksums           md5     9d0dfe251d003edb8f6a95dc4929b7b7 \
 python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
-    depends_build           port:py${python.version}-setuptools
-    depends_run-append      \
-        port:${realname}_select \
-        path:${python.pkgd}/pycodestyle:py${python.version}-codestyle
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:${realname}_select \
+                            port:py${python.version}-codestyle
+
+    test.run                yes
+    test.cmd                ${python.bin} setup.py
 
     select.group            ${realname}
     select.file             ${filespath}/${realname}-${python.version}


### PR DESCRIPTION
#### Description
- change dependence from ```path``` to ```port``` (see: https://lists.macports.org/pipermail/macports-dev/2018-May/038865.html)
- version not increased since it doesn't affect currently installed ports (it would never find the dependency and, therefore, always install py-codestyle anyway).
- enable tests
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
