### PR TITLE
py-cairo: update to 1.17.1, add py37

### DIFF
--- a/python/py-cairo/Portfile
+++ b/python/py-cairo/Portfile
@@ -5,7 +5,7 @@ PortGroup               active_variants 1.1
 PortGroup               github 1.0
 PortGroup               python 1.0
 
-github.setup            pygobject pycairo 1.17.0 v
+github.setup            pygobject pycairo 1.17.1 v
 github.tarball_from     releases
 
 name                    py-cairo
@@ -17,11 +17,11 @@ description             Pycairo is set of Python bindings for the cairo graphics
 
 long_description        ${description}
 
-checksums               rmd160  4897f0faebb7e30a3ff9d377871b93ec294e6e23 \
-                        sha256  cdd4d1d357325dec3a21720b85d273408ef83da5f15c184f2eff3212ff236b9f \
-                        size    192182
+checksums               rmd160  46c562fad05a9565df2940085ec27e335400ec52 \
+                        sha256  0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698 \
+                        size    194388
 
-python.versions         27 34 35 36
+python.versions         27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build           port:pkgconfig


### PR DESCRIPTION
#### Description
- update to version 1.17.1
- add py37 subport (all test pass)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
