### PR TITLE
poppler: update to v0.65.0

### DIFF
--- a/gnome/evince/Portfile
+++ b/gnome/evince/Portfile
@@ -7,6 +7,7 @@ PortGroup           gobject_introspection 1.0
 
 name                evince
 version             3.28.2
+revision            1
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Evince is a document viewer for multiple document formats like pdf, and many others.

--- a/gnome/gourmet/Portfile
+++ b/gnome/gourmet/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        thinkle gourmet 0.17.4
-revision            1
+revision            2
 categories          gnome python
 platforms           darwin
 supported_archs     noarch

--- a/gnome/tracker/Portfile
+++ b/gnome/tracker/Portfile
@@ -6,6 +6,7 @@ PortGroup           gobject_introspection 1.0
 
 name                tracker
 version             1.12.4
+revision            1
 license             GPL-2+ LGPL-2.1+ BSD
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Metadata database, indexer and search tool.

--- a/gnustep/Etoile-devel/Portfile
+++ b/gnustep/Etoile-devel/Portfile
@@ -3,7 +3,7 @@ PortGroup   gnustep 1.0
 
 name            Etoile-devel
 version         0.1.9
-revision        7
+revision        8
 platforms       darwin
 maintainers     nomaintainer
 homepage        http://www.etoile-project.org/

--- a/gnustep/Etoile/Portfile
+++ b/gnustep/Etoile/Portfile
@@ -3,7 +3,7 @@ PortGroup   gnustep 1.0
 
 name            Etoile
 version         0.1.9
-revision        10
+revision        11
 platforms       darwin
 license         GPL-2+ LGPL BSD
 maintainers     nomaintainer

--- a/graphics/OpenSceneGraph-devel/Portfile
+++ b/graphics/OpenSceneGraph-devel/Portfile
@@ -9,6 +9,7 @@ set git_date            20180427
 github.setup            openscenegraph OpenSceneGraph ${git_commit}
 name                    OpenSceneGraph-devel
 version                 3.7.0-${git_date}
+revision                1
 conflicts               OpenSceneGraph
 platforms               darwin
 categories              graphics

--- a/graphics/OpenSceneGraph/Portfile
+++ b/graphics/OpenSceneGraph/Portfile
@@ -5,6 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 
 github.setup            openscenegraph OpenSceneGraph 3.6.0 OpenSceneGraph-
+revision                1
 conflicts               OpenSceneGraph-devel
 platforms               darwin
 categories              graphics

--- a/graphics/gimp2-devel/Portfile
+++ b/graphics/gimp2-devel/Portfile
@@ -10,6 +10,7 @@ set git_name        gimp
 set git_commit      a48d9178e8a0cec6f828f70a27755e4fd0812980
 set git_date        20180521
 version             2.10.3-${git_date}
+revision            1
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans}

--- a/graphics/gimp2/Portfile
+++ b/graphics/gimp2/Portfile
@@ -8,6 +8,7 @@ name                gimp2
 conflicts           gimp2-devel gimp3-devel
 # please remember to update the gimp metapackage to match
 version             2.10.2
+revision            1
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans}

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -10,6 +10,7 @@ set git_name        gimp
 set git_commit      15ec52eab4381f2dd0b786366e1bdffd8ced56c7
 set git_date        20180521
 version             2.99.1-${git_date}
+revision            1
 license             GPL-3+
 categories          graphics
 maintainers         {devans @dbevans}

--- a/graphics/gle-graphics/Portfile
+++ b/graphics/gle-graphics/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 
 name                gle-graphics
 version             4.2.5
-revision            1
 set major           [lindex [split ${version} .] 0]
 categories          graphics
 platforms           darwin
@@ -65,7 +64,7 @@ configure.args      --with-jpeg=${prefix} \
 universal_variant   no
 
 if {${name} eq ${subport}} {
-    revision                0
+    revision                2
 
     depends_lib-append      port:ncurses
 
@@ -88,7 +87,7 @@ if {${name} eq ${subport}} {
 }
 
 subport QGLE {
-    revision                8
+    revision                9
     license                 GPL-2+
     
     description             graphical user interface of GLE

--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -5,10 +5,9 @@ PortSystem          1.0
 name                inkscape-devel
 conflicts           inkscape
 epoch               1
-set git_commit      f628696ae87eec8d922ae30cb2af36f6f4b86c03
-set git_date        20170815
+set git_commit      b1b33698810bb8ae6e31e509697ff27d2732e7ac
+set git_date        20180614
 version             0.92.2-${git_date}
-revision            3
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}
 categories          graphics gnome

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -6,6 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                inkscape
 conflicts           inkscape-devel
 version             0.92.3
+revision            1
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}
 categories          graphics gnome
@@ -57,6 +58,11 @@ depends_lib         port:desktop-file-utils \
                     port:py27-numpy
 
 patchfiles          patch-use-configured-perl.diff
+
+# backport fixes from upstream for poppler 0.65 compatibility
+# (patches can presumably be removed on next update)
+patchfiles-append    10e8ae0ff522d3a9caeed9a7f137cdfd795ba0a3.diff \
+                     f0697de012598ea84edafea9a326e5e101eccd2a.diff
 
 post-patch {
     reinplace "s|@@MP_PERL@@|${prefix}/bin/perl${perl_version}|" ${worksrcpath}/Makefile.am

--- a/graphics/inkscape/files/10e8ae0ff522d3a9caeed9a7f137cdfd795ba0a3.diff
+++ b/graphics/inkscape/files/10e8ae0ff522d3a9caeed9a7f137cdfd795ba0a3.diff
@@ -1,0 +1,14 @@
+diff --git src/extension/internal/pdfinput/pdf-parser.cpp src/extension/internal/pdfinput/pdf-parser.cpp
+index 721524e10afcb9979fbbab5292ac9f973f316412..a3aa3213a1c39df80f3e41e0932f4c7bfc683af7 100644
+--- src/extension/internal/pdfinput/pdf-parser.cpp
++++ src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -37,8 +37,7 @@ extern "C" {
+ #include "util/units.h"
+ 
+ #include "goo/gmem.h"
+-#include "goo/GooTimer.h"
+-#include "goo/GooHash.h"
++#include "goo/GooString.h"
+ #include "GlobalParams.h"
+ #include "CharTypes.h"
+ #include "Object.h"

--- a/graphics/inkscape/files/f0697de012598ea84edafea9a326e5e101eccd2a.diff
+++ b/graphics/inkscape/files/f0697de012598ea84edafea9a326e5e101eccd2a.diff
@@ -1,0 +1,105 @@
+diff --git src/extension/internal/pdfinput/pdf-parser.cpp src/extension/internal/pdfinput/pdf-parser.cpp
+index 604b7f80795ff10cce26b2581ba961f4dd4a0750..721524e10afcb9979fbbab5292ac9f973f316412 100644
+--- src/extension/internal/pdfinput/pdf-parser.cpp
++++ src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -2582,7 +2582,7 @@ void PdfParser::opShowSpaceText(Object args[], int /*numArgs*/)
+   }
+ }
+ 
+-void PdfParser::doShowText(GooString *s) {
++void PdfParser::doShowText(const GooString *s) {
+   GfxFont *font;
+   int wMode;
+   double riseX, riseY;
+@@ -2601,7 +2601,7 @@ void PdfParser::doShowText(GooString *s) {
+   font = state->getFont();
+   wMode = font->getWMode();
+ 
+-  builder->beginString(state, s);
++  builder->beginString(state);
+ 
+   // handle a Type 3 char
+   if (font->getType() == fontType3 && 0) {//out->interpretType3Chars()) {
+@@ -2631,7 +2631,7 @@ void PdfParser::doShowText(GooString *s) {
+     double lineX = state->getLineX();
+     double lineY = state->getLineY();
+     oldParser = parser;
+-    p = s->getCString();
++    p = g_strdup(s->getCString());
+     len = s->getLength();
+     while (len > 0) {
+       n = font->getNextChar(p, len, &code,
+@@ -2686,7 +2686,7 @@ void PdfParser::doShowText(GooString *s) {
+ 
+   } else {
+     state->textTransformDelta(0, state->getRise(), &riseX, &riseY);
+-    p = s->getCString();
++    p = g_strdup(s->getCString());
+     len = s->getLength();
+     while (len > 0) {
+       n = font->getNextChar(p, len, &code,
+@@ -2732,7 +2732,7 @@ void PdfParser::opXObject(Object args[], int /*numArgs*/)
+ {
+   Object obj1, obj2, obj3, refObj;
+ 
+-  char *name = args[0].getName();
++  char *name = g_strdup(args[0].getName());
+ #if defined(POPPLER_NEW_OBJECT_API)
+   if ((obj1 = res->lookupXObject(name)).isNull()) {
+ #else
+diff --git src/extension/internal/pdfinput/pdf-parser.h src/extension/internal/pdfinput/pdf-parser.h
+index e28fecc2e155af155d3e84205bb28d269cdda6be..f985b15cad7aa4354d0108127ecedaebb95ea540 100644
+--- src/extension/internal/pdfinput/pdf-parser.h
++++ src/extension/internal/pdfinput/pdf-parser.h
+@@ -287,7 +287,7 @@ private:
+   void opMoveShowText(Object args[], int numArgs);
+   void opMoveSetShowText(Object args[], int numArgs);
+   void opShowSpaceText(Object args[], int numArgs);
+-  void doShowText(GooString *s);
++  void doShowText(const GooString *s);
+ 
+   // XObject operators
+   void opXObject(Object args[], int numArgs);
+diff --git src/extension/internal/pdfinput/svg-builder.cpp src/extension/internal/pdfinput/svg-builder.cpp
+index a448be639761b81a62aa5b95482f11e6c54045fd..617861928d964a66e88a43666905bab5c9e7ef10 100644
+--- src/extension/internal/pdfinput/svg-builder.cpp
++++ src/extension/internal/pdfinput/svg-builder.cpp
+@@ -1020,7 +1020,7 @@ void SvgBuilder::updateFont(GfxState *state) {
+     GfxFont *font = state->getFont();
+     // Store original name
+     if (font->getName()) {
+-        _font_specification = font->getName()->getCString();
++        _font_specification = g_strdup(font->getName()->getCString());
+     } else {
+         _font_specification = (char*) "Arial";
+     }
+@@ -1361,7 +1361,7 @@ void SvgBuilder::_flushText() {
+     _glyphs.clear();
+ }
+ 
+-void SvgBuilder::beginString(GfxState *state, GooString * /*s*/) {
++void SvgBuilder::beginString(GfxState *state) {
+     if (_need_font_update) {
+         updateFont(state);
+     }
+diff --git src/extension/internal/pdfinput/svg-builder.h src/extension/internal/pdfinput/svg-builder.h
+index ad15c9c06fecba95ada6b7beb4184be2456a95a8..ed2a4d48e07b3ee4cd8a4b88c0ea4a685c2ff5b5 100644
+--- src/extension/internal/pdfinput/svg-builder.h
++++ src/extension/internal/pdfinput/svg-builder.h
+@@ -29,7 +29,6 @@ namespace Inkscape {
+ #include <glibmm/ustring.h>
+ 
+ #include "CharTypes.h"
+-class GooString;
+ class Function;
+ class GfxState;
+ struct GfxColor;
+@@ -136,7 +135,7 @@ public:
+     void clearSoftMask(GfxState *state);
+ 
+     // Text handling
+-    void beginString(GfxState *state, GooString *s);
++    void beginString(GfxState *state);
+     void endString(GfxState *state);
+     void addChar(GfxState *state, double x, double y,
+                  double dx, double dy,

--- a/graphics/ipe-tools/Portfile
+++ b/graphics/ipe-tools/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            otfried ipe-tools e5b23399a83d69fd5bb5d4645ef7325b4b57435b
 version                 20151202
-revision                10
+revision                11
 categories              graphics
 maintainers             gmail.com:m7.thon \
                         gmx.de:Torsten.Maehne \

--- a/graphics/pdf2djvu/Portfile
+++ b/graphics/pdf2djvu/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
 github.setup        jwilk pdf2djvu 0.9.9
-revision            1
+revision            2
 categories          graphics textproc
 platforms           darwin
 license             GPL-2

--- a/graphics/pdf2svg/Portfile
+++ b/graphics/pdf2svg/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dawbarton pdf2svg 0.2.3 v
-revision            1
+revision            2
 license             GPL-2
 categories          graphics
 maintainers         nomaintainer

--- a/graphics/pdfpc/Portfile
+++ b/graphics/pdfpc/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.0
 
 github.setup            pdfpc pdfpc 3.1.1 v
-revision                2
+revision                3
 maintainers             nomaintainer
 
 categories              graphics

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -4,15 +4,11 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
 PortGroup           gobject_introspection 1.0
-PortGroup           muniversal 1.0
-
-# version 0.58.0 includes C++11 extensions that break
-# build of a number of dependents (inkscape, texlive-bin, etc)
-# hold off on update until this is sorted out
+PortGroup           cmake 1.1
 
 name                poppler
 conflicts           xpdf-tools
-version             0.57.0
+version             0.65.0
 license             GPL-2+
 maintainers         {devans @dbevans} openmaintainer
 categories          graphics
@@ -26,8 +22,9 @@ master_sites        ${homepage}
 
 use_xz              yes
 
-checksums           rmd160  a535f7797241cf44b598ad8d60a05f5307afcd52 \
-                    sha256  0ea37de71b7db78212ebc79df59f99b66409a29c2eac4d882dae9f2397fe44d8
+checksums           rmd160  eeb55ce5f712287eeb01bd054df0033663a255ce \
+                    sha256  89c8cf73f83efda78c5a9bd37c28f4593ad0e8a51556dbe39ed81e1ae2dd8f07 \
+                    size    1451720
 
 depends_build       port:pkgconfig
 
@@ -40,54 +37,40 @@ depends_lib         port:bzip2 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/cairo.pc:cairo \
                     port:lcms2 \
+                    port:libiconv \
                     port:libpng \
                     port:openjpeg \
                     port:poppler-data \
                     port:tiff \
                     port:zlib
 
+configure.ldflags-append -liconv
 gobject_introspection yes
-
-# Generate newer libtool that passes -stdlib when linking dylibs.
-use_autoreconf      yes
-autoreconf.args     -fvi
 
 compiler.blacklist  {gcc-4.0 < 5493}
 
-configure.args      --disable-poppler-qt4 \
-                    --disable-poppler-qt5 \
-                    --disable-gtk-test \
-                    --disable-silent-rules \
-                    --disable-libnss \
-                    --enable-xpdf-headers \
-                    --enable-zlib \
-                    --enable-libcurl
-
-post-patch {
-    # clang: error: unknown argument: '-fno-check-new'
-    # Strip it out rather than --disable-compile-warnings
-    reinplace "s:-fno-check-new::g" ${worksrcpath}/configure.ac
-}
-
-# TODO:
-# add subport for poppler-qt4-x11 when qt4-x11 builds and port group qt4 allows
-
-subport poppler-qt4-mac {
-    PortGroup qt4 1.0
-
-    configure.env-append    MOCQT4=${qt_bins_dir}/moc
-    configure.args-delete   --disable-poppler-qt4
-}
+configure.args-append \
+                    -DENABLE_XPDF_HEADERS=ON \
+                    -DENABLE_QT5=OFF \
+                    -DBUILD_GTK_TESTS=OFF \
+                    -DBUILD_QT5_TESTS=OFF \
+                    -DBUILD_CPP_TESTS=OFF \
+                    -DWITH_NSS3=OFF
 
 subport poppler-qt5 {
     PortGroup qt5 1.0
 
+    patchfiles-append       patch-qt5-106118.diff
     configure.env-append    MOCQT5=${qt_bins_dir}/moc
-    configure.args-delete   --disable-poppler-qt5
+    configure.args-delete   -DENABLE_QT5=OFF
+    configure.args-delete   -DENABLE_XPDF_HEADERS=ON
+    configure.args-append   -DENABLE_UTILS=OFF
+    configure.args-append   -DENABLE_CPP=OFF
+    configure.args-append   -DENABLE_GLIB=OFF
 
-    # avoid:
-    #    ${prefix}/libexec/qt5/include/QtCore/qbasicatomic.h:61:4: error: "Qt requires C++11 support"
-    configure.cxxflags-append -std=c++11
+    post-destroot {
+        file delete ${destroot}${prefix}/lib/pkgconfig/poppler-cairo.pc
+    }
 }
 
 if {${subport} ne ${name}} {
@@ -99,10 +82,6 @@ if {${subport} ne ${name}} {
         system -W ${workpath} "${prefix}/bin/git clone --depth=1 http://anongit.freedesktop.org/git/poppler/test"
     }
 
-    configure.args-append   --disable-cairo-output \
-                            --disable-poppler-glib \
-                            --disable-poppler-cpp \
-                            --disable-utils
 
 # currently poppler only provides unit tests for the Qt wrappers
 

--- a/graphics/poppler/files/patch-qt5-106118.diff
+++ b/graphics/poppler/files/patch-qt5-106118.diff
@@ -1,0 +1,10 @@
+--- qt5/src/ArthurOutputDev.cc.orig	2018-05-15 16:27:29.000000000 -0700
++++ qt5/src/ArthurOutputDev.cc	2018-05-15 16:27:44.000000000 -0700
+@@ -60,6 +60,7 @@
+ #include <QGlyphRun>
+ #include <QtGui/QPainterPath>
+ #include <QPicture>
++#include <array>
+ 
+ //------------------------------------------------------------------------
+ 

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        jcupitt libvips 8.6.4 v
+revision            1
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/mail/claws-mail/Portfile
+++ b/mail/claws-mail/Portfile
@@ -5,7 +5,7 @@ PortGroup       active_variants 1.1
 
 name            claws-mail
 version         3.16.0
-revision        1
+revision        2
 categories      mail news
 platforms       darwin
 license         GPL-3+

--- a/office/zathura-plugin-pdf-poppler/Portfile
+++ b/office/zathura-plugin-pdf-poppler/Portfile
@@ -7,7 +7,7 @@ name                zathura-plugin-pdf-poppler
 conflicts           zathura-plugin-pdf-mupdf
 
 version             0.2.6
-revision            1
+revision            2
 categories          office
 platforms           darwin
 license             zlib

--- a/perl/p5-poppler/Portfile
+++ b/perl/p5-poppler/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26
 perl5.setup         Poppler 1.0101 ../by-authors/id/V/VO/VOLKENING
-revision            1
+revision            2
 platforms           darwin
 maintainers         {devans @dbevans} openmaintainer
 license             LGPL-2.1+

--- a/print/scribus-devel/Portfile
+++ b/print/scribus-devel/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.0
 PortGroup           qt5 1.0
 name                scribus-devel
 version             1.5.4
+revision            1
 categories          print
 license             LGPL-2+ BSD MIT
 platforms           darwin

--- a/python/impressive/Portfile
+++ b/python/impressive/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                impressive
 version             0.12.0
+revision            1
 categories-append   graphics
 license             GPL-2
 maintainers         nomaintainer

--- a/python/py-poppler/Portfile
+++ b/python/py-poppler/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-poppler
 set rname           pypoppler
 version             0.12.1
-revision            5
+revision            6
 
 platforms           darwin
 license             GPL-2

--- a/ruby/rb-gnome/Portfile
+++ b/ruby/rb-gnome/Portfile
@@ -4,7 +4,7 @@ PortGroup		ruby 1.0
 ruby.setup		{gnome ruby-gnome2} 1.1.3 fetch \
 				{ README NEWS } \
 				sourceforge:ruby-gnome2
-revision		1
+revision		2
 
 maintainers		{kimuraw @kimuraw}
 platforms		darwin

--- a/ruby/rb-poppler/Portfile
+++ b/ruby/rb-poppler/Portfile
@@ -5,7 +5,7 @@ PortGroup		ruby 1.0
 ruby.setup		{poppler ruby-gnome2} 1.1.3 extconf.rb \
 				{ poppler/README poppler/sample } \
 				sourceforge:ruby-gnome2
-revision		2
+revision		3
 maintainers		{kimuraw @kimuraw}
 platforms		darwin
 description		Ruby/Poppler is a Ruby binding of poppler-glib.

--- a/ruby/rb-rabbit/Portfile
+++ b/ruby/rb-rabbit/Portfile
@@ -2,7 +2,7 @@ PortSystem		1.0
 PortGroup		ruby 1.0
 
 ruby.setup		rabbit 1.0.8 setup.rb {README sample misc}
-revision		1
+revision		2
 maintainers		{kimuraw @kimuraw}
 description		An application to do presentation with RD document.
 long_description	This is an application to do presentation with RD document.\

--- a/textproc/pdf2htmlex/Portfile
+++ b/textproc/pdf2htmlex/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 github.setup        coolwanglu pdf2htmlEX 43e3174cbc
 name                pdf2htmlex
 version             0.11
-revision            22
+revision            23
 categories          textproc
 maintainers         iapa.in:iapain {mojca @mojca} openmaintainer
 platforms           darwin

--- a/textproc/pdfgrep-legacy/Portfile
+++ b/textproc/pdfgrep-legacy/Portfile
@@ -3,7 +3,7 @@ PortSystem          1.0
 name                pdfgrep-legacy
 set realname        pdfgrep
 version             1.3.2
-revision            1
+revision            2
 conflicts           pdfgrep
 categories          textproc
 platforms           darwin

--- a/textproc/pdfgrep/Portfile
+++ b/textproc/pdfgrep/Portfile
@@ -3,6 +3,7 @@ PortGroup           cxx11 1.1
 
 name                pdfgrep
 version             2.1.1
+revision            1
 conflicts           pdfgrep-legacy
 categories          textproc
 platforms           darwin

--- a/textproc/recoll/Portfile
+++ b/textproc/recoll/Portfile
@@ -5,7 +5,7 @@ PortGroup           app 1.0
 
 name                recoll
 version             1.21.3
-revision            1
+revision            2
 categories          textproc
 platforms           darwin
 license             GPL-2+

--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -48,6 +48,8 @@ if {${subport} eq ${name}} {
     conflicts               auto-multiple-choice
 }
 
+revision                1
+
 master_sites            https://gitlab.com/jojo_boulix/auto-multiple-choice/repository/archive.tar.gz?ref=${gitlab.commit}&dummy=
 distname                ${gitlab.project}-${gitlab.commit}-${gitlab.commit}
 

--- a/x11/xournal/Portfile
+++ b/x11/xournal/Portfile
@@ -5,6 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    xournal
 version                 0.4.8.2016
+revision                1
 categories              x11
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer


### PR DESCRIPTION
I'm marking this as wip since it breaks dependent ports and we haven't figured out how to (or if we should) fix that. See discussion in https://trac.macports.org/ticket/54808

This patch updates poppler to 0.65.0, which has a new cmake build system. Unfortunately, poppler has removed support for qt4 bindings, so this has to remove the poppler-qt4 subport.

I tested the dependents and the ones that break are:
 - texlive-bin (which will be fixed by #1770)
 - inkscape, inkscape-devel (I've seen a patch to fix it)
 - vips
 - pdfhtmlex (can probably be updated once #1674 is committed)

...but the real problem is the ones that depend on poppler-qt4:
 - kfilemetadata                   
 - nepomuk-core                                                                   
 - okular                                                                         
 - py*-poppler-qt4                
 - texworks
Of these, texworks can be updated to use qt5 but the others require a major and difficult update (again, see discussion in https://trac.macports.org/ticket/54808). I'm not sure what to do about that part... I don't want to break these ports, but there are also security issues with the current version of poppler that we really need to resolve.
