### PR TITLE
py-subprocess32: update to 3.5.2

### DIFF
--- a/python/py-subprocess32/Portfile
+++ b/python/py-subprocess32/Portfile
@@ -1,8 +1,10 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        google python-subprocess32 3.2.7
+github.setup        google python-subprocess32 3.5.2
 name                py-subprocess32
 categories-append   devel
 license             PSF
@@ -10,19 +12,22 @@ platforms           darwin
 supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
 
-description         Backport of the subprocess module from Python 3.2/3.3
+description         Backport of the subprocess module from Python 3.2-3.5
 long_description    This is a backport of the subprocess standard library \
-                    module from Python 3.2 & 3.3 for use on Python 2. It \
+                    module from Python 3.2 - 3.5 for use on Python 2. It \
                     includes bugfixes and some new features. On POSIX systems \
                     it is guaranteed to be reliable when used in threaded \
                     applications. It includes timeout support from Python 3.3 \
-                    but otherwise matches 3.2's API.
+                    and the run() API from 3.5 but otherwise matches 3.2's API.
 
 python.versions     27
 
-checksums           rmd160  a8ce558aba656369fc2096fdccefb1b2966ce198 \
-                    sha256  90efe090295ad0f3a9115ff10183f669739101bd42547787ad8a7ec88eaf5a91
+checksums           rmd160  b48fd17b2f5050e47e5f88599836d53de5c6fb5a \
+                    sha256  f1ab6824113f6755fef7483da85161870f20ab2e0e685480f9830c40b30c68b2 \
+                    size    96815
 
 if {${name} ne ${subport}} {
-  livecheck.type    none
+    depends_build-append \
+                    port:py${python.version}-setuptools
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to version 3.5.2
- add modeline
- add missing dependency on setuptools
- add size to checksums
- update description

Tests pass after installing, but I cannot figure out how to include them properly within the Portfile...

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
