### PR TITLE
py-spyder-devel: update to da167e4 (20180726)

### DIFF
--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -7,8 +7,8 @@ PortGroup           qt5 1.0
 PortGroup           active_variants 1.1
 PortGroup           select 1.0
 
-github.setup        spyder-ide spyder de337a2
-version             3.3.0-20180706
+github.setup        spyder-ide spyder da167e4
+version             3.3.0-20180726
 name                py-spyder-devel
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
@@ -39,9 +39,9 @@ supported_archs     noarch
 #pyNN-scipy doesn't build universal
 universal_variant   no
 
-checksums           rmd160  6cf4f26ec42c9c1d15878bf6d0163bb6a277a86c \
-                    sha256  370a4792d4481ad75f6230326e8158a8a469648a934043c4cc41ae932a762fc1 \
-                    size    4062528
+checksums           rmd160  26e47e045b13dab1fd2559d4f30e6675029f519e \
+                    sha256  81bc08608fb65f72bf98dc1c7f67e8bac51544506bde8a53c230945a927c39bf \
+                    size    4065227
 
 if {${name} ne ${subport}} {
     require_active_variants    py${python.version}-pyqt5 webengine

--- a/python/py-spyder-kernels-devel/Portfile
+++ b/python/py-spyder-kernels-devel/Portfile
@@ -42,4 +42,5 @@ if {${name} ne ${subport}} {
     livecheck.type      none
 } else {
     livecheck.type      pypi
+    livecheck.name      spyder-kernels
 }


### PR DESCRIPTION
#### Description
- update to the latest commit: da167e4 on 07/26/2018
- fix livecheck for py-spyder-kernels-devel

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
