### PR TITLE
py-tox: update to 3.0.0

### DIFF
--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -3,11 +3,9 @@
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
-PortGroup           github 1.0
-
-github.setup        tox-dev tox 2.7.0 v
 
 name                py-tox
+version             3.0.0
 categories-append   devel
 maintainers         {gmail.com:pedro.salgado @steenzout} openmaintainer
 platforms           darwin
@@ -17,34 +15,38 @@ license             MIT
 description         tox: virtualenv-based automation of test activities
 long_description    Tox as is a generic virtualenv management and test command line tool
 
-homepage            http://tox.testrun.org/
+homepage            https://tox.readthedocs.io/en/latest/
 master_sites        pypi:t/tox/
 
 distname            tox-${version}
 
-checksums           rmd160  89a1a09d8e0631a217388a8f98b1e61f8e393b2c \
-                    sha256  9c3bdc06fe411d24015e8bbbab9d03dc5243a970154496aac13f9283682435f9
+checksums           rmd160  b9eda9e6d0ba59b9b5f9ca83ee6e94c4e67bba0b \
+                    sha256  96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f \
+                    size    226055
 
 python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
-    depends_lib-append port:py${python.version}-pluggy \
-                       port:py${python.version}-py \
-                       port:py${python.version}-virtualenv \
-                       port:tox_select
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
 
-    select.group       tox
-    select.file        ${filespath}/tox${python.version}
+    depends_lib-append \
+                    port:py${python.version}-pluggy \
+                    port:py${python.version}-py \
+                    port:py${python.version}-six \
+                    port:py${python.version}-virtualenv \
+                    port:tox_select
+
+    select.group    tox
+    select.file     ${filespath}/tox${python.version}
     notes "
 To make the Python ${python.branch} version of tox the one that is run\
 when you execute the commands without a version suffix, e.g. 'tox', run:
 
 port select --set ${select.group} [file tail ${select.file}]
 "
-    livecheck.type     none
-
+    livecheck.type  none
 } else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/tox/json
-    livecheck.regex     {tox-(\d+(?:\.\d+)*)}
+    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- update to version 3.0.0
- update dependencies
- switch completely to PyPI to avoid "setuptools-scm was unable to detect version" error
- update homepage

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
