### PR TITLE
octave-devel: use correct version for HG tag

### DIFF
--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -690,7 +690,7 @@ subport ${name}-devel {
     fetch.type          hg
     hg.url              http://hg.savannah.gnu.org/hgweb/octave/
     hg.tag              2cf750f5cb7d
-    version             4.5.0+
+    version             5.0.0
     #revision            0
 
     conflicts-replace ${name}-devel ${name}


### PR DESCRIPTION
See http://hg.savannah.gnu.org/hgweb/octave/comparison/dfc6ccc2a3e8/configure.ac
See http://lists.gnu.org/archive/html/octave-maintainers/2018-03/msg00214.html

Fixes https://trac.macports.org/ticket/56663

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->