### PR TITLE
p5-net-netmask: update to 1.9101, add depends_test-append modules

### DIFF
--- a/perl/p5-net-netmask/Portfile
+++ b/perl/p5-net-netmask/Portfile
@@ -4,15 +4,21 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Net-Netmask 1.9022
+perl5.setup         Net-Netmask 1.9101
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl module to parse, manipulate and lookup IP network blocks
 long_description    Net::Netmask is a module to parse, manipulate and lookup IP network blocks
 
-checksums           rmd160  bd45252584c870075d57aed1e1aa0fde2f85eecb \
-                    sha256  07099c1ff4de752e6f5420b32de12e4338b05bbb252e53c782b740173ba31533
+checksums           rmd160  25f535253d696fb92148697155cd3756080ce03f \
+                    sha256  4951f936c0b60b3841f174f1b072e07778f7fddd5a94187a9331b172b84ec301 \
+                    size    30179
 
 platforms           darwin
 
 supported_archs     noarch
+
+if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-test-useallmodules
+}


### PR DESCRIPTION
add depends_test-append modules

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

<details><summary>Full test results:</summary>
<pre>
--->  Testing p5.26-net-netmask
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-net-netmask/p5.26-net-netmask/work/Net-Netmask-1.9101" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00-load.t ................. ok
t/author-pod-syntax.t ....... skipped: these tests are for testing by the author
t/author-test-version.t ..... skipped: these tests are for testing by the author
t/badnets.t ................. ok
t/netmasks.t ................ ok
t/release-kwalitee.t ........ skipped: these tests are for release candidate testing
t/release-trailing-space.t .. skipped: these tests are for release candidate testing
t/release-unused-vars.t ..... skipped: these tests are for release candidate testing
t/sortspeed-blocks.t ........ skipped: this is for people looking for faster sorts
t/sortspeed-ip.t ............ skipped: this is for people looking for faster sorts
t/split.t ................... ok
All tests successful.
Files=11, Tests=364,  0 wallclock secs ( 0.07 usr  0.03 sys +  0.38 cusr  0.07 csys =  0.55 CPU)
Result: PASS
</pre>
</details>
<br>

- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
