### PR TITLE
[WIP] texworks: update, drop support for Qt4

### DIFF
--- a/editors/texworks/Portfile
+++ b/editors/texworks/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           qt5 1.0
 
-github.setup        TeXworks texworks 0.6.2 release-
-# github.setup      TeXworks texworks <sha>
-# set git_date      <date>
-# version           0.6.2-git-${git_date}
+# github.setup      TeXworks texworks 0.6.2 release-
+github.setup        TeXworks texworks 70cafa3ba33e01084a6562df0303ed9bb9dab2b1
+set git_date        20180512
+version             0.6.2-git-${git_date}
 platforms           darwin
 categories          editors tex
 maintainers         {mojca @mojca} openmaintainer
@@ -18,8 +19,9 @@ long_description    TeXworks is an environment for authoring TeX (LaTeX, ConTeXt
                     with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, \
                     simple interface accessible to casual and non-technical users.
 
-checksums           rmd160  1882b85801f6c07e703ac2448af94196d47c58ed \
-                    sha256  12da6827fd34efd087a840bc5db1a5bee587a956dd6548ff5d1b6b6eee9739c9
+checksums           rmd160  bc787c0cd8bbb7dadec3473a6135029bac5a4133 \
+                    sha256  758f40f33f64160cd500ba9136d0e891122185d82b0d692d4540c45c3a804456 \
+                    size    11174155
 
 depends_build-append \
                     port:pkgconfig
@@ -27,42 +29,25 @@ depends_lib         port:fontconfig \
                     port:hunspell \
                     port:lua \
                     port:poppler \
+                    port:poppler-qt5 \
                     port:texlive-bin \
                     port:zlib
 
 # texlive-bin is needed for synctex (but maybe there is some workaround?)
 # not sure why zlib is needed
 
-cmake.out_of_source yes
-
-configure.args-append       -DWITH_LUA=ON \
-                            -DWITH_MUPDF=OFF \
-                            -DWITH_POPPLER=ON \
-                            -DWITH_PYTHON=OFF \
-                            -DQTPDF_VIEWER=OFF
-
-variant qt4 description {Build against Qt 4} {
-    PortGroup               qt4 1.0
-    depends_lib-append      port:poppler-qt4-mac
-    configure.args-append   -DDESIRED_QT_VERSION=4
-}
-
-# TODO: doesn't work at the moment
-variant qt5 description {Build against Qt 5} {
-    PortGroup               qt5 1.0
-    depends_lib-append      port:poppler-qt5
-    configure.args-append   -DDESIRED_QT_VERSION=5
-}
+configure.args-append \
+                    -DWITH_LUA=ON \
+                    -DWITH_MUPDF=OFF \
+                    -DWITH_POPPLER=ON \
+                    -DWITH_PYTHON=OFF \
+                    -DQTPDF_VIEWER=OFF
 
 # not properly tested yet
 variant qtpdf description {Build with an experimental PDF viewer} {
     # and zlib
     depends_lib-append      port:freetype
     configure.args-replace  -DQTPDF_VIEWER=OFF -DQTPDF_VIEWER=ON
-}
-
-if { ![variant_isset qt5]} {
-    default_variants        +qt4
 }
 
 post-destroot {


### PR DESCRIPTION
Qt4 bindings no longer work with the latest poppler version.
Link against Qt5 by default.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? See #2070
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

This updates TeXworks a bit to account for poppler update. The build succeeds, but the binary seems broken?