### PR TITLE
php: Add php73 version 7.3.0alpha2

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -20,7 +20,7 @@ long_description        PHP is a widely-used general-purpose scripting \
                         scripting.
 
 # The list of PHP branches this port provides.
-php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2
+php.branches            5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 
 # Fix for users specifying the subport name with the wrong case.
 set subport             [string tolower ${subport}]
@@ -144,13 +144,13 @@ switch ${subport_branch} {
         # master_sites and livecheck, and update php.latest_stable_branch in the
         # php-1.1 portgroup.
         epoch           0
-        version         7.3.0alpha1
+        version         7.3.0alpha2
         homepage        https://qa.php.net/
-        master_sites    https://downloads.php.net/~pollita/
+        master_sites    https://downloads.php.net/~cmb/
         use_xz          yes
-        checksums       rmd160  0 \
-                        sha256  0 \
-                        size    0
+        checksums       rmd160  3beceac4118b128b8cf6388408537388707244d0 \
+                        sha256  63e74a67228ec2239fda57d9c47749e5d917c50d76e4002092b145ee8d40ac39 \
+                        size    11883544
         livecheck.url   ${homepage}
         livecheck.regex php-([strsed ${subport_branch} {g/\\./\\./}](?:\\.\[0-9.\]+)*(?:(?:alpha|beta|RC)\\d+|-latest))\\.tar
     }
@@ -628,10 +628,12 @@ subport ${php}-enchant {
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${destroot.dir} CREDITS ${destroot}${docdir}
         
+        if {[vercmp ${branch} 7.3] < 0} {
         set examplesdir ${prefix}/share/examples/${subport}
         xinstall -d ${destroot}${examplesdir}
         xinstall -m 644 ${destroot.dir}/docs/examples/example1.php \
             ${destroot}${examplesdir}
+        }
     }
 }
 }
@@ -806,6 +808,12 @@ subport ${php}-mbstring {
                             encodings
     
     long_description        ${description}
+    
+    if {[vercmp ${branch} 7.3] == 0} {
+        # https://bugs.php.net/76574
+        configure.cflags-append \
+                            -DHAVE_LIMITS_H=1
+    }
 }
 
 if {[vercmp ${branch} 7.2] < 0} {

--- a/lang/php/files/patch-php73-ext-gd-config.m4.diff
+++ b/lang/php/files/patch-php73-ext-gd-config.m4.diff
@@ -1,0 +1,56 @@
+--- ext/gd/config.m4.orig	2015-07-21 14:00:36.000000000 -0500
++++ ext/gd/config.m4	2015-07-26 13:56:55.000000000 -0500
+@@ -72,7 +72,7 @@
+ AC_DEFUN([PHP_GD_WEBP],[
+   if test "$PHP_WEBP_DIR" != "no"; then
+ 
+-    for i in $PHP_WEBP_DIR /usr/local /usr; do
++    for i in $PHP_WEBP_DIR; do
+       test -f $i/include/webp/decode.h && GD_WEBP_DIR=$i && break
+     done
+ 
+@@ -80,7 +80,7 @@
+       AC_MSG_ERROR([webp/decode.h not found.])
+     fi
+ 
+-    for i in $PHP_WEBP_DIR /usr/local /usr; do
++    for i in $PHP_WEBP_DIR; do
+       test -f $i/include/webp/encode.h && GD_WEBP_DIR=$i && break
+     done
+ 
+@@ -106,7 +106,7 @@
+ AC_DEFUN([PHP_GD_JPEG],[
+   if test "$PHP_JPEG_DIR" != "no"; then
+ 
+-    for i in $PHP_JPEG_DIR /usr/local /usr; do
++    for i in $PHP_JPEG_DIR; do
+       test -f $i/include/jpeglib.h && GD_JPEG_DIR=$i && break
+     done
+ 
+@@ -131,7 +131,7 @@
+ AC_DEFUN([PHP_GD_PNG],[
+   if test "$PHP_PNG_DIR" != "no"; then
+ 
+-    for i in $PHP_PNG_DIR /usr/local /usr; do
++    for i in $PHP_PNG_DIR; do
+       test -f $i/include/png.h && GD_PNG_DIR=$i && break
+     done
+ 
+@@ -162,7 +162,7 @@
+ AC_DEFUN([PHP_GD_XPM],[
+   if test "$PHP_XPM_DIR" != "no"; then
+ 
+-    for i in $PHP_XPM_DIR /usr/local /usr/X11R6 /usr; do
++    for i in $PHP_XPM_DIR; do
+       test -f $i/include/xpm.h && GD_XPM_DIR=$i && GD_XPM_INC=$i && break
+       test -f $i/include/X11/xpm.h && GD_XPM_DIR=$i && GD_XPM_INC=$i/X11 && break
+     done
+@@ -189,7 +189,7 @@
+ AC_DEFUN([PHP_GD_FREETYPE2],[
+   if test "$PHP_FREETYPE_DIR" != "no"; then
+ 
+-    for i in $PHP_FREETYPE_DIR /usr/local /usr; do
++    for i in $PHP_FREETYPE_DIR; do
+       if test -f "$i/bin/freetype-config"; then
+         FREETYPE2_DIR=$i
+         FREETYPE2_CONFIG="$i/bin/freetype-config"

--- a/lang/php/files/patch-php73-iODBC.diff
+++ b/lang/php/files/patch-php73-iODBC.diff
@@ -1,0 +1,18 @@
+--- ext/odbc/config.m4.orig	2015-04-15 13:05:57.000000000 -0500
++++ ext/odbc/config.m4	2015-04-17 20:15:12.000000000 -0500
+@@ -104,6 +104,7 @@
+ [  --with-odbcver[=HEX]      Force support for the passed ODBC version. A hex number is expected, default 0x0300.
+                              Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0300)
+ 
++:<<'MACPORTS_DISABLED'
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH(adabas,,
+ [  --with-adabas[=DIR]       Include Adabas D support [/usr/local]])
+@@ -386,6 +387,7 @@
+   fi
+ fi
+ 
++MACPORTS_DISABLED
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH(iodbc,,
+ [  --with-iodbc[=DIR]        Include iODBC support [/usr/local]])

--- a/lang/php/files/patch-php73-sapi-fpm-php-fpm.conf.in.diff
+++ b/lang/php/files/patch-php73-sapi-fpm-php-fpm.conf.in.diff
@@ -1,0 +1,39 @@
+--- a/sapi/fpm/php-fpm.conf.in.orig	2016-08-19 01:48:00.000000000 -0500
++++ b/sapi/fpm/php-fpm.conf.in	2016-08-20 10:16:57.000000000 -0500
+@@ -14,14 +14,14 @@
+ ; Pid file
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: none
+-;pid = run/php-fpm.pid
++;pid = run/@PHP@/php-fpm.pid
+ 
+ ; Error log file
+ ; If it's set to "syslog", log is sent to syslogd instead of being written
+ ; into a local file.
+ ; Note: the default prefix is @EXPANDED_LOCALSTATEDIR@
+ ; Default Value: log/php-fpm.log
+-;error_log = log/php-fpm.log
++error_log = log/@PHP@/php-fpm.log
+ 
+ ; syslog_facility is used to specify what type of program is logging the
+ ; message. This lets syslogd specify that messages from different facilities
+@@ -34,7 +34,7 @@
+ ; instances running on the same server, you can change the default value
+ ; which must suit common needs.
+ ; Default Value: php-fpm
+-;syslog.ident = php-fpm
++syslog.ident = @PHP@-fpm
+ 
+ ; Log level
+ ; Possible Values: alert, error, warning, notice, debug
+@@ -77,8 +77,9 @@
+ ; process.priority = -19
+ 
+ ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
++; or for use with launchd.
+ ; Default Value: yes
+-;daemonize = yes
++daemonize = no
+ 
+ ; Set open file descriptor rlimit for the master process.
+ ; Default Value: system defined value

--- a/lang/php/files/patch-php73-scripts-php-config.in.diff
+++ b/lang/php/files/patch-php73-scripts-php-config.in.diff
@@ -1,0 +1,11 @@
+--- a/scripts/php-config.in.orig	2011-05-15 01:09:21.000000000 -0500
++++ b/scripts/php-config.in	2011-10-04 05:45:52.000000000 -0500
+@@ -7,7 +7,7 @@
+ version="@PHP_VERSION@"
+ vernum="@PHP_VERSION_ID@"
+ include_dir="@includedir@/php"
+-includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
++includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib -I@prefix@/include"
+ ldflags="@PHP_LDFLAGS@"
+ libs="@EXTRA_LIBS@"
+ extension_dir='@EXTENSION_DIR@'

--- a/lang/php/files/patch-php73-unixODBC.diff
+++ b/lang/php/files/patch-php73-unixODBC.diff
@@ -1,0 +1,18 @@
+--- ext/odbc/config.m4.orig	2015-04-15 13:05:57.000000000 -0500
++++ ext/odbc/config.m4	2015-04-17 20:13:57.000000000 -0500
+@@ -104,6 +104,7 @@
+ [  --with-odbcver[=HEX]      Force support for the passed ODBC version. A hex number is expected, default 0x0300.
+                              Use the special value of 0 to prevent an explicit ODBCVER to be defined. ], 0x0300)
+ 
++:<<'MACPORTS_DISABLED'
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH(adabas,,
+ [  --with-adabas[=DIR]       Include Adabas D support [/usr/local]])
+@@ -446,6 +447,7 @@
+   fi
+ fi
+ 
++MACPORTS_DISABLED
+ if test -z "$ODBC_TYPE"; then
+ PHP_ARG_WITH(unixODBC,,
+ [  --with-unixODBC[=DIR]     Include unixODBC support [/usr/local]])

--- a/lang/php/files/php73
+++ b/lang/php/files/php73
@@ -1,0 +1,6 @@
+bin/php73
+bin/php-config73
+bin/phpize73
+share/man/man1/php73.1.gz
+share/man/man1/php-config73.1.gz
+share/man/man1/phpize73.1.gz


### PR DESCRIPTION
#### Description

Add php73 subports

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1314
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
