### PR TITLE
generaluser-soundfont: Update to version 1.471.

### DIFF
--- a/audio/generaluser-soundfont/Portfile
+++ b/audio/generaluser-soundfont/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 
 name                generaluser-soundfont
-version             1.47
+version             1.471
+revision            0
 categories          audio
 #                   GeneralUser GS License v2.0
 license             Permissive
@@ -18,14 +19,30 @@ long_description    ${description} Provides the GeneralUser SoundFont by S. Chri
                     footprint (less than 30 MB of RAM). Due to its clever, detailed sound programming, \
                     GeneralUser GS can sound as good or better than SoundFonts that are 2-3 times its size.
 homepage            http://www.schristiancollins.com/generaluser.php
-master_sites        https://dl.dropboxusercontent.com/u/8126161/
+master_sites        https://www.dropbox.com/s/4x27l49kxcwamp5/
 use_zip             yes
 
 distname            GeneralUser_GS_${version}
+
+# This line can be removed once backward compatibility with MacPorts
+# base versions prior to PR macports/macports-base#55 is not needed.
 worksrcdir          "GeneralUser GS ${version}"
 
-checksums           rmd160  d1c2bf2aa5df251a18432cf8ca456e23c31faf5e \
-                    sha256  be4cf246d97f98eb059ede059be2f1bdcd9bbf3245d6c0667edaa11f3091c30d
+checksums           rmd160  aa8eabb515b0e27ff94b05b6be30ac7e1afc0414 \
+                    sha256  4203835164766f428c4926c097c9ea58dae431c7fb8f9dbe277b92d80da45ec2 \
+                    size    28373045
+
+# This block can be replaced with:
+#  fetch.user_agent curl/MacPorts/[macports_version]
+# once backward compatibility with MacPorts base versions prior to PR
+# macports/macports-base#99 is not needed.
+if {[info exists fetch.user_agent]} {
+    fetch.user_agent    curl/MacPorts/[macports_version]
+} else {
+    fetch {
+        system -W ${distpath} "curl -LO ${master_sites}/${distname}${extract.suffix}"
+    }
+}
 
 use_configure       no
 build               {}


### PR DESCRIPTION
Add backward compatibility and notes.

#### Description
Untested example of using `fetch.user_agent` with backward compatibility
[per Mojca's request](https://github.com/macports/macports-base/pull/91#issuecomment-395942059).
