### PR TITLE
kubectl: add co-maintainer

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -9,7 +9,7 @@ platforms           darwin
 supported_archs     x86_64
 license             Apache-2
 
-maintainers         {@patarra gmail.com:patarra} openmaintainer
+maintainers         {@patarra gmail.com:patarra} {lbschenkel @lbschenkel} openmaintainer
 
 description         kubernetes cluster cli
 long_description    Command line interface for running commands \

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -17,6 +17,7 @@ long_description    Command line interface for running commands \
 
 master_sites        https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/darwin/amd64
 distname            kubectl
+dist_subdir         ${name}/${version}
 extract.suffix
 extract.only
 


### PR DESCRIPTION
@patarra: I have added `minikube` to MacPorts and I am interested in co-maintaining the `kubectl` port, in case you don't mind sharing maintainership.
