### PR TITLE
qgis3: update to 3.2

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -7,10 +7,7 @@ PortGroup           cxx11   1.1
 PortGroup           github  1.0
 PortGroup           qt5     1.0
 
-github.setup        qgis QGIS 3_0_3 final-
-#github.setup        qgis QGIS c625f95
-#github.commit       c625f95
-#revision            20180410
+github.setup        qgis QGIS 3_2_0 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
 categories          gis
@@ -26,9 +23,9 @@ license             GPL-2+
 
 homepage            http://www.qgis.org/
 
-checksums           rmd160  dfbb936cd9ebcea05b3357c23f635c48083a066c \
-                    sha256  52933df056ba367332a2920304e6820efbfa6291e6bc32fc6d8a6e4fa558d39c \
-                    size    112088917
+checksums           rmd160  1b7af02ab5c236d3258e65f7cb3a18b058353231 \
+                    sha256  878c3aa8537f50692c1b1e63f323a2472598f807a997aba9f060f0afc625cb88 \
+                    size    114125408
 
 depends_lib-append  port:libiconv \
                     port:expat \


### PR DESCRIPTION
- update qgis3 to 3.2.0

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Getting a make error locally when building in trace mode – possibly from homebrew or other conflicting local dependencies – but `sudo port -vs install qgis3` works and the resulting binary seems correct.

Trace mode error:
```
sh: /bin/ps: Operation not permitted
Error running link command: Invalid argument
make[2]: *** [output/lib/qgis_core.framework/Versions/3.2/qgis_core] Error 2
make[2]: Leaving directory `/opt/local/var/macports/build/_macports-ports_gis_qgis3/qgis3/work/build'
make[1]: *** [src/core/CMakeFiles/qgis_core.dir/all] Error 2
make[1]: Leaving directory `/opt/local/var/macports/build/_macports-ports_gis_qgis3/qgis3/work/build'
make: *** [all] Error 2
make: Leaving directory `/opt/local/var/macports/build/_macports-ports_gis_qgis3/qgis3/work/build'
Command failed:  cd "/opt/local/var/macports/build/_macports-ports_gis_qgis3/qgis3/work/build" && /usr/bin/make -j8 -w all VERBOSE=ON 
Exit code: 2
```
