### PR TITLE
Added py37 subports for ligo-common and ligo-segments

### DIFF
--- a/python/py-ligo-common/Portfile
+++ b/python/py-ligo-common/Portfile
@@ -23,7 +23,7 @@ checksums  rmd160  ba7b27ac876e1133e852fd9f3f8bb2442bb24638 \
            sha256  a3e00d79bf3b0474b429f50fb60079da015453afa09658f90efcab8ae158a835 \
            size    15620
 
-python.versions         27 36
+python.versions         27 36 37
 python.default_version  27
 
 if {${name} ne ${subport}} {

--- a/python/py-ligo-segments/Portfile
+++ b/python/py-ligo-segments/Portfile
@@ -24,7 +24,7 @@ checksums   rmd160  a90803ef8a4228461a808ddb7e0caa78dbc8b5a1 \
             sha256  d8bacc5a7e0a75afab8bced7c066036e844efe3e71f14e4e098d7846a29f0dc2 \
             size    41659
 
-python.versions     27 36
+python.versions     27 36 37
 python.default_version 27
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

This PR adds py37 subports for `py-ligo-common` and `py-ligo-segments`.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
