### PR TITLE
py-functools32: fix livecheck, add size to checksums

### DIFF
--- a/python/py-functools32/Portfile
+++ b/python/py-functools32/Portfile
@@ -24,7 +24,8 @@ master_sites        pypi:f/$realName
 distname            $realName-${version}
 
 checksums           rmd160  f96924aa207ac835157f734a785216f57cdb123a \
-                    sha256  f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d
+                    sha256  f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d \
+                    size    31171
 
 python.versions     27
 
@@ -36,7 +37,5 @@ if {${subport} ne ${name}} {
     }
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi?:action=doap&name=$realName
-    livecheck.regex {<revision>(\d+(\.\d+)+(-\d+)?)</revision>}
+    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- fix livecheck
- add size to checksums

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
