### PR TITLE
py-astropy: update to 3.0.4 and 2.0.8

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             3.0.3
+version             3.0.4
 maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
 
 dist_subdir         ${name}/${version}
@@ -19,10 +19,10 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     f6fe7d5049fc0d7c7132e7ff54a8111e \
-                    rmd160  6bc981bd83bd403d7ac60485a3a67cf254e61999 \
-                    sha256  6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da \
-                    size    8058048
+checksums           md5     05ffa1d9f8288a562661c85a4f9e1a23 \
+                    rmd160  75b415a1865f1be8c606c50ec4ab0cd6a73d311c \
+                    sha256  f5d37d20632ba74bd0b12a85179c12f64a9ea037ffc916d8a2de3be4f4656c76 \
+                    size    8040822
 
 python.versions     27 34 35 36 37
 
@@ -34,14 +34,14 @@ build.args-append   --use-system-cfitsio \
 if {${name} ne ${subport}} {
 
     if {${python.version} < 35} {
-        version             2.0.7
+        version             2.0.8
         dist_subdir         ${name}/${version}
         distname            astropy-${version}
 
-        checksums           md5     044da9f6aba1dac3864a5ab95c9c11d0 \
-                            rmd160  989ab80ebe9bf1f81b71ebc65f2251ec7cdcaa14 \
-                            sha256  5c132d528fd431eb77fd73c172dfa3ec295f2ce0a98c075786908086cda8616d \
-                            size    8320349
+        checksums           md5     9a236c7f02abcaa8dc33c8a725c35007 \
+                            rmd160  22a2b3ad351420977fb1524e22b45046154ec260 \
+                            sha256  a8015f84c42051342a2a8ee710868e682b9775a3b7948fdc1e87124bcd6e69dc \
+                            size    8300320
     }
 
     depends_lib-append  port:cfitsio \


### PR DESCRIPTION
This PR bumps the astropy version(s) to the latest releases

- 2.0.8 for python<3.5
- 3.0.4 for python>=3.5

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
