### PR TITLE
py-snowballstemmer: update to 1.2.1, obsolete py26/py33 subports

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -214,6 +214,7 @@ py-w3lib                1.9.0_1     33
 py-xhtml2pdf            0.0.6_2     26
 py-pkgconfig            1.3.1       26 33
 py-alabaster            0.7.6       26 33
+py-snowballstemmer      1.2.0       26 33
 
 
 if {${subport} ne ${name}} {

--- a/python/py-snowballstemmer/Portfile
+++ b/python/py-snowballstemmer/Portfile
@@ -21,7 +21,7 @@ distname            snowballstemmer-${version}
 checksums           rmd160 fe80dd91bf4d1c5c6df947959a117c5e918d7cfc \
                     sha256 6d54f350e7a0e48903a4e3b6b2cabd1b43e23765fbc975065402893692954191
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     livecheck.type      none

--- a/python/py-snowballstemmer/Portfile
+++ b/python/py-snowballstemmer/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-snowballstemmer
-version             1.2.0
+version             1.2.1
 platforms           darwin
 supported_archs     noarch
 license             BSD
@@ -18,14 +18,14 @@ homepage            https://github.com/shibukawa/snowball_py
 master_sites        pypi:s/snowballstemmer
 distname            snowballstemmer-${version}
 
-checksums           rmd160 fe80dd91bf4d1c5c6df947959a117c5e918d7cfc \
-                    sha256 6d54f350e7a0e48903a4e3b6b2cabd1b43e23765fbc975065402893692954191
+checksums           rmd160  433de19c91b3f0914bb280f37cebc21324da4db5 \
+                    sha256  919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128 \
+                    size    49626
 
 python.versions     27 34 35 36
 
 if {$subport ne $name} {
     livecheck.type      none
 } else {
-    livecheck.type      regex
-    livecheck.url       ${master_sites}
+    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- obsolete py26/py33 ; no dependents
- update to version 1.2.1 ; add size to checksums ; fix livecheck

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
