### PR TITLE
tesseract: require C++11, fix mtree violation, fix library name

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -4,8 +4,10 @@ PortSystem          1.0
 
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
 
 github.setup        tesseract-ocr tesseract 3.05.01
+revision            1
 categories          textproc graphics pdf
 platforms           darwin
 license             Apache-2
@@ -36,6 +38,9 @@ if {${name} eq ${subport}} {
                             port:jpeg
 
     cmake.out_of_source     yes
+
+    patchfiles              patch-fix-library-name.diff \
+                            patch-fix-mtree-violation-by-cmake-files.diff
 
     livecheck.regex         "/tag/(\[\.0-9\]+\[-a-z\]*)"
 } else {

--- a/textproc/tesseract/files/patch-fix-library-name.diff
+++ b/textproc/tesseract/files/patch-fix-library-name.diff
@@ -1,0 +1,19 @@
+commit 52cac3a42ef2b823b9367b9ee2d1d84f8eda4ea0
+Author: Clayton Walker <cwalker@sofi.org>
+Date:   Tue Aug 29 15:14:13 2017 -0600
+
+    Fix library being named liblibtesseract on non win32 platforms
+
+diff --git CMakeLists.txt CMakeLists.txt
+index 09e155ff..90aea1ee 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -227,6 +227,8 @@ set_target_properties           (libtesseract PROPERTIES SOVERSION ${VERSION_MAJ
+ if (WIN32)
+ set_target_properties           (libtesseract PROPERTIES OUTPUT_NAME tesseract${VERSION_MAJOR}${VERSION_MINOR})
+ set_target_properties           (libtesseract PROPERTIES DEBUG_OUTPUT_NAME tesseract${VERSION_MAJOR}${VERSION_MINOR}d)
++else()
++set_target_properties           (libtesseract PROPERTIES OUTPUT_NAME tesseract)
+ endif()
+ 
+ if (NOT CPPAN_BUILD)

--- a/textproc/tesseract/files/patch-fix-mtree-violation-by-cmake-files.diff
+++ b/textproc/tesseract/files/patch-fix-mtree-violation-by-cmake-files.diff
@@ -1,0 +1,18 @@
+diff --git CMakeLists.txt.orig CMakeLists.txt
+index 25ded3c..d7a2160 100644
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -261,11 +261,11 @@ configure_file(tesseract.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc @ONLY
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc DESTINATION lib/pkgconfig)
+ install(TARGETS tesseract RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+ install(TARGETS libtesseract EXPORT TesseractTargets RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+-install(EXPORT TesseractTargets DESTINATION cmake)
++install(EXPORT TesseractTargets DESTINATION lib/cmake/tesseract)
+ install(FILES
+     ${CMAKE_BINARY_DIR}/TesseractConfig.cmake
+     ${CMAKE_BINARY_DIR}/TesseractConfig-version.cmake
+-    DESTINATION cmake)
++    DESTINATION lib/cmake/tesseract)
+ 
+ install(FILES
+     # from api/makefile.am


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

and

macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
