### PR TITLE
py-pyqtgraph:  add py34 and py35 subports to py-graveyard

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -169,6 +169,7 @@ py-pyobjc-qtkit         2.5.1_1     26 31 32 33
 py-pyobjc-quartz        2.5.1_1     26 31 32 33
 py-pyodbc               3.0.6_1     26
 py-pyopencl             2013.2_1    26 33
+py-pyqtgraph            0.9.10      34 35
 py-pyshp                1.2.1_1     26 32 33
 py-pytidylib            0.2.1_1     26
 py-pytools              2013.5.6_1  26 33


### PR DESCRIPTION
- [x] bugfix

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
