### PR TITLE
gtk-internet-radio-locator: New GTK+ 4.0 port

### DIFF
--- a/gnome/gtk-internet-radio-locator/Portfile
+++ b/gnome/gtk-internet-radio-locator/Portfile
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                gtk-internet-radio-locator
+version             0.0.2
+set branch          [join [lrange [split $version .] 0 1] .]
+categories          gnome
+platforms           darwin
+license             GPL-3+
+maintainers         {gnome.org:ole @oleaamot} \
+                    openmaintainer
+description         Internet Radio Locator for GTK+ 4.0
+long_description    Locate Free Internet Radio Stations
+homepage            https://www.gnome.org/~ole/gtk-internet-radio-locator
+master_sites        gnome:sources/${name}/${branch}/
+
+use_xz              yes
+
+checksums           rmd160  5f5c0e9bca2e2a27986868f892b9e62598968ae6 \
+                    sha256  b0459413ebefcd0421e24d989b28073ab4fa08a8d3c0b7bf666cd4e4e1d5a3ea \
+                    size    507932
+
+depends_build       port:autoconf \
+                    port:automake \
+                    port:geocode-glib \
+                    port:gnome-common \
+                    port:gstreamer1-gst-plugins-bad \
+                    port:gstreamer1-gst-plugins-good \
+                    port:gstreamer1-gst-plugins-ugly \
+                    port:gtk-doc \
+                    port:intltool \
+                    port:itstool \
+                    port:pkgconfig \
+                    port:yelp-tools
+
+depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/pango.pc:pango \
+                    port:desktop-file-utils \
+                    port:geocode-glib \
+                    port:gstreamer1 \
+                    port:gstreamer1-gst-plugins-base \
+                    port:gtk3 \
+                    port:libchamplain \
+                    port:libxml2 \
+                    port:zlib
+
+depends_run         port:adwaita-icon-theme \
+                    port:gstreamer1-gst-plugins-bad \
+                    port:gstreamer1-gst-plugins-good \
+                    port:gstreamer1-gst-plugins-ugly
+
+# reconfigure using autogen.sh from upstream git for intltool 0.51 compatibility
+
+post-patch {
+    xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}
+}
+
+configure.cmd       ./autogen.sh
+
+# building with optimization greater than -O0 causes crash on selecting station
+# https://trac.macports.org/ticket/52993
+configure.optflags  -O0
+configure.args      --disable-silent-rules
+
+post-activate {
+   system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
+   system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+}
+
+variant debug description {Build with debug symbols and enable debug messages} {
+    patchfiles-append   patch-enable-debug.diff
+    configure.optflags  -O0 -g
+}
+
+livecheck.type      gnome-with-unstable

--- a/gnome/gtk-internet-radio-locator/files/autogen.sh
+++ b/gnome/gtk-internet-radio-locator/files/autogen.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Run this to generate all the initial makefiles, etc.
+
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+PKG_NAME="gtk-internet-radio-locator"
+
+(test -f $srcdir/src/gtk-internet-radio-locator.c) || {
+    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
+    echo " top-level $PKG_NAME directory"
+    exit 1
+}
+
+which gnome-autogen.sh || {
+    echo "You need to install gnome-common from the GNOME CVS"
+    exit 1
+}
+
+REQUIRED_AUTOCONF_VERSION=2.59
+REQUIRED_AUTOMAKE_VERSION=1.14
+REQUIRED_INTLTOOL_VERSION=0.40.0
+REQUIRED_PKG_CONFIG_VERSION=0.16.0
+REQUIRED_GTK_DOC_VERSION=1.9
+USE_GNOME2_MACROS=1 . gnome-autogen.sh

--- a/gnome/gtk-internet-radio-locator/files/patch-enable-debug.diff
+++ b/gnome/gtk-internet-radio-locator/files/patch-enable-debug.diff
@@ -1,0 +1,11 @@
+--- src/Makefile.am.orig	2018-03-26 16:27:01.000000000 +0200
++++ src/Makefile.am	2018-03-27 15:20:55.000000000 +0200
+@@ -25,7 +25,7 @@
+ gtk_internet_radio_locator_CFLAGS  = $(GTK_INTERNET_RADIO_LOCATOR_CFLAGS) \
+ 	       -DGTK_INTERNET_RADIO_LOCATOR_DATADIR=\"$(datadir)/gtk-internet-radio-locator\" \
+ 	       -DDATADIR=\"$(datadir)\" \
+-	       -DGTK_INTERNET_RADIO_LOCATOR_DEBUG=1 \
++	       -DGTK_INTERNET_RADIO_LOCATOR_DEBUG=0 \
+ 	       -DGTK_INTERNET_RADIO_LOCATOR_CFG \
+ 	       -DGTKLOCALEDIR=\"$(datadir)/locale\"
+ 


### PR DESCRIPTION
#### Description

gtk-internet-radio-locator: New GTK+ 4.0 port

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.4 17E202
Xcode 9.3.1 9E501 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?