### PR TITLE
py-neovim: update to 0.2.6 for py37 compatibility

### DIFF
--- a/python/py-neovim/Portfile
+++ b/python/py-neovim/Portfile
@@ -1,12 +1,11 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        neovim python-client 0.2.4
+github.setup        neovim python-client 0.2.6
 name                py-neovim
-revision            1
 maintainers         {g5pw @g5pw} openmaintainer
 description         Python client for Neovim
 long_description    ${description}. Implements support for python plugins in \
@@ -17,7 +16,7 @@ license             Apache-2
 
 supported_archs     noarch
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 if { ${name} ne ${subport} } {
     depends_build-append \
@@ -30,8 +29,16 @@ if { ${name} ne ${subport} } {
         depends_lib-append  port:py${python.version}-trollius
     }
 
-    checksums           rmd160  de9fcf0868ce1eb5fa1a83c5563484febf2e4724 \
-                        sha256  ddf7c6753a75d7388d178331a07c81f1accdd5b374deccef98b641798c6496ab
+    depends_test-append \
+                        port:py${python.version}-pytest
+
+    checksums           rmd160  5ff811cafcd018996960b530d958ed6535100e75 \
+                        sha256  f73a62b702b89000900ce1dda8e7c8592f0eb069d69c573ebc4eb62e6d1d3f5d \
+                        size    50169
+
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

Note that 0.2.5 is already compatible with py37. I just want the latest
version.

Other changes:
* fix modeline
* add test

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10L213o 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?