### PR TITLE
tklib: tcllib dep, tests, SHA256/size

### DIFF
--- a/devel/tklib/Portfile
+++ b/devel/tklib/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                tklib
 version             0.6
+revision            1
 categories          devel
 license             BSD
 platforms           darwin
@@ -18,15 +19,19 @@ homepage            http://core.tcl.tk/tklib/home
 
 master_sites        http://core.tcl.tk/${name}/tarball/${distfiles}?uuid=[regsub {\.} $distname {-}]&dummy=
 
-checksums           sha1    079713e212610b3b281b099f7685d386ed8ba48c \
+checksums           size    5308298 \
+                    sha256  8f7360d702ca7255cd6a6be834305dde093cd702c02238b1b7f6c0c5df5fc00f \
                     rmd160  66f5b5341eca81f3180a91dd83b4a58fc07177f8
 
 configure.args      --mandir=${prefix}/share/man
 
 depends_lib         port:tcl \
+                    port:tcllib \
                     port:tk
 
 post-destroot {
     reinplace "1s,#!bin,#!/bin," ${destroot}${prefix}/bin/dia
     file attributes ${destroot}${prefix}/bin/bitmap-editor -permissions "+x"
 }
+
+test.run            yes


### PR DESCRIPTION
#### Description
- must depend on Tcllib (according to Tklib's README, though I don't know what bad things will happen without it):
>```
>Please note that tklib depends on tcllib, the Tcl Standard Library.
>This is true for both installation and runtime.
>```
- enable tests
- replace SHA1 with SHA256 and size
- bump revision

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing tklib
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_devel_tklib/tklib/work/tklib-0.6" && /usr/bin/make test
```
[44 tests later…]
```
Passed      44 of     44
Skipped      0 of     44
Failed       0 of     44
#Errors      0
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
