### PR TITLE
py-pytest: update to 3.7.1 

### DIFF
--- a/python/py-pathlib2/Portfile
+++ b/python/py-pathlib2/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pluggy/Portfile
+++ b/python/py-pluggy/Portfile
@@ -5,12 +5,13 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 name                py-pluggy
-version             0.6.0
+version             0.7.1
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         {gmail.com:pedro.salgado @steenzout} openmaintainer
+homepage            https://github.com/pytest-dev/pluggy
 
 description         Plugin and hook calling mechanisms for Python
 long_description    This is the plugin manager as used by pytest but \
@@ -19,13 +20,18 @@ long_description    This is the plugin manager as used by pytest but \
 master_sites        pypi:p/pluggy
 distname            pluggy-${version}
 
-checksums           rmd160  14de9c7cde01f72acc0ea4689fb6dfd368f58314 \
-                    sha256  7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff
+checksums           rmd160  75c196d15a34fe64fa0c86846645256a0d5de1db \
+                    sha256  95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1 \
+                    size    47784
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools_scm
+
     depends_lib-append  port:py${python.version}-py \
                         port:py${python.version}-setuptools
+
     livecheck.type      none
 }

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest
-version             3.6.3
-revision            0
+version             3.7.1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -20,14 +19,14 @@ description         py.test: simple powerful testing with Python
 long_description    The py.test` testing tool makes it easy to write small \
                     tests, yet scales to support complex functional testing.
 
-homepage            http://pytest.org
+homepage            https://pytest.org
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  28cdd377a030f53f07a9ead251d18608ca91ffdd \
-                    sha256  0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752 \
-                    size    830949
+checksums           rmd160  184a2446c82f9925f257a263796158bf88024b39 \
+                    sha256  86a8dbf407e437351cef4dba46736e9c5a6e3c3ac71b2e942209748e76ff2086 \
+                    size    845094
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -41,8 +40,13 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-pluggy \
                         port:py${python.version}-atomicwrites
 
-    if {${python.version} < 30} {
-        depends_lib-append  port:py${python.version}-funcsigs
+    if {${python.version} eq 27} {
+        depends_lib-append \
+                        port:py${python.version}-funcsigs
+    }
+    if {${python.version} < 36} {
+        depends_lib-append \
+                        port:py${python.version}-pathlib2
     }
 
     patchfiles-append   patch-setup.py.diff

--- a/python/py-scandir/Portfile
+++ b/python/py-scandir/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-scandir
-version             1.7
+version             1.9.0
 categories-append   devel
 platforms           darwin
 license             BSD
 
-python.versions     27 35 36
+python.versions     27 34 35 36
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -21,9 +21,22 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  7107748f76422f948eefea4a3239e2df0bee9d61 \
-                    sha256  b2d55be869c4f716084a19b1e16932f0769711316ba62de941320bf2be84763d
+checksums           rmd160  d385710210e591105d516d180a6c8c04b1498bad \
+                    sha256  44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064 \
+                    size    33315
 
 if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    if {${python.version} eq 27} {
+        depends_test-append \
+                        port:py${python.version}-mock
+    }
+
+    test.run            yes
+    test.cmd            python${python.branch} test/run_tests.py
+    test.target
+
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
This PR updates py-pytest to its latest version and also includes updates to some of its dependencies as required:

- py-pytest: update to version 3.7.1, update dependencies
- py-pluggy: update to version 0.7.1, update dependencies, add homepage
- py-pathlib2: add py34 subport as needed for py34-pytest
- py-scandir: update to version 1.9.0, add py34 subport, enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7 (where  applicable)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
