### PR TITLE
p5-devel-nytprof: add depends_test-append modules

### DIFF
--- a/perl/p5-devel-nytprof/Portfile
+++ b/perl/p5-devel-nytprof/Portfile
@@ -44,6 +44,11 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-json-maybexs \
                     port:p${perl5.major}-test-differences
 
+    depends_test-append \
+                    port:p${perl5.major}-moose \
+                    port:p${perl5.major}-test-pod \
+                    port:p${perl5.major}-test-pod-coverage
+
     patchfiles      patch-Makefile.PL.diff
 
     post-patch {


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Based on [suggestion](https://github.com/macports/macports-ports/pull/1974#issuecomment-396069422) by @mojca:
> You can add depends_test for additional dependencies to be used for testing only and increase the number of tests being run.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

I've left out the module (Test::Portability::Files) and environment variable (`NYTPROF_TEST_PORTABILITY_FILES`) needed for t/92-file_port.t to run. It is considered a "developer only" test but does not currently have the same checks as the other developer-only tests. Even when enabled, the only issues it finds are multiple dots in names of files not used in an installation (.indent.pro, .travis.yml, and t/test02.pf.csv).

<details><summary>Full test results:</summary>
<pre>
--->  Testing p5.26-devel-nytprof
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-devel-nytprof/p5.26-devel-nytprof/work/Devel-NYTProf-6.06" && /usr/bin/make test
"/opt/local/bin/perl5.26" -MExtUtils::Command::MM -e 'cp_nonempty' -- NYTProf.bs blib/arch/auto/Devel/NYTProf/NYTProf.bs 644
cp blib/arch/auto/Devel/NYTProf/NYTProf.bundle blib/lib/Devel/auto/Devel/NYTProf/NYTProf.bundle
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
# Testing Devel::NYTProf 6.06 started at Sun Jun 10 14:37:56 2018
# Compression: default level is 6, zlib version 1.2.11
# --- Perl 5.026002 Config on darwin-thread-multi-2level:
#       d_gettimeod: define
#       d_sysconf: define
t/00-load.t ............ ok
t/10-run.t ............. ok
t/22-readstream.t ...... ok
t/30-util.t ............ ok
t/31-env.t ............. ok
t/40-savesrc.t ......... ok
t/42-global.t .......... ok
t/44-model.t ........... ok
t/50-errno.t ........... ok
t/60-forkdepth.t ....... ok
t/68-hashline.t ........ skipped: Currently a developer-only test
t/70-subname.t ......... ok
t/71-moose.t ........... skipped: Test is incomplete (has no results defined yet)
t/72-autodie.t ......... skipped: Currently a developer-only test
t/80-version.t ......... ok
t/90-pod.t ............. ok
t/91-pod_coverage.t .... skipped: Currently a developer-only test
t/92-file_port.t ....... skipped: Set NYTPROF_TEST_PORTABILITY_FILES env var to enable test
t/test01.t ............. ok
t/test02.t ............. ok
t/test03.t ............. ok
t/test05.t ............. ok
t/test06.t ............. ok
t/test07.t ............. ok
t/test08.t ............. ok
t/test09.t ............. ok
t/test10.t ............. ok
t/test11.t ............. ok
t/test12.t ............. ok
t/test13.t ............. ok
t/test14.t ............. ok
t/test16.t ............. ok
t/test17-goto.t ........ ok
t/test18-goto2.t ....... ok
t/test20-streval.t ..... ok
t/test21-streval3.t .... ok
t/test22-strevala.t .... ok
t/test23-strevall.t .... ok
t/test24-strevalc.t .... ok
t/test25-strevalb.t .... ok
t/test30-fork-0.t ...... ok
t/test40pmc.t .......... ok
t/test50-disable.t ..... ok
t/test51-enable.t ...... ok
t/test60-subname.t ..... ok
t/test61-submerge.t .... ok
t/test62-subcaller1.t .. ok
t/test62-tie-a.t ....... skipped: needs perl < 5.21.1 (see t/test62-tie-b.t)
t/test62-tie-b.t ....... ok
t/test70-subexcl.t ..... ok
t/test80-recurs.t ...... ok
t/test81-swash.t ....... ok
t/test82-version.t ..... ok
t/test90-strsubref.t ... ok
# Tests ended at Sun Jun 10 14:40:24 2018
t/zzz.t ................ ok
All tests successful.
Files=55, Tests=4776, 148 wallclock secs ( 1.18 usr  0.25 sys + 58.27 cusr 17.56 csys = 77.26 CPU)
Result: PASS
</pre>
</details>
<br />

- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
