### PR TITLE
py-poppler-qt5: fix use of qt5 PortGroup

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -9,7 +9,7 @@ name                py-poppler-qt5
 python.rootname     python-poppler-qt5
 set _n              [string index ${python.rootname} 0]
 version             0.24.2
-revision            3
+revision            4
 platforms           darwin
 license             LGPL-2.1+
 maintainers         {gmail.com:davide.liessi @dliessi} openmaintainer
@@ -36,8 +36,7 @@ python.versions     27 34 35 36
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
-    depends_lib-append      port:qt5 \
-                            port:poppler-qt5 \
+    depends_lib-append      port:poppler-qt5 \
                             port:py${python.version}-sip \
                             port:py${python.version}-pyqt5
 
@@ -48,7 +47,7 @@ if {${name} ne ${subport}} {
                             patch-types.sip.diff
 
     post-patch {
-        reinplace "s|%%QMAKE%%|${qt_bins_dir}/qmake|g" ${worksrcpath}/setup.py
+        reinplace "s|%%QMAKE%%|${qt_qmake_cmd}|g" ${worksrcpath}/setup.py
         reinplace "s|%%PYQTSIPDIR%%|${python.prefix}/share/sip/PyQt5/|g" ${worksrcpath}/setup.py
     }
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/56723

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G21013
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
