### PR TITLE
Add optimizations variant to python{27,35,36,37}

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -165,6 +165,10 @@ variant ucs4 description {Enable support for UCS4} {
     configure.args-append   --enable-unicode=ucs4
 }
 
+variant optimizations description {Compile with LTO and PGO. Build time greatly increased} {
+    configure.args-append   --enable-optimizations
+}
+
 livecheck.type          regex
 livecheck.url           ${homepage}downloads/
 livecheck.regex         Python (${branch}(?:\\.\\d+)*)

--- a/lang/python35/Portfile
+++ b/lang/python35/Portfile
@@ -174,6 +174,10 @@ variant universal {
     }
 }
 
+variant optimizations description {Compile with LTO and PGO. Build time greatly increased} {
+    configure.args-append   --enable-optimizations
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)

--- a/lang/python36/Portfile
+++ b/lang/python36/Portfile
@@ -190,6 +190,10 @@ variant universal {
     }
 }
 
+variant optimizations description {Compile with LTO and PGO. Build time greatly increased} {
+    configure.args-append   --enable-optimizations
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}(?:\\.\\d+)*)

--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -191,6 +191,10 @@ variant universal {
     }
 }
 
+variant optimizations description {Compile with LTO and PGO. Build time greatly increased} {
+    configure.args-append   --enable-optimizations
+}
+
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
 livecheck.regex     Python (${branch}\[.0-9abrc\]+)


### PR DESCRIPTION
This flag does PGO (profile-guided optimization) and LTO (link-time
optimization) on builds of the Python interpreter. It greatly increases
build time so it must be disabled by default.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10.5 14F2511
Xcode 7.2 7C68

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
