### PR TITLE
grpc: update to 1.12.0

### DIFF
--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       cxx11 1.1
 
-github.setup    grpc grpc 1.11.0 v
+github.setup    grpc grpc 1.12.0 v
 categories      devel
 maintainers     nomaintainer
 license         Apache-2
@@ -20,8 +20,8 @@ long_description \
     These libraries enable communication between clients and \
     servers using any combination of the supported languages.
 
-checksums       rmd160  39d04ec6d0d5440c115454a41c21240d7d9f20b0 \
-                sha256  2f1420101d43fcaa3c2a9bca1fd4c6826af490ef703bb12b4196d9f255faef14
+checksums       rmd160  63cf7566f66feba0b2fc443503ab29329ee5c202 \
+                sha256  02f8b368a20b67f4c57727df45d7969fb6a3ba0a1246a7c843c3a4c8e4946a64
 
 patchfiles patch-Makefile.diff
 


### PR DESCRIPTION
#### Description

update grpc to 1.12.0

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Builds on:
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

Binaries are not tested. This is (hopefully) a simple revision bump.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->