### PR TITLE
jbig2enc: Remove github.version override

### DIFF
--- a/graphics/jbig2enc/Portfile
+++ b/graphics/jbig2enc/Portfile
@@ -5,7 +5,6 @@ PortGroup           github 1.0
 
 epoch               1
 github.setup        agl jbig2enc 0.29
-github.version      ${version}-dist
 categories          graphics
 platforms           darwin
 license             GPL-2


### PR DESCRIPTION
#### Description

This PR removes the port's `github.version` override. It doesn't appear to do anything.

Version 0.28 had two different upstream [tags](https://github.com/agl/jbig2enc/tags)—"0.28" and "0.28-dist"—which may explain why this line was originally added even though it didn't do anything, but 0.29 only has one tag—"0.29".
