### PR TITLE
py-graph-tool: drop py34 subport

### DIFF
--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  3da208242310af40b795974a6cf3d50af7edf631 \
                     size    14989318
 distname            ${realname}-${version}
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 python.default_version 27
 
 if {${os.major} <= 12 && ${os.platform} eq "darwin"} {

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -177,6 +177,7 @@ py-gobject              2.28.6_3    26 33
 py-gobject3             3.28.1_1    33 34
 py-goocanvas            0.14.1_7    26
 py-google-apputils      0.4.2_1     26
+py-graph-tool           2.27_1      34
 py-greenlet             0.4.14_1    26 33
 py-gst-python           0.10.22_3   26
 py-gtkhtml2             2.25.3_3    26


### PR DESCRIPTION
Dependency py-gobject3 no longer supports python34.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
