### PR TITLE
wireguard-tools: new port, version 0.0.20180613

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                wireguard-tools
+# please only update the version when the tools (in "src/tools") have
+# been modified/updated (git commit messages starting with "tools:").
+#
+# the WireGuard repository and its updates primarily deals with the
+# Linux kernel module, which isn't useful or relevant for macOS (we're
+# just interested in its tools for manipulating WireGuard interfaces).
+version             0.0.20180613
+categories          net
+platforms           darwin
+license             GPL-2
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         Tools for the WireGuard VPN
+long_description    \
+    WireGuard-tools contains command-line tools to interact with \
+    the userspace Go implementation of WireGuard. Currently there \
+    are two tools: wg, to set and retrieve configuration of \
+    WireGuard interfaces, and wg-quick, set up a WireGuard interface \
+    simply.
+
+homepage            https://www.wireguard.com/
+master_sites        https://git.zx2c4.com/WireGuard/snapshot/
+distname            WireGuard-${version}
+use_xz              yes
+
+checksums           rmd160  2df3459bc35e0598fea7f2e662132e331a414ca2 \
+                    sha256  c120cdedc3967dcb4ad5c1c7eadd2a1b04ef5dbf2fe60cc8e7c0db337bcda7dc \
+                    size    269316
+
+depends_run         port:bash \
+                    port:wireguard-go
+
+# remove the following patch for version > 0.0.20180613:
+# upstream commit from 14 Jun 2018 "tools: getentropy requires 10.12"
+# https://git.zx2c4.com/WireGuard/patch/?id=5bb62fe22f45b5b5deef4db23ae47c95e1679d1d
+# (MacPorts doesn't handle that URL properly, so replicate it locally)
+patchfiles          patch-genkey.c.diff
+patch.pre_args      -p1
+
+use_configure       no
+
+# only build and install the tools for macOS
+build.pre_args      -C src/tools
+build.target
+
+destroot.pre_args   -C src/tools
+destroot.args       install
+destroot.post_args-append PREFIX=${prefix} \
+                    SYSCONFDIR=${prefix}/etc \
+                    WITH_BASHCOMPLETION=yes \
+                    WITH_SYSTEMDUNITS=no \
+                    WITH_WGQUICK=yes

--- a/net/wireguard-tools/files/patch-genkey.c.diff
+++ b/net/wireguard-tools/files/patch-genkey.c.diff
@@ -1,0 +1,40 @@
+From 5bb62fe22f45b5b5deef4db23ae47c95e1679d1d Mon Sep 17 00:00:00 2001
+From: "Jason A. Donenfeld" <Jason@zx2c4.com>
+Date: Thu, 14 Jun 2018 04:18:15 +0200
+Subject: tools: getentropy requires 10.12
+
+---
+ src/tools/genkey.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/tools/genkey.c b/src/tools/genkey.c
+index 04de2ba..d2d4c53 100644
+--- a/src/tools/genkey.c
++++ b/src/tools/genkey.c
+@@ -14,8 +14,14 @@
+ #include <sys/syscall.h>
+ #endif
+ #ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#ifndef MAC_OS_X_VERSION_10_12
++#define MAC_OS_X_VERSION_10_12 101200
++#endif
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+ #include <sys/random.h>
+ #endif
++#endif
+ 
+ #include "curve25519.h"
+ #include "encoding.h"
+@@ -26,7 +32,7 @@ static inline ssize_t get_random_bytes(uint8_t *out, size_t len)
+ 	ssize_t ret;
+ 	int fd;
+ 
+-#if defined(__OpenBSD__) || defined(__APPLE__) || (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25)))
++#if defined(__OpenBSD__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12) || (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25)))
+ 	ret = getentropy(out, len);
+ 	if (!ret)
+ 		return len;
+-- 
+cgit v1.1-37-gf5b9
+


### PR DESCRIPTION
#### Description

New port for wireguard-tools, command-line tools to interact with the WireGuard VPN.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G21013
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
