### PR TITLE
libsbmlsim: new port, version 1.4.0

### DIFF
--- a/science/libsbmlsim/Portfile
+++ b/science/libsbmlsim/Portfile
@@ -1,0 +1,60 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        libsbmlsim libsbmlsim 1.4.0 v
+categories          science
+platforms           darwin
+maintainers         {@funasoul gmail.com:funasoul} openmaintainer
+license             LGPL-2.1+
+
+description         A library for simulating SBML models
+
+long_description    LibSBMLSim is a library for simulating an SBML model which contains \
+                    Ordinary Differential Equations (ODEs). LibSBMLSim provides simple \
+                    command-line tool and several APIs to load an SBML model, perform \
+                    numerical integration (simulate) and export its results. \
+                    Both explicit and implicit methods are supported on libSBMLSim.
+
+homepage            https://fun.bio.keio.ac.jp/software/libsbmlsim/
+
+checksums           rmd160  8986883d5e604abe8b4bfa380e0e65f5f4c7c584 \
+                    sha256  04ddf304d2a731a17b32fc4a2ca4ac07500f59ae36fa4440f169dd30daa74115 \
+                    size    35000546
+
+depends_lib-append  port:libsbml
+
+variant csharp description {Generate C# language bindings.} {
+    depends_build-append   port:swig port:swig-csharp
+    configure.args-append  -DWITH_CSHARP:BOOL=ON
+}
+
+variant java description {Generate Java language bindings.} {
+    depends_build-append   port:swig port:swig-java
+    configure.args-append  -DWITH_JAVA:BOOL=ON
+}
+
+variant python27 conflicts python36 python37 description {Generate Python version 2.7 language bindings.} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python27
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7
+}
+
+variant python36 conflicts python27 python37 description {Generate Python version 3.6 language bindings.} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python36
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6
+}
+
+variant python37 conflicts python27 python36 description {Generate Python version 3.7 language bindings.} {
+    depends_build-append  port:swig port:swig-python
+    depends_lib-append      port:python37
+    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7
+}
+
+variant ruby description {Generate Ruby language bindings.} {
+    depends_build-append   port:swig port:swig-ruby
+    configure.args-append  -DWITH_RUBY:BOOL=ON
+}


### PR DESCRIPTION
#### Description
LibSBMLSim is a library for simulating an SBML model which contains
Ordinary Differential Equations (ODEs). LibSBMLSim provides simple
command-line tool and several APIs to load an SBML model, perform
numerical integration (simulate) and export its results.
Both explicit and implicit methods are supported on libSBMLSim.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->