### PR TITLE
Update pymol to 2.2.0 release

### DIFF
--- a/python/py-pmw/Portfile
+++ b/python/py-pmw/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  2a76186192f13eb22c373b3e0e60ce65cba506fe \
 
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-tkinter

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
+PortGroup           github 1.0
 
+github.setup        schrodinger pymol-open-source 2.2.0 v
 name                pymol
-version             2.2.0
 categories          science chemistry
 license             PSF
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
@@ -17,14 +18,12 @@ long_description    PyMOL is a molecular graphics system with an embedded Python
 
 platforms           darwin
 
-homepage            http://www.pymol.org/
+homepage            https://www.pymol.org/
 
-master_sites        sourceforge
-fetch.type          git
-git.url             https://github.com/schrodinger/pymol-open-source.git
-git.branch          d4685bd052d409b6a9381132093ad5c9cdada989
-worksrcdir          pymol
-
+checksums           rmd160  ef6e7e2d4556b2bcb2429f0c3e6b627e776ff164 \
+                    sha256  b3c251de111e8016c7cb79d81e0060091d634f63b46408ffec7c3a976b978a4e \
+                    size    10515229
+                                        
 compilers.choose    cc cxx
 compilers.setup
 
@@ -59,7 +58,6 @@ depends_lib-append  port:freeglut \
                     port:py${python.version}-numpy \
                     port:py${python.version}-pmw \
                     port:py${python.version}-pyqt5 \
-                    port:py${python.version}-scipy \
                     port:py${python.version}-tkinter \
                     port:tcl \
                     port:tk
@@ -106,4 +104,3 @@ test.target         run
 
 notes "Pymol can be started with the classic Tk GUI by appending the '-N pmg_tk' runtime option."
 
-livecheck.type none

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -6,8 +6,7 @@ PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 
 name                pymol
-version             2.1.0
-revision            1
+version             2.2.0
 categories          science chemistry
 license             PSF
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
@@ -21,18 +20,19 @@ platforms           darwin
 homepage            http://www.pymol.org/
 
 master_sites        sourceforge
-fetch.type          svn
-svn.url             https://svn.code.sf.net/p/pymol/code/trunk/pymol
-svn.revision        4187
+fetch.type          git
+git.url             https://github.com/schrodinger/pymol-open-source.git
+git.branch          d4685bd052d409b6a9381132093ad5c9cdada989
 worksrcdir          pymol
 
 compilers.choose    cc cxx
 compilers.setup
 
-variant python27 conflicts python34 python35 python36 description {Use Python 2.7} {}
-variant python34 conflicts python27 python35 python36 description {Use Python 3.4} {}
-variant python35 conflicts python27 python34 python36 description {Use Python 3.5} {}
-variant python36 conflicts python27 python34 python35 description {Use Python 3.6} {}
+variant python27 conflicts python34 python35 python36 python37 description {Use Python 2.7} {}
+variant python34 conflicts python27 python35 python36 python37 description {Use Python 3.4} {}
+variant python35 conflicts python27 python34 python36 python37 description {Use Python 3.5} {}
+variant python36 conflicts python27 python34 python35 python37 description {Use Python 3.6} {}
+variant python37 conflicts python27 python34 python35 python36 description {Use Python 3.7} {}
 
 if {[variant_isset python34]} {
     python.default_version 34
@@ -40,6 +40,8 @@ if {[variant_isset python34]} {
     python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
+} elseif {[variant_isset python37]} {
+    python.default_version 37
 } else {
     default_variants +python27
     python.default_version 27
@@ -49,6 +51,7 @@ python.link_binaries no
 depends_lib-append  port:freeglut \
                     port:freetype \
                     port:glew \
+                    port:glm \
                     port:libpng \
                     port:libGLU \
                     port:mesa \
@@ -103,7 +106,4 @@ test.target         run
 
 notes "Pymol can be started with the classic Tk GUI by appending the '-N pmg_tk' runtime option."
 
-livecheck.type  regex
-livecheck.url   ${svn.url}
-livecheck.version  ${svn.revision}
-livecheck.regex {Revision (\d+):}
+livecheck.type none

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -23,7 +23,7 @@ homepage            https://www.pymol.org/
 checksums           rmd160  ef6e7e2d4556b2bcb2429f0c3e6b627e776ff164 \
                     sha256  b3c251de111e8016c7cb79d81e0060091d634f63b46408ffec7c3a976b978a4e \
                     size    10515229
-                                        
+
 compilers.choose    cc cxx
 compilers.setup
 
@@ -103,4 +103,3 @@ test.cmd            ${python.bin}
 test.target         run
 
 notes "Pymol can be started with the classic Tk GUI by appending the '-N pmg_tk' runtime option."
-

--- a/science/pymol/files/setup.py.diff
+++ b/science/pymol/files/setup.py.diff
@@ -11,19 +11,3 @@ Index: setup.py
              if sys.executable.startswith(prefix):
                  return [prefix] + X11
  
-@@ -392,12 +392,12 @@
-     libs += ["GLEW"]
-     libs += pyogl_libs
- 
--    ext_comp_args += ["-ffast-math", "-funroll-loops", "-fcommon"]
-+    ext_comp_args += ["-ffast-math", "-funroll-loops", "-fcommon", "-O3"]
- 
-     # optimization currently causes a clang segfault on OS X 10.9 when
-     # compiling layer2/RepCylBond.cpp
--    if sys.platform != 'darwin':
--        ext_comp_args += ["-O3"]
-+    if sys.platform == 'darwin':
-+        ext_comp_args += ["-fno-strict-aliasing"]
- 
- def get_pymol_version():
-     return re.findall(r'_PyMOL_VERSION "(.*)"', open('layer0/Version.h').read())[0]


### PR DESCRIPTION
#### Description

The attached changes

1) Update both pymol and its py-pmw dependency to support the py37 variant
2) Switches pymol from svn to git as upstream has switched from svn to git
3) Updates pymol to the 2.2.0 release
4) Adds the new glm dependency required for pymol at the 2.2.0 release.
5) Removes the portion of the setup.py.diff patch present now upstream

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10L213o 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-poxrts/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->