### PR TITLE
py-babel: py-setuptools is also a runtime dependency

### DIFF
--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-babel
 version             2.6.0
+revision            1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -30,8 +31,8 @@ checksums           rmd160  8641980902522636ddc58983ff9ccfe1d421cb4c \
                     size    7960433
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-    depends_lib-append      port:py${python.version}-tz
+    depends_lib-append      port:py${python.version}-setuptools \
+                            port:py${python.version}-tz
 
     depends_test-append     port:py${python.version}-pytest \
                             port:py${python.version}-freezegun


### PR DESCRIPTION
#### Description
As pointed out by @jmroot (https://github.com/macports/macports-ports/commit/b4126f44c81723d88bb2772a1977b4c3ff696d7c#r30011428) ```py-setuptools``` is also used at runtime and should, therefore, not be listed only as a build dependency. This commit fixes the mistake I made earlier.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
