### PR TITLE
auto-multiple-choice: Separate revision for each subport

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -32,6 +32,7 @@ if {${subport} eq ${name}} {
     set amc_revision        "git201805011238"
     set amc_date            "201805011238"
     version                 1.3.0.${amc_revision}
+    revision                1
     checksums               rmd160  fe210d0320577e27d09ee1975f6452cfccdd3606 \
                             sha256  4303691433ebea2e9420517d6a1c89b3ea2e1746f37753ea08109f44cdd8f2b7
     conflicts               auto-multiple-choice-devel
@@ -41,14 +42,13 @@ if {${subport} eq ${name}} {
     set amc_revision        "201805310528"
     set amc_date            "201805310528"
     version                 1.4.0.b${amc_revision}
+    revision                1
     checksums               rmd160  fb5a8adac676eff04fa3fe50fce035700031be34 \
                             sha256  7e7841eff281dd0496eb4bbc0303d16f47b97dee086f3f0e99ac18081d314e8c
     depends_build-append    port:gmake
     build.cmd               ${prefix}/bin/gmake
     conflicts               auto-multiple-choice
 }
-
-revision                1
 
 master_sites            https://gitlab.com/jojo_boulix/auto-multiple-choice/repository/archive.tar.gz?ref=${gitlab.commit}&dummy=
 distname                ${gitlab.project}-${gitlab.commit}-${gitlab.commit}


### PR DESCRIPTION
#### Description

Use a separate `revision` for each subport. This makes things easier/clearer when the version of only one of the subports is updated.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
