### PR TITLE
py-pylint: update to 1.9.2

### DIFF
--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -5,8 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pylint
-version             1.8.3
-revision            0
+version             1.9.2
 categories-append   devel
 platforms           darwin
 license             GPL-2+
@@ -31,8 +30,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  53b01a44f811070b4acc7f827a151ffe7c5df7f6 \
-                    sha256  c77311859e0c2d7932095f30d2b1bfdc4b6fe111f534450ba727a52eae330ef2
+checksums           rmd160  9b682e1380ad5eea89fa6ffbc3fc61548ac52f20 \
+                    sha256  fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3 \
+                    size    516869
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
- update to version 1.9.2 (no py37 support yet)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
