### PR TITLE
paq8: add stdlib to clang builds

### DIFF
--- a/archivers/paq8/Portfile
+++ b/archivers/paq8/Portfile
@@ -28,6 +28,12 @@ checksums           md5 a5099ae1f62c292eb16fb7930eb1f68d \
 extract.mkdir       yes
 use_configure       no
 
+# add the selected -stdlib to clang builds
+# see https://trac.macports.org/ticket/56811
+if {[string match *clang* ${configure.cxx}]} {
+    configure.cxx ${configure.cxx} -stdlib=${configure.cxx_stdlib}
+}
+
 build.cmd           ${configure.cxx}
 build.args          -O3 -DUNIX -DNOASM -o paq8
 build.target        paq${version}.cpp


### PR DESCRIPTION
fixes incorrect c++ stdlib usage
see: https://trac.macports.org/ticket/56811
