### PR TITLE
wangle: fix linking to folly

### DIFF
--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        facebook wangle 2018.05.28.00 v
+revision            1
 categories          devel
 platforms           darwin
 license             BSD
@@ -14,7 +15,7 @@ maintainers         nomaintainer
 
 description         Wangle is a framework providing a set of common \
                     client/server abstractions for building services in a \
-                    consistent, modular, and composable way.                    
+                    consistent, modular, and composable way.
 long_description    ${description}
 
 checksums           rmd160  1f6e915c90aebb9d8959e10da0997141268eb155 \


### PR DESCRIPTION
#### Description

Necessary due to #1933.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 10.13.4 17E202
Xcode 9.4 9F1027a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?