### PR TITLE
py-*: remove obsolete py26/py33 subports from various Python ports

### DIFF
--- a/python/py-celementtree/Portfile
+++ b/python/py-celementtree/Portfile
@@ -22,7 +22,7 @@ distname            cElementTree-${version}
 use_zip             yes
 checksums           sha1    b36c95fd90d53746424c10db45b102b8fab260b8
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-elementtree

--- a/python/py-checker/Portfile
+++ b/python/py-checker/Portfile
@@ -25,7 +25,7 @@ master_sites		sourceforge:pychecker
 distname		    pychecker-${version}
 checksums		    md5     ef156a631df46de150a364912f2e36c8
 
-python.versions	    26 27
+python.versions	    27
 
 if {${name} ne ${subport}} {
     patchfiles		patch-setup.py.diff

--- a/python/py-clientform/Portfile
+++ b/python/py-clientform/Portfile
@@ -23,7 +23,7 @@ checksums           md5 21e68d52cc5939ab3345b97e09f0a25a \
                     sha1 ab07cf5bc293ffa1676bb7f4c5c756cb2907d782 \
                     rmd160 f82975f171ef3c673d78fa08f7ade3205a0cc87a
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-cssutils/Portfile
+++ b/python/py-cssutils/Portfile
@@ -15,7 +15,7 @@ long_description        A Python package to parse and build \
                         CSS Cascading Style Sheets.
 
 platforms               darwin
-python.versions         26 27 34 35 36
+python.versions         27 34 35 36
 
 homepage                http://cthedot.de/cssutils/
 master_sites            https://bitbucket.org/cthedot/cssutils/downloads/

--- a/python/py-ez_setup/Portfile
+++ b/python/py-ez_setup/Portfile
@@ -20,7 +20,7 @@ distname            ez_setup-${version}
 checksums           rmd160  796b5364e8e64455468b76b4f8a2fd10f0389d1b \
                     sha256  303c5b17d552d1e3fb0505d80549f8579f557e13d8dc90e5ecef3c07d7f58642
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-flask-babel/Portfile
+++ b/python/py-flask-babel/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-flask-babel
 set real_name       Flask-Babel
 version             0.8
-python.versions     26 27
+python.versions     27
 categories-append   www
 maintainers         nomaintainer
 description         Adds i18n/l10n support to Flask applications

--- a/python/py-flask-frozen/Portfile
+++ b/python/py-flask-frozen/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-flask-frozen
 set real_name       Frozen-Flask
 version             0.9
-python.versions     26 27
+python.versions     27
 categories-append   www
 maintainers         nomaintainer
 description         Freeze a Flask application into a set of static files.

--- a/python/py-flask-uploads/Portfile
+++ b/python/py-flask-uploads/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-flask-uploads
 set real_name       Flask-Uploads
 version             0.1.3
-python.versions     26 27
+python.versions     27
 categories-append   www
 maintainers         nomaintainer
 description         Flexible upload handling for Flask applications

--- a/python/py-flup/Portfile
+++ b/python/py-flup/Portfile
@@ -24,8 +24,7 @@ checksums           md5 a005b072d144fc0e44b0fa4c5a9ba029 \
                     sha1 d1be86226a46ef031bf813497aa5520e3792b8e2 \
                     rmd160 25f58df998a7e98810e32da02c5ea4ccaeb25e40
 
-python.versions     26 27
-python.default_version 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     post-destroot   {

--- a/python/py-formalchemy/Portfile
+++ b/python/py-formalchemy/Portfile
@@ -21,7 +21,7 @@ distname            FormAlchemy-${version}
 
 checksums           rmd160 d7f78d51bf7fd20c642356002bcfa77022fb56fc
 
-python.versions     26 27
+python.versions     27
 
 if {$subport ne $name} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-geoip/Portfile
+++ b/python/py-geoip/Portfile
@@ -20,7 +20,7 @@ distname            GeoIP-${version}
 checksums           rmd160  f5cf7a7f767d748827f432ab892bfa0b4d1272f4 \
                     sha256  a890da6a21574050692198f14b07aa4268a01371278dfc24f71cd9bc87ebf0e6
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:libgeoip

--- a/python/py-gitdb/Portfile
+++ b/python/py-gitdb/Portfile
@@ -12,7 +12,7 @@ license           BSD
 description       GitDB is a pure-Python git object database
 long_description  ${description}
 
-python.versions   26 27 36
+python.versions   27 36
 python.default_version 27
 
 checksums           rmd160  fbb34a973d62c9f286dc9f994921c3abd16ccb30 \

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -274,6 +274,7 @@ py-wordaxe              0.3.3_1     26
 py-w3lib                1.9.0_1     33
 py-xhtml2pdf            0.0.6_2     26
 py-yaml                 3.13        26 33
+py-yum-metadata-parser  1.1.4_2     26
 
 
 if {${subport} ne ${name}} {

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -120,6 +120,7 @@ py-gdl                  2.25.3_2    26
 py-geoip                1.3.2_1     33
 py-geopandas            0.1.1_1     33
 py-geopy                1.11.0_1    26 33
+py-gitdb                2.0.3_1     26
 py-gitpython            2.0.2_1     26
 py-gmpy                 1.17_1      25 26 31 32 33
 py-gmpy2                2.0.7_1     26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -238,6 +238,7 @@ py-scimath              4.1.2_1     26
 py-scitools             0.9.0_2     26
 py-selenium             2.21.2_1    26
 py-snowballstemmer      1.2.0_1     26 33
+py-soaplib              1.0.0_1     26
 py-south                0.8.1_1     26
 py-sparqlwrapper        1.6.4_1     34
 py-spatialite           3.0.1_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -154,6 +154,7 @@ py-kcs11                1.2.4_1     26
 py-keyring              3.6_1       26 33
 py-keybinder            0.3.1_1     26
 py-libcloud             0.17.0_1    26 33
+py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33
 py-matplotlib           1.5.0_1     26 33
 py-mecab                0.996_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -73,6 +73,7 @@ py-cdb                  0.34_1      26
 py-celementtree         1.0.5-20051216_1    26
 py-checker              0.8.18_2    26
 py-cherrypy             2.3.0_2     26
+py-clientform           0.2.9_1     26
 py-codetools            4.0.0_2     26
 py-cog                  2.4_1       26 33
 py-configobj            5.0.6_1     25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -109,6 +109,7 @@ py-flask-auth           0.85_1      26
 py-flask-babel          0.8_1       26
 py-flask-sqlalchemy     2.0_1       26 33
 py-flask-frozen         0.9_1       26
+py-flask-uploads        0.1.3_1     26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -222,6 +222,7 @@ py-pyopencl             2013.2_1    26 33
 py-pyqtgraph            0.9.10_1    34
 py-pyrfc3339            1.1         34
 py-pyshp                1.2.1_1     26 32 33
+py-python-jenkins       0.3.4_1     26
 py-pytidylib            0.2.1_1     26
 py-pytools              2013.5.6_1  26 33
 py-pyxb                 1.2.4_2     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -150,6 +150,7 @@ py-jenkins-job-builder  0.8.1_2     26
 py-jmespath             0.9.3       34
 py-jsbeautifier         1.4.0_1     26
 py-kapteyn              2.2_1       26
+py-kcs11                1.2.4_1     26
 py-keyring              3.6_1       26 33
 py-keybinder            0.3.1_1     26
 py-libcloud             0.17.0_1    26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -274,6 +274,7 @@ py-virtualenv           15.1.0_1    26 33
 py-visa                 1.4_1       26
 py-vobject              0.8.1c_1    26
 py-watchdog             0.7.1_1     33
+py-webhelpers           1.3_1       26
 py-webkitgtk            1.1.8_8     26
 py-wordaxe              0.3.3_1     26
 py-w3lib                1.9.0_1     33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -239,6 +239,7 @@ py-scikits-samplerate   0.3.3_1     26
 py-scimath              4.1.2_1     26
 py-scitools             0.9.0_2     26
 py-selenium             2.21.2_1    26
+py-smmap                2.0.3_1     26
 py-snowballstemmer      1.2.0_1     26 33
 py-soaplib              1.0.0_1     26
 py-south                0.8.1_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -178,6 +178,7 @@ py-openssl              0.15.1_6    26 33
 py-packaging            17.1_1      26 33
 py-pathfinder           0.5.3_1     33
 py-pathtools            0.1.2_1     33
+py-paver                1.2.1_1     26
 py-pep8                 1.6.2_1     25 26 31 32 33
 py-pint                 0.7.2       33
 py-pkgconfig            1.3.1_1     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -141,6 +141,7 @@ py-html5lib             @1.0b10_2   26 33
 py-htmldocs             3.3.99      26 31 32 33
 py-http-parser          0.8.3_1     26 31 32 33
 py-id3lib               0.5.1_1     26
+py-imagesize            1.0.0_1     26 33
 py-ipy                  0.81_1      25 26
 py-isodate              0.5.4       33 34
 py-jcc                  2.13_1      26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -194,6 +194,7 @@ py-pycallgraph          1.0.1_1     33
 py-pycluster            1.50_2      26
 py-pyfftw               0.10.4_1    33
 py-pygeocoder           1.1.4_1     26
+py-pygooglechart        0.4.0_1     26
 py-pygraphviz           1.1_1       26
 py-pygresql             4.1.1_1     26
 py-pygrib               2.0.2       33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -110,6 +110,7 @@ py-flask-babel          0.8_1       26
 py-flask-sqlalchemy     2.0_1       26 33
 py-flask-frozen         0.9_1       26
 py-flask-uploads        0.1.3_1     26
+py-flup                 1.0.3.dev-20110405_1    26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -205,6 +205,7 @@ py-pygtksourceview      2.10.1_4    26
 py-pyke                 1.1.1_1     26 32 33
 py-pykerberos           1.1-10616_1 26
 py-pylibmc              1.2.3_3     26
+py-pynifti              0.20100607.1_2    26
 py-pymc                 2.3.6_1     26 33
 py-pymca                4.4.1p1_1   26
 py-pyml                 0.7.7_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -198,6 +198,7 @@ py-pygooglechart        0.4.0_1     26
 py-pygraphviz           1.1_1       26
 py-pygresql             4.1.1_1     26
 py-pygrib               2.0.2       33
+py-pygraph-core         1.8.0_1     26
 py-pygraph-dot          1.8.0_1     26
 py-pygtk                2.24.0_4    26
 py-pygtkhelpers         0.4.3_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -71,6 +71,7 @@ py-bottle-sqlalchemy    0.3_1       26
 py-bottleneck           1.2.1_1     26 33
 py-cdb                  0.34_1      26
 py-celementtree         1.0.5-20051216_1    26
+py-checker              0.8.18_2    26
 py-cherrypy             2.3.0_2     26
 py-codetools            4.0.0_2     26
 py-cog                  2.4_1       26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -200,6 +200,7 @@ py-pygresql             4.1.1_1     26
 py-pygrib               2.0.2       33
 py-pygraph-dot          1.8.0_1     26
 py-pygtk                2.24.0_4    26
+py-pygtkhelpers         0.4.3_1     26
 py-pygtksourceview      2.10.1_4    26
 py-pyke                 1.1.1_1     26 32 33
 py-pykerberos           1.1-10616_1 26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -258,6 +258,7 @@ py-tahchee              0.9.8_1     26
 py-tensorflow           1.4.1       34
 py-tensorflow-tensorboard \
                         0.4.0rc3    34
+py-tempita              0.5.2_1     26
 py-thrift               0.10.0_1    26
 py-threadpool           1.2.7_1     26
 py-tkinter              2.5.6_1     25

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -168,6 +168,7 @@ py-mock                 1.0.1_1     25 26 31 32 33
 py-mox                  0.5.1_1     26
 py-mpi4py               2.0.0_1     26 33
 py-mssql                2.1.0_1     26
+py-mx-base              3.2.8_1     26
 py-mygpoclient          1.7_1       26
 py-mysql                1.2.3_2     26
 py-notify-python        0.1.1_6     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -236,6 +236,7 @@ py-scikit-image         0.11.3_1    26 32 33
 py-scikits-samplerate   0.3.3_1     26
 py-scimath              4.1.2_1     26
 py-scitools             0.9.0_2     26
+py-selenium             2.21.2_1    26
 py-snowballstemmer      1.2.0_1     26 33
 py-south                0.8.1_1     26
 py-sparqlwrapper        1.6.4_1     34

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -156,6 +156,7 @@ py-keybinder            0.3.1_1     26
 py-libcloud             0.17.0_1    26 33
 py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33
+py-managesieve          0.4.2_1     26
 py-matplotlib           1.5.0_1     26 33
 py-mecab                0.996_1     26
 py-memprof              0.3.3_1     26 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -270,6 +270,7 @@ py-visa                 1.4_1       26
 py-vobject              0.8.1c_1    26
 py-watchdog             0.7.1_1     33
 py-webkitgtk            1.1.8_8     26
+py-wordaxe              0.3.3_1     26
 py-w3lib                1.9.0_1     33
 py-xhtml2pdf            0.0.6_2     26
 py-yaml                 3.13        26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -142,6 +142,7 @@ py-htmldocs             3.3.99      26 31 32 33
 py-http-parser          0.8.3_1     26 31 32 33
 py-id3lib               0.5.1_1     26
 py-imagesize            1.0.0_1     26 33
+py-iniparse             0.4_1       26
 py-ipy                  0.81_1      25 26
 py-isodate              0.5.4       33 34
 py-jcc                  2.13_1      26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -117,6 +117,7 @@ py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26
 py-gdbm                 2.5.6_1     25
 py-gdl                  2.25.3_2    26
+py-geoip                1.3.2_1     33
 py-geopandas            0.1.1_1     33
 py-geopy                1.11.0_1    26 33
 py-gitpython            2.0.2_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -146,6 +146,7 @@ py-iniparse             0.4_1       26
 py-ipy                  0.81_1      25 26
 py-isodate              0.5.4       33 34
 py-jcc                  2.13_1      26
+py-jenkins-job-builder  0.8.1_2     26
 py-jmespath             0.9.3       34
 py-jsbeautifier         1.4.0_1     26
 py-kapteyn              2.2_1       26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -108,6 +108,7 @@ py-fipy                 3.1_1       26
 py-flask-auth           0.85_1      26
 py-flask-babel          0.8_1       26
 py-flask-sqlalchemy     2.0_1       26 33
+py-flask-frozen         0.9_1       26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -106,6 +106,7 @@ py-ez_setup             0.9_1       26
 py-feedparser           5.1.3_1     26
 py-fipy                 3.1_1       26
 py-flask-auth           0.85_1      26
+py-flask-babel          0.8_1       26
 py-flask-sqlalchemy     2.0_1       26 33
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -82,6 +82,7 @@ py-coverage             3.7.1_1     25 26 31 32 33
 py-cairo                1.10.0_4    26 33
 py-cairosvg             2.0.1       33
 py-country              0.10_1      26
+py-cssutils             1.0.2_1     26
 py-curl                 7.19.0_2    26
 py-dateutil             2.5.1_1     26 33
 py-dispatcher           2.0.1_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -248,6 +248,7 @@ py-spyder               2.3.7_1     33
 py-spyder-devel         2.3.4_1     33
 py-sqlite               2.6.3_1     26
 py-storm                0.18_1      26
+py-suds-jurko           0.6_1       26 33
 py-swap                 3.1.3       26 33 34 35
 py-tahchee              0.9.8_1     26
 py-tensorflow           1.4.1       34

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -210,6 +210,7 @@ py-pymc                 2.3.6_1     26 33
 py-pymca                4.4.1p1_1   26
 py-pyml                 0.7.7_2     26
 py-pync                 1.4_1       33
+py-pynzb                0.1.0_2     26
 py-pyobjc               3.0.4_1     25 26 31 32 33
 py-pyobjc-cocoa         3.0.1_1     25 26 31 32 33
 py-pyobjc-fsevents      3.0.3_1     26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -111,6 +111,7 @@ py-flask-sqlalchemy     2.0_1       26 33
 py-flask-frozen         0.9_1       26
 py-flask-uploads        0.1.3_1     26
 py-flup                 1.0.3.dev-20110405_1    26
+py-formalchemy          1.4.1_1     26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -175,6 +175,7 @@ py-notify-python        0.1.1_6     26
 py-obspy                1.1.0       34
 py-openbabel            2.3.2_1     26
 py-openssl              0.15.1_6    26 33
+py-packaging            17.1_1      26 33
 py-pathfinder           0.5.3_1     33
 py-pathtools            0.1.2_1     33
 py-pep8                 1.6.2_1     25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -189,6 +189,7 @@ py-protobuf             2.6.1_3     26
 py-protobuf3            3.5.1       34
 py-pyaudio              0.2.8_1     26
 py-pyasdf               0.3.0_1     34
+py-pybtex               0.21_2      26
 py-pycallgraph          1.0.1_1     33
 py-pycluster            1.50_2      26
 py-pyfftw               0.10.4_1    33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -229,6 +229,7 @@ py-rdflib               4.2.2_1     26 33 34
 py-requests             2.16.5_1    26
 py-requests-unixsocket  0.1.5_1     26
 py-restkit              4.2.2_1     26
+py-robotremoteserver    1.0.1_1     26 33
 py-rope                 0.9.4_1     25 26 33
 py-roundup              1.4.21_1    26
 py-scikit-image         0.11.3_1    26 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -198,6 +198,7 @@ py-pygooglechart        0.4.0_1     26
 py-pygraphviz           1.1_1       26
 py-pygresql             4.1.1_1     26
 py-pygrib               2.0.2       33
+py-pygraph-dot          1.8.0_1     26
 py-pygtk                2.24.0_4    26
 py-pygtksourceview      2.10.1_4    26
 py-pyke                 1.1.1_1     26 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -245,6 +245,7 @@ py-soaplib              1.0.0_1     26
 py-south                0.8.1_1     26
 py-sparqlwrapper        1.6.4_1     34
 py-spatialite           3.0.1_2     26
+py-speaklater           1.3_1       26
 py-sphinx-contrib       0.0.20151230 26
 py-sphinx_rtd_theme     0.1.9_2     26 33
 py-spyder               2.3.7_1     33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -102,6 +102,7 @@ py-enchant              1.6.6_1     26 33
 py-envisage             4.4.0_1     26
 py-etsdevtools          4.0.2_1     26
 py-eventlet             0.22.0      26
+py-ez_setup             0.9_1       26
 py-feedparser           5.1.3_1     26
 py-fipy                 3.1_1       26
 py-flask-auth           0.85_1      26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -159,6 +159,7 @@ py-lmfit                0.9.2_1     26 33
 py-managesieve          0.4.2_1     26
 py-matplotlib           1.5.0_1     26 33
 py-mecab                0.996_1     26
+py-mechanize            0.2.5_1     26
 py-memprof              0.3.3_1     26 32 33
 py-mdp-toolkit          3.3_2       26 33
 py-mingus               0.4.2.3_1   26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -70,6 +70,7 @@ py-bottle               0.12.9_1    26
 py-bottle-sqlalchemy    0.3_1       26
 py-bottleneck           1.2.1_1     26 33
 py-cdb                  0.34_1      26
+py-celementtree         1.0.5-20051216_1    26
 py-cherrypy             2.3.0_2     26
 py-codetools            4.0.0_2     26
 py-cog                  2.4_1       26 33

--- a/python/py-imagesize/Portfile
+++ b/python/py-imagesize/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160 e7913341bc0970f17a8411675dd34f84106694e8 \
                     sha256 5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315
 distname            ${python.rootname}-${version}
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {$subport ne $name} {
     depends_build    port:py${python.version}-setuptools

--- a/python/py-iniparse/Portfile
+++ b/python/py-iniparse/Portfile
@@ -21,7 +21,7 @@ distname		iniparse-${version}
 checksums           rmd160  f4cb5edc035e787acea428a7d21343d986f85f5c \
                     sha256  abc1ee12d2cfb2506109072d6c21e40b6c75a3fe90a9c924327d80bc0d99c054
 
-python.versions 26 27
+python.versions 27
 
 if {${name} ne ${subport}} {
     post-destroot {

--- a/python/py-jenkins-job-builder/Portfile
+++ b/python/py-jenkins-job-builder/Portfile
@@ -20,7 +20,7 @@ distname            jenkins-job-builder-0.8.1
 checksums           rmd160  48625ca15fb82153844c73bb68529da8f9a72b7a \
                     sha256  5f6d1a50e2cbcbc17ed65b454394512f6c9f48d379b7c7102fbce3a9c4436ca8
 
-python.versions     26 27
+python.versions     27
 
 depends_lib-append  port:py-six
 

--- a/python/py-kcs11/Portfile
+++ b/python/py-kcs11/Portfile
@@ -21,6 +21,6 @@ distname            PyKCS11-${version}
 checksums           rmd160  b2783443913db5263410de5fb58a7ae396938936 \
                     sha256  dd90a64771b2bbf8e122ecb2c6bf83fcc127753422c0be3b10075d4a2e4da264
 
-python.versions     26 27
+python.versions     27
 
 patchfiles          patch-setup.py-no-usr-local.diff

--- a/python/py-liblzma/Portfile
+++ b/python/py-liblzma/Portfile
@@ -4,7 +4,7 @@ PortGroup python 1.0
 name			py-liblzma
 version			0.5.3
 revision		1
-python.versions         26 27
+python.versions         27
 categories-append       archivers
 platforms		darwin
 maintainers		nomaintainer

--- a/python/py-managesieve/Portfile
+++ b/python/py-managesieve/Portfile
@@ -21,7 +21,7 @@ checksums		md5 c252b3d06dc3419dcf3bff815f485b7a	\
 			sha1 39ab53e80a039df8b1213d8cb636580a22f2fec7 \
 			rmd160 c1a2753ea5276a3807160ca70bd5b1ff452c8ba6
 
-python.versions	26 27
+python.versions	27
 
 if {${name} ne ${subport}} {
     depends_build		port:py${python.version}-setuptools

--- a/python/py-mechanize/Portfile
+++ b/python/py-mechanize/Portfile
@@ -22,7 +22,7 @@ checksums           md5 32657f139fc2fb75bcf193b63b8c60b2 \
                     sha1 9d2fb74fc762e54848c0b3ed4b6a9c73722ef619 \
                     rmd160 f9deafaeb591cd4047a6f8845221463320c86d9b
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-mx-base/Portfile
+++ b/python/py-mx-base/Portfile
@@ -25,8 +25,7 @@ distname            egenix-mx-base-${version}
 checksums           rmd160  a405fddd6cbe7b936ad87482083276b7f3700db5 \
                     sha256  0da55233e45bc3f88870e62e60a79c2c86bad4098b8128343fd7be877f44a3c0
 
-python.versions     26 27
-python.default_version 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     livecheck.type      none

--- a/python/py-packaging/Portfile
+++ b/python/py-packaging/Portfile
@@ -21,7 +21,7 @@ distname            ${python.rootname}-${version}
 checksums           rmd160 cc3577c2b06262cf5901a67499379e5023647a5b \
                     sha256 f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {$subport ne $name} {
     depends_lib-append  port:py${python.version}-parsing \

--- a/python/py-paver/Portfile
+++ b/python/py-paver/Portfile
@@ -27,7 +27,7 @@ checksums           md5    78d0cea13e41a31fcb347cf37ea4577f \
                     rmd160 bde2ffebe80a49facd7b1cc40a673fb9b6009793 \
                     sha256 1e281faaef479674299ba00031f95e04b6d3bff0c33778790ef1053de51020ac
 
-python.versions		26 27
+python.versions		27
 
 if {${name} ne ${subport}} {
 

--- a/python/py-pybtex/Portfile
+++ b/python/py-pybtex/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  df7b5504fbeaabbd748801ee9917d2138b62a6a6 \
                     sha256  af8a6c7c74954ad305553b118d2757f68bc77c5dd5d5de2cc1fd16db90046000 \
                     size    364772
 
-python.versions     26 27 36 37
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pygooglechart/Portfile
+++ b/python/py-pygooglechart/Portfile
@@ -25,7 +25,7 @@ checksums       md5    247b69617aa4676ccd3b48fdbbcf2abf \
                 sha1   edb63a9f802183ab338210728e0f49ceff2c069d \
                 rmd160 e04f2eb5e11d64b7e8c9befa81074b5ec060b91a
 
-python.versions 26 27
+python.versions 27
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-pygraph-core/Portfile
+++ b/python/py-pygraph-core/Portfile
@@ -21,5 +21,4 @@ checksums           md5     a7e1911f2fb13132288843a67ac573d0 \
                     sha1    ec9af4d269a8a68085a23f0471e07d2ce4fd9186 \
                     rmd160  3add4cd4286aa46300d16735101e3ed8ede27681
 
-python.versions     26 27
-python.default_version 27
+python.versions     27

--- a/python/py-pygraph-dot/Portfile
+++ b/python/py-pygraph-dot/Portfile
@@ -23,7 +23,7 @@ checksums           md5     c9d2a2165e331b55b2ea662b49ac08e1 \
                     sha1    285fa7433a71ebcbbda1c8d0b9dbd490e2b5e354 \
                     rmd160  047edddef0953bb262aef301aa29eea1fd16f2dd
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_lib     port:py${python.version}-pygraph-core \

--- a/python/py-pygtkhelpers/Portfile
+++ b/python/py-pygtkhelpers/Portfile
@@ -19,7 +19,7 @@ distname                ${real_name}-${version}
 checksums               rmd160  cc169648a3c5df5e4aeeb169a8824a060035f332 \
                         sha256  65417d091c68f6262ebaf18c1358f55ffe9e3735261d4c1bfb0d6e5bed1905b8
 
-python.versions         26 27
+python.versions         27
 python.link_binaries    no
 python.move_binaries    no
 

--- a/python/py-pynifti/Portfile
+++ b/python/py-pynifti/Portfile
@@ -19,7 +19,7 @@ master_sites            sourceforge:project/niftilib/pynifti/${version}
 checksums               rmd160  f9337ca40681b76432ac362d088034d79ba28556 \
                         sha256  d1607d330e94576d6b0f18690b5b94c75ed1a93722c573e9ea781580f555611a
 
-python.versions         26 27
+python.versions         27
 
 if {${name} ne ${subport}} {
     depends_lib         port:py${python.version}-numpy \

--- a/python/py-pynzb/Portfile
+++ b/python/py-pynzb/Portfile
@@ -25,7 +25,7 @@ checksums       md5     63c74a36348ac28aa99732dcb8be8c59 \
                 sha1    cf39d7f32c15f281ab81b0043b4068d101a2cd1f \
                 rmd160  6c206380753f9a871e6f5d4ad237236cda96586d
 
-python.versions 26 27
+python.versions 27
 
 if {$subport ne $name} {
     depends_build     port:py${python.version}-setuptools

--- a/python/py-python-jenkins/Portfile
+++ b/python/py-python-jenkins/Portfile
@@ -19,7 +19,7 @@ distname            python-jenkins-0.3.4
 checksums           rmd160  ea6783913bd173fc6c1f7ea030969ddcb02d7aac \
                     sha256  c1bc6eca5bb211d35d9efab0a536a068581743919f998f25eab34852c6a46494
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-robotremoteserver/Portfile
+++ b/python/py-robotremoteserver/Portfile
@@ -18,7 +18,7 @@ long_description    Allows hosting test libraries on different processes \
 homepage            https://github.com/robotframework/PythonRemoteServer
 
 platforms           darwin
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 python.default_version  27
 
 universal_variant   yes

--- a/python/py-selenium/Portfile
+++ b/python/py-selenium/Portfile
@@ -4,7 +4,7 @@ PortGroup       python 1.0
 name            py-selenium
 set real_name   selenium
 version         2.21.2
-python.versions 26 27
+python.versions 27
 license         Apache-2
 maintainers     nomaintainer
 platforms       darwin

--- a/python/py-smmap/Portfile
+++ b/python/py-smmap/Portfile
@@ -16,7 +16,7 @@ checksums           rmd160  f55fa73b866e33a245d62b7cd8c87d178361533a \
                     sha256  398816859a2b19b0f154c7cdd43802649671bc1db3ba26f5ab9d2bd03d362143 \
                     size    29121
 
-python.versions   26 27 35 36
+python.versions   27 35 36
 python.default_version 36
 
 if {${name} ne ${subport}} {

--- a/python/py-soaplib/Portfile
+++ b/python/py-soaplib/Portfile
@@ -30,8 +30,7 @@ checksums           md5 1bf01194b08b72c240380bd8f0919f57 \
                     rmd160 e8fcd86554450f41bf279f88e11016baa4787d6d
 
 
-python.versions     26 27
-python.default_version 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-speaklater/Portfile
+++ b/python/py-speaklater/Portfile
@@ -24,7 +24,7 @@ distname            ${_name}-${version}
 checksums           rmd160  70c03aa32233a9f4a6dd352c4dca1fe0d1888ffe \
                     sha256  59fea336d0eed38c1f0bf3181ee1222d0ef45f3a9dd34ebe65e6bfffdd6a65a9
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  regex

--- a/python/py-suds-jurko/Portfile
+++ b/python/py-suds-jurko/Portfile
@@ -27,7 +27,7 @@ use_bzip2           yes
 checksums           rmd160  34329d93f0e784671539d08764959a18721752bb \
                     sha256  29edb72fd21e3044093d86f33c66cf847c5aaab26d64cb90e69e528ef014e57f
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 python.default_version  27
 
 if {${name} ne ${subport}} {

--- a/python/py-tempita/Portfile
+++ b/python/py-tempita/Portfile
@@ -14,7 +14,7 @@ long_description    ${description}
 license             MIT
 homepage            https://pypi.python.org/pypi/Tempita/
 
-python.versions     26 27 35 36
+python.versions     27 35 36
 
 distname            Tempita-${version}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}

--- a/python/py-webhelpers/Portfile
+++ b/python/py-webhelpers/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    py-webhelpers
 version                 1.3
-python.versions         26 27
+python.versions         27
 epoch                   2
 maintainers             nomaintainer
 platforms               darwin

--- a/python/py-wordaxe/Portfile
+++ b/python/py-wordaxe/Portfile
@@ -16,7 +16,7 @@ long_description    \
     The wordaxe library (formerly known as deco-cow) provides Python programs \
     with the ability to automatically hyphenate words using an algorithm \
     which is based on decomposition of compound words into base words, and is \
-    named DCWHyphenator in the code. 
+    named DCWHyphenator in the code.
 
 homepage            http://deco-cow.sourceforge.net/
 master_sites        sourceforge:deco-cow
@@ -27,4 +27,4 @@ checksums           md5 fc734363e526de7e5750f0292bcbe43e \
                     sha1 8336496dc79a670d207d3838dba807fef60f221b \
                     rmd160 9b52288ce444e20dfef4f0bc00c6d9f9c0a731f1
 
-python.versions     26 27
+python.versions     27

--- a/python/py-yum-metadata-parser/Portfile
+++ b/python/py-yum-metadata-parser/Portfile
@@ -4,7 +4,7 @@ PortGroup python 1.0
 name			py-yum-metadata-parser
 version			1.1.4
 revision		1
-python.versions		26 27
+python.versions		27
 license			GPL-2
 platforms		darwin
 categories		python


### PR DESCRIPTION
#### Description
This PR does some initial housekeeping on various Python ports in the tree. In particular, it removes py26/py33 subports from ports that (i) are ```nomaintainer``` and (ii) have nothing depend on them. No other changes were made, so if a port doesn't build it should not be caused by this PR. 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
I didn't squash commits yet, if this PR is deemed useful and commits need to be squashed I will do so.
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
