### PR TITLE
py-keyring: add py37 subport

### DIFF
--- a/python/py-keyring/Portfile
+++ b/python/py-keyring/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-keyring
 version             13.2.1
+revision            1
 categories-append   security
 
 license             {MIT PSF}
@@ -25,13 +26,13 @@ checksums           rmd160  09dd71fbfe911abd5f80f896c807d9fa6f420e20 \
                     sha256  6364bb8c233f28538df4928576f4e051229e0451651073ab20b315488da16a58 \
                     size    43140
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build-append   port:py${python.version}-setuptools \
-                           port:py${python.version}-setuptools_scm
+    depends_build-append   port:py${python.version}-setuptools_scm
 
-    depends_lib-append     port:py${python.version}-entrypoints
+    depends_lib-append     port:py${python.version}-setuptools \
+                           port:py${python.version}-entrypoints
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description
- add support for py37
- py-setuptools is a also runtime dependency. It was originally only set as build dependency (so I didn't make the mistake here), but prompted by the py-babel comment I realized it should also be a runtime dependency here. 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
