### PR TITLE
py-pytest: update to 3.6.3 for py37 compatibility and add py37 subport

### DIFF
--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest
-version             3.5.1
+version             3.6.3
 revision            0
 categories-append   devel
 platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -25,9 +25,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  8a41afd4c1c05838829d8d80728fd4c7d68a99b1 \
-                    sha256  54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8 \
-                    size    830571
+checksums           rmd160  28cdd377a030f53f07a9ead251d18608ca91ffdd \
+                    sha256  0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752 \
+                    size    830949
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -38,7 +38,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-six \
                         port:py${python.version}-attrs \
                         port:py${python.version}-more-itertools \
-                        port:py${python.version}-pluggy
+                        port:py${python.version}-pluggy \
+                        port:py${python.version}-atomicwrites
 
     if {${python.version} < 30} {
         depends_lib-append  port:py${python.version}-funcsigs

--- a/python/py-pytest/files/patch-setup.py.diff
+++ b/python/py-pytest/files/patch-setup.py.diff
@@ -1,11 +1,11 @@
---- setup.py.orig	2017-12-05 23:41:58.000000000 +0300
-+++ setup.py	2017-12-24 16:31:49.000000000 +0300
-@@ -77,7 +77,7 @@
-             'Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, '
-             'Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others'),
-         entry_points={'console_scripts': [
--            'pytest=pytest:main', 'py.test=pytest:main']},
-+            'py.test=pytest:main']},
+--- setup.py.orig	2018-07-06 23:28:02.000000000 +0800
++++ setup.py	2018-07-06 23:28:21.000000000 +0800
+@@ -99,7 +99,7 @@
+             "Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, "
+             "Floris Bruynooghe, Brianna Laugher, Florian Bruhin and others"
+         ),
+-        entry_points={"console_scripts": ["pytest=pytest:main", "py.test=pytest:main"]},
++        entry_points={"console_scripts": ["py.test=pytest:main"]},
          classifiers=classifiers,
          keywords="test unittest",
-         cmdclass={'test': PyTest},
+         # the following should be enabled for release


### PR DESCRIPTION
#### Description

Ref: https://github.com/pytest-dev/pytest/pull/3497

py37-pytest passed `py.test-3.7 -k 'not test_entry_points'`.
test_entry_points fails as the pytest entry point is patched away

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.5 17F77
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?