### PR TITLE
matrix-structs: Add port matrix-structs

### DIFF
--- a/net/matrix-structs/Portfile
+++ b/net/matrix-structs/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+github.setup        mujx matrix-structs 8de04af
+version             2018-07-14
+categories          net devel
+platforms           darwin
+license             public-domain
+maintainers         {@scarface-one disroot.org:scarface} openmaintainer
+description         structs for the matrix library
+long_description    Collection of structs used in the Matrix protocol \
+                    with built in serialization/deserialization to/from \
+                    json.
+
+checksums           rmd160  a8cb9bf9e3da1ebfad3d77198015f0fda16a80d7 \
+                    sha256  894f15d0a83a4970c5783e099bde296187ae0f0a3ca752a5a9cecef323e8878c \
+                    size    412111


### PR DESCRIPTION
#### Description

Add port matrix-structs. matrix-structs is a collection of structs used in the Matrix protocol with built in serialization/deserialization to/from json. Its written in C++. See also https://github.com/mujx/matrix-structs . Required by #2204 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A336e
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
