### PR TITLE
p5-tcl: update to 1.16, add p5-devel-refcount to depends_test

### DIFF
--- a/perl/p5-tcl/Portfile
+++ b/perl/p5-tcl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Tcl 1.12
+perl5.setup         Tcl 1.16
 
 platforms           darwin
 maintainers         {@mojca mojca} openmaintainer
@@ -13,11 +13,13 @@ license             {Artistic-1 GPL}
 description         Tcl extension module for Perl
 long_description    ${description}
 
-checksums           rmd160  8c2dfb5d669b01b90bb5f36569560ef9b716e644 \
-                    sha256  3d1f150a79cce870492d20b5cd858d0f601717866ed7c53cd1e1e41422bd9aef \
-                    size    164500
+checksums           rmd160  9315e054720886257ac2447335beb421b3cf103c \
+                    sha256  5e518f177858da8b606476208ddef8b19644da2d79d9be36f929fa118530a292 \
+                    size    170044
 
 if {${perl5.major} != ""} {
+    depends_test-append \
+                    port:p${perl5.major}-devel-refcount
     depends_lib-append \
                     port:tcl
     configure.args-append \


### PR DESCRIPTION


#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing p5.26-tcl
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl/p5.26-tcl/work/Tcl-1.16" && /usr/bin/make test
"/opt/local/bin/perl5.26" -MExtUtils::Command::MM -e 'cp_nonempty' -- Tcl.bs blib/arch/auto/Tcl/Tcl.bs 644
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/call.t ............. ok
t/constants.t ........ ok
t/createcmd.t ........ ok
t/disposal-subs-a.t .. ok
t/disposal-subs-b.t .. ok
t/disposal-subs-c.t .. ok
t/disposal-subs-d.t .. ok
t/disposal-subs-e.t .. ok
t/disposal-subs-f.t .. ok
[[::perl::Eval ::perl::CODE(0x7fdb65a097d8); ]]
t/disposal-subs.t .... ok
t/eval.t ............. ok
t/export_to_tcl.t .... ok
t/info.t ............. ok
t/memleak-a.t ........ ok
t/result.t ........... ok
t/set-callback.t ..... ok
t/subclass.t ......... ok
t/trace.t ............ ok
t/unicode.t .......... ok
t/var.t .............. ok
All tests successful.
Files=20, Tests=107, 34 wallclock secs ( 0.10 usr  0.06 sys +  1.32 cusr  0.45 csys =  1.93 CPU)
Result: PASS
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
