### PR TITLE
p5-tk: remove unused dependency tk

### DIFF
--- a/perl/p5-tk/Portfile
+++ b/perl/p5-tk/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26
 perl5.setup         Tk 804.034
+revision            1
 license             {Artistic-1 GPL} MIT
 maintainers         nomaintainer
 description         p5-tk is a Perl interface to Tk
@@ -16,7 +17,8 @@ checksums           rmd160  899afc1936811a318110430b5250303cb61ed5c3 \
                     sha256  fea6b144c723528a2206c8cd9175844032ee9c14ee37791f0f151e5e5b293fe2
 
 if {${perl5.major} != ""} {
-depends_lib-append  port:tk \
+depends_lib-append \
+                    port:xorg-libX11 \
                     port:p${perl5.major}-term-readkey \
                     port:jpeg \
                     port:libpng


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
[Since the beginning of time](https://github.com/macports/macports-ports/commit/d537faff373a824aa985dab2eeb23cd4eed85c37) the p5-tk port has listed tk as a dependency. However, Perl/Tk is separate from and makes no use of an "actual" Tcl/Tk installation.

Something that **was** missing was a direct dependency on xorg-libX11; nothing complained about this earlier because Tk or its dependencies listed it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?

I haven't figured out how to run X11 tests from macports. I'm guessing it involves somehow letting the `macports` user know about the `$DISPLAY` variable and my ~/.Xauthority file.

- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
