### PR TITLE
wireshark2: Force reindex by applying some change

### DIFF
--- a/net/wireshark2/Portfile
+++ b/net/wireshark2/Portfile
@@ -5,7 +5,6 @@ PortGroup           cmake 1.0
 
 name                wireshark2
 version             2.4.6
-revision            0
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         darkart.com:opendarwin.org


### PR DESCRIPTION
The wireshark24 port identified as wireshark2 before and was added to
PortIndex with that name. Although the name of wireshark24 was fixed in
879e68cd17, the wrong entry for wireshark2 stayed in PortIndex. The
wireshark2 Portfile also needs to be changed to force a reindex to
replace the wrong entry in PortIndex.

Removing revision as 0 is the default.

See: https://trac.macports.org/ticket/56459
See: https://lists.macports.org/pipermail/macports-dev/2018-May/038915.html

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
