### PR TITLE
maven3: update to 3.5.4

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -4,8 +4,7 @@ PortSystem 1.0
 PortGroup select 1.0
 
 name            maven3
-version         3.5.3
-revision        1
+version         3.5.4
 
 categories      java devel
 license         Apache-2
@@ -34,9 +33,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160 4d6124a0dc34ea2c0692103dc7113c681ede8a25 \
-                sha256 b52956373fab1dd4277926507ab189fb797b3bc51a2a267a193c931fffad8408 \
-                size   8799579
+checksums       rmd160 d6922772982fa8f95f68d43f7faeb24a79e3cc8e \
+                sha256 ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d \
+                size   8842660
 
 depends_run     port:maven_select \
                 bin:java:kaffe


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.5.4.

###### Tested on

macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->