### PR TITLE
dylibbundler: Use the right CXXFLAGS

### DIFF
--- a/devel/dylibbundler/Portfile
+++ b/devel/dylibbundler/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dylibbundler
 version             0.4.4
-revision            2
+revision            3
 categories          devel
 platforms           darwin
 maintainers         strasweb.fr:rudloff openmaintainer
@@ -48,7 +48,7 @@ use_configure       no
 
 variant universal {}
 
-build.args          CXX="${configure.cxx} [get_canonical_archflags cxx]"
+build.args          CXX="${configure.cxx} ${configure.cxxflags} [get_canonical_archflags cxx]"
 
 destroot.args       PREFIX=${prefix}
 


### PR DESCRIPTION
#### Description

Makes dylibbundler use the right CXXFLAGS. This includes using our optimization flags, so the built result is different, so the revision is increased. It also causes it to use the right C++ standard library, fixing [a problem reported on the mailing list](https://lists.macports.org/pipermail/macports-dev/2018-May/039023.html) by @kencu .

Maintainer: @Rudloff

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->