### PR TITLE
p5-webservice-musicbrainz: new port, version 1.0.4

### DIFF
--- a/audio/abcde/Portfile
+++ b/audio/abcde/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               perl5 1.0
 
 name                    abcde
-version                 2.8.1
+version                 2.9.1
 categories              audio
 platforms               darwin
 maintainers             eclipsed.net:gr openmaintainer
@@ -19,8 +20,11 @@ long_description        abcde is a frontend command-line utility (actually, a \
 homepage                https://abcde.einval.com/
 master_sites            ${homepage}download/
 
-checksums               rmd160  e98d53ec173ecec0386282f9249423af7f9190fe \
-                        sha256  e49c71d7ddcd312dcc819c3be203abd3d09d286500ee777cde434c7881962b39
+checksums               rmd160  f3a2d81e3d3454221cd88c4bbebb56dc0c7a260b \
+                        sha256  70ec6e06b791115fbe88dee313f58f691f9b559ee992f2af5ed64fe6ad2e55d7 \
+                        size    159563
+
+perl5.branches          5.26
 
 depends_lib             port:vorbis-tools \
                         port:lame \
@@ -28,16 +32,17 @@ depends_lib             port:vorbis-tools \
                         port:cd-discid \
                         port:cdparanoia \
                         port:id3v2 \
-                        port:normalize
+                        port:normalize \
+                        port:p5-digest-sha \
+                        port:p5-musicbrainz-discid \
+                        port:p5-webservice-musicbrainz
 
 patchfiles              patch-Makefile-fixpaths.diff
+
+post-patch {
+    reinplace "s|#!/usr/bin/perl|#!${perl5.bin}|g" ${worksrcpath}/abcde-musicbrainz-tool
+}
 
 use_configure           no
 
 destroot.destdir        prefix=${destroot}${prefix}
-
-post-destroot {
-    # default has always been to use cddb
-    # This requires perl modules not in macports
-    delete "${destroot}${prefix}/bin/abcde-musicbrainz-tool"
-}

--- a/perl/p5-webservice-musicbrainz/Portfile
+++ b/perl/p5-webservice-musicbrainz/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26
+perl5.setup         WebService-MusicBrainz 1.0.4
+
+platforms           darwin
+maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
+license             {Artistic-1 GPL}
+
+# Uncomment this line if you know there will be no arch-specific code:
+supported_archs     noarch
+
+description         API to search the musicbrainz.org database
+
+long_description    \
+    This module will search the MusicBrainz database through \
+    their web service and return objects with the found data. \
+    This module is not backward compatible with pre-1.0 versions. \
+    Version 1.0 is a complete re-write based on Mojolicious and \
+    implements MusicBrainz Web Service Version 2 \
+    (https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2).
+
+checksums           rmd160  807198e39be094ae56a9af85d734fc0db8b4b72b \
+                    sha256  6ac02bbccf2801552131083982edc2a26338bcd47a8edacb3cda4ca9641f5fa0 \
+                    size    9937
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-mojolicious
+}
+
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
(See new [comment](https://github.com/macports/macports-ports/pull/1973#issuecomment-395864348) below)
~~There are 2 new commits:~~
~~- add port p5-webservice-musicbrainz~~
~~- abcde: re-enable abcde-musicbrainz-tool (all of its other Perl dependencies are already available as ports)~~

~~Note: this depends on https://github.com/macports/macports-ports/pull/1967 (abcde 2.8.1 is incompatible with WebService::MusicBrainz >0.94). I have included that PR's commit for CI testing to work, under the assumption that one will get merged before this one. If that PR should be considered superseded by this one, I can squash the changes to abcde.~~

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] ~~tried existing tests with `sudo port test`?~~ (No tests to perform)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
