### PR TITLE
git-crypt: use cxx11 1.1 PortGroup

### DIFF
--- a/devel/git-crypt/Portfile
+++ b/devel/git-crypt/Portfile
@@ -2,8 +2,10 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               cxx11 1.1
 
 github.setup            AGWA git-crypt 0.6.0
+revision                1
 homepage                https://www.agwa.name/projects/git-crypt/
 categories              devel
 platforms               darwin
@@ -33,5 +35,13 @@ depends_build-append    bin:xsltproc:libxslt \
 
 use_configure           no
 
-build.args-append       CXX=${configure.cxx}
+variant universal       {}
+
+build.env               CXX="${configure.cxx}" \
+                        CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                        CC="${configure.cc}" \
+                        CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                        LDFLAGS="${configure.ldflags}  [get_canonical_archflags ld]" \
+                        PREFIX=${prefix}
+
 destroot.args           ENABLE_MAN=yes PREFIX=${prefix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->