### PR TITLE
py-gwdatafind: new port

### DIFF
--- a/python/py-gwdatafind/Portfile
+++ b/python/py-gwdatafind/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-gwdatafind
+version             1.0.0
+
+categories-append   science
+maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+
+platforms           darwin
+license             GPL-3
+
+description         The client library for the LIGO Data Replicator (LDR) \
+                    service.
+long_description    The DataFind service allows users to query for the \
+                    location of Gravitational-Wave Frame (GWF) files \
+                    containing data from the current gravitational-wave \
+                    detectors.
+homepage            https://gwdatafind.readthedocs.io
+
+master_sites        pypi:g/gwdatafind
+distname            gwdatafind-${version}
+checksums           rmd160  d6ee9ee4ab579341543458acef32b6a12cf6d628 \
+                    sha256  1441ad9dc445fc906bd3f589a059b878976958870cfad9ef20b9e2b8255378f4 \
+                    size    31273
+
+python.versions     27 36 37
+python.default_version 36
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-six \
+                        port:py${python.version}-ligo-segments \
+                        port:py${python.version}-openssl
+
+    depends_build-append port:py${python.version}-setuptools
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description

This PR adds a python port for [`gwdatafind`](//pypi.org/project/gwdatafind).
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
