### PR TITLE
Add port olm

### DIFF
--- a/devel/olm/Portfile
+++ b/devel/olm/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+name                olm
+version             2.3.0
+categories          devel security
+platforms           darwin
+maintainers         {@scarface-one disroot.org:scarface} openmaintainer
+description         An implementation of the Double Ratchet cryptographic ratchet in C++
+long_description    An implementation of the Double Ratchet cryptographic ratchet described by \
+                    https://whispersystems.org/docs/specifications/doubleratchet/, written in C \
+                    and C++11 and exposed as a C API.
+
+license             Apache-2
+homepage            http://git.matrix.org/git/olm/about/
+
+master_sites        http://git.matrix.org/git/olm/snapshot
+
+checksums           rmd160  f848e0fe13866943c0af07a2cbbfc16aee6de229 \
+                    sha256  533714fb84860e04c185790d16ef9085f15e902c2105db941d5c7e92b0565ef8 \
+                    size    480801
+
+use_configure       no
+
+build.cmd           make
+build.pre_args-delete all
+build.pre_args-append static
+
+destroot {
+    copy ${worksrcpath}/build/libolm.a ${destroot}${prefix}/lib/libolm.a
+    copy ${worksrcpath}/include/olm ${destroot}${prefix}/include
+}


### PR DESCRIPTION
#### Description

olm is a cryptography library, written in C++. It is required by #2204 .
Home page : https://git.matrix.org/git/olm

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A336e
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
