### PR TITLE
Added new jwt variant to nginx

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -30,7 +30,8 @@ master_sites        http://nginx.org/download:nginx \
                     https://github.com/slact/nchan/archive/:http_push_module \
                     https://github.com/simpl/ngx_devel_kit/archive/:devel_kit_module \
                     https://github.com/openresty/lua-nginx-module/archive/:lua_module \
-                    https://github.com/openresty/headers-more-nginx-module/archive/:h_more_module
+                    https://github.com/openresty/headers-more-nginx-module/archive/:h_more_module \
+                    https://github.com/TeslaGov/ngx-http-auth-jwt-module/archive/:jwt_module
 
 distfiles           ${name}-${version}${extract.suffix}:nginx
 checksums           ${name}-${version}${extract.suffix} \
@@ -398,6 +399,19 @@ variant headers_more description {Enable headers-more module (https://github.com
                               sha256  c6d9dab8ea1fc997031007e2e8f47cced01417e203cd88d53a9fe9f6ae138720
 
     configure.args-append     --add-module=${workpath}/${ngx_h_more_distname}
+}
+
+variant jwt description {Add JWT (Javascript Web Token) support to server using TeslaGov's ngx-http-auth-jwt-module (https://github.com/TeslaGov/ngx-http-auth-jwt-module)} {
+    set jwt_filename     ngx-http-auth-jwt-module
+    set jwt_version      0.0.2
+    set jwt_distname     ${jwt_filename}-${jwt_version}
+    distfiles-append     v${jwt_version}.tar.gz:jwt_module
+    checksums-append        v${jwt_version}.tar.gz \
+                            rmd160  7c87e95adcf654f2684e5ce1c932ce56b32b403c \
+                            sha256  2ff4f6ee29cfb708ce215f2f110aa360ba5823ad0355033d7ec2ec39610d5087 \
+                            size    13681
+    configure.args-append   --add-dynamic-module=${workpath}/${jwt_distname}
+    depends_lib-append      port:libjwt
 }
 
 


### PR DESCRIPTION
#### Description

Add JWT (Javascript Web Token) support to nginx server using TeslaGov's ngx-http-auth-jwt-module 

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.5 17F77
Xcode 9.4 9F1027a 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
