### PR TITLE
py-markupsafe: update to 1.0, enable test

### DIFF
--- a/python/py-markupsafe/Portfile
+++ b/python/py-markupsafe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-markupsafe
-version             0.23
+version             1.0
 categories-append   textproc
 platforms           darwin
 license             BSD
@@ -21,11 +21,15 @@ master_sites        pypi:M/MarkupSafe
 
 distname            MarkupSafe-${version}
 
-checksums           rmd160  8d1dd780a46a18b6f6bad78bf92eeca2d06a1f54 \
-                    sha256  a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3
+checksums           rmd160  625a540aafd068e65a7d61693862d7cdc8e9d0a1 \
+                    sha256  a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665 \
+                    size    14356
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+
+    test.run                yes
+    test.cmd                ${python.bin} setup.py
 
     livecheck.type          none
 


### PR DESCRIPTION
#### Description
- update to verision 1.0
- add size to checksums 
- enable tests

This port still has the obsolete py26/py33 subports present, removing them would also mean that these subports would need to be removed from py-jinja2, py-mako, and py-webhelpers. I could do that as part of this PR, but haven't... is there any reason to keep these around?
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
