### PR TITLE
groovy: update to 2.5.0

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.4.15
+version         2.5.0
 
 categories      lang java
 maintainers     breun.nl:nils openmaintainer
@@ -37,8 +37,8 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  4a7ecc9838ebab03580f5ddbe2d663bae4b4e809 \
-                sha256  bd4ca37a4d1b3704526d56fc48c119a8f70d418093d8703724407d65250f4aed
+checksums       rmd160  36351dc50789f575bc5200f79e95a6ae7c816479 \
+                sha256  13903caed7da4875b2c805ddaa5ac4a3c877342f339700fab9a54b8c628eece3
 
 worksrcdir      ${name}-${version}
 
@@ -53,7 +53,7 @@ destroot {
     xinstall -m 755 -d ${target}
 
     # Copy over the needed elements of our directory tree
-    foreach d { bin conf embeddable indy lib } {
+    foreach d { bin conf grooid indy lib } {
         copy ${worksrcpath}/${d} ${target}
     }
 
@@ -63,7 +63,7 @@ destroot {
     }
 
     # Add symlinks to the scripts
-    foreach f { grape groovy groovyConsole groovyc groovydoc groovysh java2groovy startGroovy } {
+    foreach f { grape grape_completion groovy groovyConsole groovyConsole_completion groovy_completion groovyc groovyc_completion groovydoc groovydoc_completion groovysh groovysh_completion java2groovy startGroovy } {
         ln -s ../share/java/${name}/bin/${f} ${destroot}${prefix}/bin
     }
 }


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.0.

###### Tested on

macOS 10.13.5 17F77
Xcode 9.4 9F1027a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->