### PR TITLE
meson: use git version to fix RPATH handling

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -4,7 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        mesonbuild meson 0.46.1
+# we need a newer version for the sake of fixing a bug with RPATH handling
+# https://github.com/mesonbuild/meson/pull/3691
+github.setup        mesonbuild meson 87871e7b95d4cc89627971f316bdeffebde048e5
+# github.tarball_from releases
+version             0.46.1
+revision            1
 license             Apache-2
 categories          devel python
 maintainers         nomaintainer
@@ -20,11 +25,9 @@ long_description    Meson  is  a  build system designed to optimize programmer p
                     Valgrind,  CCache  and  the like. It is both extremely fast, and, even more importantly, \
                     as user friendly as possible.
 
-github.tarball_from releases
-
-checksums           rmd160  f0e822e1927fcbc17bdf47a37534a234ae3392a7 \
-                    sha256  19497a03e7e5b303d8d11f98789a79aba59b5ad4a81bd00f4d099be0212cee78 \
-                    size    1203713
+checksums           rmd160  b9a5011595c2bc747fd0c09d5c3937a33ecd77f7 \
+                    sha256  efe087b9fda52742fbb3db459f2ba6d23da15fa9911e20749c9ec20b30871be8 \
+                    size    1798369
 
 # as of verison 0.45.0,requires python 3.5 or better
 


### PR DESCRIPTION
#### Description

This switches to a newer version of meson for the sake of fixing a nasty bug with RPATH handling.

See: https://github.com/mesonbuild/meson/pull/3691

@kencu, @dbevans etc.: I would be grateful for more testing. I tried `libhttpseverywhere`. The installed library seems OK, but the test fails due to `@rpath` again (however I'm not yet sure if that's a bug in meson or a bug in the `libhttpseverywhere`'s meson build script itself). I wanted to try epiphany, but was a bit scared after I saw all the dependencies :) I'll try to check a few more.

Not sure about version. It says
```
meson --version
0.47.0.dev1
```
but I don't want to use this exact string, else we'll need to change the epoch later.

If this works as expected, we should remove `install_name_tool` workarounds from ports using meson.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
