### PR TITLE
hugo: update to 0.42.1

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,29 +3,30 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        gohugoio hugo 0.30.2 v
+github.setup        gohugoio hugo 0.42.1 v
 revision            0
 categories          www
 platforms           darwin
-license             BSD
-maintainers         nomaintainer
+license             Apache-2
+maintainers         {isi.edu:calvin @cardi} openmaintainer
 description         A Fast and Flexible Static Site Generator built with love in GoLang
 long_description    ${description}
 
-checksums           rmd160  123ba1b7892fb676d731c6215d918d89bc1338cd \
-                    sha256  7a653978a340b916b80098443a56a9e5ccc675753e836922171add355edc186a
+checksums           rmd160  aab5a4d78efb50867090efc191fc9cd604a3d3fa \
+                    sha256  4f1f7ea18c9bb8ed804a0601f4bdbc7af939217e6aa6c24947c1d16c0e31bb10 \
+                    size    16530183
 
-depends_build-append port:git \
-                     port:govendor
+depends_build-append port:dep \
+                     port:git
 
 universal_variant   no
 
 worksrcdir          src/github.com/${github.author}/${github.project}
 
-configure.cmd       ${prefix}/bin/govendor
+configure.cmd       ${prefix}/bin/dep
 configure.pre_args  {}
-configure.args      sync
-configure.post_args {}
+configure.args      ensure
+configure.post_args -vendor-only
 configure.env       GOPATH=${workpath}
 
 build.cmd           go
@@ -44,6 +45,13 @@ post-extract {
 destroot {
     xinstall -d ${destroot}${prefix}/bin
     xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+}
+
+post-destroot {
+    # generate man pages then install them
+    system -W ${workpath} "${workpath}/bin/${name} gen man"
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 {*}[glob ${workpath}/man/*.1] ${destroot}${prefix}/share/man/man1/
 }
 
 variant bash_completion {


### PR DESCRIPTION
#### Description

Updates hugo from 0.30.2 to 0.42.1.

Additional changes:
* update software license
* update dependency tool from govendor to dep
* builds and installs man pages
* add maintainer's github handle

(Note: trace-mode on `sudo port -vst install` will not work due to https://trac.macports.org/ticket/49039)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G21013
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
