### PR TITLE
Fix emacs app inline patch

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -44,9 +44,7 @@ if {$subport eq $name || $subport eq "emacs-app"} {
                     sha256  760382d5e8cdc5d0d079e8f754bce1136fbe1473be24bb885669b0e38fc56aa3 \
                     size    65007481
 
-    # our dbus is autolaunched by launchd, so disable the check that it's running
-    patchfiles      patch-src_dbusbind.c.diff \
-                    patch-configure.diff
+    patchfiles      patch-configure.diff
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
@@ -103,33 +101,6 @@ post-destroot {
     delete ${destroot}${prefix}/share/man/man1/ctags.1.gz
 }
 
-
-variant x11 description {Builds emacs as a X11 program with Lucid widgets} {
-    configure.args-delete   --without-x
-    configure.args-append   --with-x-toolkit=lucid \
-                            --without-xaw3d \
-                            --without-imagemagick \
-                            --with-xpm \
-                            --with-jpeg \
-                            --with-tiff \
-                            --with-gif \
-                            --with-png \
-                            --without-rsvg \
-                            --with-xft
-    depends_lib-append      port:xorg-libXmu \
-                            port:xorg-libXaw \
-                            port:xpm \
-                            port:jpeg \
-                            port:tiff \
-                            port:giflib \
-                            port:libpng \
-                            port:Xft2
-
-    # autoconf appears to be dropping linker flags for freetype &
-    # fontconfig; work around this. See #28083
-    configure.ldflags-append -lfreetype -lfontconfig
-}
-
 platform darwin {
     post-patch {
         # Leopard's XCode 3.1.x ld(1) man page claims -no_pie is supported, but it's not
@@ -141,8 +112,34 @@ platform darwin {
     }
 }
 
-if {${subport} eq ${name} || ${subport} eq "emacs-devel"} {
+if {$subport eq $name || $subport eq "emacs-devel"} {
     PortGroup  muniversal 1.0
+
+    variant x11 description {Builds emacs as a X11 program with Lucid widgets} {
+        configure.args-delete   --without-x
+        configure.args-append   --with-x-toolkit=lucid \
+            --without-xaw3d \
+            --without-imagemagick \
+            --with-xpm \
+            --with-jpeg \
+            --with-tiff \
+            --with-gif \
+            --with-png \
+            --without-rsvg \
+            --with-xft
+        depends_lib-append      port:xorg-libXmu \
+            port:xorg-libXaw \
+            port:xpm \
+            port:jpeg \
+            port:tiff \
+            port:giflib \
+            port:libpng \
+            port:Xft2
+
+        # autoconf appears to be dropping linker flags for freetype &
+        # fontconfig; work around this. See #28083
+        configure.ldflags-append -lfreetype -lfontconfig
+    }
 
     variant motif requires x11 description {Builds emacs as an X11 program with Motif widgets} {
         configure.args-delete   --with-x-toolkit=lucid

--- a/editors/emacs/files/patch-inline-25.2-20170426.diff
+++ b/editors/emacs/files/patch-inline-25.2-20170426.diff
@@ -1,6 +1,6 @@
-diff -crN emacs-25.2_orig/configure.ac emacs-25.2/configure.ac
-*** emacs-25.2_orig/configure.ac	2017-02-03 23:34:30.000000000 +0900
---- emacs-25.2/configure.ac	2017-04-26 14:45:40.000000000 +0900
+diff -crN configure.ac configure.ac
+*** configure.ac	2017-02-03 23:34:30.000000000 +0900
+--- configure.ac	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 1915,1921 ****
        INSTALL_ARCH_INDEP_EXTRA=
@@ -35,9 +35,9 @@ diff -crN emacs-25.2_orig/configure.ac emacs-25.2/configure.ac
        if test "$NS_IMPL_COCOA" = "yes"; then
           libs_nsgui="$libs_nsgui -framework IOKit"
        fi
-diff -crN emacs-25.2_orig/lisp/term/common-win.el emacs-25.2/lisp/term/common-win.el
-*** emacs-25.2_orig/lisp/term/common-win.el	2017-02-03 19:25:44.000000000 +0900
---- emacs-25.2/lisp/term/common-win.el	2017-04-26 14:45:40.000000000 +0900
+diff -crN lisp/term/common-win.el lisp/term/common-win.el
+*** lisp/term/common-win.el	2017-02-03 19:25:44.000000000 +0900
+--- lisp/term/common-win.el	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 73,78 ****
 --- 73,79 ----
@@ -48,9 +48,9 @@ diff -crN emacs-25.2_orig/lisp/term/common-win.el emacs-25.2/lisp/term/common-wi
   	       ))))
       (set-terminal-parameter frame 'x-setup-function-keys t)))
   
-diff -crN emacs-25.2_orig/lisp/term/ns-win.el emacs-25.2/lisp/term/ns-win.el
-*** emacs-25.2_orig/lisp/term/ns-win.el	2017-02-03 19:25:44.000000000 +0900
---- emacs-25.2/lisp/term/ns-win.el	2017-04-26 14:45:40.000000000 +0900
+diff -crN lisp/term/ns-win.el lisp/term/ns-win.el
+*** lisp/term/ns-win.el	2017-02-03 19:25:44.000000000 +0900
+--- lisp/term/ns-win.el	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 169,175 ****
   (define-key global-map [ns-new-frame] 'make-frame)
@@ -752,9 +752,9 @@ diff -crN emacs-25.2_orig/lisp/term/ns-win.el emacs-25.2/lisp/term/ns-win.el
   (provide 'ns-win)
   
   ;;; ns-win.el ends here
-diff -crN emacs-25.2_orig/src/Makefile.in emacs-25.2/src/Makefile.in
-*** emacs-25.2_orig/src/Makefile.in	2017-02-03 19:25:44.000000000 +0900
---- emacs-25.2/src/Makefile.in	2017-04-26 14:45:40.000000000 +0900
+diff -crN src/Makefile.in src/Makefile.in
+*** src/Makefile.in	2017-02-03 19:25:44.000000000 +0900
+--- src/Makefile.in	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 409,415 ****
   SOME_MACHINE_OBJECTS = dosfns.o msdos.o \
@@ -772,9 +772,9 @@ diff -crN emacs-25.2_orig/src/Makefile.in emacs-25.2/src/Makefile.in
     w32.o w32console.o w32fns.o w32heap.o w32inevt.o w32notify.o \
     w32menu.o w32proc.o w32reg.o w32select.o w32term.o w32xfns.o \
     w16select.o widget.o xfont.o ftfont.o xftfont.o ftxfont.o gtkutil.o \
-diff -crN emacs-25.2_orig/src/keyboard.c emacs-25.2/src/keyboard.c
-*** emacs-25.2_orig/src/keyboard.c	2017-04-20 23:50:42.000000000 +0900
---- emacs-25.2/src/keyboard.c	2017-04-26 14:45:40.000000000 +0900
+diff -crN src/keyboard.c src/keyboard.c
+*** src/keyboard.c	2017-04-20 23:50:42.000000000 +0900
+--- src/keyboard.c	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 2472,2481 ****
   	swallow_events (false);		/* May clear input_pending.  */
@@ -829,9 +829,9 @@ diff -crN emacs-25.2_orig/src/keyboard.c emacs-25.2/src/keyboard.c
     /* Here we used to use `ignore-event' which would simple set prefix-arg to
        current-prefix-arg, as is done in `handle-switch-frame'.
        But `handle-switch-frame is not run from the special-map.
-diff -crN emacs-25.2_orig/src/macim.m emacs-25.2/src/macim.m
-*** emacs-25.2_orig/src/macim.m	1970-01-01 09:00:00.000000000 +0900
---- emacs-25.2/src/macim.m	2017-04-26 14:50:48.000000000 +0900
+diff -crN src/macim.m src/macim.m
+*** src/macim.m	1970-01-01 09:00:00.000000000 +0900
+--- src/macim.m	2017-04-26 14:50:48.000000000 +0900
 ***************
 *** 0 ****
 --- 1,193 ----
@@ -1028,9 +1028,9 @@ diff -crN emacs-25.2_orig/src/macim.m emacs-25.2/src/macim.m
 +   defsubr (&Smac_toggle_input_source);
 + }
 + #endif
-diff -crN emacs-25.2_orig/src/nsfns.m emacs-25.2/src/nsfns.m
-*** emacs-25.2_orig/src/nsfns.m	2017-02-03 19:25:45.000000000 +0900
---- emacs-25.2/src/nsfns.m	2017-04-26 14:45:40.000000000 +0900
+diff -crN src/nsfns.m src/nsfns.m
+*** src/nsfns.m	2017-02-03 19:25:45.000000000 +0900
+--- src/nsfns.m	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 3136,3141 ****
 --- 3136,3157 ----
@@ -1069,9 +1069,9 @@ diff -crN emacs-25.2_orig/src/nsfns.m emacs-25.2/src/nsfns.m
     as_status = 0;
     as_script = Qnil;
     as_result = 0;
-diff -crN emacs-25.2_orig/src/nsterm.h emacs-25.2/src/nsterm.h
-*** emacs-25.2_orig/src/nsterm.h	2017-02-03 19:25:45.000000000 +0900
---- emacs-25.2/src/nsterm.h	2017-04-26 14:45:40.000000000 +0900
+diff -crN src/nsterm.h src/nsterm.h
+*** src/nsterm.h	2017-02-03 19:25:45.000000000 +0900
+--- src/nsterm.h	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 757,762 ****
 --- 757,764 ----
@@ -1083,9 +1083,9 @@ diff -crN emacs-25.2_orig/src/nsterm.h emacs-25.2/src/nsterm.h
   
   /* could use list to store these, but rest of emacs has a big infrastructure
      for managing a table of bitmap "records" */
-diff -crN emacs-25.2_orig/src/nsterm.m emacs-25.2/src/nsterm.m
-*** emacs-25.2_orig/src/nsterm.m	2017-02-03 19:25:45.000000000 +0900
---- emacs-25.2/src/nsterm.m	2017-04-26 14:45:40.000000000 +0900
+diff -crN src/nsterm.m src/nsterm.m
+*** src/nsterm.m	2017-02-03 19:25:45.000000000 +0900
+--- src/nsterm.m	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 4859,4865 ****
     /*   [[NSNotificationCenter defaultCenter] addObserver: NSApp
@@ -1291,9 +1291,9 @@ diff -crN emacs-25.2_orig/src/nsterm.m emacs-25.2/src/nsterm.m
     /* Tell Emacs about this window system.  */
     Fprovide (Qns, Qnil);
   
-diff -crN emacs-25.2_orig/src/termhooks.h emacs-25.2/src/termhooks.h
-*** emacs-25.2_orig/src/termhooks.h	2017-02-03 19:25:45.000000000 +0900
---- emacs-25.2/src/termhooks.h	2017-04-26 14:45:40.000000000 +0900
+diff -crN src/termhooks.h src/termhooks.h
+*** src/termhooks.h	2017-02-03 19:25:45.000000000 +0900
+--- src/termhooks.h	2017-04-26 14:45:40.000000000 +0900
 ***************
 *** 59,64 ****
 --- 59,65 ----


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
CI didn't test subports for #1936 , and it turns out the emacs-app port failed at the patch phase, this PR should fix it.

This PR also moved the x11 variant to go under the emacs and emacs-devel ports, it makes no sense to compile the emacs-app subport for X.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
