### PR TITLE
Use consistent maintainer designation for esafak

### DIFF
--- a/python/py-agate-dbf/Portfile
+++ b/python/py-agate-dbf/Portfile
@@ -8,7 +8,7 @@ name                py-agate-dbf
 version             0.2.0
 python.versions     27 35 36
 platforms           darwin
-maintainers         @esafak openmaintainer
+maintainers         {gmail.com:esafak @esafak} openmaintainer
 license             MIT
 
 description         Adds read support for DBF files to agate

--- a/python/py-agate-excel/Portfile
+++ b/python/py-agate-excel/Portfile
@@ -8,7 +8,7 @@ name                py-agate-excel
 version             0.2.1
 python.versions     27 35 36
 platforms           darwin
-maintainers         @esafak openmaintainer
+maintainers         {gmail.com:esafak @esafak} openmaintainer
 license             MIT
 
 description         Adds read support for Excel files (xls and xlsx) to agate

--- a/python/py-agate-sql/Portfile
+++ b/python/py-agate-sql/Portfile
@@ -8,7 +8,7 @@ name                py-agate-sql
 version             0.5.2
 python.versions     27 35 36
 platforms           darwin
-maintainers         @esafak
+maintainers         {gmail.com:esafak @esafak}
 license             MIT
 
 description         agate-sql adds SQL read/write support to agate.

--- a/python/py-agate/Portfile
+++ b/python/py-agate/Portfile
@@ -9,7 +9,7 @@ version             1.6.0
 python.versions     27 35 36
 revision            1
 platforms           darwin
-maintainers         @esafak
+maintainers         {gmail.com:esafak @esafak}
 license             MIT
 
 description         A Python data analysis library that is optimized for humans instead of machines

--- a/python/py-awesome_slugify/Portfile
+++ b/python/py-awesome_slugify/Portfile
@@ -9,7 +9,7 @@ version             1.6.5
 python.versions     27 35 36
 categories-append   textproc
 platforms           darwin
-maintainers         @esafak
+maintainers         {gmail.com:esafak @esafak}
 license             GPL-3
 
 description         Flexible slugify function

--- a/python/py-csvkit/Portfile
+++ b/python/py-csvkit/Portfile
@@ -10,7 +10,7 @@ version             1.0.2
 python.versions     27 35 36
 categories-append   textproc
 platforms           darwin
-maintainers         @esafak openmaintainer
+maintainers         {gmail.com:esafak @esafak} openmaintainer
 license             MIT
 supported_archs     noarch
 

--- a/python/py-dbfread/Portfile
+++ b/python/py-dbfread/Portfile
@@ -9,7 +9,7 @@ version             2.0.7
 python.versions     27 35 36
 
 platforms           darwin
-maintainers         @esafak openmaintainer
+maintainers         {gmail.com:esafak @esafak} openmaintainer
 license             MIT
 
 description         Read DBF Files with Python

--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -10,7 +10,7 @@ python.versions     26 27 35 36
 
 license             BSD
 platforms           darwin
-maintainers         @esafak
+maintainers         {gmail.com:esafak @esafak}
 
 description         An ISO 8601 date/time/duration parser and formatter
 long_description    This module implements ISO 8601 date, time and duration \

--- a/python/py-leather/Portfile
+++ b/python/py-leather/Portfile
@@ -9,7 +9,7 @@ version             0.3.3
 python.versions     27 35 36
 
 platforms           darwin
-maintainers         @esafak
+maintainers         {gmail.com:esafak @esafak}
 license             MIT
 
 description         Python charting for 80% of humans

--- a/python/py-pytimeparse/Portfile
+++ b/python/py-pytimeparse/Portfile
@@ -8,7 +8,7 @@ name                py-$base_name
 version             1.1.6
 python.versions     27 35 36
 platforms           darwin
-maintainers         openmaintainer @esafak
+maintainers         openmaintainer {gmail.com:esafak @esafak}
 license             MIT
 
 description         A small Python module to parse various kinds of time expressions

--- a/python/py-slugify/Portfile
+++ b/python/py-slugify/Portfile
@@ -11,7 +11,7 @@ python.versions     27 35 36
 
 categories-append   textproc
 platforms           darwin
-maintainers         openmaintainer @esafak
+maintainers         openmaintainer {gmail.com:esafak @esafak}
 license             MIT
 
 description         Returns unicode slugs

--- a/python/py-unidecode/Portfile
+++ b/python/py-unidecode/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc
 platforms           darwin
 supported_archs     noarch
 license             GPL-2+
-maintainers         {phas.ubc.ca:jfcaron @jfcaron3} @esafak openmaintainer
+maintainers         {phas.ubc.ca:jfcaron @jfcaron3} {gmail.com:esafak @esafak} openmaintainer
 
 description         ASCII transliterations of Unicode text
 long_description    Unidecode takes Unicode data and tries to \

--- a/sysutils/sift/Portfile
+++ b/sysutils/sift/Portfile
@@ -13,7 +13,7 @@ platforms           darwin
 categories          sysutils
 license             GPL-3+
 installs_libs       no
-maintainers         {kahuna.com:esafak @esafak}
+maintainers         {gmail.com:esafak @esafak}
 description         A fast and powerful open source alternative to grep
 long_description    sift is an alternative that aims for both speed and flexibility, \
                     adding features while trying to reach (or even surpass) the performance \


### PR DESCRIPTION
Use consistent maintainer designation for @esafak.

Most of your ports did not list an email address; I added your GMail address, to match what was already listed in your py-pew port. One of your ports, sift, was using a Kahuna address; I changed this to the GMail address to match.

If the GMail address is not the one you want listed, let me know and I can change it (or you can [modify the commit in this PR](https://trac.macports.org/wiki/WorkingWithGit#WorkingwithsomeoneelsespullrequestthroughitsID)).

For any ports that you become the maintainer of in the future, be sure to list both your GitHub handle and your chosen email address.

<!-- [skip notification] -->