### PR TITLE
Update to binwalk - 56341

### DIFF
--- a/cross/binwalk/Portfile
+++ b/cross/binwalk/Portfile
@@ -4,11 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        devttys0 binwalk 2.1.1 v
+github.setup        ReFirmLabs binwalk 2.1.1 v
 categories          cross
 platforms           darwin
 license             MIT
 supported_archs     noarch
+
+# enable stealth update https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
+dist_subdir        ${name}/${version}_1
 
 python.default_version  27
 
@@ -19,8 +22,8 @@ long_description    ${description}
 
 homepage            http://binwalk.org
 
-checksums           rmd160  272e9b9aae95cca266376d069d3e7a87207e6eb3 \
-                    sha256  ae9c17b76fc5a318a5feea37d4fa082a9a897a38ffbe8f585eef5c8d6cbb046b
+checksums           rmd160  e666b01813647e2d90d64900276a4f583afb8d0d \
+                    sha256  5115b736f5aebda7059ed0c538befde46807f66f8071e6769a87a9263c6907ac
 
 depends_lib-append  port:py${python.default_version}-setuptools \
                     port:py${python.default_version}-liblzma


### PR DESCRIPTION
#### Description

While attempting to `port install binwalk` I found the checksum fails. This was originally reported by [camoulin in 56341](https://trac.macports.org/ticket/56341).

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

* macOS 10.13.3 17D102
* Xcode 9.2 9C40b 

firmware extraction using newly installed `binwalk` now successful.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- - [ ] tried existing tests with `sudo port test`? no test -->
<!-- - [ ] tried a full install with `sudo port -vst install`? -->
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->