### PR TITLE
boost: find library when using -flat_namespace

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -301,6 +301,10 @@ if {$subport eq $name} {
 
     if {[mpi_variant_isset]} {
 
+        # see https://trac.macports.org/ticket/49748
+        # see http://www.openradar.me/25313838
+        configure.ldflags-append -Lstage/lib
+
         # There is a conflict with debug support.
         # The issue has been reported to both the MacPorts team and the boost team, as per:
         # <http://trac.macports.org/ticket/23667> and <https://svn.boost.org/trac/boost/ticket/4461>


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/49748

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->