### PR TITLE
rtl_433: update to version 18.05

### DIFF
--- a/science/rtl_433/Portfile
+++ b/science/rtl_433/Portfile
@@ -4,18 +4,20 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 
-github.setup        merbanan rtl_433 bf4f9b4ebd4da642dfc788052d1a99d5812519f8
-version             20160420
+github.setup        merbanan rtl_433 18.05
+version             18.05
+epoch               1
 
 categories          science comms
 license             GPL-2
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@ducksauz duksta.org:john} openmaintainer
 
 description         RTL-SDR 433.92 MHz generic data receiver
 long_description    rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92 MHz generic data receiver
 
-checksums           rmd160  fc20f59f2b9f142b67aed11da98a4998dacd2043 \
-                    sha256  74d13373ff8321e584f0edb1211f8505a1808d1c313f317aa9fa69a51641ab9a
+checksums           rmd160  1fb72247598346407098bb86e3205b8ae93e5c6f \
+                    sha256  88cee0fa07435d6ce88f3d5ce9b5facd5a10cafa3e5467df471468d5a11857c3 \
+                    size    231912
 
 depends_lib-append  port:rtl-sdr


### PR DESCRIPTION
#### Description
Bringing rtl_433 up to the latest tagged release (18.05) for the package.

###### Type(s)
update

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
