### PR TITLE
poppler: fix GIR generation during the build

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -48,6 +48,9 @@ depends_lib-append  port:bzip2 \
 configure.ldflags-append -liconv
 gobject_introspection yes
 
+# https://bugs.freedesktop.org/show_bug.cgi?id=106417
+patchfiles-append   patch-bug106417.diff
+
 compiler.blacklist  {gcc-4.0 < 5493}
 
 configure.args-append \

--- a/graphics/poppler/files/patch-bug106417.diff
+++ b/graphics/poppler/files/patch-bug106417.diff
@@ -1,0 +1,12 @@
+diff --git glib/CMakeLists.txt glib/CMakeLists.txt
+index 33c66082..53c47ce7 100644
+--- glib/CMakeLists.txt
++++ glib/CMakeLists.txt
+@@ -119,6 +119,7 @@ if (HAVE_INTROSPECTION AND BUILD_SHARED_LIBS)
+   include(GObjectIntrospectionMacros)
+   set(INTROSPECTION_GIRS)
+   set(INTROSPECTION_SCANNER_ARGS "--add-include-path=${CMAKE_CURRENT_SOURCE_DIR} --warn-all")
++  set(INTROSPECTION_SCANNER_ARGS "--library-path=${CMAKE_CURRENT_BINARY_DIR}")
+   set(INTROSPECTION_COMPILER_ARGS "--includedir=${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+   set(introspection_files ${poppler_glib_SRCS} ${poppler_glib_public_headers})


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/56680

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 10.0 10L176w

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A - only poppler-qt5 has tests)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files? - not sure how to test it