### PR TITLE
py-*: remove obsolete py26/py33 subports from various Python ports

### DIFF
--- a/fuse/py-fuse/Portfile
+++ b/fuse/py-fuse/Portfile
@@ -19,7 +19,7 @@ platforms           darwin
 checksums           rmd160  c0acad069284e3adba7db8aaf957c7d228c488fc \
                     sha256  e61f453aac7c4e7db8afefb1df0665949111e6685a20fad28876dc64ed5fe699
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append    port:pkgconfig

--- a/python/py-PyRSS2Gen/Portfile
+++ b/python/py-PyRSS2Gen/Portfile
@@ -20,7 +20,7 @@ distname            PyRSS2Gen-${version}
 checksums           rmd160  0dea97364066f78189b99a512015e851601aa2fa \
                     sha256  2a9a3ee7c8e30cb40434ef3a295f9a60166f7d8c3eaefac9f46f7ed4b27c2269
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     post-destroot {

--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-backports-ssl_match_hostname/Portfile
+++ b/python/py-backports-ssl_match_hostname/Portfile
@@ -12,7 +12,7 @@ license             PSF
 supported_archs     noarch
 
 # do not add subports for python > 3.4
-python.versions     27 33 34
+python.versions     27 34
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-backports_abc/Portfile
+++ b/python/py-backports_abc/Portfile
@@ -12,7 +12,7 @@ license             PSF
 supported_archs     noarch
 
 # do not add subports for python > 3.4
-python.versions     27 33 34
+python.versions     27 34
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-cheetah/Portfile
+++ b/python/py-cheetah/Portfile
@@ -29,7 +29,7 @@ homepage            http://www.cheetahtemplate.org/
 master_sites        pypi:C/Cheetah3/
 distname            Cheetah3-${version}
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
 

--- a/python/py-chronic/Portfile
+++ b/python/py-chronic/Portfile
@@ -16,7 +16,7 @@ long_description    ${description}  Add decorators or wrap code in with \
 platforms           darwin
 license             MIT
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 if { $subport ne $name } {
     checksums           rmd160  4320705a0656fad02dfa4a73bdc044bbb1c593f2 \

--- a/python/py-cogen/Portfile
+++ b/python/py-cogen/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     26 27
+python.versions     27
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-colorama/Portfile
+++ b/python/py-colorama/Portfile
@@ -19,7 +19,7 @@ long_description    ${description} Makes ANSI escape character sequences, for \
 
 homepage            https://code.google.com/p/colorama/
 master_sites        pypi:c/colorama/
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 
 if {${name} ne ${subport}} {

--- a/python/py-couchdb/Portfile
+++ b/python/py-couchdb/Portfile
@@ -25,7 +25,7 @@ checksums           md5    67afd226fed4c641eeb13a9930d334f7 \
                     rmd160 f581679a63834890ac00d6d0dee89c13de24359e \
                     sha256 a1cf5071b5adb47048199bbfbaf1500e69c88b27afe14ba26efa0f4044c3baee
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     # Use py-setuptools as a library dependency instead of a build

--- a/python/py-couchdbkit/Portfile
+++ b/python/py-couchdbkit/Portfile
@@ -31,7 +31,7 @@ checksums           md5    d5f6382665697b0f126f68a211c1a5a2 \
                     rmd160 58f1fe17b32c3b307851b9f2701a987aab8d9849
 
 # Python >= 2.6 required, Python 3.x supported "soon"
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-ctags/Portfile
+++ b/python/py-ctags/Portfile
@@ -31,4 +31,4 @@ checksums                       md5 6579b49942c73abd1d22a5cfd559856b \
                                 sha1 999283046710d37f93b646bf3e7cadde7b3d2619 \
                                 rmd160 119aa4509acded405c1879b5da8cec6c515e8c82
 
-python.versions                 26 27
+python.versions                 27

--- a/python/py-cvxopt/Portfile
+++ b/python/py-cvxopt/Portfile
@@ -31,7 +31,7 @@ homepage            http://cvxopt.org/
 checksums           rmd160  bff5c419f73203fe35dc23a1be74f7d4c3aa7322 \
                     sha256  5cbc2f3ab1573bace9fca6d39cddab86370828f0a50c84fdbd056269c6ec10ac
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${subport} ne ${name}} {
     # ignore empty BLAS and LAPACK inputs

--- a/python/py-cycler/Portfile
+++ b/python/py-cycler/Portfile
@@ -16,7 +16,7 @@ long_description    $description
 checksums           rmd160  cf3cceb56449e99d74920b57c9119ecb30fe5e77 \
                     sha256  5fd8508cb46ec86a4e08b13e946eb7fef16217e76fdb95601ae2c069e3efbbaf
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {${subport} ne ${name}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-deap/Portfile
+++ b/python/py-deap/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             LGPL
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-distutils-extra/Portfile
+++ b/python/py-distutils-extra/Portfile
@@ -29,7 +29,7 @@ distname                ${my_name}-${version}
 checksums               rmd160  ec5fcffc0ac6258bc86a68c2108af2f5b2dda419 \
                         sha256  723f24f4d65fc8d99b33a002fbbb3771d4cc9d664c97085bf37f3997ae8063af
 
-python.versions         27 33 34 35 36
+python.versions         27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-djvubind/Portfile
+++ b/python/py-djvubind/Portfile
@@ -6,7 +6,7 @@ PortGroup                       python 1.0
 name                            py-djvubind
 version                         1.2.1
 revision                        1
-python.versions                 33 34 35 36
+python.versions                 34 35 36
 platforms                       darwin
 supported_archs                 noarch
 maintainers                     {raphael @raphael-st} openmaintainer

--- a/python/py-dnspython/Portfile
+++ b/python/py-dnspython/Portfile
@@ -21,7 +21,7 @@ homepage           http://www.dnspython.org/
 master_sites       ${homepage}kits/${version}
 distname           dnspython-${version}
 
-python.versions    26 27 33 34 35 36
+python.versions    27 34 35 36
 
 checksums          rmd160 b3bf88a627850d29b5da6e67d5f2e9643283bc65 \
                    sha256 11598ae5735746e63921f8eebdfdee4a2e7d0ba842ebd57ba02682d4aed8244b

--- a/python/py-ecdsa/Portfile
+++ b/python/py-ecdsa/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-elementtree/Portfile
+++ b/python/py-elementtree/Portfile
@@ -6,7 +6,7 @@ PortGroup python 1.0
 name			py-elementtree
 # if version or revision change, be sure to update the py24 subport revision
 version			1.2.6-20050316
-python.versions 26 27
+python.versions 27
 platforms		darwin
 maintainers		{snc @nerdling} openmaintainer
 license         MIT

--- a/python/py-enthoughtbase/Portfile
+++ b/python/py-enthoughtbase/Portfile
@@ -22,7 +22,7 @@ checksums           md5     1d8f6365d20dfd5c4232334e80b0cfdf \
                     sha1    b764ddbc1c28b0ac9263f996498a1a0ed1a2963d \
                     rmd160  be66500d5c2fa944b252eb0a205211ac96eb688f
 
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools

--- a/python/py-enum34/Portfile
+++ b/python/py-enum34/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  b6bf8846921ddbbd4c1a70de69e9036f0a41a9b4 \
                     sha256  8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1
 
 # works in 24 25 26 27 31 32 33
-python.versions     26 27 33
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ephem/Portfile
+++ b/python/py-ephem/Portfile
@@ -26,7 +26,7 @@ checksums           md5     405a109f3017251ecd8c2890d850f649 \
                     rmd160  32e5fcb0e74936706b68bd811a9dcdf55b97b1f8 \
                     sha256  7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} eq ${subport}} {
     livecheck.type  regex

--- a/python/py-etsproxy/Portfile
+++ b/python/py-etsproxy/Portfile
@@ -15,7 +15,7 @@ long_description    This is the ETS proxy package, it contains the proxy\
                     modules for all ETS projects which map the old enthought\
                     namespace imports (version 3) to the namespace-refactored\
                     ETS packages (version 4).
-                    
+
 platforms           darwin
 supported_archs     noarch
 homepage            https://github.com/enthought/etsproxy
@@ -26,8 +26,7 @@ checksums           md5     dadb306652834f29693133859753c8bb \
                     sha1    16aa8e8770bbf2b18915eb64da813e0d0fd27411 \
                     rmd160  e8de667a7cd05534e51020c97f8b60280f3c53b7
 
-python.versions     26 27
-python.default_version 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build    port:py${python.version}-setuptools

--- a/python/py-eyed3/Portfile
+++ b/python/py-eyed3/Portfile
@@ -20,7 +20,7 @@ master_sites	${homepage}releases/
 distname		eyeD3-${version}
 
 # setyp.py is not compatible with python 2.5 as of 0.7.1
-python.versions	26 27
+python.versions	27
 
 if {${name} ne ${subport}} {
     # override commands because they add --no-user-cfg which is not supported

--- a/python/py-flask-login/Portfile
+++ b/python/py-flask-login/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        maxcountryman flask-login 0.4.1
 name                py-${name}
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 license             MIT
 platforms           darwin
 supported_archs     noarch

--- a/python/py-flask-script/Portfile
+++ b/python/py-flask-script/Portfile
@@ -6,7 +6,7 @@ PortGroup python 1.0
 name                py-flask-script
 set realname        Flask-Script
 version             2.0.5
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 license             BSD
 platforms           darwin
 supported_archs     noarch

--- a/python/py-fortranformat/Portfile
+++ b/python/py-fortranformat/Portfile
@@ -17,7 +17,7 @@ long_description    Generates text from a Python list of variables or will \
 checksums           md5 d78c5a320fedcbdf21f823cd18e28ac0 \
                     rmd160 212edf59a6da06b8127322f30806e6559353ea79 \
                     sha256 ec76c1c7bc07972aa98e01ff2303bb0aefe77306be8ff2723bc40b7c7775292c
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 bitbucket.tarball_from downloads
 distname            fortranformat-${version}

--- a/python/py-freeling/Portfile
+++ b/python/py-freeling/Portfile
@@ -10,7 +10,7 @@ categories-append   devel textproc
 platforms           darwin
 license             GPL-3+
 
-python.versions     27 33
+python.versions     27
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-ftputil/Portfile
+++ b/python/py-ftputil/Portfile
@@ -27,7 +27,7 @@ checksums         md5    df1880064485be39b3e6eeefbd812b03 \
                   rmd160 cd7bd7bfcb40c82b13f5d9daa1ba15a0a26c4b51
 
 
-python.versions     26 27
+python.versions   27
 
 if {${name} ne ${subport}} {
   depends_build   port:py${python.version}-setuptools

--- a/python/py-generator/Portfile
+++ b/python/py-generator/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  5ce5ba93b7f512bcbd7a04eb4a8471bd72dd93d1 \
 
 use_configure       no
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     build {}

--- a/python/py-gevent/Portfile
+++ b/python/py-gevent/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     i386 x86_64
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-gflags/Portfile
+++ b/python/py-gflags/Portfile
@@ -27,7 +27,7 @@ checksums           sha1    db309e6964b102ff36de319ce551db512a78281e \
                     rmd160  b54a08bbb4dfb79cea17aef60e65f0847aab0a26 \
                     sha256  311066217acb8cd8519a4c872cb3fe64f02bcf105802bb761ab0de55c2386cd6
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -55,6 +55,7 @@ py-async-task           0.6.2_1     26
 py-atpy                 0.9.7_3     26
 py-autopep8             1.1.1_1     26 31 32 33
 py-awscli               1.14.63     34
+py-babel                2.5.3_1     26 33
 py-backcall             0.1.0_1     33
 py-backports-ssl        0.0.7_1     33
 py-backports.weakref    1.0.post1   34

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -178,6 +178,7 @@ py-html5lib             @1.0b10_2   26 33
 py-htmldocs             3.3.99      26 31 32 33
 py-http-parser          0.8.3_1     26 31 32 33
 py-id3lib               0.5.1_1     26
+py-idlsave              1.0.0_3     26
 py-imagesize            1.0.0_1     26 33
 py-iniparse             0.4_1       26
 py-ipy                  0.81_1      25 26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -201,6 +201,7 @@ py-libcloud             0.17.0_1    26 33
 py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33
 py-lz4                  0.8.2_1     26
+py-macfsevents          0.8.1_1     33
 py-managesieve          0.4.2_1     26
 py-matplotlib           1.5.0_1     26 33
 py-mecab                0.996_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -112,6 +112,7 @@ py-flask-frozen         0.9_1       26
 py-flask-uploads        0.1.3_1     26
 py-flup                 1.0.3.dev-20110405_1    26
 py-formalchemy          1.4.1_1     26
+py-fuse                 0.2.1_4     26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -60,6 +60,7 @@ py-backcall             0.1.0_1     33
 py-backports-ssl        0.0.7_1     33
 py-backports-ssl_match_hostname \
                         3.5.0.1_1   33
+py-backports_abc        0.5_1       33
 py-backports.weakref    1.0.post1   34
 py-biggles              1.6.7_2     26
 py-bitarray             0.8.1_1     26 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -124,6 +124,7 @@ py-enum34               1.1.6_1     26 33
 py-envisage             4.4.0_1     26
 py-ephem                3.7.6.0_1   26 33
 py-etsdevtools          4.0.2_1     26
+py-etsproxy             0.1.1_1     26
 py-eventlet             0.22.0      26
 py-ez_setup             0.9_1       26
 py-feedparser           5.1.3_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -221,6 +221,7 @@ py-mongoengine          0.8.7_1     26
 py-montage              0.9.8_1     26 33
 py-mox                  0.5.1_1     26
 py-mpi4py               2.0.0_1     26 33
+py-msgpack              0.5.6_1     26 33
 py-mssql                2.1.0_1     26
 py-mx-base              3.2.8_1     26
 py-mygpoclient          1.7_1       26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -208,6 +208,8 @@ py-mecab                0.996_1     26
 py-mechanize            0.2.5_1     26
 py-memprof              0.3.3_1     26 32 33
 py-meta                 0.4.1_1     26
+py-meta-devel           0.4.1_20130223 \
+                                    26 33
 py-mdp-toolkit          3.3_2       26 33
 py-mingus               0.4.2.3_1   26
 py-mitmproxy            0.10.1_2    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -222,6 +222,7 @@ py-pyodbc               3.0.6_1     26
 py-pyopencl             2013.2_1    26 33
 py-pyqtgraph            0.9.10_1    34
 py-pyrfc3339            1.1         34
+py-PyRSS2Gen            1.1_1       26
 py-pyshp                1.2.1_1     26 32 33
 py-pysvn                1.8.0_1     26
 py-python-jenkins       0.3.4_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -98,6 +98,7 @@ py-curl                 7.19.0_2    26
 py-cvxopt               1.1.9_1     33
 py-cycler               0.10.0_1    26 33
 py-dateutil             2.5.1_1     26 33
+py-deap                 1.2.2_1     26 33
 py-dispatcher           2.0.1_1     26
 py-dispel4py-devel      0.0.1-3_1   26
 py-dispel4py-registry-devel \

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -184,7 +184,7 @@ py-imagesize            1.0.0_1     26 33
 py-iniparse             0.4_1       26
 py-ipy                  0.81_1      25 26
 py-iso8601              0.1.12_1    26 33
-py-isodate              0.5.4       33 34
+py-isodate              0.5.4_1     26 33 34
 py-jcc                  2.13_1      26
 py-jenkins-job-builder  0.8.1_2     26
 py-jmespath             0.9.3       34

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -103,6 +103,7 @@ py-dispatcher           2.0.1_1     26
 py-dispel4py-devel      0.0.1-3_1   26
 py-dispel4py-registry-devel \
                         0.0.1-3_1   26
+py-distutils-extra      2.39_1      33
 py-django               1.7.1_1     26 33
 py-django-debug-toolbar 0.9.4_1     26
 py-django-extensions    1.1.1_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -122,6 +122,7 @@ py-enchant              1.6.6_1     26 33
 py-enthoughtbase        3.1.0_1     26
 py-enum34               1.1.6_1     26 33
 py-envisage             4.4.0_1     26
+py-ephem                3.7.6.0_1   26 33
 py-etsdevtools          4.0.2_1     26
 py-eventlet             0.22.0      26
 py-ez_setup             0.9_1       26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -132,6 +132,7 @@ py-feedparser           5.1.3_1     26
 py-fipy                 3.1_1       26
 py-flask-auth           0.85_1      26
 py-flask-babel          0.8_1       26
+py-flask-login          0.4.1_1     26 33
 py-flask-sqlalchemy     2.0_1       26 33
 py-flask-frozen         0.9_1       26
 py-flask-uploads        0.1.3_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -95,6 +95,7 @@ py-country              0.10_1      26
 py-cssutils             1.0.2_1     26
 py-ctags                1.0.5_1     26
 py-curl                 7.19.0_2    26
+py-cvxopt               1.1.9_1     33
 py-dateutil             2.5.1_1     26 33
 py-dispatcher           2.0.1_1     26
 py-dispel4py-devel      0.0.1-3_1   26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -194,6 +194,7 @@ py-kapteyn              2.2_1       26
 py-kcs11                1.2.4_1     26
 py-keyring              3.6_1       26 33
 py-keybinder            0.3.1_1     26
+py-kivy                 1.10.1_1    26
 py-libcloud             0.17.0_1    26 33
 py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -173,6 +173,7 @@ py-h5py                 2.8.0       26 33 34
 py-hat-trie             0.3_1       33
 py-hcluster             0.2.0_2     26
 py-hgsvn                0.1.9_1     26
+py-hiredis              0.2.0_1     33
 py-html5lib             @1.0b10_2   26 33
 py-htmldocs             3.3.99      26 31 32 33
 py-http-parser          0.8.3_1     26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -153,6 +153,7 @@ py-generator            0.1.20120721_1 \
 py-geoip                1.3.2_1     33
 py-geopandas            0.1.1_1     33
 py-geopy                1.11.0_1    26 33
+py-gevent               1.3.3_1     26 33
 py-gitdb                2.0.3_1     26
 py-gitpython            2.0.2_1     26
 py-gmpy                 1.17_1      25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -109,6 +109,7 @@ py-django-debug-toolbar 0.9.4_1     26
 py-django-extensions    1.1.1_1     26
 py-django-nose          0.7.0_1     26
 py-django-htmlmin       1.2_1       26
+py-djvubind             1.2.1_2     33
 py-docx                 0.0.2_2     26
 py-eggtrayicon          2.25.3_3    26
 py-elib.intl            0.0.3-20110711_2 \

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -74,6 +74,7 @@ py-bottle               0.12.9_1    26
 py-bottle-sqlalchemy    0.3_1       26
 py-bottleneck           1.2.1_1     26 33
 py-cdb                  0.34_1      26
+py-cheetah              3.1.0_1     26
 py-celementtree         1.0.5-20051216_1    26
 py-checker              0.8.18_2    26
 py-cherrypy             2.3.0_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -148,6 +148,8 @@ py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26
 py-gdbm                 2.5.6_1     25
 py-gdl                  2.25.3_2    26
+py-generator            0.1.20120721_1 \
+                                    26 33
 py-geoip                1.3.2_1     33
 py-geopandas            0.1.1_1     33
 py-geopy                1.11.0_1    26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -154,6 +154,7 @@ py-geoip                1.3.2_1     33
 py-geopandas            0.1.1_1     33
 py-geopy                1.11.0_1    26 33
 py-gevent               1.3.3_1     26 33
+py-gflags               2.0_1       26
 py-gitdb                2.0.3_1     26
 py-gitpython            2.0.2_1     26
 py-gmpy                 1.17_1      25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -126,6 +126,7 @@ py-ephem                3.7.6.0_1   26 33
 py-etsdevtools          4.0.2_1     26
 py-etsproxy             0.1.1_1     26
 py-eventlet             0.22.0      26
+py-eyed3                0.7.10_1    26
 py-ez_setup             0.9_1       26
 py-feedparser           5.1.3_1     26
 py-fipy                 3.1_1       26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -200,6 +200,7 @@ py-lepl                 5.1.3_1     26
 py-libcloud             0.17.0_1    26 33
 py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33
+py-lz4                  0.8.2_1     26
 py-managesieve          0.4.2_1     26
 py-matplotlib           1.5.0_1     26 33
 py-mecab                0.996_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -93,6 +93,7 @@ py-couchdb              0.9_1       26
 py-couchdbkit           0.6.5_1     26
 py-country              0.10_1      26
 py-cssutils             1.0.2_1     26
+py-ctags                1.0.5_1     26
 py-curl                 7.19.0_2    26
 py-dateutil             2.5.1_1     26 33
 py-dispatcher           2.0.1_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -96,6 +96,7 @@ py-cssutils             1.0.2_1     26
 py-ctags                1.0.5_1     26
 py-curl                 7.19.0_2    26
 py-cvxopt               1.1.9_1     33
+py-cycler               0.10.0_1    26 33
 py-dateutil             2.5.1_1     26 33
 py-dispatcher           2.0.1_1     26
 py-dispel4py-devel      0.0.1-3_1   26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -112,6 +112,7 @@ py-django-htmlmin       1.2_1       26
 py-djvubind             1.2.1_2     33
 py-dnspython            1.15.0_1    26 33
 py-docx                 0.0.2_2     26
+py-ecdsa                0.13_1      33
 py-eggtrayicon          2.25.3_3    26
 py-elib.intl            0.0.3-20110711_2 \
                                     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -189,6 +189,7 @@ py-jcc                  2.13_1      26
 py-jenkins-job-builder  0.8.1_2     26
 py-jmespath             0.9.3       34
 py-jsbeautifier         1.4.0_1     26
+py-jug                  1.6.7_1     33
 py-kapteyn              2.2_1       26
 py-kcs11                1.2.4_1     26
 py-keyring              3.6_1       26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -114,6 +114,8 @@ py-dnspython            1.15.0_1    26 33
 py-docx                 0.0.2_2     26
 py-ecdsa                0.13_1      33
 py-eggtrayicon          2.25.3_3    26
+py-elementtree          1.2.6-20050316_1 \
+                                    26
 py-elib.intl            0.0.3-20110711_2 \
                                     26
 py-enchant              1.6.6_1     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -183,6 +183,7 @@ py-igraph               0.7_1       26
 py-imagesize            1.0.0_1     26 33
 py-iniparse             0.4_1       26
 py-ipy                  0.81_1      25 26
+py-iso8601              0.1.12_1    26 33
 py-isodate              0.5.4       33 34
 py-jcc                  2.13_1      26
 py-jenkins-job-builder  0.8.1_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -207,6 +207,7 @@ py-matplotlib           1.5.0_1     26 33
 py-mecab                0.996_1     26
 py-mechanize            0.2.5_1     26
 py-memprof              0.3.3_1     26 32 33
+py-meta                 0.4.1_1     26
 py-mdp-toolkit          3.3_2       26 33
 py-mingus               0.4.2.3_1   26
 py-mitmproxy            0.10.1_2    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -223,6 +223,7 @@ py-mox                  0.5.1_1     26
 py-mpi4py               2.0.0_1     26 33
 py-msgpack              0.5.6_1     26 33
 py-mssql                2.1.0_1     26
+py-multipledispatch     0.5.0_1     33
 py-mx-base              3.2.8_1     26
 py-mygpoclient          1.7_1       26
 py-mysql                1.2.3_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -170,6 +170,7 @@ py-gtkhtml2             2.25.3_3    26
 py-gtkmvc               1.99.1_3    26
 py-gtkspell             2.25.3_4    26
 py-h5py                 2.8.0       26 33 34
+py-hat-trie             0.3_1       33
 py-hcluster             0.2.0_2     26
 py-hgsvn                0.1.9_1     26
 py-html5lib             @1.0b10_2   26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -133,6 +133,7 @@ py-fipy                 3.1_1       26
 py-flask-auth           0.85_1      26
 py-flask-babel          0.8_1       26
 py-flask-login          0.4.1_1     26 33
+py-flask-script         2.0.5_1     33
 py-flask-sqlalchemy     2.0_1       26 33
 py-flask-frozen         0.9_1       26
 py-flask-uploads        0.1.3_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -217,6 +217,7 @@ py-mingus               0.4.2.3_1   26
 py-mitmproxy            0.10.1_2    26
 py-mlpy                 3.5.0_2     26 33
 py-mock                 1.0.1_1     25 26 31 32 33
+py-mongoengine          0.8.7_1     26
 py-mox                  0.5.1_1     26
 py-mpi4py               2.0.0_1     26 33
 py-mssql                2.1.0_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -196,6 +196,7 @@ py-keyring              3.6_1       26 33
 py-keybinder            0.3.1_1     26
 py-kivy                 1.10.1_1    26
 py-kyotocabinet         1.18_1      26
+py-lepl                 5.1.3_1     26
 py-libcloud             0.17.0_1    26 33
 py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -142,6 +142,7 @@ py-formalchemy          1.4.1_1     26
 py-fortranformat        0.2.3_1     26 33
 py-fuse                 0.2.1_4     26
 py-freeling             3.1_1       33
+py-ftputil              2.6_1       26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -88,6 +88,7 @@ py-construct            2.5.2_1     26 33
 py-coverage             3.7.1_1     25 26 31 32 33
 py-cairo                1.10.0_4    26 33
 py-cairosvg             2.0.1       33
+py-colorama             0.3.7_1     26 33
 py-country              0.10_1      26
 py-cssutils             1.0.2_1     26
 py-curl                 7.19.0_2    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -225,6 +225,7 @@ py-msgpack              0.5.6_1     26 33
 py-mssql                2.1.0_1     26
 py-multipledispatch     0.5.0_1     33
 py-mustache             0.5.4_1     26 33
+py-mutagen              1.41.0_1    26
 py-mx-base              3.2.8_1     26
 py-mygpoclient          1.7_1       26
 py-mysql                1.2.3_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -195,6 +195,7 @@ py-kcs11                1.2.4_1     26
 py-keyring              3.6_1       26 33
 py-keybinder            0.3.1_1     26
 py-kivy                 1.10.1_1    26
+py-kyotocabinet         1.18_1      26
 py-libcloud             0.17.0_1    26 33
 py-liblzma              0.5.3_2     26
 py-lmfit                0.9.2_1     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -75,6 +75,7 @@ py-bottle-sqlalchemy    0.3_1       26
 py-bottleneck           1.2.1_1     26 33
 py-cdb                  0.34_1      26
 py-cheetah              3.1.0_1     26
+py-chronic              0.3.1_1     33
 py-celementtree         1.0.5-20051216_1    26
 py-checker              0.8.18_2    26
 py-cherrypy             2.3.0_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -119,6 +119,7 @@ py-elementtree          1.2.6-20050316_1 \
 py-elib.intl            0.0.3-20110711_2 \
                                     26
 py-enchant              1.6.6_1     26 33
+py-enthoughtbase        3.1.0_1     26
 py-envisage             4.4.0_1     26
 py-etsdevtools          4.0.2_1     26
 py-eventlet             0.22.0      26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -90,6 +90,7 @@ py-cairo                1.10.0_4    26 33
 py-cairosvg             2.0.1       33
 py-colorama             0.3.7_1     26 33
 py-couchdb              0.9_1       26
+py-couchdbkit           0.6.5_1     26
 py-country              0.10_1      26
 py-cssutils             1.0.2_1     26
 py-curl                 7.19.0_2    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -212,6 +212,7 @@ py-meta-devel           0.4.1_20130223 \
                                     26 33
 py-mdp-toolkit          3.3_2       26 33
 py-milk                 0.6.1_1     26
+py-minfx                1.0.3_1     26
 py-mingus               0.4.2.3_1   26
 py-mitmproxy            0.10.1_2    26
 py-mock                 1.0.1_1     25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -82,6 +82,7 @@ py-cherrypy             2.3.0_2     26
 py-clientform           0.2.9_1     26
 py-codetools            4.0.0_2     26
 py-cog                  2.4_1       26 33
+py-cogen                0.2.1_1     26
 py-configobj            5.0.6_1     25 26 31 32 33
 py-construct            2.5.2_1     26 33
 py-coverage             3.7.1_1     25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -110,6 +110,7 @@ py-django-extensions    1.1.1_1     26
 py-django-nose          0.7.0_1     26
 py-django-htmlmin       1.2_1       26
 py-djvubind             1.2.1_2     33
+py-dnspython            1.15.0_1    26 33
 py-docx                 0.0.2_2     26
 py-eggtrayicon          2.25.3_3    26
 py-elib.intl            0.0.3-20110711_2 \

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -211,6 +211,7 @@ py-meta                 0.4.1_1     26
 py-meta-devel           0.4.1_20130223 \
                                     26 33
 py-mdp-toolkit          3.3_2       26 33
+py-milk                 0.6.1_1     26
 py-mingus               0.4.2.3_1   26
 py-mitmproxy            0.10.1_2    26
 py-mock                 1.0.1_1     25 26 31 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -215,6 +215,7 @@ py-milk                 0.6.1_1     26
 py-minfx                1.0.3_1     26
 py-mingus               0.4.2.3_1   26
 py-mitmproxy            0.10.1_2    26
+py-mlpy                 3.5.0_2     26 33
 py-mock                 1.0.1_1     25 26 31 32 33
 py-mox                  0.5.1_1     26
 py-mpi4py               2.0.0_1     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -120,6 +120,7 @@ py-elib.intl            0.0.3-20110711_2 \
                                     26
 py-enchant              1.6.6_1     26 33
 py-enthoughtbase        3.1.0_1     26
+py-enum34               1.1.6_1     26 33
 py-envisage             4.4.0_1     26
 py-etsdevtools          4.0.2_1     26
 py-eventlet             0.22.0      26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -218,6 +218,7 @@ py-mitmproxy            0.10.1_2    26
 py-mlpy                 3.5.0_2     26 33
 py-mock                 1.0.1_1     25 26 31 32 33
 py-mongoengine          0.8.7_1     26
+py-montage              0.9.8_1     26 33
 py-mox                  0.5.1_1     26
 py-mpi4py               2.0.0_1     26 33
 py-mssql                2.1.0_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -58,6 +58,8 @@ py-awscli               1.14.63     34
 py-babel                2.5.3_1     26 33
 py-backcall             0.1.0_1     33
 py-backports-ssl        0.0.7_1     33
+py-backports-ssl_match_hostname \
+                        3.5.0.1_1   33
 py-backports.weakref    1.0.post1   34
 py-biggles              1.6.7_2     26
 py-bitarray             0.8.1_1     26 32 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -141,6 +141,7 @@ py-flup                 1.0.3.dev-20110405_1    26
 py-formalchemy          1.4.1_1     26
 py-fortranformat        0.2.3_1     26 33
 py-fuse                 0.2.1_4     26
+py-freeling             3.1_1       33
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26
 py-gdata                2.0.18_1    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -139,6 +139,7 @@ py-flask-frozen         0.9_1       26
 py-flask-uploads        0.1.3_1     26
 py-flup                 1.0.3.dev-20110405_1    26
 py-formalchemy          1.4.1_1     26
+py-fortranformat        0.2.3_1     26 33
 py-fuse                 0.2.1_4     26
 py-gda                  2.25.3_4    26
 py-gdal                 2.0.0_1     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -89,6 +89,7 @@ py-coverage             3.7.1_1     25 26 31 32 33
 py-cairo                1.10.0_4    26 33
 py-cairosvg             2.0.1       33
 py-colorama             0.3.7_1     26 33
+py-couchdb              0.9_1       26
 py-country              0.10_1      26
 py-cssutils             1.0.2_1     26
 py-curl                 7.19.0_2    26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -224,6 +224,7 @@ py-mpi4py               2.0.0_1     26 33
 py-msgpack              0.5.6_1     26 33
 py-mssql                2.1.0_1     26
 py-multipledispatch     0.5.0_1     33
+py-mustache             0.5.4_1     26 33
 py-mx-base              3.2.8_1     26
 py-mygpoclient          1.7_1       26
 py-mysql                1.2.3_2     26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -179,6 +179,7 @@ py-htmldocs             3.3.99      26 31 32 33
 py-http-parser          0.8.3_1     26 31 32 33
 py-id3lib               0.5.1_1     26
 py-idlsave              1.0.0_3     26
+py-igraph               0.7_1       26
 py-imagesize            1.0.0_1     26 33
 py-iniparse             0.4_1       26
 py-ipy                  0.81_1      25 26

--- a/python/py-hat-trie/Portfile
+++ b/python/py-hat-trie/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-hiredis/Portfile
+++ b/python/py-hiredis/Portfile
@@ -10,7 +10,7 @@ categories-append   devel databases
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-idlsave/Portfile
+++ b/python/py-idlsave/Portfile
@@ -27,7 +27,7 @@ checksums           md5  2b2d4d0cc69d12d327bff2a78bcb737d \
                     sha1  345a4f25b208c57be5996f4096061e86b8968284 \
                     rmd160  78e648439ca2eaab8a4e8529efca88e21dd25623
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_run-append  port:py${python.version}-numpy

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -9,7 +9,7 @@ categories-append   math
 platforms           darwin
 license             GPL-2+
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {snc @nerdling} openmaintainer
 

--- a/python/py-iso8601/Portfile
+++ b/python/py-iso8601/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-isodate/Portfile
+++ b/python/py-isodate/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 set base_name       isodate
 name                py-$base_name
 version             0.5.4
-python.versions     26 27 35 36
+python.versions     27 35 36
 
 license             BSD
 platforms           darwin

--- a/python/py-jug/Portfile
+++ b/python/py-jug/Portfile
@@ -9,7 +9,7 @@ revision            0
 platforms           darwin
 license             MIT
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-kivy/Portfile
+++ b/python/py-kivy/Portfile
@@ -9,7 +9,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     26 27 35 36
+python.versions     27 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-kyotocabinet/Portfile
+++ b/python/py-kyotocabinet/Portfile
@@ -23,8 +23,7 @@ distname            kyotocabinet-python-legacy-${version}
 checksums           rmd160  e73ace1daa317770cedd743346d7ba65170158d3 \
                     sha256  0139ac994ff041067965fcaac99e55ebbf7a268814e489877ac448364594197b
 
-python.default_version  27
-python.versions     26 27
+python.versions     27
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:kyotocabinet \

--- a/python/py-lepl/Portfile
+++ b/python/py-lepl/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  dc5bb15465e38d7748a440e644adbc3a2984a929 \
                     sha256  a8715c709308350ce4afed5d525682656886d38141387ec87d44421da8d41397
 
 python.default_version  27
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-lz4/Portfile
+++ b/python/py-lz4/Portfile
@@ -18,7 +18,7 @@ distname            lz4-${version}
 checksums           rmd160  77fde62ba95eb293912a389d7af85b92e9f98898 \
                     sha256  6bf49061d73d69c453e892ace4586b99ccffc7de558f921d18b9418235692ac7
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append        port:py${python.version}-setuptools

--- a/python/py-macfsevents/Portfile
+++ b/python/py-macfsevents/Portfile
@@ -9,7 +9,7 @@ revision            0
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-meta-devel/Portfile
+++ b/python/py-meta-devel/Portfile
@@ -13,7 +13,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-meta/Portfile
+++ b/python/py-meta/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27
+python.versions     27
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-milk/Portfile
+++ b/python/py-milk/Portfile
@@ -10,7 +10,7 @@ categories-append   science
 platforms           darwin
 license             MIT
 
-python.versions     26 27
+python.versions     27
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-minfx/Portfile
+++ b/python/py-minfx/Portfile
@@ -18,5 +18,4 @@ checksums           md5    30a919cc470c6128876644bc9d25d337 \
                     sha1   b99d7c2691d9d931e4859d78058e2b0897a4136c \
                     rmd160 d80fbf432e38eddc08dbcb8f2af128ca249ee323
 
-python.versions     26 27
-python.default_version 27
+python.versions     27

--- a/python/py-mlpy/Portfile
+++ b/python/py-mlpy/Portfile
@@ -31,7 +31,7 @@ distname            mlpy-${version}
 
 checksums           sha1    32f986f7f0f7cce5c773d2909d34705eab39df16
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-mongoengine/Portfile
+++ b/python/py-mongoengine/Portfile
@@ -21,7 +21,7 @@ long_description    \
 
 homepage            http://mongoengine.org/
 
-python.versions     26 27 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-montage/Portfile
+++ b/python/py-montage/Portfile
@@ -25,7 +25,7 @@ checksums           md5     f309653b9858e5cab5b1bdce3f152978 \
                     sha1    4ad4e086adb11313f7675ad39c24c2131c2ccd3b \
                     rmd160  7e1065df27b996df0e2773aca0fb59dd6d036ddc
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_run-append  port:py${python.version}-numpy \

--- a/python/py-msgpack/Portfile
+++ b/python/py-msgpack/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             Apache
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-multipledispatch/Portfile
+++ b/python/py-multipledispatch/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 33 34 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-mustache/Portfile
+++ b/python/py-mustache/Portfile
@@ -19,7 +19,7 @@ long_description    \
 checksums           rmd160  07b303af8cb3841fb1afb1bf73c625cf54b6fe94 \
                     sha256  f7bbc265fb957b4d6c7c042b336563179444ab313fb93a719759111eabd3b85a
 
-python.versions     26 27 33 34 35 36
+python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append   port:py${python.version}-setuptools

--- a/python/py-mutagen/Portfile
+++ b/python/py-mutagen/Portfile
@@ -25,7 +25,7 @@ homepage        http://mutagen.readthedocs.io
 master_sites    https://github.com/quodlibet/mutagen/releases/download/release-${version}/
 checksums           rmd160  f64ae253ecb783cd7c4f88e51feb95b817d9c315 \
                     sha256  dab6038c7f0e17c1b67fb8f56303e8be21e73ac47760f1a8e716856f1bdf5057
-python.versions 26 27 34 35 36 37
+python.versions 27 34 35 36 37
 
 if {${name} eq ${subport}} {
     livecheck.type		regex


### PR DESCRIPTION
#### Description
This PR contains a second round of housekeeping on various Python ports in the tree by removing obsolete py26/py33 subports.

In here is the first half of ports that (i) have a maintainer listed and (ii) have nothing depend on them. No other changes were made, so if a port doesn't build it should not be caused by this PR.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
In requested commits can be squashed, right now there is one commit per port.
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
