### PR TITLE
py-dill: update to 0.2.8.2, add py37

### DIFF
--- a/python/py-dill/Portfile
+++ b/python/py-dill/Portfile
@@ -7,7 +7,7 @@ set _name           dill
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.2.7.1
+version             0.2.8.2
 
 platforms           darwin
 supported_archs     noarch
@@ -30,12 +30,11 @@ homepage            https://github.com/uqfoundation/dill
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-checksums           md5     e58b860720a9bf47195e117636fe3c6a \
-                    rmd160  a37a53f39a163251a30fb0cd2339077021d6a917 \
-                    sha256  97fd758f5fe742d42b11ec8318ecfcff8776bccacbfcec05dfd6276f5d450f73 \
-                    size    64485
+checksums           rmd160  c1273104d82c63bc55d0273ea017f2e3a1eb5761 \
+                    sha256  624dc244b94371bb2d6e7f40084228a2edfff02373fe20e018bef1ee92fdd5b3 \
+                    size    150078
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
- update to version 0.2.8.2
- add py37 subport

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
