### PR TITLE
mpc: whitespace changes only

### DIFF
--- a/audio/mpc/Portfile
+++ b/audio/mpc/Portfile
@@ -1,37 +1,39 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup  meson 1.0
+PortSystem          1.0
+PortGroup           meson 1.0
 
-name            mpc
-version         0.30
-set branch      [join [lrange [split ${version} .] 0 0] .]
-categories      audio
-maintainers     {lbschenkel @lbschenkel} openmaintainer
-license         GPL-2+
-description     a command line tool for MPD
-long_description \
-    mpc is a simple command line client for MPD.\
-    Music Player Daemon (MPD) allows remote access for playing music (MP3, Ogg\
-    Vorbis, FLAC, AAC, Mod, and wave files) and managing playlists. MPD is\
-    designed for integrating a computer into a stereo system that provides\
-    control for music playback over a local network. It also makes a great\
-    desktop music player, especially if you are a console junkie, like\
-    frontend options, or restart X often.
-homepage        https://www.musicpd.org/clients/${name}/ 
-master_sites    https://www.musicpd.org/download/${name}/${branch}/
-platforms       darwin
+name                mpc
+version             0.30
+set branch          [join [lrange [split ${version} .] 0 0] .]
+categories          audio
+maintainers         {lbschenkel @lbschenkel} openmaintainer
+license             GPL-2+
+
+description         a command line tool for MPD
+long_description    mpc is a simple command line client for MPD.\
+                    Music Player Daemon (MPD) allows remote access for playing music (MP3, Ogg\
+                    Vorbis, FLAC, AAC, Mod, and wave files) and managing playlists. MPD is\
+                    designed for integrating a computer into a stereo system that provides\
+                    control for music playback over a local network. It also makes a great\
+                    desktop music player, especially if you are a console junkie, like\
+                    frontend options, or restart X often.
+
+homepage            https://www.musicpd.org/clients/${name}/
+master_sites        https://www.musicpd.org/download/${name}/${branch}/
+platforms           darwin
 depends_build-append \
-                port:pkgconfig
-depends_lib     port:libiconv port:libmpdclient
+                    port:pkgconfig
+depends_lib         port:libiconv \
+                    port:libmpdclient
 
-use_xz          yes
+use_xz              yes
 
-checksums       rmd160  aac3298e45cf3378e1c2374f5ace04c4829834a1 \
-                sha256  65fc5b0a8430efe9acbe6e261127960682764b20ab994676371bdc797d867fce \
-                size    41968
+checksums           rmd160  aac3298e45cf3378e1c2374f5ace04c4829834a1 \
+                    sha256  65fc5b0a8430efe9acbe6e261127960682764b20ab994676371bdc797d867fce \
+                    size    41968
 
-patchfiles      patch-iconv.diff
+patchfiles          patch-iconv.diff
 
-livecheck.url   http://www.musicpd.org/download/${name}/${branch}/
-livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)"
+livecheck.url       http://www.musicpd.org/download/${name}/${branch}/
+livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)"


### PR DESCRIPTION
#### Description

I was checking out various ports depending on meson, but this one is not affected by the bug anyway, I only wanted to fix the spacing, if maintainer agrees.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
