### PR TITLE
Remove maintainer gmail.com:michel.sylvan

### DIFF
--- a/python/py-sphinx/Portfile
+++ b/python/py-sphinx/Portfile
@@ -8,7 +8,7 @@ name                py-sphinx
 version             1.7.5
 categories-append   textproc devel
 license             BSD
-maintainers         {jmr @jmroot} gmail.com:michel.sylvan openmaintainer
+maintainers         {jmr @jmroot} openmaintainer
 description         Python documentation generator
 long_description \
     Sphinx is a tool that makes it easy to create intelligent and beautiful \


### PR DESCRIPTION
Remove maintainer gmail.com:michel.sylvan (@michel-slm)

The only reason he was added as maintainer of this port in 2011 in https://trac.macports.org/ticket/31501 was because he had originally submitted Python 2.4 and 2.5 ports for this module in 2008 in https://trac.macports.org/ticket/14838.

He is in fact a MacPorts committer with the handle hircus; his last (only?) commit to MacPorts was a66aebd267f48b8a9de61d07dcb05852d40a7c7b in late 2008.

He was moved to the Retired section of the [MacPortsDevelopers](https://trac.macports.org/wiki/MacPortsDevelopers#retired) wiki page in 2017.