### PR TITLE
lynis: Fix 56891 and add bash completion.

### DIFF
--- a/security/lynis/Portfile
+++ b/security/lynis/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                lynis
 version             2.6.6
+revision            1
 
 categories          security
 license             GPL-3
@@ -38,20 +39,31 @@ build {}
 set target_dir ${prefix}/etc/${name}
 
 pre-destroot {
-    reinplace -E "s|(t.+_TARGETS=)\".+\"|\\1\"${target_dir}\"|g" \
+    reinplace -E "s|(t.+_TARGETS=)\".+ \.(.*)\"|\\1\"${target_dir}\\2\"|g" \
         ${worksrcpath}/lynis \
         ${worksrcpath}/include/functions
 }
 
 destroot {
+    # Main binary
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+
+    # Additional config
     xinstall -d ${destroot}${target_dir}
     file copy ${worksrcpath}/db \
               ${worksrcpath}/include \
               ${worksrcpath}/plugins \
               {*}[glob ${worksrcpath}/*.prf] \
         ${destroot}${target_dir}
+
+    # Man page
     xinstall ${worksrcpath}/${name}.8 ${destroot}${prefix}/share/man/man8
+
+    # Bash completion
+    set completions_path ${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${completions_path}
+    xinstall -m 644 ${worksrcpath}/extras/bash_completion.d/${name} \
+        ${destroot}${completions_path}
 }
 
 livecheck.type      regex


### PR DESCRIPTION
- https://trac.macports.org/ticket/56891 was caused by the reinplace
regex being incorrect. I've now fixed this so that the
${prefix}/etc/${name} paths are correct. What's more, I recently learnt
that the ${prefix}/etc/${name} directory will get wiped on upgrade and
uninstallation, so I've now kept all the other paths so that they take
precedence over files in ${prefix}/etc/${name}, and added a note to
urge users not to store their custom files there.

- Also, just realised that they include a bash completion file so I've
installed that now too.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->