### PR TITLE
groovy: update to 2.5.1

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.0
+version         2.5.1
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,8 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  36351dc50789f575bc5200f79e95a6ae7c816479 \
-                sha256  13903caed7da4875b2c805ddaa5ac4a3c877342f339700fab9a54b8c628eece3
+checksums       rmd160  18a02d9217047b0a24d4a89ea6e12be7fff795c8 \
+                sha256  7a7c1215620047f36ae66c8ca396864aa602cc90f7238851cd8714acb41418ff \
+                size    28300476
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.1.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?