### PR TITLE
clang-6.0: Restore missing O_CLOEXEC patchfile

### DIFF
--- a/lang/llvm-6.0/files/2001-xray-Define-O_CLOEXEC-for-older-SDKs-that-don-t-have.patch
+++ b/lang/llvm-6.0/files/2001-xray-Define-O_CLOEXEC-for-older-SDKs-that-don-t-have.patch
@@ -1,0 +1,49 @@
+From 585a864b88b65cfbe57765d769b92b771bfaf762 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Wed, 27 Dec 2017 23:21:37 -0800
+Subject: [PATCH 2002/2002] xray: Define O_CLOEXEC for older SDKs that don't
+ have it
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ lib/xray/xray_utils.cc  | 6 ++++++
+ lib/xray/xray_x86_64.cc | 6 ++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git llvm_master/projects/compiler-rt/lib/xray/xray_utils.cc macports_master/projects/compiler-rt/lib/xray/xray_utils.cc
+index b9a38d1b9..b26a76893 100644
+--- llvm_master/projects/compiler-rt/lib/xray/xray_utils.cc
++++ macports_master/projects/compiler-rt/lib/xray/xray_utils.cc
+@@ -25,6 +25,12 @@
+ #include <unistd.h>
+ #include <utility>
+ 
++#ifdef __APPLE__
++#ifndef O_CLOEXEC
++#define O_CLOEXEC 0x1000000
++#endif
++#endif
++
+ namespace __xray {
+ 
+ void printToStdErr(const char *Buffer) XRAY_NEVER_INSTRUMENT {
+diff --git llvm_master/projects/compiler-rt/lib/xray/xray_x86_64.cc macports_master/projects/compiler-rt/lib/xray/xray_x86_64.cc
+index e34806fa1..74ac35e47 100644
+--- llvm_master/projects/compiler-rt/lib/xray/xray_x86_64.cc
++++ macports_master/projects/compiler-rt/lib/xray/xray_x86_64.cc
+@@ -12,6 +12,12 @@
+ #include <tuple>
+ #include <unistd.h>
+ 
++#ifdef __APPLE__
++#ifndef O_CLOEXEC
++#define O_CLOEXEC 0x1000000
++#endif
++#endif
++
+ namespace __xray {
+ 
+ static std::pair<ssize_t, bool>
+-- 
+2.15.1
+


### PR DESCRIPTION
* Closes: https://trac.macports.org/ticket/56854

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
