### PR TITLE
wireguard-go: new port, version 0.0.20180613

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                wireguard-go
+version             0.0.20180613
+categories          net
+platforms           darwin
+license             GPL-2
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         Userspace Go implementation of WireGuard VPN
+long_description    \
+    WireGuard-go is the userspace Go implementation of WireGuard, a \
+    novel VPN that runs inside the Linux Kernel and utilizes \
+    state-of-the-art cryptography. It aims to be faster, simpler, \
+    leaner, and more useful than IPSec, while avoiding the massive \
+    headache. It intends to be considerably more performant than \
+    OpenVPN. WireGuard is designed as a general purpose VPN for \
+    running on embedded interfaces and super computers alike, fit for \
+    many different circumstances. It runs over UDP.
+
+homepage            https://www.wireguard.com/
+master_sites        https://git.zx2c4.com/wireguard-go/snapshot/
+use_xz              yes
+
+checksums           rmd160  eaca7df0a711c0f02f288c41bed6b0375f827773 \
+                    sha256  3e22e6f2a715f05f9bbc5b1a9c737ab2edc8f26b2af61f9cc31f83391cd663ff \
+                    size    53628
+
+depends_build       port:dep \
+                    port:git \
+                    port:go
+
+use_configure       no
+
+build.target
+
+use_parallel_build  no
+
+destroot.args       DESTDIR=${destroot} \
+                    PREFIX=${prefix}


### PR DESCRIPTION
#### Description

New port for '''wireguard-go''', the userspace Go implementation of WireGuard VPN.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G21013
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
