### PR TITLE
scheme48: avoid conflict with libevent

### DIFF
--- a/lang/scheme48/Portfile
+++ b/lang/scheme48/Portfile
@@ -23,10 +23,6 @@ checksums           rmd160  81f7f253f4fb9ff7771c44b28f437ebb77756669 \
                     sha256  9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4 \
                     size    3951356
 
-variant universal   {}
-
-#patchfiles patch-Makefile.in.diff
-
 configure.args      --mandir=${prefix}/share/man --enable-gc=bibop
 
 build.target        enough

--- a/lang/scheme48/Portfile
+++ b/lang/scheme48/Portfile
@@ -20,7 +20,8 @@ master_sites        ${homepage}/${version}/
 extract.suffix      .tgz
 
 checksums           rmd160  81f7f253f4fb9ff7771c44b28f437ebb77756669 \
-                    sha256  9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4
+                    sha256  9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4 \
+                    size    3951356
 
 variant universal   {}
 

--- a/lang/scheme48/Portfile
+++ b/lang/scheme48/Portfile
@@ -23,6 +23,10 @@ checksums           rmd160  81f7f253f4fb9ff7771c44b28f437ebb77756669 \
                     sha256  9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4 \
                     size    3951356
 
+# event.h should be included from ${worksrcdir}
+# event.h can be installed by libevent
+configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
+
 configure.args      --mandir=${prefix}/share/man --enable-gc=bibop
 
 build.target        enough


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->