### PR TITLE
various py-* ports: remove obsolete py26/py33 subports

### DIFF
--- a/python/py-acor/Portfile
+++ b/python/py-acor/Portfile
@@ -23,7 +23,7 @@ checksums           md5     8681b949f50e0f9a02bfbd15f7a3d56c \
                     rmd160  d6e0c55e4db74b45e2ed632a0a553851ef6fe017 \
                     sha256  4c647d30326004cfcfbcf630e97586ce574954e36bebf75b657d33d5d79e94e3
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  pypi

--- a/python/py-acora/Portfile
+++ b/python/py-acora/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc devel
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-appdirs/Portfile
+++ b/python/py-appdirs/Portfile
@@ -24,7 +24,7 @@ checksums           md5     44c679904082a2133f5566c8a0d3ab42 \
                     rmd160  5c20593d89aa579dc571d533efeeb8ee72eb0d58 \
                     sha256  9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     post-destroot {

--- a/python/py-astrolibcoords/Portfile
+++ b/python/py-astrolibcoords/Portfile
@@ -22,7 +22,7 @@ distname                ${realname}-${version}
 checksums               sha1    8de4563e2d2b43d9c1b308f6dad0dd702e795a1a \
                         rmd160  bb273716fd4bd3f5df7558f5cdb19dde732ee5c3
 
-python.versions         26 27
+python.versions         27
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-astropy-helpers/Portfile
+++ b/python/py-astropy-helpers/Portfile
@@ -21,7 +21,7 @@ license             BSD
 checksums           rmd160  49e3b005326bb5f35dbe3d606678aafce7e4ec03 \
                     sha256  8ebe5afe20d54423c55d3374abc2a90de29a765daeca937eec29c0e3e055f853
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-async-task/Portfile
+++ b/python/py-async-task/Portfile
@@ -22,8 +22,7 @@ long_description  Async is one more attempt to make the definition and \
 checksums           rmd160  381ca69e9e2413c4cf44bb7ca523b355caf39f64 \
                     sha256  f2dc9df8ac31890acbc98d787290083504d3987b0713b61a4414631dbf39fbc2
 
-python.versions   26 27
-python.default_version 27
+python.versions   27
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-atpy/Portfile
+++ b/python/py-atpy/Portfile
@@ -26,7 +26,7 @@ checksums           md5     2306195fcefff7c1e4d36ae92a894ff2 \
                     sha1    93525db0a36770b7cbbafefa6041fc80aac51c61 \
                     rmd160  a2c76ef4ac595d0f9cbfb0a21d3bf1bf98b088cf
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-backcall/Portfile
+++ b/python/py-backcall/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-beautifulsoup/Portfile
+++ b/python/py-beautifulsoup/Portfile
@@ -22,7 +22,7 @@ checksums           md5 5ad1a8550a19bfc945baac23eb8293ed \
                     sha1 b23e78f058240eb8779dbc1b8a8d76bba4916df1 \
                     rmd160 4e771d39bf89d5cb2f68a04bf6a457ab3324f3ad
 
-python.versions     26 27
+python.versions     27
 
 livecheck.type      regex
 livecheck.regex     BeautifulSoup-(\[0-9.\]+)${extract.suffix}

--- a/python/py-boto/Portfile
+++ b/python/py-boto/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 maintainers         nomaintainer
 

--- a/python/py-bottle-sqlalchemy/Portfile
+++ b/python/py-bottle-sqlalchemy/Portfile
@@ -28,7 +28,7 @@ distname            ${_name}-${version}
 checksums           md5 b139d97424efcf917474f142851f0231 \
                     sha256 197189c4aa92dad32c49fcb6e8a1c365679b1d024129640a4f30eee0b2db6b78
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_lib     port:py${python.version}-bottle

--- a/python/py-bottle/Portfile
+++ b/python/py-bottle/Portfile
@@ -27,7 +27,7 @@ homepage            http://bottlepy.org/
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 checksums           rmd160 eef8c9d10ef39436aad0c776bf0bd23a5dcf15f8 \
                     sha256 fe0a24b59385596d02df7ae7845fe7d7135eea73799d03348aeb9f3771500051

--- a/python/py-bottleneck/Portfile
+++ b/python/py-bottleneck/Portfile
@@ -10,7 +10,7 @@ categories-append   math
 platforms           darwin
 license             BSD
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         stromnov openmaintainer
 

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -35,22 +35,35 @@ proc unknown args {
     }
 }
 
+py-acor                 1.1.1_1     26 33
+py-acora                2.1_1       33
 py-alabaster            0.7.6_1     26 33
+py-appdirs              1.4.3_1     26 33
 py-argh                 0.24.1_1    33
 py-asn1                 0.1.9_2     26
 py-astlib               0.8.0_1     26 32
+py-astrolibcoords       0.37_1      26
+py-astropy-helpers      2.0.2_1     33
 py-astroquery           0.3.6_1     33
 py-astroML              0.3_1       26 33
+py-async-task           0.6.2_1     26
+py-atpy                 0.9.7_3     26
 py-autopep8             1.1.1_1     26 31 32 33
 py-awscli               1.14.63     34
+py-backcall             0.1.0_1     33
 py-backports-ssl        0.0.7_1     33
 py-backports.weakref    1.0.post1   34
 py-biggles              1.6.7_2     26
 py-bitarray             0.8.1_1     26 32 33
 py-blockcanvas          4.0.3_1     26
+py-beautifulsoup        3.2.1_1     26
 py-beautifulsoup4       4.5.3_1     26 33
+py-boto                 2.45.0_1    26
 py-boto3                1.6.16      34
 py-botocore             1.9.16      34
+py-bottle               0.12.9_1    26
+py-bottle-sqlalchemy    0.3_1       26
+py-bottleneck           1.2.1_1     26 33
 py-cdb                  0.34_1      26
 py-cherrypy             2.3.0_2     26
 py-codetools            4.0.0_2     26


### PR DESCRIPTION
#### Description
First attempt to actively remove py26/py33 subports, for now just a few to start with and only ones that have nothing depend on them. Tested with ```port echo depends:py??-<portname>```, which will not flag ports that used them as dependencies in non-default variants (if I am correct), but probably there aren't many of those... Anyway, if this is deemed an useful activity I can slowly continue to go through the Python ports that still have obsolete  subports (i.e., <27 for Python 2 and <34 for Python 3) and do some housekeeping. After that other ports that use these python versions in variants or as ```python.default_version``` should probably be updated as well. 

Are there any ports that should be kept around explicitly for older Python versions? 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
