### PR TITLE
py*-requests: update to 2.19.1.

### DIFF
--- a/python/py-requests/Portfile
+++ b/python/py-requests/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-requests
-version             2.18.4
+version             2.19.1
 revision            0
 categories-append   devel
 platforms           darwin
@@ -30,8 +30,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  8217810eff11d3364445efb9f723772adeb80e48 \
-                    sha256  9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e
+checksums           rmd160  c61074e9faf32196083c6124c5db5235e7fe6b91 \
+                    sha256  ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a \
+                    size    131068
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update py*-requests to 2.19.1.
Closes: https://trac.macports.org/ticket/56670 , which is just a simple version conflict with updated py*-liburl3 @1.23_0 in https://github.com/macports/macports-ports/commit/04f095f64a7010aaa1853f17cf76b74cf446eeea

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1408
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?