### PR TITLE
py-astropy: bumped to 2.0.7 for py<35

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -33,13 +33,13 @@ build.args-append   --use-system-cfitsio \
 if {${name} ne ${subport}} {
 
     if {${python.version} < 35} {
-        version             2.0.5
+        version             2.0.7
         dist_subdir         ${name}/${version}
         distname            astropy-${version}
 
-        checksums           md5     37b215f8ab47c188e8abd3f61c9a6987 \
-                            rmd160  0de0d9c30caa6d341c7cbf078ec8335c517f2b1a \
-                            sha256  55b8e2888da512cc7d80aed98e0bcfe87f2d0490024430531a435591161adf35
+        checksums           md5     044da9f6aba1dac3864a5ab95c9c11d0 \
+                            rmd160  989ab80ebe9bf1f81b71ebc65f2251ec7cdcaa14 \
+                            sha256  5c132d528fd431eb77fd73c172dfa3ec295f2ce0a98c075786908086cda8616d
     }
 
     depends_lib-append  port:cfitsio \


### PR DESCRIPTION
This PR updates `py{27,33,34}-astropy` to 2.0.7.

This is required to work alongside `h5py-2.8.0`, which was added in macports/macports-ports@a2e128e268b250679dfffead90e766b336413789 (see astropy/astropy#7509).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
