### PR TITLE
py-netaddr: add missing dependency

### DIFF
--- a/python/py-netaddr/Portfile
+++ b/python/py-netaddr/Portfile
@@ -5,7 +5,6 @@ PortGroup           python 1.0
 
 name                py-netaddr
 version             0.7.19
-revision            0
 categories-append   devel
 platforms           darwin
 license             BSD MIT
@@ -24,8 +23,21 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  726d351f5c2a2e13446322c9ffd169215deb2601 \
-                    sha256  38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd
+                    sha256  38aeec7cdd035081d3a4c306394b19d677623bf76fa0913f6695127c7753aefd \
+                    size    1622835
 
 if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_test-append \
+                        port:py${python.version}-pytest
+
+    # patch for tests from commit 2ab73f1; remove at next update
+    patchfiles          patch-test_ieee_parsers.py.diff
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+
     livecheck.type      none
 }

--- a/python/py-netaddr/files/patch-test_ieee_parsers.py.diff
+++ b/python/py-netaddr/files/patch-test_ieee_parsers.py.diff
@@ -1,0 +1,38 @@
+--- netaddr/tests/eui/test_ieee_parsers.py.orig	2018-07-24 09:41:13.000000000 -0400
++++ netaddr/tests/eui/test_ieee_parsers.py	2018-07-24 09:42:08.000000000 -0400
+@@ -12,7 +12,7 @@
+ def test_oui_parser_py2():
+     from cStringIO import StringIO
+     outfile = StringIO()
+-    with open(os.path.join(SAMPLE_DIR, 'sample_oui.txt')) as infile:
++    with open(os.path.join(SAMPLE_DIR, 'sample_oui.txt'), 'rb') as infile:
+         iab_parser = OUIIndexParser(infile)
+         iab_parser.attach(FileIndexer(outfile))
+         iab_parser.parse()
+@@ -23,7 +23,7 @@
+ def test_iab_parser_py2():
+     from cStringIO import StringIO
+     outfile = StringIO()
+-    with open(os.path.join(SAMPLE_DIR, 'sample_iab.txt')) as infile:
++    with open(os.path.join(SAMPLE_DIR, 'sample_iab.txt'), 'rb') as infile:
+         iab_parser = IABIndexParser(infile)
+         iab_parser.attach(FileIndexer(outfile))
+         iab_parser.parse()
+@@ -34,7 +34,7 @@
+ def test_oui_parser_py3():
+     from io import StringIO
+     outfile = StringIO()
+-    with open(os.path.join(SAMPLE_DIR, 'sample_oui.txt')) as infile:
++    with open(os.path.join(SAMPLE_DIR, 'sample_oui.txt'), 'rb') as infile:
+         iab_parser = OUIIndexParser(infile)
+         iab_parser.attach(FileIndexer(outfile))
+         iab_parser.parse()
+@@ -45,7 +45,7 @@
+ def test_iab_parser_py3():
+     from io import StringIO
+     outfile = StringIO()
+-    with open(os.path.join(SAMPLE_DIR, 'sample_iab.txt')) as infile:
++    with open(os.path.join(SAMPLE_DIR, 'sample_iab.txt'), 'rb') as infile:
+         iab_parser = IABIndexParser(infile)
+         iab_parser.attach(FileIndexer(outfile))
+         iab_parser.parse()


### PR DESCRIPTION
#### Description
- add missing dependency on py-setuptools
- enable tests
- add size to checksums

Closes: https://trac.macports.org/ticket/56849

The port does not yet support Python 3.7 as the tests fail.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->