### PR TITLE
wireguard-tools: update to 0.0.20180718, use SYSCONFDIR

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -9,7 +9,7 @@ name                wireguard-tools
 # the WireGuard repository and its updates primarily deals with the
 # Linux kernel module, which isn't useful or relevant for macOS (we're
 # just interested in its tools for manipulating WireGuard interfaces).
-version             0.0.20180620
+version             0.0.20180718
 categories          net
 platforms           darwin
 license             GPL-2
@@ -27,9 +27,9 @@ master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
 
-checksums           rmd160  fea2eea47173a33ea3c87e8862adc38dd46b7997 \
-                    sha256  b4db98ea751c8e667454f98ea1c15d704a784fe1bc093b03bd64575418a7c242 \
-                    size    270920
+checksums           rmd160  2bcde188d8531b54765e068732078d1fd4498662 \
+                    sha256  083c093a6948c8d38f92e7ea5533f9ff926019f24dc2612ea974851ed3e24705 \
+                    size    272072
 
 depends_run         port:bash \
                     port:wireguard-go
@@ -47,3 +47,10 @@ destroot.post_args-append PREFIX=${prefix} \
                     WITH_BASHCOMPLETION=yes \
                     WITH_SYSTEMDUNITS=no \
                     WITH_WGQUICK=yes
+
+post-destroot {
+    set completions_path ${prefix}/share/bash-completion/completions
+    set sysconfdir ${prefix}/etc
+    reinplace -E "s|^\(CONFIG_SEARCH_PATHS=.*\)\(/usr/local/etc\)|\\1${sysconfdir}|" ${destroot}${prefix}/bin/wg-quick
+    reinplace -E "s|\(search_paths\\+=.*\)\(/usr/local/etc\)|\\1${sysconfdir}|" ${destroot}${completions_path}/wg-quick
+}


### PR DESCRIPTION
#### Description

Update to 0.0.20180718.

Patch fixes `wg-quick` script and bash-completion file to look for configuration files in the directory set by `SYSCONFDIR` instead of the current hard-coded path `/usr/local/etc/wireguard`.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 10.11.6 15G21013
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
