### PR TITLE
p5-tcl-ptk: new port, version 0.92

### DIFF
--- a/perl/p5-tcl-ptk/Portfile
+++ b/perl/p5-tcl-ptk/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26
+perl5.setup         Tcl-pTk 0.92
+
+platforms           darwin
+maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
+license             {Artistic-1 GPL}
+
+supported_archs     noarch
+
+description         Tcl::pTk - Interface to Tcl/Tk with Perl/Tk compatible sytax
+
+long_description    Tcl::pTk interfaces perl to an existing Tcl/Tk \
+                    installation on your computer. It has fully perl/tk \
+                    compatible syntax for running existing perl/tk scripts, \
+                    as well as direct-tcl syntax for using any other Tcl/Tk \
+                    features. \
+                    \n\nUsing this module an interpreter object is created, \
+                    which then provides access to all the installed Tcl \
+                    libraries (Tk, Tix, BWidgets, BLT, etc) and existing \
+                    features (for example native-looking widgets using the \
+                    Tile package).\n
+
+checksums           rmd160  3155582f86ed22285f36531dde56a16c2406e8e1 \
+                    sha256  2fcb68e8b0dd7a7b1871b192eee2281842ded4555cb407e276ace14462f17583 \
+                    size    528082
+
+if {${perl5.major} != ""} {
+    # Only used for a test removed by patch;
+    # doesn't get stored in configuration
+    #configure.args-append \
+    #                --tclsh ${prefix}/bin/tclsh
+
+    depends_lib-append \
+                    port:tk \
+                    port:tix \
+                    port:p${perl5.major}-tcl \
+                    port:p${perl5.major}-class-isa \
+                    port:p${perl5.major}-sub-name
+    # Cf.
+    # https://rt.cpan.org/Ticket/Display.html?id=125048
+    # https://rt.cpan.org/Ticket/Display.html?id=125050
+    # https://rt.cpan.org/Ticket/Display.html?id=125460
+    # This distribution contains a mix of LF and CRLF,
+    # so these patches also contain CRLF
+    patchfiles-append \
+                    patch-Widget.pm.diff \
+                    patch-Text.pm.diff
+    # Two seaparate fixes:
+    # - https://rt.cpan.org/Ticket/Display.html?id=116432
+    # - Bypass the test-for-tk since it doesn't work
+    #   (Perl never gets any output from tclsh for some reason)
+    patchfiles-append \
+                    patch-Makefile.PL.diff \
+}

--- a/perl/p5-tcl-ptk/files/patch-Makefile.PL.diff
+++ b/perl/p5-tcl-ptk/files/patch-Makefile.PL.diff
@@ -1,0 +1,74 @@
+--- /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92/Makefile.PL	2015-07-04 10:34:13.000000000 -0500
++++ Makefile.PL	2018-06-16 15:19:40.000000000 -0500
+@@ -32,6 +32,7 @@
+     PREREQ_PM => {
+ 	Tcl => 0.90,
+ 	'Class::ISA' => 0.36,
++	'Sub::Name' => 0.05,
+     }
+ );
+ 
+@@ -46,63 +47,6 @@
+ );
+ 
+ 
+-# Allow the tclsh prog to be provided by env var or arg
+-if ($tclshArg) {
+-    $tclsh = $tclshArg;
+-} elsif (defined($ENV{'TCLSH_PROG'})) {
+-    $tclsh = $ENV{'TCLSH_PROG'};
+-}
+-
+-open TCLSH, "$tclsh test-for-tk.tcl|";
+-my $res = join '', <TCLSH>;
+-
+-unless ($res =~ /^ok1/m) {
+-  die <<EOS;
+-
+-#####################  Error   ####################################
+-Your Tcl installation ($tclsh) doesn't appear to include the Tk package.
+-One of possible reasons is missing file 'pkgIndex.tcl' in ..../tk8.4/
+-directory; Please check if you can feed 'package require Tk' to tclsh
+-EOS
+-}
+-
+-unless ($res =~ /^ok_Tix/m) {
+-  warn <<EOS;
+-
+-##################### Warning ####################################
+-Your Tcl/Tk installation does not appear to include the Tix package.
+-Tix is needed for full compatibility with perl/tk.
+-Build can continue, but some functionality will be missing.
+-
+-Information on Tix can be found at http://tix.sourceforge.net
+-EOS
+-}
+-
+-my ($TclVersion) = ($res =~ /TclVersion\s+(\S+)/ );
+-
+-if( $TclVersion < 8.4 ){
+-  die <<EOS;
+-
+-##################### Error ####################################
+-Your Tcl/Tk installation version is less than 8.4. This is not
+-supported. Upgrade your Tcl/Tk installation.
+-Tcl/Tk information can be found at http://www.tcl.tk/
+-EOS
+-
+-}
+-
+-if( $TclVersion < 8.5 ){
+-  warn <<EOS;
+-
+-##################### Warning ####################################
+-You have an older Tcl/Tk installation (Version 8.4).
+-Version 8.5 or higher is recommended for full functionality (including
+-the new Tile Widget support).
+-Build can continue, but some functionality will be missing.
+-Tcl/Tk information can be found at http://www.tcl.tk/
+-EOS
+-
+-}
+ 
+ 
+ 

--- a/perl/p5-tcl-ptk/files/patch-Text.pm.diff
+++ b/perl/p5-tcl-ptk/files/patch-Text.pm.diff
@@ -1,0 +1,25 @@
+--- /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92/lib/Tcl/pTk/Text.pm	2016-08-21 07:34:35.000000000 -0500
++++ lib/Tcl/pTk/Text.pm	2018-06-10 00:00:26.000000000 -0500
+@@ -3,6 +3,8 @@
+ 
+ package Tcl::pTk::Text;
+ 
++use Text::Tabs;
++
+ our ($VERSION) = ('0.92');
+ 
+ # borrowed from Tk/Text.pm without any modifications
+@@ -26,7 +28,12 @@
+ {
+  my ($class,$mw) = @_;
+  $class->SUPER::ClassInit($mw, 'Text'); # Call with optional 'Text' Tag
+- $mw->bind($class, '<3>', ['PostPopupMenu', Tcl::pTk::Ev('X'), Tcl::pTk::Ev('Y')]  ); # right-click menu
++ # right-click menu
++ $mw->bind(
++   $class,
++   $mw->windowingsystem eq 'aqua' ? '<2>' : '<3>',
++   ['PostPopupMenu', Tcl::pTk::Ev('X'), Tcl::pTk::Ev('Y')],
++  );
+  
+  # We use the 'Text' tag for the bindings below, because we are adding to the tcl text-widget
+  #  bindings, which are under the 'Text' bindtag.

--- a/perl/p5-tcl-ptk/files/patch-Widget.pm.diff
+++ b/perl/p5-tcl-ptk/files/patch-Widget.pm.diff
@@ -1,0 +1,16 @@
+--- /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92/lib/Tcl/pTk/Widget.pm	2016-08-21 07:34:35.000000000 -0500
++++ lib/Tcl/pTk/Widget.pm	2018-06-14 19:10:26.000000000 -0500
+@@ -2417,9 +2417,11 @@
+  # events on other platforms.
+ 
+  $mw->bind($class, '<MouseWheel>',
+-	       [ sub { $_[0]->yview('scroll',-int(($_[1]/120)),'units') }, Tcl::pTk::Ev("D")]);
++    $mw->windowingsystem eq 'aqua'
++	    ?  [ sub { $_[0]->yview('scroll',-($_[1]),'units') }, Tcl::pTk::Ev("D")]
++	    :  [ sub { $_[0]->yview('scroll',-int(($_[1]/120)),'units') }, Tcl::pTk::Ev("D")]);
+ 
+- if ($Tcl::pTk::platform eq 'unix')
++ if ($mw->windowingsystem eq 'x11')
+   {
+    # Support for mousewheels on Linux/Unix commonly comes through mapping
+    # the wheel to the extended buttons.  If you have a mousewheel, find


### PR DESCRIPTION
I've included patches for issues reported upstream but not yet included in the distribution. Several weeks ago the developer offered to add me as a co-maintainer to help get a new version of Tcl::pTk published with any fixes, but I'm still waiting to hear back.

Part of the patch to Makefile.PL is to remove its test for making sure Tcl can find Tk and Tix. This test fails, at least in trace mode (raimue suggested this might be due to sandboxing). So for now I've removed that test since its results don't affect the configuration, and MacPorts should already have installed Tk and Tix.
 
This port is (or was?) affected by the same issue I had reported for p5-tkx, where the system Tcl/Tk might get used instead of the one installed by MacPorts: https://trac.macports.org/ticket/56638. I've since resolved the issue somehow, but need to retrace my steps more carefully to determine whether it was strictly an issue with my installation.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

 I only tried tests using the `tk +quartz` variant; I still haven't figured out how to run tests for the `+x11` variant (probably involves letting MacPorts know about the `$DISPLAY` variable and .Xauthority file).

A lot of these don't pass, but I think it's less likely to be MacPorts' fault. For example the issue with `t/bgerror2.t` and `t/tkHijack_bgerror2.t` has already been reported here: https://rt.cpan.org/Public/Bug/Display.html?id=119754

<details><summary>Full test results:</summary>
<pre>
--->  Testing p5.26-tcl-ptk
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/after.t ..................... ok
t/afterDestroy.t .............. ok
t/afterIdle.t ................. ok
t/balloon.t ................... ok
Balloon should appear over 'Balloon Text' button
t/balloon2.t .................. ok
t/bgerror1.t .................. ok
# Failed test 1 in t/bgerror2.t at line 139
#  t/bgerror2.t line 139 is: ok( $errMessages =~ /Undefined subroutine\s+\&main\:\:bogus/);
# Failed test 2 in t/bgerror2.t at line 140
#  t/bgerror2.t line 140 is: ok( $errMessages =~ /command executed by scale/);
# Failed test 3 in t/bgerror2.t at line 141
#  t/bgerror2.t line 141 is: ok( $errMessages =~ /Error Started at t\/bgerror2.t line 123/);
# Failed test 4 in t/bgerror2.t at line 142
#  t/bgerror2.t line 142 is: ok( $errMessages =~ / Undefined subroutine \&main::bogus called at t\/bgerror2.t line 112/);
t/bgerror2.t ..................
Failed 4/4 subtests
Error Dialog Should Show. This is expected
t/bgerror3.t .................. ok
t/bind.t ...................... ok
t/bindBreak.t ................. ok
t/bitmapSubClass.t ............ ok
t/browseEntry.t ............... ok
t/browseEntry2.t .............. ok
t/busy.t ...................... ok
t/callback.t .................. ok
t/callbackSet.t ............... ok
t/canFind.t ................... ok
t/canIndex.t .................. ok
t/canScale.t .................. ok
t/checkradio.t ................ ok
t/cleanupCrashTest.t .......... ok
t/command.t ................... ok
t/configureReturn.t ........... ok
t/dialog.t .................... ok
t/dialogBox.t ................. ok
t/dirtree.t ................... ok
t/dndlocal.t .................. ok
t/emptyMenuButtonSubclass.t ... ok
t/emptyMenuSubclass.t ......... ok
t/emptySubclass.t ............. ok
t/entry.t ..................... ok
t/entryPaste.t ................ ok
t/entryValidate.t ............. ok
# Test 1 got: <UNDEF> (t/fileevent.t at line 42)
#   Expected: "Sleep 5" (fileevent)
#  t/fileevent.t line 42 is: ok($lineFromFile, 'Sleep 5', "fileevent");
# Test 2 got: "0" (t/fileevent.t at line 45)
#   Expected: "1" (Fileevent Pipe Closed Test)
#  t/fileevent.t line 45 is: skip(
t/fileevent.t .................
Failed 2/2 subtests
# Test 1 got: <UNDEF> (t/fileevent2.t at line 37)
#   Expected: "Sleep 5" (fileevent)
#  t/fileevent2.t line 37 is: ok($lineFromFile, 'Sleep 5', "fileevent");
t/fileevent2.t ................
Failed 1/1 subtests
# Test 11 got: "12" (t/font.t at line 102 fail #2)
#    Expected: "-12" (Value of -size)
#  t/font.t line 102 is:   skip($skip_times, lc $val, lc $expected,"Value of $key");
t/font.t ......................
Failed 1/13 subtests
t/font2.t ..................... ok
t/fontAttr.t .................. ok
t/frameForeground.t ........... ok
(TixForm) Error:Trying to use more than one geometry
          manager for the same master window.
          Giving up after 50 iterations.
t/geomgr.t .................... ok
t/hlist.t .....................
Failed 1/5 subtests
t/iconimage.t ................. ok
t/imageLoad.t ................. ok
t/itemStyle.t .................
Failed 1/1 subtests
t/labEntry.t .................. ok
t/labEntryFacelift.t .......... ok
t/labEntryParentChild.t ....... ok
t/libLoad.t ...................
Failed 1/1 subtests
t/listbox.t ................... ok
t/mainloopMult.t .............. ok
t/menub-cascade.t ............. ok
t/menub_newMenu.t ............. ok
t/menubarpath.t ............... ok
t/menuitems.t ................. ok
t/messageBox.t ................ ok
t/moveResizeWindow.t .......... ok
t/moveToplevelWindow.t ........ ok
t/multMainWindow1.t ........... ok
t/multMainWindow2.t ........... ok
t/notebook.t ..................
Failed 2/2 subtests
t/onDestroy.t ................. ok
t/optmenu.t ................... ok
t/palette.t ................... ok
t/pane.t ...................... ok
t/photo.t ..................... skipped: no Img extension available (can't find package Img at /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92/blib/lib/Tcl/pTk.pm line 1168.
t/photoGetImage.t ............. skipped: no Img extension available (can't find package Img at /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92/blib/lib/Tcl/pTk.pm line 1168.
t/photoSubClass.t ............. ok
t/progBar.t ................... ok
t/protocol.t .................. ok
t/ptk-compat.t ................ ok
# Test 1 got: "1" (t/ptk-compat2.t at line 38)
#   Expected: "2" (Number of entries in the popup)
#  t/ptk-compat2.t line 38 is: ok($noEntries, 2, "Number of entries in the popup");
t/ptk-compat2.t ...............
Failed 1/4 subtests
t/repeat.t .................... ok
t/repeatSubReuse.t ............ ok
t/scrolled.t .................. ok
t/scrolledOptional.t .......... ok
t/selection.t ................. ok
t/slideMegaWidget.t ........... ok
t/slideMegaWidget2.t .......... ok
t/spreadsheetHideRows.t ....... ok
t/table.t ..................... ok
t/tableFacelift.t ............. ok
t/tableMatrixCallbacks.t ...... ok
t/tableMatrixCleanup.t ........ ok
t/tableMatrixDebug.t .......... ok
t/tableMatrixSpreadsheet.t .... ok
t/tclVersion.t ................ ok
t/text.t ...................... ok
t/text2.t ..................... ok
t/text3.t ..................... ok
t/textEdit.t .................. ok
# Test 4 got: "" (t/textRO.t at line 111)
#   Expected: "Tcl::pTk::Callback" (Inherited <3> binding from the text widget)
#  t/textRO.t line 111 is: ok(ref($binding), 'Tcl::pTk::Callback', "Inherited <3> binding from the text widget");
t/textRO.t ....................
Failed 1/4 subtests
t/textSubwidget.t ............. ok
t/textUndo.t .................. ok
t/tileLabelFont.t ............. ok
t/tileTree.t .................. ok
t/tileWidget.t ................ ok
t/tixTree.t ...................
Failed 1/1 subtests
t/tk-mw.t ..................... ok
t/tkFacelift_BEsubclass.t ..... ok
t/tkFacelift_browseEntry.t .... ok
t/tkFacelift_frameSubclass.t .. ok
t/tkFacelift_mega1.t .......... ok
t/tkFacelift_simple.t .........
Failed 1/1 subtests
t/tkHijack_BEsubclass.t ....... ok
t/tkHijack_bgerror1.t ......... ok
# Failed test 1 in t/tkHijack_bgerror2.t at line 140
#  t/tkHijack_bgerror2.t line 140 is: ok( $errMessages =~ /Undefined subroutine\s+\&main\:\:bogus/);
# Failed test 2 in t/tkHijack_bgerror2.t at line 141
#  t/tkHijack_bgerror2.t line 141 is: ok( $errMessages =~ /command executed by scale/);
# Failed test 3 in t/tkHijack_bgerror2.t at line 142
#  t/tkHijack_bgerror2.t line 142 is: ok( $errMessages =~ /Error Started at t\/tkHijack_bgerror2.t line 124/);
# Failed test 4 in t/tkHijack_bgerror2.t at line 143
#  t/tkHijack_bgerror2.t line 143 is: ok( $errMessages =~ / Undefined subroutine \&main::bogus called at t\/tkHijack_bgerror2.t line 113/);
t/tkHijack_bgerror2.t .........
Failed 4/4 subtests
t/tkHijack_bgerror3.t ......... ok
t/tkHijack_mega1.t ............ ok
t/tkHijack_simple.t ...........
Failed 1/1 subtests
t/tkHijack_spreadsheet.t ...... ok
t/trace.t ..................... ok
t/tree.t ...................... ok
t/ttkBrowseEntry.t ............ ok
t/ttkEntryValidate.t .......... ok
t/unicode.t ................... ok
t/virtualEv.t ................. ok
t/widgetDelete.t .............. ok
t/widgetName.t ................ ok
t/wmForget.t .................. ok
t/xevent.t .................... ok
t/zzPhoto.t ................... skipped: no Img extension available
&nbsp;
Test Summary Report
-------------------
t/bgerror2.t                (Wstat: 0 Tests: 4 Failed: 4)
  Failed tests:  1-4
t/fileevent.t               (Wstat: 0 Tests: 2 Failed: 2)
  Failed tests:  1-2
t/fileevent2.t              (Wstat: 0 Tests: 1 Failed: 1)
  Failed test:  1
t/font.t                    (Wstat: 0 Tests: 13 Failed: 1)
  Failed test:  11
t/hlist.t                   (Wstat: 11 Tests: 4 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 5 tests but ran 4.
t/itemStyle.t               (Wstat: 11 Tests: 0 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 1 tests but ran 0.
t/libLoad.t                 (Wstat: 11 Tests: 0 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 1 tests but ran 0.
t/notebook.t                (Wstat: 11 Tests: 0 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 2 tests but ran 0.
t/ptk-compat2.t             (Wstat: 0 Tests: 4 Failed: 1)
  Failed test:  1
t/textRO.t                  (Wstat: 0 Tests: 4 Failed: 1)
  Failed test:  4
t/tixTree.t                 (Wstat: 11 Tests: 0 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 1 tests but ran 0.
t/tkFacelift_simple.t       (Wstat: 11 Tests: 0 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 1 tests but ran 0.
t/tkHijack_bgerror2.t       (Wstat: 0 Tests: 4 Failed: 4)
  Failed tests:  1-4
t/tkHijack_simple.t         (Wstat: 11 Tests: 0 Failed: 0)
  Non-zero wait status: 11
  Parse errors: Bad plan.  You planned 1 tests but ran 0.
Files=121, Tests=417, 642 wallclock secs ( 1.01 usr  0.77 sys + 95.48 cusr 84.30 csys = 181.56 CPU)
Result: FAIL
Failed 14/121 test programs. 14/417 subtests failed.
make: *** [test_dynamic] Error 255
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-ptk/p5.26-tcl-ptk/work/Tcl-pTk-0.92" && /usr/bin/make test
Exit code: 2
</pre>
</details><br />

- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

`widgetTclpTk-5.26` seems to work

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
