### PR TITLE
Thunar: update to 1.6.15

### DIFF
--- a/xfce/Thunar/Portfile
+++ b/xfce/Thunar/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            Thunar
-version         1.6.12
+version         1.6.15
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      xfce
 platforms       darwin
@@ -16,9 +16,9 @@ homepage        https://docs.xfce.org/xfce/thunar/start
 master_sites    http://archive.xfce.org/src/xfce/thunar/${branch}/
 use_bzip2       yes
 
-checksums       rmd160  191cd85bf3c1afd0c92846b1c6da348044a97c34 \
-                sha256  fb22091f07ec6de2c9d9d89c61289d2bc3436b36c8c53ccbc9c32ca8a99f2086 \
-                size    1929112
+checksums       rmd160  5ad7f64a2476c6ba8f959f9fe22eeadf807f4e30 \
+                sha256  e81291a8519f495e0a059ff1f2d29608bc6d37c0be83b1f38f3c9aa25f8d252d \
+                size    1964447
 
 configure.args  --enable-dbus --enable-startup-notification \
                 --enable-pcre --enable-exif


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
I am aware that 1.8 was released but that might be a less trivial update (moves to GTK+ 3), and supposedly many fixes were backported to 1.6.x.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for Thunar
Warning: Variant quartz conflicts with non-existing variant x11
--->  0 errors and 1 warnings found.
```
- [ ] ~~tried existing tests with `sudo port test`?~~ (No tests for Thunar.)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Observations (not introduced with this version):
- Does not depend on an icon theme being installed
- quartz variant seems to behave just like regular variant (still uses X11)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
