### PR TITLE
py-lmfit: update to 0.9.11, add dependency

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-lmfit
-version                 0.9.10
+version                 0.9.11
 categories-append       math
 license                 BSD
 maintainers             {gmail.com:jjstickel @jjstickel} {gmail.com:ottenr.work @reneeotten} openmaintainer
@@ -18,9 +18,9 @@ homepage                https://lmfit.github.io/lmfit-py/
 master_sites            pypi:l/lmfit/
 distname                lmfit-${version}
 
-checksums               rmd160  d6280d2da50a2ada0f44e1d4715e526383320c7c \
-                        sha256  72ff4abdeb7b97ad8434ed3796783425750ce6286e032a265ae44ade05d92eae \
-                        size    1590006
+checksums               rmd160  fe1c29354627524f769cde7f03517dad45d7cacb \
+                        sha256  f635c69fa67cd4d3daa1148f449abc2ff1e19adf5761b3eac7d314224d7506e2 \
+                        size    1600601
 
 python.versions         27 34 35 36
 
@@ -30,7 +30,8 @@ if {$subport ne $name} {
     depends_lib-append         port:py${python.version}-scipy \
                                port:py${python.version}-numpy \
                                port:py${python.version}-six \
-                               port:py${python.version}-asteval
+                               port:py${python.version}-asteval \
+                               port:py${python.version}-uncertainties
 
     depends_test-append        port:py${python.version}-pytest
     test.run                   yes


### PR DESCRIPTION
#### Description
* update to version 0.9.11
* add dependency on ```py-uncertainties```

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
