### PR TITLE
avahi: use base support for multiple startupitems

### DIFF
--- a/net/avahi/Portfile
+++ b/net/avahi/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        lathiat avahi 0.7 v
-revision            1
+revision            2
 categories          net devel
 maintainers         nomaintainer
 license             LGPL-2.1+
@@ -53,12 +53,12 @@ depends_lib         port:expat \
 
 gobject_introspection yes
 
-if {![variant_isset underscore]} {
-    set avahi_user  avahi
-    set avahi_group avahi
-} else {
+if {${os.platform} eq "darwin" && ${os.major} >= 9} {
     set avahi_user  _avahi
     set avahi_group _avahi
+} else {
+    set avahi_user  avahi
+    set avahi_group avahi
 }
 add_users ${avahi_user} group=${avahi_group} realname=Avahi\ Service
 
@@ -89,33 +89,28 @@ configure.args      --disable-autoipd \
 # __APPLE_USE_RFC_2292 should be removed once avhi is updated to support RFC 3542
 configure.cppflags-append   -L${prefix}/lib -D__APPLE_USE_RFC_2292
 
-set launch_daemons {org.freedesktop.avahi-daemon.plist org.freedesktop.avahi-dnsconfd.plist}
+set daemon_uniquename   org.freedesktop.avahi-daemon
+set dnsconfd_uniquename org.freedesktop.avahi-dnsconfd
+
+startupitem.type    launchd
+startupitem.create  no
+startupitems        name        avahi-daemon \
+                    location    LaunchDaemons \
+                    uniquename  ${daemon_uniquename} \
+                    plist       ${daemon_uniquename}.plist \
+                    name        avahi-dnsconfd \
+                    location    LaunchDaemons \
+                    uniquename  ${dnsconfd_uniquename} \
+                    plist       ${dnsconfd_uniquename}.plist
 
 post-destroot {
-    xinstall -d -m 0755 ${destroot}${prefix}/Library/LaunchDaemons
-    foreach fl ${launch_daemons} {
-        file attributes ${destroot}/Library/LaunchDaemons/${fl} -permissions 0644
-        move ${destroot}/Library/LaunchDaemons/${fl} ${destroot}${prefix}/Library/LaunchDaemons
-    }
-
-    # previous command should move all LaunchDaemons
-    foreach fl [glob -nocomplain -tails -directory ${destroot}/Library/LaunchDaemons *] {
-        ui_error "${destroot}/Library/LaunchDaemons should be empty"
-        ui_error "${fl} should not exist in ${destroot}/Library/LaunchDaemons"
-        return -code error "unaccounted for file in LaunchDaemons"
-    }
-
-    if {${startupitem.install}} {
-        foreach fl ${launch_daemons} {
-            ln -s ${prefix}/Library/LaunchDaemons/${fl} ${destroot}/Library/LaunchDaemons/${fl}
-        }
-    }
-}
-
-post-activate {
-    if {${startupitem.install}} {
-        foreach fl ${launch_daemons} {
-            file attributes ${prefix}/Library/LaunchDaemons/${fl} -owner root -group wheel
+    foreach uniquename "${daemon_uniquename} ${dnsconfd_uniquename}" {
+        xinstall -d -m 0755 ${destroot}${prefix}/etc/LaunchDaemons/${uniquename}
+        move ${destroot}/Library/LaunchDaemons/${uniquename}.plist ${destroot}${prefix}/etc/LaunchDaemons/${uniquename}/
+        if {${startupitem.install} && [geteuid] == 0} {
+            ln -s ${prefix}/etc/LaunchDaemons/${uniquename}/${uniquename}.plist ${destroot}/Library/LaunchDaemons/
+        } else {
+            ln -s ${prefix}/etc/LaunchDaemons/${uniquename}/${uniquename}.plist ${destroot}${prefix}/etc/LaunchDaemons
         }
     }
 }
@@ -196,32 +191,4 @@ variant quartz conflicts x11 {
 
 if {![variant_isset quartz]} {
     default_variants-append +x11
-}
-
-variant underscore description {Put underscore in front of Avahi daemon user} {
-    # For darwin ${os.major} > 8, daemon users have an underscore in front of the usernames and groups.
-    # This variant allows the user to follow that convention.
-}
-
-if {${startupitem.install}} {
-    notes "############################################################################
-# Startup items have been generated that will aid in
-# starting ${name} with launchd. They are disabled
-# by default. Execute the following commands to start them,
-# and to cause them to launch at startup:
-#"
-    foreach fl ${launch_daemons} {
-        notes-append "# sudo launchctl load -w /Library/LaunchDaemons/${fl}"
-    }
-    notes-append "############################################################################"
-} else {
-        notes "############################################################################
-# Startup items were not installed for ${name}
-# Some programs which depend on ${name} might not function properly.
-# To load ${name} manually, run
-#"
-    foreach fl ${launch_daemons} {
-        notes-append "# sudo launchctl load -w ${prefix}/Library/LaunchDaemons/${fl}"
-    }
-    notes-append "############################################################################"
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->