### PR TITLE
dbus: use base support for multiple startupitems

### DIFF
--- a/devel/dbus/Portfile
+++ b/devel/dbus/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name            dbus
 version         1.12.8
-revision        1
+revision        2
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 categories      devel
 platforms       darwin
@@ -39,11 +39,11 @@ if {$macosx_deployment_target eq "10.4"} {
 depends_build       \
     port:pkgconfig
 
-if { [variant_isset no_root] } {
+if {[getuid] != 0} {
     set dbus_user     ${install.user}
     set dbus_group    ${install.group}
 } else {
-    if { [variant_isset underscore] } {
+    if {${os.platform} eq "darwin" && ${os.major} >= 9} {
         set dbus_user     _messagebus
     } else {
         set dbus_user     messagebus
@@ -51,6 +51,19 @@ if { [variant_isset no_root] } {
     set dbus_group    ${dbus_user}
     add_users         ${dbus_user} group=${dbus_group} realname=Message\ Bus
 }
+set daemon_uniquename   org.freedesktop.dbus-system
+set agent_uniquename    org.freedesktop.dbus-session
+
+startupitem.type    launchd
+startupitem.create  no
+startupitems        name        dbus-system \
+                    location    LaunchDaemons \
+                    uniquename  ${daemon_uniquename} \
+                    plist       ${daemon_uniquename}.plist \
+                    name        dbus-session \
+                    location    LaunchAgents \
+                    uniquename  ${agent_uniquename} \
+                    plist       ${agent_uniquename}.plist
 
 depends_lib     port:expat
 
@@ -59,16 +72,14 @@ configure.args  --disable-doxygen-docs \
                 --disable-ducktype-docs \
                 --without-x \
                 --enable-launchd \
-                --with-launchd-agent-dir=${prefix}/Library/LaunchAgents \
+                --with-launchd-agent-dir=${prefix}/etc/LaunchAgents/${agent_uniquename} \
                 --with-dbus-user=${dbus_user} \
                 --disable-tests
 
 post-patch {
-    if {${startupitem.install} && ![variant_isset no_root]} {
-        # Disable if installed into startup directory.
-        reinplace "s|</array>|</array>\\\n\\\n\\\t<key>Disabled</key>\\\n\\\t<true/>|" \
-            ${worksrcpath}/bus/org.freedesktop.dbus-session.plist.in
-    }
+    # Make agent initially disabled.
+    reinplace "s|</array>|</array>\\\n\\\n\\\t<key>Disabled</key>\\\n\\\t<true/>|" \
+        ${worksrcpath}/bus/org.freedesktop.dbus-session.plist.in
 }
 
 use_parallel_build  yes
@@ -102,8 +113,8 @@ pre-destroot {
 post-destroot {
     # Simplify startup script over startupitem.install.
     # See #15081
-    xinstall -d -m 0755 ${destroot}${prefix}/Library/LaunchDaemons
-    set plist [open "${destroot}${prefix}/Library/LaunchDaemons/org.freedesktop.dbus-system.plist" w 0644]
+    xinstall -d -m 0755 ${destroot}${prefix}/etc/LaunchDaemons/${daemon_uniquename}
+    set plist [open "${destroot}${prefix}/etc/LaunchDaemons/${daemon_uniquename}/${daemon_uniquename}.plist" w 0644]
 
     puts ${plist} "<?xml version='1.0' encoding='UTF-8'?>"
     puts ${plist} "<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\""
@@ -111,7 +122,7 @@ post-destroot {
     puts ${plist} "<plist version='1.0'>"
     puts ${plist} "<dict>"
 
-    puts ${plist} "<key>Label</key><string>org.freedesktop.dbus-system</string>"
+    puts ${plist} "<key>Label</key><string>${daemon_uniquename}</string>"
 
     puts ${plist} "<key>ProgramArguments</key>"
     puts ${plist} "<array>"
@@ -125,20 +136,21 @@ post-destroot {
         puts ${plist} "<key>KeepAlive</key><true/>"
     }
 
-    if {${startupitem.install} && ![variant_isset no_root]} {
-        puts ${plist} "<key>Disabled</key><true/>"
-    }
+    puts ${plist} "<key>Disabled</key><true/>"
 
     puts ${plist} "</dict>"
     puts ${plist} "</plist>"
 
     close ${plist}
 
-    if {${startupitem.install} && ![variant_isset no_root]} {
+    if {${startupitem.install} && [geteuid] == 0} {
         xinstall -d -m 0755 ${destroot}/Library/LaunchDaemons
         xinstall -d -m 0755 ${destroot}/Library/LaunchAgents
-        ln -s ${prefix}/Library/LaunchDaemons/org.freedesktop.dbus-system.plist ${destroot}/Library/LaunchDaemons
-        ln -s ${prefix}/Library/LaunchAgents/org.freedesktop.dbus-session.plist ${destroot}/Library/LaunchAgents
+        ln -s ${prefix}/etc/LaunchDaemons/${daemon_uniquename}/${daemon_uniquename}.plist ${destroot}/Library/LaunchDaemons
+        ln -s ${prefix}/etc/LaunchAgents/${agent_uniquename}/${agent_uniquename}.plist ${destroot}/Library/LaunchAgents
+    } else {
+        ln -sf ${prefix}/etc/LaunchDaemons/${daemon_uniquename}/${daemon_uniquename}.plist ${destroot}${prefix}/etc/LaunchDaemons
+        ln -sf ${prefix}/etc/LaunchAgents/${agent_uniquename}/${agent_uniquename}.plist ${destroot}${prefix}/etc/LaunchAgents
     }
 
     system "env DYLD_LIBRARY_PATH=${destroot}${prefix}/lib ${destroot}${prefix}/bin/dbus-uuidgen --ensure=${destroot}${prefix}/var/lib/dbus/machine-id"
@@ -147,19 +159,7 @@ post-destroot {
 post-activate {
     file attributes ${prefix}/var/run/dbus -group ${dbus_group} -owner ${dbus_user}
     file attributes ${prefix}/libexec/dbus-daemon-launch-helper -group ${dbus_group}
-
-    if {${startupitem.install} && ![variant_isset no_root]} {
-        file attributes ${prefix}/Library/LaunchAgents/org.freedesktop.dbus-session.plist -owner root -group wheel
-        file attributes ${prefix}/Library/LaunchDaemons/org.freedesktop.dbus-system.plist -owner root -group wheel
-    }
 }
-
-#pre-deactivate {
-#    if {${startupitem.install} && ![variant_isset no_root]} {
-#        catch {system "launchctl unload /Library/LaunchDaemons/org.freedesktop.dbus-system.plist"}
-#        catch {system "launchctl unload /Library/LaunchAgents/org.freedesktop.dbus-session.plist"}
-#    }
-#}
 
 # XXX Building with tests enabled causes dbus to link with dbus-glib,
 # which it shouldn't do because that port depends on this one: see #30088
@@ -171,41 +171,6 @@ variant test description {enable tests (Only Works if dbus is Already Installed)
     depends_build-append      port:glib2
     depends_build-append      port:python27 port:dbus-python27 port:py27-gobject port:dbus-python
     configure.python        ${prefix}/bin/python2.7
-}
-
-if {${startupitem.install} && ![variant_isset no_root]} {
-    notes "############################################################################
-# Startup items have been generated that will aid in
-# starting ${name} with launchd. They are disabled
-# by default. Execute the following commands to start them,
-# and to cause them to launch at startup:
-#
-# sudo launchctl load -w /Library/LaunchDaemons/org.freedesktop.dbus-system.plist
-# launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
-############################################################################"
-} else {
-    notes "############################################################################
-# Startup items were not installed for ${name}
-# Some programs which depend on ${name} might not function properly.
-# To load ${name} manually, run
-#
-# launchctl load -w ${prefix}/Library/LaunchDaemons/org.freedesktop.dbus-system.plist
-# launchctl load -w ${prefix}/Library/LaunchAgents/org.freedesktop.dbus-session.plist
-############################################################################"
-}
-
-variant no_root conflicts underscore description {Run the DBUS daemon as MacPorts install user} {
-    pre-fetch {
-        if {${install.user} eq "root" || ${install.group} eq "wheel"} {
-            ui_error "The DBUS daemon should not be run as root."
-            error "Please do not use this variant with your MacPorts configuration."
-        }
-    }
-}
-
-variant underscore conflicts no_root description {Put underscore in front of DBUS daemon user} {
-    # For darwin ${os.major} > 8, daemon users have an underscore in front of the usernames and groups.
-    # This variant allows the user to follow that convention.
 }
 
 set cross_opts  "ac_cv_have_abstract_sockets=no"


### PR DESCRIPTION
The plists are now installed to the standard startupitem locations, so
users can use 'port load'.

Also removes the no_root and underscore variants. Both root- and
non-root-owned installations should work correctly without users having to
choose a variant, and the username can be selected consistently based on the
OS version and root privileges.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4
