### PR TITLE
Update Portfile and patch for octave 5.0 or later

### DIFF
--- a/math/octave-communications/files/patch-fixes_for_4.4.0_5.diff
+++ b/math/octave-communications/files/patch-fixes_for_4.4.0_5.diff
@@ -1,0 +1,58 @@
+--- a/src/genqamdemod.cc.orig	2015-04-04 12:28:43.000000000 -0400
++++ b/src/genqamdemod.cc	2018-06-27 15:23:26.000000000 -0400
+@@ -16,6 +16,7 @@
+ 
+ #include <octave/oct.h>
+ 
++#define empty_arg(n, r, c) ((r) == 0 || (c) == 0)
+ DEFUN_DLD (genqamdemod, args, ,
+  "-*- texinfo -*-\n\
+ @deftypefn {Loadable Function} {@var{y} =} genqamdemod (@var{x}, @var{C})\n\
+--- a/src/gf.cc	2015-04-04 12:28:43.000000000 -0400
++++ b/src/gf.cc	2018-06-27 23:23:58.000000000 -0400
+@@ -40,6 +40,7 @@
+ #include "galois.h"
+ #include "ov-galois.h"
+ 
++#define empty_arg(n, r, c) ((r) == 0 || (c) == 0)
+ static bool galois_type_loaded = false;
+ 
+ // PKG_ADD: autoload ("isgalois", "gf.oct");
+@@ -1066,7 +1067,7 @@
+     }
+   if (nr != nc)
+     {
+-      gripe_square_matrix_required ("ginverse");
++      gripe_square_matrix_required ("ginverse", NULL);
+       return retval;
+     }
+ 
+@@ -1164,7 +1165,7 @@
+ 
+   if (nr != nc)
+     {
+-      gripe_square_matrix_required ("det");
++      gripe_square_matrix_required ("det", NULL);
+       return retval;
+     }
+ 
+--- a/src/ov-galois.cc	2018-06-27 15:50:05.000000000 -0400
++++ b/src/ov-galois.cc	2018-06-27 23:38:19.000000000 -0400
+@@ -328,7 +328,7 @@
+ 
+   if (rows () > 0 && columns () > 0)
+     {
+-      gripe_implicit_conversion ("Octave:array-as-scalar",
++      warn_implicit_conversion ("Octave:array-as-scalar",
+                                  "real matrix", "real scalar");
+ 
+       retval = (double) gval (0, 0);
+@@ -348,7 +348,7 @@
+ 
+   if (rows () > 0 && columns () > 0)
+     {
+-      gripe_implicit_conversion ("Octave:array-as-scalar",
++      warn_implicit_conversion ("Octave:array-as-scalar",
+                                  "real matrix", "real scalar");
+ 
+       retval = (double) gval (0, 0);


### PR DESCRIPTION
#### Description

This is a workaround for the deprecation and replacement of "gripe_*" functions in favor of "err_*" and "warn_*" in octave 4.4 and later.
###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G22008
Xcode 8.2.1 8C1002
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->