### PR TITLE
lmdbxx: Update to 0.9.14.1

### DIFF
--- a/databases/lmdbxx/Portfile
+++ b/databases/lmdbxx/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                lmdbxx
-version             0.9.14.0
-categories          databases
+github.setup        bendiken lmdbxx 0b43ca87
+#version is not a real release, made up
+version             0.9.14.0.1
+categories          databases devel
 platforms           darwin
 supported_archs     noarch
 license             public-domain
@@ -17,12 +19,10 @@ long_description    This is a comprehensive C++ wrapper for the LMDB embedded   
                     interface and an object-oriented resource interface with RAII \
                     semantics.
 
-homepage            http://lmdbxx.sourceforge.net/
-master_sites        sourceforge:project/${name}/${version}/
-use_xz              yes
+checksums           rmd160  68c36abcb3adb9fa50d0509c8c06e25a81cdb3d9 \
+sha256              a7958341d13280ca8400263e8373da50116e806c6ad4e9fa4beca82d9629df8c \
+size                47503
 
-checksums           rmd160  c5cc24adacd88cd080159b3da4b6599025dd6911 \
-                    sha256  29caf35dcd6962909be5a2d8147f85e65fe098030992f1ecdd902633dbcdcbde
 
 depends_lib         port:lmdb
 


### PR DESCRIPTION
#### Description

This creates more up-to-date version of the port `lmdbxx`. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A336e
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
