### PR TITLE
py*-ansible: updated ansible from 2.4.2.0 to 2.5.4 (current stable on PyPI)

### DIFF
--- a/python/py-ansible/Portfile
+++ b/python/py-ansible/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-ansible
-version             2.4.2.0
+version             2.5.4
 revision            1
 license             GPL-3+
 
@@ -20,8 +20,9 @@ homepage            https://github.com/ansible/ansible
 description         SSH-based configuration management and deployment system
 
 distname            ansible-${version}
-checksums           rmd160  79f6caa72917471cde3cf4a367a7241ecc42400d \
-                    sha256  315f1580b20bbc2c2f1104f8b5e548c6b4cac943b88711639c5e0d4dfc4d7658
+checksums           rmd160  b079086f1f6e3a5c4e153ef4e251faceeffb9521 \
+                    sha256  33a76684c47d1857d6e917af4f2eafac87521161f8181037edaa159a60deaeb3 \
+                    size    10146881
 
 conflicts           ansible
 


### PR DESCRIPTION
* update to latest stable release of ansible (2.5.4)
* 2.5.x series is finally compatible to Python 3 target machines

#### Description

This is just a simple update to the latest stable version of ansible. It's much needed for anyone using ansible to deploy to Python 3 systems (like Ubuntu 16.04 or newer) as full Python 3 support is only available with ansible as of version 2.5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4 9F1027a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
