### PR TITLE
PyPy support for pip & setuptools, using the PortGroup

### DIFF
--- a/python/py-pip/Portfile
+++ b/python/py-pip/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     26 27 33 34 35 36 37
+python.versions     pypy pypy3 26 27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -33,7 +33,7 @@ checksums           rmd160  ccb38f5c23bbf1d8c583f25565af5b614772ca94 \
                     size    1249656
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools
+    depends_lib-append  port:${python.group}-setuptools
     depends_run         port:pip_select
 
     if {[lsearch {26} ${python.version}] != -1} {
@@ -59,12 +59,18 @@ if {${name} ne ${subport}} {
         xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}/reference
         xinstall -m 644 {*}[glob -types f ${worksrcpath}/docs/reference/*] ${destroot}${prefix}/share/doc/${subport}/reference
 
-        delete ${destroot}${prefix}/bin/pip[string range ${python.version} 0 end-1]-${python.branch}
-        delete ${destroot}${prefix}/bin/pip${python.branch}-${python.branch}
+        delete ${destroot}${prefix}/bin/pip[string range ${python.language_version} 0 0]-${python.branch}
+        delete ${destroot}${prefix}/bin/pip${python.language_version}-${python.branch}
     }
 
     select.group        ${python.rootname}
-    select.file         ${filespath}/${python.rootname}${python.version}
+
+    # use different naming conventions to avoid ugliness like `pippy3` :(
+    if {[string match pypy* ${python.group}]} {
+        select.file         ${filespath}/${subport}
+    } else {
+        select.file         ${filespath}/${python.rootname}${python.version}
+    }
 
     notes "
     To make the Python ${python.branch} version of pip the one that is run\

--- a/python/py-pip/files/pypy-pip
+++ b/python/py-pip/files/pypy-pip
@@ -1,0 +1,1 @@
+lib/pypy/bin/pip

--- a/python/py-pip/files/pypy3-pip
+++ b/python/py-pip/files/pypy3-pip
@@ -1,0 +1,1 @@
+lib/pypy3/bin/pip

--- a/python/py-setuptools/Portfile
+++ b/python/py-setuptools/Portfile
@@ -29,7 +29,7 @@ use_zip             yes
 checksums           rmd160 1469a5e097c197e725df125456cb47e9ca6582ce \
                     sha256 012adb8e25fbfd64c652e99e7bab58799a3aaf05d39ab38561f69190a909015f
 
-python.versions     26 27 33 34 35 36 37
+python.versions     pypy pypy3 26 27 33 34 35 36 37
 python.link_binaries no
 
 if {$subport ne $name} {


### PR DESCRIPTION
#### Description

This pull request adds support for installing `pip` and `setuptools` for PyPy. 

PyPy doesn't conform to the regular directory layout, and furthermore the strings "pypy" and "pypy3" don't conform to the previous "pyNN" prefix. In addition, `distutils` just uses the Python language version for binaries, which will now be different from the port version.

To simplify things, I added a few new variables:
* `${python.group}` corresponds to the port prefix
* `${python.language_version}` corresponds to `python.branch`, except in
  PyPy.

The select groups for `pip` use a slightly different stile that the preexisting options such as `pip27`, given that both `pippy` and `pippypy` are horribly ugly. The change uses `pypy-pip` instead:

```console
$ port select --list pip
Available versions for pip:
	none
	pip27
	pip35
	pip36
	pip37
	pypy3-pip (active)
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix