### PR TITLE
new ports: p5-future (0.38), p5-io-async (0.72)

### DIFF
--- a/perl/p5-future/Portfile
+++ b/perl/p5-future/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26
+perl5.setup         Future 0.38 ../by-authors/id/P/PE/PEVANS
+
+platforms           darwin
+maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
+license             {Artistic-1 GPL}
+
+supported_archs     noarch
+
+description         Future - represent an operation awaiting completion
+
+long_description    ${description}
+
+checksums           rmd160  3fdcebdc931fb5836b67f66fa08f1d268a917749 \
+                    sha256  68426ec98108b0d6311994b9201e8644cb25ee46497e6501b71a4555c9218463 \
+                    size    87772
+
+if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-test-fatal \
+                    port:p${perl5.major}-test-identity \
+                    port:p${perl5.major}-test-pod \
+                    port:p${perl5.major}-test-refcount
+    depends_lib-append \
+                    port:p${perl5.major}-test-simple \
+                    port:p${perl5.major}-test-refcount \
+                    port:p${perl5.major}-time-hires
+}
+
+perl5.use_module_build

--- a/perl/p5-io-async/Portfile
+++ b/perl/p5-io-async/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26
+perl5.setup         IO-Async 0.72
+
+platforms           darwin
+maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
+license             {Artistic-1 GPL}
+
+supported_archs     noarch
+
+description         IO::Async - Asynchronous event-driven programming
+
+long_description    ${description}
+
+checksums           rmd160  431ef96865feb16a2b50a1aaa89f071225273353 \
+                    sha256  76420062a5d694de5775f56eaa49b7f56a104dc88459287a032f4a69ebbad964 \
+                    size    236223
+
+if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-file-temp \
+                    port:p${perl5.major}-test-fatal \
+                    port:p${perl5.major}-test-identity \
+                    port:p${perl5.major}-test-simple \
+                    port:p${perl5.major}-test-refcount \
+                    port:p${perl5.major}-test-pod
+    depends_lib-append \
+                    port:p${perl5.major}-future \
+                    port:p${perl5.major}-io \
+                    port:p${perl5.major}-socket \
+                    port:p${perl5.major}-storable \
+                    port:p${perl5.major}-struct-dumb \
+                    port:p${perl5.major}-time-hires \
+                    port:p${perl5.major}-io-socket-ip
+}
+
+perl5.use_module_build


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

<span>
<details><summary>Full results for p5-future:</summary> 
<pre>
--->  Testing p5.26-future
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-future/p5.26-future/work/Future-0.38" && /opt/local/bin/perl5.26 Build test
t/00use.t ..................... ok
t/01future.t .................. ok
t/02cancel.t .................. ok
t/03then.t .................... ok
t/04else.t .................... ok
t/05then-else.t ............... ok
t/06followed_by.t ............. ok
t/07catch.t ................... ok
t/09transform.t ............... ok
t/10wait_all.t ................ ok
t/11wait_any.t ................ ok
t/12needs_all.t ............... ok
t/13needs_any.t ............... ok
t/20subclass.t ................ ok
t/21debug.t ................... ok
t/22wrap_cb.t ................. ok
t/30utils-call.t .............. ok
t/31utils-call-with-escape.t .. ok
t/32utils-repeat.t ............ ok
t/33utils-repeat-generate.t ... ok
t/34utils-repeat-foreach.t .... ok
t/35utils-map-void.t .......... ok
t/36utils-map.t ............... ok
t/40mutex.t ................... ok
t/50test-future.t ............. ok
t/90legacy.t .................. ok
t/99pod.t ..................... ok
All tests successful.
Files=27, Tests=649,  3 wallclock secs ( 0.14 usr  0.08 sys +  2.62 cusr  0.45 csys =  3.29 CPU)
Result: PASS
</pre>
</details>
<br />
</span>

<span>
<details><summary>Full results for p5-io-async:</summary> 
<pre>
--->  Testing p5.26-io-async
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-io-async/p5.26-io-async/work/IO-Async-0.72" && /opt/local/bin/perl5.26 Build test
t/00use.t .................... ok
t/01timequeue.t .............. ok
t/02os.t ..................... ok
t/03loop-magic.t ............. ok
t/04notifier.t ............... ok
t/05notifier-loop.t .......... ok
t/06notifier-mixin.t ......... ok
t/07notifier-future.t ........ ok
t/10loop-poll-io.t ........... ok
t/10loop-select-io.t ......... ok
t/11loop-poll-timer.t ........ ok
t/11loop-select-timer.t ...... ok
t/12loop-poll-signal.t ....... ok
t/12loop-select-signal.t ..... ok
t/13loop-poll-idle.t ......... ok
t/13loop-select-idle.t ....... ok
t/14loop-poll-child.t ........ ok
t/14loop-select-child.t ...... ok
t/15loop-poll-control.t ...... ok
t/15loop-select-control.t .... ok
t/18loop-poll-legacy.t ....... ok
t/18loop-select-legacy.t ..... ok
t/19loop-future.t ............ ok
t/19test.t ................... ok
t/20handle.t ................. ok
t/21stream-1read.t ........... ok
t/21stream-2write.t .......... ok
t/21stream-3split.t .......... ok
t/21stream-4encoding.t ....... ok
t/22timer-absolute.t ......... ok
t/22timer-countdown.t ........ ok
t/22timer-periodic.t ......... ok
t/23signal.t ................. ok
t/24listener.t ............... ok
t/25socket.t ................. ok
t/26pid.t .................... ok
t/27file.t ................... ok
t/28filestream.t ............. ok
t/30loop-fork.t .............. ok
t/31loop-spawnchild.t ........ ok
t/32loop-spawnchild-setup.t .. ok
t/33process.t ................ ok
t/34process-handles.t ........ ok
t/35loop-openprocess.t ....... ok
t/36loop-runchild.t .......... ok
t/37loop-child-root.t ........ skipped: not root
t/38loop-thread.t ............ ok
t/40channel.t ................ ok
t/41routine.t ................ ok
Warning: unable to close filehandle $wr properly: Bad file descriptor during global destruction.
Warning: unable to close filehandle $wr properly: Bad file descriptor during global destruction.
Warning: unable to close filehandle $out properly: Bad file descriptor during global destruction.
Warning: unable to close filehandle $out properly: Bad file descriptor during global destruction.
Warning: unable to close filehandle properly: Bad file descriptor during global destruction.
Warning: unable to close filehandle properly: Bad file descriptor during global destruction.
t/42function.t ............... ok
t/50resolver.t ............... ok
t/51loop-connect.t ........... ok
t/52loop-listen.t ............ ok
t/53loop-extend.t ............ ok
t/60protocol.t ............... ok
t/61protocol-stream.t ........ ok
t/62protocol-linestream.t .... ok
t/63handle-connect.t ......... ok
t/64handle-bind.t ............ ok
t/99pod.t .................... ok
All tests successful.
Files=60, Tests=1615, 111 wallclock secs ( 0.38 usr  0.18 sys + 11.09 cusr  2.38 csys = 14.03 CPU)
Result: PASS
</pre>
</details>
<br />
</span>

- [x] tried a full install with `sudo port -vst install`?
- [ ] ~~tested basic functionality of all binary files?~~

No scripts get installed. I've tried some of the examples from [IO-Async-0.72/examples](https://metacpan.org/source/PEVANS/IO-Async-0.72/examples) and [Future-0.38/examples](https://metacpan.org/source/PEVANS/Future-0.38/examples); io-async.pl, whoami-server.pl, chat-server.pl, and tail-logfile.pl work. But the example for [IO::Async::Stream](https://metacpan.org/pod/IO::Async::Stream#SYNOPSIS) doesn't seem to work. 

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
