### PR TITLE
libjwt: Update to version 1.9.0

### DIFF
--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -1,13 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-# Please do not update this Port to version 1.9 of libjwt.  1.8 is presently a dependency for the 'jwt' variant of the nginx port.
-# This Port will be updated as soon as the 'ngx-http-auth-jwt-module' project (https://github.com/TeslaGov/ngx-http-auth-jwt-module)
-# officially supports 1.9.
-
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        benmcollins libjwt 1.8.0 v
+github.setup        benmcollins libjwt 1.9.0 v
 
 platforms           darwin
 categories          devel
@@ -19,9 +15,9 @@ description         C library for Javascript Web Tokens (JWT's)
 long_description    ${description}
 
 
-checksums           rmd160  f7ea338b7f2d85ed7625e693b741a1c1d0d95bc8 \
-                    sha256  da3df9cec73249523c9dad355ea37ea236791bf22b578cb4c92f6503de0c04d0 \
-                    size    75820
+checksums           rmd160  9745d46848cec2a49c251a61d12e5af8cec5047c \
+                    sha256  8ca0e7faa09e36106a004cada03f0a047bafbd2b976add1b3bb8a8ffaeee6297 \
+                    size    92772
 
 use_autoreconf      yes
 


### PR DESCRIPTION
Previous version was 'locked' to version 1.8.0 of upstream.
This was due to dependency support of ngx-http-auth-jwt-module,
the 'jwt' variant of the nginx port.

#### Description

Update libjwt port to version 1.9.0.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4 9F1027a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
