### PR TITLE
py-mock/py-funcsigs: add python 37

### DIFF
--- a/python/py-funcsigs/Portfile
+++ b/python/py-funcsigs/Portfile
@@ -11,20 +11,21 @@ platforms           darwin
 license             Apache-2
 supported_archs     noarch
 
-python.versions     26 27 34 35 36
+python.versions     26 27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+
 long_description    ${description}
 
-homepage            http://funcsigs.readthedocs.org/
+homepage            https://funcsigs.readthedocs.org/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  b42f623b0351d9d6444ce9dd29af870246b0429f \
-                    sha256  a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50
+                    sha256  a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50 \
+                    size    27947
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -7,7 +7,7 @@ name                py-mock
 set real_name       mock
 version             2.0.0
 revision            2
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -27,7 +27,8 @@ master_sites        pypi:m/${real_name}
 distname            ${real_name}-${version}
 
 checksums           rmd160  10f4cb9343d99620e298cc0ffea143ee321e4ec2 \
-                    sha256  b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba
+                    sha256  b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba \
+                    size    73684
 
 if {${name} eq ${subport}} {
     livecheck.type  pypi


### PR DESCRIPTION
#### Description
- add py37 subports
- add size to checksums
- update homepage for py-funcsigs

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
