### PR TITLE
py-yapf: update to 0.22.0

### DIFF
--- a/python/py-yapf/Portfile
+++ b/python/py-yapf/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-github.setup        google yapf 0.20.1 v
+github.setup        google yapf 0.22.0 v
 name                py-yapf
 categories-append   devel
 license             Apache-2
@@ -17,13 +17,21 @@ long_description \
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  513668fb0d10adfa78c28fd5dc60b4f6e6066c4b \
-                    sha256  6a42aae3447d5bcb85d4cac96ce330a034306d9427914dc5123c87616683c0ff
+checksums           rmd160  fa227c45a1b98564f46844333593cefbde75997c \
+                    sha256  d50d0014de635a86fb45350cbea0b121236aa69276f0a68baea9e2bf6525ef0e \
+                    size    142823
 
 python.versions     27 35 36
 
 if {$subport ne $name} {
-    depends_run     port:yapf_select
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:yapf_select
+
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
 
     select.group    yapf
     select.file     ${filespath}/py${python.version}-yapf


### PR DESCRIPTION
#### Description
- update to version 0.22.0
- add missing dependency on setuptools
- add size to checksums
- enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
