### PR TITLE
py-greenlet: update to 0.4.14 for py37 compatibility

### DIFF
--- a/python/py-greenlet/Portfile
+++ b/python/py-greenlet/Portfile
@@ -4,13 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-greenlet
-version             0.4.13
-revision            0
+version             0.4.14
 categories-append   devel
 platforms           darwin
 license             MIT PSF
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -47,12 +46,17 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            greenlet-${version}
 
-checksums           rmd160  e4dfd568ec416e78738d953cd992f6d4052cdb2a \
-                    sha256  0fef83d43bf87a5196c91e73cb9772f945a4caaff91242766c5916d1dd1381e4
+checksums           rmd160  f8ff6cfc24da9c1e993522aae559f94cecf9449e \
+                    sha256  f1cc268a15ade58d9a0c04569fe6613e19b8b0345b64453064e2c3c6d79051af \
+                    size    59385
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
+
+    test.run            yes
+    test.cmd            python${python.branch}
+    test.target         run-tests.py -n
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

And add tests

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10L213o

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?