### PR TITLE
emacs-app: update inline patch

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -38,7 +38,7 @@ depends_build-append port:autoconf port:automake port:libtool
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         26.1
-    revision        1
+    revision        2
 
     checksums       rmd160  f13fe104345738c853bcce2e3e061dbfb8692bc5 \
                     sha256  760382d5e8cdc5d0d079e8f754bce1136fbe1473be24bb885669b0e38fc56aa3 \
@@ -199,8 +199,8 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 
     if {$subport eq "emacs-app"} {
         variant inline description {Apply inline patch} {
-            # https://gist.github.com/takaxp/5294b6c52782d0be0b25342be62e4a77
-            patchfiles-append    patch-inline-25.2-20170426.diff
+            # https://gist.github.com/takaxp/3314a153f6d02d82ef1833638d338ecf
+            patchfiles-append    patch-inline-25.2-20170425.diff
             build.target         bootstrap
         }
 

--- a/editors/emacs/files/patch-inline-25.2-20170425.diff
+++ b/editors/emacs/files/patch-inline-25.2-20170425.diff
@@ -1,6 +1,6 @@
 diff -crN configure.ac configure.ac
 *** configure.ac	2017-02-03 23:34:30.000000000 +0900
---- configure.ac	2017-04-26 14:45:40.000000000 +0900
+--- configure.ac	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 1915,1921 ****
        INSTALL_ARCH_INDEP_EXTRA=
@@ -37,7 +37,7 @@ diff -crN configure.ac configure.ac
        fi
 diff -crN lisp/term/common-win.el lisp/term/common-win.el
 *** lisp/term/common-win.el	2017-02-03 19:25:44.000000000 +0900
---- lisp/term/common-win.el	2017-04-26 14:45:40.000000000 +0900
+--- lisp/term/common-win.el	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 73,78 ****
 --- 73,79 ----
@@ -50,7 +50,7 @@ diff -crN lisp/term/common-win.el lisp/term/common-win.el
   
 diff -crN lisp/term/ns-win.el lisp/term/ns-win.el
 *** lisp/term/ns-win.el	2017-02-03 19:25:44.000000000 +0900
---- lisp/term/ns-win.el	2017-04-26 14:45:40.000000000 +0900
+--- lisp/term/ns-win.el	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 169,175 ****
   (define-key global-map [ns-new-frame] 'make-frame)
@@ -754,7 +754,7 @@ diff -crN lisp/term/ns-win.el lisp/term/ns-win.el
   ;;; ns-win.el ends here
 diff -crN src/Makefile.in src/Makefile.in
 *** src/Makefile.in	2017-02-03 19:25:44.000000000 +0900
---- src/Makefile.in	2017-04-26 14:45:40.000000000 +0900
+--- src/Makefile.in	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 409,415 ****
   SOME_MACHINE_OBJECTS = dosfns.o msdos.o \
@@ -774,7 +774,7 @@ diff -crN src/Makefile.in src/Makefile.in
     w16select.o widget.o xfont.o ftfont.o xftfont.o ftxfont.o gtkutil.o \
 diff -crN src/keyboard.c src/keyboard.c
 *** src/keyboard.c	2017-04-20 23:50:42.000000000 +0900
---- src/keyboard.c	2017-04-26 14:45:40.000000000 +0900
+--- src/keyboard.c	2017-04-25 16:56:30.000000000 +0900
 ***************
 *** 2472,2481 ****
   	swallow_events (false);		/* May clear input_pending.  */
@@ -831,10 +831,10 @@ diff -crN src/keyboard.c src/keyboard.c
        But `handle-switch-frame is not run from the special-map.
 diff -crN src/macim.m src/macim.m
 *** src/macim.m	1970-01-01 09:00:00.000000000 +0900
---- src/macim.m	2017-04-26 14:50:48.000000000 +0900
+--- src/macim.m	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 0 ****
---- 1,193 ----
+--- 1,173 ----
 + /* Implementation of Input Method Extension for MacOS X.
 +    Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011
 +    Taiichi Hashimoto <taiichi2@mac.com>.
@@ -933,27 +933,7 @@ diff -crN src/macim.m src/macim.m
 +         locale = [[NSLocale currentLocale]
 +                   objectForKey:NSLocaleLanguageCode];
 +       }
-+       if ( [locale hasPrefix:@"ja"] ) {
-+         is = TISCopyInputSourceForLanguage((CFStringRef)locale);
-+       } else {
-+         NSString *targetID = [NSString stringWithUTF8String:"com.google.inputmethod.Japanese.base"];
-+         if ( targetID == nil) {
-+           return arg;
-+         }
-+ 
-+         NSArray *is_list = (NSArray *)TISCreateInputSourceList(NULL, false);
-+         int list_size = [is_list count];
-+         for(int i=0; i< list_size; i++) {
-+           NSString *id = (NSString *)TISGetInputSourceProperty((TISInputSourceRef)[is_list objectAtIndex:i], kTISPropertyInputSourceID);
-+ //          NSLog(@"%d: %@", i, [is_list objectAtIndex:i]);
-+           if ( [id compare:targetID] == NSOrderedSame ) {
-+             is = (TISInputSourceRef)[is_list objectAtIndex:i];
-+             break;
-+           }
-+         }
-+ //      NSLog(@"%@", locale);
-+ //      NSLog(@"%@", is);
-+       }
++       is = TISCopyInputSourceForLanguage((CFStringRef)locale);
 +     }
 +   if (is) TISSelectInputSource(is);
 +                 
@@ -1030,7 +1010,7 @@ diff -crN src/macim.m src/macim.m
 + #endif
 diff -crN src/nsfns.m src/nsfns.m
 *** src/nsfns.m	2017-02-03 19:25:45.000000000 +0900
---- src/nsfns.m	2017-04-26 14:45:40.000000000 +0900
+--- src/nsfns.m	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 3136,3141 ****
 --- 3136,3157 ----
@@ -1071,7 +1051,7 @@ diff -crN src/nsfns.m src/nsfns.m
     as_result = 0;
 diff -crN src/nsterm.h src/nsterm.h
 *** src/nsterm.h	2017-02-03 19:25:45.000000000 +0900
---- src/nsterm.h	2017-04-26 14:45:40.000000000 +0900
+--- src/nsterm.h	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 757,762 ****
 --- 757,764 ----
@@ -1085,7 +1065,7 @@ diff -crN src/nsterm.h src/nsterm.h
      for managing a table of bitmap "records" */
 diff -crN src/nsterm.m src/nsterm.m
 *** src/nsterm.m	2017-02-03 19:25:45.000000000 +0900
---- src/nsterm.m	2017-04-26 14:45:40.000000000 +0900
+--- src/nsterm.m	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 4859,4865 ****
     /*   [[NSNotificationCenter defaultCenter] addObserver: NSApp
@@ -1293,7 +1273,7 @@ diff -crN src/nsterm.m src/nsterm.m
   
 diff -crN src/termhooks.h src/termhooks.h
 *** src/termhooks.h	2017-02-03 19:25:45.000000000 +0900
---- src/termhooks.h	2017-04-26 14:45:40.000000000 +0900
+--- src/termhooks.h	2017-04-25 16:52:18.000000000 +0900
 ***************
 *** 59,64 ****
 --- 59,65 ----


### PR DESCRIPTION
#### Description
https://qiita.com/takaxp/items/e07bb286d80fa9dd8e05

> 最後に，locateが en で，Google IME を使う人は，次を（パッチが違います）

Google Translate: Finally, if locate is en and who uses the Google IME, (patch is different)

So the generic inline patch is https://gist.github.com/takaxp/3314a153f6d02d82ef1833638d338ecf, not https://gist.github.com/takaxp/5294b6c52782d0be0b25342be62e4a77.