### PR TITLE
py-snowballstemmer: add py37 subport

### DIFF
--- a/python/py-snowballstemmer/Portfile
+++ b/python/py-snowballstemmer/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  433de19c91b3f0914bb280f37cebc21324da4db5 \
                     sha256  919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128 \
                     size    49626
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {$subport ne $name} {
     livecheck.type      none


### PR DESCRIPTION
#### Description
Closes: https://trac.macports.org/ticket/56890

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
