### PR TITLE
LibreCAD: update to 2.1.3

### DIFF
--- a/cad/LibreCAD/Portfile
+++ b/cad/LibreCAD/Portfile
@@ -2,15 +2,47 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           qmake 1.0
+PortGroup           qmake5 1.0
+PortGroup           cxx11 1.1
 
-github.setup        LibreCAD LibreCAD 2.0.8
-revision            2
+name                LibreCAD
+subport             LibreCAD-devel {}
+
+qt5.depends_component qtsvg qttranslations qttools
+
+if {${subport} eq "${name}"} {
+
+    conflicts           LibreCAD-devel
+    github.setup        LibreCAD LibreCAD 2.1.3
+    checksums           rmd160  2f50b879e95c0ecc019dd5b7f6a218f62744cc1b \
+                        sha256  5d0bc37efa1006742785c06ec30737c7866b0366048553c5560e06a3e442f7b3 \
+                        size    22416015
+                 
+    post-extract {
+        reinplace "s|lrelease|${qt_bins_dir}/lrelease|g" scripts/postprocess-osx.sh
+    }
+
+} elseif {${subport} eq "${name}-devel"} {
+
+    conflicts           LibreCAD
+    github.setup        LibreCAD LibreCAD 58deefa34cb07a3b7b4ed97cd1ac70f9b7fc56d0
+    version             2.2.0-20180216
+
+    checksums           rmd160  ad84d422534a69c49a85017e0f04ba050115fb89 \
+                        sha256  c23e6a1ccd0368c089e74772c02a420a5b475fdeb205ae6be39a93b3abeda965 \
+                        size    13578523
+}
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        ui_error "${name} ${version} requires an OS supporting qt5 to function."
+        return -code error "incompatible OS X version"
+    }
+}
+
 categories          cad
 platforms           darwin
-maintainers         rvt.dds.nl:librecad \
-                    gmail.com:dongxuli2011 \
-                    openmaintainer
+maintainers         nomaintainer
 
 license             GPL-2+
 
@@ -24,61 +56,15 @@ long_description    LibreCAD is a free Open Source CAD application for \
 
 homepage            http://librecad.org/
 
-checksums           rmd160  d5dc079046ac43265b971bd00f85dfae77e14b92 \
-                    sha256  ec13e47f3c960ae716040a16da0b688c58cd85e63f7c17cd44afc5bf73b01b84
-
 depends_lib-append  port:boost \
                     port:freetype \
                     port:libxmlxx2
 
-pre-configure {
-                    configure.args-append CONFIG+=\"build_muparser\"
-}
-
-if {${os.platform} eq "darwin" && ${os.major} < 13} {
-                    configure.compiler macports-gcc-4.8
-                    # -r ensure's that we will build all Makefiles when QMake get's executed
-                    configure.pre_args -r
-
-                    # Fixing -Xarch_X86_64 issues within the Makefile
-                    post-configure  {
-                        ui_info "Removing -Xarch_x86_64 from Makefiles"
-                        fs-traverse Makefile ${worksrcpath} {
-                            if {[string match "*/Makefile" ${Makefile}]} {
-                                ui_info "Fixing Xarch ${Makefile}"
-                                reinplace "s|-Xarch_x86_64||" ${Makefile}
-                            }
-                        }
-                    }
-}
-
-variant universal {}
-
-build.args          CC="${configure.cc} [get_canonical_archflags cc]" \
-                    CXX="${configure.cxx} [get_canonical_archflags cxx]" \
-                    LINK="${configure.cxx} [get_canonical_archflags cxx]"
+configure.args-append CONFIG+=\"build_muparser\"
 
 destroot {
-    if {${os.platform} eq "darwin" && ${os.major} < 13} {
+    # to make a self-contained application for deployment, the following command can be uncommented
+    # system -W ${worksrcpath} "${qt_bins_dir}/macdeployqt LibreCAD.app"
 
-        # copy libgcc files over to within the application, a bug in macdeployqt prevent's this from happening correctly
-        set librecad "${worksrcpath}/LibreCAD.app/Contents/MacOS/LibreCAD"
-        file mkdir ${worksrcpath}/LibreCAD.app/Contents/Frameworks
-        foreach dep [exec otool -L ${librecad} | grep libgcc] {
-            if [string match -nocase "*/libgcc*.dylib" ${dep}] {
-                ui_info "Copy libgcc files over from ${dep} to ${worksrcpath}/LibreCAD.app/Contents/Frameworks"
-                file copy ${dep} ${worksrcpath}/LibreCAD.app/Contents/Frameworks/
-            }
-        }
-
-        # Set these libgcc libraries to local
-        # TODO: Put these in the foreach loop somehow
-        system "install_name_tool -change /opt/local/lib/libgcc/libstdc++.6.dylib \
-            @executable_path/../Frameworks/libstdc++.6.dylib ${librecad}"
-        system "install_name_tool -change /opt/local/lib/libgcc/libgcc_s.1.dylib \
-            @executable_path/../Frameworks/libgcc_s.1.dylib ${librecad}"
-
-    }
-    system -W ${worksrcpath} "${qt_bins_dir}/macdeployqt LibreCAD.app"
     copy ${worksrcpath}/LibreCAD.app ${destroot}${applications_dir}
 }


### PR DESCRIPTION
LibreCAD-devel: new port @2.2.0-rc1
change both to qt5
add cxx11 1.1 PG
simplify Portfile structure

closes: https://trac.macports.org/ticket/43276
closes: https://trac.macports.org/ticket/48806
closes: https://trac.macports.org/ticket/54722
closes: https://trac.macports.org/ticket/55834
closes: https://trac.macports.org/ticket/56024

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13, 10.7, 10.9
Xcode various

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

This should be pretty close to a comprehensive fix. Unfortunately had to drop 10.6.8 and below due to qt5 needs now. Have not tested a build on 10.7 - 10.12 as yet.

Let's see if the buildbots like it. 

Note I have (at present) removed the logic that copied all the supporting libraries into the app bundle -- this builds and runs on MacPorts with the deps installed, which matches the way almost all the other ports build.