### PR TITLE
p5-devel-nytprof: update to 6.06

### DIFF
--- a/perl/p5-devel-nytprof/Portfile
+++ b/perl/p5-devel-nytprof/Portfile
@@ -3,7 +3,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Devel-NYTProf 6.05
+perl5.setup         Devel-NYTProf 6.06
 license             {Artistic-1 GPL}
 maintainers         naegler.org:michael openmaintainer
 
@@ -29,9 +29,9 @@ long_description    Devel::NYTProf is a powerful feature-rich perl source code p
                     \n\
                     \nNYTProf is effectively two profilers in one: a statement profiler, and a subroutine profiler.
 
-checksums           rmd160  6c0b72089636424e0883f700a724c00c5987a061 \
-                    sha256  b2a9f8b49afb9be8d087ddb50ef77a53f3796481b37eb5a965e1d4055445db1c \
-                    size    467105
+checksums           rmd160  cc3e2193f263de9a43c612688649fb1e83a14219 \
+                    sha256  a14227ca79f1750b92cc7b8b0a5806c92abc4964a21a7fb100bd4907d6c4be55 \
+                    size    468188
 
 platforms           darwin
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? ~~(No tests for port.)~~
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

I have only tested `nytprofcsv`. There is currently an issue with this port where `nytprofhtml` can't find nytprofcalls, presumably because it was renamed to nytprofcalls-5.26; will open a ticket for this.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
