### PR TITLE
py-jedi: update to 0.12.1

### DIFF
--- a/python/py-jedi/Portfile
+++ b/python/py-jedi/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jedi
-version             0.12.0
-revision            0
+version             0.12.1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -23,8 +22,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  b8b5608be9f2bb6bdf38c05f31020bd6be843df3 \
-                    sha256  1972f694c6bc66a2fac8718299e2ab73011d653a6d8059790c3476d2353b99ad
+checksums           rmd160  2512abe6a9241735ed12db01fa25369fb57edb2d \
+                    sha256  b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1 \
+                    size    361831
 
 if {${name} ne ${subport}} {
     # setuptools is mandatory due to 'include_package_data' option

--- a/python/py-parso/Portfile
+++ b/python/py-parso/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        davidhalter parso 0.2.1 v
+github.setup        davidhalter parso 0.3.1 v
 
 name                py-parso
 categories-append   devel
@@ -12,20 +12,26 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         A Python Parser
 long_description    ${description}
 
-checksums           rmd160  85b916a88ba0acf78830d6bc91e01285f401c55b \
-                    sha256  d2912fee727aa14059904860ed5202338c9fda1875e59076434c2331d74806fd \
-                    size    376606
+checksums           rmd160  3db05ee6b98d8521751f13e809554abcd470d614 \
+                    sha256  b4aa1ce85e212a521cadb436d1464c101032694aee18801a3642bd4db5c2226f \
+                    size    375267
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
+
+    depends_test-append \
+                        port:py${python.version}-pytest
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update py-jedi  to latest version, 0.12.1 (does not yet support py37)
- update its dependency (py-parso) also to the latest version, add py37 and enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? [only py-parso has tests enabled]
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
