### PR TITLE
py-filelock: new port, version 3.0.4

### DIFF
--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-filelock
+version             3.0.4
+maintainers         {@funasoul gmail.com:funasoul} openmaintainer
+platforms           darwin
+supported_archs     noarch
+
+description         A platform independent file lock
+long_description    This package contains a single module, which implements \
+                    a platform independent file lock in Python, which \
+                    provides a simple way of inter-process communication:
+license             public-domain
+homepage            http://pypi.python.org/pypi/filelock/
+
+distname            filelock-${version}
+master_sites        pypi:f/filelock/
+
+checksums           rmd160  51423a7699221b2d24b0fbe4fa4fd117b546a2fe \
+                    sha256  011327d4ed939693a5b28c0fdf2fd9bda1f68614c1d6d0643a89382ce9843a71 \
+                    size    6496
+
+python.versions     27 36 37
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.url   https://pypi.python.org/pypi/filelock/
+    livecheck.regex filelock (\\d(\\.\\d+)*)
+}


### PR DESCRIPTION
#### Description
This package contains a single module, which implements a platform
independent file lock in Python, which provides a simple way of
inter-process communication:

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->