### PR TITLE
py-chainer: update to version 1.24.0

### DIFF
--- a/python/py-chainer/Portfile
+++ b/python/py-chainer/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pfnet chainer 1.1.1 v
+github.setup        chainer chainer 1.24.0 v
 name                py-chainer
-maintainers         nomaintainer
+maintainers         {@funasoul gmail.com:funasoul} openmaintainer
 license             MIT
 supported_archs     noarch
 
@@ -16,14 +16,16 @@ long_description    ${description}
 homepage            https://chainer.org/
 platforms           darwin
 
-python.versions     27 34 35 36
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
-    checksums           rmd160  d09dcb82a97bffeb14fd53ab271679c891eb95cb \
-                        sha256  e68a17eea76d3de6cb29cf228ad76dea1491c3b03724000feaedf60e1a6a8edd
+    checksums           rmd160  42d1f80b4415de0f33d1fdbd9d29cdc5281fa56a \
+                        sha256  a8c87992ed7685b671cb9cee76f0cbbdf4a142c7e173db1b89a21db095cc1a06 \
+                        size    2517241
 
     depends_lib-append  port:py${python.version}-numpy \
-                        port:py${python.version}-scikit-learn
+                        port:py${python.version}-filelock \
+                        port:py${python.version}-six
 
     post-destroot {
         # install additional documents
@@ -36,6 +38,18 @@ if {${name} ne ${subport}} {
         foreach f [glob -directory ${worksrcpath}/examples *] {
             copy $f ${destroot}${docdir}/examples/[file tail $f]
         }
+    }
+
+    variant hdf5 description {Support HDF5 serialization} {
+        depends_lib-append      port:py${python.version}-h5py
+    }
+
+    variant imagedataset description {Support image dataset} {
+        depends_lib-append      port:py${python.version}-Pillow
+    }
+
+    variant protobuf description {Caffe model support} {
+        depends_lib-append      port:py${python.version}-protobuf3
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description
* update to version 1.24.0
* changed depends_lib
* add maintainer
* add hdf5, imagedataset and protobuf variants
* add Python37 binding
* remove Python34 and Python35 bindings

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->