### PR TITLE
cquery: update to v20180718

### DIFF
--- a/devel/cquery/Portfile
+++ b/devel/cquery/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem      1.0
 
-PortGroup       waf 1.0
+PortGroup       cmake 1.1
 PortGroup       xcodeversion 1.0
 PortGroup       github 1.0
+PortGroup       cxx11 1.1
 
 categories      devel
 license         MIT
@@ -23,7 +24,7 @@ long_description \
 
 platforms          darwin
 
-github.setup       cquery-project cquery 20180302 v
+github.setup       cquery-project cquery 20180718 v
 
 fetch.type      git
 
@@ -38,21 +39,24 @@ subport cquery-devel {
     conflicts   ${name}
 }
 
-configure.args-delete        --nocache
+# needs a c++14 compatible compiler
+compiler.blacklist-append   {clang < 602}
 
-if {${subport} eq ${name}} {
-    depends_lib port:clang-5.0
-    configure.args-append    --llvm-config=llvm-config-mp-5.0
-    build.args-append        --llvm-config=llvm-config-mp-5.0
-}
+depends_lib                 port:clang-6.0
+
+cmake.build_type            release
+
+set llvm_path               ${prefix}/libexec/llvm-6.0
+
+configure.pre_args-delete   -DCMAKE_INSTALL_NAME_DIR="${prefix}/lib"
+configure.pre_args-replace  -DCMAKE_MODULE_PATH="${prefix}/share/cmake/Modules" -DCMAKE_MODULE_PATH="${llvm_path}/cmake/llvm\;${llvm_path}/cmake/clang"
+configure.pre_args-replace  -DCMAKE_PREFIX_PATH="${prefix}/share/cmake/Modules" -DCMAKE_PREFIX_PATH="${llvm_path}"
+
+configure.args-append       -DSYSTEM_CLANG=ON
 
 if {${subport} eq "cquery-devel"} {
     minimum_xcodeversions {16 8.3}
 
-    github.setup             cquery-project cquery ce362a888dd1fc00469ab1af58bc4f0a8c081a5f
-    version                  20180621
-
-    depends_lib              port:clang-6.0
-    configure.args-append    --llvm-config=llvm-config-mp-6.0
-    build.args-append        --llvm-config=llvm-config-mp-6.0
+    github.setup             cquery-project cquery 5b73464d0d8470a85a24f2023bf4976e492022e1
+    version                  20180722
 }


### PR DESCRIPTION
* Switch PortGroup from waf to cmake
* Remove dependency on clang-5.0 in cquery
* Blacklist C++ compiler not compatible with C++14

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
