### PR TITLE
py-re2: Update to 1.0.6

### DIFF
--- a/python/py-re2/Portfile
+++ b/python/py-re2/Portfile
@@ -1,17 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        facebook pyre2 33b22739b01d
+github.setup        facebook pyre2 1.0.6 v
 name                py-re2
-version             0.1.20160526
-
 categories-append   devel
 license             BSD
 platforms           darwin
-supported_archs     noarch
 maintainers         sean openmaintainer
 
 description         Python wrapper of Google's RE2 library.
@@ -19,8 +17,9 @@ long_description    pyre2 is a Python extension that wraps Google's RE2 regular 
                     expression library. It implements many of the features of \
                     Python's built-in re module with compatible interfaces.
 
-checksums           rmd160  3c06bd1c9fea9feb1e86c4ad33696d20c7879274 \
-                    sha256  1516f08f8ea159dc9866508ee29a846f68e4953cd9632acb75888e3ccb72022a
+checksums           rmd160  89241df1d53076189327e53d0e99efa62091956d \
+                    sha256  b332f9fb53318fc8410e047e29b0a0c6952fd1c1eebf8ee06f72e2f637c909dc \
+                    size    11291
 
 python.versions     27
 


### PR DESCRIPTION
#### Description

py-re2: Update to 1.0.6

https://github.com/macports/macports-ports/pull/1904 should be merged first.

Note that this will not build on 10.8 or earlier until a [bug in the python portgroup](https://trac.macports.org/ticket/56567) is fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->