### PR TITLE
folly: Update to 2018.05.28.00

### DIFF
--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
-github.setup        facebook folly 2017.03.20.00 v
-revision            2
+github.setup        facebook folly 2018.05.28.00 v
 categories          devel
 platforms           darwin
 license             Apache-2
@@ -15,8 +14,9 @@ maintainers         sean openmaintainer
 description         An open-source C++ library developed and used at Facebook.
 long_description    ${description}
 
-checksums           rmd160  5dc40b05e7c9852001546e9f5e9737e26b197494 \
-                    sha256  8e58e5841890bcd999971663754f4f1c064acf0acb2c2efaddbd4488d2497f95
+checksums           rmd160  8ab6f6652a14a34610b27ca97b70476400f9defe \
+                    sha256  73c5bfa832ff9e1053dd3c3010850280da111f7e75b36b6c86cc791e22a684f9 \
+                    size    2318525
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

This updates folly to 2018.05.28.00 as requested in https://trac.macports.org/ticket/56565.

https://github.com/macports/macports-ports/pull/1901 must be merged first.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->