### PR TITLE
gnome-internet-radio-locator: update to 1.4.0

### DIFF
--- a/gnome/gnome-internet-radio-locator/Portfile
+++ b/gnome/gnome-internet-radio-locator/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gnome-internet-radio-locator
-version             1.3.0
+version             1.4.0
 set branch          [join [lrange [split $version .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -17,9 +17,9 @@ master_sites        gnome:sources/${name}/${branch}/
 
 use_xz              yes
 
-checksums           rmd160  4e8ac0c666b134bc9212f6509f297c86304a5a78 \
-                    sha256  0613024d38540c7d995227d137a8c60bdfd02a2aa381d6b36c410a00b130a221 \
-                    size    540516
+checksums           rmd160  d8e90b9346816bff181a56be72d22643ccd6d0d2 \
+                    sha256  12859a60086dedcfd9a49e3f5f947e11394ddbfe914a4ee8cc0a86492b4e46e7 \
+                    size    540400
 
 depends_build       port:autoconf \
                     port:automake \


### PR DESCRIPTION
#### Description

gnome-internet-radio-locator: update to 1.4.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->