### PR TITLE
TOra: Fix build with clang-902.0.39.2 (Xcode 9.4.1)

### DIFF
--- a/aqua/TOra/Portfile
+++ b/aqua/TOra/Portfile
@@ -25,7 +25,10 @@ depends_lib             port:qscintilla-qt4
 
 patchfiles              patch-cmake-modules-FindOracle.cmake.diff \
                         patch-osx_tools-Info.plist.in.diff \
-                        patch-cmake-modules-FindQScintilla.cmake.diff
+                        patch-cmake-modules-FindQScintilla.cmake.diff \
+                        patch-src-toextract.h \
+                        patch-src-toextract.cpp \
+                        patch-src-toreport.cpp
 
 configure.pre_args      -DCMAKE_INSTALL_PREFIX=${prefix}/tmprelease/
 # -Dmacports_prefix is there due to the patch for the Info.plist file

--- a/aqua/TOra/files/patch-src-toextract.cpp
+++ b/aqua/TOra/files/patch-src-toextract.cpp
@@ -1,0 +1,10 @@
+--- src/toextract.cpp.orig	2018-07-19 16:07:16.000000000 +0700
++++ src/toextract.cpp	2018-07-19 16:07:31.000000000 +0700
+@@ -46,6 +46,7 @@
+ #include "toextract.h"
+ 
+ #include <stdio.h>
++#include <unistd.h>
+ 
+ #include <qapplication.h>
+ #include <qlabel.h>

--- a/aqua/TOra/files/patch-src-toextract.h
+++ b/aqua/TOra/files/patch-src-toextract.h
@@ -1,0 +1,18 @@
+--- src/toextract.h.orig	2018-07-19 16:05:27.000000000 +0700
++++ src/toextract.h	2018-07-19 16:05:18.000000000 +0700
+@@ -782,13 +782,13 @@
+         }
+         /** Implement sort order based only on Order field.
+          */
+-        bool operator <(const columnInfo &inf)
++        bool operator <(const columnInfo &inf) const
+         {
+             return Order < inf.Order;
+         }
+         /** Implement sort order based only on Order field.
+          */
+-        bool operator ==(const columnInfo &inf)
++        bool operator ==(const columnInfo &inf) const
+         {
+             return Order == inf.Order;
+         }

--- a/aqua/TOra/files/patch-src-toreport.cpp
+++ b/aqua/TOra/files/patch-src-toreport.cpp
@@ -1,0 +1,11 @@
+--- src/toreport.cpp.orig	2018-07-19 16:08:26.000000000 +0700
++++ src/toreport.cpp	2018-07-19 16:08:40.000000000 +0700
+@@ -47,6 +47,8 @@
+ #include "toextract.h"
+ #include "toreport.h"
+ 
++#include <unistd.h>
++
+ #include <qapplication.h>
+ #include <qdatetime.h>
+ #ifdef Q_OS_WIN32


### PR DESCRIPTION
#### Description

Fix build with clang-902.0.39.2 (Xcode 9.4.1)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->