### PR TITLE
py-lmfit/py-uncertainties: add py37 subport

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -22,7 +22,7 @@ checksums               rmd160  fe1c29354627524f769cde7f03517dad45d7cacb \
                         sha256  f635c69fa67cd4d3daa1148f449abc2ff1e19adf5761b3eac7d314224d7506e2 \
                         size    1600601
 
-python.versions         27 34 35 36
+python.versions         27 34 35 36 37
 
 if {$subport ne $name} {
     depends_build-append       port:py${python.version}-setuptools

--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -12,16 +12,18 @@ license                 BSD
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 description             The python uncertainties package.
 long_description        The uncertainties package transparently handles\
-                        calculations for numbers with\
-                        uncertainties.
+                        calculations for numbers with uncertainties.
 platforms               darwin
 
 checksums               rmd160  4954e8e43e56322ad3d8ac888163d9c436e87a95 \
                         sha256  4d5d7f0035ed13e78a123a04bd17bb8711d887220f0e2ae109274b33c5bb92ae \
                         size    146359
 
-python.versions         27 34 35 36
+python.versions         27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build-append       port:py${python.version}-setuptools
+    depends_build-append  \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- add py37 subports to py-lmfit and its dependency py-uncertainties
- disable livecheck in the subports for py-uncertainties

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
