### PR TITLE
emacs-mac-app: update to 7.0 (emacs 26.1)

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           bitbucket 1.0
 
-set emacs_version   25.3
-set emacs_mac_ver   6.9a
+set emacs_version   26.1
+set emacs_mac_ver   7.0
 
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
@@ -15,14 +15,15 @@ maintainers         nomaintainer
 
 description         Emacs Mac port
 
-long_description    ${name} is "Mac port" addition to GNU Emacs 25. This provides a native \
-                    GUI support for Mac OS X 10.6 - macOS 10.13.
+long_description    ${name} is "Mac port" addition to GNU Emacs ${emacs_version}. \
+                    This provides a native GUI support for Mac OS X 10.6 - macOS 10.13.
 
 platforms           darwin
 license             GPL-3+
 
-checksums           rmd160  f38a66a987c05226b69b379c46e4c3ce9d5ebd6b \
-                    sha256  4f4d2056cc8cd08b0b822af521a46d7629320d87aac71d1bb3440648c174f1d4
+checksums           rmd160  3fa9aa1febdfb0246921bed2dc89a50b565780e5 \
+                    sha256  aa43760a187ec0fdb7e6486ca4324d65659cf914fc2cdb87396e533959b010e8 \
+                    size    41586354
 
 depends_lib         port:ncurses \
                     port:libxml2 \
@@ -39,6 +40,7 @@ universal_variant   no
 
 use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
+autoreconf.args     all
 
 depends_build       port:autoconf port:automake port:libtool port:texinfo
 

--- a/aqua/emacs-mac-app/files/patch-src_emacs.c.diff
+++ b/aqua/emacs-mac-app/files/patch-src_emacs.c.diff
@@ -1,16 +1,15 @@
---- src/emacs.c.orig	2017-08-24 01:04:59.000000000 +0000
-+++ src/emacs.c	2017-08-28 13:47:52.000000000 +0000
-@@ -24,6 +24,8 @@
+--- src/emacs.c.orig	2018-05-29 03:16:36.000000000 +0000
++++ src/emacs.c	2018-05-29 14:25:27.000000000 +0000
+@@ -24,6 +24,7 @@
  #include <errno.h>
  #include <fcntl.h>
- #include <stdio.h>
-+#include <stdlib.h>
+ #include <stdlib.h>
 +#include <string.h>
  
- #include <sys/types.h>
  #include <sys/file.h>
-@@ -754,6 +756,25 @@
- #ifdef DARWIN_OS
+ #include <unistd.h>
+@@ -771,6 +772,25 @@
+ #if defined DARWIN_OS && !defined CANNOT_DUMP
    if (!initialized)
      unexec_init_emacs_zone ();
 +
@@ -34,4 +33,4 @@
 +  }
  #endif
  
-   atexit (close_output_streams);
+   init_standard_fds ();


### PR DESCRIPTION
#### Description

Update emacs-mac-app to 7.0 (based on emacs 26.1)

###### Tested on
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
