### PR TITLE
py-ligo-segments @1.0.0: new port

### DIFF
--- a/python/py-ligo-segments/Portfile
+++ b/python/py-ligo-segments/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-ligo-segments
+version             1.0.0
+
+categories-append   science
+maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+
+platforms           darwin
+license             GPL-3
+
+description         Representations of semi-open intervals
+long_description    Defines the `segment`, `segmentlist`, and \
+                    `segmentlistdict` objects for manipulating semi-open \
+                    intervals.
+homepage            https://git.ligo.org/lscsoft/ligo-segments
+
+master_sites        pypi:l/ligo-segments
+distname            ligo-segments-${version}
+checksums   rmd160  a90803ef8a4228461a808ddb7e0caa78dbc8b5a1 \
+            sha256  d8bacc5a7e0a75afab8bced7c066036e844efe3e71f14e4e098d7846a29f0dc2 \
+            size    41659
+
+python.versions     27 36
+python.default_version 27
+
+if {${name} ne ${subport}} {
+
+    depends_lib-append  port:py${python.version}-six \
+                        port:py${python.version}-ligo-common
+
+    depends_build-append port:py${python.version}-setuptools
+
+}


### PR DESCRIPTION
#### Description

[`ligo-segments`](https://pypi.org/project/ligo-segments/) is a python package (in the `ligo` namespace) that provides representations of semi-open intervals.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
