### PR TITLE
devel/boost: add python37 variant, small patch update for python37

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -182,7 +182,7 @@ post-destroot {
     }
 }
 
-set pythons_suffixes {26 27 33 34 35 36}
+set pythons_suffixes {26 27 33 34 35 36 37}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {

--- a/devel/boost/files/patch-boost-python3.diff
+++ b/devel/boost/files/patch-boost-python3.diff
@@ -19,3 +19,24 @@
  else:
 -    import mpi
 +    from . import mpi
+ 
+--- libs/python/src/converter/builtin_converters.cpp.orig
++++ libs/python/src/converter/builtin_converters.cpp
+@@ -45,11 +45,16 @@
+   {
+       return PyString_Check(obj) ? PyString_AsString(obj) : 0;
+   }
+-#else
++#elif PY_VERSION_HEX < 0x03070000
+   void* convert_to_cstring(PyObject* obj)
+   {
+       return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
+   }
++#else
++  void* convert_to_cstring(PyObject* obj)
++  {
++      return PyUnicode_Check(obj) ? const_cast<void*>(reinterpret_cast<const void*>(_PyUnicode_AsString(obj))) : 0;
++  }
+ #endif
+
+   // Given a target type and a SlotPolicy describing how to perform a


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
This is revised version of PR #2154 that now uses the upstream fix for python 3.7 (https://github.com/boostorg/python/commit/660487c43fde76f3e64f1cb2e644500da92fe582).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2208
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
