### PR TITLE
py-babel: update to 2.6.0

### DIFF
--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -4,14 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-babel
-version             2.5.3
-revision            0
+version             2.6.0
 categories-append   devel
 platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -26,12 +25,20 @@ master_sites        pypi:B/Babel
 
 distname            Babel-${version}
 
-checksums           rmd160  7217c8d7278b958844a5bd6f5e1a6f160b1c1abd \
-                    sha256  8ce4cb6fdd4393edd323227cba3a077bceb2a6ce5201c902c65e730046f41f14
+checksums           rmd160  8641980902522636ddc58983ff9ccfe1d421cb4c \
+                    sha256  8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23 \
+                    size    7960433
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-tz
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-tz
+
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-freezegun
+
+    test.run                yes
+    test.cmd                py.test-${python.branch}
+    test.target
 
     livecheck.type      none
 } else {

--- a/python/py-freezegun/Portfile
+++ b/python/py-freezegun/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  25d767068dd31b1315d24ad399237083a2974267 \
                     sha256  853379dc1cd7ae2c9dec46d52d8360f51c5a185343e7479c5d0c68c15a3f6a6c \
                     size    20484
 
-python.versions     27 35 36 37
+python.versions     27 34 35 36 37
 
 # Fixes py37 compatibility
 patchfiles-append   pr231.patch


### PR DESCRIPTION
#### Description
- update to latest version
- make py-setuptools a build dependency
- enable tests
- add py37 subport

Closes: https://trac.macports.org/ticket/56876

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? 
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
