### PR TITLE
py-nmrglue: add py37 subport, enable tests

### DIFF
--- a/python/py-nmrglue/Portfile
+++ b/python/py-nmrglue/Portfile
@@ -25,13 +25,19 @@ checksums           rmd160  37534eaaee6d72f5301a6e7933594e8db74229ef \
                     sha256  2392555a8d0e558c7d12eee6f0d1bd71c5571972517bb252bf803484cf3c1300 \
                     size    150827
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-scipy \
                         port:py${python.version}-numpy
 
+    depends_test-append  \
+                    port:py${python.version}-nose
+    test.run        yes
+    test.cmd        nosetests-${python.branch}
+    test.target
+
     livecheck.type  none
 } else {
-    livecheck.type      pypi
+    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- add py27 subport
- enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
