### PR TITLE
ocatve: stop modifying OCTAVE_VERSION variable

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -13,7 +13,7 @@ compiler.blacklist-append   {*gcc-4.6} {clang < 700}
 name                octave
 version             4.4.0
 set package_version 4.x.x
-revision            4
+revision            5
 categories          math science
 platforms           darwin
 license             GPL-3+
@@ -86,26 +86,11 @@ post-patch {
         set configure_file configure.ac
     }
     reinplace \
-        "s|__MACPORTS__PACKAGE_VERSION|${package_version}|g" \
-        ${configure_file}
-    reinplace \
         "s|__MACPORTS_canonical_host_type__|${short_host_name}|g" \
         ${configure_file}
-    reinplace \
-        "s|__MACPORTS__PACKAGE_VERSION|${package_version}|g" \
-        src/main.in.cc
     reinplace \
         "s|__MACPORTS_canonical_host_type__|${short_host_name}|g" \
         build-aux/subst-default-vals.in.sh
-    # see https://trac.macports.org/ticket/56624
-    if {${subport} eq ${name}} {
-        set version_file libinterp/version.in.h
-    } else {
-        set version_file liboctave/version.in.h
-    }
-    reinplace \
-        "s|%OCTAVE_VERSION%|\"${version}\"|g" \
-        ${version_file}
 }
 
 pre-configure {
@@ -517,11 +502,11 @@ variant app description "build application bundle to launch ${subport}" {
         if { [variant_isset qt4] || [variant_isset qt5] } {
             puts ${script} "#!/bin/sh"
             puts ${script} ""
-            puts ${script} "${prefix}/bin/octave-${package_version} --gui \"\$@\""
+            puts ${script} "${prefix}/bin/octave-${version} --gui \"\$@\""
         } else {
             puts ${script} "#!/usr/bin/osascript"
             puts ${script} ""
-            puts ${script} "tell application \"Terminal\" to do script \"${prefix}/bin/octave-${package_version} --no-gui-libs; exit\""
+            puts ${script} "tell application \"Terminal\" to do script \"${prefix}/bin/octave-${version} --no-gui-libs; exit\""
         }
         close ${script}
 
@@ -651,7 +636,14 @@ post-destroot {
         # install the libc++ fix, no matter if used or not, since it is
         # required for projects including these headers.
         xinstall -m 644 ${worksrcpath}/liboctave/operators/libcxx-fix.h \
-            ${destroot}${prefix}/include/${name}-${package_version}/${name}/libcxx-fix.h
+            ${destroot}${prefix}/include/${name}-${version}/${name}/libcxx-fix.h
+    }
+
+    # do not force upgrade of every dependency every time the version changes
+    foreach lib {liboctave.5.dylib liboctgui.3.dylib liboctinterp.5.dylib} {
+        xinstall -d -m 0755 ${destroot}${prefix}/lib/octave/${package_version}
+        ln -s ../${version}/${lib} ${destroot}${prefix}/lib/octave/${package_version}/${lib}
+        system "install_name_tool -id ${prefix}/lib/octave/${package_version}/${lib} ${destroot}${prefix}/lib/octave/${version}/${lib}"
     }
 }
 

--- a/math/octave/files/patch-versions-devel.diff
+++ b/math/octave/files/patch-versions-devel.diff
@@ -9,28 +9,8 @@
  DEFAULT_PAGER="@DEFAULT_PAGER@"
  EXEEXT="@EXEEXT@"
  man1ext="@man1ext@"
---- src/main.in.cc.orig 2018-04-30 10:03:56.000000000 -0700
-+++ src/main.in.cc      2018-05-19 10:32:26.000000000 -0700
-@@ -211,7 +211,7 @@
-   std::string octave_bindir = get_octave_bindir ();
-   std::string octave_archlibdir = get_octave_archlibdir ();
-   std::string octave_cli
--    = octave_bindir + dir_sep_char + "octave-cli-" OCTAVE_VERSION;
-+    = octave_bindir + dir_sep_char + "octave-cli-__MACPORTS__PACKAGE_VERSION";
-   std::string octave_gui = octave_archlibdir + dir_sep_char + "octave-gui";
-
- #if defined (HAVE_OCTAVE_QT_GUI)
 --- configure.ac.orig	2018-05-20 10:22:18.000000000 -0700
 +++ configure.ac	2018-05-20 10:24:18.000000000 -0700
-@@ -33,7 +33,7 @@
- OCTAVE_PATCH_VERSION=0
- 
- dnl PACKAGE_VERSION is set by the AC_INIT VERSION argument.
--OCTAVE_VERSION="$PACKAGE_VERSION"
-+OCTAVE_VERSION="__MACPORTS__PACKAGE_VERSION"
- 
- OCTAVE_COPYRIGHT="Copyright (C) 2018 John W. Eaton and others."
- 
 @@ -97,37 +97,37 @@
  ## This path usually includes the Octave version and configuration name, so
  ## that configurations for multiple versions of Octave may be installed at once.

--- a/math/octave/files/patch-versions.diff
+++ b/math/octave/files/patch-versions.diff
@@ -9,28 +9,8 @@
  DEFAULT_PAGER="@DEFAULT_PAGER@"
  EXEEXT="@EXEEXT@"
  man1ext="@man1ext@"
---- src/main.in.cc.orig 2018-04-30 10:03:56.000000000 -0700
-+++ src/main.in.cc      2018-05-19 10:32:26.000000000 -0700
-@@ -211,7 +211,7 @@
-   std::string octave_bindir = get_octave_bindir ();
-   std::string octave_archlibdir = get_octave_archlibdir ();
-   std::string octave_cli
--    = octave_bindir + dir_sep_char + "octave-cli-" OCTAVE_VERSION;
-+    = octave_bindir + dir_sep_char + "octave-cli-__MACPORTS__PACKAGE_VERSION";
-   std::string octave_gui = octave_archlibdir + dir_sep_char + "octave-gui";
-
- #if defined (HAVE_OCTAVE_QT_GUI)
 --- configure.orig	2018-04-30 10:03:56.000000000 -0700
 +++ configure	2018-05-20 10:18:36.000000000 -0700
-@@ -5110,7 +5110,7 @@
- OCTAVE_MINOR_VERSION=4
- OCTAVE_PATCH_VERSION=0
- 
--OCTAVE_VERSION="$PACKAGE_VERSION"
-+OCTAVE_VERSION="__MACPORTS__PACKAGE_VERSION"
- 
- OCTAVE_COPYRIGHT="Copyright (C) 2018 John W. Eaton and others."
- 
 @@ -8051,7 +8051,7 @@
  ## This path usually includes the Octave version and configuration name, so
  ## that configurations for multiple versions of Octave may be installed at once.


### PR DESCRIPTION
Modifying OCTAVE_VERSION caused problems
See https://trac.macports.org/ticket/56624
See https://trac.macports.org/ticket/56659

Fixes https://trac.macports.org/ticket/56659

Instead, attempt to prevent unnecessary revbumps by changing the
identification names of libraries

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->