### PR TITLE
SuiteSparse: Use MacPorts CXXFLAGS

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -6,7 +6,7 @@ PortGroup           compilers 1.0
 name                SuiteSparse
 epoch               20120107
 version             4.2.1
-revision            4
+revision            5
 categories          math science
 platforms           darwin
 maintainers         {michaelld @michaelld} openmaintainer
@@ -105,9 +105,8 @@ use_parallel_build  no
 
 pre-build {
     build.args-append \
-        CC="${configure.cc}" \
-        CXX="${configure.cxx}" \
-        CFLAGS="${configure.cflags}" \
+        CC="${configure.cc} ${configure.cflags}" \
+        CXX="${configure.cxx} ${configure.cxxflags}" \
         TARGET_ARCH="[get_canonical_archflags]"
 }
 


### PR DESCRIPTION
#### Description

SuiteSparse: Use MacPorts CXXFLAGS

This allows the correct C++ standard library to be used.

The build system uses CFLAGS for both C and C++ code and doesn't provide a separate variable to use for C++ code, so the flags have to be moved into the CC and CXX variables.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- [skip notification] -->