### PR TITLE
py-alabaster: revert the incorrect use of github.tarball_from

### DIFF
--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -5,7 +5,6 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        bitprophet alabaster 0.7.10
-github.tarball_from releases
 name                py-alabaster
 platforms           darwin
 supported_archs     noarch


### PR DESCRIPTION
#### Description
I did test this the other PR yesterday night, and didn't see an error. I probably forgot to do a clean and still had a distfile around or something (if that makes sense)... My mistake, sorry about that and thanks to Rainer for pointing it out.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
