### PR TITLE
php-zip: Get from PECL instead of bundled with PHP

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -1385,18 +1385,6 @@ subport ${php}-xsl {
     configure.cppflags-append   -I${prefix}/include/${php}/php/ext/dom
 }
 
-subport ${php}-zip {
-    categories-append       archivers
-    
-    description             PHP zip functions
-    
-    long_description        ${description}
-    
-    depends_lib-append      port:zlib
-    
-    configure.args-append   --with-zlib-dir=${prefix}
-}
-
 }
 
 # These variables are not only required by the subsequent code but also by

--- a/php/php-zip/Portfile
+++ b/php/php-zip/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           php 1.1
+
+name                php-zip
+categories-append   archivers
+platforms           darwin
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             PHP-3.01
+
+php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2
+php.pecl            yes
+
+if {[vercmp ${php.branch} 4.3] >= 0} {
+    epoch           3
+    version         1.15.3
+    revision        0
+    checksums       rmd160  554e0943f43d1ee2c37ccbe1bb5ed0414ffba290 \
+                    sha256  6766799a8fb09f2990224fc7d40e01737294a515d3ffd8895fa25249c31ba0a7 \
+                    size    267715
+}
+
+description         PHP zip functions
+
+long_description    This PHP extension lets you create, read and modify zip \
+                    files.
+
+if {${name} ne ${subport}} {
+    depends_lib-append      port:libzip \
+                            port:zlib
+
+    configure.args-append   --enable-zip \
+                            --with-libzip=${prefix} \
+                            --with-zlib-dir=${prefix}
+}


### PR DESCRIPTION
#### Description

This updates php-zip to a newer version, for older versions of PHP which bundled older versions.

It now uses an external copy of libzip instead of a bundled one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
