### PR TITLE
php-solr: Add php72-solr subport and fix dependencies

### DIFF
--- a/php/php-solr/Portfile
+++ b/php/php-solr/Portfile
@@ -14,6 +14,7 @@ php.pecl                yes
 
 if {[vercmp ${php.branch} 5.3] >= 0} {
     version             2.4.0
+    revision            1
     checksums           rmd160  e4f025a3833b53dae8e066c4604c37026310d6c1 \
                         sha256  22865dafb76fc5839e84a5bd423bb37d5062883e5dfc4d064b43129ac9f2752c \
                         size    256316
@@ -27,10 +28,9 @@ long_description        ${name} is an extremely fast, light-weight, feature-rich
 
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:curl \
-                            port:libxml2
-    
-    depends_lib-append      port:${php}-curl
+    depends_lib-append      port:curl \
+                            port:libxml2 \
+                            port:${php}-curl
 
     patchfiles-append       php72.patch
     

--- a/php/php-solr/Portfile
+++ b/php/php-solr/Portfile
@@ -4,14 +4,20 @@ PortSystem              1.0
 PortGroup               php 1.1
 
 name                    php-solr
-version                 2.4.0
 categories-append       devel
 license                 PHP-3.01
 platforms               darwin
-maintainers             ryandesign openmaintainer
+maintainers             {ryandesign @ryandesign} openmaintainer
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2
 php.pecl                yes
+
+if {[vercmp ${php.branch} 5.3] >= 0} {
+    version             2.4.0
+    checksums           rmd160  e4f025a3833b53dae8e066c4604c37026310d6c1 \
+                        sha256  22865dafb76fc5839e84a5bd423bb37d5062883e5dfc4d064b43129ac9f2752c \
+                        size    256316
+}
 
 description             a PHP interface to Apache Solr
 
@@ -19,14 +25,14 @@ long_description        ${name} is an extremely fast, light-weight, feature-rich
                         library that allows PHP developers to communicate easily \
                         and efficiently with Apache Solr server instances.
 
-checksums               rmd160  e4f025a3833b53dae8e066c4604c37026310d6c1 \
-                        sha256  22865dafb76fc5839e84a5bd423bb37d5062883e5dfc4d064b43129ac9f2752c
 
 if {${name} ne ${subport}} {
     depends_build-append    port:curl \
                             port:libxml2
     
     depends_lib-append      port:${php}-curl
+
+    patchfiles-append       php72.patch
     
     configure.args-append   --with-curl=${prefix} \
                             --with-libxml-dir=${prefix}

--- a/php/php-solr/files/php72.patch
+++ b/php/php-solr/files/php72.patch
@@ -1,0 +1,85 @@
+Fix build on PHP 7.2+
+https://bugs.php.net/bug.php?id=75631
+https://github.com/php/pecl-search_engine-solr/commit/744e32915d5989101267ed2c84a407c582dc6f31
+--- src/php7/php_solr.c.orig
++++ src/php7/php_solr.c
+@@ -566,7 +566,7 @@ static zend_function_entry solr_document_methods[] = {
+ 	SOLR_CTOR(SolrDocument, __construct, SolrDocument__construct_args)
+ 	SOLR_DTOR(SolrDocument, __destruct, Solr_no_args)
+ 
+-	PHP_ME(SolrDocument, __clone, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CLONE)
++	PHP_ME(SolrDocument, __clone, NULL, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrDocument, __set, SolrDocument_addField_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrDocument, __get, SolrDocument_getField_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrDocument, __isset, SolrDocument_fieldExists_args, ZEND_ACC_PUBLIC)
+@@ -609,7 +609,7 @@ static zend_function_entry solr_document_methods[] = {
+ static zend_function_entry solr_input_document_methods[] = {
+ 	SOLR_CTOR(SolrInputDocument, __construct, SolrInputDocument__construct_args)
+ 	SOLR_DTOR(SolrInputDocument, __destruct, Solr_no_args)
+-	PHP_ME(SolrInputDocument, __clone, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CLONE)
++	PHP_ME(SolrInputDocument, __clone, NULL, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrInputDocument, __sleep, Solr_no_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrInputDocument, __wakeup, NULL, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrInputDocument, setBoost, SolrInputDocument_setBoost_args, ZEND_ACC_PUBLIC)
+@@ -645,7 +645,7 @@ static zend_function_entry solr_client_methods[] = {
+ 	SOLR_DTOR(SolrClient, __destruct, Solr_no_args)
+ 	PHP_ME(SolrClient, __sleep, Solr_no_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrClient, __wakeup, NULL, ZEND_ACC_PUBLIC)
+-	PHP_ME(SolrClient, __clone, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CLONE)
++	PHP_ME(SolrClient, __clone, NULL, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrClient, getOptions, Solr_no_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrClient, getDebug, Solr_no_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrClient, setServlet, SolrClient_setServlet_args, ZEND_ACC_PUBLIC)
+@@ -722,7 +722,7 @@ static zend_function_entry solr_params_methods[] = {
+ 	PHP_ME(SolrParams, getParams, Solr_no_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrParams, getParam, SolrParams_getParam_args, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrParams, getPreparedParams, Solr_no_args, ZEND_ACC_PUBLIC)
+-	PHP_ME(SolrParams, __clone, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CLONE)
++	PHP_ME(SolrParams, __clone, NULL, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrParams, serialize,   NULL, ZEND_ACC_PUBLIC)
+ 	PHP_ME(SolrParams, unserialize,  SolrParams_unserialize_args, ZEND_ACC_PUBLIC)
+ 	PHP_MALIAS(SolrParams, add, addParam, SolrParams_addParam_args, ZEND_ACC_PUBLIC)
+--- src/php7/solr_functions_helpers.c.orig
++++ src/php7/solr_functions_helpers.c
+@@ -1404,19 +1404,28 @@ PHP_SOLR_API long solr_get_json_last_error(TSRMLS_D)
+ static inline int solr_pcre_replace_into_buffer(solr_string_t *buffer, char * search, char *replace)
+ {
+     zend_string *result;
+-    zval replace_val;
+     int limit = -1;
+     int replace_count = -1;
+     zend_string *regex_str = zend_string_init(search, strlen(search), 0);
+     zend_string *subject_str = zend_string_init(buffer->str, buffer->len, 0);
++#if PHP_VERSION_ID >= 70200
++    zend_string *replace_str = zend_string_init(replace, strlen(replace), 0);
++#else
++    zval replace_val;
+     ZVAL_STRING(&replace_val, replace);
++#endif
++
+     result = php_pcre_replace(
+             regex_str,
+             subject_str,
+             buffer->str,
+             buffer->len,
++#if PHP_VERSION_ID >= 70200
++            replace_str,
++#else
+             &replace_val,
+             0,
++#endif
+             limit,
+             &replace_count
+     );
+@@ -1424,7 +1433,11 @@ static inline int solr_pcre_replace_into_buffer(solr_string_t *buffer, char * se
+     solr_string_set_ex(buffer, (solr_char_t *)result->val, (size_t)result->len);
+ /*    fprintf(stdout, "%s", buffer->str); */
+     efree(result);
++#if PHP_VERSION_ID >= 70200
++    zend_string_release(replace_str);
++#else
+     zval_ptr_dtor(&replace_val);
++#endif
+     zend_string_release(regex_str);
+     zend_string_release(subject_str);
+ 


### PR DESCRIPTION
#### Description

php-solr: Add php72-solr subport and fix dependencies
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->