### PR TITLE
httpie, http-prompt: use Python 3.6

### DIFF
--- a/net/http-prompt/Portfile
+++ b/net/http-prompt/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        eliangcs http-prompt 0.11.2 v
+revision            1
 
 maintainers         {lbschenkel @lbschenkel}
 categories          net
@@ -19,7 +20,7 @@ checksums           rmd160  9ca85c90ddae6afd93408effb2596233197ca68b \
                     size    323322
 
 # It MUST match default_version of httpie
-python.default_version 35
+python.default_version 36
 
 depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-parsimonious \

--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        jakubroztocil httpie 0.9.8
+revision            1
 
 maintainers         {g5pw @g5pw} openmaintainer
 categories          net
@@ -20,7 +21,7 @@ platforms           darwin
 license             BSD
 homepage            http://httpie.org
 
-python.default_version      35
+python.default_version      36
 
 depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-pygments


### PR DESCRIPTION
#### Description

Make `httpie` and `http-prompt` command-line tools depend on Python 3.6.

Closes: https://trac.macports.org/ticket/54941

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
