### PR TITLE
openjdk10: new submission

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk10
+version          10.0.1
+
+categories       java devel
+maintainers      {@breun breun.nl:nils} openmaintainer
+platforms        darwin
+license          GPL-2
+supported_archs  x86_64
+
+description      Open Java Development Kit 10
+
+long_description Production-ready, free and open-source build of the Java \
+                 Development Kit, an implementation of the Java Standard \
+                 Edition (SE) 10 Platform. OpenJDK is the official reference \
+                 implementation of Java SE. Included components are the \
+                 HotSpot virtual machine, the Java class library and the Java \
+                 compiler. 
+
+homepage         http://jdk.java.net/10/
+master_sites     https://download.java.net/java/GA/jdk10/${version}/fb4372174a714e6b8c52526dc134031e/10/
+distname         openjdk-${version}_osx-x64_bin
+
+checksums        rmd160  00a1a8a0e63901ecdea7d013f8307ea601e83a55 \
+                 sha256  650e06c203a9d2752d686dc62206580afdc909af924b7ea8573b1c671e182ab0 \
+                 size    200863681
+
+worksrcdir       jdk-${version}.jdk
+
+use_configure    no
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+destroot {
+    set target ${destroot}/Library/Java/JavaVirtualMachines
+    xinstall -m 755 -d ${target}
+    copy ${worksrcpath} ${target}
+}
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     "Java Development Kit, version (\\d+(?:\\.\\d+)*(?:-\\d+)?)"


### PR DESCRIPTION
#### Description

New port for OpenJDK 10.

###### Tested on

macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?