### PR TITLE
py-gwpy: added py37 subport

### DIFF
--- a/python/py-gwpy/Portfile
+++ b/python/py-gwpy/Portfile
@@ -26,7 +26,7 @@ checksums   rmd160  7ef4e4697558c0a17a1fa45faa1fb21fffa0294e \
             sha256  47a17967508f006cee9c1c4a62cceff4d6d9870096cad9eedf9f1a4af788ba17 \
             size    1166915
 
-python.versions     27 36
+python.versions     27 36 37
 python.default_version 27
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

This PR adds a python3.7 (`py37`) subport for `py-gwpy`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
