### PR TITLE
py-h5py: add py34 subport back

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -183,7 +183,7 @@ py-gst-python           0.10.22_3   26
 py-gtkhtml2             2.25.3_3    26
 py-gtkmvc               1.99.1_3    26
 py-gtkspell             2.25.3_4    26
-py-h5py                 2.8.0       26 33 34
+py-h5py                 2.8.0       26 33
 py-hat-trie             0.3_1       33
 py-hcluster             0.2.0_2     26
 py-hgsvn                0.1.9_1     26

--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -8,7 +8,7 @@ PortGroup               mpi 1.0
 github.setup            h5py h5py 2.8.0
 name                    py-h5py
 # h5py needs to be re-built after hdf5 upgrades
-revision                0
+revision                1
 
 platforms               darwin
 license                 BSD
@@ -38,7 +38,7 @@ subport                 py34-h5py-devel {set DEV_VERSION 34}
 subport                 py35-h5py-devel {set DEV_VERSION 35}
 subport                 py36-h5py-devel {set DEV_VERSION 36}
 
-python.versions         27 35 36 37
+python.versions         27 34 35 36 37
 python.default_version  27
 
 checksums \


### PR DESCRIPTION
#### Description
- add py34 subport back as other ports depend on it.
Only remove subports it there are no other ports that depend on it, or remove this subport (py34) recursively from all dependencies as well.

Closes: https://trac.macports.org/ticket/56896
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 3.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
