### PR TITLE
p5-tcl-tk: remove test-for-tk in Makefile.PL

### DIFF
--- a/perl/p5-tcl-tk/Portfile
+++ b/perl/p5-tcl-tk/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26
 perl5.setup         Tcl-Tk 1.12
+revision            1
 
 platforms           darwin
 supported_archs     noarch
@@ -39,12 +40,17 @@ checksums           rmd160  632740b27d2754fe27209ead0c771fcb5866fc92 \
                     size    331882
 
 if {${perl5.major} != ""} {
-    configure.args-append \
-                    --tclsh ${prefix}/bin/tclsh
+    # Only used for a test removed by patch;
+    # doesn't get stored in configuration
+    #configure.args-append \
+    #               --tclsh ${prefix}/bin/tclsh
+
     depends_lib-append \
                     port:p${perl5.major}-tcl \
                     port:tk \
                     port:tklib
+    # Bypass the test-for-tk since it doesn't work from MacPorts
+    # (Perl never gets any output from tclsh for some reason)
+    patchfiles-append \
+                    patch-Makefile.PL.diff
 }
-
-

--- a/perl/p5-tcl-tk/files/patch-Makefile.PL.diff
+++ b/perl/p5-tcl-tk/files/patch-Makefile.PL.diff
@@ -1,0 +1,39 @@
+diff --git Makefile.PL Makefile.PL
+index 9fcd993..7de4fae 100755
+--- Makefile.PL
++++ Makefile.PL
+@@ -37,34 +37,6 @@ EOT
+ }
+ 
+ 
+-open TCLSH, "$tclsh test-for-tk.tcl|";
+-my $res = join '', <TCLSH>;
+-
+-unless ($res =~ /^ok1/m) {
+-  _die <<EOS;
+-
+-Your Tcl installation ($tclsh) fails to find Tk package.
+-One of possible reasons is missing file 'pkgIndex.tcl' in ..../tk8.4/
+-directory; Please check if you can feed 'package require Tk' to tclsh
+-EOS
+-}
+-
+-unless ($res =~ /^ok2/m) {
+-  warn <<EOS;
+-
+-Your Tk installation fails to find 'snit' package.
+-Some old copy of snit1 will be used. The correct one is prefered.
+-EOS
+-}
+-
+-unless ($res =~ /^ok3/m) {
+-  warn <<EOS;
+-
+-Your Tk installation fails to find 'tklib' package. This package is recommended,
+-otherwise we'll substitute some older version.
+-Be informed on this and better have this package installed within your Tcl/Tk.
+-EOS
+-}
+ 
+ WriteMakefile(
+     NAME => "Tcl::Tk",


### PR DESCRIPTION
Cf. https://trac.macports.org/ticket/56825. I used the same workaround as I did for p5-tcl-ptk since I haven't figured out why it's failing in the first place.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing p5.26-tcl-tk
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-tk/p5.26-tcl-tk/work/Tcl-Tk-1.12" && /usr/bin/make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/after.t ....... ok
t/canvas.t ...... ok
t/geomgr.t ...... ok
t/optmenu.t ..... ok
t/photo.t ....... skipped: no Img extension available (can't find package Img at /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl-tk/p5.26-tcl-tk/work/Tcl-Tk-1.12/blib/lib/Tcl/Tk.pm line 742.
t/ptk-compat.t .. ok
t/text.t ........ ok
t/tk-mw.t ....... ok
t/unicode.t ..... ok
t/zzPhoto.t ..... skipped: no Img extension available
All tests successful.
Files=10, Tests=59, 30 wallclock secs ( 0.06 usr  0.04 sys +  9.10 cusr  1.58 csys = 10.78 CPU)
Result: PASS
```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
