### PR TITLE
libdazzle: new port @ 2.29.3

### DIFF
--- a/gnome/libdazzle/Portfile
+++ b/gnome/libdazzle/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           meson 1.0
+
+name                libdazzle
+version             3.29.3
+license             GPL-3+
+set branch          [join [lrange [split ${version} .] 0 1] .]
+description         ${name} is a companion library to GObject and Gtk+.
+long_description    ${description}  It includes a collection of dazzling Gtk widgets, \
+                    data structures, search engines, a shortcut engine, panels, \
+                    desktop integration, and those missing pieces from common libraries \
+                    that help you write cleaner and safer code
+
+# {devans @dbevans} -- feel free to add yourself if you wish
+maintainers         {kencu @kencu} openmaintainer
+categories          gnome
+platforms           darwin
+homepage            https://gitlab.gnome.org/GNOME/${name}
+master_sites        gnome:sources/${name}/${branch}/
+
+use_xz              yes
+
+checksums           rmd160  05d2f0fcc6612a103ba59c8c13285cdac94be792 \
+                    sha256  35e46c2b28bab7f74c4a7fec7ff3158c2dca1d3f887d09fb709bf00f6454a6bf \
+                    size    423200
+
+depends_build-append \
+                    port:pkgconfig \
+                    port:vala \
+                    port:gobject-introspection
+
+depends_lib-append  port:gtk3
+livecheck.type      gnome


### PR DESCRIPTION
support library for gnome applications
required for newer epiphany versions

@dbevans -- would you take a look at this? It's my first gnome submission, and I don't know all the nuances of gnome. I put you down as a maintainer, just because you're a maintainer of every other gnome thing so it only seemed correct.