### PR TITLE
p5-app-cli: update to 0.50, add depends_test

### DIFF
--- a/perl/p5-app-cli/Portfile
+++ b/perl/p5-app-cli/Portfile
@@ -4,15 +4,16 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         App-CLI 0.49
+perl5.setup         App-CLI 0.50
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Dispatcher module for command line interface programs.
 long_description    App::CLI provides a simple interface for dispatching \
                     command line applications.
 
-checksums           rmd160  8ba5d3150b2ed7c198ff470f7cc71b23068ae766 \
-                    sha256  636f7975513e8c4fbf4158bccae2d71cf1405b4dac6395566e4cc5ce346b643f
+checksums           rmd160  c4f26851c1236cee4dc10e39870869a6ed907e9f \
+                    sha256  51d3f5833ab519fb46e5552b60e5455e4f9c1c6827d1eee4153d0b409f2a9345 \
+                    size    15624
 
 platforms           darwin
 supported_archs     noarch
@@ -23,4 +24,6 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-class-load \
                     port:p${perl5.major}-locale-maketext-simple \
                     port:p${perl5.major}-pod-simple
+    depends_test-append \
+                    port:p${perl5.major}-test-pod
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

Added `p5-test-pod` as a testing dependency; the only other testing dependency Test::Kwalitee isn't a port, and is only used "for release candidate testing".

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

```
--->  Testing p5.26-app-cli
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-app-cli/p5.26-app-cli/work/App-CLI-0.50" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01-basic.t ..... ok
t/02-command.t ... ok
t/03-pod.t ....... ok
t/99-kwalitee.t .. skipped: these tests are for release candidate testing
All tests successful.
Files=4, Tests=24,  1 wallclock secs ( 0.04 usr  0.03 sys +  0.56 cusr  0.19 csys =  0.82 CPU)
Result: PASS
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
