### PR TITLE
Use consistent maintainer designation for KubaO

### DIFF
--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name            maxima
 version         5.41.0
 categories      math
-maintainers     mareimbrium.org:kuba openmaintainer
+maintainers     {mareimbrium.org:kuba @KubaO} openmaintainer
 platforms       darwin
 license         GPL-2+
 description     The Maxima computer algebra system

--- a/python/py-filterpy/Portfile
+++ b/python/py-filterpy/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        rlabbe filterpy 1.0.0
 name                py-filterpy
 categories-append   science
-maintainers         @KubaO openmaintainer
+maintainers         {mareimbrium.org:kuba @KubaO} openmaintainer
 license             MIT
 platforms           darwin
 


### PR DESCRIPTION
Use consistent maintainer designation for @KubaO. For maxima, I added the missing GitHub handle. For py-filterpy, I added the missing email address. In future, please ensure any new ports you maintain list both.

<!-- [skip notification] -->