### PR TITLE
py-pyscard: update to 1.9.7

### DIFF
--- a/python/py-pyscard/Portfile
+++ b/python/py-pyscard/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        LudovicRousseau pyscard 1.9.6 release-
+github.setup        LudovicRousseau pyscard 1.9.7 release-
 name                py-pyscard
 platforms           darwin
 license             GPL
@@ -15,8 +15,9 @@ long_description    ${description}
 
 homepage            https://pyscard.sourceforge.io/
 
-checksums           rmd160  1c8ed2bf25edfe573b59f0010ceca4f5a3fac25b \
-                    sha256  2ce5b157e77e1ecb70fdf7f6275f1f701f23fa80918d56d54f8b9ea88a8277ff
+checksums           rmd160  6718baf57c8a1ceadbe56e867cacf8d79b33d453 \
+                    sha256  1f1512d4db939f831e4ab1b83df3963473d56e13b3e808868aadb8934d58dfa7 \
+                    size    175823
 
 python.versions     27 35 36
 


### PR DESCRIPTION
#### Description

Update py-pyscard to 1.9.7. The project has not yet indicated compatibility with Python 3.7, so I haven't added it yet.
