### PR TITLE
tomcat-native: update to 1.2.17

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                tomcat-native
-version             1.2.16
+version             1.2.17
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
 license             Apache-2
@@ -16,8 +16,9 @@ long_description    This port provides access to native apr and other \
 homepage            http://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  65dc8256c78d3fa2e1f3133c5cf650c108c23b8e \
-                    sha256  1e9409584c19d868efd056f7dbafc767a630a5a95ee3cd516de8b7aaa4cd97b6
+checksums           rmd160  947417c6c0580570e86081931dcad57db2bec4f9 \
+                    sha256  e16858e6ad91c26c17491a26f3ed4a53ab441c44fb3490caf09075ef4dda857e \
+                    size    408967
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native
@@ -37,8 +38,8 @@ if {[info exists env(JAVA_HOME)]} {
 build.args          EXTRA_LDFLAGS="-shrext .jnilib"
 
 notes "
-To integrate this into tomcat, add something like
--Djava.library.path=${prefix} to the tomcat options.
+To integrate this into tomcat, add -Djava.library.path=${prefix} to the tomcat options or
+to CATALINA_OPTS.
 
 You then need to configure a Connector in server.xml
 with the appropriate apr protocol class for your use,
@@ -51,7 +52,8 @@ As in:
     <Connector port=\"8081\" maxHttpHeaderSize=\"8192\"
                maxThreads=\"150\" minSpareThreads=\"25\" maxSpareThreads=\"75\"
                enableLookups=\"false\" redirectPort=\"8443\" acceptCount=\"100\"
-               connectionTimeout=\"20000\" disableUploadTimeout=\"true\" protocol=\"org.apache.coyote.http11.Http11AprProtocol\" />
+               connectionTimeout=\"20000\" disableUploadTimeout=\"true\"
+               protocol=\"org.apache.coyote.http11.Http11AprProtocol\" />
 
 For further information please see https://tomcat.apache.org/native-doc/index.html
 "


### PR DESCRIPTION
#### Description

Update Tomcat-native to 1.2.17

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.5
Xcode 9.4.1

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
