### PR TITLE
Update dbcli related software. Add python37 support.

### DIFF
--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli mycli 1.16.0 v
+github.setup        dbcli mycli 1.17.0 v
 
 categories          databases python
 maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -16,13 +16,15 @@ long_description    ${description}
 
 homepage            http://mycli.net
 
-checksums           rmd160  baed20c0ef502c73b66e436c3f5d7604666949c3 \
-                    sha256  76e1ba3bca1bcda5c958c89a5e35e587f69fefab7ada00fbccdcdd5d7c5424af
+checksums           rmd160  60e893719fe8a4182bd05426966637889cf29fa2 \
+                    sha256  ed4ca1b595a5b0d319f9743277c34039d7ab5440d042e8bfa22304b89ee0d5f9 \
+                    size    276803
 
-variant python27 conflicts python34 python35 python36 description "Use Python 2.7" {}
-variant python34 conflicts python27 python35 python36 description "Use Python 3.4" {}
-variant python35 conflicts python27 python34 python36 description "Use Python 3.5" {}
-variant python36 conflicts python27 python34 python35 description "Use Python 3.6" {}
+variant python27 conflicts python34 python35 python36 python37 description "Use Python 2.7" {}
+variant python34 conflicts python27 python35 python36 python37 description "Use Python 3.4" {}
+variant python35 conflicts python27 python34 python36 python37 description "Use Python 3.5" {}
+variant python36 conflicts python27 python34 python35 python37 description "Use Python 3.6" {}
+variant python37 conflicts python27 python34 python35 python36 description "Use Python 3.7" {}
 
 if {[variant_isset python34]} {
     python.default_version 34
@@ -30,6 +32,8 @@ if {[variant_isset python34]} {
     python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
+} elseif {[variant_isset python37]} {
+    python.default_version 37
 } else {
     default_variants +python27
     python.default_version 27

--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli pgcli 1.9.1 v
+github.setup        dbcli pgcli 1.10.3 v
 
 categories          databases python
 maintainers         {g5pw @g5pw} {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -16,13 +16,15 @@ long_description    ${description}
 
 homepage            http://pgcli.com
 
-checksums           rmd160  922f2cf729ab173edef221f39005d9e2d4d1c81c \
-                    sha256  e42291b45e762176218e2e937e7d1603f6f8eb32d17fd97907bb625d003e93dd
+checksums           rmd160  61fbaba17dd699f0fa0faf1a042a4525c7dead23 \
+                    sha256  75a5012a43462bf12d48baeb6bf25378dc117f9380af837112c3cf95fd945ee3 \
+                    size    428744
 
-variant python27 conflicts python34 python35 python36 description "Use Python 2.7" {}
-variant python34 conflicts python27 python35 python36 description "Use Python 3.4" {}
-variant python35 conflicts python27 python34 python36 description "Use Python 3.5" {}
-variant python36 conflicts python27 python34 python35 description "Use Python 3.6" {}
+variant python27 conflicts python34 python35 python36 python37 description "Use Python 2.7" {}
+variant python34 conflicts python27 python35 python36 python37 description "Use Python 3.4" {}
+variant python35 conflicts python27 python34 python36 python37 description "Use Python 3.5" {}
+variant python36 conflicts python27 python34 python35 python37 description "Use Python 3.6" {}
+variant python37 conflicts python27 python34 python35 python36 description "Use Python 3.7" {}
 
 if {[variant_isset python34]} {
     python.default_version 34
@@ -30,6 +32,8 @@ if {[variant_isset python34]} {
     python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
+} elseif {[variant_isset python37]} {
+    python.default_version 37
 } else {
     default_variants +python27
     python.default_version 27

--- a/python/py-cli-helpers/Portfile
+++ b/python/py-cli-helpers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cli-helpers
-version             1.0.1
+version             1.0.2
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -14,14 +14,15 @@ long_description    CLI Helpers is a Python package that makes it easy \
                     to perform common tasks when building command-line apps. \
                     It’s a helper library for command-line interfaces.
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            cli_helpers-${version}
 
-checksums           rmd160  d9a431a99f9a605bab1837d385c5cf7d41549d0a \
-                    sha256  55353117960700dfbe000a71cda0bad1ac865e3a9999f1fa81047fa9e1322d42
+checksums           rmd160  4e1f6bb54c161a0a4eb7dc9e27eb574470e2749c \
+                    sha256  f77837c5fbcbea39e0cb782506515459a0da75465489bae35e46da7f51c5b9fc \
+                    size    23557
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-configobj/Portfile
+++ b/python/py-configobj/Portfile
@@ -17,14 +17,15 @@ long_description    ConfigObj is a simple but powerful config file \
                     with a straightforward programmer's interface and \
                     a simple syntax for config files.
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/configobj/
 master_sites        pypi:c/configobj/
 distname            configobj-${version}
 
 checksums           rmd160  9b7dd0b9e08477914da104585369921c549eec01 \
-                    sha256  a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902
+                    sha256  a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902 \
+                    size    33248
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-humanize/Portfile
+++ b/python/py-humanize/Portfile
@@ -12,15 +12,15 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Python humanize utilities
 long_description    ${description}
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            humanize-${version}
 
-checksums           md5     e8473d9dc1b220911cac2edd53b1d973 \
-                    rmd160  7c5a7c9c5ac28eb29b04e80e83506e14bf46f811 \
-                    sha256  a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19
+checksums           rmd160  7c5a7c9c5ac28eb29b04e80e83506e14bf46f811 \
+                    sha256  a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19 \
+                    size    14250
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pgspecial/Portfile
+++ b/python/py-pgspecial/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pgspecial
-version             1.10.0
+version             1.11.2
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -13,15 +13,15 @@ description         Meta-commands handler for Postgres Database
 long_description    This package provides an API to execute meta-commands \
                     (AKA “special”, or “backslash commands”) on PostgreSQL.
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     6e617cb1915f414d6ecdc075d77d5f87 \
-                    rmd160  ba666f257b7f54c1bb2be05b91e9c41f10fc1c5b \
-                    sha256  eadb0108cdbcf8b38a69bcc9e403b352dbd6d30622e417f48e659180150ee1b6
+checksums           rmd160  35f6e53c5faa0a3d8da4d18ef5e96216f3ebf258 \
+                    sha256  60e81ed02c3a2d43a4eb70d5bbdeea7b0c5244580d3017edf89a6fd66e6503fb \
+                    size    60446
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-prompt_toolkit
-version             1.0.14
+version             1.0.15
 license             Permissive
 platforms           darwin
 supported_archs     noarch
@@ -12,14 +12,15 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Library for building powerful interactive command lines in Python
 long_description    ${description}
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  c0c4aa0c917981767d45abf76fdff00c0fb9aa8d \
-                    sha256  cc66413b1b4b17021675d9f2d15d57e640b06ddfd99bb724c73484126d22622f
+checksums           rmd160  195e01e80e62e631f7c4b12d4f2cd5d4481a0752 \
+                    sha256  858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917 \
+                    size    243734
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-psycopg2/Portfile
+++ b/python/py-psycopg2/Portfile
@@ -18,7 +18,7 @@ long_description    Psycopg2 is a postgresql database adapter for python. \
                     designed for heavily multi-threaded applications \
                     featuring connection pooling.
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            http://initd.org/psycopg/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
@@ -26,7 +26,8 @@ distname            ${python.rootname}-${version}
 
 checksums           md5     9e7d6f695fc7f8d1c42a7905449246c9 \
                     rmd160  da723cedd2b1000b6af489cb4a9c614776d4dddc \
-                    sha256  eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e
+                    sha256  eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e \
+                    size    426358
 
 if {${name} ne ${subport}} {
     depends_lib-append  path:lib/libssl.dylib:openssl

--- a/python/py-pymysql/Portfile
+++ b/python/py-pymysql/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pymysql
-version             0.8.0
+version             0.9.2
 license             MIT
 platforms           darwin
 supported_archs     noarch
@@ -12,14 +12,15 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Pure-Python MySQL client library
 long_description    ${description}
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            PyMySQL-${version}
 
-checksums           rmd160  6bb48cc4b0028666b94bfedb36f3841bb9f34a10 \
-                    sha256  32da4a66397077d42908e449688f2ec71c2b18892a6cd04f03ab2aa828a70f40
+checksums           rmd160  6c5c1015e61591e59927b4b8588acf274b6e6edd \
+                    sha256  9ec760cbb251c158c19d6c88c17ca00a8632bac713890e465b2be01fdc30713f \
+                    size    74532
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-setproctitle/Portfile
+++ b/python/py-setproctitle/Portfile
@@ -13,15 +13,15 @@ description         A Python module to customize the process title
 long_description    The setproctitle module allows a process to change \
                     its title (as displayed by system tools such as ps and top).
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     2dcdd1b761700a5a13252fea3dfd1977 \
-                    rmd160  c2a6c024fcd7d30f6d2f3ead2b021821a5ecaa34 \
-                    sha256  6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398
+checksums           rmd160  c2a6c024fcd7d30f6d2f3ead2b021821a5ecaa34 \
+                    sha256  6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398 \
+                    size    24042
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sqlparse/Portfile
+++ b/python/py-sqlparse/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-sqlparse
-version             0.2.2
+version             0.2.4
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -13,7 +13,7 @@ description         Non-validating SQL parser
 long_description    ${description} that provides support for parsing, splitting \
                     and formatting SQL statements.
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 categories-append   textproc
 
@@ -21,8 +21,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  6264e56cbfdca0273b11c0f6a3334891ac9c574b \
-                    sha256  d446296b2c26f9466860dd85fa32480bec523ab96bda8879262c38e8e8fbba21
+checksums           rmd160  cbc1000e0fea6334d1981e6b5bee1d9dd95b8102 \
+                    sha256  ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec \
+                    size    61614
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-tabulate/Portfile
+++ b/python/py-tabulate/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,7 +24,8 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  3d9ac75ebe95d6be225ad2300fd862c794913c8d \
-                    sha256  e4ca13f26d0a6be2a2915428dc21e732f1e44dad7f76d7030b2ef1ec251cf7f2
+                    sha256  e4ca13f26d0a6be2a2915428dc21e732f1e44dad7f76d7030b2ef1ec251cf7f2 \
+                    size    45758
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools

--- a/python/py-terminaltables/Portfile
+++ b/python/py-terminaltables/Portfile
@@ -13,14 +13,15 @@ description         Generate simple tables in terminals from a nested list of st
 long_description    Easily draw tables in terminal/console applications from \
                     a list of lists of strings. Supports multi-line rows.
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  3978da76ff2bc1fec403cc29f36427834151305b \
-                    sha256  f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81
+                    sha256  f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81 \
+                    size    12478
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-wcwidth/Portfile
+++ b/python/py-wcwidth/Portfile
@@ -12,14 +12,15 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Library for building powerful interactive command lines in Python
 long_description    ${description}
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  11891327c61ce243072d1bfc1fdd589037d4c113 \
-                    sha256  3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e
+                    sha256  3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e \
+                    size    22884
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

* mycli: 1.17.0
* pgcli: 1.10.3
* py-cli-helpers: 1.0.2
* py-pgspecial: 1.11.2
* py-prompt_toolkit: 1.0.15
* py-pymysql: 0.9.2 (closes https://trac.macports.org/ticket/56902)
* py-sqlparse: 0.2.4

###### Type(s)

- [x] update
- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 9.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?