### PR TITLE
libsndfile +octave: drop the gsed dependency

### DIFF
--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -47,7 +47,6 @@ variant no_external_libs description {Disable FLAC, Ogg and Vorbis support} {
 }
 
 variant octave description {Enable support for Octave} {
-    depends_build-append  port:gsed
     depends_lib-append    path:bin/octave:octave
     configure.args-append --enable-octave
     configure.args-delete --disable-octave


### PR DESCRIPTION
The octave variant of libsndfile does not need to declare a dependency on gsed.
Octave itself declares a gsed dependency.
