### PR TITLE
yelp: remove libstdc++ peg

### DIFF
--- a/gnome/yelp/Portfile
+++ b/gnome/yelp/Portfile
@@ -37,7 +37,8 @@ depends_lib         port:desktop-file-utils \
                     port:sqlite3 \
                     port:xz \
                     port:bzip2 \
-                    port:yelp-xsl
+                    port:yelp-xsl \
+                    path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
 
 #
 # if yelp is invoked without a URI argument
@@ -69,16 +70,4 @@ post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
 }
 
-platform darwin {
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-        # version 3.17.3+ requires webkit2gtk-4.0 >= 2.7.1
-        version             3.17.2
-        checksums           rmd160  38ef9ea1773b01a4407808be798cc9752457b9ff \
-                            sha256  0626f7a954d7969e058474a9d5e05977eb886703c76aaba7a48cb7cd236fcd27
-        depends_lib-append  path:lib/pkgconfig/webkitgtk-3.0.pc:webkit-gtk3-2.0
-        livecheck.type      none
-    } else {
-        depends_lib-append  path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
-        livecheck.type      gnome
-    }
-}
+livecheck.type      gnome


### PR DESCRIPTION
brings all systems up to the same yelp version
closes: https://trac.macports.org/ticket/56914
closes: https://trac.macports.org/ticket/54852

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
