### PR TITLE
py-alabaster: update to 0.7.10; remove py26/py33 subports

### DIFF
--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        bitprophet alabaster 0.7.6
+github.setup        bitprophet alabaster 0.7.10
+github.tarball_from releases
 name                py-alabaster
 platforms           darwin
 supported_archs     noarch
@@ -14,8 +15,9 @@ maintainers         nomaintainer
 description         A configurable sidebar enabled Sphinx theme
 long_description    ${description}
 
-checksums           rmd160  33d9ddb282a79f1d14cbf48f1eda52f51422e303 \
-                    sha256  765b9609fedf1abbb9541bfc47272f9a07d1c67c4ff39a2320729b1bc5e89cb2
+checksums           rmd160  028e309cdaa93308e9227ea26bf8852fed447de5 \
+                    sha256  d1ad082998f091b2fb6cee244c9733650a36daade2daea597278653b8035b42d \
+                    size    19870
 
 python.versions     27 34 35 36
 

--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -17,7 +17,7 @@ long_description    ${description}
 checksums           rmd160  33d9ddb282a79f1d14cbf48f1eda52f51422e303 \
                     sha256  765b9609fedf1abbb9541bfc47272f9a07d1c67c4ff39a2320729b1bc5e89cb2
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -213,6 +213,7 @@ py-webkitgtk            1.1.8_8     26
 py-w3lib                1.9.0_1     33
 py-xhtml2pdf            0.0.6_2     26
 py-pkgconfig            1.3.1       26 33
+py-alabaster            0.7.6       26 33
 
 
 if {${subport} ne ${name}} {


### PR DESCRIPTION
#### Description
- update to version 0.7.10; add size, use github.tarball_from releaes
- remove py26 and py33 subports ; nothing depends on them
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
