### PR TITLE
cargo: do not create empty distfiles entry

### DIFF
--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -137,7 +137,7 @@ if {${subport} ne "${name}-bootstrap"} {
         distfiles  ${name}-${version}-${rust_platform}${extract.suffix}:stage0
         worksrcdir ${name}-${version}-${rust_platform}
     } else {
-        distfiles ""
+        distfiles
         foreach arch ${universal_archs} {
             set rust_platform [cargo.rust_platform ${arch}]
             distfiles-append  ${name}-${version}-${rust_platform}${extract.suffix}:stage0


### PR DESCRIPTION
This causes an error when running reclaim

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->