### PR TITLE
Make FFMpeg binary redistributable again

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -36,6 +36,10 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gdk-pixbuf2 \
                     port:vala
 
+license_noconflict  gobject-introspection \
+                    rust \
+                    vala
+
 set pyversion 2.7
 depends_run         port:python[join [split ${pyversion} "."] ""]
 

--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -66,6 +66,8 @@ compiler.blacklist  *gcc* {clang < 800} macports-clang-3.3 macports-clang-3.4 ma
 # as the first, and thus selected, fallback option (even though it has been blacklisted earlier).
 compiler.fallback-prepend macports-clang-3.9
 
+license_noconflict  clang-3.9
+
 # As of 1.7.0: builds both static and shared libraries
 # doesn't install docs or examples correctly, so disable them.
 configure.args      --enable-vp8 \


### PR DESCRIPTION
#### Description

Before version 3.4, ffmpeg is binary redistributable [1]. As version 3.4 adds support for librsvg, it's not anymore [2]. This pull request aims to get things back.

[1] http://packages.macports.org/ffmpeg/
[2] https://github.com/macports/macports-ports/commit/d29cf89b54354dec54e7d6bd1e0322078a9580e4#commitcomment-25068578

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?