### PR TITLE
bind9: use https, fix livecheck

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -18,7 +18,7 @@ long_description	The BIND DNS Server is used on the vast majority of name \
 				and Internet addresses and is intended to be linked with applications \
 				requiring name service.
 
-homepage		http://www.isc.org
+homepage		https://www.isc.org/
 
 distname		bind-${version}
 master_sites		isc:${name}/${version}
@@ -120,5 +120,5 @@ variant python36 description {Build python36 module} {
 	configure.args-append --with-python=${prefix}/bin/python3.6
 }
 livecheck.type	regex
-livecheck.url	${homepage}/downloads/
-livecheck.regex	"target=\"_blank\">BIND (\\d+\.\\d+\.\\d+(?:-P\\d+)?) - tar.gz</a>"
+livecheck.url	${homepage}downloads/
+livecheck.regex	"bind-(\\d+\.\\d+\.\\d+(?:-P\\d+)?).tar.gz - tar.gz\\s*</a>"


### PR DESCRIPTION
#### Description
```
$ curl -I http://www.isc.org
HTTP/1.1 301 Moved Permanently

Location: https://www.isc.org/
```
