### PR TITLE
Adjust maintainers line of Carles Fernandez ports

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -8,7 +8,7 @@ PortGroup           active_variants 1.1
 PortGroup           cxx11 1.1
 
 name                gnss-sdr
-maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @gnss-sdr} openmaintainer
+maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
 description         An Open Source Global Navigation Satellite Systems (GNSS)(for example: GPS, Galileo, Glonass, Beidou, etc) Software Defined Radio (SDR) Receiver
 categories          science
 license             GPL-3

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -8,7 +8,7 @@ PortGroup           active_variants 1.1
 PortGroup           cxx11 1.1
 
 name                volk-gnss-sdr
-maintainers         {michaelld @michaelld} {gmail.com:carlesfernandez @gnss-sdr} openmaintainer
+maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @gnss-sdr} openmaintainer
 description         Volk modules for GNSS-SDR
 categories          science
 license             GPL-3

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -8,7 +8,7 @@ PortGroup           active_variants 1.1
 PortGroup           cxx11 1.1
 
 name                volk-gnss-sdr
-maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @gnss-sdr} openmaintainer
+maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
 description         Volk modules for GNSS-SDR
 categories          science
 license             GPL-3


### PR DESCRIPTION
Use the same email address for all ports maintained by Carles Fernandez. Gmail allows periods to be inserted anywhere in the username portion of the email, but let's be consistent.

@michaelld added the GitHub handle @gnss-sdr to this email address as part of 9b104fbd33274ce33302626d6785bbb8985295e0 but it seems like the handle @carlesfernandez would be more correct. The `maintainers` line is supposed to list individuals, not organizations. Typically, not all members of an organization work on Portfiles; those individuals that do should be listed.

<!-- [skip notification] -->