### PR TITLE
octave: have OCTAVE_VERSION return correct value

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -13,7 +13,7 @@ compiler.blacklist-append   {*gcc-4.6} {clang < 700}
 name                octave
 version             4.4.0
 set package_version 4.x.x
-revision            2
+revision            3
 categories          math science
 platforms           darwin
 license             GPL-3+
@@ -97,6 +97,15 @@ post-patch {
     reinplace \
         "s|__MACPORTS_canonical_host_type__|${short_host_name}|g" \
         build-aux/subst-default-vals.in.sh
+    # see https://trac.macports.org/ticket/56624
+    if {${subport} eq ${name}} {
+        set version_file libinterp/version.in.h
+    } else {
+        set version_file liboctave/version.in.h
+    }
+    reinplace \
+        "s|%OCTAVE_VERSION%|\"${version}\"|g" \
+        ${version_file}
 }
 
 pre-configure {


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/56624

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->