### PR TITLE
py-asteval: add py37, enable test

### DIFF
--- a/python/py-asteval/Portfile
+++ b/python/py-asteval/Portfile
@@ -24,13 +24,20 @@ checksums               rmd160  68782a598a9532d5384151796883fb42f1138b8a \
                         sha256  38f3b0592cae7e7f65adc687e37aad1824a8e518245603a29ec33258277e779b \
                         size    50686
 
-python.versions         27 34 35 36
+python.versions         27 34 35 36 37
 
 if {$subport ne $name} {
     depends_build-append       port:py${python.version}-setuptools
 
     depends_lib-append         port:py${python.version}-numpy \
                                port:py${python.version}-six
+
+    depends_test-append        port:py${python.version}-pytest
+    test.run                   yes
+    test.cmd                   py.test-${python.branch}
+    test.target
+    test.env                   PYTHONPATH=${worksrcpath}/build/lib
+
     livecheck.type      none
 } else {
     livecheck.type      pypi


### PR DESCRIPTION
#### Description
- add Python 3.7
- enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
