### PR TITLE
mtxclient: new portfile

### DIFF
--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
+#NOTE: requires C++14
+
+github.setup        mujx mtxclient 2f519d2
+version             2018-07-14
+categories          net chat devel
+platforms           darwin
+license             GPL-3
+maintainers         {@scarface-one disroot.org:scarface} openmaintainer
+description         Client API for Matrix
+long_description    Client API library for the Matrix protocol, built on top of Boost.Asio.
+
+checksums           rmd160  28330b8f5c028792aaa5a1dbdd3738aea4854e7d \
+                    sha256  760a03fabae4cca250a5a7aa1328e7fb922186b431c1b65530ad083dcb9fda4c \
+                    size    92272
+
+#C++14 was first fully supported by clang 3.4 aka apple clang 503.0.38
+compiler.blacklist-append {clang < 503.0.38}
+
+configure.args-append   -DBUILD_LIB_TESTS=OFF \
+                        -DBUILD_LIB_EXAMPLES=OFF \
+                        -DOLM_INCLUDE_DIR=${prefix}/include/olm \
+                        -DOLM_LIBRARY=${prefix}/lib/libolm.a \
+                        -DOPENSSL_ROOT_DIR=${prefix}/include/openssl \
+                        -DSODIUM_ROOT_DIR=${prefix}/include/ \
+                        -Dsodium_INCLUDE_DIR=${prefix}/include \
+                        -Dsodium_LIBRARY_RELEASE=${prefix}/lib/libsodium.dylib \
+
+depends_build-append port:olm \
+                    port:openssl \
+                    port:pkgconfig \
+                    port:spdlog
+
+depends_lib-append  port:boost \
+                    port:libsodium \
+                    port:matrix-structs


### PR DESCRIPTION
#### Description

mtxclient is a client library for matrix. See https://github.com/mujx/mtxclient https://matrix.org . This is the last port required by #2204 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A336e
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
