### PR TITLE
py-pip: update from 10.0.1 to 18.0

### DIFF
--- a/python/py-pip/Portfile
+++ b/python/py-pip/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pip
-version             10.0.1
+version             18.0
 revision            0
 categories-append   www
 platforms           darwin
@@ -28,9 +28,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  008e4a069e4969ee08ad383eb1d0070eeb63b405 \
-                    sha256  f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68 \
-                    size    1246072
+checksums           rmd160  ccb38f5c23bbf1d8c583f25565af5b614772ca94 \
+                    sha256  a0e11645ee37c90b40c46d607070c4fd583e2cd46231b1c06e389c5e814eed76 \
+                    size    1249656
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools
@@ -42,6 +42,15 @@ if {${name} ne ${subport}} {
         distname            ${python.rootname}-${version}
         checksums           rmd160  9cf0429a7a7e9897339ffc5a141e9b2e1da8086e \
                             sha256  7bf48f9a693be1d58f49f7af7e0ae9fe29fd671cde8a55e6edca3581c4ef5796
+    }
+
+    if {[lsearch {33} ${python.version}] != -1} {
+        version             10.0.1
+        revision            0
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  008e4a069e4969ee08ad383eb1d0070eeb63b405 \
+                            sha256  f2bd08e0cd1b06e10218feaf6fef299f473ba706582eb3bd9d52203fdbd7ee68 \
+                            size    1246072
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description
Python's pip tool was updated to v18.0 (now following calendar versioning) on July 22, 2018.

https://github.com/pypa/pip/releases/tag/18.0
https://pip.pypa.io/en/stable/news/

Note that pip v18.0 does not support Python 3.3, so the Portfile freezes py33-pip at 10.0.1.

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](l) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
   ```console
   $ sudo port test
   --->  Computing dependencies for py-pip
   --->  Fetching distfiles for py-pip
   --->  Verifying checksums for py-pip
   --->  Extracting py-pip
   --->  Configuring py-pip
   --->  Building py-pip
   --->  Testing py-pip
   Error: Failed to test py-pip: py-pip has no tests turned on. see 'test.run' in portfile(7)
   Error: See /opt/local/var/macports/logs/_Users_magus_Ports_python_py-pip/py-pip/main.log for details.
   Error: Follow https://guide.macports.org/#project.tickets to report a bug.
   Error: Processing of port py-pip failed
   ```
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
   No, I have only tested pip functionality under Python 3.6 and 3.7.