### PR TITLE
shards: new port, version 0.8.1-devel

### DIFF
--- a/www/shards/Portfile
+++ b/www/shards/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        crystal-lang shards 0.8.1-devel v
+
+categories          www
+platforms           darwin
+license             Apache-2
+maintainers         {@conradwt gmail.com:conradwt} openmaintainer
+
+description         Crystal application dependency manager
+
+long_description    Shards is a dependency manager for the Crystal Programming Language.
+
+depends_lib         port:crystal
+
+checksums           rmd160  dc60ef24d2e9e812138e042659c6f1599c68a312 \
+                    sha256  d4a56101262ae9a9ce4352f534d532941dc2a2429e67fc263460d682eba088ff \
+                    size    31381
+
+pre-fetch {
+  if {${os.major} < 16} {
+    ui_error "${name} @${version} requires macOS 10.12 or newer."
+    return -code error "incompatible macOS version"
+  }
+}
+
+use_configure       no
+
+build.args          CRFLAGS=--release
+
+destroot.args       PREFIX=${prefix}
+
+test.run            yes
+test.cmd            bin/shards install && make test


### PR DESCRIPTION
#### Description

Shards is a dependency manager for the Crystal Programming Language.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A314h
Xcode 10.0 10L177m 

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
