### PR TITLE
abcde: update to 2.9.1

### DIFF
--- a/audio/abcde/Portfile
+++ b/audio/abcde/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    abcde
-version                 2.8.1
+version                 2.9.1
 categories              audio
 platforms               darwin
 maintainers             eclipsed.net:gr openmaintainer
@@ -19,8 +19,9 @@ long_description        abcde is a frontend command-line utility (actually, a \
 homepage                https://abcde.einval.com/
 master_sites            ${homepage}download/
 
-checksums               rmd160  e98d53ec173ecec0386282f9249423af7f9190fe \
-                        sha256  e49c71d7ddcd312dcc819c3be203abd3d09d286500ee777cde434c7881962b39
+checksums               rmd160  f3a2d81e3d3454221cd88c4bbebb56dc0c7a260b \
+                        sha256  70ec6e06b791115fbe88dee313f58f691f9b559ee992f2af5ed64fe6ad2e55d7 \
+                        size    159563
 
 depends_lib             port:vorbis-tools \
                         port:lame \


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

Note: the comment in the portfile saying that CDDB is default is no longer true; MusicBrainz is the default as of 2.8.

https://github.com/macports/macports-ports/blob/ffeb9048f4471871304be97f3af83e6de06602a5/audio/abcde/Portfile#L40-L44

Since there's only one module needed by abcde-musicbrainz-tool which isn't already a perl port ([WebService::MusicBrainz](https://metacpan.org/release/WebService-MusicBrainz)), I'm inclined to submit that as a new port and re-enable abcde-musicbrainz-tool. (In fact abcde would've needed to be updated to 2.9+ first for compatibility with WebService::MusicBrainz 1.0.4.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] ~~tried existing tests with `sudo port test`?~~
```
Error: Failed to test abcde: abcde has no tests turned on.
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
