### PR TITLE
snappy: Provide shared library only

### DIFF
--- a/archivers/snappy/Portfile
+++ b/archivers/snappy/Portfile
@@ -36,5 +36,7 @@ checksums           rmd160  a512cb6b3954ef42a8a54c30787fda79d430bb20 \
 depends_lib         port:lzo2 \
                     port:zlib
 
+patchfiles          api-version.patch
+
 configure.args-append \
                     -DBUILD_SHARED_LIBS=ON

--- a/archivers/snappy/Portfile
+++ b/archivers/snappy/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        google snappy 1.1.7
+revision            1
 categories          archivers
 platforms           darwin
 maintainers         nomaintainer
@@ -34,3 +35,6 @@ checksums           rmd160  a512cb6b3954ef42a8a54c30787fda79d430bb20 \
 
 depends_lib         port:lzo2 \
                     port:zlib
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON

--- a/archivers/snappy/files/api-version.patch
+++ b/archivers/snappy/files/api-version.patch
@@ -1,0 +1,18 @@
+Fix API version in header
+https://github.com/google/snappy/pull/61
+https://github.com/google/snappy/commit/26102a0c66175bc39edbf484c994a21902e986dc.patch
+--- snappy-stubs-public.h.in.orig
++++ snappy-stubs-public.h.in
+@@ -48,9 +48,9 @@
+ #include <sys/uio.h>
+ #endif  // HAVE_SYS_UIO_H
+ 
+-#define SNAPPY_MAJOR ${SNAPPY_MAJOR}
+-#define SNAPPY_MINOR ${SNAPPY_MINOR}
+-#define SNAPPY_PATCHLEVEL ${SNAPPY_PATCHLEVEL}
++#define SNAPPY_MAJOR ${PROJECT_VERSION_MAJOR}
++#define SNAPPY_MINOR ${PROJECT_VERSION_MINOR}
++#define SNAPPY_PATCHLEVEL ${PROJECT_VERSION_PATCH}
+ #define SNAPPY_VERSION \
+     ((SNAPPY_MAJOR << 16) | (SNAPPY_MINOR << 8) | SNAPPY_PATCHLEVEL)
+ 

--- a/databases/leveldb/Portfile
+++ b/databases/leveldb/Portfile
@@ -22,7 +22,7 @@ platform darwin 10 {
 PortGroup           muniversal 1.0
 
 github.setup        google leveldb 1.20 v
-revision            2
+revision            3
 categories          databases
 platforms           darwin
 license             BSD

--- a/databases/rocksdb/Portfile
+++ b/databases/rocksdb/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        facebook rocksdb 5.11.3 rocksdb-
 
-revision            0
+revision            1
 categories          databases devel
 platforms           darwin
 license             BSD

--- a/databases/sparkey/Portfile
+++ b/databases/sparkey/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 
 github.setup        spotify sparkey ee53521e1025
 version             0.2.99
+revision            1
 maintainers         nomaintainer
 categories          databases
 description         Simple constant key/value storage library, for read-heavy \

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        facebook fbthrift 2018.05.28.00 v
+revision            1
 categories          devel
 platforms           darwin
 license             Apache-2

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -6,7 +6,7 @@ PortGroup           cxx11 1.1
 PortGroup           cmake 1.1
 
 github.setup        facebook folly 2018.05.28.00 v
-revision            1
+revision            2
 categories          devel
 platforms           darwin
 license             Apache-2

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name                    qemu
 version                 2.12.0
+revision                1
 categories              emulators
 license                 GPL-2+
 platforms               darwin

--- a/java/hadoop/Portfile
+++ b/java/hadoop/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                hadoop
 version             1.2.1
+revision            1
 categories          java devel science
 maintainers         nomaintainer
 

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
-revision            6
+revision            7
 categories          math science
 maintainers         nomaintainer
 

--- a/math/shogun-devel/Portfile
+++ b/math/shogun-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.0
 name                shogun-devel
 version             4.0.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            9
+revision            10
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/math/shogun/Portfile
+++ b/math/shogun/Portfile
@@ -6,7 +6,7 @@ PortGroup           compilers 1.0
 name                shogun
 version             2.1.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-revision            14
+revision            15
 categories          math science
 platforms           darwin
 license             GPL-3

--- a/security/aff4/Portfile
+++ b/security/aff4/Portfile
@@ -8,6 +8,7 @@ github.setup        Velocidex c-aff4 fd984ea3cddc034740d5d03ba510a407a2e451a3
 name                aff4
 epoch               1
 version             1.0-20180212
+revision            1
 categories          security
 platforms           darwin
 license             Apache-2


### PR DESCRIPTION
#### Description

The snappy port accidentally only provided a static libsnappy.a instead of libsnappy.dylib as a shared libary. All ports linking with libsnappy need to be rebuilt due to the change in snappy @1.1.7_1.

See: https://trac.macports.org/ticket/55583

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1408
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
