### PR TITLE
dmd-bootstrap: set configure.cxx_stdlib

### DIFF
--- a/lang/dmd-bootstrap/Portfile
+++ b/lang/dmd-bootstrap/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 name                dmd-bootstrap
 # version should be same as HOST_DMD_VER found in posix.mak from dmd port
 version             2.068.2
+revision            1
 categories          lang
 platforms           darwin
 license             {GPL-1 Artistic-1} Boost-1 Restrictive
@@ -18,6 +19,9 @@ master_sites        http://downloads.dlang.org/releases/2.x/${version}
 
 supported_archs     x86_64
 universal_variant   no
+
+# prebuilt binary uses libstdc++
+configure.cxx_stdlib libstdc++
 
 use_zip             yes
 distfiles           dmd.${version}.osx${extract.suffix}


### PR DESCRIPTION
prebuilt binary uses libstdc++

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->