### PR TITLE
p5-type-tiny-xs: update to 0.014

### DIFF
--- a/perl/p5-type-tiny-xs/Portfile
+++ b/perl/p5-type-tiny-xs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Type-Tiny-XS 0.013 ../../authors/id/T/TO/TOBYINK
+perl5.setup         Type-Tiny-XS 0.014 ../../authors/id/T/TO/TOBYINK
 platforms           darwin
 maintainers         nomaintainer
 license             {Artistic-1 GPL}
@@ -14,6 +14,11 @@ description         Type::Tiny::XS - provides an XS boost for some of \
 long_description    This module is optionally used by Type::Tiny to provide \
                     faster, C-based implementations of some type constraints.
 
-checksums           rmd160  ced60667d4ed9b6705f937765fb1bc5771292d84 \
-                    sha256  7f905830adac593f612658c9759a4bf7a19c5fe21b815765308c55cde9142e76 \
-                    size    76322
+checksums           rmd160  e4d5c616dc8023381a6e9f3f3bbada1df86b2828 \
+                    sha256  828bde64f3c31e1df541ffa0af91fe91e441c9f749e3d465f8a9562e1a7c7bad \
+                    size    76772
+
+if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-type-tiny
+}


### PR DESCRIPTION

#### Description
Note: added p5-type-tiny to depends_test

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

<details><summary>Full test results:</summary>
<pre>
--->  Testing p5.26-type-tiny-xs
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-type-tiny-xs/p5.26-type-tiny-xs/work/Type-Tiny-XS-0.014" && /usr/bin/make test
"/opt/local/bin/perl5.26" -MExtUtils::Command::MM -e 'cp_nonempty' -- XS.bs blib/arch/auto/Type/Tiny/XS/XS.bs 644
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01basic.t .............. ok
t/02int.t ................ ok
t/03positiveint.t ........ ok
t/04positiveorzeroint.t .. ok
t/05nonemptystr.t ........ ok
t/06map.t ................ ok
t/07tuple.t .............. ok
t/08enum.t ............... ok
t/09anyof_allof.t ........ ok
t/10bool.t ............... ok
t/99parsing.t ............ ok
All tests successful.
Files=11, Tests=134,  1 wallclock secs ( 0.06 usr  0.04 sys +  0.72 cusr  0.22 csys =  1.04 CPU)
Result: PASS
</pre>
</details>
<br />


- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
