### PR TITLE
plumed: update to 2.4.2

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -9,10 +9,8 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.4.1 v
+github.setup        plumed plumed2 2.4.2 v
 name                plumed
-
-revision            1
 
 categories          science
 
@@ -30,8 +28,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  8762d5c2f28c5281da0410691b0ede4575b73c82 \
-                    sha256  1cf9a2fda224b1c12c64b966c81c9a0e52c1468cf35dfbbe7dad51f3e976b102
+checksums           rmd160  f225ddd0ef3429684246df5d4db1717d44162dd4 \
+                    sha256  90f7cad08ca5f8591db251233a7f559197d186a1b4df7efdb6d263c43a39489d \
+                    size    62368247
 
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
@@ -108,19 +107,21 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 f0eab70af62be7797ed007565d42a2ab88c6303b
-    version             2.5-20180302
-    revision            1
+    github.setup        plumed plumed2 2c38c46c08b8485113de5b07d98799fc9e3bd223
+    version             2.5-20180702
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  ae098ee9a8c2aee503d6c174f9d21bd30cc9c4e5 \
-                        sha256  7f28caafbae93fb81ec3cf17c1a2929313f5b5d79adf9adee6c443cf3826e16d
+    checksums           rmd160  df647cdc23c98778570aad4468f8b9e4fd0eed37 \
+                        sha256  1b96b5b413e440684520a0acb6a2dc1300fd06d020d09b7a07090bc5dfb82d63 \
+                        size    64982448
     configure.ldflags-delete -lmatheval
     depends_lib-delete       port:libmatheval
 # plumed 2.5 supports python. However, I disable it here since it is
 # not correctly integrated with MacPorts yet
     configure.args-append --disable-python
+# install bash completions
+    configure.args-append BASH_COMPLETION_DIR=${prefix}/share/bash-completion/completions
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

Update plumed version. Notice that I updated the plumed-devel port as well, today snapshot.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G20015
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
