### PR TITLE
py-graveyard: correct versions, restore alphabetical order

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -35,6 +35,7 @@ proc unknown args {
     }
 }
 
+py-alabaster            0.7.6_1     26 33
 py-argh                 0.24.1_1    33
 py-asn1                 0.1.9_2     26
 py-astlib               0.8.0_1     26 32
@@ -137,6 +138,7 @@ py-pathfinder           0.5.3_1     33
 py-pathtools            0.1.2_1     33
 py-pep8                 1.6.2_1     25 26 31 32 33
 py-pint                 0.7.2       33
+py-pkgconfig            1.3.1_1     26 33
 py-plumbum              1.6.2       32
 py-powerline            2.2_1       26 33
 py-progressbar          2.3_1       26
@@ -182,6 +184,7 @@ py-scikit-image         0.11.3_1    26 32 33
 py-scikits-samplerate   0.3.3_1     26
 py-scimath              4.1.2_1     26
 py-scitools             0.9.0_2     26
+py-snowballstemmer      1.2.0_1     26 33
 py-south                0.8.1_1     26
 py-sparqlwrapper        1.6.4_1     34
 py-spatialite           3.0.1_2     26
@@ -212,9 +215,6 @@ py-watchdog             0.7.1_1     33
 py-webkitgtk            1.1.8_8     26
 py-w3lib                1.9.0_1     33
 py-xhtml2pdf            0.0.6_2     26
-py-pkgconfig            1.3.1       26 33
-py-alabaster            0.7.6       26 33
-py-snowballstemmer      1.2.0       26 33
 
 
 if {${subport} ne ${name}} {


### PR DESCRIPTION
Correct my earlier oversights..... see: https://lists.macports.org/pipermail/macports-dev/2018-May/038981.html

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->