### PR TITLE
graphene: fix build on leopard

### DIFF
--- a/graphics/graphene/Portfile
+++ b/graphics/graphene/Portfile
@@ -38,6 +38,13 @@ platform darwin i386 {
     compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 212}
 }
 
+# 10.5 or less has no special memalign but doesn't absolutely need it
+# as the fallthrough to malloc returns aligned memory. Passes all tests.
+if {${os.platform} eq "darwin" && ${os.major} < 10 } {
+    patchfiles-append patch-graphene-leopard.diff
+    patchfiles-append patch-src-bench-matrix.diff
+}
+
 # attempt to fix build on 10.6 using gcc-4.2
 # error: ‘for’ loop initial declaration used outside C99 mode
 configure.cflags-append \

--- a/graphics/graphene/files/patch-graphene-leopard.diff
+++ b/graphics/graphene/files/patch-graphene-leopard.diff
@@ -1,0 +1,19 @@
+--- meson.build.orig	2018-07-12 09:05:18.000000000 -0700
++++ meson.build	2018-07-12 09:18:40.000000000 -0700
+@@ -92,7 +92,6 @@
+     '-Wcast-align',
+     '-Wno-unused-local-typedefs',
+     '-Werror=float-conversion',
+-    '-Werror=redundant-decls',
+     '-Werror=missing-prototypes',
+     '-Werror=missing-declarations',
+     '-Werror=format=2',
+@@ -163,7 +162,7 @@
+ elif cc.has_function('posix_memalign', prefix: '#include <stdlib.h>') and not (host_system == 'windows')
+   conf.set10('HAVE_POSIX_MEMALIGN', 1, description: 'Define if posix_memalign() is available')
+ else
+-  error('No aligned malloc function could be found.')
++ # error('No aligned malloc function could be found.')
+ endif
+ 
+ # Look for sincosf(), a GNU libc extension

--- a/graphics/graphene/files/patch-src-bench-matrix.diff
+++ b/graphics/graphene/files/patch-src-bench-matrix.diff
@@ -1,0 +1,11 @@
+--- src/bench/matrix.c.orig	2018-04-12 18:56:35.000000000 -0700
++++ src/bench/matrix.c	2018-04-12 18:56:56.000000000 -0700
+@@ -59,7 +59,7 @@
+ #elif defined(HAVE_MEMALIGN)
+   res = memalign (alignment, real_size);
+ #else
+-#error "Need some type of aligned allocation function"
++  res = malloc (real_size);
+ #endif
+ 
+   g_assert (res != NULL);


### PR DESCRIPTION
by taking out the error during configuration, graphene
fall back to malloc if no aligned memory call available
fixes build on 10.5 ppc and perhaps others
passes all tests
