### PR TITLE
MythTV 29.1 and MythWeb 29.1 Updates

### DIFF
--- a/multimedia/mythtv29/Portfile
+++ b/multimedia/mythtv29/Portfile
@@ -1,0 +1,668 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qt5 1.0
+PortGroup           perl5 1.0
+PortGroup           github 1.0
+PortGroup           active_variants 1.1
+PortGroup           conflicts_build 1.0
+
+set shorthash       e5fc66e822
+# set fullhash      8238e839c90de35f7c64380d2c4e360192862a34
+set majorversion    29
+set minorversion    .1
+set lastcommit      20180820
+set corerev         2
+set pluginsrev      1
+set metarev         0
+github.setup        MythTV mythtv ${shorthash}
+checksums           rmd160  62efbd440a1e8c50a8d496535f64ccd12a6a844f \
+                    sha256  25d67dda2e5c052a89b6bcc80cabb1ca3e670bbecdff3494b83dc8bd5ed498ff
+
+name                mythtv${majorversion}
+categories          multimedia
+platforms           darwin
+# i386 unsupported -- https://trac.macports.org/ticket/40337
+supported_archs     x86_64
+license             GPL-2
+maintainers         {ctreleaven @ctreleaven} openmaintainer
+homepage            https://www.mythtv.org/
+universal_variant   no
+
+livecheck.version   ${majorversion}${minorversion}
+livecheck.regex     "archive/v(${majorversion}\[\\.\\d\]?)${extract.suffix}"
+
+set nick            mythtv
+set mythtvhomedir   ${prefix}/var/mythtvuser
+set mythtvlogdir    ${prefix}/var/log/${nick}${majorversion}
+set mythtvrundir    ${prefix}/var/run/${nick}${majorversion}
+set mythtvpidfile   ${mythtvrundir}/${nick}
+set plistdir        ${prefix}/Library/LaunchDaemons
+set plistlabel      org.mythtv.mythbackend
+set plistfile       org.mythtv.mythbackend.plist
+set mythverstring   v${majorversion}${minorversion}-${shorthash}-MacPorts
+set mythbranch      fixes/${majorversion}
+set applescripts    {Myth_Frontend Myth_Filldatabase Myth_Setup Myth_Stop_Start}
+set mysqlver        mariadb
+set pythonbranch    2.7
+set pythonver       python${pythonbranch}
+set pythonbin       ${prefix}/bin/${pythonver}
+set pymodver        py27
+perl5.branches      5.26
+# change to 1 to print reinplace warnings
+set maintainer_mode 0
+if {!$maintainer_mode} {
+	set qflag "-q"
+} else {
+	set qflag ""
+}
+
+subport mythtv-core${majorversion} { }
+subport mythtv-plugins${majorversion} { }
+
+if {$subport eq "mythtv-core${majorversion}"} {
+    PortGroup           compiler_blacklist_versions 1.0
+    revision            ${corerev}
+    name                mythtv-core${majorversion}
+    version             ${majorversion}${minorversion}-Fixes-${lastcommit}
+
+    description         personal video recorder (PVR) and media centre system
+    long_description    The ultimate Digital Video Recorder and home media \
+                        center hub. Think of it as a Free and Open Source alternative \
+                        to Windows Media Center or Tivo.
+
+    depends_lib-append  port:bzip2 \
+                        port:exiv2 \
+                        port:libass \
+                        port:libbluray \
+                        port:libcdio \
+                        port:libdvdcss \
+                        port:libiconv \
+                        port:libxml2 \
+                        port:fftw-3 \
+                        port:fftw-3-single \
+                        port:freetype \
+                        port:lame \
+                        path:lib/libssl.dylib:openssl \
+                        port:faac \
+                        port:x264 \
+                        port:x265 \
+                        port:qt5-mysql-plugin \
+                        port:qt5-qtscript \
+                        port:qt5-qtwebkit \
+                        port:taglib \
+                        port:zlib \
+                        port:${pymodver}-future \
+                        port:${pymodver}-mysql \
+                        port:${pymodver}-lxml \
+                        port:${pymodver}-requests-cache \
+                        port:${pymodver}-urlgrabber \
+                        port:p${perl5.major}-dbd-mysql \
+                        port:p${perl5.major}-http-request-ascgi \
+                        port:p${perl5.major}-lwp-useragent-determined \
+                        port:p${perl5.major}-io-socket-inet6 \
+                        port:p${perl5.major}-date-manip \
+                        port:p${perl5.major}-net-upnp
+    
+    depends_build-append \
+                        port:yasm
+    
+    conflicts           mythtv-core.25 mythtv-core.26 mythtv-core.27 mythtv-core.28
+    conflicts_build     hdhomerun
+
+    depends_run         port:logrotate \
+                        port:dejavu-fonts \
+			            port:liberation-fonts
+
+    require_active_variants \
+                        qt5-mysql-plugin mariadb55 mysql56
+    require_active_variants \
+                        p${perl5.major}-dbd-mysql mariadb {mariadb10_0 mariadb10_1 mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 percona}
+    require_active_variants \
+                        ${pymodver}-mysql mariadb55 {mysql4 mysql51 mysql55 mysql56 percona55}
+    require_active_variants \
+                        logrotate startupitem
+    
+    pre-fetch {
+        if {${os.platform} eq "darwin" && ${os.major} < 13} {
+            ui_error "${name} ${version} requires Mac OS X 10.9 or greater."
+            return -code error "incompatible Mac OS X version"
+        }
+    }
+    
+    post-extract {
+        file mkdir ${worksrcpath}/macports
+        foreach {applescript} ${applescripts} {
+            copy ${filespath}/${applescript}.applescript ${worksrcpath}/macports/${applescript}.applescript
+        }
+        copy ${filespath}/${plistfile} ${worksrcpath}/macports/${plistfile}
+        copy ${filespath}/logrotate.conf ${worksrcpath}/macports/logrotate.conf
+        copy ${filespath}/logrotate.mythtv ${worksrcpath}/macports/logrotate.mythtv
+        copy ${filespath}/my.cnf ${worksrcpath}/macports/my.cnf
+        copy ${filespath}/mythconverg_init.sql ${worksrcpath}/macports/mythconverg_init.sql
+    }
+    
+    # revert rpath linking stuff as it is non-functional in MacPorts
+    patchfiles-append   patch-rpath_linking.diff
+    # If MacPorts libdvdnav is installed, Myth #Includes an old version of libmythdvdnav ?!?
+    # occurs following ffmpeg re-sync, see https://github.com/MythTV/mythtv/commit/4f02b2f98a60940449bca05eab67ac764fc1e1e7#diff-282748943dcb8e362702042df95a1d98
+    patchfiles-append   patch-dvdnav_include_path.diff
+    # if mesa is installed, prevent Myth from finding/using it
+    patchfiles-append   patch-configure_opengl_check.diff
+    # https://code.mythtv.org/trac/ticket/12857
+    patchfiles-append   patch-mythwidgets_osx_focus.diff
+    # https://code.mythtv.org/trac/ticket/13001
+    patchfiles-append   patch_01_typlayer_qsp_ua_detection.diff
+    
+    post-patch {
+        set sedPath ${worksrcpath}/mythtv/
+        ui_info "Make Myth utils use MacPorts Perl"
+        reinplace -locale C "s|check_cmd perl -e|check_cmd ${perl5.bin} -e|" \
+            ${sedPath}configure
+    
+        reinplace -locale C "s|#!/usr/bin/env perl|#!${perl5.bin}|" \
+            ${sedPath}programs/scripts/internetcontent/topdocumentaryfilm.pl  \
+            ${sedPath}programs/scripts/internetcontent/twit.tv.pl
+    
+        reinplace -locale C "s|#!/usr/bin/perl|#!${perl5.bin}|" \
+            ${sedPath}bindings/perl/Makefile.PL  \
+            ${sedPath}contrib/maintenance/optimize_mythdb.pl  \
+            ${sedPath}contrib/user_jobs/mythlink.pl  \
+            ${sedPath}programs/scripts/database/mythconverg_backup.pl \
+            ${sedPath}programs/scripts/database/mythconverg_restore.pl
+    
+        reinplace -locale C "s|/usr/local/bin|${prefix}/lib/${mysqlver}/bin|"  \
+            ${sedPath}programs/scripts/database/mythconverg_backup.pl
+    
+        ui_info "Record Myth version strings"
+        reinplace -locale C "s#\${SOURCE_VERSION}#${mythverstring}#g" ${sedPath}version.sh
+        reinplace -locale C "s#\${BRANCH}#${mythbranch}#g" ${sedPath}version.sh
+    
+        ui_info "Make Myth scripts use MacPorts Python  <<<<"
+        # Hack to install Python bindings in ${prefix}/Library/Frameworks/Python.framework/Versions/2.7
+        reinplace -locale C "s|\$(ROOT_FLAGS) \$(PREFIX_FLAGS)|\$(ROOT_FLAGS) \--prefix=\"${frameworks_dir}/Python.framework/Versions/${pythonbranch}\"|" \
+            ${sedPath}/bindings/python/Makefile
+        reinplace -locale C "s|/usr/local|${prefix}|" ${worksrcpath}/mythtv/bindings/python/MythTV/static.py
+        fs-traverse f ${sedPath}/bindings/python/ {
+            if [string equal [ file extension ${f} ] ".py" ] {
+                reinplace {*}$qflag -locale C "s|^#! */usr/bin/env python\$|#!${pythonbin}|" ${f}
+            }
+        }
+        fs-traverse f ${sedPath}/programs/scripts/ {
+            if [string equal [ file extension ${f} ] ".py" ] {
+                reinplace {*}$qflag -locale C "s|^#! */usr/bin/env python\$|#!${pythonbin}|" ${f}
+            }
+        }
+        foreach f [glob -directory ${sedPath}/programs/scripts/hardwareprofile *.py] {
+        # fix even though they're currently non-functional on OS X
+            reinplace {*}$qflag -locale C "s|^#!/usr/bin/python\$|#!${pythonbin}|" ${f}
+        }
+    
+        foreach {applescript} ${applescripts} {
+            reinplace {*}$qflag -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/macports/${applescript}.applescript
+            reinplace {*}$qflag -locale C "s|@APPLICATIONS_DIR@|${applications_dir}|" ${worksrcpath}/macports/${applescript}.applescript
+            reinplace {*}$qflag -locale C "s|@MYTHTVLOGDIR@|${mythtvlogdir}|" ${worksrcpath}/macports/${applescript}.applescript
+            reinplace {*}$qflag -locale C "s|@MYTHTVPIDFILE@|${mythtvpidfile}|" ${worksrcpath}/macports/${applescript}.applescript
+        }
+        reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/macports/${plistfile}
+        reinplace -locale C "s|@PLISTLABEL@|${plistlabel}|g" ${worksrcpath}/macports/${plistfile}
+        reinplace -locale C "s|@PYTHONVER@|${pythonver}|" ${worksrcpath}/macports/${plistfile}
+        reinplace -locale C "s|@MYTHTVLOGDIR@|${mythtvlogdir}|" ${worksrcpath}/macports/${plistfile}
+        reinplace -locale C "s|@MYTHTVPIDFILE@|${mythtvpidfile}|" ${worksrcpath}/macports/${plistfile}
+        reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/macports/logrotate.conf
+        reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/macports/my.cnf
+        reinplace -locale C "s|@MYTHTVLOGDIR@|${mythtvlogdir}|g" ${worksrcpath}/macports/logrotate.mythtv
+    }
+    # Block various compilers:
+    #
+    # (shamelessly stolen from Qt4-mac, thanks Michael!)
+    # * Some older versions of CLANG do not honor the LIBRARY_PATH
+    # environment variable, which is required for compiling
+    # this port when using MacPorts.  The versions seem to be: MacPorts
+    # CLANG 3.0 or earlier, and Apple CLANG 318.0.61 or older (XCode 4.3.3 and prior).
+    #
+    # See http://code.mythtv.org/trac/ticket/11070
+    # Run-time failures experienced with certain versions of Clang.  Unable to discern cause.
+    # Most recent version of clang seems OK, let's try again
+    
+    compiler.fallback-append apple-gcc-4.2
+    compiler.blacklist-append { clang <= 500.2.79 } \
+        macports-clang*
+    
+    # Clear all MacPorts flags...MythTV is smart enough to set up its own.
+    # (ala qt4-mac/Portfile)
+    configure.cflags
+    configure.cppflags
+    configure.cxxflags
+    configure.objcflags
+    configure.ldflags
+    
+    configure.universal_cflags
+    configure.universal_cppflags
+    configure.universal_cxxflags
+    configure.universal_ldflags
+    
+    configure.cc_archflags
+    configure.cxx_archflags
+    configure.ld_archflags
+    
+    # make pkg-config act like on Linux, no '-I/opt/local/include' in cflags
+    configure.env-append    PKG_CONFIG_SYSTEM_INCLUDE_PATH=${prefix}/include
+    
+    configure.dir       ${worksrcpath}/mythtv
+    configure.args      --compile-type=release \
+                        --qmake=${qt_qmake_cmd} \
+                        --cc=${configure.cc} \
+                        --cxx=${configure.cxx} \
+                        --extra-ldflags='-framework ApplicationServices' \
+                        --python=${pythonbin} \
+                        --disable-mythlogserver \
+                        --disable-ceton \
+                        --disable-firewire \
+                        --disable-audio-jack --disable-indev=jack \
+                        --disable-audio-pulseoutput \
+                        --disable-gnutls \
+                        --disable-libcec \
+                        --disable-libpulse \
+                        --disable-libvpx \
+                        --disable-libxcb \
+                        --disable-libxvid \
+                        --disable-lzma \
+                        --disable-openssl \
+                        --disable-qtdbus \
+                        --disable-sdl \
+                        --disable-systemd_notify \
+                        --disable-videotoolbox \
+                        --disable-xlib \
+                        --disable-xrandr \
+                        --disable-xv \
+                        --enable-iconv \
+                        --enable-fft \
+                        --enable-libbluray \
+                        --enable-libcrypto \
+                        --enable-libmp3lame \
+                        --enable-libass \
+                        --enable-libx264 --enable-nonfree \
+                        --enable-libx265 \
+                        --enable-securetransport \
+                        --enable-vbox \
+                        --enable-vda \
+                        --enable-zlib
+    
+    # VideoToolBox: Myth does not currently use this acceleration API even though the
+    # underlying ffmpeg does.  Maybe someday...
+    
+    # --extra-ldflags should not be necessary, see
+    # https://code.mythtv.org/trac/ticket/12596
+    
+    if {${configure.ccache} != "yes"} {
+        configure.args-append --disable-ccache
+    }
+    
+    if {${configure.distcc} != "yes"} {
+        configure.args-append --disable-distcc
+    }
+
+    build.dir           ${worksrcpath}/mythtv
+    # make Myth's copy of ffmpeg build verbosely
+    build.env-append    V=1
+    
+    pre-build {
+        # workaround broken linker flags, see
+        # https://trac.macports.org/ticket/40136
+        # 0.28, problem sometimes appears with ffserver, other ffmpeg libs OK?!?        #reinplace -locale C "s|LDFLAGS=  |LDFLAGS= -headerpad_max_install_names |" ${worksrcpath}/mythtv/external/FFmpeg/config.mak
+        reinplace -locale C "s|LDFLAGS-ffserver=|LDFLAGS-ffserver=-headerpad_max_install_names |" ${worksrcpath}/mythtv/external/FFmpeg/config.mak
+    
+        ui_info "Build Myth AppleScript helper apps"
+        # Compile applescrips
+        foreach {applescript} ${applescripts} {
+            system "osacompile -x -o ${worksrcpath}/macports/${applescript}.app ${worksrcpath}/macports/${applescript}.applescript"
+        }
+        # Myth custom icon for a couple of the applets
+        copy -force ${configure.dir}/programs/mythfrontend/mythfrontend.icns ${worksrcpath}/macports/Myth_Frontend.app/Contents/Resources/applet.icns
+        copy -force ${configure.dir}/programs/mythfrontend/mythfrontend.icns ${worksrcpath}/macports/Myth_Stop_Start.app/Contents/Resources/applet.icns
+    }
+    
+    # All tests fail with messages like:
+    # dyld: Library not loaded: @rpath//opt/local/lib/libmythbase-0.27.0.dylib
+    #   Referenced from: /opt/local/var/macports/build/_Users_craigtreleaven_MacPortsTemp_mythtv-core-devel/mythtv-core.27/work/mythtv-8b542e20/mythtv/libs/././libmyth/test/test_audioconvert/test_audioconvert
+    #   Reason: image not found
+    # ../programs/scripts/unittests.sh: line 15: 41587 Trace/BPT trap          ./$RUNNABLE
+    # Need to investigate why rpath not working under MacPorts...
+    
+    # test.run            yes
+    
+    destroot.destdir    INSTALL_ROOT=${destroot}
+    
+    post-destroot {
+    # make some directories myth will need
+        xinstall -d -m 755 ${destroot}${mythtvhomedir}
+        xinstall -d -m 777 ${destroot}${mythtvlogdir}
+        xinstall -d -m 777 ${destroot}${mythtvlogdir}/old
+        xinstall -d -m 755 ${destroot}${prefix}/etc/logrotate.d
+        xinstall -d -m 744 ${destroot}${mythtvrundir}
+    
+        destroot.keepdirs \
+            ${destroot}${mythtvhomedir} \
+            ${destroot}${mythtvlogdir} \
+            ${destroot}${mythtvlogdir}/old \
+            ${destroot}${mythtvrundir}
+    
+    # install logrotate.mythtv
+        xinstall -m 400 ${worksrcpath}/macports/logrotate.mythtv ${destroot}${prefix}/etc/logrotate.d
+    
+    # install the launchd plist for the backend
+        ui_info "Installing startupitem/launchd plist..."
+        xinstall -d -m 0755 ${destroot}${plistdir}
+        xinstall ${worksrcpath}/macports/${plistfile} ${destroot}${plistdir}
+    
+    # install scripts we want in share/contrib
+        ui_info "Installing share/$name/contrib scripts..."
+    
+        xinstall -d -m 755 ${destroot}${prefix}/share/${nick}/database
+        xinstall -d -m 755 ${destroot}${prefix}/share/${nick}/contrib
+    
+        xinstall -m 755 \
+            ${configure.dir}/database/mc.sql \
+            ${worksrcpath}/macports/mythconverg_init.sql \
+            ${worksrcpath}/macports/my.cnf \
+            ${destroot}${prefix}/share/${nick}/database
+        xinstall -m 755 \
+            ${configure.dir}/contrib/maintenance/optimize_mythdb.pl \
+            ${configure.dir}/contrib/user_jobs/mythlink.pl \
+            ${destroot}${prefix}/share/${nick}/contrib
+    
+    # install some simple Applescripts to launch common myth apps
+        ui_info "Installing Applescript helpers..."
+        # compile the Applescripts
+        xinstall -m 755 -d ${destroot}${applications_dir}/MythTV
+    
+        foreach {applescript} ${applescripts} {
+            copy ${worksrcpath}/macports/${applescript}.app ${destroot}${applications_dir}/MythTV/${applescript}.app
+        }
+    
+    # Myth custom icon for a couple of the applets
+        copy -force ${configure.dir}/programs/mythfrontend/mythfrontend.icns ${destroot}${applications_dir}/MythTV/Myth_Frontend.app/Contents/Resources/applet.icns
+        copy -force ${configure.dir}/programs/mythfrontend/mythfrontend.icns ${destroot}${applications_dir}/MythTV/Myth_Stop_Start.app/Contents/Resources/applet.icns
+    
+    # Fix up library entries in dylibs and executables ...
+    # need to loop on arch's if/when build universal ?!?
+        set libdir ${prefix}/lib
+    
+        ui_info "Correcting library entries in dylibs..."
+    
+        foreach {dylib} [glob -types f -tails -directory ${destroot}${libdir} *.dylib] {
+            # glob gives us both files and links to files
+            if { [file type ${destroot}${libdir}/${dylib}] == "file" } {
+                ui_debug "... for ${dylib}"
+                system "install_name_tool -id ${libdir}/${dylib} ${destroot}${libdir}/${dylib}"
+    
+                set otool [lrange [split [exec otool -L ${destroot}${libdir}/${dylib}] \n] 1 end]
+    
+                foreach {otoolentry} ${otool} {
+                    # fix entries like "libmythswscale.dylib" to "${prefix}/lib/libmythswscale.dylib"
+                    # assume anything without a leading slash needs fixing
+                    set firstchar [string range [string trimleft ${otoolentry}] 0 0]
+                    if  { ${firstchar} != "/" }  {
+                        set lib [lindex ${otoolentry} 0]
+                        ui_debug "      Change ${lib}  to  ${libdir}/[file tail ${lib}]"
+                        system "install_name_tool -change \
+                            ${lib} \
+                            ${libdir}/[file tail ${lib}] \
+                            ${destroot}${libdir}/${dylib}"
+                    }
+                }
+            }
+        }
+        set bindir ${prefix}/bin
+        ui_info "Correcting library entries in executables..."
+    
+        foreach {prog} [glob -types f -tails -directory ${destroot}${bindir} *] {
+            # glob gives us files and links to files but should be no links in bin dir
+            ui_debug "... for ${prog}"
+    
+            set otool [lrange [split [exec otool -L ${destroot}${bindir}/${prog}] \n] 1 end]
+    
+            foreach {otoolentry} ${otool} {
+                # fix entries like "libmythswscale.dylib" to "${prefix}/lib/libmythswscale.dylib"
+                # assume anything without a leading slash needs fixing
+                set firstchar [string range [string trimleft ${otoolentry}] 0 0]
+                if  { ${firstchar} != "/" }  {
+                    set lib [lindex ${otoolentry} 0]
+                    ui_debug "      Change ${lib} to ${libdir}/[file tail ${lib}]"
+                    system "install_name_tool -change \
+                        ${lib} \
+                        ${libdir}/[file tail ${lib}] \
+                        ${destroot}${bindir}/${prog}"
+                }
+            }
+        }
+    
+    # fix lib entries in filters
+        set fltdir ${prefix}/lib/mythtv/filters
+        set liblist [glob -types f -tails -directory ${destroot}${libdir} -- *.dylib]
+        ui_info "Correcting library entries in plugins..."
+    
+        foreach {flt} [glob -types f -tails -directory ${destroot}${fltdir} *] {
+            # glob gives us files and links to files but should be no links in filters dir
+            ui_debug "... for ${flt}"
+    
+            set otool [lrange [split [exec otool -L ${destroot}${fltdir}/${flt}] \n] 1 end]
+    
+            foreach {otoolentry} ${otool} {
+                # fix entries like "libmythswscale.dylib" to "${prefix}/lib/libmythswscale.dylib"
+                # assume anything without a leading slash needs fixing
+                set firstchar [string range [string trimleft ${otoolentry}] 0 0]
+                if  { ${firstchar} != "/" }  {
+                    set lib [lindex ${otoolentry} 0]
+                    if { [ lsearch $liblist ${lib} ] > 0 } {
+                        set goodprefix ${libdir}
+                    } else {
+                        set goodprefix ${fltdir}
+                    }
+                    ui_debug "      Change ${lib} to ${goodprefix}/[file tail ${lib}]"
+                    system "install_name_tool -change \
+                        ${lib} \
+                        ${goodprefix}/[file tail ${lib}] \
+                        ${destroot}${fltdir}/${flt}"
+                }
+            }
+        }
+
+    # move mythwikiscripts to a more useful spot
+    move ${destroot}${frameworks_dir}/Python.framework/Versions/${pythonbranch}/bin/mythwikiscripts \
+        ${destroot}${prefix}/bin/
+
+    }
+    
+    universal_variant           no
+
+    set fontdir ${prefix}/share/mythtv/fonts
+
+    post-activate {
+        # make logrotate ready to go
+        if {![file exists ${prefix}/etc/logrotate.conf]} {
+            file copy ${destroot}logrotate.conf ${prefix}/etc/logrotate.conf
+        }
+        # delete leftover file, if any
+        if [file exists /Library/LaunchDaemons/${plistfile}] {
+            file delete -force /Library/LaunchDaemons/${plistfile}
+        }
+        # If "startupitem.install" is set to "no" in macports.conf then do not link.
+        if {${startupitem.install} != "no"} {
+            ln -s ${plistdir}/${plistfile} /Library/LaunchDaemons
+        } else {
+            notes-append "
+            Installation of the startup item was prohibited due to a setting."
+        }
+        ui_debug "Make fonts available to Myth"
+        system -W ${fontdir} "ln -sfv ${prefix}/share/fonts/dejavu-fonts/DejaVuSans*.ttf ."
+        system -W ${fontdir} "ln -sfv ${prefix}/share/fonts/liberation-fonts/LiberationSans*.ttf ."
+    }
+    
+    pre-deactivate {
+         file delete -force ${plistdir}/${plistfile}
+         file delete -force ${fontdir}/DejaVuSans*.ttf
+         file delete -force ${fontdir}/LiberationSans*.ttf
+    }
+
+    notes "############################################################################
+#
+# See http://www.mythtv.org/wiki/Myth_for_Mac_with_MacPorts for information
+# essential to finishing the initial installation of MythTV!
+#
+# NB -
+# For troubleshooting, all Myth-related logs are stored in
+# ${mythtvlogdir}
+#
+############################################################################"
+}
+
+if {$subport eq "mythtv-plugins${majorversion}"} {
+    name                mythtv-plugins${majorversion}
+    version             ${majorversion}${minorversion}-Fixes-${lastcommit}
+    revision            ${pluginsrev}
+    description         MythTV plugins for slideshows, music and weather
+    long_description    ${description}  \
+                        Each plugin is a variant.  The non-default plugins currently do not \
+                        work on OS X, such as MythNews, MythBrowser and MythNetVision.
+    dist_subdir         mythtv-core${majorversion}
+
+    post-patch {
+        set sedPath ${worksrcpath}/mythplugins/
+        reinplace -locale C "s|check_cmd perl -e|check_cmd ${perl5.bin} -e|" \
+            ${sedPath}configure
+        reinplace -locale C "s|python=\"python\"|python=\"${pythonbin}\"|" \
+            ${sedPath}configure
+        # do fixups regardless of whether variant is selected or not
+        foreach fixfile [exec find ${sedPath}/mythweather/mythweather/scripts -name "*.p?"] {
+            reinplace {*}$qflag "s;/usr/bin/perl;${perl5.bin};g" ${fixfile}
+            reinplace {*}$qflag "s;/usr/share/mythtv;${perl5.bin};g" ${fixfile}
+        }
+    }
+
+    conflicts_build     ffmpeg \
+                        metaio
+
+    depends_lib-append  port:mythtv-core${majorversion} \
+                        path:lib/libssl.dylib:openssl
+    # NB mythplugins/configure reads ${prefix}/include/mythtv/mythconfig.mak
+    # and sets several values from that, including cc and cxx
+
+    configure.dir       ${worksrcpath}/mythplugins
+
+    # make pkg-config act like on Linux, no '-I/opt/local/include' in cflags
+    configure.env-append    PKG_CONFIG_SYSTEM_INCLUDE_PATH=${prefix}/include
+
+    configure.args      --compile-type=release \
+                        --qmake=${qt_qmake_cmd} \
+                        --python=${pythonbin} \
+                        --disable-mytharchive \
+                        --disable-mythgame \
+                        --disable-mythzoneminder \
+                        --disable-mythbrowser \
+                        --disable-mythnetvision \
+                        --disable-mythgallery \
+                        --disable-mythmusic \
+                        --disable-mythnews \
+                        --disable-mythweather
+
+    build.dir           ${worksrcpath}/mythplugins
+    destroot.destdir    INSTALL_ROOT=${destroot}
+
+    if {[variant_isset mythnetvision] || [variant_isset mythweather]} {
+    # for both MythNetvision and MythWeather (Canada)
+        depends_lib-append      port:p${perl5.major}-perlmagick
+    }
+
+    # Linking error, see https://code.mythtv.org/trac/ticket/12839
+    # also need to patch 3 occurrences of mysql/mysql.h to mariadb/mysql/mysql.h
+    #variant mythzoneminder description {Interface with a ZoneMinder video surveillance system} {
+    #    configure.args-delete   --disable-mythzoneminder
+    #    configure.args-append   --enable-mythzoneminder
+    #}
+
+    variant mytharchive description {Create DVDs from recorded shows and any video files available on Myth.} {
+        configure.args-delete   --disable-mytharchive
+        configure.args-append   --enable-mytharchive
+    }
+
+    variant mythbrowser description {WebKit-based browser within Myth.} {
+        configure.args-delete   --disable-mythbrowser
+    #   configure.args-append   --enable-mythbrowser
+    }
+
+    variant mythnetvision description {Find and play internet videos within Myth.} {
+        depends_lib-append      port:${pymodver}-oauth
+        configure.args-delete   --disable-mythnetvision
+    #   configure.args-append   --enable-mythnetvision
+    }
+
+    variant mythgallery description {Myth photo browser and slideshow plugin.} {
+        depends_lib-append      port:libexif \
+                                port:dcraw
+        configure.args-delete   --disable-mythgallery
+        configure.args-append   --enable-mythgallery --enable-opengl --enable-new-exif
+    }
+
+    variant mythmusic description {Myth plugin to play and manage music files.} {
+        depends_lib-append      port:libvorbis \
+                                port:flac \
+                                port:taglib \
+                                port:lame
+    #                           port:cdio port:fftw-3  -- included in mythtv-core
+        configure.args-delete   --disable-mythmusic
+        configure.args-append   --enable-mythmusic --enable-fftw  --enable-cdio
+    }
+
+    variant mythnews description {Check news sources through RSS feeds with this Myth plugin.} {
+        configure.args-delete   --disable-mythnews
+    #   configure.args-append   --enable-mythnews
+    }
+
+    variant mythweather description {Weather information for your chosen locations via Myth plugin.} {
+        depends_lib-append      port:p${perl5.major}-date-manip\
+                                port:p${perl5.major}-xml-simple \
+                                port:p${perl5.major}-xml-xpath \
+                                port:p${perl5.major}-image-size \
+                                port:p${perl5.major}-datetime-format-iso8601 \
+                                port:p${perl5.major}-soap-lite \
+                                port:p${perl5.major}-json
+        configure.args-delete   --disable-mythweather
+    #   configure.args-append   --enable-mythweather
+    }
+    default_variants +mythgallery +mythmusic +mythweather
+
+}
+
+if {$subport eq "mythtv${majorversion}"} {
+    version             ${majorversion}${minorversion}-Fixes-${lastcommit}
+    revision            ${metarev}
+    description         installs complete MythTV system
+    long_description    \
+    Installs a complete MythTV system including the frontend, backend, and database \
+    server software plus MythWeb
+
+    depends_lib         port:mythtv-plugins${majorversion} \
+                        port:mythweb${majorversion}
+
+    depends_run         port:mariadb-server
+    
+    distfiles
+    installs_libs no
+    use_configure no
+    build {}
+    destroot {
+        xinstall -m 0755 ${filespath}/README_mythtv${majorversion}_MacPorts.txt \
+            ${destroot}${prefix}/share/mythtv-readme
+    }
+
+    pre-pkg {
+        xinstall -m 0755 ${filespath}/preinstall ${filespath}/postinstall \
+            ${package.scripts}/
+        reinplace -locale C "s|@PREFIX@|${prefix}|g" \
+            ${package.scripts}/preinstall \
+            ${package.scripts}/postinstall
+        long_description-append .  Install prefix ${prefix}
+    }
+}

--- a/multimedia/mythtv29/files/Myth_Filldatabase.applescript
+++ b/multimedia/mythtv29/files/Myth_Filldatabase.applescript
@@ -1,0 +1,47 @@
+(*  Applescript to run 'Unix' version of mythfilldatabase
+For use with MacPorts install of Myth
+Author:  Craig Treleaven, ctreleaven at cogeco.ca
+Myth Version: 0.27.0
+Modified: 2012May17, 2013Sep25
+
+*)
+property MFDappPath : "@PREFIX@/bin/mythfilldatabase"
+property MFDlogArg : "--logpath @MYTHTVLOGDIR@"
+property MFDlogLevel : "warning" -- single string
+property MFDverboseLevel : {"general"} -- a list, can be multiple strings
+
+set welcome to "In a 'production' system, mythfilldatabase is run automatically by mythbackend at the times suggested by the listings source, usually daily.  
+
+This applescript program allows you to run mythfilldatabase 'manually'; perhaps when Myth is first set up or if there are problems with the automatic runs. 
+ 
+"
+
+try
+	set Clicked to display dialog welcome with title "Run mythfilldatabase" buttons {"Cancel", "Options", "Start Run"} default button "Start Run"
+on error
+	set Clicked to false
+end try
+
+set CmdList to {MFDappPath, MFDlogArg, "--loglevel " & MFDlogLevel, "--verbose " & joinlist(MFDverboseLevel, ",")}
+set Cmd to (joinlist(CmdList, " "))
+--display alert button returned of Clicked
+
+if Clicked is not false then
+	if button returned of Clicked = "Start Run" then
+		do shell script Cmd -- run it!
+	else if button returned of Clicked = "Options" then
+		display alert "Options"
+		-- let user select verbose and loglevel options
+	end if
+end if
+
+-- -- -- -- -- -- -- -- 
+-- Handlers
+to joinlist(aList, delimiter)
+	set retVal to ""
+	set prevDelimiter to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to delimiter
+	set retVal to aList as string
+	set AppleScript's text item delimiters to prevDelimiter
+	return retVal
+end joinlist

--- a/multimedia/mythtv29/files/Myth_Frontend.applescript
+++ b/multimedia/mythtv29/files/Myth_Frontend.applescript
@@ -1,0 +1,38 @@
+(*  Applescript to run 'Unix' version of mythfronted
+For use with MacPorts install of Myth
+Author:  Craig Treleaven, ctreleaven at cogeco.ca
+Version: 0.27.0
+Modified: 2012May15
+          2012Nov20 -- handle 'thread not shut down error' on exit, add --quiet to prevent 
+            console output from being returned to AppleScript, allow experimental AirPlay
+          2013Sep25 -- revert logserver stuff, remove AirPlay setting that is now unnecessary 
+
+*)
+property MFEappPath : "@PREFIX@/bin/mythfrontend"
+property MFElogArg : "--logpath @MYTHTVLOGDIR@"
+property MFElogLevel : "info" -- single string
+property MFEverboseLevel : {"general"} -- a list, can be multiple strings
+
+set CmdList to {MFEappPath, MFElogArg, "--loglevel " & MFElogLevel, "--verbose " & joinlist(MFEverboseLevel, ",")}
+set Cmd to (joinlist(CmdList, " "))
+
+try
+	do shell script Cmd 
+on error the error_message number the error_number
+	if the error_number is not 133 then
+		set the error_text to "Error: " & the error_number & ". " & the error_message
+		display dialog the error_text buttons {"OK"} default button 1
+		return the error_text
+	end if
+end try
+
+-- -- -- -- -- -- -- -- 
+-- Handlers
+to joinlist(aList, delimiter)
+	set retVal to ""
+	set prevDelimiter to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to delimiter
+	set retVal to aList as string
+	set AppleScript's text item delimiters to prevDelimiter
+	return retVal
+end joinlist

--- a/multimedia/mythtv29/files/Myth_Setup.applescript
+++ b/multimedia/mythtv29/files/Myth_Setup.applescript
@@ -1,0 +1,49 @@
+(*  Applescript to run 'Unix' version of mythtv-setup
+For use with MacPorts install of Myth
+Author:  Craig Treleaven, ctreleaven at cogeco.ca
+Myth Version: 0.27.0
+Modified: 2012May17
+          2012Sep08 Force working themepainter
+          2013Sep25 revert logserver stuff, themepainter no longer necessary
+
+*)
+property MSUappPath : "@PREFIX@/bin/mythtv-setup"
+property MSUlogArg : "--logpath @MYTHTVLOGDIR@"
+property MSUlogLevel : "info" -- single string
+property MSUverboseLevel : {"general"} -- a list, can be multiple strings
+
+set welcome to "Initial setup of Myth is done through the mythtv-setup program.  
+
+This includes defining where recordings and other media are stored, tuners and sources of listings data and scanning for available channels, etc.
+ 
+"
+--Should test if mythbackend is running and warn user...
+
+try
+	set Clicked to display dialog welcome with title ¬
+		"Run mythtv-setup" buttons {"Cancel", "Start"} default button "Start"
+on error
+	set Clicked to false
+end try
+
+set CmdList to {MSUappPath, MSUlogArg, "--loglevel " & MSUlogLevel, "--verbose " & joinlist(MSUverboseLevel, ",")}
+set Cmd to (joinlist(CmdList, " "))
+--display alert button returned of Clicked
+
+if Clicked is not false then
+	if button returned of Clicked = "Start" then
+		--display alert Cmd
+		do shell script Cmd -- run it!
+	end if
+end if
+
+-- -- -- -- -- -- -- -- 
+-- Handlers
+to joinlist(aList, delimiter)
+	set retVal to ""
+	set prevDelimiter to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to delimiter
+	set retVal to aList as string
+	set AppleScript's text item delimiters to prevDelimiter
+	return retVal
+end joinlist

--- a/multimedia/mythtv29/files/Myth_Stop_Start.applescript
+++ b/multimedia/mythtv29/files/Myth_Stop_Start.applescript
@@ -1,0 +1,92 @@
+(*  Applescript to stop/start Myth background apps
+For use with MacPorts install of Myth
+Author:  Craig Treleaven, ctreleaven at cogeco.ca
+Version: 0.27.x
+
+NB - if mbe is running, we only stop it if it was launched under launchd
+*)
+set mysqld to " not running on this machine.  Is it on another machine on your network?"
+set rotatorStatus to ""
+set logrotButton to ""
+set mythbackend to ""
+set mythbackendButton to "Donno"
+set newline to "
+"
+set indent to space & space & space & space
+set myResult to ""
+
+repeat until (myResult contains "Close")
+	if (do shell script "sudo launchctl list" with administrator privileges) contains ".logrotate" then
+		set rotatorStatus to "runs daily"
+		set logrotButton to "Disable log rotation"
+	else
+		set rotatorStatus to "is not scheduled"
+		set logrotButton to "Schedule log rotation"
+	end if
+	
+	set processes to do shell script "ps -Ac"
+	if the processes contains "mysqld" then
+		set mysqld to " running."
+	end if
+	
+	if the processes contains "mythbackend" then
+		set mythbackend to " running."
+		set mythbackendButton to "Stop MythBackend"
+		try
+			do shell script "@PREFIX@/bin/mythshutdown --status"
+		on error the error_message number the error_number
+			set mythbackend to " running but busy with something.  Are you sure you want to shut down now?  Status: " & error_number
+		end try
+	else
+		set mythbackend to " not running."
+		set mythbackendButton to "Start MythBackend"
+	end if
+	
+	set myResult to display dialog newline & "Simple tool to start and stop Myth's background processes" & Â
+		newline & newline & newline & "Currently... " & Â
+		newline & newline & indent & "Log rotation " & rotatorStatus & Â
+		newline & newline & indent & "Database (MySQL/MariaDB) is" & mysqld & Â
+		newline & newline & indent & "MythBackend is" & mythbackend & newline & newline Â
+		with icon note with title Â
+		"Stop/Start Myth-related programs" buttons {logrotButton, mythbackendButton, "Close"} Â
+		default button "Close" -- cancel button "Close" 
+	set myResult to button returned of myResult
+	if myResult contains "Start MythBackend" then
+		my startBackend()
+	else if myResult contains "Stop MythBackend" then
+		if ((do shell script "sudo launchctl list" with administrator privileges) contains "mythbackend") then
+			do shell script "sudo launchctl unload -w /Library/LaunchDaemons/org.mythtv.mythbackend.plist" with administrator privileges
+			-- there is a longish delay while myth closes down.
+		else
+			display alert " MythBackend appears not to have been started in the normal fashion.  Unable to shut down." message "Was mythbackend started directly from a command line session?" as warning
+		end if
+		set myResult to "Close"
+	else if myResult contains "Schedule log rotation" then
+		my enableLogRotation()
+	else if myResult contains "Disable log rotation" then
+		do shell script "sudo launchctl unload -w /Library/LaunchDaemons/org.macports.logrotate.plist" with administrator privileges
+	end if
+end repeat
+
+on startBackend()
+	--ensure plist is ready
+	if (not my FileExists("/Library/LaunchDaemons/org.mythtv.mythbackend.plist")) then
+		do shell script "sudo ln -s @PREFIX@/Library/LaunchDaemons/org.mythtv.mythbackend.plist /Library/LaunchDaemons/org.mythtv.mythbackend.plist" with administrator privileges
+	end if
+	do shell script "sudo launchctl load -w /Library/LaunchDaemons/org.mythtv.mythbackend.plist" with administrator privileges
+end startBackend
+
+on enableLogRotation()
+	--check for existence of conf file
+	if (not my FileExists("@PREFIX@/etc/logrotate.conf")) then
+		do shell script "sudo cp @PREFIX@/share/logrotate/logrotate.conf.example @PREFIX@/etc/logrotate.conf" with administrator privileges
+	end if
+	if (not my FileExists("/Library/LaunchDaemons/org.macports.logrotate.plist")) then
+		do shell script "sudo ln -s @PREFIX@/share/logrotate/org.macports.logrotate.plist.example /Library/LaunchDaemons/org.macports.logrotate.plist" with administrator privileges
+	end if
+	do shell script "sudo launchctl load -w /Library/LaunchDaemons/org.macports.logrotate.plist" with administrator privileges
+end enableLogRotation
+
+on FileExists(theFile) -- (String) as Boolean
+	tell application "System Events" to return (exists file theFile)
+end FileExists

--- a/multimedia/mythtv29/files/README_mythtv29_MacPorts.txt
+++ b/multimedia/mythtv29/files/README_mythtv29_MacPorts.txt
@@ -1,0 +1,2 @@
+See http://www.mythtv.org/wiki/MacPorts
+

--- a/multimedia/mythtv29/files/logrotate.conf
+++ b/multimedia/mythtv29/files/logrotate.conf
@@ -1,0 +1,22 @@
+# ${prefix}/etc/logrotate.conf
+# 2012Sep11 Craig Treleaven
+# MacPorts logrotate port -- set up for MythTV
+#
+# see "man logrotate" for details
+# rotate log files weekly
+weekly
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+# use date as a suffix of the rotated file
+dateext
+
+# uncomment this if you want your log files compressed
+#compress
+
+# Drop log rotation information into this directory
+include @PREFIX@/etc/logrotate.d

--- a/multimedia/mythtv29/files/logrotate.mythtv
+++ b/multimedia/mythtv29/files/logrotate.mythtv
@@ -1,0 +1,49 @@
+# ${prefix}/etc/logrotate.d/logrotate.mythtv
+# 2012Sep20 Craig Treleaven
+# MacPorts logrotate port -- set up for MythTV
+#
+# based on http://www.mythtv.org/wiki/Logrotate_-_all_applications
+
+# Common settings
+su root admin
+missingok
+ifempty
+nocreate
+nocompress
+sharedscripts
+olddir @MYTHTVLOGDIR@/old
+
+
+# programs that may run for extended periods
+@MYTHTVLOGDIR@/mythbackend*.log @MYTHTVLOGDIR@/mythfrontend*.log @MYTHTVLOGDIR@/mythjobqueue*.log @MYTHTVLOGDIR@/mythwelcome*.log @MYTHTVLOGDIR@/mythmediaserver*.log @MYTHTVLOGDIR@/mythlcdserver*.log {
+        weekly
+        rotate 8
+        lastaction
+                killall -HUP mythbackend
+                killall -HUP mythfrontend
+                killall -HUP mythjobqueue
+                killall -HUP mythwelcome
+                killall -HUP mythmediaserver
+                killall -HUP mythlcdserver
+                find @MYTHTVLOGDIR@ -type f -mtime +20 -delete
+                find @MYTHTVLOGDIR@/old -type f -mtime +30 -delete
+        endscript
+}
+
+# tranient programs
+# these won't be running and writing to a log that needs rotating
+@MYTHTVLOGDIR@/mythfilldatabase*.log @MYTHTVLOGDIR@/mythcommflag*.log @MYTHTVLOGDIR@/mythmetadatalookup*.log @MYTHTVLOGDIR@/mythtranscode*.log @MYTHTVLOGDIR@/mythtv-setup*.log @MYTHTVLOGDIR@/mythutil*.log {
+        weekly
+        rotate 0
+}
+
+# VERY transient
+# many, many previews
+@MYTHTVLOGDIR@/mythpreviewgen*.log {
+        daily
+        rotate 0
+        lastaction
+                find @MYTHTVLOGDIR@ -name 'mythpreviewgen*' -type f -mtime +6 -delete
+                find @MYTHTVLOGDIR@/old -name 'mythpreviewgen*' -type f -mtime +6 -delete
+        endscript
+}

--- a/multimedia/mythtv29/files/my.cnf
+++ b/multimedia/mythtv29/files/my.cnf
@@ -1,0 +1,25 @@
+# Use default MacPorts settings
+# MacPorts MythTV mods - 
+# Disable loading of macports-default.cnf so that
+# networking is not disabled
+# 2014Oct16
+#!include @PREFIX@/etc/mariadb/macports-default.cnf
+
+# The MySQL server
+[mysqld]
+
+#  Settings on the command line:
+#  /opt/local/bin/daemondo --label=mariadb-server --start-cmd /opt/local/lib/mariadb/bin/mysqld --user=_mysql ; --pid=exec
+#  /opt/local/bin/daemondo
+#    --label=mariadb-server
+#    --start-cmd /opt/local/lib/mariadb/bin/mysqld
+#    --user=_mysql ;
+#    --pid=exec
+
+log-error=@PREFIX@/var/db/mariadb/localhost.err
+
+[client]
+socket=@PREFIX@/var/run/mariadb/mysqld.sock
+port=3306
+
+# End MacPorts MythTV mods

--- a/multimedia/mythtv29/files/mythconverg_init.sql
+++ b/multimedia/mythtv29/files/mythconverg_init.sql
@@ -1,0 +1,7 @@
+CREATE DATABASE IF NOT EXISTS mythconverg;
+GRANT ALL ON mythconverg.* TO mythtv@localhost IDENTIFIED BY "mythtv";
+FLUSH PRIVILEGES;
+grant all on mythconverg.* to mythtv@"%" identified by "mythtv";
+FLUSH PRIVILEGES;
+ALTER DATABASE mythconverg DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
+FLUSH PRIVILEGES;

--- a/multimedia/mythtv29/files/org.mythtv.mythbackend.plist
+++ b/multimedia/mythtv29/files/org.mythtv.mythbackend.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Disabled</key><true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>@PREFIX@/var/mythtvuser</string>
+        <key>PATH</key>
+        <string>@PREFIX@/bin:@PREFIX@/lib/mariadb/bin:@PREFIX@/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/X11/bin</string>
+        <key>PYTHONPATH</key>
+        <string>@PREFIX@/lib/@PYTHONVER@/site-packages:$PYTHONPATH</string>
+    </dict>
+    <key>KeepAlive</key>
+    <true/>
+    <key>Label</key>
+    <string>@PLISTLABEL@</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>@PREFIX@/bin/mythbackend</string>
+        <string>--logpath</string>
+        <string>@MYTHTVLOGDIR@</string>
+        <string>--pidfile</string>
+        <string>@MYTHTVPIDFILE@</string>
+        <string>--loglevel</string>
+        <string>info</string>
+        <string>--quiet</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>300</integer>
+</dict>
+</plist>

--- a/multimedia/mythtv29/files/patch-configure_opengl_check.diff
+++ b/multimedia/mythtv29/files/patch-configure_opengl_check.diff
@@ -1,0 +1,13 @@
+--- mythtv/configure.prev	2016-08-17 13:26:45.000000000 -0400
++++ mythtv/configure	2016-08-17 13:27:12.000000000 -0400
+@@ -6819,9 +6819,7 @@
+                              { check_cpp_condition "OpenCL/cl.h" "defined(CL_VERSION_1_2)" ||
+                                check_cpp_condition "CL/cl.h" "defined(CL_VERSION_1_2)" ||
+                                die "ERROR: opencl must be installed and version must be 1.2 or compatible"; }
+-enabled opengl            && { check_lib GL/glx.h glXGetProcAddress "-lGL" ||
+-                               check_lib2 windows.h wglGetProcAddress "-lopengl32 -lgdi32" ||
+-                               check_lib2 OpenGL/gl3.h glGetError "-Wl,-framework,OpenGL" ||
++enabled opengl            && { check_lib2 OpenGL/gl3.h glGetError "-Wl,-framework,OpenGL" ||
+                                check_lib2 ES2/gl.h glGetError "-isysroot=${sysroot} -Wl,-framework,OpenGLES" ||
+                                check_lib2 GLES/gl.h glGetError "-Wl,-framework,OpenGLES" ||
+                                { check_lib2 GLES2/gl2.h glGetError "-lGLESv2" &&

--- a/multimedia/mythtv29/files/patch-configure_verbosity.diff
+++ b/multimedia/mythtv29/files/patch-configure_verbosity.diff
@@ -1,0 +1,44 @@
+--- mythtv/configure.orig	2016-01-12 20:12:09.000000000 -0500
++++ mythtv/configure	2016-01-12 20:34:32.000000000 -0500
+@@ -7739,6 +7739,7 @@
+   echo "OpenGL video              ${opengl_video-no}"
+   if test x"$target_os" = x"darwin" ; then
+     echo "VDA support               ${vda-no}"
++    echo "VideoToolBox support      ${videotoolbox-no}"
+   fi
+   if test x"$target_os" = x"mingw32" ; then
+     echo "Windows (Direct3D)        yes"
+@@ -7750,16 +7751,22 @@
+ fi
+ 
+ echo "# Misc Features"
++echo "Frontend                  ${frontend-no}"
++echo "Backend                   ${backend-no}"
++echo "mythlogserver             ${mythlogserver-no}"
+ echo "multi threaded libavcodec ${threads-no}"
+ if enabled frontend; then
+   echo "libxml2 support           ${libxml2-no} [$libxml2_path]"
+ fi
+ echo "libdns_sd (Bonjour)       ${libdns_sd-no}"
+ echo "libcrypto                 ${libcrypto-no}"
+-echo "Frontend                  ${frontend-no}"
+-echo "Backend                   ${backend-no}"
++  if test x"$target_os" = x"darwin" ; then
++    echo "TLS -"
++    echo "OpenSSL                   ${tls_openssl_protocol-no}"
++    echo "gnutls                    ${tls_gnutls_protocol-no}"
++    echo "Secure Transport          ${tls_securetransport_protocol-no}"
++  fi
+ echo "OpenGL ES 2.0             ${opengles-no}"
+-echo "mythlogserver             ${mythlogserver-no}"
+ echo "BD-J (Bluray java)        ${bdjava-no}"
+ echo "BD-J type                 ${bdj_type}"
+ echo "systemd_notify            ${systemd_notify-no}"
+@@ -7779,6 +7787,7 @@
+ echo "faac                      ${libfaac-no}"
+ echo "xvid                      ${libxvid-no}"
+ echo "x264                      ${libx264-no}"
++echo "x265 (HEVC)               ${libx265-no}"
+ echo "vpx                       ${libvpx-no}"
+ echo "SDL                       ${sdl-no}"
+ echo ""

--- a/multimedia/mythtv29/files/patch-dvdnav_include_path.diff
+++ b/multimedia/mythtv29/files/patch-dvdnav_include_path.diff
@@ -1,0 +1,28 @@
+--- mythtv/libs/libmythtv/libmythtv.pro.orig	2016-08-06 13:50:29.000000000 -0400
++++ mythtv/libs/libmythtv/libmythtv.pro	2016-08-06 13:52:06.000000000 -0400
+@@ -259,8 +259,8 @@
+ DEPENDPATH  += ../../external/libmythdvdnav/dvdread # for dvd_reader.h & dvd_input.h
+ 
+ !win32-msvc* {
+-  QMAKE_CXXFLAGS += -isystem ../../external/libmythdvdnav/dvdnav
+-  QMAKE_CXXFLAGS += -isystem ../../external/libmythdvdnav/dvdread
++  INCLUDEPATH += ../../external/libmythdvdnav/dvdnav
++  INCLUDEPATH += ../../external/libmythdvdnav/dvdread
+ }
+ 
+ win32-msvc* {
+ 
+
+--- mythtv/programs/programs-libs.pro.orig	2016-08-06 13:54:51.000000000 -0400
++++ mythtv/programs/programs-libs.pro	2016-08-06 13:56:03.000000000 -0400
+@@ -7,8 +7,8 @@
+ INCLUDEPATH += ../../libs/libmythlivemedia ../../libs/libmythbase
+ 
+ !win32-msvc* {
+-  QMAKE_CXXFLAGS += -isystem ../../external/libmythdvdnav/dvdnav
+-  QMAKE_CXXFLAGS += -isystem ../../external/libmythdvdnav/dvdread
++  INCLUDEPATH += ../../external/libmythdvdnav/dvdnav
++  INCLUDEPATH += ../../external/libmythdvdnav/dvdread
+ }
+ 
+ win32-msvc* {

--- a/multimedia/mythtv29/files/patch-mythwidgets_osx_focus.diff
+++ b/multimedia/mythtv29/files/patch-mythwidgets_osx_focus.diff
@@ -1,0 +1,13 @@
+--- mythtv/libs/libmyth/mythwidgets.cpp.orig	2016-08-22 10:41:09.000000000 -0400
++++ mythtv/libs/libmyth/mythwidgets.cpp	2016-08-22 10:44:22.000000000 -0400
+@@ -22,6 +22,10 @@
+ {
+     setObjectName(name);
+     setEditable(rw);
++#ifdef Q_OS_MAC
++    // Qt 5 changed OS X combobox behaviour
++    setFocusPolicy(Qt::WheelFocus);
++#endif
+ }
+ 
+ MythComboBox::~MythComboBox()

--- a/multimedia/mythtv29/files/patch-rpath_linking.diff
+++ b/multimedia/mythtv29/files/patch-rpath_linking.diff
@@ -1,0 +1,24 @@
+--- mythtv/settings.pro.orig	2013-09-18 17:28:07.000000000 -0400
++++ mythtv/settings.pro	2013-09-19 14:57:41.000000000 -0400
+@@ -306,7 +306,6 @@
+ 
+ macx {
+     using_firewire:using_backend:EXTRA_LIBS += -F$${CONFIG_MAC_AVC} -framework AVCVideoServices
+-    QMAKE_LFLAGS_SONAME  = -Wl,-install_name,@rpath/
+     _RPATH_="-rpath,"
+ } else {
+     _RPATH_="-rpath="
+
+
+--- mythtv/external/Makefile.orig	2013-09-18 17:28:07.000000000 -0400
++++ mythtv/external/Makefile	2013-09-19 14:52:56.000000000 -0400
+@@ -34,9 +34,6 @@
+ 
+ zeromq-all:	zeromq/Makefile
+ 	${MAKE} -C zeromq all
+-ifeq ($(CONFIG_DARWIN),yes)
+-	install_name_tool -id "@rpath/$(LIBPREF)zmq.1$(SLIBSUF)" zeromq/src/.libs/$(LIBPREF)zmq.1$(SLIBSUF)
+-endif
+ 
+ zeromq-install zeromq-uninstall zeromq-clean zeromq-distclean:
+ 	${MAKE} -C zeromq ${@:zeromq-%=%} DESTDIR=${INSTALL_ROOT}

--- a/multimedia/mythtv29/files/patch_01_typlayer_qsp_ua_detection.diff
+++ b/multimedia/mythtv29/files/patch_01_typlayer_qsp_ua_detection.diff
@@ -1,0 +1,11 @@
+--- mythtv/html/tv/tvplayer.qsp.orig	2017-02-20 08:42:00.000000000 -0500
++++ mythtv/html/tv/tvplayer.qsp	2017-02-20 08:49:02.000000000 -0500
+@@ -71,7 +71,7 @@
+ 
+     // iOS and Android (Browser, Opera but not Firefox) supports HLS
+     // with HTML 5 but JW Player 5 doesn't fallback as it should
+-    var useHTML5Video = (ua.match(/android/g) || ua.match(/(iPhone|iPad)/g)) ? true : false;
++    var useHTML5Video = (ua.match(/android/g) || ua.match(/(macintosh|iphone|ipad)/g)) ? true : false;
+ %>
+ 
+ <div id="playerContainer" class="playerContainer">

--- a/multimedia/mythtv29/files/postinstall
+++ b/multimedia/mythtv29/files/postinstall
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# MythTV installer support, postinstall script
+# runs as root after installer successfully copies payload to destination
+# assume database installer package has initialized and started db server
+
+DB_BIN=@PREFIX@/lib/mariadb/bin
+
+echo $0 Starting
+echo make sure database has a config
+if [ ! -f @PREFIX@/etc/mariadb/my.cnf ] ; then
+    cp @PREFIX@/share/mythtv/database/my.cnf @PREFIX@/etc/mariadb
+    echo start/restart db for pick up our config
+    if /bin/launchctl list "org.macports.mariadb-server" &> /dev/null; then
+        echo Unload db server...
+        /bin/launchctl unload "/Library/LaunchDaemons/org.macports.mariadb-server.plist"
+    fi
+    echo Load the db server
+    /bin/launchctl load -w /Library/LaunchDaemons/org.macports.mariadb-server.plist
+fi
+
+echo MariaDB server may be starting...
+sleep 6
+echo ...should be up now
+
+# Check mythconverg database
+if [ ! -d "/opt/local/var/db/mariadb/mythconverg" ] ; then
+    echo Set up mythconverg db and mythtv user
+    $DB_BIN/mysql -u root < @PREFIX@/share/mythtv/database/mythconverg_init.sql
+    echo Add time zone support tables
+    $DB_BIN/mysql_tzinfo_to_sql /usr/share/zoneinfo | $DB_BIN/mysql -u root mysql
+fi
+
+echo Make fonts available to Myth
+ln -sfv @PREFIX@/share/fonts/dejavu-fonts/DejaVuSans*.ttf @PREFIX@/share/mythtv/fonts
+ln -sfv @PREFIX@/share/fonts/liberation-fonts/LiberationSans*.ttf @PREFIX@/share/mythtv/fonts
+
+echo $0 Finished

--- a/multimedia/mythtv29/files/preinstall
+++ b/multimedia/mythtv29/files/preinstall
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# MythTV installer support, preinstall script
+# Note that all the preinstall scripts are run (as root), then the payload is 'shove'd into place
+# After that, all the postinstall scripts are run.  
+# Script also runs in a sandbox with no access to /Private and other directories
+# note that launchctl requires sudo
+
+echo mythtv.28 preinstall script starting
+
+echo if backend loaded, unload before continuing install
+if /bin/launchctl list "org.mythtv.mythbackend" &> /dev/null; then
+    /bin/launchctl unload "/Library/LaunchDaemons/org.mythtv.mythbackend.plist"
+    echo ...backend now unloaded
+fi
+
+echo mythtv.28 preinstall script finished

--- a/multimedia/mythweb29/Portfile
+++ b/multimedia/mythweb29/Portfile
@@ -1,0 +1,99 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+# set fullhash      ed8d6a1c9621c612fb3e69d85c78614cdf0996fa
+set shorthash       6a6eb1a
+github.setup        MythTV mythweb ${shorthash}
+set majorversion    29
+set minorversion    .1
+name                mythweb${majorversion}
+version             ${majorversion}${minorversion}-Fixes-20180522
+revision            2
+checksums           rmd160  fa90a953b30248c6f249b84a110dd77e1a7ccefc \
+                    sha256  5f0208d4b9cbefea74fa674515d14eeffac06cfc0b118d9649253e2d17c445d3
+categories          multimedia www
+platforms           darwin
+license             GPL-2 LGPL-2.1
+maintainers         {ctreleaven @ctreleaven} openmaintainer
+supported_archs     noarch
+conflicts           mythweb.25 mythweb.26 mythweb.27 mythweb.28
+
+description         control your Myth system via a web browser
+long_description    MythWeb provides a frontend to MythTV using a web browser. \
+                    Review program listings, schedule recordings, browse previous recordings, \
+                    check on the status of your system and much more.  Note that this is an \
+                    INSECURE installation intended for local network access only.  Take steps to \
+                    secure if access from the internet is to be allowed.
+
+homepage            https://www.mythtv.org/
+
+set perlver         perl5.26
+set perlbin         ${prefix}/bin/${perlver}
+set perlmodver      p5.26
+set phpver          php54
+set webroot         ${prefix}/www/apache2/html
+#set webroot         ${prefix}/apache2/htdocs
+
+depends_run         port:mythtv-core${majorversion} \
+                    port:${perlmodver}-http-request-ascgi \
+                    port:${perlmodver}-dbd-mysql \
+                    port:${phpver}-apache2handler \
+                    port:${phpver}-mysql \
+                    port:${phpver}-posix \
+                    port:${phpver}-sockets
+
+# mythtv-core already ensures p5.26-dbd-mysql +mariadb variant is active. 
+# No need to repeat here
+
+patchfiles          patch-mythweb.conf.diff
+
+use_configure       no
+build               {}
+
+pre-patch {
+    copy ${worksrcpath}/mythweb.conf.apache ${worksrcpath}/mythweb.conf
+}
+
+post-patch {
+    reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/mythweb.conf
+    reinplace -locale C "s|/usr/local|${prefix}|" ${worksrcpath}/mythweb.php
+
+    reinplace -locale C "s|#!/usr/bin/perl|#!${perlbin}|" \
+         ${worksrcpath}/mythweb.pl \
+         ${worksrcpath}/modules/_shared/lang/build_translation.pl \
+         ${worksrcpath}/modules/coverart/handler.pl \
+         ${worksrcpath}/modules/stream/handler.pl \
+         ${worksrcpath}/modules/stream/stream_asx.pl \
+         ${worksrcpath}/modules/stream/stream_flv.pl \
+         ${worksrcpath}/modules/stream/stream_flvp.pl \
+         ${worksrcpath}/modules/stream/stream_mp4.pl \
+         ${worksrcpath}/modules/stream/stream_raw.pl \
+         ${worksrcpath}/modules/stream/tv.pl
+}
+
+destroot {
+    xinstall -d ${destroot}${webroot}
+    copy ${worksrcpath} ${destroot}${webroot}
+    file rename ${destroot}${webroot}/mythweb-${shorthash} \
+        ${destroot}${webroot}/MythWeb
+    system "chown -R _www:_www ${destroot}${webroot}/MythWeb/data"
+    destroot.keepdirs \
+        ${destroot}${webroot}/MythWeb/data/cache \
+        ${destroot}${webroot}/MythWeb/data/tv_icons
+}
+
+notes "\
+############################################################################
+#
+# If this is the first time installing MythWeb, please see
+# http://www.mythtv.org/wiki/MythWeb_via_MacPorts for information
+# essential to finishing the installation of MythWeb!
+#
+# Upgrading for the first time after October 20, 2017?  Check your 
+# configuration with the above wiki page.
+#
+############################################################################"
+
+livecheck.type              none

--- a/multimedia/mythweb29/files/patch-mythweb.conf.diff
+++ b/multimedia/mythweb29/files/patch-mythweb.conf.diff
@@ -1,0 +1,74 @@
+--- mythweb.conf.orig	2014-05-06 03:08:30.000000000 -0400
++++ mythweb.conf	2014-06-03 11:11:36.000000000 -0400
+@@ -3,6 +3,8 @@
+ # requirements and troubleshooting, along with the comments in this file.
+ #
+ 
++Alias /MythWeb @PREFIX@/www/apache2/html/MythWeb
++
+ ############################################################################
+ # If you intend to use authentication for MythWeb (see below), you will
+ # probably also want to uncomment the following rules, which disable
+@@ -26,13 +28,13 @@
+ #    /var/www/html/mythweb
+ #    /srv/www/htdocs/mythweb
+ #
+-    <Directory "/var/www/html/data">
++    <Directory @PREFIX@/www/apache2/html/MythWeb/data>
+         # For Apache 2.2
+         #Options -All +FollowSymLinks +IncludesNoExec
+         # For Apache 2.4+
+         Options +FollowSymLinks +IncludesNoExec
+     </Directory>
+-    <Directory "/var/www/html" >
++    <Directory @PREFIX@/www/apache2/html/MythWeb>
+ 
+     ############################################################################
+     # I *strongly* urge you to turn on authentication for MythWeb.  It is disabled
+@@ -81,7 +83,7 @@
+         # (eg. for security reasons), set this variable to the directory that
+         # contains the directories like languages and templates.  eg.
+         #
+-        #   setenv include_path      "/usr/share/mythweb"
++           setenv include_path      "@PREFIX@/www/apache2/html/MythWeb"
+ 
+         # If you want MythWeb to email php/database errors (and a backtrace) to you,
+         # uncomment and set the email address below.
+@@ -149,7 +151,7 @@
+     # If MythWeb is installed outside of the document root (eg. using Alias) then
+     # you will need to set this directive to the base URL that MythWeb is visible
+     # from externally.  If you do not, the web server will return 'not found'.
+-    #    RewriteBase    /mythweb
++        RewriteBase    /MythWeb
+ 
+     # Skip out early if we've already been through rewrites,
+     # or if this is a /css/, /js/ or /cache/ directory request.
+@@ -197,20 +199,20 @@
+     # to enable mod_deflate by default, but I strongly recommend that you
+     # enable this section.
+     #
+-    #    BrowserMatch ^Mozilla/4 gzip-only-text/html
+-    #    BrowserMatch ^Mozilla/4\.0[678] no-gzip
+-    #    BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+-    #
+-    #    AddOutputFilterByType DEFLATE text/html
+-    #    AddOutputFilterByType DEFLATE text/css
+-    #    AddOutputFilterByType DEFLATE application/x-javascript
++        BrowserMatch ^Mozilla/4 gzip-only-text/html
++        BrowserMatch ^Mozilla/4\.0[678] no-gzip
++        BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
++
++        AddOutputFilterByType DEFLATE text/html
++        AddOutputFilterByType DEFLATE text/css
++        AddOutputFilterByType DEFLATE application/x-javascript
+ 
+     # This is helpful for mod_deflate -- it prevents proxies from changing
+     # the user agent to/from this server, which can prevent compression from
+     # being enabled.  It is disabled here because many distros seem not to
+     # enable mod_headers by default, but I recommend that you enable it.
+     #
+-    #    Header append Vary User-Agent env=!dont-vary
++    Header append Vary User-Agent env=!dont-vary
+ 
+     # Set up the perl handler so we can stream properly.  Do not use mod_perl
+     # because it has a tendency to hold onto child processes, which causes


### PR DESCRIPTION
#### Description

Updating MythTV.28 and MythWeb.28 to MythTV29.1 and MythWeb29.1

Updates Ports:
- mythtv.28
- mythtv-core.28
- mythtv-pkg.28
- mythtv-plugins.28
- mythweb.28

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G29
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->