### PR TITLE
Add py37 subport to several packages, to be able to use py37-requests-oauthlib

### DIFF
--- a/python/py-asn1crypto/Portfile
+++ b/python/py-asn1crypto/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-blinker/Portfile
+++ b/python/py-blinker/Portfile
@@ -24,7 +24,7 @@ checksums           md5     8b3722381f83c2813c52de3016b68d33 \
                     sha256  471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6 \
                     rmd160  54a649ae37e54924ebfe75149c3d19b0d25aa1a4
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     livecheck.type  none

--- a/python/py-cffi/Portfile
+++ b/python/py-cffi/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -11,7 +11,7 @@ categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jwt/Portfile
+++ b/python/py-jwt/Portfile
@@ -25,7 +25,7 @@ checksums           md5     739494379f582ca98c89fb7ac229915b \
                     rmd160  276a1f712de978422ad64772abd3d3e55a07186c \
                     sha256  500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \

--- a/python/py-oauthlib/Portfile
+++ b/python/py-oauthlib/Portfile
@@ -26,7 +26,7 @@ checksums           md5     02772867bf246b3b37f4ed22786c41f5 \
                     rmd160  07c48a5947b47d4511428c690452569f2191cc11 \
                     sha256  ef4bfe4663ca3b97a995860c0173b967ebd98033d02f38c9e1b2cbb6c191d9ad
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-pycparser/Portfile
+++ b/python/py-pycparser/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-requests-oauthlib/Portfile
+++ b/python/py-requests-oauthlib/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  68b6809fc06529853d8af28198a5edf1d5ad6fb6 \
                     sha256  30a058af913da9b2f8faea8edcda4e116b422a537004d462dd8eac3765012699 \
                     size    43190
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Portfile updates to add a py37 subport to packages depended on by py-requests-oauthlib, to be able to use this with py37.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 