### PR TITLE
libressl-devel: update to 2.7.4

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libressl-devel
-version             2.7.3
+version             2.7.4
 distname            libressl-${version}
 
 categories          security devel
@@ -23,8 +23,8 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160 54394d02692a63ec51445a7ea7eab37dabe931f5 \
-                    sha256 16c70d8fe1de6e9bedea0d67804b55f3894717693a05ed45e15e0e2f939c2795
+checksums           rmd160 e2fff57fe8ae432a4b3104561d2ba1ee16804242 \
+                    sha256 1e3a9fada06c1c060011470ad0ff960de28f9a0515277d7336f7e09362517da6
 
 patchfiles \
     openssldir-cert.pem.patch


### PR DESCRIPTION
This updated libressl-devel to the latest release.
Tested on MacOSX 10.13.5 with curl, ldns, lynx, openssh, xar.

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
