### PR TITLE
revamp grep port due to 35915ffebe and adjust its dependents

### DIFF
--- a/audio/tagtool/Portfile
+++ b/audio/tagtool/Portfile
@@ -27,9 +27,7 @@ checksums \
 
 patchfiles      patch-str_util-lp64.diff
 
-depends_build   bin:grep:grep \
-                bin:fgrep:grep \
-                port:pkgconfig \
+depends_build   port:pkgconfig \
                 port:intltool
 depends_lib     port:id3lib \
                 port:libvorbis \

--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -24,7 +24,6 @@ checksums           rmd160  7db2c08a47ea1351d1b8dbb5d1d273e69e5cf24e \
                     sha256  a304382a24d7cc0cb9e5e00dc24474705e4da915e3f670857aa825491dcdbf39 \
                     size    19992333
 
-depends_build       bin:grep:grep
 depends_lib         port:ncurses \
                     port:gettext \
                     port:libiconv

--- a/editors/poedit1/Portfile
+++ b/editors/poedit1/Portfile
@@ -27,13 +27,12 @@ checksums           md5     f5b53ec66a606f088b0aa388595ea5f9 \
 
 wxWidgets.use       wxWidgets-3.0
 
-depends_build       bin:grep:grep \
-                    port:pkgconfig \
+depends_build       port:pkgconfig \
                     port:boost
 depends_lib         port:gettext \
                     port:${wxWidgets.port}
 
-depends_skip_archcheck grep pkgconfig boost
+depends_skip_archcheck pkgconfig boost
 
 patchfiles          patch-src-edframe.cpp.diff
 

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -22,7 +22,6 @@ checksums           rmd160  f849255ee0493d0a82cc3a0fe5b03b8b5e434e55 \
                     sha256  5519e03e956e192e318236139f2e6f76e4b8ee9a309e7959d0b97c29999d7d7b \
                     size    13648310
 
-depends_build       bin:grep:grep
 depends_lib         port:ncurses \
                     port:gettext \
                     port:libiconv

--- a/games/xmoto/Portfile
+++ b/games/xmoto/Portfile
@@ -22,8 +22,6 @@ distname        xmoto-${version}-src
 checksums       rmd160  4b005c37871489f54c16c9557e6a8556cd2121b4 \
                 sha256  a584a6f9292b184686b72c78f16de4b82d5c5b72ad89e41912ff50d03eca26b2
 
-depends_build   bin:grep:grep
-
 depends_lib     port:libpng \
                 port:jpeg \
                 port:libsdl \

--- a/math/gfm/Portfile
+++ b/math/gfm/Portfile
@@ -19,7 +19,6 @@ checksums           md5     9376fb0b59e3c7fac17d675fb165ff53 \
 use_bzip2           yes
 
 depends_build       port:pkgconfig \
-                    bin:grep:grep \
                     bin:groff:groff
 
 depends_lib         port:libiconv \

--- a/math/libticables2/Portfile
+++ b/math/libticables2/Portfile
@@ -18,8 +18,7 @@ checksums           md5     1e412cd5b27fa38099cc4c5326ba99e0 \
                     sha1    468fc783e07a6349f27185498f340f5ee6af565c \
                     rmd160  0d8df15f82fe587caa235672c1ccf357e5066404
 
-depends_build       port:pkgconfig \
-                    bin:grep:grep
+depends_build       port:pkgconfig
 
 depends_lib         port:libticonv \
                     port:libtifiles2 \

--- a/math/libticalcs2/Portfile
+++ b/math/libticalcs2/Portfile
@@ -19,8 +19,7 @@ checksums           md5     bb88a1200e3bce4e58718a0284933e97 \
                     sha1    cda1d356816b352618d25fc2d7afed59352a91ad \
                     rmd160  c5bed4064c708489835dc591d04bbc7d7fa5a747
 
-depends_build       bin:grep:grep \
-                    port:pkgconfig
+depends_build       port:pkgconfig
 
 depends_lib         port:gettext \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \

--- a/math/libticonv/Portfile
+++ b/math/libticonv/Portfile
@@ -18,8 +18,7 @@ checksums           md5     c669598f9917a8f98b26eed1fa27242f \
                     sha1    54ea00bf8123e1d8ea33d2a1adec3ffaf99317a0 \
                     rmd160  5077248d2e878473d19999f0211b04d8f44a4f80
 
-depends_build       port:pkgconfig \
-                    bin:grep:grep
+depends_build       port:pkgconfig
 
 depends_lib         port:libiconv \
                     port:libusb-compat \

--- a/math/libtifiles2/Portfile
+++ b/math/libtifiles2/Portfile
@@ -18,8 +18,7 @@ checksums           md5     3a0efc82d841a6c232837c34a18a8a24 \
                     sha1    ed08600bd767cf878e56cbd55143e16d42ecd372 \
                     rmd160  cdac8e83f70c1019d00ba0d7e230911d770ec173
 
-depends_build       port:pkgconfig \
-                    bin:grep:grep
+depends_build       port:pkgconfig
 
 depends_lib         port:libticonv \
                     port:gettext \

--- a/math/tiemu3/Portfile
+++ b/math/tiemu3/Portfile
@@ -22,7 +22,6 @@ checksums           md5     2736440d717a0ee97cdb35189814fc93 \
                     rmd160  88bc445977f5301bb6c57b19df3e982b5f703068
 
 depends_build       port:pkgconfig \
-                    bin:grep:grep \
                     bin:groff:groff
 
 depends_lib         port:libiconv \

--- a/math/tilp2/Portfile
+++ b/math/tilp2/Portfile
@@ -19,7 +19,6 @@ checksums           md5     eaea086a5041bb970977de7e65fd9bfa \
 use_bzip2           yes
 
 depends_build       port:pkgconfig \
-                    bin:grep:grep \
                     bin:groff:groff
 
 depends_lib         port:libiconv \

--- a/net/mcabber/Portfile
+++ b/net/mcabber/Portfile
@@ -38,6 +38,9 @@ depends_build       port:autoconf \
                     port:grep \
                     port:gsed
 
+# To find GNU grep instead of system grep
+configure.env-append GREP=${prefix}/libexec/gnubin/grep
+
 configure.args      --enable-otr \
                     --with-libotr-prefix=${prefix}/lib \
                     --with-libotr-inc-prefix=${prefix}/include

--- a/science/liquid-dsp/Portfile
+++ b/science/liquid-dsp/Portfile
@@ -41,8 +41,8 @@ pre-configure {
 
 configure.env-append \
     SED=${prefix}/bin/gsed \
-    GREP=${prefix}/bin/grep \
-    EGREP="${prefix}/bin/grep -E"
+    GREP=${prefix}/bin/ggrep \
+    EGREP="${prefix}/bin/ggrep -E"
 
 # remove top-level include path, such that internal headers are used
 # instead of any already-installed ones.

--- a/security/openvas-client/Portfile
+++ b/security/openvas-client/Portfile
@@ -26,8 +26,7 @@ long_description \
     the client component.
 
 depends_build \
-    port:pkgconfig \
-    bin:grep:grep
+    port:pkgconfig
 
 depends_lib \
     path:bin/gdlib-config:gd2 \

--- a/security/openvas-libraries/Portfile
+++ b/security/openvas-libraries/Portfile
@@ -26,8 +26,7 @@ long_description \
     contains the libraries used by the server component.
 
 depends_build \
-    port:pkgconfig \
-    bin:grep:grep
+    port:pkgconfig
 
 depends_lib             port:gettext \
                         path:lib/pkgconfig/glib-2.0.pc:glib2 \

--- a/security/openvas-plugins/Portfile
+++ b/security/openvas-plugins/Portfile
@@ -26,7 +26,6 @@ long_description \
 
 depends_build \
     port:pkgconfig \
-    bin:grep:grep \
     path:bin/gsed:gsed
 
 depends_lib \

--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -106,8 +106,8 @@ checksums-append    bash44-001 \
                     sha256  4fec236f3fbd3d0c47b893fdfa9122142a474f6ef66c20ffb6c0f4864dd591b6 \
                     size    1557
 
-depends_build           bin:grep:grep \
-                        bin:bison:bison
+depends_build           bin:bison:bison
+
 depends_lib             port:gettext \
                         port:ncurses
 

--- a/sysutils/grep/Portfile
+++ b/sysutils/grep/Portfile
@@ -24,6 +24,8 @@ checksums       rmd160  6eaaac1245c653628fd57f07df25b3a60e842891 \
 # Ensure system version of grep is used instead of a possibly broken MacPorts version.
 configure.env   PATH=/usr/bin:$env(PATH)
 
+configure.args --program-prefix=g
+
 depends_lib     port:pcre port:gettext
 
 pre-test {
@@ -33,6 +35,25 @@ pre-test {
 test.run        yes
 test.target     check
 
-variant g_prefix description {Install the program as ggrep} {
-    configure.args-append --program-prefix=g
+post-destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/gnubin
+    foreach binary [glob -tails -directory ${destroot}${prefix}/bin g*] {
+        ln -s ${prefix}/bin/${binary} ${destroot}${prefix}/libexec/gnubin/[string range $binary 1 end]
+    }
+
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/gnubin/man/man1
+    foreach manpage [glob -tails -directory ${destroot}${prefix}/share/man/man1 g*] {
+        ln -s ${prefix}/share/man/man1/${manpage}.gz ${destroot}${prefix}/libexec/gnubin/man/man1/[string range $manpage 1 end].gz
+    }
 }
+
+notes "
+This port previously installed itself without a g* prefix, thus overshadowing
+system binaries such as grep, fgrep, and egrep. The port is now changed so that
+it does install with a g* prefix, like other GNU ports. This means that you'll
+now find GNU grep at ${prefix}/bin/ggrep. If you dislike typing ggrep, you can
+create a shell alias or you can add ${prefix}/libexec/gnubin to your PATH,
+wherein non-g* prefixed symlinks are installed. In other words,
+${prefix}/libexec/gnubin contains GNU binaries without any prefix to the file-
+names, so you can type grep and get GNU grep just as before.
+"

--- a/sysutils/pwgen/Portfile
+++ b/sysutils/pwgen/Portfile
@@ -20,6 +20,4 @@ checksums       sha1    6406deba61297784888c2ec0c14e3c735a85a2b6 \
                 rmd160  2a6550c8aebf570d7116deb28e927ad7f40ae55b \
                 sha256  dab03dd30ad5a58e578c5581241a6e87e184a18eb2c3b2e0fffa8a9cf105c97b
 
-depends_build   bin:grep:grep
-
 configure.args-append    --mandir=${prefix}/share/man

--- a/textproc/dict/Portfile
+++ b/textproc/dict/Portfile
@@ -23,6 +23,10 @@ depends_build       port:bison port:flex port:grep port:libtool
 depends_lib         port:libmaa port:zlib
 configure.env       LIBTOOL=${prefix}/bin/glibtool
 
+# To find GNU grep instead of system grep
+configure.env       GREP=${prefix}/libexec/gnubin/grep \
+                    LIBTOOL=${prefix}/bin/glibtool
+
 set conf_file       ${prefix}/etc/dict.conf
 
 post-destroot {

--- a/textproc/less/Portfile
+++ b/textproc/less/Portfile
@@ -23,7 +23,6 @@ checksums       rmd160  84b4f46be4f93e7a6db3817d43d0bfd1d01d4ff5 \
                 sha256  503f91ab0af4846f34f0444ab71c4b286123f0044a4964f1ae781486c617f2e2 \
                 size    339723
 
-depends_build   bin:grep:grep
 depends_lib     port:ncurses \
                 port:gettext
 


### PR DESCRIPTION
Made as per the discussion on the mailing list about how 35915ffebe breaks things. The beginning of said discussion can be found [here.](https://lists.macports.org/pipermail/macports-dev/2018-June/039101.html) A description of what's going on in these changes can be found in my commit message body.

The only problem that I can see are a couple of particular ports which are actually scripts instead of binaries. They are `p5-config-autoconf` and `vcs`. These ports specify a dependency on `port:grep` specifically so I assume that they rely on GNU grep during runtime. I guess they need to be modified to look for `ggrep`. Should this be done via `post-destroot` and `reinplace` or should something else be done here?

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
