### PR TITLE
poppler-qt4-mac: version 0.61.1

### DIFF
--- a/graphics/poppler-qt4-mac/Portfile
+++ b/graphics/poppler-qt4-mac/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cxx11 1.1
+PortGroup           gobject_introspection 1.0
+PortGroup           cmake 1.1
+PortGroup           qt4 1.0
+
+name                poppler-qt4-mac
+conflicts           xpdf-tools
+version             0.61.1
+license             GPL-2+
+maintainers         {kencu @kencu} openmaintainer
+categories          graphics
+platforms           darwin
+homepage            https://poppler.freedesktop.org/
+
+description         Poppler is a PDF rendering library based on the xpdf-3.0 code base.
+long_description    ${description}
+
+master_sites        ${homepage}
+distname            poppler-${version}
+
+use_xz              yes
+
+checksums           rmd160  62fa0f917e31e0c733228ea9289b4493a0fc29a8 \
+                    sha256  1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9 \
+                    size    1433696
+
+depends_build       port:pkgconfig
+
+depends_lib         port:bzip2 \
+                    port:curl \
+                    port:expat \
+                    port:fontconfig \
+                    port:freetype \
+                    port:jpeg \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/cairo.pc:cairo \
+                    port:lcms2 \
+                    port:libpng \
+                    port:openjpeg \
+                    port:poppler-data \
+                    port:tiff \
+                    port:zlib
+
+configure.ldflags-append -liconv
+configure.cxxflags-append -std=c++11
+
+gobject_introspection yes
+configure.env-append  MOCQT4=${qt_bins_dir}/moc
+
+cmake.install_prefix ${prefix}/libexec/${name}
+cmake.install_rpath  ${destroot}${prefix}/libexec/${name}/lib
+cmake_share_module_dir ${prefix}/libexec/${name}/share/cmake/Modules
+
+configure.args-append \
+                    -DENABLE_XPDF_HEADERS=ON \
+                    -DENABLE_QT4=ON \
+                    -DENABLE_QT5=OFF \
+                    -DBUILD_GTK_TESTS=OFF \
+                    -DBUILD_QT5_TESTS=OFF \
+                    -DBUILD_CPP_TESTS=OFF \
+                    -DWITH_NSS3=OFF
+
+
+patchfiles-append    patch-CVE-2017-18267.diff
+
+# fix library not found during gir introspection
+# https://bugs.freedesktop.org/show_bug.cgi?id=106417
+patchfiles-append   patch-bug106417.diff
+
+notes {
+This port is based on the last version of poppler (0.61.1) that supported qt4. It will be kept \
+as up-to-date as possible with security updates, but is not expected to be as up-to-date as the \
+official poppler port (that no longer supports qt4). You should consider this when deciding when \ 
+and whether it is appropriate to use this port.
+
+To use this port to build poppler-based ports that require qt4, you will need to pass in the \
+directions to the pkgconfig files or otherwise direct the build to find these headers and libraries. \
+For example, these lines may be useful:
+
+configure.env-append PKG_CONFIG_PATH="${prefix}/libexec/poppler-qt4-mac/lib/pkgconfig:${prefix}/lib/pkgconfig"
+build.env-append PKG_CONFIG_PATH="${prefix}/libexec/poppler-qt4-mac/lib/pkgconfig:${prefix}/lib/pkgconfig"
+
+}
+

--- a/graphics/poppler-qt4-mac/files/patch-CVE-2017-18267.diff
+++ b/graphics/poppler-qt4-mac/files/patch-CVE-2017-18267.diff
@@ -1,0 +1,42 @@
+From 60b4fe65bc9dc9b82bbadf0be2e3781be796a13d Mon Sep 17 00:00:00 2001
+From: Albert Astals Cid <aacid@kde.org>
+Date: Tue, 1 May 2018 02:46:17 +0200
+Subject: FoFiType1C::cvtGlyph: Fix infinite recursion on malformed documents
+
+Bugs #104942, #103238
+---
+ fofi/FoFiType1C.cc | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git fofi/FoFiType1C.cc fofi/FoFiType1C.cc
+index 03e7799..b14561f 100644
+--- fofi/FoFiType1C.cc
++++ fofi/FoFiType1C.cc
+@@ -32,6 +32,7 @@
+ #include <math.h>
+ #include "goo/gmem.h"
+ #include "goo/gstrtod.h"
++#include "goo/GooLikely.h"
+ #include "goo/GooString.h"
+ #include "poppler/Error.h"
+ #include "FoFiEncodings.h"
+@@ -1361,7 +1362,7 @@ void FoFiType1C::cvtGlyph(int offset, int nBytes, GooString *charBuf,
+ 	  --nOps;
+ 	  ok = gTrue;
+ 	  getIndexVal(subrIdx, k, &val, &ok);
+-	  if (ok) {
++	  if (likely(ok && val.pos != offset)) {
+ 	    cvtGlyph(val.pos, val.len, charBuf, subrIdx, pDict, gFalse);
+ 	  }
+ 	} else {
+@@ -1596,7 +1597,7 @@ void FoFiType1C::cvtGlyph(int offset, int nBytes, GooString *charBuf,
+ 	  --nOps;
+ 	  ok = gTrue;
+ 	  getIndexVal(&gsubrIdx, k, &val, &ok);
+-	  if (ok) {
++	  if (likely(ok && val.pos != offset)) {
+ 	    cvtGlyph(val.pos, val.len, charBuf, subrIdx, pDict, gFalse);
+ 	  }
+ 	} else {
+-- 
+cgit v1.1

--- a/graphics/poppler-qt4-mac/files/patch-bug106417.diff
+++ b/graphics/poppler-qt4-mac/files/patch-bug106417.diff
@@ -1,0 +1,12 @@
+diff --git glib/CMakeLists.txt glib/CMakeLists.txt
+index 33c66082..53c47ce7 100644
+--- glib/CMakeLists.txt
++++ glib/CMakeLists.txt
+@@ -119,6 +119,7 @@ if (HAVE_INTROSPECTION AND BUILD_SHARED_LIBS)
+   include(GObjectIntrospectionMacros)
+   set(INTROSPECTION_GIRS)
+   set(INTROSPECTION_SCANNER_ARGS "--add-include-path=${CMAKE_CURRENT_SOURCE_DIR} --warn-all")
++  set(INTROSPECTION_SCANNER_ARGS "--library-path=${CMAKE_CURRENT_BINARY_DIR}")
+   set(INTROSPECTION_COMPILER_ARGS "--includedir=${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+   set(introspection_files ${poppler_glib_SRCS} ${poppler_glib_public_headers})


### PR DESCRIPTION
As requested.

This is the pegged last version of poppler that supported the qt4 interfaces. 

Co-installs with poppler, and does not interfere with it in my tests. Allows a number of ports that require poppler-qt4-mac to build and install, while accepting an older poppler version.

This version of poppler was current as of Nov 2017.

There is a list of distros and the current versions of poppler they support here <https://poppler.freedesktop.org/> to give an idea of the version distribution.

I'll switch the maintainer to me as I'm sure Dave doesn't want this one on his plate as well as the current poppler.