### PR TITLE
mpv: update to 0.28.2 and make it binary redistributable

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -5,8 +5,7 @@ PortGroup               github 1.0
 PortGroup               waf 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
-github.setup            mpv-player mpv 0.26.0 v
-revision                8
+github.setup            mpv-player mpv 0.28.2 v
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic}
@@ -30,11 +29,13 @@ distfiles-append        ${waf_distfile}:waf
 extract.only-delete     ${waf_distfile}
 
 checksums               ${mpv_distfile} \
-                        rmd160  9218deaee02382a74af81f1f08d3a088ca2c4ae4 \
-                        sha256  069875c74ce60f5db337aa4040416795c421a8b94641a886652516585d150eb1 \
+                        rmd160  f74e0471685be85fafbb6548362997f146ff11a3 \
+                        sha256  9cac0613be59f766f5635da5380b0782d0141c9471c55815e8a1ddc9f2cb0b24 \
+                        size    2982853 \
                         ${waf_distfile} \
                         rmd160  d1a5d0e0f42a0101f5832abb33cd71018505405f \
-                        sha256  167dc42bab6d5bd823b798af195420319cb5c9b571e00db7d83df2a0fe1f4dbf
+                        sha256  167dc42bab6d5bd823b798af195420319cb5c9b571e00db7d83df2a0fe1f4dbf \
+                        size    100685
 
 installs_libs           no
 
@@ -69,8 +70,6 @@ configure.args-append   --enable-manpage-build \
                         --enable-cplugins \
                         --enable-zlib \
                         --disable-html-build \
-                        --disable-videotoolbox-hwaccel-old \
-                        --disable-videotoolbox-hwaccel-new \
                         --disable-videotoolbox-gl \
                         --disable-cuda-hwaccel \
                         --disable-opensles \
@@ -185,13 +184,9 @@ platform darwin {
 
     # VideotoolBox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".
     # It provides support for H264, H263, MPEG1, MPEG2 and MPEG4.
-    # Note that the new API requires FFMPEG 3.4 (currently unreleased or only available as ffmpeg-devel.)
-    # Switch to the new API once ffmpeg 3.4 hits the "stable" ffmpeg port.
     if {${os.major} > 11} {
-        configure.args-delete   --disable-videotoolbox-hwaccel-old \
-                                --disable-videotoolbox-gl
-        configure.args-append   --enable-videotoolbox-hwaccel-old \
-                                --enable-videotoolbox-gl
+        configure.args-delete   --disable-videotoolbox-gl
+        configure.args-append   --enable-videotoolbox-gl
     }
 
     # It looks like mpv expects a CUDA API version 7050 or higher, which might mean >= 7.0.50.
@@ -300,7 +295,10 @@ foreach ver ${python.versions} {
         append variant_line " conflicts python${over}"
     }
 
-    append variant_line " { depends_build-append port:py${ver}-docutils }"
+    append variant_line " {
+        depends_build-append    port:py${ver}-docutils
+        license_noconflict      py${ver}-docutils
+    }"
     eval $variant_line
 }
 


### PR DESCRIPTION
#### Description

About hwaccel-related changes: in https://github.com/mpv-player/mpv/commit/9b60398f4e2710e304eb4bbb51ed70e0b8523845,
support for videotoolbox-hwaccel-old is removed, and seems
videotoolbox-hwaccel is no longer configurable.

About py*-docutils: mpv uses that just for generating man pages from rst
docs (rst2man), which does not involve linking.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10L213o

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?