### PR TITLE
kotlin: update to 1.2.51

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.2.50 v
+github.setup        JetBrains kotlin 1.2.51 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,9 +21,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  caa141a7690cbf748fcbe81bfd86baf3940867db \
-                    sha256  bc062c303b376711097a27bda4c28047eda0744e9acc64b9db640c19c7d171a9 \
-                    size    35814395
+checksums           rmd160  fc303c6029bd9e52a2351ea9a36c8ec524e5092b \
+                    sha256  8a74711c805d3d265b93c13d8c40af5b4dad324591450d2eef0eafc1c9a6f92c \
+                    size    35810810
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.2.51.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?