### PR TITLE
mozjs52: update to 52.6.0

### DIFF
--- a/lang/mozjs52/Portfile
+++ b/lang/mozjs52/Portfile
@@ -5,8 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                mozjs52
-version             52.2.1
-revision            1
+version             52.6.0
 categories          lang
 platforms           darwin
 license             {MPL-2 LGPL-2.1+}
@@ -21,9 +20,11 @@ homepage            https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Sp
 master_sites        http://ftp.gnome.org/pub/GNOME/teams/releng/tarballs-needing-help/mozjs/
 
 distname            mozjs-${version}gnome1
+use_xz              yes
 
-checksums           rmd160  65e4ffaedab76dc5a74020e0156d35536e5acb5a \
-                    sha256  31697943b1dbbb51ba9aee35b8269a353c487d7af4d336010b90054dc4f9b0af
+checksums           rmd160  b8815d4e62c36c41dc4e568d44a7430a4da2c86e \
+                    sha256  786647e0ee743ab8ebd67d307ab406f93d50363ead7d7d05e29eeb113ebbf525 \
+                    size    24712740
 
 depends_build       port:autoconf213 \
                     port:pkgconfig \
@@ -38,6 +39,8 @@ depends_lib         port:icu \
 # Requires clang-3.6 or equivalent
 # While clang-602.0.53 (Xcode 6.4) is based on 3.6, it apparently doesn't pass the configure check
 compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 700} macports-clang-3.3 macports-clang-3.4
+
+extract.mkdir       yes
 
 # Use absolute path for install_name
 post-patch {


### PR DESCRIPTION
#### Description
I'm not sure if `.../tarballs-needing-help/...` is the right upstream. Updating anyway to fix some security vulnerabilities (assuming the new tarball does contain the fixes).

Fixes: https://trac.macports.org/ticket/56428

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
