### PR TITLE
olm: add cxx11 and cleanup portfile

### DIFF
--- a/devel/olm/Portfile
+++ b/devel/olm/Portfile
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
+
 name                olm
 version             2.3.0
 categories          devel security
@@ -22,9 +24,7 @@ checksums           rmd160  f848e0fe13866943c0af07a2cbbfc16aee6de229 \
 
 use_configure       no
 
-build.cmd           make
-build.pre_args-delete all
-build.pre_args-append static
+build.target        static
 
 destroot {
     copy ${worksrcpath}/build/libolm.a ${destroot}${prefix}/lib/libolm.a


### PR DESCRIPTION
* Set build.target as static instead of deleteing and appending args
* Don't set build.cmd as make since its the default
* Add PortGroup cxx11

It was also requested that a shared library be created instead of a static library, but static libraries don't seem to be supported for macOS right now. I could create a patch file for the `Makefile` though.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A336e
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
