### PR TITLE
py-backports-functools_lru_cache: fix activation issue

### DIFF
--- a/python/py-backports-functools_lru_cache/Portfile
+++ b/python/py-backports-functools_lru_cache/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-backports-functools_lru_cache
 version             1.5
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -31,6 +32,19 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm
+
+    depends_lib-append \
+                    port:py${python.version}-backports
+
+    post-destroot {
+        foreach f {__init__.py __init__.pyc __init__.pyo __pycache__} {
+            set fp "${destroot}${python.pkgd}/backports/$f"
+            if {[file exists ${fp}]} {
+                file delete -force ${fp}
+            }
+        }
+    }
+
     livecheck.type  none
 } else {
     livecheck.type  pypi


### PR DESCRIPTION
#### Description
The ```__init__.py``` file is present in various packages within the backports namespace, preventing port activation. Therefore, add py-backports as a dependency and do not install those files from this port. Solution taken from several other py-backports-* Portfiles; see, for example, py-backports-lzma, py-backports-ssl, py-backports-shutil_get_terminal_size.

Closes: https://trac.macports.org/ticket/56789

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->