### PR TITLE
libxmlxx2: use autoreconf

### DIFF
--- a/textproc/libxmlxx2/Portfile
+++ b/textproc/libxmlxx2/Portfile
@@ -26,10 +26,14 @@ use_xz              yes
 checksums           rmd160  e99658fce15316319b21823c5e4cb5462b5cff1c \
                     sha256  4ad4abdd3258874f61c2e2a41d08e9930677976d303653cd1670d3e9f35463e9
 
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:mm-common
 
 depends_lib         port:libxml2 \
                     port:glibmm
+
+use_autoreconf      yes
+autoreconf.args     -fvi
 
 configure.perl      /usr/bin/perl
 


### PR DESCRIPTION
included libtool does not respect stdlib
also needs mm-common to autoreconf