### PR TITLE
libblocksruntime: add openmaintainer and remove clang_select depends

### DIFF
--- a/devel/libblocksruntime/Portfile
+++ b/devel/libblocksruntime/Portfile
@@ -7,7 +7,7 @@ version             0.4.1
 categories          devel
 platforms           darwin
 license             MIT
-maintainers         {@adsun701 gmail.org:adsun701}
+maintainers         {@adsun701 gmail.org:adsun701} openmaintainer
 description         compiler-rt Blocks runtime library for Clang
 long_description    libblocksruntime is a target-independent implementation of Apple "Blocks" runtime interfaces.
 homepage            https://compiler-rt.llvm.org
@@ -17,4 +17,3 @@ worksrcdir          ${name}-${version}
 checksums           rmd160  43196c58a5c85b48ec94a583bd67dc2120467977 \
                     sha256  7807e18d7d6cabd90f77c8b8a8ebd472516fa4ed6a02df82e0c33b1c5e112abc \
                     size    312180
-depends_build       port:clang_select


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E199
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
