### PR TITLE
macdependency: new port, version 1.1.0

### DIFF
--- a/devel/MacDependency/Portfile
+++ b/devel/MacDependency/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+
+github.setup        kwin macdependency 1.1.0
+name                MacDependency
+
+categories          devel
+license             GPL-3
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+description         MacDependency shows all dependent libraries and frameworks of a given executable, \
+                    dynamic library or framework on Mac OS.
+long_description    ${description} It is a GUI replacement for the otool command, \
+                    and provides almost the same functionality as the Dependency Walker (http://www.dependencywalker.com) on Windows.
+
+platforms           darwin
+
+checksums           rmd160  071c900c94d61f6796125b667df7a67e85daa91f \
+                    sha256  83aab373efefa4e0f1b1b9653d21ab6702924ac0202f09b0c2b73faf3ae01cf9 \
+                    size    1268109
+
+xcode.project       MacDependency/MacDependency.xcodeproj
+
+# framework
+subport MacDependency-MachO {
+    description         A framework that provides access to the properties of Mach-O files.
+    long_description    ${description} Required by the MacDependency app.
+    xcode.project       MachO/MachO.xcodeproj
+    xcode.destroot.type framework
+}
+
+# main app
+if {${name} eq ${subport}} {
+    xcode.build.settings FRAMEWORK_SEARCH_PATHS=${frameworks_dir}
+    xcode.destroot.settings FRAMEWORK_SEARCH_PATHS=${frameworks_dir}
+    depends_lib-append port:MacDependency-MachO
+}


### PR DESCRIPTION
#### Description

New port submission. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G20015
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
