### PR TITLE
py-astropy: bumped to 3.0.3 for py>=35

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             3.0.1
+version             3.0.3
 maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod}
 
 dist_subdir         ${name}/${version}
@@ -19,9 +19,9 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     d54c2571fdb82642fcce27f5a88f33d3 \
-                    rmd160  0fc1b310f3bafbf2f75f22a9b4d6a32706cd2e0e \
-                    sha256  c35f4433c14ddfcaf2407cc815385f3d85396727e9a1e660cf66a7c4f5dd1067
+checksums           md5     f6fe7d5049fc0d7c7132e7ff54a8111e \
+                    rmd160  6bc981bd83bd403d7ac60485a3a67cf254e61999 \
+                    sha256  6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da
 
 python.versions     27 33 34 35 36
 

--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -21,7 +21,8 @@ master_sites        pypi:a/astropy/
 distname            astropy-${version}
 checksums           md5     f6fe7d5049fc0d7c7132e7ff54a8111e \
                     rmd160  6bc981bd83bd403d7ac60485a3a67cf254e61999 \
-                    sha256  6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da
+                    sha256  6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da \
+                    size    8058048
 
 python.versions     27 33 34 35 36
 
@@ -39,7 +40,8 @@ if {${name} ne ${subport}} {
 
         checksums           md5     044da9f6aba1dac3864a5ab95c9c11d0 \
                             rmd160  989ab80ebe9bf1f81b71ebc65f2251ec7cdcaa14 \
-                            sha256  5c132d528fd431eb77fd73c172dfa3ec295f2ce0a98c075786908086cda8616d
+                            sha256  5c132d528fd431eb77fd73c172dfa3ec295f2ce0a98c075786908086cda8616d \
+                            size    8320349
     }
 
     depends_lib-append  port:cfitsio \

--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
 version             3.0.3
-maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod}
+maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
 
 dist_subdir         ${name}/${version}
 


### PR DESCRIPTION
This PR updates `py{35,36}-astropy` to 3.0.3.

This is required to work alongside `h5py-2.8.0`, which was added in macports/macports-ports@a2e128e268b250679dfffead90e766b336413789 (see astropy/astropy#7509).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5 17F77
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
