### PR TITLE
p5-file-find-object-rule: update to 0.0309, minor improvements

### DIFF
--- a/perl/p5-file-find-object-rule/Portfile
+++ b/perl/p5-file-find-object-rule/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         File-Find-Object-Rule 0.0306
+perl5.setup         File-Find-Object-Rule 0.0309
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         File::Find::Object::Rule - Alternative interface to File::Find::Object
@@ -12,10 +12,16 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  3d57b7daac7b6b70aa0af83d1b90bbb3a82d6c89 \
-                    sha256  2ce55766b25fb8799d37b95bca61e8a71d8a437e28541e1cd06b7eb89f7739d1
+supported_archs     noarch
+
+checksums           rmd160  47b07bd2c86a2ad4027c68143e52595c674bd0a6 \
+                    sha256  a184e11b271646c1b5b40ac01ca15d87750dc2b16a66dda3be0bd8976ece21e3 \
+                    size    38070
 
 if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-test-pod \
+                    port:p${perl5.major}-test-pod-coverage
     depends_lib-append \
                     port:p${perl5.major}-class-xsaccessor \
                     port:p${perl5.major}-file-find-object \
@@ -23,5 +29,4 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-text-glob
 
     perl5.use_module_build
-    supported_archs noarch
 }


### PR DESCRIPTION
- add test dependencies
- move `supported_archs noarch` to outside `if` (cf. #1985)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing p5.26-file-find-object-rule
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-file-find-object-rule/p5.26-file-find-object-rule/work/File-Find-Object-Rule-0.0309" && /opt/local/bin/perl5.26 Build test
t/00-compile.t .............. ok
t/File-Find-Rule.t .......... ok
t/findorule.t ............... ok
t/pod-coverage.t ............ ok
t/pod.t ..................... ok
t/readme-pod.t .............. ok
t/release-trailing-space.t .. skipped: these tests are for release candidate testing
All tests successful.
Files=7, Tests=55,  2 wallclock secs ( 0.05 usr  0.03 sys +  1.03 cusr  0.36 csys =  1.47 CPU)
Result: PASS
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
