### PR TITLE
py-spyder-kernels[-devel]: update to latest versions

### DIFF
--- a/python/py-spyder-kernels-devel/Portfile
+++ b/python/py-spyder-kernels-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-spyder-kernels-devel
-version             1.0.1
+version             1.0.3
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -21,21 +21,32 @@ master_sites        pypi:s/spyder-kernels
 
 distname            spyder-kernels-${version}
 
-checksums           rmd160  ed9295929fb6cbe7c2c36526766d2a2a9a0c25e0 \
-                    sha256  ce4950684a3b82cd995700e2623c8749d1194823f990d6ed24711e7db4cf202a \
-                    size    35936
+checksums           rmd160  e27e5e5a468fb8e715554414226cf33a1a322dea \
+                    sha256  4acf8539a19d72469087394b597201a2d4fa9c06bbd815cc170ed4ee59f93688 \
+                    size    38722
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-spyder-kernels
 
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-ipykernel \
-                        port:py${python.version}-cloudpickle
+    depends_build-append    port:py${python.version}-setuptools
+
+    depends_lib-append      port:py${python.version}-cloudpickle \
+                            port:py${python.version}-ipykernel \
+                            port:py${python.version}-jupyter_client \
+                            port:py${python.version}-zmq
+
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-numpy \
+                            port:py${python.version}-pandas
+
+    test.run                yes
+    test.cmd                py.test-${python.branch}
+    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} LICENSE CHANGELOG.md README.md \
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt CHANGELOG.md README.md \
             ${destroot}${docdir}
     }
 

--- a/python/py-spyder-kernels/Portfile
+++ b/python/py-spyder-kernels/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-spyder-kernels
-version             0.2.4
+version             0.2.6
 epoch               1
 categories-append   devel
 platforms           darwin
@@ -22,21 +22,32 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            spyder-kernels-${version}
 
-checksums           rmd160  feb2ede60f40356e95e7866cd3d0a9d7ce451a4f \
-                    sha256  d5bfc5fdbc98c8bef7910ac4a28638272179c9077a45e4b9b820ba87a916b18a \
-                    size    35750
+checksums           rmd160  7bdfeab3c027d3aa64849bdf06b20a1f8cbb0418 \
+                    sha256  26c8e9f78f90ac107ee72ccf78b2550d65d437010990aaf30396d0f90af3282c \
+                    size    38507
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-spyder-kernels-devel
 
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-ipykernel \
-                        port:py${python.version}-cloudpickle
+    depends_build-append    port:py${python.version}-setuptools
+
+    depends_lib-append      port:py${python.version}-cloudpickle \
+                            port:py${python.version}-ipykernel \
+                            port:py${python.version}-jupyter_client \
+                            port:py${python.version}-zmq
+
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-numpy \
+                            port:py${python.version}-pandas
+
+    test.run                yes
+    test.cmd                py.test-${python.branch}
+    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} LICENSE CHANGELOG.md README.md \
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt CHANGELOG.md README.md \
             ${destroot}${docdir}
     }
 


### PR DESCRIPTION
#### Description
- update py-spyder-kernels to version 0.2.6 and py-spyder-kernels-devel to version 1.0.3
- update new dependencies and move py-setuptools to depends_build
- enable tests 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
