### PR TITLE
MacDependency: new port, version 1.1.0

### DIFF
--- a/devel/MacDependency/Portfile
+++ b/devel/MacDependency/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+
+github.setup        kwin macdependency 1.1.0
+name                MacDependency
+
+categories          devel
+license             GPL-3
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+description         MacDependency shows all dependent libraries and frameworks of a given executable, \
+                    dynamic library or framework on Mac OS.
+long_description    ${description} It is a GUI replacement for the otool command, \
+                    and provides almost the same functionality as the Dependency Walker (http://www.dependencywalker.com) on Windows.
+
+platforms           darwin
+
+checksums           rmd160  071c900c94d61f6796125b667df7a67e85daa91f \
+                    sha256  83aab373efefa4e0f1b1b9653d21ab6702924ac0202f09b0c2b73faf3ae01cf9 \
+                    size    1268109
+
+xcode.project       MacDependency/MacDependency.xcodeproj
+xcode.build.settings FRAMEWORK_SEARCH_PATHS=${worksrcpath} CONFIGURATION_BUILD_DIR=${worksrcpath}/build
+xcode.destroot.settings CONFIGURATION_BUILD_DIR=${worksrcpath}/build


### PR DESCRIPTION
#### Description

New port submission. See #1953.

@pmetzger @l2dy @kencu thanks for your comments. In this new pull request I have a single port (no separate subport for the framework). I found that it builds correctly by providing some paths.

I noticed that there are still for some reason two copies of the framework (see output of `port content MacDependency` below), one in `/Applications/MacPorts/MacDependency.app/Contents/Frameworks/` and one in `/Applications/MacPorts/`. I guess this is the way the installer works. If this is ok, for me we can merge. Thanks!

Giovanni

````
Port MacDependency contains:
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Headers
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/MachO
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/MachO.framework
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Resources
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/dylibcommand.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/genericcommand.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/loadcommand.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/macho.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/macho_global.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/machoarchitecture.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/machocache.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/machodemangleexception.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/machoexception.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/machofile.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/machoheader.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/symboltablecommand.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Headers/symboltableentry.h
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/MachO
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Resources/English.lproj/InfoPlist.strings
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/A/Resources/Info.plist
  /Applications/MacPorts/MacDependency.app/Contents/Frameworks/MachO.framework/Versions/Current
  /Applications/MacPorts/MacDependency.app/Contents/Info.plist
  /Applications/MacPorts/MacDependency.app/Contents/MacOS/MacDependency
  /Applications/MacPorts/MacDependency.app/Contents/PkgInfo
  /Applications/MacPorts/MacDependency.app/Contents/Resources/AppIcon.icns
  /Applications/MacPorts/MacDependency.app/Contents/Resources/English.lproj/Credits.rtf
  /Applications/MacPorts/MacDependency.app/Contents/Resources/English.lproj/InfoPlist.strings
  /Applications/MacPorts/MacDependency.app/Contents/Resources/English.lproj/Localizable.strings
  /Applications/MacPorts/MacDependency.app/Contents/Resources/English.lproj/MainMenu.nib
  /Applications/MacPorts/MacDependency.app/Contents/Resources/English.lproj/MyDocument.nib
  /Applications/MacPorts/MachO.framework/Headers
  /Applications/MacPorts/MachO.framework/MachO
  /Applications/MacPorts/MachO.framework/Resources
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/dylibcommand.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/genericcommand.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/loadcommand.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/macho.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/macho_global.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/machoarchitecture.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/machocache.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/machodemangleexception.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/machoexception.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/machofile.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/machoheader.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/symboltablecommand.h
  /Applications/MacPorts/MachO.framework/Versions/A/Headers/symboltableentry.h
  /Applications/MacPorts/MachO.framework/Versions/A/MachO
  /Applications/MacPorts/MachO.framework/Versions/A/Resources/English.lproj/InfoPlist.strings
  /Applications/MacPorts/MachO.framework/Versions/A/Resources/Info.plist
  /Applications/MacPorts/MachO.framework/Versions/Current
```` 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G20015
Xcode 8.1 8B62

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
