### PR TITLE
py-lxml: patch out -isysroot addition

### DIFF
--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -31,6 +31,9 @@ checksums           rmd160  9dd038937c8579c0bfa6bf95b845e4945f31c5d0 \
                     sha256  e2629cdbcad82b83922a3488937632a4983ecc0fed3e5cfbf430d069382eeb9b \
                     size    4284267
 
+# https://trac.macports.org/ticket/56666
+patchfiles-append   patch-setupinfo-remove-xcrun-call.diff
+
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools

--- a/python/py-lxml/files/patch-setupinfo-remove-xcrun-call.diff
+++ b/python/py-lxml/files/patch-setupinfo-remove-xcrun-call.diff
@@ -1,0 +1,11 @@
+--- setupinfo.py.orig	2018-06-14 13:42:56.000000000 -0700
++++ setupinfo.py	2018-06-14 13:45:12.000000000 -0700
+@@ -124,7 +124,7 @@
+         ])
+     _library_dirs = _prefer_reldirs(base_dir, library_dirs(static_library_dirs))
+     _cflags = cflags(static_cflags)
+-    _ldflags = ['-isysroot', get_xcode_isysroot()] if sys.platform == 'darwin' else None
++    _ldflags =  None
+     _define_macros = define_macros()
+     _libraries = libraries()
+ 


### PR DESCRIPTION
1. calls xcrun, which is 10.8+ only
2. we want to pass in -isysroot if needed

closes: https://trac.macports.org/ticket/56666
