### PR TITLE
py-backports-functools_lru_cache: update to 1.5

### DIFF
--- a/python/py-backports-functools_lru_cache/Portfile
+++ b/python/py-backports-functools_lru_cache/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-backports-functools_lru_cache
-version             1.2.1
+version             1.5
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -23,8 +23,9 @@ master_sites        pypi:b/backports.functools_lru_cache
 
 distname            backports.functools_lru_cache-${version}
 
-checksums           rmd160  7cb67361aed652c6d3f6b472da850bba1e4dda0f \
-                    sha256  1c20e07f1a8a36a19d5d258b6b076e588d78d8fc7c2c4487ffe3a280f55a7bd1
+checksums           rmd160  16dc3b1816cb66a51e265c90e21bc992861bd0ce \
+                    sha256  9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a \
+                    size    7891
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
- update to version 1.5
- add size to checksums

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
