### PR TITLE
stellarium: update to 0.18.1

### DIFF
--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       github 1.0
 PortGroup       cmake 1.0
 PortGroup       qt5 1.0
 
@@ -11,19 +12,40 @@ license         GPL-2+
 maintainers     {michaelld @michaelld} openmaintainer
 
 description     Stellarium is a free open source planetarium for your computer.
-long_description \
-    Stellarium is a free open source planetarium for your computer. \
+long_description ${description} \
     It shows a realistic sky in 3D, just like what you see with the naked eye, \
     binoculars or a telescope. It is being used in planetarium projectors. Just \
     set your coordinates and go.
+
+subport stellarium-devel {}
+
+if {${name} eq ${subport}} {
+
+    # release
+
+    conflicts       stellarium-devel
+    github.setup    Stellarium stellarium 0.18.1 v
+    checksums       rmd160  cb90746754d2b3dc2342711a8df3b409ffd3ec79 \
+                    sha256  7bd1daad2c60cd7a4aaea1535274bc8a00cee65cc6d15e3beab0b3194516b627 \
+                    size    259842941
+
+} else {
+
+    # devel
+
+    long_description  ${long_description}: \
+        This port is kept up with the Stellarium GIT master branch, which is typically updated daily to weekly.
+
+    conflicts       stellarium
+    github.setup    Stellarium stellarium 15519727b86a961c82912ca37d5e522ec5d1af23
+    version         20180725
+    checksums       rmd160 7f40763dc47b5e14a53683073d0e4c9e97533a2b \
+                    sha256 193d0dd1739a349a7b44ef75830223dfdde6581d9f6188d6156f8b8e62b6a558 \
+                    size   260387188
+
+}
+
 homepage        http://stellarium.org/
-
-master_sites    sourceforge
-
-version         0.16.1
-revision        1
-checksums       rmd160 96fcc1e87ebdffeb5c30afc899bbb3289ac88f36 \
-                sha256 b001c252afddaa1c470fb444fcbb5595b7f7a7db028d884743d20bcb5635fd20
 
 # builds as 64-bit only, according to its top-level CMakeLists.txt file
 universal_variant no
@@ -89,6 +111,3 @@ post-destroot {
     copy ${qt_plugins_dir}/platforms/libqcocoa.dylib \
         ${appdir}/plugins/platforms
 }
-
-livecheck.url http://sourceforge.net/projects/stellarium/files/
-livecheck.regex "Stellarium-sources/.*/stellarium-(.*)[quotemeta ${extract.suffix}]"

--- a/science/stellarium/files/patch-CMakeLists.txt.diff
+++ b/science/stellarium/files/patch-CMakeLists.txt.diff
@@ -1,11 +1,11 @@
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -497,7 +497,7 @@
+@@ -506,7 +506,7 @@
  ########### Set some global variables ###########
  IF(UNIX AND NOT WIN32)
       IF(APPLE)
 -          SET(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/Stellarium.app/Contents")
 +          SET(CMAKE_INSTALL_PREFIX "${MP_APPLICATIONS_DIR}/Stellarium.app/Contents")
       ELSE()
-           ADD_DEFINITIONS(-DINSTALL_DATADIR="${CMAKE_INSTALL_PREFIX}/share/stellarium")
+           ADD_DEFINITIONS(-DINSTALL_DATADIR="${CMAKE_INSTALL_PREFIX}/share/${PACKAGE}")
            ADD_DEFINITIONS(-DINSTALL_LOCALEDIR="${CMAKE_INSTALL_PREFIX}/share/locale")


### PR DESCRIPTION
#### Description
* Update stellarium to 0.18.1
* Change download source to github since the project moved away from sourceforge
* Update patch to match new source file

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
