### PR TITLE
llvm-*: Add 6.0 to clang versions to blacklist

### DIFF
--- a/lang/llvm-3.3/Portfile
+++ b/lang/llvm-3.3/Portfile
@@ -170,7 +170,7 @@ variant assertions description "Enable assertions for error detection (has perfo
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {3.3 3.4 3.7 3.8 3.9 4.0 5.0 devel} {
+foreach ver {3.3 3.4 3.7 3.8 3.9 4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -207,7 +207,7 @@ variant assertions description "Enable assertions for error detection (has perfo
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {3.4 3.7 3.8 3.9 4.0 5.0 devel} {
+foreach ver {3.4 3.7 3.8 3.9 4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-3.5/Portfile
+++ b/lang/llvm-3.5/Portfile
@@ -97,7 +97,7 @@ compiler.blacklist *gcc* {clang < 425.0.24}
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {3.5 3.6 3.7 3.8 3.9 4.0 5.0 devel} {
+foreach ver {3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -203,7 +203,7 @@ compiler.blacklist *gcc* {clang < 500}
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {3.7 3.8 3.9 4.0 5.0 devel} {
+foreach ver {3.7 3.8 3.9 4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-3.8/Portfile
+++ b/lang/llvm-3.8/Portfile
@@ -244,7 +244,7 @@ if {${subport} eq "clang-${llvm_version}"} {
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {3.8 3.9 4.0 5.0 devel} {
+foreach ver {3.8 3.9 4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-3.9/Portfile
+++ b/lang/llvm-3.9/Portfile
@@ -237,7 +237,7 @@ if {${subport} eq "clang-${llvm_version}"} {
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {3.9 4.0 5.0 devel} {
+foreach ver {3.9 4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -292,7 +292,7 @@ if {${subport} eq "clang-${llvm_version}"} {
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {4.0 5.0 devel} {
+foreach ver {4.0 5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -309,7 +309,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {5.0 devel} {
+foreach ver {5.0 6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -308,7 +308,7 @@ if {${subport} eq "lldb-${llvm_version}"} {
 
 # blacklist current and future versions if they're not available in order to
 # help break potential dependency cycles.
-foreach ver {devel} {
+foreach ver {6.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }


### PR DESCRIPTION
#### Description

llvm-*: Add 6.0 to clang versions to blacklist

This will ensure there are no problems when clang 6.0 is added to the compiler fallback list in base, which is included in https://github.com/macports/macports-base/pull/88.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix
