### PR TITLE
update perl5 PortGroup livecheck.regex

### DIFF
--- a/_resources/port1.0/group/perl5-1.0.tcl
+++ b/_resources/port1.0/group/perl5-1.0.tcl
@@ -231,7 +231,7 @@ proc perl5.setup {module vers {cpandir ""}} {
     
     if {${perl5.use_search_cpan_org}} {
         livecheck.url       http://search.cpan.org/dist/${perl5.module}/
-        livecheck.regex     >[quotemeta ${perl5.module}]-(\[^"\]+?)<
+        livecheck.regex     >[quotemeta ${perl5.module}]-(\[^"\ \]+?)<
     } else {
         livecheck.url       https://fastapi.metacpan.org/v1/release/${perl5.module}/
         livecheck.regex     \"name\" : \"[quotemeta ${perl5.module}]-(\[^"\]+?)\"


### PR DESCRIPTION
Ports which currently have `use_search_cpan_org` now appear to be redirecting from `http://search.cpan.org/dist/${perl5.module}/` to `https://metacpan.org/release/${perl5.module}/`. The livecheck regex was capturing the module description in the page's `<title>` tag as being part of the version, e.g.
```html
<title>mytop-1.2 - display MySQL server performance info like `top' - metacpan.org</title>
```
resulting in:
```
p5-mytop seems to have been updated (port version: 1.2, new version: 1.2 - display MySQL server performance info like `top' - metacpan.org)
```

A workaround for this is to have `livecheck.regex` exclude spaces so that it stops before the description. While some of the affected portfiles do livecheck and fetch properly if `use_search_cpan_org` is removed, this is a quicker fix for the time being.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
