### PR TITLE
cquery: remove asan variant and update devel

### DIFF
--- a/devel/cquery/Portfile
+++ b/devel/cquery/Portfile
@@ -40,11 +40,6 @@ subport cquery-devel {
 
 configure.args-delete        --nocache
 
-variant asan description {Address Sanitizer} {
-    configure.args-append    --variant=asan-release
-    build.args-append        --variant=asan-release
-}
-
 if {${subport} eq ${name}} {
     depends_lib port:clang-5.0
     configure.args-append    --llvm-config=llvm-config-mp-5.0
@@ -54,8 +49,8 @@ if {${subport} eq ${name}} {
 if {${subport} eq "cquery-devel"} {
     minimum_xcodeversions {16 8.3}
 
-    github.setup             cquery-project cquery 634f73b581815c3bdd5c2d273dcf888596e212fd
-    version                  20180609
+    github.setup             cquery-project cquery ce362a888dd1fc00469ab1af58bc4f0a8c081a5f
+    version                  20180621
 
     depends_lib              port:clang-6.0
     configure.args-append    --llvm-config=llvm-config-mp-6.0


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

* remove asan variant as it is useful only for debugging cquery
* update cquery-devel to ce362a888dd1fc00469ab1af58bc4f0a8c081a5f

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
