### PR TITLE
zstd: Use CXXFLAGS and LDFLAGS and don't build contrib, examples, or manual

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        facebook zstd 1.3.4 v
+revision            1
 categories          archivers devel
 platforms           darwin
 license             {BSD GPL-2}
@@ -27,11 +28,13 @@ use_configure       no
 
 variant universal {}
 
-build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \
-                    CXX="${configure.cxx} [get_canonical_archflags cxx]" \
-                    CFLAGS="${configure.cflags}" \
-                    PREFIX="${prefix}"
-
 use_parallel_build  no
+
+build.env-append    CC="${configure.cc}" \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    CXX="${configure.cxx}" \
+                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]" \
+                    PREFIX="${prefix}"
 
 destroot.env-append {*}${build.env}

--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -34,7 +34,4 @@ build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \
 
 use_parallel_build  no
 
-destroot.env-append CC="${configure.cc} [get_canonical_archflags cc]" \
-                    CXX="${configure.cxx} [get_canonical_archflags cxx]" \
-                    CFLAGS="${configure.cflags}" \
-                    PREFIX="${prefix}"
+destroot.env-append {*}${build.env}

--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -28,7 +28,7 @@ use_configure       no
 
 variant universal {}
 
-use_parallel_build  no
+build.target        allmost
 
 build.env-append    CC="${configure.cc}" \
                     CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \


### PR DESCRIPTION
#### Description

Fix zstd build on older systems by not building contrib, examples, or manual, which aren't installed anyway. This also allows parallel building to be reenabled.

MacPorts CXXFLAGS and LDFLAGS are also now used. Actually, now that contrib, examples, and manual are not built, C++ isn't used at all. But we may as well set the flags in case C++ is used by the main programs and libraries in the future.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->