### PR TITLE
ld64: default to +ld64_xcode on Xcode9+

### DIFF
--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -4,6 +4,7 @@ PortGroup               compiler_blacklist_versions 1.0
 name                    ld64
 epoch                   2
 version                 3
+revision                1
 set dyld_version        421.2
 categories              devel
 platforms               darwin
@@ -198,6 +199,11 @@ if {${subport} eq ${name}} {
         } elseif {${os.major} < 11} {
             default_variants +ld64_127
         }
+    }
+
+    if {[vercmp $xcodeversion 9.0] >= 0} {
+        # only ld64_xcode speaks tapi at present
+        default_variants +ld64_xcode
     }
 
     if {[variant_isset ld64_97]} {


### PR DESCRIPTION
ld64 does not understand tapi in the open-source
versions at present.

I **believe** that XCode 9+ generates the tapi lookups -- open to fine-tuning of the details on this.

closes: https://trac.macports.org/ticket/56843
closes: https://trac.macports.org/ticket/53784
closes: https://trac.macports.org/ticket/56398
closes: https://trac.macports.org/ticket/56277
see:    https://trac.macports.org/ticket/56647
see:    https://trac.macports.org/ticket/54510
see:    https://trac.macports.org/ticket/54506
see:    https://trac.macports.org/ticket/53151
