### PR TITLE
New port: libjwt

### DIFF
--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libjwt
+version             1.8.0
+revision            0
+categories          devel
+platforms           darwin
+license             MIT
+
+maintainers         nomaintainer
+
+description         C library for Javascript Web Tokens (JWT's)
+long_description    ${description}
+
+homepage            https://github.com/benmcollins/libjwt
+master_sites        https://github.com/benmcollins/libjwt/archive/
+
+checksums           rmd160  944a9f4604e67d4a780a41454c616a5979d8d5db \
+                    sha256  e97c15c14dbd49d5ba435cb26e06e6cdd6e32cf9f0be6b6e9a2d2d330923ea17
+
+use_autoreconf      yes
+
+distfiles           v${version}.tar.gz
+depends_lib         port:jansson

--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -1,26 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                libjwt
-version             1.8.0
-revision            0
-categories          devel
+github.setup        benmcollins libjwt 1.8.0 v
+
 platforms           darwin
-license             MIT
+categories          devel
+license             LGPL-3
 
-maintainers         nomaintainer
+maintainers         @KensingtonTech openmaintainer
 
 description         C library for Javascript Web Tokens (JWT's)
 long_description    ${description}
 
-homepage            https://github.com/benmcollins/libjwt
-master_sites        https://github.com/benmcollins/libjwt/archive/
 
-checksums           rmd160  944a9f4604e67d4a780a41454c616a5979d8d5db \
-                    sha256  e97c15c14dbd49d5ba435cb26e06e6cdd6e32cf9f0be6b6e9a2d2d330923ea17
+checksums           rmd160  f7ea338b7f2d85ed7625e693b741a1c1d0d95bc8 \
+                    sha256  da3df9cec73249523c9dad355ea37ea236791bf22b578cb4c92f6503de0c04d0 \
+                    size    75820
 
 use_autoreconf      yes
 
-distfiles           v${version}.tar.gz
-depends_lib         port:jansson port:openssl
+depends_lib         port:jansson port:openssl port:pkgconfig

--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -23,4 +23,4 @@ checksums           rmd160  944a9f4604e67d4a780a41454c616a5979d8d5db \
 use_autoreconf      yes
 
 distfiles           v${version}.tar.gz
-depends_lib         port:jansson
+depends_lib         port:jansson port:openssl


### PR DESCRIPTION
#### Description

libjwt is a C library for working with JSON Web Tokens (JWT's).  It depends on the jansson library and openssl.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?