### PR TITLE
php73: Update to 7.3.0alpha3

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -815,9 +815,7 @@ subport ${php}-mbstring {
     long_description        ${description}
     
     if {[vercmp ${branch} 7.3] == 0} {
-        # https://bugs.php.net/76574
-        configure.cflags-append \
-                            -DHAVE_LIMITS_H=1
+        patchfiles-append   patch-${php}-ext-mbstring-config.m4.diff
     }
 }
 

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -144,13 +144,13 @@ switch ${subport_branch} {
         # master_sites and livecheck, and update php.latest_stable_branch in the
         # php-1.1 portgroup.
         epoch           0
-        version         7.3.0alpha2
+        version         7.3.0alpha3
         homepage        https://qa.php.net/
         master_sites    https://downloads.php.net/~cmb/
         use_xz          yes
-        checksums       rmd160  3beceac4118b128b8cf6388408537388707244d0 \
-                        sha256  63e74a67228ec2239fda57d9c47749e5d917c50d76e4002092b145ee8d40ac39 \
-                        size    11883544
+        checksums       rmd160  51a2678fc01c9ec7d844c1197e431650390f9cf8 \
+                        sha256  78a3154997e7fc0debc66e4979506b30725cd8b0c6dfa4142caebf24044362c6 \
+                        size    11890052
         livecheck.url   ${homepage}
         livecheck.regex php-([strsed ${subport_branch} {g/\\./\\./}](?:\\.\[0-9.\]+)*(?:(?:alpha|beta|RC)\\d+|-latest))\\.tar
     }

--- a/lang/php/files/patch-php73-ext-mbstring-config.m4.diff
+++ b/lang/php/files/patch-php73-ext-mbstring-config.m4.diff
@@ -1,0 +1,12 @@
+https://bugs.php.net/76574
+--- ext/mbstring/config.m4.orig
++++ ext/mbstring/config.m4
+@@ -96,7 +96,7 @@
+         ])
+       ])
+ 
+-      AC_CHECK_HEADERS([stdlib.h string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h])
++      AC_CHECK_HEADERS([stdlib.h string.h strings.h unistd.h sys/time.h sys/times.h stdarg.h limits.h])
+       AC_CHECK_SIZEOF(int, 4)
+       AC_CHECK_SIZEOF(short, 2)
+       AC_CHECK_SIZEOF(long, 4)


### PR DESCRIPTION
#### Description

php73: Update to 7.3.0alpha3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1408
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
