### PR TITLE
portfile update for ALPSCore from version 1.0 to version 2.2

### DIFF
--- a/science/ALPSCore/Portfile
+++ b/science/ALPSCore/Portfile
@@ -6,7 +6,6 @@ PortGroup           github 1.0
 PortGroup           mpi 1.0
 
 github.setup        ALPSCore ALPSCore 2.2.0 v
-revision            1
 categories          science
 platforms           darwin
 license             GPL-2
@@ -20,12 +19,14 @@ long_description    ALPSCore contains the core libraries of the applications and
 homepage            http://alpscore.org
 
 checksums           rmd160  7ef9f655f55a21658da9d7af00025d2eb7ab5a9a \
-                    sha256  01ae0c7be844d4497da96bd8b329bced3eeb4dce1101f193206e9b1c0c68068f
+                    sha256  01ae0c7be844d4497da96bd8b329bced3eeb4dce1101f193206e9b1c0c68068f \
+                    size 1405042
 
 compiler.blacklist  gcc-4.2
 
 depends_lib         port:boost \
                     port:hdf5
+                    port:eigen3
 
 compilers.choose    cc cxx
 mpi.setup           -gcc

--- a/science/ALPSCore/Portfile
+++ b/science/ALPSCore/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        ALPSCore ALPSCore 1.0.0 v
-revision            3
+github.setup        ALPSCore ALPSCore 2.2.0 v
+revision            1
 categories          science
 platforms           darwin
 license             GPL-2
@@ -19,8 +19,8 @@ long_description    ALPSCore contains the core libraries of the applications and
 
 homepage            http://alpscore.org
 
-checksums           rmd160  bf0fac92dfaa831379198d19e1593a241378841a \
-                    sha256  5468f73a11e603cdfe7e99ec0b5cbb55915f7fadfc04201e6c97beaa16aed4b7
+checksums           rmd160  7ef9f655f55a21658da9d7af00025d2eb7ab5a9a \
+                    sha256  01ae0c7be844d4497da96bd8b329bced3eeb4dce1101f193206e9b1c0c68068f
 
 compiler.blacklist  gcc-4.2
 


### PR DESCRIPTION
#### Description

This updates the ALPSCore package from version 1.0 to version 2.2

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 