### PR TITLE
py-alabaster: update to 0.7.11, add py37

### DIFF
--- a/python/py-alabaster/Portfile
+++ b/python/py-alabaster/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        bitprophet alabaster 0.7.10
+github.setup        bitprophet alabaster 0.7.11
 name                py-alabaster
 platforms           darwin
 supported_archs     noarch
@@ -14,11 +14,11 @@ maintainers         nomaintainer
 description         A configurable sidebar enabled Sphinx theme
 long_description    ${description}
 
-checksums           rmd160  028e309cdaa93308e9227ea26bf8852fed447de5 \
-                    sha256  d1ad082998f091b2fb6cee244c9733650a36daade2daea597278653b8035b42d \
-                    size    19870
+checksums           rmd160  8e4ee43fc612e7b7797ccc00cdbe0e17239d9c72 \
+                    sha256  43de11deee41a462fa68c8d7720b99444a1c0d8b3554a2251979d146a9710391 \
+                    size    21901
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
- update to version 0.7.11
- add py37 subport

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
