### PR TITLE
folly: build with cmake

### DIFF
--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -3,8 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
+PortGroup           cmake 1.1
 
 github.setup        facebook folly 2018.05.28.00 v
+revision            1
 categories          devel
 platforms           darwin
 license             Apache-2
@@ -18,14 +20,7 @@ checksums           rmd160  8ab6f6652a14a34610b27ca97b70476400f9defe \
                     sha256  73c5bfa832ff9e1053dd3c3010850280da111f7e75b36b6c86cc791e22a684f9 \
                     size    2318525
 
-use_autoreconf      yes
-
-worksrcdir          ${worksrcdir}/folly
-
-# needed for ax_boost and friends
-depends_build-append \
-                    port:autoconf-archive \
-                    port:pkgconfig
+patchfiles          patch-cmakelists.diff patch-cmake-config.diff
 
 # doesn't build with libressl as of 2016-09-05
 depends_lib-append  port:boost \
@@ -41,3 +36,5 @@ depends_lib-append  port:boost \
                     path:lib/libssl.dylib:openssl \
                     port:zlib \
                     port:zstd
+
+configure.args-append -DBUILD_SHARED_LIBS=ON

--- a/devel/folly/files/patch-cmake-config.diff
+++ b/devel/folly/files/patch-cmake-config.diff
@@ -1,0 +1,18 @@
+--- CMake/FollyConfigChecks.cmake.orig	2018-06-02 01:57:39.000000000 +0400
++++ CMake/FollyConfigChecks.cmake	2018-06-02 01:58:59.000000000 +0400
+@@ -61,6 +61,7 @@
+   endif()
+ endif()
+ 
++list(REMOVE_ITEM CMAKE_REQUIRED_FLAGS -std=gnu++14)
+ check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
+ 
+ # Unfortunately check_symbol_exists() does not work for memrchr():
+@@ -75,6 +76,7 @@
+   FOLLY_HAVE_CPLUS_DEMANGLE_V3_CALLBACK
+ )
+ check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
++list(APPEND CMAKE_REQUIRED_FLAGS -std=gnu++14)
+ 
+ check_cxx_source_compiles("
+   #pragma GCC diagnostic error \"-Wattributes\"

--- a/devel/folly/files/patch-cmakelists.diff
+++ b/devel/folly/files/patch-cmakelists.diff
@@ -1,0 +1,14 @@
+--- CMakeLists.txt.orig	2018-06-02 01:57:39.000000000 +0400
++++ CMakeLists.txt	2018-06-02 22:10:47.000000000 +0400
+@@ -206,9 +206,8 @@
+ 
+ target_include_directories(folly_deps
+   INTERFACE
+-    $<BUILD_INTERFACE:
+-      ${CMAKE_CURRENT_SOURCE_DIR}
+-      ${CMAKE_CURRENT_BINARY_DIR}>
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+     $<INSTALL_INTERFACE:include>
+ )
+ 


### PR DESCRIPTION
#### Description

Required for updating fbthrift - https://trac.macports.org/ticket/56572.

The other patch is needed due to [weird behavior](https://gitlab.kitware.com/cmake/cmake/issues/16686) by CMake causing the build directory to be added to `INTERFACE_INCLUDE_DIRECTORIES` in `$prefix/lib/cmake/folly/folly-targets.cmake`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.4 9F1027a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?