### PR TITLE
py-opengl, py-opengl-accelerate: add py37 subport

### DIFF
--- a/python/py-opengl-accelerate/Portfile
+++ b/python/py-opengl-accelerate/Portfile
@@ -20,9 +20,15 @@ checksums           md5 489338a4818fa63ea54ff3de1b48995c \
                     rmd160 7d353f43a341fbc34ed580076b8555bae60cc4d5 \
                     sha256 927f4670b893d46e2f6273ae938bf0a1db27ffae3336eba94813ccef6260c410
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-numpy
+    depends_build-append port:py${python.version}-cython
+    patchfiles      patch-use-cython.diff
+    post-patch {
+        delete {*}[glob ${worksrcpath}/src/*.c]
+    }
 }
+
 livecheck.type  none

--- a/python/py-opengl-accelerate/files/patch-use-cython.diff
+++ b/python/py-opengl-accelerate/files/patch-use-cython.diff
@@ -1,0 +1,61 @@
+--- setup.py     2014-06-27 09:47:37.000000000 -0500
++++ setup.py 2018-07-17 20:31:51.000000000 -0500
+@@ -18,7 +18,7 @@
+
+ version = None
+ # get version from __init__.py
+-for line in open( os.path.join( HERE,'__init__.py') ):
++for line in open( os.path.join( HERE,'OpenGL_accelerate','__init__.py') ):
+     if line.startswith( '__version__' ):
+         version = eval(line.split( '=' )[1].strip())
+ assert version, """Couldn't determine version string!"""
+@@ -138,7 +138,7 @@
+             },
+         },
+         package_dir = {
+-            'OpenGL_accelerate':'.',
++            'OpenGL_accelerate':'OpenGL_accelerate',
+         },
+         ext_modules=extensions,
+         **extraArguments
+--- OpenGL_accelerate/__init__.py        1969-12-31 18:00:00.000000000 -0600
++++ OpenGL_accelerate/__init__.py    2018-07-17 20:31:51.000000000 -0500
+@@ -0,0 +1,10 @@
++"""Cython-coded accelerators for the PyOpenGL wrapper
++
++This package contains Cython accelerator modules which
++attempt to speed up certain aspects of the PyOpenGL 3.x
++wrapper mechanism.  The source code is part of the
++PyOpenGL package and is built via the setupaccel.py
++script in the top level of the PyOpenGL source package.
++"""
++__version__ = '3.1.0'
++__version_tuple__ = (3,1,0)
+--- OpenGL_accelerate/formathandler.pxd	1969-12-31 18:00:00.000000000 -0600
++++ OpenGL_accelerate/formathandler.pxd	2018-07-17 20:31:51.000000000 -0500
+@@ -0,0 +1,13 @@
++"""Cython import description for formathandler types"""
++
++cdef class FormatHandler:
++	cdef public int ERROR_ON_COPY
++	cdef object c_from_param( self, object instance, object typeCode)
++	cdef object c_dataPointer( self, object instance )
++	cdef c_zeros( self, object dims, object typeCode )
++	cdef c_arraySize( self, object instance, object typeCode )
++	cdef c_arrayByteCount( self, object instance )
++	cdef c_arrayToGLType( self, object value )
++	cdef c_asArray( self, object instance, object typeCode)
++	cdef c_unitSize( self, object instance, typeCode )
++	cdef c_dimensions( self, object instance)
+--- OpenGL_accelerate/wrapper.pxd	1969-12-31 18:00:00.000000000 -0600
++++ OpenGL_accelerate/wrapper.pxd	2018-07-17 20:31:51.000000000 -0500
+@@ -0,0 +1,9 @@
++"""Importable Cython declarations for wrapper module"""
++cdef class cArgConverter:
++	cdef object c_call( self, tuple pyArgs, int index, object baseOperation )
++cdef class pyArgConverter:
++	cdef object c_call( self, object incoming, object function, tuple arguments )
++cdef class cArgumentConverter:
++	cdef object c_call( self, object incoming )
++cdef class returnConverter:
++	cdef object c_call( self, object result, object baseOperation, tuple pyArgs, tuple cArgs )

--- a/python/py-opengl/Portfile
+++ b/python/py-opengl/Portfile
@@ -24,7 +24,7 @@ checksums           md5    0de021941018d46d91e5a8c11c071693 \
                     rmd160 75728a3b53e62a41e634037c4f00efd4ba1ee67b \
                     sha256 9b47c5c3a094fa518ca88aeed35ae75834d53e4285512c61879f67a48c94ddaf
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 if {$subport ne $name} {
     depends_build   port:py${python.version}-setuptools


### PR DESCRIPTION
The pre-generated *.c files in py-opengl-accelerate don't work with
python 3.7. They can easily be generated with cython. The patch adds
files from the repository that are missing from the source
distribution that are needed for this.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2208
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
