### PR TITLE
openjdk10: update to 10.0.2

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 name             openjdk10
-version          10.0.1
+version          10.0.2
 
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
@@ -21,12 +21,12 @@ long_description Production-ready, free and open-source build of the Java \
                  compiler. 
 
 homepage         http://jdk.java.net/10/
-master_sites     https://download.java.net/java/GA/jdk10/${version}/fb4372174a714e6b8c52526dc134031e/10/
+master_sites     https://download.java.net/java/GA/jdk10/${version}/19aef61b38124481863b1413dce1855f/13/
 distname         openjdk-${version}_osx-x64_bin
 
-checksums        rmd160  00a1a8a0e63901ecdea7d013f8307ea601e83a55 \
-                 sha256  650e06c203a9d2752d686dc62206580afdc909af924b7ea8573b1c671e182ab0 \
-                 size    200863681
+checksums        rmd160  d29498411adc487bf8191adbc4276c72602022cf \
+                 sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
+                 size    200916897
 
 worksrcdir       jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 10.0.2.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?