### PR TITLE
mandoc: update to 1.14.4

### DIFF
--- a/textproc/mandoc/Portfile
+++ b/textproc/mandoc/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                mandoc
-version             1.14.3
-revision            6
+version             1.14.4
 description         UNIX manpage compiler
 homepage            https://mandoc.bsd.lv/
 categories          textproc
@@ -20,8 +19,8 @@ long_description    mandoc is a suite of tools compiling mdoc, \
 
 master_sites        https://mandoc.bsd.lv/snapshots/
 
-checksums           rmd160 0155d0670421c37aa79c1887ecab3904236907cd \
-                    sha256 0b0c8f67958c1569ead4b690680c337984b879dfd2ad4648d96924332fd99528
+checksums           rmd160 5e3702e49a70a270184132bf08f891eb12100ea2 \
+                    sha256 24eb72103768987dcc63b53d27fdc085796330782f44b3b40c4660b1e1ee9b9c
 
 pre-configure {
     set filename "${worksrcpath}/configure.local"


### PR DESCRIPTION
This is a maintanance release, with many bugfixes,
improved eqn(7) rendering, and improned HTML/CSS output.

Tested on macOS 10.13.6 17G65, Xcode 9.4.1 9F2000

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
