### PR TITLE
gnucash: force use of python 3.6, remove peg for webkit-gtk3-2.0 on libstdc++, and add PortGroup cxx11 1.1

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -108,6 +108,10 @@ configure.args    -DENABLE_BINRELOC=OFF \
                   -DWITH_PYTHON=ON
 configure.perl    ${perl5.bin}
 
+# force use of the requested python 3.6
+configure.args-append -DPYTHON_EXECUTABLE:FILEPATH=${prefix}/bin/python3.6
+configure.args-append -DPYTHON_INCLUDE_DIR:PATH=${frameworks_dir}/Python.framework/Versions/3.6/include/python3.6m
+configure.args-append -DPYTHON_LIBRARY:FILEPATH=${frameworks_dir}/Python.framework/Versions/3.6/lib/libpython3.6.dylib
 
 post-destroot {
     file delete ${destroot}${prefix}/lib/libgwengui-gtk3.dylib

--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -93,13 +93,6 @@ if {![variant_isset quartz]} {
     depends_run-append port:yelp
 }
 
-platform darwin {
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-       depends_lib-delete path:${prefix}/libpkgconfig/webkitgtk-3.0.pc:webkit-gtk3
-       depends_lib-append path:${prefix}/libpkgconfig/webkitgtk-3.0.pc:webkit-gtk3-2.0
-    }
-}
-
 # aqbanking is not universal
 universal_variant no
 

--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -3,6 +3,7 @@
 PortSystem        1.0
 PortGroup         perl5 1.0
 PortGroup         cmake 1.1
+PortGroup         cxx11 1.1
 
 name              gnucash
 conflicts         gnucash gnucash-devel


### PR DESCRIPTION
python 3.6 was previously listed as a build dep,
but was not actually used in many cases. This
commit forces the use of python 3.6 during the build.

closes: https://trac.macports.org/ticket/56538
PS: @horasio: I'll share that beer with drkp :>

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
