### PR TITLE
abcde: depend on p5.xx subports

### DIFF
--- a/audio/abcde/Portfile
+++ b/audio/abcde/Portfile
@@ -5,6 +5,7 @@ PortGroup               perl5 1.0
 
 name                    abcde
 version                 2.9.1
+revision                1
 categories              audio
 platforms               darwin
 maintainers             eclipsed.net:gr openmaintainer
@@ -33,9 +34,9 @@ depends_lib             port:vorbis-tools \
                         port:cdparanoia \
                         port:id3v2 \
                         port:normalize \
-                        port:p5-digest-sha \
-                        port:p5-musicbrainz-discid \
-                        port:p5-webservice-musicbrainz
+                        port:p${perl5.major}-digest-sha \
+                        port:p${perl5.major}-musicbrainz-discid \
+                        port:p${perl5.major}-webservice-musicbrainz
 
 patchfiles              patch-Makefile-fixpaths.diff
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Based on [feedback](https://github.com/macports/macports-ports/pull/1973#pullrequestreview-127372136) from @l2dy on #1973:

> ```diff
>  depends_lib             port:vorbis-tools \
>                          port:lame \
>                          port:flac \
>                          port:cd-discid \
>                          port:cdparanoia \
>                          port:id3v2 \
> -                        port:normalize
> +                        port:normalize \
> +                        port:p5-digest-sha \
> +                        port:p5-musicbrainz-discid \
> +                        port:p5-webservice-musicbrainz
> ```
> 
> These p5-* ports aren't frozen at 5.26, so you should use p${perl5.major}- instead. See port mosh for an example.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] ~~tried existing tests with `sudo port test`?~~ (No tests for abcde.)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
