### PR TITLE
cquery: new port

### DIFF
--- a/devel/cquery/Portfile
+++ b/devel/cquery/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+PortGroup       waf 1.0
+PortGroup       xcodeversion 1.0
+
+name            cquery
+
+categories      devel
+license         MIT
+maintainers     {wyuenho @wyuenho} openmaintainer
+
+description     C/C++/Objective C Language Server Protocol support
+
+long_description \
+    cquery is a highly-scalable, low-latency language server for \
+    C/C++/Objective-C. It is tested and designed for large code bases like \
+    Chromium. cquery provides accurate and fast semantic analysis without \
+    interrupting workflow. \
+    \
+    cquery implements almost the entire language server protocol and provides some \
+    extra features.
+
+platforms       darwin
+os.version      16.0.0
+homepage        https://github.com/cquery-project/cquery
+
+version         20180302
+
+fetch.type      git
+git.url         https://github.com/cquery-project/cquery
+git.branch      v${version}
+
+if {${subport} eq ${name}} {
+    conflicts   cquery-devel
+}
+subport cquery-devel {
+    conflicts   ${name}
+}
+
+pre-configure {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+configure.args-delete   --nocache
+
+variant asan description {Address Sanitizer} {
+    configure.args-append    --variant=asan-release
+    build.args-append        --variant=asan-release
+}
+
+if {${subport} eq ${name}} {
+    depends_lib port:clang-5.0
+    configure.args-append    --llvm-config=llvm-config-mp-5.0
+    build.args-append        --llvm-config=llvm-config-mp-5.0
+}
+
+if {${subport} eq "cquery-devel"} {
+    minimum_xcodeversions {16 8.3}
+    version       20180609
+    git.branch    634f73b581815c3bdd5c2d273dcf888596e212fd
+
+    depends_lib              port:clang-6.0
+    configure.args-append    --llvm-config=llvm-config-mp-6.0
+    build.args-append        --llvm-config=llvm-config-mp-6.0
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
cquery: new port

* requires clang-5.0
* subport - cquery-devel, requires clang-6.0

Closes: https://trac.macports.org/ticket/56630

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
