### PR TITLE
zstd: Update to 1.3.4

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        facebook zstd 1.3.3 v
+github.setup        facebook zstd 1.3.4 v
 categories          archivers devel
 platforms           darwin
 license             {BSD GPL-2}
@@ -15,8 +15,9 @@ long_description    Zstd, short for Zstandard, is a fast lossless compression \
                     algorithm, targeting real-time compression scenarios at \
                     zlib-level and better compression ratios.
 
-checksums           rmd160  d75657f500f4610805b131e0de339733ba3991f0 \
-                    sha256  19d6ea91151f5d747743502e2d5ffa130e2fc1b3f1b516781ec56d93f4e2e1b9
+checksums           rmd160  adf63ec9f17c52de9a3b052011df263f1e4eb59c \
+                    sha256  4b140e3a1688b6253ef78db0d6c24dbe08cb01dfd7719b162a8505528ef2ea05 \
+                    size    2060274
 
 post-patch {
     reinplace -W ${worksrcpath} "s/-Wvla //g" lib/Makefile programs/Makefile tests/Makefile tests/fuzz/Makefile


### PR DESCRIPTION
#### Description

This PR updates zstd to 1.3.4.

This is required in order to be able to update folly, as requested in https://trac.macports.org/ticket/56565.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->