### PR TITLE
todotxt: install symlinked command name `todo.sh`.

### DIFF
--- a/office/todotxt/Portfile
+++ b/office/todotxt/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 
 github.setup        todotxt todo.txt-cli 2.11.0 v
 name                todotxt
+revision            1
 categories          office
 license             GPL-3
 maintainers         {snc @nerdling} openmaintainer
@@ -31,6 +32,7 @@ post-patch {
 
 destroot {
     xinstall -m 755 ${worksrcpath}/todo.sh ${destroot}${prefix}/bin/$name
+    ln -s $name ${destroot}${prefix}/bin/todo.sh
     xinstall -d -m 755 ${destroot}${prefix}/share/${name}
     xinstall -m 644 ${worksrcpath}/todo.cfg ${destroot}${prefix}/share/${name}/todo.cfg-dist
 }


### PR DESCRIPTION
#### Description

Create a symlink `todo.sh` to the main command `todotxt` as discussed in [issue 56762](https://trac.macports.org/ticket/56762).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1408
Xcode 8.3.3 8E3004b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
