### PR TITLE
devhelp: remove older version peg

### DIFF
--- a/gnome/devhelp/Portfile
+++ b/gnome/devhelp/Portfile
@@ -15,6 +15,8 @@ maintainers         {devans @dbevans} openmaintainer
 categories          gnome
 platforms           darwin
 homepage            https://wiki.gnome.org/Apps/Devhelp
+set branch          [join [lrange [split ${version} .] 0 1] .]
+
 default master_sites {gnome:sources/${name}/${branch}/}
 
 use_xz              yes
@@ -25,7 +27,8 @@ checksums           rmd160  ac1b639cfdc5a675f5dfa4976673a6a7ca8a6850 \
 depends_build       port:pkgconfig
 
 depends_lib         port:desktop-file-utils \
-                    port:gtk3
+                    port:gtk3 \
+                    path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
 
 depends_run         port:adwaita-icon-theme
 
@@ -33,7 +36,8 @@ depends_run         port:adwaita-icon-theme
 
 configure.python    /usr/bin/python
 configure.args      --disable-silent-rules \
-                    --disable-schemas-compile
+                    --disable-schemas-compile \
+                    --enable-compile-warnings=minimum
 
 post-activate {
     system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
@@ -41,39 +45,4 @@ post-activate {
     system "${prefix}/bin/glib-compile-schemas ${prefix}/share/glib-2.0/schemas"
 }
 
-platform darwin {
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-        version                 3.8.2
-        revision                5
-        checksums               rmd160  8d855f485742a0bdc766591d36af09bdbea61801 \
-                                sha256  a245b53824c6f2ff89245ff807bb2140bde74951ea6f1d759a0fd0c6959ca9f7
-
-        depends_build-append    port:intltool \
-                                port:autoconf \
-                                port:automake \
-                                port:gnome-common \
-                                port:libtool
-
-        depends_lib-append      path:lib/pkgconfig/webkitgtk-3.0.pc:webkit-gtk3-2.0
-        patchfiles              patch-configure.ac.diff
-
-        # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
-
-        post-patch {
-            xinstall -m 755 ${filespath}/autogen.sh-3.8.2 ${worksrcpath}/autogen.sh
-            copy ${worksrcpath}/libgd/libgd.m4 ${worksrcpath}/m4
-        }
-
-        configure.cmd           ./autogen.sh
-
-        configure.args-append   --with-webkit2=no
-        livecheck.type          none
-    } else {
-        depends_lib-append path:lib/pkgconfig/webkit2gtk-4.0.pc:webkit2-gtk
-
-        configure.args-append   --enable-compile-warnings=minimum
-        livecheck.type          gnome
-    }
-}
-
-set branch          [join [lrange [split ${version} .] 0 1] .]
+livecheck.type          gnome


### PR DESCRIPTION
now that webkit2-gtk builds on all supported systems,
all systems can use the current version of devhelp

One more for you to consider, @dbevans -- hoping you're finding these helpful.