### PR TITLE
py-pysvn: update to 1.9.6

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -222,6 +222,7 @@ py-pyopencl             2013.2_1    26 33
 py-pyqtgraph            0.9.10_1    34
 py-pyrfc3339            1.1         34
 py-pyshp                1.2.1_1     26 32 33
+py-pysvn                1.8.0_1     26
 py-python-jenkins       0.3.4_1     26
 py-pytidylib            0.2.1_1     26
 py-pytools              2013.5.6_1  26 33

--- a/python/py-pysvn/Portfile
+++ b/python/py-pysvn/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup python    1.0
 
 name                py-pysvn
-version             1.8.0
+version             1.9.6
 categories-append   devel
 maintainers         {blair @blair} openmaintainer
 platforms           darwin
@@ -18,11 +18,11 @@ homepage            http://pysvn.tigris.org/
 
 master_sites        http://pysvn.barrys-emacs.org/source_kits/
 distname            pysvn-${version}
-checksums           md5    3999a7680f4d3c4d3bddfc45edf65788 \
-                    sha1   f1d584bc3b0d15eb27606ca1a6c364dc44fee345 \
-                    sha256 39596f4884ed689cdb5a4e210e421724302a566c7ba756cc4d46bbfeb0c8326b
+checksums           rmd160  b4bf58b682408c79e01b50d3f6902dba17814117 \
+                    sha256  1508f63e66fc9d1303f8fd0f49547b59492f6977be4434914c38bc29dc82b2d6 \
+                    size    515394
 
-python.versions     26 27
+python.versions     27 36
 
 set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}]} {
@@ -41,7 +41,6 @@ if {${name} ne ${subport}} {
     configure.universal_args-delete --disable-dependency-tracking
 
     pre-configure {
-        system "cd ${worksrcpath} && ${python.bin} setup.py backport"
         reinplace "s|'gcc|'${configure.cc}|g" \
             ${worksrcpath}/setup_configure.py
         reinplace "s|'g\+\+|'${configure.cxx} ${cxx_stdlibflags}|g" \
@@ -53,7 +52,10 @@ if {${name} ne ${subport}} {
     configure.args  --apr-inc-dir=${prefix}/include/apr-1 \
                     --apu-inc-dir=${prefix}/include/apr-1 \
                     --apr-lib-dir=${prefix}/lib \
-                    --svn-root-dir=${prefix}
+                    --svn-bin-dir=${prefix}/bin \
+                    --svn-inc-dir=${prefix}/include/subversion-1 \
+                    --svn-lib-dir=${prefix}/lib \
+                    --pycxx-dir=${worksrcpath}/../Import/pycxx-7.0.3
     configure.universal_args-delete --disable-dependency-tracking
 
     post-configure {

--- a/python/py-pysvn/Portfile
+++ b/python/py-pysvn/Portfile
@@ -1,27 +1,28 @@
-PortSystem 1.0
-PortGroup python 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            py-pysvn
-version         1.8.0
-categories-append      devel
-maintainers     {blair @blair} openmaintainer
-platforms       darwin
-license         Apache-1.1
-description     Python Subversion Extension (pysvn)
-long_description \
-    The pysvn module is a python interface to the Subversion version \
-    control system. This API exposes client interfaces for managing a \
-    working copy, querying a repository, and synchronizing the two.
+PortSystem          1.0
+PortGroup python    1.0
 
-homepage        http://pysvn.tigris.org/
+name                py-pysvn
+version             1.8.0
+categories-append   devel
+maintainers         {blair @blair} openmaintainer
+platforms           darwin
+license             Apache-1.1
+description         Python Subversion Extension (pysvn)
+long_description    The pysvn module is a python interface to the Subversion version \
+                    control system. This API exposes client interfaces for managing a \
+                    working copy, querying a repository, and synchronizing the two.
 
-master_sites    http://pysvn.barrys-emacs.org/source_kits/
-distname        pysvn-${version}
-checksums       md5    3999a7680f4d3c4d3bddfc45edf65788 \
-                sha1   f1d584bc3b0d15eb27606ca1a6c364dc44fee345 \
-                sha256 39596f4884ed689cdb5a4e210e421724302a566c7ba756cc4d46bbfeb0c8326b
+homepage            http://pysvn.tigris.org/
 
-python.versions 26 27
+master_sites        http://pysvn.barrys-emacs.org/source_kits/
+distname            pysvn-${version}
+checksums           md5    3999a7680f4d3c4d3bddfc45edf65788 \
+                    sha1   f1d584bc3b0d15eb27606ca1a6c364dc44fee345 \
+                    sha256 39596f4884ed689cdb5a4e210e421724302a566c7ba756cc4d46bbfeb0c8326b
+
+python.versions     26 27
 
 set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}]} {
@@ -29,7 +30,8 @@ if {[string match *clang* ${configure.cxx}]} {
 }
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:subversion
+    depends_lib-append \
+                    port:subversion
 
     patchfiles      patch-Source_setup_configure.py.diff
 

--- a/python/py-pysvn/Portfile
+++ b/python/py-pysvn/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  b4bf58b682408c79e01b50d3f6902dba17814117 \
                     sha256  1508f63e66fc9d1303f8fd0f49547b59492f6977be4434914c38bc29dc82b2d6 \
                     size    515394
 
-python.versions     27 36
+python.versions     27 36 37
 
 set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}]} {
@@ -33,7 +33,9 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:subversion
 
-    patchfiles      patch-Source_setup_configure.py.diff
+    patch.dir       ${worksrcpath}
+    patchfiles      patch-Source_setup_configure.py.diff \
+                    patch-IndirectPythonInterface.cxx.diff
 
     worksrcdir      ${worksrcdir}/Source
 

--- a/python/py-pysvn/files/patch-IndirectPythonInterface.cxx.diff
+++ b/python/py-pysvn/files/patch-IndirectPythonInterface.cxx.diff
@@ -1,0 +1,11 @@
+--- Import/pycxx-7.0.3/Src/IndirectPythonInterface.cxx.orig	2018-07-24 16:44:03.000000000 -0400
++++ Import/pycxx-7.0.3/Src/IndirectPythonInterface.cxx	2018-07-24 16:44:28.000000000 -0400
+@@ -468,7 +468,7 @@
+ int &_Py_OptimizeFlag()                 { return Py_OptimizeFlag; }
+ int &_Py_NoSiteFlag()                   { return Py_NoSiteFlag; }
+ int &_Py_VerboseFlag()                  { return Py_VerboseFlag; }
+-char *__Py_PackageContext()             { return _Py_PackageContext; }
++char *__Py_PackageContext()             { return (char *)(_Py_PackageContext); }
+ 
+ //
+ //    Needed to keep the abstactions for delayload interface

--- a/python/py-pysvn/files/patch-Source_setup_configure.py.diff
+++ b/python/py-pysvn/files/patch-Source_setup_configure.py.diff
@@ -1,9 +1,8 @@
-diff -ru ../../pysvn-1.8.0.FCS/Source/setup_configure.py ./setup_configure.py
---- ../../pysvn-1.8.0.FCS/Source/setup_configure.py	2015-08-18 10:28:19.000000000 -0700
-+++ ./setup_configure.py	2015-11-22 17:09:15.000000000 -0800
-@@ -527,8 +527,8 @@
-                     self._find_paths_svn_lib,
-                     self.get_lib_name_for_platform( 'libsvn_client-1' ) )
+--- setup_configure.py.orig	2018-06-29 11:47:16.000000000 -0400
++++ setup_configure.py	2018-06-29 11:48:44.000000000 -0400
+@@ -568,8 +568,8 @@
+             raise last_exception
+ 
          # if we are using the Fink SVN then remember this
 -        self.is_mac_os_x_fink = folder.startswith( '/sw/' )
 -        self.is_mac_os_x_darwin_ports = folder.startswith( '/opt/local/' )
@@ -12,7 +11,7 @@ diff -ru ../../pysvn-1.8.0.FCS/Source/setup_configure.py ./setup_configure.py
          return folder
  
      def find_apr_inc( self ):
-@@ -1032,7 +1032,7 @@
+@@ -1103,7 +1103,7 @@
  
      def setupUtilities( self ):
          self._addVar( 'CCCFLAGS',
@@ -21,12 +20,12 @@ diff -ru ../../pysvn-1.8.0.FCS/Source/setup_configure.py ./setup_configure.py
                                          '-Wall -fPIC -fexceptions -frtti '
                                          '-I. -I%(APR_INC)s -I%(APU_INC)s -I%(SVN_INC)s '
                                          '-D%(DEBUG)s' )
-@@ -1048,7 +1048,7 @@
+@@ -1131,7 +1131,7 @@
          self._addVar( 'PYTHON_INC',         distutils.sysconfig.get_python_inc() )
  
          py_cflags_list = [
 -                    '-g',
-+                    '-g -O2',
-                     '-Wall -fPIC -fexceptions -frtti',
++                    '-g -O2 ',
+                     '-Wall -fPIC',
                      '-I. -I%(APR_INC)s -I%(APU_INC)s -I%(SVN_INC)s',
                      '-DPYCXX_PYTHON_2TO3 -I%(PYCXX)s -I%(PYCXX_SRC)s -I%(PYTHON_INC)s',

--- a/python/py-pysvn/files/patch-Source_setup_configure.py.diff
+++ b/python/py-pysvn/files/patch-Source_setup_configure.py.diff
@@ -1,18 +1,18 @@
---- setup_configure.py.orig	2018-06-29 11:47:16.000000000 -0400
-+++ setup_configure.py	2018-06-29 11:48:44.000000000 -0400
+--- Source/setup_configure.py.orig	2018-06-29 11:47:16.000000000 -0400
++++ Source/setup_configure.py	2018-06-29 11:48:44.000000000 -0400
 @@ -568,8 +568,8 @@
              raise last_exception
- 
+
          # if we are using the Fink SVN then remember this
 -        self.is_mac_os_x_fink = folder.startswith( '/sw/' )
 -        self.is_mac_os_x_darwin_ports = folder.startswith( '/opt/local/' )
 +        self.is_mac_os_x_fink = False
 +        self.is_mac_os_x_darwin_ports = False
          return folder
- 
+
      def find_apr_inc( self ):
 @@ -1103,7 +1103,7 @@
- 
+
      def setupUtilities( self ):
          self._addVar( 'CCCFLAGS',
 -                                        '-g  '
@@ -22,7 +22,7 @@
                                          '-D%(DEBUG)s' )
 @@ -1131,7 +1131,7 @@
          self._addVar( 'PYTHON_INC',         distutils.sysconfig.get_python_inc() )
- 
+
          py_cflags_list = [
 -                    '-g',
 +                    '-g -O2 ',


### PR DESCRIPTION
#### Description
Based on patches from josephsacco in mentioned Trac tickets:

- add modeline, adjust whitespace
- remove obsolete py26 subport, add py36 (py37 doesn't compile)
- remove "backport" call, only needed for Python 2.6 and earlier
- modernize checksums

Closes: https://trac.macports.org/ticket/56750
Closes: https://trac.macports.org/ticket/56751
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
