### PR TITLE
libjwt: Add comment to Portfile to not update to v1.9

### DIFF
--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -1,5 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# Please do not update this Port to version 1.9 of libjwt.  1.8 is presently a dependency for the 'jwt' variant of the nginx port.
+# This Port will be updated as soon as the 'ngx-http-auth-jwt-module' project (https://github.com/TeslaGov/ngx-http-auth-jwt-module)
+# officially supports 1.9.
+
 PortSystem          1.0
 PortGroup           github 1.0
 


### PR DESCRIPTION
#### Description

libjwt: Add comment to Portfile to not update to v1.9

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4 9F1027a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
