### PR TITLE
Add GitHub handle matteocorti to maintainers

### DIFF
--- a/games/roll/Portfile
+++ b/games/roll/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        matteocorti roll 2.1.1 v
 categories          games
 platforms           darwin
-maintainers         corti.li:matteo
+maintainers         {corti.li:matteo @matteocorti}
 license             GPL-2
 
 description         Dice roller

--- a/perl/p5-file-slurp/Portfile
+++ b/perl/p5-file-slurp/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26
 perl5.setup         File-Slurp 9999.19
-maintainers         gmail.com:matteo.corti
+maintainers         {corti.li:matteo @matteocorti}
 license             {Artistic-1 GPL}
 description         Efficient reading/writing of complete files
 long_description    This module provides subs that allow you to read or \


### PR DESCRIPTION
Add GitHub handle @matteocorti to maintainers.

I also changed the email address for p5-file-slurp to match.

For any other ports that you become the maintainer of in the future, please remember to list both email address and GitHub handle.

<!-- [skip notification] -->