### PR TITLE
qpid-proton: update to version 0.24.0

### DIFF
--- a/net/qpid-proton/Portfile
+++ b/net/qpid-proton/Portfile
@@ -19,12 +19,13 @@ homepage            https://qpid.apache.org
 
 PortGroup           github 1.0
 
-github.setup        apache qpid-proton 0.23.0
+github.setup        apache qpid-proton 0.24.0
 
 PortGroup           cmake 1.0
 
-checksums           rmd160  bb3ad84994749ded1a6bdd32b938917ff2ad15f4 \
-                    sha256  a419e76e1b45db1bda24bdbcfa71b8e20ad17a086303eb9d9009b2ac5e5a6e08
+checksums           rmd160  fe3a5ee7f1067dcac24d0afcb46bd4b90a6d4bb0 \
+                    sha256  dd551d3dd985fb9a6d40cb307c5243721b22d433c67e9dfad10c7bb5714bfc8f \
+                    size    1108630
 
 cmake.out_of_source yes
 configure.args-append \
@@ -34,7 +35,8 @@ configure.args-append \
                     -DBUILD_PERL=OFF \
                     -DBUILD_PYTHON=OFF \
                     -DBUILD_GO=OFF \
-                    -DBUILD_RUBY=OFF
+                    -DBUILD_RUBY=OFF \
+                    -DENABLE_VALGRIND=OFF
 
 default_variants    +openssl
 


### PR DESCRIPTION
* update to version 0.24.0
* added size to checksum in Portfile
* set ENABLE_VALGRIND to default to OFF

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.11.6 15G1611
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
