### PR TITLE
yubikey-manager: update to 0.7.0

### DIFF
--- a/python/py-fido2/Portfile
+++ b/python/py-fido2/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-fido2
+github.setup        Yubico python-fido2 0.3.0
+categories          python security crypto
+platforms           darwin
+license             BSD
+maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
+
+description         Library for working with FIDO devices
+
+long_description    Provides library functionality for communicating with a \
+                    FIDO device over USB as well as verifying attestation \
+                    and assertion signatures.
+
+checksums           rmd160  372caa822a78066d45612df1d09ad7a9d87ea22f \
+                    sha256  706ef4db259918811584b0486baa5e34c9d038f3529c23603ce5729eb470ff7c \
+                    size    134466
+
+python.versions     27 35 36
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:py${python.version}-six \
+        port:py${python.version}-cryptography
+
+    livecheck.type  none
+}

--- a/security/yubikey-manager/Portfile
+++ b/security/yubikey-manager/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 name                yubikey-manager
-github.setup        Yubico yubikey-manager 0.6.0 yubikey-manager-
+github.setup        Yubico yubikey-manager 0.7.0 yubikey-manager-
 categories          security python
 platforms           darwin
 license             BSD
@@ -16,8 +16,9 @@ long_description    ${description}
 
 homepage            https://developers.yubico.com/yubikey-manager/
 
-checksums           rmd160  f4a621975f73ed2ec22f95e5813c5307b269dd6f \
-                    sha256  2a14d0f648f323bfcf97076908d2cb8d7070effb5ff4c8222c44cd687e9c0262
+checksums           rmd160  ecc8dce9bc431f48c06af25d709f11981e5b4da2 \
+                    sha256  cce5851801d5c34a23ba667c1ab6855410e2036b5488650d9ea1cf5130133478 \
+                    size    91905
 
 python.default_version 36
 
@@ -30,7 +31,8 @@ depends_lib-append \
     port:py${python.version}-pyusb \
     port:py${python.version}-click \
     port:py${python.version}-cryptography \
-    port:py${python.version}-openssl
+    port:py${python.version}-openssl \
+    port:py${python.version}-fido2
 
 depends_run-append \
     port:ykpers \


### PR DESCRIPTION
#### Description

Update yubikey-manager to 0.7.0

Includes a new port for a dependency added in this version: py-fido2

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4 9F1027a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
