### PR TITLE
p5-event-rpc: update to 1.10, move `supported_archs noarch` to outside `if`

### DIFF
--- a/perl/p5-event-rpc/Portfile
+++ b/perl/p5-event-rpc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Event-RPC 1.08
+perl5.setup         Event-RPC 1.10
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Event::RPC - Event based transparent Client/Server RPC framework
@@ -12,8 +12,11 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  f3c55e47b6f0687dd8ecf59b68a2e25cf18f78b7 \
-                    sha256  c752c98e06c4f0394eb90ba4dba3dbff78e6f394fa173ee8d0fd9daaf39149b1
+supported_archs     noarch
+
+checksums           rmd160  6f48963d526b717493b68b169aec077b386d69a9 \
+                    sha256  93a5d52641c85688f3dc7eb3ab544b7a89f4e6cc5e4f094d574ec6992c498d06 \
+                    size    51373
 
 if {${perl5.major} != ""} {
     depends_lib-append \
@@ -24,6 +27,4 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-json-xs \
                     port:p${perl5.major}-net-ssleay \
                     port:p${perl5.major}-sereal
-
-    supported_archs noarch
 }


### PR DESCRIPTION
#### Description

(Cf. #1985 for why to move `noarch`) 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

One of the tests hangs when run from `port test`. The same things happens with the old version (1.08). 
```
--->  Testing p5.26-event-rpc
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-event-rpc/p5.26-event-rpc/work/Event-RPC-1.08" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01.use.t ............................... ok
t/02.cnct.t .............................. ok
t/03.cnct-auth.t ......................... ok
t/04.cnct-auth-ssl-verifypeer-noca.t ..... ok
Can't open SSL connection to localhost:27816: SSL connect attempt failed error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed at t/04.cnct-auth-ssl-verifypeer-wrongca.t line 57.
# Looks like your test exited with 255 just after 2.
```

But the tests work fine when run manually:
```
Downloads/Event-RPC-1.10$ make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01.use.t ............................... ok
t/02.cnct.t .............................. ok
t/03.cnct-auth.t ......................... ok
t/04.cnct-auth-ssl-verifypeer-noca.t ..... ok
t/04.cnct-auth-ssl-verifypeer-wrongca.t .. ok
t/04.cnct-auth-ssl-verifypeer.t .......... ok
t/04.cnct-auth-ssl.t ..................... ok
t/05.func.t .............................. ok
t/06.object2.t ........................... ok
t/07.maxpacket.t ......................... ok
t/08.msg_formats.t ....................... ok
All tests successful.
Files=11, Tests=155,  8 wallclock secs ( 0.08 usr  0.04 sys +  2.14 cusr  0.70 csys =  2.96 CPU)
Result: PASS
```

Any ideas? It appears to be network-related, are there certain restrictions on what `port` can do?

- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
