### PR TITLE
p5-image-exiftool: remove -p5* suffix from binary

### DIFF
--- a/perl/p5-image-exiftool/Portfile
+++ b/perl/p5-image-exiftool/Portfile
@@ -1,10 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           perl5 1.0
 
-perl5.branches      5.26
-perl5.setup         Image-ExifTool 11.03
+name                p5-image-exiftool
+version             11.03
+
+if {$subport ne "exiftool"} {
+    PortGroup           perl5 1.0
+    perl5.branches      5.26
+    perl5.setup         Image-ExifTool ${version}
+}
+
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 platforms           darwin
@@ -22,4 +28,18 @@ master_sites        sourceforge:project/exiftool/
 
 livecheck.type      regex
 livecheck.url       ${homepage}
-livecheck.regex     ${perl5.module}-(\[0-9.\]+)${extract.suffix}
+if {$subport ne "exiftool"} {
+    livecheck.regex     ${perl5.module}-(\[0-9.\]+)${extract.suffix}
+}
+
+subport exiftool {
+    distfiles
+    use_configure   no
+    depends_run     port:p5.26-image-exiftool
+    build {}
+
+    destroot {
+        xinstall -d ${destroot}${prefix}/bin
+        ln -s ${prefix}/bin/exiftool-5.26 ${destroot}${prefix}/bin/exiftool
+    }
+}


### PR DESCRIPTION
#### Description

This port creates a binary with a `-p5*` suffix, which makes it awkward to use. This PR removes the suffix.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
