### PR TITLE
dict: drop needless dependencies

### DIFF
--- a/textproc/dict/Portfile
+++ b/textproc/dict/Portfile
@@ -19,13 +19,9 @@ master_sites        sourceforge:project/${name}/dictd/${distname}/
 checksums           rmd160  6c8b2ea5a8afa26fde019dea686d52ab5007ea17 \
                     sha256  a237f6ecdc854ab10de5145ed42eaa2d9b6d51ffdc495f7daee59b05cc363656
 
-depends_build       port:bison port:flex port:grep port:libtool
+depends_build       port:libtool
 depends_lib         port:libmaa port:zlib
 configure.env       LIBTOOL=${prefix}/bin/glibtool
-
-# To find GNU grep instead of system grep
-configure.env       GREP=${prefix}/libexec/gnubin/grep \
-                    LIBTOOL=${prefix}/bin/glibtool
 
 set conf_file       ${prefix}/etc/dict.conf
 


### PR DESCRIPTION
textproc/dict builds fine with the system grep, bison, flex,
so drop the dependency. It still needs the GNU libtool though
(but no need to say so twice).

- [ ] bugfix
- [x] enhancement
- [ ] security fix

Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
