### PR TITLE
wxMaxima: new port (18.02.0 and development)

### DIFF
--- a/math/wxMaxima/Portfile
+++ b/math/wxMaxima/Portfile
@@ -1,59 +1,110 @@
-PortSystem      1.0
-PortGroup       active_variants 1.1
-PortGroup       wxWidgets 1.0
+PortSystem          1.0
 
-name            wxMaxima
-version         15.04.0
-revision        0
-maintainers     nomaintainer
-license         gpl
-platforms       darwin
-categories      math aqua
-description     Graphical user interface for Maxima
-long_description \
-                wxMaxima is a cross platform GUI for the computer algebra \
-                system maxima based on wxWidgets.
-homepage        http://wxmaxima.sourceforge.net/
-master_sites    sourceforge:project/[string tolower ${name}]/${name}/${version}
-livecheck.regex (?:[string tolower ${name}]|${name})-(\[a-z0-9.\]+)${extract.suffix}
-checksums       rmd160  04295f10ccd074d7069d00b1a0fe41884817687c \
-                sha256  0005029798703470333309fda29c731e79c85de1c7fc09b16cb87045a03aa4ba
+PortGroup           active_variants 1.1
+PortGroup           wxWidgets 1.0
+PortGroup           github 1.0
 
-# Upstream changed the distname's spelling some time after 13.x.
-distname        wxmaxima-${version}
+name                wxMaxima
+version             18.02.0
+maintainers         nomaintainer
+license             GPL-2
+# openssl is a dependency of curl in cmake
+license_noconflict  openssl
+platforms           darwin
+categories          math aqua
+description         Graphical user interface for Maxima based on wxWidgets
+homepage            http://andrejv.github.io/wxmaxima/
 
-wxWidgets.use   wxWidgets-3.0
+subport wxMaxima-devel {
+    conflicts       wxMaxima
+    long_description ${description}: \
+                    Provides the development version, which is typically updated every day.
 
-patchfiles      patch-src_main.cpp.diff \
-                patch-src_Dirstructure.h.diff \
-                patch-src_wxMaxima.cpp.diff
+    # git describe --tags : Version-16.12.x-1834-gb32fed0
+    github.setup    andrejv wxmaxima b32fed0d535c05d589d1f573d2c0f4f839180d18
+    checksums       rmd160  86fcf85ddae42e84884a708d55acff393152ed23 \
+                    sha256  e34256294c51a37d80947b92d3cd979456bf0c8ae53a21ce6cbab63d99143bf2 \
+                    size    12739940
+    version         18.02-dev-20180616
 
-depends_lib     port:libiconv \
-                port:libsdl \
-                port:libxml2 \
-                port:${wxWidgets.port} \
-                port:zlib
-depends_run     port:maxima
+    patchfiles      patch-devel-src_Dirstructure.cpp.diff
+    post-patch {
+        reinplace -W ${worksrcpath} "s|@@PREFIX@@|${prefix}|g" \
+                                    src/Dirstructure.cpp
+    }
 
-require_active_variants gnuplot wxwidgets
-
-post-patch {
-    reinplace "s|@@PREFIX@@|${prefix}|" ${worksrcpath}/src/main.cpp
+    livecheck.type  none
 }
 
-depends_skip_archcheck  maxima
-configure.args  --enable-printing --with-wxdir=${wxWidgets.wxdir}
-build.target-append wxMaxima.app
+if {${subport} eq ${name}} {
+    conflicts       wxMaxima-devel
+    long_description ${description}: \
+                    Provides the release version, which is typically updated every four months.
+
+    # get the source tarball from github.
+    github.setup    andrejv wxmaxima 18.02.0 Version-
+    checksums       rmd160  d1017d56bfd76e9c51dcc3230be89ebca1724560 \
+                    sha256  77f0414be54d8ea15acedfc3cedf72a57cc2b3ba5d4835a53f3009e050c05483 \
+                    size    10131293
+
+    patchfiles      patch-src_Dirstructure.cpp.diff
+    post-patch {
+        reinplace -W ${worksrcpath} "s|@@PREFIX@@|${prefix}|g" \
+                                    src/Dirstructure.cpp
+    }
+    
+    livecheck.regex Version-(\[a-z0-9.\]+)${extract.suffix}
+}
+
+universal_variant   no
+
+variant wx32 description {Use wxWidgets 3.2 - experimental!} {}
+
+if {[variant_exists wx32] && [variant_isset wx32]} {
+    # we want to use the wxWidgets-3.2
+    wxWidgets.use   wxWidgets-3.2
+} else {
+    wxWidgets.use   wxWidgets-3.0
+}
+
+depends_lib         port:${wxWidgets.port}
+
+depends_build       port:cmake
+
+depends_run         bin:maxima:maxima
+
+patch.pre_args      -Np0
+
+use_configure       no
+
+build {
+    system -W ${worksrcpath}       "mkdir ./build"
+    system -W ${worksrcpath}/build "cmake -DwxWidgets_CONFIG_EXECUTABLE:FILEPATH=${wxWidgets.wxconfig} .."
+    system -W ${worksrcpath}/build "cmake --build ."
+}
 
 destroot {
     xinstall -m 755 -d ${destroot}${applications_dir}
-    file copy ${worksrcpath}/wxMaxima.app ${destroot}${applications_dir}
-
-    set docPath ${prefix}/share/doc/${name}
-    xinstall -m 755 -d ${destroot}${docPath}
-    foreach f { AUTHORS COPYING README } {
-        xinstall -m 644 ${worksrcpath}/${f} ${destroot}${docPath}
-    }
+    file copy ${worksrcpath}/build/wxMaxima.app ${destroot}${applications_dir}
 }
 
-
+notes "
+    Be careful: \n\
+    If you want to use wxMaxima with default setting, \n\
+    you should enter the command \n\
+    \"open -a ${applications_dir}/wxMaxima.app\" \n\
+    on Terminal.app in order to launch wxMaxima. \n\
+    Because you must let wxMaxima know the path to software \n\
+    installed with MacPorts. \n\n\
+    On the other hand, \n\
+    when you launch directly wxMaxima on the Finder, \n\
+    the path to maxima (e.g. \"${prefix}/bin/maxima\") is automatically set \n\
+    on the configuration dialog. \n\
+    But you should enter the maxima expression \n\
+    gnuplot_command:\"${prefix}/bin/gnuplot\"\$ \n\
+    in order to use gnuplot. \n\n\
+    Some configuration files are automatically created by wxMaxima. \n\
+    You can enter the command \n\
+    \"find \$HOME/Library -name '*wxMaxima*'\" \n\
+    on Terminal.app in order to find them.
+"

--- a/math/wxMaxima/files/patch-devel-src_Dirstructure.cpp.diff
+++ b/math/wxMaxima/files/patch-devel-src_Dirstructure.cpp.diff
@@ -1,0 +1,15 @@
+--- src/Dirstructure.cpp.orig	2018-06-01 18:24:00.000000000 +0900
++++ src/Dirstructure.cpp	2018-06-03 23:04:26.000000000 +0900
+@@ -296,10 +296,8 @@
+     command = wxT("/Applications/Maxima.app");
+   if (wxFileExists("/Applications/maxima.app"))
+     command = wxT("/Applications/maxima.app");
+-  else if (wxFileExists("/usr/local/bin/maxima"))
+-    command = wxT("/usr/local/bin/maxima");
+-  else if (wxFileExists("/usr/bin/maxima"))
+-    command = wxT("/usr/bin/maxima");
++  else if (wxFileExists("@@PREFIX@@/bin/maxima"))
++    command = wxT("@@PREFIX@@/bin/maxima");
+   else
+     command = wxT("maxima");
+   return command;

--- a/math/wxMaxima/files/patch-src_Dirstructure.cpp.diff
+++ b/math/wxMaxima/files/patch-src_Dirstructure.cpp.diff
@@ -1,0 +1,37 @@
+--- src/Dirstructure.cpp.orig	2018-02-17 23:54:32.000000000 +0900
++++ src/Dirstructure.cpp	2018-05-31 23:28:55.000000000 +0900
+@@ -249,7 +249,20 @@
+   else
+   {
+     wxFileName maximaName(result);
+-    maximaName.RemoveLastDir();
++    if(maximaName.GetDirCount() > 1)
++    {
++      maximaName.RemoveLastDir();
++    }
++    else
++    {
++      wxArrayString output;
++      wxExecute(wxT("which maxima"), output, (wxEXEC_SYNC | wxEXEC_NOEVENTS));
++      if(output.GetCount() > 0)
++      {
++        wxFileName fullpath(output[0] ,wxPATH_NATIVE);
++        return fullpath.GetPath();
++      }
++    }
+     return maximaName.GetPath();
+   }
+ }
+@@ -279,10 +292,8 @@
+     command = wxT("/Applications/Maxima.app");
+   if (wxFileExists("/Applications/maxima.app"))
+     command = wxT("/Applications/maxima.app");
+-  else if (wxFileExists("/usr/local/bin/maxima"))
+-    command = wxT("/usr/local/bin/maxima");
+-  else if (wxFileExists("/usr/bin/maxima"))
+-    command = wxT("/usr/bin/maxima");
++  else if (wxFileExists("@@PREFIX@@/bin/maxima"))
++    command = wxT("@@PREFIX@@/bin/maxima");
+   else
+     command = wxT("maxima");
+   return command;


### PR DESCRIPTION
* Update wxMaxima from version 15.04.0 to 18.02.0.
* Change the value of homepage to 'http://andrejv.github.io/wxmaxima/'.
* Use 'cmake' instead of 'autoconf' because current version of wxMaxima
  does not support 'autoconf' any more.
* Add patch to avoid an error when launching.
* Add 'wx32' variant to be able to choose wxWidgets-3.1 instead of 3.0.
* Add 'devel' variant to be able to get a git version of wxMaxima.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G21013
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
