### PR TITLE
iperf3: Enable livecheck for iperf3-devel

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        esnet iperf 3.5
 name                iperf3
 categories          net
 platforms           darwin
@@ -15,11 +14,6 @@ long_description    ${name} is a tool for active measurements of the maximum \
                     of various parameters related to timing, protocols, and \
                     buffers. For each test it reports the bandwidth, loss, \
                     and other parameters.
-
-conflicts           ${name}-devel
-
-checksums           rmd160  f2e3512c38dd508f92dfc35d59a6c9d58d0c8c3d \
-                    sha256  2f7b2fe2bf7ea2212ef11b3d58cb02aa8b325429124db5956452c9bff8d43046
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 
@@ -33,6 +27,15 @@ post-destroot {
         ${destroot}${prefix}/share/doc/${name}
 }
 
+if {${subport} eq ${name}} {
+    github.setup        esnet iperf 3.5
+
+    checksums           rmd160  f2e3512c38dd508f92dfc35d59a6c9d58d0c8c3d \
+                        sha256  2f7b2fe2bf7ea2212ef11b3d58cb02aa8b325429124db5956452c9bff8d43046
+
+    conflicts           ${name}-devel
+}
+
 subport ${name}-devel {
     github.setup        esnet iperf 3e58489a5823126fd1d51fcfb74994f9e8fe4e86
     version             20180323
@@ -41,6 +44,4 @@ subport ${name}-devel {
                         sha256  48fa6d02db5e82da71e5cecf61c9a3ff45d055a7328b5173a374963befe7e75c
 
     conflicts           ${name}
-
-    livecheck.type      none
 }


### PR DESCRIPTION
#### Description

iperf3: Enable livecheck for iperf3-devel

This is accomplished by restructuring the port so that directives that only apply to the main port are enclosed in an `if {${subport} eq ${name}}` block.

Closes: https://trac.macports.org/ticket/56581

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
