### PR TITLE
qt59-qtlocation: avoid C++17

### DIFF
--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1231,6 +1231,10 @@ foreach {module module_info} [array get modules] {
                         reinplace "s|return 0;|return 0;\\\n#error turn off test|g" ${worksrcpath}/config.tests/${test}/main.cpp
                     }
                 }
+
+                # see https://trac.macports.org/ticket/56615
+                # see https://bugreports.qt.io/browse/QTBUG-67810
+                patchfiles-append patch-qtlocation-no-cxx17.diff
             }
 
             # special case

--- a/aqua/qt59/files/patch-qtlocation-no-cxx17.diff
+++ b/aqua/qt59/files/patch-qtlocation-no-cxx17.diff
@@ -1,0 +1,10 @@
+--- src/3rdparty/mapbox-gl-native/mapbox-gl-native.pro.orig	2017-11-29 10:38:56.000000000 -0800
++++ src/3rdparty/mapbox-gl-native/mapbox-gl-native.pro	2018-06-10 10:32:18.000000000 -0700
+@@ -3,6 +3,7 @@
+ load(qt_helper_lib)
+ 
+ CONFIG += qt c++14 exceptions warn_off staticlib object_parallel_to_source
++CONFIG -= c++1z
+ 
+ QT += network-private \
+       gui-private \


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/56615
See https://bugreports.qt.io/browse/QTBUG-67810

No revbump because the port either builds successfully or not at all

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->