### PR TITLE
New port: packer

### DIFF
--- a/sysutils/packer/Portfile
+++ b/sysutils/packer/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        hashicorp packer 1.2.5 v
+
+categories          sysutils
+license             MPL-2
+maintainers         {newtonne @newtonne} openmaintainer
+platforms           darwin
+supported_archs     x86_64
+
+description         A tool for creating identical machine images for multiple \
+                    platforms from a single source configuration.
+
+long_description    ${description} \
+                    Packer is lightweight, runs on every major operating \
+                    system, and is highly performant, creating machine images \
+                    for multiple platforms in parallel. Packer comes out of \
+                    the box with support for many platforms, the full list of \
+                    which can be found at \
+                    https://www.packer.io/docs/builders/index.html.
+
+homepage            https://www.packer.io
+
+fetch.type          git
+
+use_configure       no
+
+worksrcdir          ${distname}/src/github.com/hashicorp/packer
+
+pre-build {
+    reinplace "/go get.*govendor/d" ${worksrcpath}/Makefile
+}
+
+depends_build       port:go \
+                    port:govendor
+
+build.env           GOPATH=${workpath}/${distname} \
+                    XC_ARCH=amd64 \
+                    XC_OS=darwin
+
+build.target        releasebin
+
+destroot {
+    xinstall -d ${destroot}${prefix}/bin
+    xinstall -m 755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

Add a new port for packer: https://www.packer.io

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->