### PR TITLE
Fix rookie mistakes in packer portfile

### DIFF
--- a/sysutils/packer/Portfile
+++ b/sysutils/packer/Portfile
@@ -7,7 +7,7 @@ github.setup        hashicorp packer 1.2.5 v
 
 categories          sysutils
 license             MPL-2
-maintainers         {newtonne @newtonne} openmaintainer
+maintainers         {gmail.com:newtonne.github @newtonne} openmaintainer
 platforms           darwin
 supported_archs     x86_64
 
@@ -44,6 +44,5 @@ build.env           GOPATH=${workpath}/${distname} \
 build.target        releasebin
 
 destroot {
-    xinstall -d ${destroot}${prefix}/bin
     xinstall -m 755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin/${name}
 }


### PR DESCRIPTION
- Add valid email address to maintainers field

- Remove line that creates ${destroot}${prefix}/bin as this directory
already exists in the default Macports hierarchy

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?