### PR TITLE
gptfdisk: Use the right C++ compiler and C++ standard library

### DIFF
--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -36,6 +36,7 @@ use_configure           no
 
 build.args              -f Makefile.mac \
                         CC="${configure.cc}" \
+                        CXX="${configure.cxx}" \
                         FATBINFLAGS="[get_canonical_archflags]"
 
 destroot {

--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 
 name                    gptfdisk
 version                 1.0.3
+revision                1
 categories              sysutils
 platforms               darwin
 license                 GPL-2+
@@ -16,7 +17,6 @@ long_description        GPT fdisk (gdisk) is a disk partitioning tool loosely mo
 
 homepage                http://www.rodsbooks.com/gdisk/
 master_sites            sourceforge:project/gptfdisk/gptfdisk/${version}
-
 
 checksums               md5 07b625a583b66c8c5840be5923f3e3fe \
                         sha1 9a74bbe7805d562316e92417f71e4b03155308e6 \
@@ -35,8 +35,8 @@ depends_lib             port:ncurses \
 use_configure           no
 
 build.args              -f Makefile.mac \
-                        CC="${configure.cc}" \
-                        CXX="${configure.cxx}" \
+                        CC="${configure.cc} ${configure.cflags}" \
+                        CXX="${configure.cxx} ${configure.cxxflags}" \
                         FATBINFLAGS="[get_canonical_archflags]"
 
 destroot {

--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -34,8 +34,8 @@ depends_lib             port:ncurses \
 
 use_configure           no
 
-build.args              -f Makefile.mac CC="${configure.cc} [get_canonical_archflags cc]" \
-                        LN="${configure.cc}"
+build.args              -f Makefile.mac \
+                        CC="${configure.cc} [get_canonical_archflags cc]"
 
 destroot {
     xinstall -m 0755 -d ${destroot}${prefix}/bin

--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -35,7 +35,8 @@ depends_lib             port:ncurses \
 use_configure           no
 
 build.args              -f Makefile.mac \
-                        CC="${configure.cc} [get_canonical_archflags cc]"
+                        CC="${configure.cc}" \
+                        FATBINFLAGS="[get_canonical_archflags]"
 
 destroot {
     xinstall -m 0755 -d ${destroot}${prefix}/bin

--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -34,6 +34,8 @@ depends_lib             port:ncurses \
 
 use_configure           no
 
+variant universal {}
+
 build.args              -f Makefile.mac \
                         CC="${configure.cc} ${configure.cflags}" \
                         CXX="${configure.cxx} ${configure.cxxflags}" \

--- a/sysutils/gptfdisk/files/patch-Makefile.mac.diff
+++ b/sysutils/gptfdisk/files/patch-Makefile.mac.diff
@@ -5,10 +5,11 @@
  CC=gcc
  CXX=clang++
  FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.4
- CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
+-CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
 -#CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
 -CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -I /usr/local/include -I/opt/local/include -g
-+CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I$(prefix)/include -g
++CFLAGS=$(FATBINFLAGS) -D_FILE_OFFSET_BITS=64 -g
++CXXFLAGS=$(FATBINFLAGS) -Wall -D_FILE_OFFSET_BITS=64 -I$(prefix)/include -g
  LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
  MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
  #LIB_SRCS=$(NAMES:=.cc)

--- a/sysutils/gptfdisk/files/patch-Makefile.mac.diff
+++ b/sysutils/gptfdisk/files/patch-Makefile.mac.diff
@@ -4,8 +4,7 @@
 +prefix=__PREFIX__
  CC=gcc
  CXX=clang++
--FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.4
-+FATBINFLAGS=
+ FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.4
  CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
 -#CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
 -CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -I /usr/local/include -I/opt/local/include -g

--- a/sysutils/gptfdisk/files/patch-Makefile.mac.diff
+++ b/sysutils/gptfdisk/files/patch-Makefile.mac.diff
@@ -1,5 +1,5 @@
---- Makefile.mac.orig	2017-08-07 13:33:46.000000000 +0300
-+++ Makefile.mac	2017-08-07 18:09:48.000000000 +0300
+--- Makefile.mac.orig	2017-07-27 20:41:20.000000000 -0500
++++ Makefile.mac	2018-05-31 21:57:18.000000000 -0500
 @@ -1,9 +1,9 @@
 +prefix=__PREFIX__
  CC=gcc
@@ -9,7 +9,7 @@
  CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
 -#CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
 -CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -I /usr/local/include -I/opt/local/include -g
-+CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I$(prefix)/include -I $(prefix)/include -I$(prefix)/include -g
++CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I$(prefix)/include -g
  LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
  MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
  #LIB_SRCS=$(NAMES:=.cc)


### PR DESCRIPTION
#### Description

Numerous fixes for the gptfdisk port, most importantly using the right C++ compiler and C++ standard library, fixing [a problem reported on the mailing list](https://lists.macports.org/pipermail/macports-dev/2018-May/039030.html).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->