### PR TITLE
cctools: Enforce xcode variant on Xcode 9+ systems

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -1,9 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
 
 name                    cctools
 # Xcode 8.1
 version                 895
-revision                5
+revision                6
 set ld64_version        274.1
 categories              devel
 platforms               darwin
@@ -60,6 +62,19 @@ foreach variantname $all_llvm_variants {
         set llvm_version        $this_llvm_version
         depends_lib-append      port:llvm-${this_llvm_version}
     "
+}
+
+# Disable all llvm variants on Xcode 9 systems, to force use of xcode variant
+# base has variant_set, but no variant_unset, so emulate it.
+global variations
+if {[vercmp $xcodeversion 9.0] >= 0} {
+    foreach variantname $all_llvm_variants {
+        if {[variant_isset ${variantname}]} {
+            ui_msg "Forcibly disabling variant ${variantname}"
+            default_variants -${variantname}
+            set variations(${variantname}) -
+        }
+    } 
 }
 
 proc some_llvm_variant_set {} {


### PR DESCRIPTION
#### Description

The cctools port was recently updated to by default on systems using Xcode 9 or newer install using a new Xcode variant that simply installs wrapper scripts around the Xcode provided utilities. This was done to solve issues with the fact that previously the tool kit installed by cctools was based on Xcode 8, and this was starting to cause issues on Xcode9 and newer based systems.

One issue though was the fact the port previously already had a default on this systems, +llvm50. This means on regular updates this variant is preserved, instead of using the new Xcode variant. This has started to cause issues, specifically with gfortran from the gcc ports

https://trac.macports.org/ticket/56938

https://trac.macports.org/ticket/56938

My guess is this is due to the fact when built on the buildbots, the cctools port has the defaults, +xcode, whereas the user does not.

This update forces the use of this variant, by removing the previous one.

```
Oberon ~/Projects/MacPorts/ports > sudo port outdated
The following installed ports are outdated:
cctools                        895_5 < 895_6             
Oberon ~/Projects/MacPorts/ports > sudo port installed cctools
The following ports are currently installed:
  cctools @895_5+llvm50 (active)
Oberon ~/Projects/MacPorts/ports > sudo port upgrade outdated
Forcibly disabling variant llvm50
--->  Fetching archive for cctools
--->  Attempting to fetch cctools-895_6+xcode.darwin_17.noarch.tbz2 from http://mse.uk.packages.macports.org/sites/packages.macports.org/cctools
--->  Attempting to fetch cctools-895_6+xcode.darwin_17.noarch.tbz2 from http://lil.fr.packages.macports.org/cctools
--->  Attempting to fetch cctools-895_6+xcode.darwin_17.noarch.tbz2 from https://packages.macports.org/cctools
--->  Fetching distfiles for cctools
--->  Verifying checksums for cctools
--->  Extracting cctools
--->  Configuring cctools
--->  Building cctools
--->  Staging cctools into destroot
--->  Installing cctools @895_6+xcode
--->  Cleaning cctools
--->  Deactivating cctools @895_5+llvm50
--->  Cleaning cctools
--->  Activating cctools @895_6+xcode
--->  Cleaning cctools
--->  Scanning binaries for linking errors
--->  No broken files found.
--->  No broken ports found.
```

- [x] bugfix

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
