### PR TITLE
todotxt: Portfile fixes to bash_completion variant and config file regex

### DIFF
--- a/office/todotxt/Portfile
+++ b/office/todotxt/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        todotxt todo.txt-cli 2.11.0 v
 name                todotxt
-revision            1
+revision            2
 categories          office
 license             GPL-3
 maintainers         {snc @nerdling} openmaintainer
@@ -46,11 +46,7 @@ post-destroot {
 patch {
     # default cfg will try to write in ${prefix}/bin, since this isn't obvious from the config
     # file we help the user avoiding this
-    reinplace "s|TODO_DIR=`dirname \"\$0\"`|TODO_DIR=\"\$HOME\"/.todo|" ${worksrcpath}/todo.cfg
-}
-
-variant bash_completion {
-    depends_run-append  path:etc/bash_completion:bash-completion
+    reinplace "s|TODO_DIR=\$\(dirname \"\$0\"\)|TODO_DIR=\"\$HOME\"/.todo|" ${worksrcpath}/todo.cfg
 }
 
 notes "Copy the default configuration file from  ${prefix}/share/${name}/todo.cfg-dist \


### PR DESCRIPTION
#### Description

- The bash_completion script was installed unconditionally, now it will only be installed if the variant is actually enabled.
- The regex patching 'todo.cfg' to include a different `TODO_DIR` was outdated and has been fixed.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1408
Xcode 8.3.3 8E3004b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?