### PR TITLE
cctools: Add xcode variant that installs wrapper scripts around Xcode commands

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -28,8 +28,6 @@ checksums               ld64-274.1.tar.gz \
                         rmd160  e46dd79bd87c727f1326c569d0b8e9eadcc57495 \
                         sha256  ce66034fa35117f9ae76bbb7dd72d8068c405778fa42e877e8a13237a10c5cb7
 
-depends_build           port:libunwind-headers
-
 patchfiles \
     cctools-829-lto.patch \
     PR-37520.patch \
@@ -58,7 +56,7 @@ set llvm_version {}
 
 foreach variantname $all_llvm_variants {
     set this_llvm_version $llvm_variant_version($variantname)
-    variant $variantname conflicts {*}[ldelete $all_llvm_variants $variantname] description "Use llvm-${this_llvm_version} for libLTO, llvm-mc, llvm-size, and llvm-nm" "
+    variant $variantname conflicts xcode {*}[ldelete $all_llvm_variants $variantname] description "Use llvm-${this_llvm_version} for libLTO, llvm-mc, llvm-size, and llvm-nm" "
         set llvm_version        $this_llvm_version
         depends_lib-append      port:llvm-${this_llvm_version}
     "
@@ -74,7 +72,7 @@ proc some_llvm_variant_set {} {
     return no
 }
 
-if {![some_llvm_variant_set]} {
+if { ![some_llvm_variant_set] && ![variant_isset xcode] } {
     if {${os.major} == 12 || ${os.major} == 13} {
         # Using llvm-3.7 to break a dependency cycle (https://trac.macports.org/ticket/53138)
         default_variants +llvm37
@@ -88,45 +86,82 @@ if {![some_llvm_variant_set]} {
     #     default_variants +llvm33
     # }
 
-    if {![some_llvm_variant_set] && ${os.major} >= 10} {
+    if {[vercmp $xcodeversion 9.0] >= 0} {
+        default_variants +xcode
+    } elseif {![some_llvm_variant_set] && ${os.major} >= 10} {
         default_variants +llvm50
     }
+
+}
+
+variant xcode description "Use Xcode supplied toolkit" { }
+if {[variant_isset xcode]} {
+   patchfiles
+   distfiles
+   build { }
+   pre-destroot { }
+   post-destroot { }
+   destroot {
+       set xcode_cmds {bitcode-strip nm nm-classic as ar otool ranlib lipo libtool segedit strip size size-classic strings}
+       foreach xcode_cmd $xcode_cmds {
+           set mp_cmd ${destroot}${prefix}/bin/${xcode_cmd}
+           # Create script that uses xcrun to run the Xcode provided command
+           system "echo '#!/bin/bash'                                          > ${mp_cmd}"
+           system "echo 'if \[\[ \-x \/usr\/bin\/xcrun \]\] \; then'          >> ${mp_cmd}"
+           system "echo '  exec \/usr\/bin\/xcrun ${xcode_cmd} \"\$\{\@\}\"'  >> ${mp_cmd}"
+           system "echo 'elif \[\[ \-x \/usr\/bin\/${xcode_cmd} \]\] \; then' >> ${mp_cmd}"
+           system "echo '  exec \/usr\/bin/${xcode_cmd} \"\$\{\@\}\"'         >> ${mp_cmd}"
+           system "echo 'else'                                                >> ${mp_cmd}"
+           system "echo '  exec ${xcode_cmd} \"\$\{\@\}\"'                    >> ${mp_cmd}"
+           system "echo 'fi'                                                  >> ${mp_cmd}"
+           # make executable
+           system "chmod +x ${mp_cmd}"
+     }
+   }
 }
 
 use_configure           no
 destroot.args           RAW_DSTROOT=${destroot} DSTROOT=${destroot}${prefix} RC_ProjectSourceVersion=${version}
 
+if {![variant_isset xcode]} {
+   depends_build           port:libunwind-headers
+}
+
 post-extract {
-    file copy ${worksrcpath}/../ld64-${ld64_version}/src/other/PruneTrie.cpp ${worksrcpath}/misc
-    system "touch ${worksrcpath}/../ld64-${ld64_version}/src/abstraction/configure.h"
+    if {![variant_isset xcode]} {	
+       file copy ${worksrcpath}/../ld64-${ld64_version}/src/other/PruneTrie.cpp ${worksrcpath}/misc
+       system "touch ${worksrcpath}/../ld64-${ld64_version}/src/abstraction/configure.h"
+    }
 }
 
 post-patch {
-    # We don't want to build cctools ld.  We want to use ld64
-    reinplace "/^SUBDIRS_32/s/ld//" ${worksrcpath}/Makefile
-    reinplace "/^COMMON_SUBDIRS/s/ ld / /" ${worksrcpath}/Makefile
+    if {![variant_isset xcode]} {		
+          # We don't want to build cctools ld.  We want to use ld64
+          reinplace "/^SUBDIRS_32/s/ld//" ${worksrcpath}/Makefile
+          reinplace "/^COMMON_SUBDIRS/s/ ld / /" ${worksrcpath}/Makefile
 
-    # Use our chosen version of llvm
-    if {${llvm_version} ne ""} {
-        reinplace "s:\"llvm-objdump\":\"llvm-objdump-mp-${llvm_version}\":" ${worksrcpath}/otool/main.c
-        reinplace "s:\"llvm-mc\":\"llvm-mc-mp-${llvm_version}\":" ${worksrcpath}/as/driver.c
-        reinplace "s:@@LLVM_LIBDIR@@:${prefix}/libexec/llvm-${llvm_version}/lib:" ${worksrcpath}/libstuff/lto.c
-    }
+   	  # Use our chosen version of llvm
+    	  if {${llvm_version} ne ""} {
+             reinplace "s:\"llvm-objdump\":\"llvm-objdump-mp-${llvm_version}\":" ${worksrcpath}/otool/main.c
+             reinplace "s:\"llvm-mc\":\"llvm-mc-mp-${llvm_version}\":" ${worksrcpath}/as/driver.c
+             reinplace "s:@@LLVM_LIBDIR@@:${prefix}/libexec/llvm-${llvm_version}/lib:" ${worksrcpath}/libstuff/lto.c
+          }
 
-    foreach file [glob ${worksrcpath}/{*/,}Makefile] {
-        reinplace "s:/usr/local:@PREFIX@:g" ${file}
-        reinplace "s:/usr:@PREFIX@:g" ${file}
-        reinplace "s:@PREFIX@:${prefix}:g" ${file}
-        reinplace "s:${prefix}/efi:${prefix}:g" ${file}
-        reinplace "s:/Developer${prefix}:${prefix}:g" ${file}
-        reinplace "s:${prefix}/man:${prefix}/share/man:g" ${file}
+    	  foreach file [glob ${worksrcpath}/{*/,}Makefile] {
+             reinplace "s:/usr/local:@PREFIX@:g" ${file}
+             reinplace "s:/usr:@PREFIX@:g" ${file}
+             reinplace "s:@PREFIX@:${prefix}:g" ${file}
+             reinplace "s:${prefix}/efi:${prefix}:g" ${file}
+             reinplace "s:/Developer${prefix}:${prefix}:g" ${file}
+             reinplace "s:${prefix}/man:${prefix}/share/man:g" ${file}
 
-        # Don't strip installed binaries
-        reinplace "s:\\(install .*\\)-s :\\1:g" ${file}
+             # Don't strip installed binaries
+             reinplace "s:\\(install .*\\)-s :\\1:g" ${file}
 
-        if {${os.major} < 10} {
-            reinplace "s:${prefix}/bin/mig:/usr/bin/mig:g" ${file}
-        }
+             if {${os.major} < 10} {
+                reinplace "s:${prefix}/bin/mig:/usr/bin/mig:g" ${file}
+            }
+	 }
     }
 }
 
@@ -146,50 +181,54 @@ if {[string match *clang* ${configure.cxx}]} {
 configure.cppflags-append -I${worksrcpath}/../ld64-${ld64_version}/src/abstraction -I${worksrcpath}/../ld64-${ld64_version}/src/other -I${worksrcpath}/include
 
 pre-build {
-    build.args-append \
-        RC_ProjectSourceVersion=${version} \
-        USE_DEPENDENCY_FILE=NO \
-        BUILD_DYLIBS=NO \
-        CC="${configure.cc} ${configure.cflags}" \
-        CXX="${configure.cxx} ${configure.cxxflags}" \
-        CXXLIB="${cxx_stdlibflags}" \
-        TRIE=-DTRIE_SUPPORT \
-        RC_ARCHS="[get_canonical_archs]" \
-        SDK="${configure.cppflags}"
+    if {![variant_isset xcode]} {	
+       	build.args-append \
+            RC_ProjectSourceVersion=${version} \
+       	    USE_DEPENDENCY_FILE=NO \
+            BUILD_DYLIBS=NO \
+            CC="${configure.cc} ${configure.cflags}" \
+            CXX="${configure.cxx} ${configure.cxxflags}" \
+            CXXLIB="${cxx_stdlibflags}" \
+            TRIE=-DTRIE_SUPPORT \
+            RC_ARCHS="[get_canonical_archs]" \
+            SDK="${configure.cppflags}"
 
-    if {${llvm_version} ne ""} {
-        build.args-append \
-            LTO=-DLTO_SUPPORT \
-            RC_CFLAGS="[get_canonical_archflags] `llvm-config-mp-${llvm_version} --cflags`" \
-            LLVM_MC="llvm-mc-mp-${llvm_version}"
-    } else {
-        build.args-append \
-            LTO= \
-            RC_CFLAGS="[get_canonical_archflags]"
+        if {${llvm_version} ne ""} {
+            build.args-append \
+                LTO=-DLTO_SUPPORT \
+                RC_CFLAGS="[get_canonical_archflags] `llvm-config-mp-${llvm_version} --cflags`" \
+                LLVM_MC="llvm-mc-mp-${llvm_version}"
+        } else {
+            build.args-append \
+                LTO= \
+                RC_CFLAGS="[get_canonical_archflags]"
+        }
     }
 }
 
 pre-destroot {
-    destroot.args-append \
-        RC_ProjectSourceVersion=${version} \
-        USE_DEPENDENCY_FILE=NO \
-        BUILD_DYLIBS=NO \
-        CC="${configure.cc} ${configure.cflags}" \
-        CXX="${configure.cxx} ${configure.cxxflags}" \
-        CXXLIB="${cxx_stdlibflags}" \
-        TRIE=-DTRIE_SUPPORT \
-        RC_ARCHS="[get_canonical_archs]" \
-        SDK="${configure.cppflags}"
+    if {![variant_isset xcode]} {
+        destroot.args-append \
+            RC_ProjectSourceVersion=${version} \
+            USE_DEPENDENCY_FILE=NO \
+            BUILD_DYLIBS=NO \
+            CC="${configure.cc} ${configure.cflags}" \
+            CXX="${configure.cxx} ${configure.cxxflags}" \
+            CXXLIB="${cxx_stdlibflags}" \
+            TRIE=-DTRIE_SUPPORT \
+            RC_ARCHS="[get_canonical_archs]" \
+            SDK="${configure.cppflags}"
 
-    if {${llvm_version} ne ""} {
-        destroot.args-append \
-            LTO=-DLTO_SUPPORT \
-            RC_CFLAGS="[get_canonical_archflags] `llvm-config-mp-${llvm_version} --cflags`" \
-            LLVM_MC="llvm-mc-mp-${llvm_version}"
-    } else {
-        destroot.args-append \
-            LTO= \
-            RC_CFLAGS="[get_canonical_archflags]"
+        if {${llvm_version} ne ""} {
+            destroot.args-append \
+                LTO=-DLTO_SUPPORT \
+                RC_CFLAGS="[get_canonical_archflags] `llvm-config-mp-${llvm_version} --cflags`" \
+                LLVM_MC="llvm-mc-mp-${llvm_version}"
+        } else {
+            destroot.args-append \
+                LTO= \
+                RC_CFLAGS="[get_canonical_archflags]"
+	}
     }
 }
 
@@ -201,32 +240,34 @@ platform macosx {
 destroot.target install_tools
 destroot.args-append DSTROOT=${destroot}
 post-destroot {
-    file delete -force ${destroot}${prefix}/OpenSourceLicenses
-    file delete -force ${destroot}${prefix}/OpenSourceVersions
-    file delete -force ${destroot}${prefix}/RelNotes
+    if {![variant_isset xcode]} {
+        file delete -force ${destroot}${prefix}/OpenSourceLicenses
+        file delete -force ${destroot}${prefix}/OpenSourceVersions
+        file delete -force ${destroot}${prefix}/RelNotes
 
-    if {${os.major} < 10} {
-        file delete -force ${destroot}/Developer
-    }
+        if {${os.major} < 10} {
+            file delete -force ${destroot}/Developer
+        }
 
-    # Provided by port:cctools-headers
-    file delete -force ${destroot}${prefix}/include
+        # Provided by port:cctools-headers
+        file delete -force ${destroot}${prefix}/include
 
-    # Older versions of llvm either don't have some tools, or they're not compatible
+        # Older versions of llvm either don't have some tools, or they're not compatible
 
-    file delete -force ${destroot}${prefix}/bin/nm
-    file delete -force ${destroot}${prefix}/bin/size
-    if {${llvm_version} eq "3.4" || ${llvm_version} eq "3.7" || ${llvm_version} eq ""} {
-        ln -s nm-classic ${destroot}${prefix}/bin/nm
-        ln -s size-classic ${destroot}${prefix}/bin/size
+        file delete -force ${destroot}${prefix}/bin/nm
+        file delete -force ${destroot}${prefix}/bin/size
+        if {${llvm_version} eq "3.4" || ${llvm_version} eq "3.7" || ${llvm_version} eq ""} {
+            ln -s nm-classic ${destroot}${prefix}/bin/nm
+            ln -s size-classic ${destroot}${prefix}/bin/size
 
-        # https://trac.macports.org/ticket/53099
-        file delete -force ${destroot}${prefix}/bin/otool
-        file delete -force ${destroot}${prefix}/bin/llvm-otool
-        ln -s otool-classic ${destroot}${prefix}/bin/otool
-    } else {
-        ln -s llvm-nm-mp-${llvm_version} ${destroot}${prefix}/bin/nm
-        ln -s llvm-size-mp-${llvm_version} ${destroot}${prefix}/bin/size
+            # https://trac.macports.org/ticket/53099
+            file delete -force ${destroot}${prefix}/bin/otool
+            file delete -force ${destroot}${prefix}/bin/llvm-otool
+            ln -s otool-classic ${destroot}${prefix}/bin/otool
+        } else {
+            ln -s llvm-nm-mp-${llvm_version} ${destroot}${prefix}/bin/nm
+            ln -s llvm-size-mp-${llvm_version} ${destroot}${prefix}/bin/size
+        }
     }
 }
 


### PR DESCRIPTION

#### Description

Adds a new optional variant that, similar to the one in the ld64 port, installs wrapper scripts that uses xcrun to find and use the selected Xcode installation, instead of installing new versions.

Useful on newer OSes where the provided Xcode is newer than the Xcode 8 based utilities the port would (currently) otherwise install.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
