### PR TITLE
libvpx: Don't force use of clang-3.9

### DIFF
--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -103,9 +103,11 @@ destroot.args       verbose=1
 #
 # This is an intentional change to Clang. It now parses the assembly output by default even when emitting assembly so that the diagnostics are consistent between "clang -c" and "clang -S".
 # The solution is either to pass -fno-integrated-as to the compiler, or change the assembly produced (& probably the script that processes it) so that it's valid. Note that commenting out the line won't work: comments get stripped by the same process.
-# Current Xcode versions of clang > 602 corresponding to Xcode 6.3 or greater also need this fix
+# Current Xcode versions of clang > 602 corresponding to Xcode 6.3 or greater also need this fix.
 
-if {[string match "macports-clang-3.\[5-9\]" ${configure.compiler}] ||
+if {[string match {macports-clang-3.[5-9]} ${configure.compiler}] ||
+    [string match {macports-clang-[4-9].*} ${configure.compiler}] ||
+    [string match {macports-clang-[1-9][0-9].*} ${configure.compiler}] ||
     (${configure.compiler} eq "clang" && [compiler_blacklist_versions._get_compiler_version ${configure.compiler}] > 602)} {
         build.args-append CFLAGS_S=-fno-integrated-as
 }

--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -64,7 +64,7 @@ compiler.blacklist  *gcc* {clang < 800} macports-clang-3.3 macports-clang-3.4 ma
 # Make sure that mp-clang-3.9 is picked if all compilers were blacklisted.
 # Especially important for 10.6 on libc++, since the fallback list contains macports-clang-3.7
 # as the first, and thus selected, fallback option (even though it has been blacklisted earlier).
-compiler.fallback-prepend macports-clang-3.9
+compiler.fallback-append macports-clang-3.9
 
 license_noconflict  clang-3.9
 


### PR DESCRIPTION
#### Description

libvpx: Don't force use of clang-3.9

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->