### PR TITLE
Update Portfile to install octave-signal with octave-devel 5.0.0_0

### DIFF
--- a/math/octave-signal/Portfile
+++ b/math/octave-signal/Portfile
@@ -5,6 +5,7 @@ PortGroup           octave 1.0
 
 octave.setup        signal 1.4.0
 revision            1
+categories          math science
 platforms           darwin
 license             GPL-3+ public-domain
 maintainers         nomaintainer

--- a/math/octave-signal/Portfile
+++ b/math/octave-signal/Portfile
@@ -18,3 +18,11 @@ checksums           rmd160  9d63ca9b94b3e6649f01964639e2eea40a4f0d8d \
 
 depends_lib-append  port:octave-control \
                     port:octave-specfun
+
+post-patch {
+    reinplace -W ${worksrcpath}/src -E \
+        "s|\[\[:<:\]\]gripe_(\[\[:alnum:\]_\]*)\[\[:>:\]\]|err_\\1|g;\n \
+        s|\[\[:<:\]\]NINT\[\[:>:\]\]|octave::math::x_nint|g;\n \
+        s|#include +<octave/gripes.h> *$||" \
+        remez.cc sosfilt.cc upfirdn.cc
+}


### PR DESCRIPTION
Update Portfile to install octave-signal with octave-devel 5.0.0_0

#### Description

Why:
Recent changes in octave-devel 5.0.0_0 seem to have broken octave-signal.
Specifically:

1. Nearest integer macro/template NINT() is replaced with template x_nint()
2. Function defines of the form gripe_...() in include gripes.h have been renamed to err_...() and moved into err_warn.h  
3. gripes.h has disappeared

Detail: https://savannah.gnu.org/bugs/?47042 

The update changes the affected files, in a single search and replace ("reinplace") operation as a post-patch phase, which is triggered even if there is no patch.
The Regexp is very ugly but has been verified to work with a successful install, both with octave 4.4 and 5.0 .
Good only as a workaround until the upstream source is updated.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G22008
Xcode 8.2.1 8C1002 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->