### PR TITLE
gradle: update to 4.8.1

### DIFF
--- a/devel/gradle/Portfile
+++ b/devel/gradle/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gradle
-version             4.8
+version             4.8.1
 categories          devel java groovy
 license             Apache-2
 maintainers         {@amake madlon-kay.com:aaron+macports} openmaintainer
@@ -20,9 +20,9 @@ platforms           darwin
 distname            ${name}-${version}-bin
 master_sites        https://services.gradle.org/distributions
 
-checksums           rmd160  317bd8d2b67ae5b665638f55844c93bcaacd5b9a \
-                    sha256  f3e29692a8faa94eb0b02ebf36fa263a642b3ae8694ef806c45c345b8683f1ba \
-                    size    75885015
+checksums           rmd160  fa30591ec3d3e426e505d1ff6201c38b2a23a75c \
+                    sha256  af334d994b5e69e439ab55b5d2b7d086da5ea6763d78054f49f147b06370ed71 \
+                    size    75889282
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Gradle 4.8.1.

###### Tested on

macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->