### PR TITLE
Allow cmake-devel to satisfy cmake dependency

### DIFF
--- a/audio/audacity/Portfile
+++ b/audio/audacity/Portfile
@@ -92,7 +92,6 @@ if {![catch {set wxw_stdlib [active_variants ${wxWidgets.port} stdlib]} err]} {
 }
 
 depends_build-append \
-                    port:cmake \
                     port:pkgconfig \
                     port:python27
 depends_lib-append  port:freetype \

--- a/devel/flusspferd/Portfile
+++ b/devel/flusspferd/Portfile
@@ -12,7 +12,7 @@ long_description    ${name} ${description}
 homepage            http://flusspferd.org/
 
 platforms           darwin
-depends_build       port:cmake
+depends_build       path:bin/cmake:cmake
 depends_lib         port:spidermonkey \
                     port:boost
 

--- a/devel/xcbuild/Portfile
+++ b/devel/xcbuild/Portfile
@@ -26,7 +26,7 @@ depends_lib-append  port:libpng \
                     port:pkgconfig \
                     port:zlib \
                     port:libxml2 \
-                    port:cmake \
+                    path:bin/cmake:cmake \
                     port:ninja
 
 conflicts           libplist

--- a/graphics/InsightToolkit/Portfile
+++ b/graphics/InsightToolkit/Portfile
@@ -47,7 +47,7 @@ platforms       darwin
 
 depends_build   port:gmake \
                 port:gawk \
-                port:cmake \
+                path:bin/cmake:cmake \
                 port:bison
 
 depends_lib     port:ossp-uuid

--- a/graphics/InsightToolkit312/Portfile
+++ b/graphics/InsightToolkit312/Portfile
@@ -38,7 +38,7 @@ extract.only    InsightToolkit-${version}.tar.gz \
 
 platforms       darwin
 
-depends_build   port:cmake \
+depends_build   path:bin/cmake:cmake \
                 port:gmake \
                 port:gawk \
                 port:bison

--- a/graphics/InsightToolkit314/Portfile
+++ b/graphics/InsightToolkit314/Portfile
@@ -44,7 +44,7 @@ extract.only    InsightToolkit-${version}.tar.gz \
 
 platforms       darwin
 
-depends_build   port:cmake \
+depends_build   path:bin/cmake:cmake \
                 port:gmake \
                 port:gawk \
                 port:bison

--- a/graphics/VirtualPlanetBuilder/Portfile
+++ b/graphics/VirtualPlanetBuilder/Portfile
@@ -31,7 +31,7 @@ checksums               md5     e084fec6150c31b01412dfb4d2a9959f \
 
 patchfiles              patch-CMakeLists.txt.diff
 
-depends_build           port:cmake
+depends_build           path:bin/cmake:cmake
 
 depends_lib             port:OpenSceneGraph
 

--- a/graphics/lprof/Portfile
+++ b/graphics/lprof/Portfile
@@ -26,7 +26,7 @@ cvs.module          lprof
 
 depends_lib-append  port:libusb-compat port:libpng port:tiff \
                     port:zlib port:qt-assistant port:vigra
-depends_build-append port:cmake
+depends_build-append path:bin/cmake:cmake
 depends_skip_archcheck cmake
 
 worksrcdir          lprof

--- a/kde/kdevelop/Portfile
+++ b/kde/kdevelop/Portfile
@@ -30,7 +30,7 @@ checksums           rmd160  047f2d2203f25a66a69e7f5b38a2a70cb2005966 \
 
 use_xz              yes
 
-depends_run-append  port:cmake
+depends_run-append  path:bin/cmake:cmake
 
 depends_lib-append  port:kdelibs4 \
                     port:kdevplatform \

--- a/lang/qore-qt4-module/Portfile
+++ b/lang/qore-qt4-module/Portfile
@@ -27,7 +27,7 @@ patchfiles          patch-smoke-qt-smokeconfig.xml.diff \
 
 depends_lib-append  port:qore
 
-depends_build-append port:cmake
+depends_build-append path:bin/cmake:cmake
 
 configure.cmd       cmake
 configure.pre_args  -DCMAKE_INSTALL_PREFIX=${prefix}

--- a/math/newran/Portfile
+++ b/math/newran/Portfile
@@ -17,7 +17,7 @@ checksums         md5 db2bb22b6d96f1c04ce25f91ec7aeece \
                   sha1 6c5b0493b11732c2f9152fe0f73bb6d4605f2da8 \
                   rmd160 4693b8a85945468c173695c0da07a63d408d0392
 
-depends_build     port:cmake
+depends_build     path:bin/cmake:cmake
 configure.cmd     cmake
 
 configure.pre_args

--- a/multimedia/HandBrake/Portfile
+++ b/multimedia/HandBrake/Portfile
@@ -75,7 +75,7 @@ universal_variant   no
 # Yasm: libav, libvpx, x264, x265
 depends_build       port:autoconf \
                     port:automake \
-                    port:cmake \
+                    path:bin/cmake:cmake \
                     port:libtool \
                     port:pkgconfig \
                    {bin:python2(\.(4|5|6|7))?:python27} \

--- a/net/urbit/Portfile
+++ b/net/urbit/Portfile
@@ -23,7 +23,7 @@ depends_lib         port:gmp \
 depends_build       port:autoconf \
                     port:automake \
                     port:libtool \
-                    port:cmake
+                    path:bin/cmake:cmake
 
 patchfiles          patch-Makefile.diff
 

--- a/python/py-dynd/Portfile
+++ b/python/py-dynd/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  dc0c24136b8b295ab85046489b6a3b05146ce8b2 \
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools \
-                        port:cmake
+                        path:bin/cmake:cmake
 
     depends_lib-append  port:libdynd \
                         port:py${python.version}-numpy \

--- a/python/py-pyne/Portfile
+++ b/python/py-pyne/Portfile
@@ -32,7 +32,7 @@ if {${name} ne ${subport}} {
     destroot.args       --hdf5=${prefix}
 
     depends_build-append \
-                        port:cmake \
+                        path:bin/cmake:cmake \
                         port:py${python.version}-cython
 
     depends_lib-append  port:hdf5 \

--- a/science/uclatools/Portfile
+++ b/science/uclatools/Portfile
@@ -14,7 +14,7 @@ checksums		      md5 48246c595203f7c17bc1956d65ce58e5 \
                   sha1 0e1c010ee5406ca2677569cc0588e8dd30cb7746 \
                   rmd160 e57fed6bdaa6d85e2c75fde99f391f2c4c6d593a 
 
-depends_build port:cmake
+depends_build path:bin/cmake:cmake
 configure.cmd cmake
 
 configure.pre_args

--- a/www/midori/Portfile
+++ b/www/midori/Portfile
@@ -23,7 +23,7 @@ worksrcdir          midori-${version}
 checksums           rmd160  66aaf624d39fbb86c1bec42972fba7998965ef50 \
                     sha256  96191a96be71144ae848a409fae5a1d6d52a00e583f33122081f47ead9c49c3d
 
-depends_build       port:cmake \
+depends_build       path:bin/cmake:cmake \
                     port:pkgconfig \
                     port:intltool
 

--- a/x11/awesome/Portfile
+++ b/x11/awesome/Portfile
@@ -31,7 +31,7 @@ use_xz              yes
 checksums           rmd160  87f834bd4c9b133dce991678c017d5bb4a5bfee1 \
                     sha256  37f49de187825425cb3096fc870959d5fec9302b22ffd0f2874d8a18e85046d7
 
-depends_build       port:cmake \
+depends_build       path:bin/cmake:cmake \
                     port:ImageMagick \
                     port:pkgconfig
 


### PR DESCRIPTION
#### Description

Allow cmake-devel to satisfy cmake dependency

I know of no reason why this should not be permitted.

If any port is not compatible with cmake-devel, it should indicate that unusual condition in the portfile with a comment, so that we won't have to wonder about it in the future.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
