### PR TITLE
py-protobuf3: fix build on older systems

### DIFF
--- a/python/py-protobuf3/Portfile
+++ b/python/py-protobuf3/Portfile
@@ -3,6 +3,7 @@
 PortSystem      1.0
 PortGroup       python 1.0
 PortGroup       github 1.0
+PortGroup       cxx11 1.1
 
 name            py-protobuf3
 version         3.5.1
@@ -40,6 +41,7 @@ checksums       sha256  13d3c15ebfad8c28bee203dd4a0f6e600d2a7d2243bac8b5d0e51746
 
 platforms       darwin
 
+
 python.versions 27 35 36
 
 if {${name} ne ${subport}} {
@@ -49,6 +51,25 @@ if {${name} ne ${subport}} {
     depends_lib     port:protobuf3-cpp
 
     worksrcdir      ${worksrcdir}/python
+    
+    # tricks to force the right -stdlib setting
+    # and to put a needed CXX flag on the 10.6 build
+    # see https://trac.macports.org/ticket/56482
+    patchfiles-append patch-py-protobuf3-settings.diff
+
+    post-patch {
+        if {[string match *clang* ${configure.compiler}]} {
+            set clang_stdlib -stdlib=${configure.cxx_stdlib}
+
+            if {${os.platform} eq "darwin" && ${os.major} < 11} {
+                set extraargs -DGOOGLE_PROTOBUF_NO_THREADLOCAL
+            }
+        }
+        
+        reinplace "s|@@MACPORTS_STDLIB@@|${clang_stdlib}|g" setup.py
+        reinplace "s|@@MACPORTS_EXTRAARG@@|${extraargs}|g" setup.py
+    }
+
 
     destroot.cmd-append    --cpp_implementation
 

--- a/python/py-protobuf3/files/patch-py-protobuf3-settings.diff
+++ b/python/py-protobuf3/files/patch-py-protobuf3-settings.diff
@@ -1,0 +1,11 @@
+--- setup.py.old	2018-05-24 19:42:16.000000000 -0700
++++ setup.py	2018-05-24 19:43:21.000000000 -0700
+@@ -197,6 +197,8 @@
+       v = float('.'.join(v.split('.')[:2]))
+       if v >= 10.12:
+         extra_compile_args.append('-std=c++11')
++        extra_compile_args.append('@@MACPORTS_STDLIB@@')
++        extra_compile_args.append('@@MACPORTS_EXTRAARG@@')
+ 
+     if warnings_as_errors in sys.argv:
+       extra_compile_args.append('-Werror')


### PR DESCRIPTION
add cxx11 1.1 PG
add -stdlib flag to clang builds
add needed CXX flag to systems without thread_local
