### PR TITLE
auto-multiple-choice-devel: update to 1.4.0.b201805310528

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -31,22 +31,25 @@ if {${subport} eq ${name}} {
     set gitlab.commit       "a488cdbc7f8d6d1d6b7fde48b6ce92e9d972d62a"
     set amc_revision        "git201805011238"
     set amc_date            "201805011238"
+    version                 1.3.0.${amc_revision}
     checksums               rmd160  fe210d0320577e27d09ee1975f6452cfccdd3606 \
                             sha256  4303691433ebea2e9420517d6a1c89b3ea2e1746f37753ea08109f44cdd8f2b7
     conflicts               auto-multiple-choice-devel
 } else {
     # devel
-    set gitlab.commit       "3e19f40ce6e72f0d454a068b03d1bf6d02398d40"
-    set amc_revision        "git201805020726"
-    set amc_date            "201805020726"
-    checksums               rmd160  87006ab2e9923a58fa6eeb756f25e59fcc9fcb86 \
-                            sha256  edf1d4919a90c8481a5c915317cf211fdcfc53eba80922a7cec2375429bacb00
+    set gitlab.commit       "4ca39bbf03488828a87e05a873379ae39cdce6cf"
+    set amc_revision        "201805310528"
+    set amc_date            "201805310528"
+    version                 1.4.0.b${amc_revision}
+    checksums               rmd160  fb5a8adac676eff04fa3fe50fce035700031be34 \
+                            sha256  7e7841eff281dd0496eb4bbc0303d16f47b97dee086f3f0e99ac18081d314e8c
+    depends_build-append    port:gmake
+    build.cmd               ${prefix}/bin/gmake
     conflicts               auto-multiple-choice
 }
 
 master_sites            https://gitlab.com/jojo_boulix/auto-multiple-choice/repository/archive.tar.gz?ref=${gitlab.commit}&dummy=
 distname                ${gitlab.project}-${gitlab.commit}-${gitlab.commit}
-version                 1.3.0.${amc_revision}
 
 depends_build-append    \
                         port:dblatex \


### PR DESCRIPTION
auto-multiple-choice-devel: update to 1.4.0.b201805310528
• update devel to 1.4.0.b201805310528
• use gmake instead of too old Xcode make
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.4 9F1027a 

macOS 10.11.6 15G20015
Xcode 8.2.1 8C1002 

macOS 10.10.5 14F2511
Xcode 7.2.1 7C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->