### PR TITLE
vtk: Add variant to compile HDF5-related stuff

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -24,6 +24,8 @@ long_description    Visualization Toolkit (VTK) is an open-source, freely \
 homepage            http://www.vtk.org
 master_sites        http://www.vtk.org/files/release/${branch}
 
+patchfiles          patch-cmake-install-dir.diff
+
 distname            VTK-${version}
 
 checksums           rmd160  bfc1baf925ba1f497f14a4576fd0a7956ee42d29 \
@@ -87,6 +89,16 @@ variant python36 conflicts python27 python35 description {Add Python 3.6 support
                         -DVTK_WRAP_PYTHON:BOOL=ON \
                         -DPYTHON_EXECUTABLE:STRING=${prefix}/bin/python3.6 \
                         -DVTK_INSTALL_PYTHON_MODULE_DIR=${frameworks_dir}/Python.framework/Versions/3.6/lib/python3.6/site-packages
+}
+
+variant hdf5 description {Add hdf5 readers} {
+    depends_lib-append port:hdf5 port:boost port:netcdf-cxx
+    configure.args-append \
+    -DVTK_USE_SYSTEM_HDF5=ON \
+    -DVTK_USE_SYSTEM_NETCDF=ON \
+    -DNETCDF_DIR=${prefix} \
+    -DBOOST_ROOT=${prefix} \
+    -DModule_vtkIOXdmf3:BOOL=ON 
 }
 
 if {![variant_isset python35] && ![variant_isset python36]} {

--- a/graphics/vtk/files/patch-cmake-install-dir.diff
+++ b/graphics/vtk/files/patch-cmake-install-dir.diff
@@ -1,0 +1,8 @@
+--- ThirdParty/xdmf3/vtkxdmf3/CMakeLists.txt.orig	2018-07-02 09:17:38.000000000 -0700
++++ ThirdParty/xdmf3/vtkxdmf3/CMakeLists.txt	2018-07-02 09:18:44.000000000 -0700
+@@ -446,4 +446,4 @@
+ 
+ xdmf_create_config_file(${PROJECT_NAME})
+ install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+-  DESTINATION ${CMAKE_INSTALL_PREFIX})
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")


### PR DESCRIPTION
#### Description
Adding to VTK port the possibility of building HDF5 readers. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
