### PR TITLE
gri: allow recent Perl version to be used

### DIFF
--- a/science/gri/Portfile
+++ b/science/gri/Portfile
@@ -36,7 +36,8 @@ depends_build       port:ghostscript \
                     bin:tex:texlive
 
 patchfiles          patch-doc-gri.texi.diff \
-                    patch-doc-texinfo2HTML.diff
+                    patch-doc-texinfo2HTML.diff \
+                    patch-illegal-regex.diff
 
 # makeinfo: rename gri.info failed: No such file or directory
 use_parallel_build  no

--- a/science/gri/files/patch-illegal-regex.diff
+++ b/science/gri/files/patch-illegal-regex.diff
@@ -1,0 +1,196 @@
+From 6d178b36a7ac2b0e5d67868fdcd3992ac04f2cd4 Mon Sep 17 00:00:00 2001
+From: Dan Kelley <kelley.dan@gmail.com>
+Date: Wed, 21 Jun 2017 17:14:56 -0300
+Subject: [PATCH] doc-building update
+
+Thanks to Damyan Ivanov for the patch. Below is the info from the
+associated message to the debian bug tracking system:
+
+Bug#865482: src:gri: FTBFS with perl 5.26 -- Unescaped left brace in
+regex is illegal
+Package: src:gri
+Version: 2.12.23-10
+Severity: important
+Tags: patch upstream
+User: debian-perl@lists.debian.org
+Usertags: perl-5.26-transition
+
+gri fails to build with perl 5.26 currently in experimental.
+
+The attached patch makes it build again by escaping curly braces in
+regular
+expressions.
+
+-- dam
+
+-- System Information:
+Debian Release: 9.0
+ APT prefers unstable
+ APT policy: (500, 'unstable'), (1, 'experimental')
+Architecture: amd64 (x86_64)
+
+Kernel: Linux 4.9.0-3-amd64 (SMP w/4 CPU cores)
+Locale: LANG=bg_BG.UTF-8, LC_CTYPE=bg_BG.UTF-8 (charmap=UTF-8),
+LANGUAGE=bg_BG.UTF-8 (charmap=UTF-8)
+Shell: /bin/sh linked to /bin/dash
+Init: systemd (via /run/systemd/system)
+---
+ doc/texinfo2HTML | 72 ++++++++++++++++++++++++++++----------------------------
+ 1 file changed, 36 insertions(+), 36 deletions(-)
+
+diff --git a/doc/texinfo2HTML b/doc/texinfo2HTML
+index 618d6ad..15962b3 100755
+--- doc/texinfo2HTML
++++ doc/texinfo2HTML
+@@ -119,7 +119,7 @@ while(get_a_line()) {
+ 	next;
+     }
+     # Process image commands (NOT...it's there already) 
+-    if (/\@image{(.*)}/) {
++    if (/\@image\{(.*)\}/) {
+ 	#print "<img src=\"$1.gif\" border=\"1\">\n";
+ 	next;
+     }
+@@ -207,12 +207,12 @@ while(get_a_line()) {
+     s,<,&lt;,og;
+     # Special tweak to make 'Gri' look cooler.
+ 	#    s, Gri , G<FONT SIZE=-1>RI</FONT> ,og;
+-    s,\@code{\@\@},\@code{TEXINFO2HTML-AT-AT},og; 
++    s,\@code\{\@\@\},\@code{TEXINFO2HTML-AT-AT},og;
+     s,\@},TEXINFO2HTML-CLOSE-BRACE,og; # retain inside e.g. @code{}
+     s,\@\@,TEXINFO2HTML-AT-AT,og;
+-    s,\@{,{,og;
+-    s,\@TeX{},TeX,og;
+-    s,\@dots{},...,og;
++    s,\@\{,{,og;
++    s,\@TeX\{\},TeX,og;
++    s,\@dots\{\},...,og;
+     # Put in place-holders for some accents.  I should check for all
+     # of them, but for now, I'm just kludging in a couple, 
+     # to solve an immediate problem and to serve as a place-holder
+@@ -236,18 +236,18 @@ while(get_a_line()) {
+ 	}
+ 	next;
+     }
+-    while (/\@url{([^}]*)}/) {
++    while (/\@url\{([^}]*)\}/) {
+ 	$the_url = $1;
+-        s:\@url{[^}]*}:<a href="$the_url">\@code{$the_url}</a>:;
++        s:\@url\{[^}]*\}:<a href="$the_url">\@code{$the_url}</a>:;
+     }
+-    while (/\@uref{([^}]*)}/) {
++    while (/\@uref\{([^}]*)\}/) {
+ 	@items = split(/,/, $1);
+         if ($#items == 0) {
+-            s:\@uref{[^}]*}:<a href="$items[0]">$items[0]</a>:;
++            s:\@uref\{[^}]*\}:<a href="$items[0]">$items[0]</a>:;
+         } elsif ($#items == 1) {
+-            s:\@uref{[^}]*}:<a href="$items[0]">$items[1]</a>:;
++            s:\@uref\{[^}]*\}:<a href="$items[0]">$items[1]</a>:;
+         } elsif ($#items == 2) {
+-            s:\@uref{[^}]*}:\@code{$items[2]}:;
++            s:\@uref\{[^}]*\}:\@code{$items[2]}:;
+         } else {
+             die "Cannot have more than 3 items in a 'uref' at \"$_\"";
+         }
+@@ -329,7 +329,7 @@ while(get_a_line()) {
+ 	while(get_a_line()) {
+ 	    next if /\@sp/;
+ 	    next if /\@cindex/;
+-            s|\@anchor{([^}]*)}|<a name=\"$1\"></a>|g;
++            s|\@anchor\{([^}]*)\}|<a name=\"$1\"></a>|g;
+ 	    &process_examples();
+ 	    # Handle HTML inserts
+ 	    if (/^\@c HTML (.*)/o) {
+@@ -345,10 +345,10 @@ while(get_a_line()) {
+ 	    }
+ 	    if (/\s*\@item\s*(.*)/o) {
+                 $the_item = $1;
+-		$the_item =~ s:\@{:{:og;
+-		$the_item =~ s:\@}:}:og;
++		$the_item =~ s:\@\{:{:og;
++		$the_item =~ s:\@\}:}:og;
+ 		$the_item =~ s:\@\@:\@:og;
+-		$the_item =~ s:\@code{([^}]*)}:`<font color="$ex_color"><code>$1</code></font>':og;
++		$the_item =~ s:\@code\{([^}]*)\}:`<font color="$ex_color"><code>$1</code></font>':og;
+ 		print "<dt> $start_item$the_item$end_item\n<dd>";
+ 	    } else {
+ 		print "<p>" if (/^$/o);
+@@ -401,38 +401,38 @@ sub process_examples() {
+     } else {
+         s,\@value\{([^}]*)\},$value{$1},g; # Substitute set/value pair
+         s,\@},},og;
+-        s,\@{,{,og;
++        s,\@\{,{,og;
+     }
+ }
+ 
+ 
+ sub sub_refs {
+-    die "line $. of file: cannot have multiple refs on one line" if (/\@[px]*ref{(.*)}(.*)\@[px]*ref{(.*)}/);
++    die "line $. of file: cannot have multiple refs on one line" if (/\@[px]*ref\{(.*)\}(.*)\@[px]*ref\{(.*)\}/);
+     # anchors
+-    s|\@anchor{([^}]*)}|<a name=\"$1\"></a>|g;
++    s|\@anchor\{([^}]*)\}|<a name=\"$1\"></a>|g;
+     # Change e.g. 
+     #     @xref{Viewing}
+     # into
+     #     <a href="#Viewing">see Viewing</a>
+ 
+     #if (/\@ref/){print "AAA[$_]AAA\n";
+-    s|\@ref{([^}]*)}|see <a href="#$1">$1</a>|g;
++    s|\@ref\{([^}]*)\}|see <a href="#$1">$1</a>|g;
+     #print "BBB[$_]BBB\n";}
+ 
+-    s|\@xref{([^}]*)}|see <a href="#$1">$1</a>|g;
+-    s|\@pxref{([^}]*)}|see <a href="#$1">$1.</a>|g;
+-    while (/\@url{([^}]*)}/) {
++    s|\@xref\{([^}]*)\}|see <a href="#$1">$1</a>|g;
++    s|\@pxref\{([^}]*)\}|see <a href="#$1">$1.</a>|g;
++    while (/\@url\{([^}]*)\}/) {
+ 	$the_url = $1;
+-        s:\@url{[^}]*}:<a href="$the_url">\@code{$the_url}</a>:;
++        s:\@url\{[^}]*\}:<a href="$the_url">\@code{$the_url}</a>:;
+     }
+-    while (/\@uref{([^}]*)}/) {
++    while (/\@uref\{([^}]*)\}/) {
+ 	@items = split(/,/, $1);
+         if ($#items == 0) {
+-            s:\@uref{[^}]*}:<a href="$items[0]">$items[0]</a>:;
++            s:\@uref\{[^}]*\}:<a href="$items[0]">$items[0]</a>:;
+         } elsif ($#items == 1) {
+-            s:\@uref{[^}]*}:<a href="$items[0]">$items[1]</a>:;
++            s:\@uref\{[^}]*\}:<a href="$items[0]">$items[1]</a>:;
+         } elsif ($#items == 2) {
+-            s:\@uref{[^}]*}:\@code{$items[2]}:;
++            s:\@uref\{[^}]*\}:\@code{$items[2]}:;
+         } else {
+             die "Cannot have more than 3 items in a 'uref' at \"$_\"";
+         }
+@@ -465,17 +465,17 @@ sub sub_headings {
+ sub sub_emphasis {
+     s,<<,&lt&lt,g;
+     s,>>,&gt&gt,g;
+-    s,\@emph{([^}]*)},<em>$1</em>,g;
+-    s,\@strong{([^}]*)},<b>$1</b>,g;
+-    s,\@footnote{([^}]*)}, [$1],g;
+-    s,\@b{([^}]*)},<b>$1</b>,g;
++    s,\@emph\{([^}]*)\},<em>$1</em>,g;
++    s,\@strong\{([^}]*)\},<b>$1</b>,g;
++    s,\@footnote\{([^}]*)\}, [$1],g;
++    s,\@b\{([^}]*)\},<b>$1</b>,g;
+ 
+-    s,\@code{([^}]*)},`<font color="$ex_color"><code>$1</code></font>',g;
++    s,\@code\{([^}]*)\},`<font color="$ex_color"><code>$1</code></font>',g;
+     s,\@\@,\@,g;
+-    s,\@samp{([^}]*)},`<font color="$ex_color"><samp>$1</samp></font>',g;
+-    s,\@key{([^}]*)},`<font color="$ex_color"><kbd>$1</kbd></font>',g;
+-    s,\@kbd{([^}]*)},`<font color="$ex_color"><kbd>$1</kbd></font>',g;
+-    s,\@file{([^}]*)},`<font color="$ex_color"><samp>$1</samp></font>',g;
++    s,\@samp\{([^}]*)\},`<font color="$ex_color"><samp>$1</samp></font>',g;
++    s,\@key\{([^}]*)\},`<font color="$ex_color"><kbd>$1</kbd></font>',g;
++    s,\@kbd\{([^}]*)\},`<font color="$ex_color"><kbd>$1</kbd></font>',g;
++    s,\@file\{([^}]*)\},`<font color="$ex_color"><samp>$1</samp></font>',g;
+     s,TEXINFO2HTML-CLOSE-BRACE,},g;
+     s,TEXINFO2HTML-AT-AT,\@,g;
+     s,TEXINFO2HTML-ACCENT-ACUTE-a,&#225,g;


### PR DESCRIPTION
No revbump since port either builds correctly or not at all
See https://github.com/dankelley/gri/commit/6d178b36a7ac2b0e5d67868fdcd3992ac04f2cd4

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->