### PR TITLE
pypy: update to 6.0.0, fix issues

### DIFF
--- a/lang/pypy/Portfile
+++ b/lang/pypy/Portfile
@@ -4,6 +4,7 @@
 
 PortSystem          1.0
 PortGroup           bitbucket 1.0
+PortGroup           select 1.0
 
 name                pypy
 bitbucket.setup     pypy pypy 6.0.0 {release-pypy${python.branch}-v}
@@ -27,6 +28,8 @@ depends_lib         port:libffi \
                     port:gettext \
                     port:gdbm \
                     port:ncurses
+depends_run         port:python_select
+select.entries      [list python python-$subport $subport]
 
 patchfiles          darwin.py.diff \
                     make_output.diff \
@@ -52,6 +55,9 @@ subport pypy3 {
 
     depends_lib-append port:xz
 
+    depends_run-append port:python3_select
+    select.entries-append [list python3 python3-$subport $subport]
+
     distname            pypy3-v${version}-src
 
     checksums           rmd160  18f1511e9bcbcd6911e44aefa73e874cda09d4e4 \
@@ -62,6 +68,9 @@ subport pypy3 {
 if {$subport == ${name}} {
     set python.branch 2.7
     set pypy_c_name pypy-c
+
+    depends_run-append port:python2_select
+    select.entries-append [list python2 python2-$subport $subport]
 
     distname            pypy2-v${version}-src
     checksums           rmd160  4a9568322ac0b8e1c53be81861c7474c1d1926e6 \

--- a/lang/pypy/Portfile
+++ b/lang/pypy/Portfile
@@ -1,5 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
+# Please remember to keep this file in sync with the pypy-tkinter port!
+
 PortSystem          1.0
 PortGroup           bitbucket 1.0
 

--- a/lang/pypy/Portfile
+++ b/lang/pypy/Portfile
@@ -1,12 +1,10 @@
-
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           bitbucket 1.0
 
 name                pypy
-bitbucket.setup     pypy pypy 5.10.0 {release-pypy${python.branch}-v}
-revision            1
+bitbucket.setup     pypy pypy 6.0.0 {release-pypy${python.branch}-v}
 categories          lang python devel
 license             MIT PSF
 maintainers         {danchr @danchr} openmaintainer
@@ -15,13 +13,11 @@ platforms           darwin
 
 homepage            http://pypy.org/
 use_bzip2           yes
-distname            pypy2-v${version}-src
 bitbucket.tarball_from \
                     downloads
-checksums           rmd160  1672fec524ccc3037069119498ef9027ebc9382a \
-                    sha256  1209f2db718e6afda17528baa5138177a14a0938588a7d3e1b7c722c483079a8
 
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:py27-docutils
 depends_lib         port:libffi \
                     port:sqlite3 \
                     port:bzip2 \
@@ -32,32 +28,68 @@ depends_lib         port:libffi \
 
 patchfiles          darwin.py.diff \
                     make_output.diff \
-                    ffiplatform.py.diff
+                    ffiplatform.py.diff \
+                    paths.diff
+
+use_configure       no
+
+# a simple mapping from scripts to modules -- ideally, upstream
+# provided these
+array set module_scripts {
+    pydoc pydoc
+    2to3 lib2to3
+    smtpd.py smtpd
+}
 
 subport pypy3 {
-    revision       1
     set python.branch 3.5
-    set python.libdir 3
-    livecheck.regex downloads/pypy3-v(\[0-9.\]+)-src\\.tar\\.bz2
+    set pypy_c_name pypy3-c
+
+    set module_scripts(venv) venv
+    set module_scripts(idle) idlelib
 
     depends_lib-append port:xz
-    depends_build-replace port:pypy-bootstrap port:pypy
 
     distname            pypy3-v${version}-src
 
-    checksums           rmd160  f8a8c5d290d33fb087924fcc2ed752dfafd5659f \
-                        sha256  a6e4cffde71e3f08b6e1befa5c0352a9bcc5f4e9f5cbf395001e0763a1a0d9e3
-
-    set pypy_c_name pypy3-c
-
-    destroot.args-append --no-embed-dependencies
+    checksums           rmd160  18f1511e9bcbcd6911e44aefa73e874cda09d4e4 \
+                        sha256  ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3 \
+                        size    22648140
 }
 
 if {$subport == ${name}} {
     set python.branch 2.7
-    set python.libdir 2.7
-
     set pypy_c_name pypy-c
+
+    distname            pypy2-v${version}-src
+    checksums           rmd160  4a9568322ac0b8e1c53be81861c7474c1d1926e6 \
+                        sha256  6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d \
+                        size    19741694
+}
+
+build.env           PYPY_USESSION_DIR=${workpath} PYPY_LOCALBASE=${prefix} \
+                    CFLAGS="${configure.cc_archflags} ${configure.cppflags}" \
+                    LDFLAGS="${configure.ld_archflags} ${configure.ldflags}"
+
+build.dir           ${worksrcpath}/pypy/goal
+build.args          --batch --verbose \
+                    --cc=${configure.cc} --opt=jit \
+                    --make-jobs=${build.jobs}
+build.target        ../../rpython/bin/rpython
+build.post_args     targetpypystandalone
+
+destroot.env        ${build.env}
+destroot.dir        ${worksrcpath}/pypy/tool/release
+destroot.args       --builddir ${destroot}${prefix}/lib \
+                    --archive-name ${subport} \
+                    --without-tk
+destroot.target     package.py
+destroot.post_args
+
+if {$subport == "pypy3"} {
+    # we need to do this after assigning to the variable above -- and
+    # since ${worksrcpath} depends on the subport, we can't do it earlier either
+    destroot.args-append --no-embedded-dependencies
 }
 
 description         A fast interpreter for Python ${python.branch}
@@ -66,33 +98,40 @@ long_description \
     instead of CPython is speed, as it runs generally faster.
 
 post-patch {
-    reinplace "s+('/sw/', '/opt/local/')+('__PREFIX__',)+g" \
-        ${worksrcpath}/pypy/tool/cpyext/extbuild.py
-
-    # sanity check, useful when upgrading
-    if { ![catch {exec grep -lwre "/sw" -e "/opt/local" ${worksrcpath}}] } {
-        return -code error "didn't catch all references to /sw or /opt/local!"
+    # sanity check, useful when upgrading, as upstream tends to move these around
+    if { ![catch {exec grep --exclude "*.orig" -lwre /sw -e ${prefix} ${worksrcpath}} result] } {
+        return -code error "didn't catch all references to /sw and ${prefix}:\n$result"
     }
 
-    reinplace "s|__PREFIX__|${prefix}|" ${worksrcpath}/lib_pypy/cffi/ffiplatform.py \
-                                        ${worksrcpath}/pypy/tool/cpyext/extbuild.py
+    reinplace "s|__PREFIX__|${prefix}|" \
+        ${worksrcpath}/pypy/module/test_lib_pypy/ctypes_tests/conftest.py \
+        ${worksrcpath}/pypy/tool/cpyext/extbuild.py \
+        ${worksrcpath}/lib_pypy/cffi/ffiplatform.py \
+        ${worksrcpath}/lib_pypy/_tkinter/tklib_build.py
 
     # sanity check, likewise
-    if { ![catch {exec grep -lwre "__PREFIX__" ${worksrcpath}}] } {
-        return -code error "didn't catch all references to __PREFIX__!"
+    if { ![catch {exec grep --exclude "*.orig" -lwre __PREFIX__ ${worksrcpath}} result] } {
+        return -code error "didn't catch all references to __PREFIX__:\n$result"
     }
 }
 
-use_configure       no
-
-# use pypy to build if it's already installed, and we're not in trace mode
-if {![tbool ports_trace] && [file executable ${prefix}/lib/pypy/pypy]} {
+# Which Python binary should we use? Building PyPy is _very_ resource
+# intensive, and one of the best cases for using PyPy itself over
+# CPython.
+if {$subport ne $name} {
+    # just use our own pypy2 for building pypy3
+    depends_build-append port:pypy
+    build.cmd       ${prefix}/lib/pypy/bin/pypy
+} elseif {![tbool ports_trace] && [file executable ${prefix}/lib/pypy/pypy]} {
+    # if we're not in trace mode, use pypy from this port if it's available
     build.cmd       ${prefix}/lib/pypy/pypy
 } else {
     if {${os.platform} eq "darwin" && ${os.arch} eq "i386" && ![catch {sysctl hw.cpu64bit_capable} is64bit] && $is64bit == 1} {
+        # use a binary distribution of pypy itself
         depends_build-append port:pypy-bootstrap
         build.cmd       ${prefix}/lib/pypy-bootstrap/bin/pypy
     } else {
+        # fall back to good old CPython...
         depends_build-append port:python27
         build.cmd       ${prefix}/bin/python2.7
     }
@@ -124,24 +163,6 @@ platform darwin {
         build.cmd arch -${build_arch} ${build.cmd}
     }
 }
-build.env           PYPY_USESSION_DIR=${workpath} PYPY_LOCALBASE=${prefix} \
-                    CFLAGS="${configure.cc_archflags} ${configure.cppflags}" \
-                    LDFLAGS="${configure.ld_archflags} ${configure.ldflags}"
-
-build.dir           ${worksrcpath}/pypy/goal
-build.args          --batch --verbose \
-                    --cc=${configure.cc} --opt=jit \
-                    --make-jobs=${build.jobs}
-build.target        ../../rpython/bin/rpython
-build.post_args     targetpypystandalone
-
-destroot.env        ${build.env}
-destroot.dir        ${worksrcpath}/pypy/tool/release
-destroot.args       --builddir ${destroot}${prefix}/lib \
-                    --archive-name ${subport} \
-                    --without-tk
-destroot.target     package.py
-destroot.post_args
 
 # JIT is not available on powerpc at present
 if {${os.arch} ne "i386"} {
@@ -149,16 +170,22 @@ if {${os.arch} ne "i386"} {
     build.args-append --opt=3
 }
 
-post-build {
-    # some modules have to be compiled in an extra step
-    foreach script {_audioop_build.py _curses_build.py _pwdgrp_build.py _sqlite3_build.py _syslog_build.py} {
-        system -W ${worksrcpath}/lib_pypy "${build.dir}/${pypy_c_name} $script"
-    }
-}
-
 post-destroot {
     file delete ${destroot}${prefix}/lib/${subport}.tar.bz2
     ln -s ../lib/${subport}/bin/${subport} ${destroot}${prefix}/bin
+
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    system -W ${worksrcpath}/pypy/doc/man \
+        "rst2man-2.7.py pypy.1.rst ${destroot}${prefix}/share/man/man1/${subport}.1"
+
+    foreach script [array names module_scripts] {
+        set module $module_scripts($script)
+        set scriptpath "${destroot}/${prefix}/lib/${subport}/bin/${script}"
+
+        xinstall -m 755 ${filespath}/module-script.sh $scriptpath
+        reinplace "s+__PYPY__+${prefix}/bin/${subport}+" $scriptpath
+        reinplace "s+__MODULE__+${module}+" $scriptpath
+    }
 }
 
 variant opt1 description {use optimization level 1 for faster build (but slower execution)} {

--- a/lang/pypy/files/module-script.sh
+++ b/lang/pypy/files/module-script.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec __PYPY__ -m "__MODULE__" "$@"

--- a/lang/pypy/files/paths.diff
+++ b/lang/pypy/files/paths.diff
@@ -1,0 +1,36 @@
+diff --git lib_pypy/_tkinter/tklib_build.py lib_pypy/_tkinter/tklib_build.py
+--- lib_pypy/_tkinter/tklib_build.py
++++ lib_pypy/_tkinter/tklib_build.py
+@@ -18,7 +18,7 @@ elif sys.platform == 'win32':
+     linklibs = ['tcl85', 'tk85']
+     libdirs = []
+ elif sys.platform == 'darwin':
+-    incdirs = ['/System/Library/Frameworks/Tk.framework/Versions/Current/Headers/']
++    incdirs = ['__PREFIX__/include']
+     linklibs = ['tcl', 'tk']
+     libdirs = []
+ else:
+diff --git pypy/module/test_lib_pypy/ctypes_tests/conftest.py pypy/module/test_lib_pypy/ctypes_tests/conftest.py
+--- pypy/module/test_lib_pypy/ctypes_tests/conftest.py
++++ pypy/module/test_lib_pypy/ctypes_tests/conftest.py
+@@ -62,7 +62,7 @@ def c_compile(cfilenames, outputfilename
+         link_extra = link_extra + ['/DEBUG']  # generate .pdb file
+     if sys.platform == 'darwin':
+         # support Fink & Darwinports
+-        for s in ('/sw/', '/opt/local/'):
++        for s in ('__PREFIX__',):
+             if (s + 'include' not in include_dirs
+                     and os.path.exists(s + 'include')):
+                 include_dirs.append(s + 'include')
+diff --git pypy/tool/cpyext/extbuild.py pypy/tool/cpyext/extbuild.py
+--- pypy/tool/cpyext/extbuild.py
++++ pypy/tool/cpyext/extbuild.py
+@@ -175,7 +175,7 @@ def c_compile(cfilenames, outputfilename
+         link_extra = link_extra + ['/DEBUG']  # generate .pdb file
+     if sys.platform == 'darwin':
+         # support Fink & Darwinports
+-        for s in ('/sw/', '/opt/local/'):
++        for s in ('__PREFIX__',):
+             if (s + 'include' not in include_dirs
+                     and os.path.exists(s + 'include')):
+                 include_dirs.append(s + 'include')

--- a/lang/pypy/files/python-pypy
+++ b/lang/pypy/files/python-pypy
@@ -1,0 +1,13 @@
+lib/pypy/bin/pypy
+-
+-
+-
+lib/pypy/bin/pydoc
+lib/pypy/bin/smtpd.py
+lib/pypy/bin/2to3
+-
+share/man/man1/pypy.1.gz
+-
+-
+-
+-

--- a/lang/pypy/files/python-pypy3
+++ b/lang/pypy/files/python-pypy3
@@ -1,0 +1,13 @@
+lib/pypy3/bin/pypy3
+-
+-
+lib/pypy3/bin/idle
+lib/pypy3/bin/pydoc
+lib/pypy3/bin/smtpd.py
+lib/pypy3/bin/2to3
+-
+share/man/man1/pypy3.1.gz
+-
+-
+-
+-

--- a/lang/pypy/files/python2-pypy
+++ b/lang/pypy/files/python2-pypy
@@ -1,0 +1,13 @@
+lib/pypy/bin/pypy
+-
+-
+-
+lib/pypy/bin/pydoc
+lib/pypy/bin/smtpd.py
+lib/pypy/bin/2to3
+-
+share/man/man1/pypy.1.gz
+-
+-
+-
+-

--- a/lang/pypy/files/python3-pypy3
+++ b/lang/pypy/files/python3-pypy3
@@ -1,0 +1,13 @@
+lib/pypy3/bin/pypy3
+-
+-
+lib/pypy3/bin/idle
+lib/pypy3/bin/pydoc
+lib/pypy3/bin/smtpd.py
+lib/pypy3/bin/2to3
+-
+share/man/man1/pypy3.1.gz
+-
+-
+-
+-

--- a/python/pypy-tkinter/Portfile
+++ b/python/pypy-tkinter/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+# Please remember to keep this file in sync with the pypy port!
+
+PortSystem          1.0
+PortGroup           bitbucket 1.0
+
+name                pypy-tkinter
+bitbucket.setup     pypy pypy 6.0.0 {release-pypy${python.branch}-v}
+categories          python graphics
+license             MIT PSF
+maintainers         {danchr @danchr} openmaintainer
+
+description         PyPy bindings to the Tk widget set
+long_description    ${description}
+
+platforms           darwin
+
+homepage            http://pypy.org/
+use_bzip2           yes
+use_configure       no
+bitbucket.tarball_from \
+                    downloads
+
+set pypy_version    [string range ${subport} 0 [string first "-" ${subport}]-1]
+set pypy_root       ${prefix}/lib/${pypy_version}
+
+depends_build       port:pkgconfig \
+                    port:tcl
+depends_lib         port:${pypy_version} \
+                    port:tk
+
+# copied from the pypy port, as trace mode prevents us from sharing
+# them between ports
+patchfiles          ffiplatform.py.diff \
+                    paths.diff
+
+build.cmd           ${pypy_root}/bin/${pypy_version}
+build.args          lib_pypy/_tkinter/tklib_build.py
+build.target
+build.post_args
+
+distname            pypy2-v${version}-src
+
+checksums           rmd160  4a9568322ac0b8e1c53be81861c7474c1d1926e6 \
+                    sha256  6097ec5ee23d0d34d8cd27a1072bed041c8a080ad48731190a03a2223029212d \
+                    size    19741694
+
+subport pypy3-tkinter {
+    build.cmd           ${prefix}/bin/${pypy_version}
+    distname            ${pypy_version}-v${version}-src
+
+    checksums           rmd160  18f1511e9bcbcd6911e44aefa73e874cda09d4e4 \
+                        sha256  ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3 \
+                        size    22648140
+}
+
+post-patch {
+    reinplace "s|__PREFIX__|${prefix}|" \
+        ${worksrcpath}/pypy/module/test_lib_pypy/ctypes_tests/conftest.py \
+        ${worksrcpath}/pypy/tool/cpyext/extbuild.py \
+        ${worksrcpath}/lib_pypy/cffi/ffiplatform.py \
+        ${worksrcpath}/lib_pypy/_tkinter/tklib_build.py
+}
+
+destroot {
+    xinstall -m 755 -d ${destroot}${pypy_root}/lib_pypy/_tkinter
+    xinstall -m 755 \
+        [glob -directory ${worksrcpath}/lib_pypy/_tkinter tklib_cffi.*.so] \
+        ${destroot}${pypy_root}/lib_pypy/_tkinter
+}

--- a/python/pypy-tkinter/files/ffiplatform.py.diff
+++ b/python/pypy-tkinter/files/ffiplatform.py.diff
@@ -1,0 +1,11 @@
+--- lib_pypy/cffi/ffiplatform.py.orig	2016-03-19 04:52:25.000000000 +1100
++++ lib_pypy/cffi/ffiplatform.py	2016-03-22 14:49:10.000000000 +1100
+@@ -47,6 +47,8 @@
+     options['force'] = ('ffiplatform', True)
+     options['build_lib'] = ('ffiplatform', tmpdir)
+     options['build_temp'] = ('ffiplatform', tmpdir)
++    options['include_dirs'] = ('ffiplatform', '__PREFIX__/include')
++    options['library_dirs'] = ('ffiplatform', '__PREFIX__/lib')
+     #
+     try:
+         old_level = distutils.log.set_threshold(0) or 0

--- a/python/pypy-tkinter/files/paths.diff
+++ b/python/pypy-tkinter/files/paths.diff
@@ -1,0 +1,36 @@
+diff --git lib_pypy/_tkinter/tklib_build.py lib_pypy/_tkinter/tklib_build.py
+--- lib_pypy/_tkinter/tklib_build.py
++++ lib_pypy/_tkinter/tklib_build.py
+@@ -18,7 +18,7 @@ elif sys.platform == 'win32':
+     linklibs = ['tcl85', 'tk85']
+     libdirs = []
+ elif sys.platform == 'darwin':
+-    incdirs = ['/System/Library/Frameworks/Tk.framework/Versions/Current/Headers/']
++    incdirs = ['__PREFIX__/include']
+     linklibs = ['tcl', 'tk']
+     libdirs = []
+ else:
+diff --git pypy/module/test_lib_pypy/ctypes_tests/conftest.py pypy/module/test_lib_pypy/ctypes_tests/conftest.py
+--- pypy/module/test_lib_pypy/ctypes_tests/conftest.py
++++ pypy/module/test_lib_pypy/ctypes_tests/conftest.py
+@@ -62,7 +62,7 @@ def c_compile(cfilenames, outputfilename
+         link_extra = link_extra + ['/DEBUG']  # generate .pdb file
+     if sys.platform == 'darwin':
+         # support Fink & Darwinports
+-        for s in ('/sw/', '/opt/local/'):
++        for s in ('__PREFIX__',):
+             if (s + 'include' not in include_dirs
+                     and os.path.exists(s + 'include')):
+                 include_dirs.append(s + 'include')
+diff --git pypy/tool/cpyext/extbuild.py pypy/tool/cpyext/extbuild.py
+--- pypy/tool/cpyext/extbuild.py
++++ pypy/tool/cpyext/extbuild.py
+@@ -175,7 +175,7 @@ def c_compile(cfilenames, outputfilename
+         link_extra = link_extra + ['/DEBUG']  # generate .pdb file
+     if sys.platform == 'darwin':
+         # support Fink & Darwinports
+-        for s in ('/sw/', '/opt/local/'):
++        for s in ('__PREFIX__',):
+             if (s + 'include' not in include_dirs
+                     and os.path.exists(s + 'include')):
+                 include_dirs.append(s + 'include')


### PR DESCRIPTION
* Bump to latest version, as mentioned.
* Address issues identified by Ryan Schmidt in the PR referenced
  below, such as too much cleverness with replacements.
* Properly suppress dependency embedding -- use ours instead.
* Reorganise the port to avoid duplication wherever possible.
* Add manual page.
* Add some comments.
* Use pypy2 for building pypy3.
* Add scripts for pydoc, IDLE and so on, hidden in ${prefix}/lib for
  now.
* Add selections for both pypy & pypy3, utilising the aforementioned
  scripts.
* Add 'tkinter' ports so that it's available, but not a default -- and
  prevent it from using the system-provided Tk.

Closes: https://trac.macports.org/ticket/55679
Refs: https://github.com/macports/macports-ports/pull/1475

#### Description

This is an update to my previous PR, #1475, made some time ago. Since it's a rather invasive change to the port and adds some extra infrastructure, I'd appreciate any feedback you might have.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

