### PR TITLE
openjdk9: new submission

### DIFF
--- a/java/openjdk9/Portfile
+++ b/java/openjdk9/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk9
+version          9.0.4
+
+categories       java devel
+maintainers      {@breun breun.nl:nils} openmaintainer
+platforms        darwin
+license          GPL-2
+supported_archs  x86_64
+
+description      OpenJDK -- Open Java Development Kit
+
+long_description Production-ready, free and open-source build of the Java \
+                 Development Kit, an implementation of the Java Standard \
+                 Edition (SE) 9 Platform. OpenJDK is the official reference \
+                 implementation of Java SE. Included components are the \
+                 HotSpot virtual machine, the Java class library and the Java \
+                 compiler. 
+
+homepage         http://jdk.java.net/9/
+
+master_sites     https://download.java.net/java/GA/jdk9/${version}/binaries/
+distname         openjdk-${version}_osx-x64_bin
+
+checksums        rmd160  0b38a97b6534649ec362d897e7cbd601121bb3eb \
+                 sha256  66415406716fc42cff36e2d74ae991d46c42b3cf317b0425c7bf67697c616716 \
+                 size    188745049
+
+worksrcdir       jdk-${version}.jdk
+
+use_configure    no
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+destroot {
+    set target ${destroot}/Library/Java/JavaVirtualMachines
+    xinstall -m 755 -d ${target}
+    copy ${worksrcpath} ${target}
+}


### PR DESCRIPTION
#### Description

New port for OpenJDK 9.

###### Tested on

macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?