### PR TITLE
New port: lynis

### DIFF
--- a/security/lynis/Portfile
+++ b/security/lynis/Portfile
@@ -9,7 +9,7 @@ categories          security
 license             GPL-3
 maintainers         {gmail.com:newtonne.github @newtonne} openmaintainer
 platforms           darwin
-supported_archs     x86_64
+supported_archs     noarch
 
 description         Security and system auditing tool to harden systems
 
@@ -23,7 +23,6 @@ long_description    Lynis is a battle-tested security tool for systems running \
 homepage            https://cisofy.com/lynis/
 
 master_sites        https://downloads.cisofy.com/${name}
-distname            ${name}-${version}
 
 checksums           rmd160 4dba3f3d3bd5038a139ec3428340ff97bd3c1d6e \
                     sha256 6b254cf2975eed6db9c39960e7c07e8ff4ddf61f974274980aa62a74745020e4 \
@@ -36,12 +35,11 @@ worksrcdir          ${name}
 # Package is a shell script
 build {}
 
-set target_dir ${prefix}/libexec/${name}
+set target_dir ${prefix}/etc/${name}
 
 pre-destroot {
-    reinplace "s|/usr/local/lynis|${target_dir}|g" \
-        ${worksrcpath}/lynis
-    reinplace "s|/usr/local/lynis|${target_dir}|g" \
+    reinplace -E "s|(t.+_TARGETS=)\".+\"|\\1\"${target_dir}\"|g" \
+        ${worksrcpath}/lynis \
         ${worksrcpath}/include/functions
 }
 

--- a/security/lynis/Portfile
+++ b/security/lynis/Portfile
@@ -1,0 +1,61 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                lynis
+version             2.6.6
+
+categories          security
+license             GPL-3
+maintainers         {gmail.com:newtonne.github @newtonne} openmaintainer
+platforms           darwin
+supported_archs     x86_64
+
+description         Security and system auditing tool to harden systems
+
+long_description    Lynis is a battle-tested security tool for systems running \
+                    Linux, macOS, or Unix-based operating system. \
+                    It performs an extensive health scan of your systems to \
+                    support system hardening and compliance testing. The \
+                    project is open source software with the GPL license and \
+                    available since 2007.
+
+homepage            https://cisofy.com/lynis/
+
+master_sites        https://downloads.cisofy.com/${name}
+distname            ${name}-${version}
+
+checksums           rmd160 4dba3f3d3bd5038a139ec3428340ff97bd3c1d6e \
+                    sha256 6b254cf2975eed6db9c39960e7c07e8ff4ddf61f974274980aa62a74745020e4 \
+                    size   274658
+
+use_configure       no
+
+worksrcdir          ${name}
+
+# Package is a shell script
+build {}
+
+set target_dir ${prefix}/libexec/${name}
+
+pre-destroot {
+    reinplace "s|/usr/local/lynis|${target_dir}|g" \
+        ${worksrcpath}/lynis
+    reinplace "s|/usr/local/lynis|${target_dir}|g" \
+        ${worksrcpath}/include/functions
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -d ${destroot}${target_dir}
+    file copy ${worksrcpath}/db \
+              ${worksrcpath}/include \
+              ${worksrcpath}/plugins \
+              {*}[glob ${worksrcpath}/*.prf] \
+        ${destroot}${target_dir}
+    xinstall ${worksrcpath}/${name}.8 ${destroot}${prefix}/share/man/man8
+}
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     >${name}-(\\d+(\\.\\d+)+)${extract.suffix}<


### PR DESCRIPTION
- lynis is a security and system auditing tool to harden systems

- It's a shell script, but can be (and is) delivered as a package on
many *nix systems

- The script reads extra configuration which is included in the tarball.
I've put this in ${prefix}/libexec/lynis as this seemed like the best
place for it. Let me know if it should go elsewhere.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->