### PR TITLE
devel/boost: add python37 variant, small patch update for python37

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -182,7 +182,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {26 27 33 34 35 36}
+set pythons_suffixes {26 27 33 34 35 36 37}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {

--- a/devel/boost/files/patch-boost-python3.diff
+++ b/devel/boost/files/patch-boost-python3.diff
@@ -3,14 +3,25 @@
 @@ -13,6 +13,10 @@
  #include <boost/mpi/python/serialize.hpp>
  #include <boost/mpi.hpp>
- 
+
 +#if PY_MAJOR_VERSION >= 3
 +#define PyInt_Type PyLong_Type
 +#endif
 +
  namespace boost { namespace mpi { namespace python {
- 
+
  void export_datatypes()
+--- libs/python/src/converter/builtin_converters.cpp.orig	2017-12-13 17:56:47.000000000 -0600
++++ libs/python/src/converter/builtin_converters.cpp	2018-07-05 22:46:05.000000000 -0500
+@@ -48,7 +48,7 @@
+ #else
+   void* convert_to_cstring(PyObject* obj)
+   {
+-      return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
++      return (void*)(PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0);
+   }
+ #endif
+
 --- libs/mpi/build/__init__.py.orig
 +++ libs/mpi/build/__init__.py
 @@ -6,5 +6,5 @@


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->