### PR TITLE
maxima: Revbump for sbcl 1.4.9

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -4,10 +4,7 @@ PortSystem      1.0
 
 name            sbcl
 
-# TODO: Figure out if outstanding request to revbump ../../math/maxima
-# when this port changes is still applicable
-# c.f <https://github.com/macports/macports-ports/commit/f564833fda44e715f61fe9c5e34e521a7ddc1882>
-
+# Please revbump maxima and maxima-devel when this port changes
 version         1.4.9
 
 categories      lang

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -3,7 +3,6 @@
 PortSystem 1.0
 
 name            maxima
-version         5.41.0
 categories      math
 maintainers     mareimbrium.org:kuba openmaintainer
 platforms       darwin
@@ -39,6 +38,7 @@ subport maxima-devel {
     # Date:  Fri Jun 15 17:26:53 2018 -0500
     # commit 7e71fc4b6a95cab6418227754f01fc44ac845da1
     version     5.41-dev-20180615
+    revision    1
     fetch.type  git
     git.url     https://git.code.sf.net/p/maxima/code
     git.branch  7e71fc4b6a95cab6418227754f01fc44ac845da1
@@ -51,6 +51,8 @@ subport maxima-devel {
 if {${subport} eq ${name}} {
     conflicts   maxima-devel
 
+    version     5.41.0
+    revision    1
     # get the source tarball from sourceforge.
     master_sites    sourceforge:project/maxima/Maxima-source/${version}-source
 


### PR DESCRIPTION
#### Description

Revbump to rebuild with sbcl 1.4.9.

See 7078ae882ba039c300f08c84a822468a010c1917 and https://github.com/macports/macports-ports/commit/f564833fda44e715f61fe9c5e34e521a7ddc1882#commitcomment-29557240.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
