### PR TITLE
update mirror.aarnet.edu.au urls

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -15,7 +15,7 @@ set portfetch::mirror_sites::sites(afterstep) {
 }
 
 set portfetch::mirror_sites::sites(apache) {
-    http://mirror.aarnet.edu.au/pub/apache/
+    https://mirror.aarnet.edu.au/pub/apache/
     http://archive.apache.org/dist/
     http://www.apache.org/dist/
     http://mirror.cc.columbia.edu/pub/software/apache/
@@ -34,7 +34,7 @@ set portfetch::mirror_sites::sites(apache) {
 # Equivalent to "perl_cpan"; neither name takes precedence over the other.
 set portfetch::mirror_sites::sites(cpan) {
     https://cpan.metacpan.org/modules/by-module/
-    http://mirror.aarnet.edu.au/pub/CPAN/modules/by-module/
+    https://mirror.aarnet.edu.au/pub/CPAN/modules/by-module/
     ftp://ftp.auckland.ac.nz/pub/perl/CPAN/modules/by-module/
     http://ftp.carnet.hr/pub/CPAN/modules/by-module/
     http://mirror.cogentco.com/pub/CPAN/modules/by-module/
@@ -59,7 +59,7 @@ set portfetch::mirror_sites::sites(cpan) {
 
 # Equivalent to "tex_ctan"; neither name takes precedence over the other.
 set portfetch::mirror_sites::sites(ctan) {
-    http://mirror.aarnet.edu.au/pub/CTAN/
+    https://mirror.aarnet.edu.au/pub/CTAN/
     http://mirror.cc.columbia.edu/pub/software/ctan/
     ftp://ftp.dante.de/tex-archive/
     ftp://ftp.funet.fi/pub/TeX/CTAN/
@@ -313,7 +313,6 @@ set portfetch::mirror_sites::sites(isc) {
 }
 
 set portfetch::mirror_sites::sites(kde) {
-    http://mirror.aarnet.edu.au/pub/KDE/
     http://mirror.cc.columbia.edu/pub/software/kde/
     http://mirror.facebook.net/kde/
     http://ftp.gtlib.gatech.edu/pub/kde/
@@ -632,7 +631,7 @@ set portfetch::mirror_sites::sites(php) {
 }
 
 set portfetch::mirror_sites::sites(postgresql) {
-    http://mirror.aarnet.edu.au/pub/postgresql/
+    https://mirror.aarnet.edu.au/pub/postgresql/
     https://www.mirrorservice.org/sites/ftp.postgresql.org/
     http://ftp.postgresql.org/pub/
 }
@@ -744,7 +743,7 @@ set portfetch::mirror_sites::sites(xcontrib) {
 }
 
 set portfetch::mirror_sites::sites(xfree) {
-    http://mirror.aarnet.edu.au/pub/xfree86/
+    https://mirror.aarnet.edu.au/pub/xfree86/
     ftp://ftp.esat.net/pub/X11/XFree86/
     http://ftp-stud.fht-esslingen.de/pub/Mirrors/ftp.xfree86.org/XFree86/
     http://www.gtlib.gatech.edu/pub/XFree86/

--- a/databases/mariadb-10.0/Portfile
+++ b/databases/mariadb-10.0/Portfile
@@ -33,7 +33,7 @@ if {$subport eq $name} {
         http://mirrors.supportex.net/mariadb/mariadb-${version}/source/ \
         http://mirrors.fe.up.pt/pub/mariadb/mariadb-${version}/source/ \
         http://gd.tuwien.ac.at/db/mariadb/mariadb-${version}/source/ \
-        http://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
+        https://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
         http://ftp.heanet.ie/mirrors/mariadb/mariadb-${version}/source/ \
         http://mirror.switch.ch/mirror/mariadb/mariadb-${version}/source/
 

--- a/databases/mariadb-10.1/Portfile
+++ b/databases/mariadb-10.1/Portfile
@@ -33,7 +33,7 @@ if {$subport eq $name} {
         http://mirrors.supportex.net/mariadb/mariadb-${version}/source/ \
         http://mirrors.fe.up.pt/pub/mariadb/mariadb-${version}/source/ \
         http://gd.tuwien.ac.at/db/mariadb/mariadb-${version}/source/ \
-        http://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
+        https://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
         http://ftp.heanet.ie/mirrors/mariadb/mariadb-${version}/source/ \
         http://mirror.switch.ch/mirror/mariadb/mariadb-${version}/source/
 

--- a/databases/mariadb-10.2/Portfile
+++ b/databases/mariadb-10.2/Portfile
@@ -33,7 +33,7 @@ if {$subport eq $name} {
         http://mirrors.supportex.net/mariadb/mariadb-${version}/source/ \
         http://mirrors.fe.up.pt/pub/mariadb/mariadb-${version}/source/ \
         http://gd.tuwien.ac.at/db/mariadb/mariadb-${version}/source/ \
-        http://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
+        https://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
         http://ftp.heanet.ie/mirrors/mariadb/mariadb-${version}/source/ \
         http://mirror.switch.ch/mirror/mariadb/mariadb-${version}/source/
 

--- a/databases/mariadb/Portfile
+++ b/databases/mariadb/Portfile
@@ -33,7 +33,7 @@ if {$subport eq $name} {
         http://mirrors.supportex.net/mariadb/mariadb-${version}/source/ \
         http://mirrors.fe.up.pt/pub/mariadb/mariadb-${version}/source/ \
         http://gd.tuwien.ac.at/db/mariadb/mariadb-${version}/source/ \
-        http://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
+        https://mirror.aarnet.edu.au/pub/MariaDB/mariadb-${version}/source/ \
         http://ftp.heanet.ie/mirrors/mariadb/mariadb-${version}/source/
 
 # Mirrors with bad distfiles

--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -20,7 +20,7 @@ homepage            http://www.sourceware.org/libffi
 
 master_sites        https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/ \
                     http://ftp-stud.fht-esslingen.de/pub/Mirrors/sourceware.org/libffi/ \
-                    http://mirror.aarnet.edu.au/pub/sourceware/libffi/ \
+                    https://mirror.aarnet.edu.au/pub/sourceware/libffi/ \
                     http://ftp.cs.pu.edu.tw/Linux/sourceware/libffi/ \
                     ftp://sourceware.org/pub/libffi/
 checksums           rmd160  9b546a3d002380bec3f00d86fc47d730abf51dfd \

--- a/net/squid/Portfile
+++ b/net/squid/Portfile
@@ -21,7 +21,7 @@ long_description    Squid is a high-performance proxy caching server for \
                 implements negative caching of failed requests.
 
 homepage        http://www.squid-cache.org/
-master_sites    http://mirror.aarnet.edu.au/pub/squid/squid/ \
+master_sites    https://mirror.aarnet.edu.au/pub/squid/squid/ \
                 https://www.mirrorservice.org/sites/ftp.squid-cache.org/pub/squid/ \
                 http://ftp.ring.gr.jp/archives/net/www/squid/ \
                 ftp://ftp.is.co.za/pub/squid/ \

--- a/net/squid3/Portfile
+++ b/net/squid3/Portfile
@@ -20,7 +20,7 @@ long_description    Squid is a high-performance proxy caching server for \
                 implements negative caching of failed requests.
 
 homepage        http://www.squid-cache.org/
-master_sites    http://mirror.aarnet.edu.au/pub/squid/squid/ \
+master_sites    https://mirror.aarnet.edu.au/pub/squid/squid/ \
                 https://www.mirrorservice.org/sites/ftp.squid-cache.org/pub/squid/ \
                 http://ftp.ring.gr.jp/archives/net/www/squid/ \
                 ftp://ftp.is.co.za/pub/squid/ \


### PR DESCRIPTION
- remove defunct link (no longer mirrors KDE)
- use https for working links

Note: the link for mariadb (5.5.x) doesn't work for the version currently in the port (5.5.57), but will work if the version is updated (to e.g. 5.5.58 or later).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4 9F1027a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
