### PR TITLE
p5-tcl-tk: new port, version 1.12

### DIFF
--- a/perl/p5-tcl-tk/Portfile
+++ b/perl/p5-tcl-tk/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26
+perl5.setup         Tcl-Tk 1.12
+
+platforms           darwin
+supported_archs     noarch
+maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
+license             {Artistic-1 GPL}
+
+description         Tcl::Tk - Extension module for Perl giving access to Tk \
+                    via the Tcl extension
+
+long_description    The Tcl::Tk extension (not to be confused with the \
+                    \"native\" perl5 Perl/Tk extension) provides a raw but \
+                    complete interface to the whole of Tk via the Tcl \
+                    extension. \
+                    \
+                    \n\nTcl::Tk is pure-perl, with all binary bindings \
+                    offloaded to Tcl perl module. \
+                    \
+                    \n\nTcl::Tk has full support for perl/Tk syntax. This \
+                    does not mean 100% compatibility though. perl/Tk syntax \
+                    is taken, but it is not followed when it is not tcl/tk \
+                    compatible. Do not expect full perl/tk compatibility, \
+                    just use the same syntax. \
+                    \
+                    \n\nThis approach allows you to intermix tcl/tk and \
+                    perl/tk code, for example you can use pure-tcl to create \
+                    entire GUI and then use perl/Tk syntax to access \
+                    individual widgets. This also allows you to design GUI \
+                    with any tcl/tk GUI designer. \n
+
+checksums           rmd160  632740b27d2754fe27209ead0c771fcb5866fc92 \
+                    sha256  d7455f8d4b8f601628c07cc2f74f8929ab97cfed4ccf831e0ac1723d14fd93ef \
+                    size    331882
+
+if {${perl5.major} != ""} {
+    configure.args-append \
+                    --tclsh ${prefix}/bin/tclsh
+    depends_lib-append \
+                    port:p${perl5.major}-tcl \
+                    port:tk \
+                    port:tklib
+}
+
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

```
--->  Testing p5.26-tcl-tk
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-tk/p5.26-tcl-tk/work/Tcl-Tk-1.12" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/after.t ....... ok
t/canvas.t ...... ok
t/geomgr.t ...... ok
t/optmenu.t ..... ok
t/photo.t ....... skipped: no Img extension available (can't find package Img at /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-tk/p5.26-tcl-tk/work/Tcl-Tk-1.12/blib/lib/Tcl/Tk.pm line 742.
t/ptk-compat.t .. ok
t/text.t ........ ok
t/tk-mw.t ....... ok
t/unicode.t ..... ok
t/zzPhoto.t ..... skipped: no Img extension available
All tests successful.
Files=10, Tests=59, 32 wallclock secs ( 0.06 usr  0.04 sys + 11.09 cusr  1.90 csys = 13.09 CPU)
Result: PASS
```

- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

No binaries/scripts; I have imported and used the module successfully with example code.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
