### PR TITLE
transcode: Don't override portfetch::assemble_url

### DIFF
--- a/multimedia/transcode/Portfile
+++ b/multimedia/transcode/Portfile
@@ -68,24 +68,11 @@ patchfiles      \
                 patch-filter-subtitler-load_font.c.diff
 
 # https://www.archlinux.org/packages/community/x86_64/transcode/
-patch_sites     https://git.archlinux.org/svntogit/community.git/plain/trunk/?h=packages/transcode
+patch_sites     https://git.archlinux.org/svntogit/community.git/plain/trunk/transcode-ffmpeg3.patch?h=packages/transcode&dummy=:ffmpeg3 \
+                https://git.archlinux.org/svntogit/community.git/plain/trunk/transcode-ffmpeg4.patch?h=packages/transcode&dummy=:ffmpeg4
 patchfiles-append \
-                transcode-ffmpeg3.patch \
-                transcode-ffmpeg4.patch
-
-# Simple macports-base/src/port1.0/fetch_common.tcl does not parse query in url.
-proc portfetch::assemble_url {site distfile} {
-	package require uri
-	set parts [uri::split $site]
-	if {[string index [dict get $parts path] end] ne "/"} {
-		set slash /
-	} else {
-		set slash ""
-	}
-	dict append parts path $slash [percent_encode ${distfile}]
-	set rval [uri::join {*}$parts]
-	return "$rval"
-}
+                transcode-ffmpeg3.patch:ffmpeg3 \
+                transcode-ffmpeg4.patch:ffmpeg4
 
 use_autoreconf  yes
 autoreconf.args -fiv


### PR DESCRIPTION
#### Description

Don't override `portfetch::assemble_url`. Instead, use https://trac.macports.org/wiki/PortfileRecipes#fetchwithgetparams

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1408           
Xcode 9.2 9C40b 
