### PR TITLE
pymol: update to 2.2.0

### DIFF
--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 
+github.setup        schrodinger pymol-open-source 2.2.0 v
 name                pymol
-version             2.1.0
-revision            1
+
 categories          science chemistry
 license             PSF
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
@@ -18,13 +19,11 @@ long_description    PyMOL is a molecular graphics system with an embedded Python
 
 platforms           darwin
 
-homepage            http://www.pymol.org/
+homepage            https://www.pymol.org/
 
-master_sites        sourceforge
-fetch.type          svn
-svn.url             https://svn.code.sf.net/p/pymol/code/trunk/pymol
-svn.revision        4187
-worksrcdir          pymol
+checksums           rmd160  ef6e7e2d4556b2bcb2429f0c3e6b627e776ff164 \
+                    sha256  b3c251de111e8016c7cb79d81e0060091d634f63b46408ffec7c3a976b978a4e \
+                    size    10515229
 
 compilers.choose    cc cxx
 compilers.setup
@@ -51,6 +50,7 @@ depends_lib-append  port:freeglut \
                     port:glew \
                     port:libpng \
                     port:libGLU \
+                    port:glm \
                     port:mesa \
                     port:msgpack1 \
                     port:py${python.version}-numpy \
@@ -102,8 +102,3 @@ test.cmd            ${python.bin}
 test.target         run
 
 notes "Pymol can be started with the classic Tk GUI by appending the '-N pmg_tk' runtime option."
-
-livecheck.type  regex
-livecheck.url   ${svn.url}
-livecheck.version  ${svn.revision}
-livecheck.regex {Revision (\d+):}

--- a/science/pymol/files/setup.py.diff
+++ b/science/pymol/files/setup.py.diff
@@ -1,7 +1,5 @@
-Index: setup.py
-===================================================================
---- setup.py	(revision 4187)
-+++ setup.py	(working copy)
+--- setup.py.orig	2018-07-26 09:40:50.000000000 -0400
++++ setup.py	2018-07-26 09:46:35.000000000 -0400
 @@ -87,7 +87,7 @@
      X11 = ['/usr/X11'] * (not options.osx_frameworks)
  
@@ -11,19 +9,3 @@ Index: setup.py
              if sys.executable.startswith(prefix):
                  return [prefix] + X11
  
-@@ -392,12 +392,12 @@
-     libs += ["GLEW"]
-     libs += pyogl_libs
- 
--    ext_comp_args += ["-ffast-math", "-funroll-loops", "-fcommon"]
-+    ext_comp_args += ["-ffast-math", "-funroll-loops", "-fcommon", "-O3"]
- 
-     # optimization currently causes a clang segfault on OS X 10.9 when
-     # compiling layer2/RepCylBond.cpp
--    if sys.platform != 'darwin':
--        ext_comp_args += ["-O3"]
-+    if sys.platform == 'darwin':
-+        ext_comp_args += ["-fno-strict-aliasing"]
- 
- def get_pymol_version():
-     return re.findall(r'_PyMOL_VERSION "(.*)"', open('layer0/Version.h').read())[0]


### PR DESCRIPTION

#### Description
- update to version 2.2.0
- upstream switched to GitHub, do the same
- add checksums
- add new dependency on glm
- update homepage
- refresh patch for setup.py, most were included upstream

I don't completely understand where the dependencies on ```py-scipy``` and ```xdpyinfo``` originate from, but probably @jwhowarth knows. Also, it would be nice to eventually separate the Qt and Tk parts into variants, but I see how that is problematic for some of the plugins that still need Tk. On the other hand, these are legacy plugins and do not seem to work on Python 3 anyway.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
