### PR TITLE
py-kivy: Fix checksums and size

### DIFF
--- a/python/py-kivy/Portfile
+++ b/python/py-kivy/Portfile
@@ -25,9 +25,9 @@ master_sites        pypi:K/Kivy
 
 distname            Kivy-${version}
 
-checksums           rmd160  e15020f68fcc17da6e1896fdcf6adbab8422fc6a \
-                    sha256  794e45cc7bcc7882f7cd95f1673bc6701f3215a20a54c915cac0c5e46a449b4c \
-                    size    24318169
+checksums           rmd160  1198e106fe0c56d2bb45eef50362ba2968753570 \
+                    sha256  7ce9e88b75de47a3f1d52cbe6924c18cafc83fa102e54f6794d241746e93fdff \
+                    size    24326312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
References: https://trac.macports.org/ticket/56795

#### Description

Fix bad checksums and size
https://trac.macports.org/ticket/56795

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
