### PR TITLE
Add new port : Nheko

### DIFF
--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
+#NOTE: requires C++14
+
+github.setup        mujx nheko 0.5.2 v
+categories          net chat
+platforms           darwin
+license             GPL-3
+maintainers         {@scarface-one gmail.com:sireeshkodali1}
+description         A matrix chat client
+long_description    Nheko is a native desktop matrix \
+                    chat client. It aims to be more \
+                    like a chat app and less like an \
+                    IRC client
+
+checksums           rmd160  be32b10c51960a1d27dd4fa410f82e5dd1e98534 \
+                    sha256  d7c189efd04ffa032b46c5eb24cf076ade5ddec3434b937ec9d0de952bb8f79b \
+                    size    4526124
+
+#C++14 was first fully supported by clang 3.4 aka apple clang 503.0.38
+# But TLS was first implemented by apple clang 800.0.38
+compiler.blacklist-append {clang < 800.0.38}
+
+if {(${os.major} < 16)} {
+    pre-fetch {
+        ui_error "${name} ${version} requires features in the macOS 10.12 or greater SDK to run"
+        return -code error "incompatible OS X version"
+    }
+}
+
+configure.cxxflags-append -fno-sized-deallocation
+
+depends_build-append port:lmdbxx \
+                    port:matrix-structs \
+                    port:mtxclient \
+                    port:olm \
+                    port:tweeny
+
+depends_lib-append  port:boost \
+                    port:fontconfig \
+                    port:libsodium \
+                    port:lmdb \
+                    port:qt5-qtbase \
+                    port:qt5-qtmacextras \
+                    port:qt5-qtmultimedia \
+                    port:qt5-qtsvg \
+                    port:qt5-qttools \
+                    port:spdlog
+
+destroot {
+    copy ${workpath}/build/nheko.app ${destroot}${applications_dir}/Nheko.app
+}


### PR DESCRIPTION
This patch adds a portfile for matrix chat client, nheko

#### Description

Nheko is a cross-platform matrix based chat client. Matrix is a decentralised, secure communication protocol.

Nheko home page : https://github.com/mujx/nheko
Matrix home page : https://matrix.org 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.14 18A326h
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
