### PR TITLE
py-six: added py37 subport

### DIFF
--- a/python/py-six/Portfile
+++ b/python/py-six/Portfile
@@ -25,7 +25,7 @@ distname            six-${version}
 checksums           rmd160  db622293776cc4fa176220af760dc368f9d866fb \
                     sha256  70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 if {${name} ne ${subport}} {
     livecheck.type      none


### PR DESCRIPTION
#### Description

This PR adds a py37 subport for `six`.

I'm not sure about the etiquette of suggesting such a change for a port of which I'm not a maintainer, so apologies if this sort of contribution isn't kosher.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
