### PR TITLE
emacs: update dependencies for 26.1 and devel

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -36,40 +36,6 @@ subport emacs-app-devel {
 
 depends_build-append port:autoconf port:automake port:libtool
 
-if {$subport eq $name || $subport eq "emacs-app"} {
-    version         26.1
-    revision        1
-
-    checksums       rmd160  f13fe104345738c853bcce2e3e061dbfb8692bc5 \
-                    sha256  760382d5e8cdc5d0d079e8f754bce1136fbe1473be24bb885669b0e38fc56aa3 \
-                    size    65007481
-
-    patchfiles      patch-configure.diff
-
-    pre-configure {
-        system -W ${worksrcpath} "sh ./autogen.sh"
-    }
-}
-
-if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
-    epoch           1
-    version         20180606
-    
-    fetch.type      git
-    git.url         http://git.savannah.gnu.org/r/emacs.git
-    git.branch      4a51deb993d923767f0eddd4f350e636fe8d7c0b
-
-    pre-configure {
-        system -W ${worksrcpath} "sh ./autogen.sh"
-    }
-
-    livecheck.type none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://ftp.gnu.org/gnu/emacs/?C=M&O=D
-    livecheck.regex ${name}-(\\d+\\.\\d+\\w*)\\.tar
-}
-
 configure.args  --without-ns \
                 --without-x \
                 --without-dbus \
@@ -77,7 +43,7 @@ configure.args  --without-ns \
                 --without-libotf \
                 --without-m17n-flt \
                 --without-gpm \
-                --without-gnutls \
+                --with-gnutls \
                 --with-xml2 \
                 --with-modules \
                 --infodir ${prefix}/share/info/${name}
@@ -85,7 +51,8 @@ configure.args  --without-ns \
 depends_build-append   port:pkgconfig \
                        port:texinfo
 depends_lib-append     port:ncurses \
-                       port:libxml2
+                       port:libxml2 \
+                       port:gnutls
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/emacs/${version}/leim
@@ -104,6 +71,43 @@ platform darwin {
     }
 }
 
+if {$subport eq $name || $subport eq "emacs-app"} {
+    version         26.1
+    revision        2
+
+    checksums       rmd160  f13fe104345738c853bcce2e3e061dbfb8692bc5 \
+                    sha256  760382d5e8cdc5d0d079e8f754bce1136fbe1473be24bb885669b0e38fc56aa3 \
+                    size    65007481
+
+    patchfiles      patch-configure.diff
+
+    pre-configure {
+        system -W ${worksrcpath} "sh ./autogen.sh"
+    }
+}
+
+if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
+    epoch           1
+    version         20180621
+
+    fetch.type      git
+    git.url         http://git.savannah.gnu.org/r/emacs.git
+    git.branch      5583e6460c38c5d613e732934b066421349a5259
+
+    pre-configure {
+        system -W ${worksrcpath} "sh ./autogen.sh"
+    }
+
+    configure.args-append  --with-json
+    depends_lib-append     port:jansson
+
+    livecheck.type none
+} else {
+    livecheck.type  regex
+    livecheck.url   https://ftp.gnu.org/gnu/emacs/?C=M&O=D
+    livecheck.regex ${name}-(\\d+\\.\\d+\\w*)\\.tar
+}
+
 if {$subport eq $name || $subport eq "emacs-devel"} {
     PortGroup  muniversal 1.0
 
@@ -117,6 +121,7 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
             --with-tiff \
             --with-gif \
             --with-png \
+            --with-lcms2 \
             --without-rsvg \
             --with-xft
         depends_lib-append      port:xorg-libXmu \
@@ -126,6 +131,7 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
             port:tiff \
             port:giflib \
             port:libpng \
+            port:lcms2
             port:Xft2
 
         # autoconf appears to be dropping linker flags for freetype &
@@ -179,8 +185,10 @@ if {$subport eq $name || $subport eq "emacs-devel"} {
 if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
     categories-append   aqua
 
-    configure.args-append --with-ns
-    configure.args-delete --without-ns --without-x
+    configure.args-append  --with-ns     --with-lcms2
+    configure.args-delete  --without-ns  --without-x
+
+    depends_lib-append     port:lcms2
 
     universal_variant   no
 
@@ -198,7 +206,7 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
     }
 
     if {$subport eq "emacs-app"} {
-        revision 2
+        revision 3
     }
 
     variant multicolor_font description {Apply multicolor font patch} {
@@ -210,5 +218,10 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
     variant imagemagick description {Use ImageMagick} {
         depends_lib-append  port:ImageMagick
         configure.args-append --with-imagemagick
+    }
+
+    variant rsvg description {Use librsvg} {
+        depends_lib-append     port:librsvg
+        configure.args-append  --with-rsvg
     }
 }


### PR DESCRIPTION
* require gnutls
* require lcms2 for GUI subports
* require jansson for emacs-devel*
* add rsvg variant for emacs-app*

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Emacs 26.1 has added support for [Little CMS](https://github.com/emacs-mirror/emacs/blob/emacs-26/etc/NEWS) that exposes a number of color profile management functions to emacs-lisp. It makes sense to require it by default for GUI subports for 3 reasons:

1. The Portfile currently doesn't not blacklist `lcms2` in `configure.args`, so if it's installed before you install Emacs, it's automatically picked up by Emacs anyway, but this breaks build reproducibility.
2. For X11, all the dependencies required by `lcms2` would have already been required, it doesn't take much more effort to bake that in.
3. It's useful if you are manipulating images in Emacs.

For emacs-devel*, `starttls.el` and `tls.el` has been obsoleted, so `gnutls` is pretty much required now to open a TLS connection in Emacs. `jansson` is added so Emacs can decode/encode JSON in C.

The `rsvg` variant is added to supplant `ImageMagick` as it can't display SVGs with transparent background in Emacs.

#### Updates:
Require gnutls for all ports because the Emacs 26.1 NEWS file claims it's required.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
