### PR TITLE
py-twine: upgrade to 1.11.0

### DIFF
--- a/python/py-pkginfo/Portfile
+++ b/python/py-pkginfo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pkginfo
-version             1.4.1
+version             1.4.2
 platforms           darwin
 license             MIT
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
@@ -19,9 +19,9 @@ homepage            https://pypi.python.org/pypi/pkginfo
 master_sites        pypi:p/pkginfo/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  1cdc3a99119f793f92029178b6ff076f6884260f \
-                    sha256  bb1a6aeabfc898f5df124e7e00303a5b3ec9a489535f346bfbddb081af93f89e \
-                    size    32001
+checksums           rmd160  65db4ba7d508330ae31741d6fc61e8b26c32b70e \
+                    sha256  5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474 \
+                    size    33539
 
 python.versions     27 36
 

--- a/python/py-twine/Portfile
+++ b/python/py-twine/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pypa twine 1.9.1
+github.setup        pypa twine 1.11.0
 
 name                py-twine
 platforms           darwin
@@ -14,9 +14,9 @@ maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 description         Twine is a utility for interacting with PyPI.
 long_description    ${description}
 
-checksums           rmd160  ee278694354444004b321b87fbb7701ac92e192a \
-                    sha256  c382d996bc4bb5d1eaf7cac6cf3bb439680e28613a5de2ba6bf225dd0b51ca31 \
-                    size    48813
+checksums           rmd160  6cfbb4a0779f31cc8ef0e7d5f3e5f2bb0be6b842 \
+                    sha256  fbd8c24bec3dbb8ccbbb638a08eb5e0e712d69c2cdb4e9b53933974f41b35749 \
+                    size    55304
 
 python.versions     27 36
 


### PR DESCRIPTION
#### Description

This PR upgrades `py-twine` to 1.11.0 (latest release on pypi.org), and `py-pkginfo` to 1.4.2 to match.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
