### PR TITLE
py-lmfit: add myself as maintainer, remove obsolete notes

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -7,7 +7,7 @@ name                    py-lmfit
 version                 0.9.10
 categories-append       math
 license                 BSD
-maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
+maintainers             {gmail.com:jjstickel @jjstickel} {gmail.com:ottenr.work @reneeotten} openmaintainer
 description             Least-Squares Minimization with Bounds and Constraints
 long_description        Built on top of scipy.optimize, lmfit provides a\
                         Parameter object which can be set as fixed or free,\
@@ -38,8 +38,6 @@ if {$subport ne $name} {
     test.target
     test.env                   PYTHONPATH=${worksrcpath}/build/lib
 
-    notes-append "If py${python.version}-uncertainties is also installed, propagation of uncertainties to constrained parameters will be enabled."
-    notes-append "If upgrading from 0.8.x, any scripts using lmfit must be changed https://lmfit.github.io/lmfit-py/whatsnew.html#whatsnew-090-label"
     livecheck.type      none
 
     post-destroot {


### PR DESCRIPTION
#### Description
- add myself as co-maintainer, see #1836
- remove obsolete notes (py-uncertainties is now a dependency and upgrading from 0.8 has happened ~3 years ago)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
