### PR TITLE
libressl-devel: update to 2.8.0

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libressl-devel
-version             2.7.4
+version             2.8.0
 distname            libressl-${version}
 
 categories          security devel
@@ -23,9 +23,8 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160  e2fff57fe8ae432a4b3104561d2ba1ee16804242 \
-                    sha256  1e3a9fada06c1c060011470ad0ff960de28f9a0515277d7336f7e09362517da6 \
-                    size    3359012
+checksums           rmd160 92cbbe323ae16197e8ae90fb8e7e5d783910b7d0 \
+                    sha256 af2bba965b06063518eec6f192d411631dfe1d07713760c67c3c29d348789dc3
 
 patchfiles \
     openssldir-cert.pem.patch


### PR DESCRIPTION
This updates the libressl-devel port to LibreSSL 2.8.0.
Among many other improvements, the most relevant here seem to be

 * Extensive documentation updates and additional API history.
 * Fixed a pair of 20+ year-old bugs in X509_NAME_add_entry
 * Removed three remaining single DES cipher suites.
 * Added const annotations to many existing APIs from OpenSSL,
   making interoperability easier for downstream applications.
 * Fixed a potential leak/incorrect return value in DSA signature generation.
 * Added ECC constant time scalar multiplication support.
 * Cleaned up BN_* implementations following changes made in OpenSSL

- [x] bugfix
- [x] enhancement
- [x] security fix

Tested on macOS 10.13.6 17G65 with Xcode 9.4.1 9F2000.
Tested against openssh, lynx, curl, opusfile - please help test your dependent ports.

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
