### PR TITLE
p5-tkx: add dependency on tk

### DIFF
--- a/perl/p5-tkx/Portfile
+++ b/perl/p5-tkx/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26
 perl5.setup         Tkx 1.09
+revision            1
 
 platforms           darwin
 maintainers         {@mojca mojca} openmaintainer
@@ -20,6 +21,7 @@ checksums           rmd160  d9901b5c3c033a49003331ff04c9d152746edc2b \
 
 if {${perl5.major} != ""} {
     depends_lib-append \
+                    port:tk \
                     port:p${perl5.major}-tcl
 
     livecheck.type  none


### PR DESCRIPTION
Resolves issue I had put in the title of https://trac.macports.org/ticket/56638 (it doesn't resolve the separate issue of p5-tcl potentially not using MacPorts' Tcl/Tk).

~~The livecheck works when I falsify the version, so I have re-enabled it. Let me know if there's a reason not to.~~

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

As in #2036, I have only managed to test using `tk +quartz` and not `tk +x11`.

<details><summary>Full test results:</summary>
<pre>
--->  Testing p5.26-tkx
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tkx/p5.26-tkx/work/Tkx-1.09" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/LabEntry.t ...... ok
t/mega-config.t ... ok
t/mega.t .......... ok
t/nul-char.t ...... ok
t/tcl-callback.t .. ok
# Test 18 got: "Tcl error 'Foo at /opt/local/lib/perl5/vendor_perl/5.26/darwin-thread-multi-2level/Tcl.pm line 585.\n' while invoking scalar result call:\n\t\"error Foo\" at t/tcl.t line 38.\n" (t/tcl.t at line 39)
#    Expected: "Foo at t/tcl.t line 38.\n"
#  t/tcl.t line 39 is: ok($@, "Foo at @{[__FILE__]} line @{[__LINE__ - 1]}.\n");
t/tcl.t ...........
Failed 1/18 subtests
t/tk.t ............ ok
t/utf8.t .......... ok
&nbsp;
Test Summary Report
-------------------
t/tcl.t         (Wstat: 0 Tests: 18 Failed: 1)
  Failed test:  18
Files=8, Tests=54, 22 wallclock secs ( 0.06 usr  0.03 sys +  2.64 cusr  2.58 csys =  5.31 CPU)
Result: FAIL
Failed 1/8 test programs. 1/54 subtests failed.
make: *** [test_dynamic] Error 255
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tkx/p5.26-tkx/work/Tkx-1.09" && /usr/bin/make test
Exit code: 2
</pre>
</details>
<br />

- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
