### PR TITLE
p5-mac-errors: update to 1.192, minor improvements

### DIFF
--- a/perl/p5-mac-errors/Portfile
+++ b/perl/p5-mac-errors/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Mac-Errors 1.191
-license             {Artistic-1 GPL}
+perl5.setup         Mac-Errors 1.192
+license             {Artistic-2}
 maintainers         nomaintainer
 
 description         Constants for Mac error codes
@@ -15,8 +15,15 @@ long_description    Constants for Mac error codes. The %MacErrors hash indexes \
                     number, and description. The \$MacError scalar performs \
                     some tied magic to translate MacPerl's \$^E to the error text.
 
-checksums           rmd160  c373847917b4fde0843b6adddaf5a0298656cd21 \
-                    sha256  391ce2c22841d5ed4365d662dc3baf557462599ca4096e6a8c47aa9702dea035
+checksums           rmd160  991ea77d801a766a09b780a38cfee9d0f2c9f60e \
+                    sha256  c1a084fc12bc40c8b49f6e7862378d0320d33c3fbb8716ced25f5e397852e89d \
+                    size    102225
 
 platforms           darwin
 supported_archs     noarch
+
+if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-test-pod \
+                    port:p${perl5.major}-test-pod-coverage
+}


### PR DESCRIPTION
- license is now Artistic 2.0
- add test dependencies

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing p5.26-mac-errors
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-mac-errors/p5.26-mac-errors/work/Mac-Errors-1.192" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/errors.t ........ ok
t/import.t ........ ok
t/load.t .......... ok
t/object.t ........ ok
t/pod.t ........... ok
t/pod_coverage.t .. ok
All tests successful.
Files=6, Tests=44,  2 wallclock secs ( 0.06 usr  0.05 sys +  1.08 cusr  0.22 csys =  1.41 CPU)
Result: PASS
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
