### PR TITLE
crystal: update to 0.25.1

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 0.25.0
+github.setup        crystal-lang crystal 0.25.1
 categories          lang
 platforms           darwin
 supported_archs     x86_64
@@ -37,13 +37,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-${build_arch}${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bd6a5e4437dd1ec1c3755c1f186c0bfe92492d50 \
-                    sha256  5a21e5aa31f14403d04cea5efdc0b3b644f9073f27aeafc65e18b9d226401cac \
-                    size    1957811 \
+                    rmd160  b84aef3bf9c892928cd429fcd189021de245850f \
+                    sha256  118e2a3d2184353bb4a0cf83165b86f786d8ca82fab9fbaac02b2272ce25b6af \
+                    size    1962737 \
                     ${name}-${cr_full_ver}-${os.platform}-${build_arch}${extract.suffix} \
-                    rmd160  1d8ef6070b735f315b61936b06a8dec219968495 \
-                    sha256  3e1ec645a2fd86917e9af86fe9352812ae3e6bd17622ac69b9b311948a14ce00 \
-                    size    15164501
+                    rmd160  0280b37db34d5db780b997d4f7fa3161a4808a7a \
+                    sha256  c0fb9d11f468b00fc0704d19269f7b2334823d54f739b3567f91051d3f4c66c0 \
+                    size    15233249
 
 patchfiles          patch-compiler.diff patch-readline.diff \
                     patch-crypto.diff patch-ssl.diff patch-xml.diff


### PR DESCRIPTION
#### Description

Tests fail to run due to crystal-lang/crystal#5951, but should be fixed in the next version.

###### Tested on
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?