### PR TITLE
py-Pillow: update to 5.2.0

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-Pillow
-version             5.1.0
-revision            0
+version             5.2.0
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -24,8 +23,9 @@ master_sites        pypi:0f/57/25be1a4c2d487942c3ed360f6eee7f41c5b9196a09ca71c54
 
 distname            Pillow-${version}
 
-checksums           rmd160  300e2626b33b803b7bb6a553a15c5beab82922ea \
-                    sha256  cee9bc75bff455d317b6947081df0824a8f118de2786dc3d74a3503fd631f4ef
+checksums           rmd160  e2cfed9c172ea3e345d369b1f4357920cd5c7cb2 \
+                    sha256  f8b3d413c5a8f84b12cd4c5df1d8e211777c9852c6be3ee9c094b626644d3eab \
+                    size    14499068
 
 if {${name} ne ${subport}} {
     conflicts           py${python.version}-pil
@@ -37,7 +37,8 @@ if {${name} ne ${subport}} {
                             pypi:[string index ${python.rootname} 0]/${python.rootname}
         distname            Pillow-${version}
         checksums           rmd160  40f983f9a57844c8338c1649b3473a8339dd85cf \
-                            sha256  0ee9975c05602e755ff5000232e0335ba30d507f6261922a658ee11b1cec36d1
+                            sha256  0ee9975c05602e755ff5000232e0335ba30d507f6261922a658ee11b1cec36d1 \
+                            size    10814666
     }
 
     depends_build-append \
@@ -52,7 +53,11 @@ if {${name} ne ${subport}} {
                         port:openjpeg \
                         port:freetype
 
-    patchfiles          patch-setup.py.diff
+    if {[lsearch {26 33} ${python.version}] != -1} {
+        patchfiles          patch-setup-3.4.2.py.diff
+    } else {
+        patchfiles          patch-setup.py.diff
+    }
 
     post-patch {
         reinplace "s|@prefix@|${prefix}|g" ${worksrcpath}/setup.py

--- a/python/py-Pillow/files/patch-setup-3.4.2.py.diff
+++ b/python/py-Pillow/files/patch-setup-3.4.2.py.diff
@@ -1,0 +1,47 @@
+--- setup.py.orig	2016-10-18 15:12:54.000000000 -0400
++++ setup.py	2018-07-21 12:04:06.000000000 -0400
+@@ -233,42 +233,8 @@
+                                         sys.version[:3], "config"))
+ 
+         elif sys.platform == "darwin":
+-            # attempt to make sure we pick freetype2 over other versions
+-            _add_directory(include_dirs, "/sw/include/freetype2")
+-            _add_directory(include_dirs, "/sw/lib/freetype2/include")
+-            # fink installation directories
+-            _add_directory(library_dirs, "/sw/lib")
+-            _add_directory(include_dirs, "/sw/include")
+-            # darwin ports installation directories
+-            _add_directory(library_dirs, "/opt/local/lib")
+-            _add_directory(include_dirs, "/opt/local/include")
+-
+-            # if Homebrew is installed, use its lib and include directories
+-            try:
+-                prefix = subprocess.check_output(['brew', '--prefix']).strip(
+-                ).decode('latin1')
+-            except:
+-                # Homebrew not installed
+-                prefix = None
+-
+-            ft_prefix = None
+-
+-            if prefix:
+-                # add Homebrew's include and lib directories
+-                _add_directory(library_dirs, os.path.join(prefix, 'lib'))
+-                _add_directory(include_dirs, os.path.join(prefix, 'include'))
+-                ft_prefix = os.path.join(prefix, 'opt', 'freetype')
+-
+-            if ft_prefix and os.path.isdir(ft_prefix):
+-                # freetype might not be linked into Homebrew's prefix
+-                _add_directory(library_dirs, os.path.join(ft_prefix, 'lib'))
+-                _add_directory(include_dirs,
+-                               os.path.join(ft_prefix, 'include'))
+-            else:
+-                # fall back to freetype from XQuartz if
+-                # Homebrew's freetype is missing
+-                _add_directory(library_dirs, "/usr/X11/lib")
+-                _add_directory(include_dirs, "/usr/X11/include")
++            _add_directory(library_dirs, "@prefix@/lib")
++            _add_directory(include_dirs, "@prefix@/include")
+ 
+         elif sys.platform.startswith("linux"):
+             arch_tp = (plat.processor(), plat.architecture()[0])


### PR DESCRIPTION
#### Description
- update to version 5.2.0
- add size to checksums
- patch is not for py26/py33 subports

Closes: https://trac.macports.org/ticket/56833
Closes: https://trac.macports.org/ticket/56823

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
