### PR TITLE
git-ftp: update to 1.5.1

### DIFF
--- a/devel/git-ftp/Portfile
+++ b/devel/git-ftp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        git-ftp git-ftp 1.5.0
+github.setup        git-ftp git-ftp 1.5.1
 maintainers         {g5pw @g5pw} openmaintainer
 
 categories          devel
@@ -18,9 +18,9 @@ supported_archs     noarch
 depends_run         port:curl \
                     port:git
 
-checksums           rmd160  1ff3b7aac1e44e62f3d4c7ee55eed4db9362ea01 \
-                    sha256  d3adb441ee5d511d39ab98535caf6515f9af55da861462fd945b23f75c235238 \
-                    size    1811514
+checksums           rmd160  5e5eb37795da14cd1892601be15075881b478dba \
+                    sha256  277bd15ce4fed12e194c38a6288f00ccf91a33e015f6e97a7f0642b242df429c \
+                    size    1812549
 
 use_configure       no
 


### PR DESCRIPTION
#### Description
https://github.com/git-ftp/git-ftp/compare/1.5.0...1.5.1
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
