### PR TITLE
py-graveyard/p5-graveyard: add support for epoch

### DIFF
--- a/perl/p5-graveyard/Portfile
+++ b/perl/p5-graveyard/Portfile
@@ -18,7 +18,12 @@ proc unknown args {
         lappend args {*}$defaultBranches
     }
     set replaced_branches [lassign $args superport version_string]
-    lassign [split $version_string _] ver rev
+    if [string match "*@*" $version_string] {
+        lassign [split $version_string {@ _}] epo ver rev
+    } else {
+        lassign [split $version_string _] ver rev
+        set epo 0
+    }
     if {$rev eq ""} {
         set rev 0
     }
@@ -38,9 +43,16 @@ proc unknown args {
 # editor's tab width to 8 to ensure proper alignment, and verify that
 # you're inserting tab characters and not spaces.
 #
+# The list can be automatically generated using the command below, but
+# if you want/need to add entries manually please keep the list of ports
+# sorted in alphabetical order. When adding ports to the list, the
+# epoch@version_revision listed must be greater than it was before,
+# otherwise the port is not considered outdated and replacement does
+# not occur.
+#
 # The current list was generated at 2018-03-08T10:15:00Z with:
 #
-# $ port -q info --index --line --version --revision --name 'p5-*' | awk '
+# $ port -q info --index --line --epoch --version --revision --name 'p5-*' | awk '
 #       BEGIN {
 #           blacklist["p5-graveyard"] = ""
 #           blacklist["p5-test2-workflow"] = ""
@@ -49,21 +61,27 @@ proc unknown args {
 #           blacklist["p5-alien-base"] = ""
 #       }
 #       {
-#           if ($3 in blacklist)
+#           # Warning: Order of output may change in the future.
+#           # https://trac.macports.org/ticket/57003
+#           version = $1
+#           revision = $2
+#           epoch = $3
+#           name = $4
+#           if (name in blacklist)
 #               next
-#           padding = (48 - length($3)) / 8
+#           padding = (48 - length(name)) / 8
 #           if (padding != int(padding))
 #               padding = int(padding) + 1
-#           printf "%s", $3
+#           printf "%s", name
 #           for (i = 0; i < padding; ++i)
 #               printf "\t"
-#           printf "%s_%d%s", $1, ($2 + 1), ORS
+#           printf "%s%s_%d%s", epoch ? epoch "@" : "", version, revision + 1, ORS
 #       }
 #   '
 
 #                                                               REPLACED BRANCHES
 #                                                               (optional, defaults to
-# SUPERPORT                                     VERSION_REV     "5.24")
+# SUPERPORT                                     EPO@VER_REV      "5.24")
 p5-acme-lolcat					0.0.5_4
 p5-algorithm-annotate				0.100.0_4
 p5-algorithm-c3					0.100.0_1
@@ -103,7 +121,7 @@ p5-archive-extract				0.800.0_1
 p5-archive-tar					2.260.0_1
 p5-archive-tar-wrapper				0.230.0_1
 p5-archive-zip					1.600.0_1
-p5-array-compare				3.0.0_1
+p5-array-compare				1@3.0.0_1
 p5-asa						1.30.0_1
 p5-astro					0.780.0_1
 p5-astro-app-satpass2				0.35.0_1
@@ -182,7 +200,7 @@ p5-catalyst-helper-authdbic			0.170.0_1
 p5-catalyst-log-log4perl			1.60.0_1
 p5-catalyst-model-adaptor			0.100.0_2
 p5-catalyst-model-dbic-schema			0.650.0_2
-p5-catalyst-plugin-authentication		0.100.230_1
+p5-catalyst-plugin-authentication		1@0.100.230_1
 p5-catalyst-plugin-authentication-store-dbic	0.110.0_5
 p5-catalyst-plugin-authorization-acl		0.160.0_1
 p5-catalyst-plugin-authorization-roles		0.90.0_1
@@ -225,7 +243,7 @@ p5-cgi-simple					1.150.0_1
 p5-cgi-ssi					0.920.0_2
 p5-cgi-struct					1.210.0_1
 p5-chart					2.4.10_1
-p5-chemistry-elements				1.72.0_1
+p5-chemistry-elements				1@1.72.0_1
 p5-chi						0.600.0_1
 p5-class-accessor				0.510.0_1
 p5-class-accessor-chained			0.10.0_5
@@ -413,10 +431,10 @@ p5-date-calc					6.400.0_1
 p5-date-holidays-de				1.900.0_1
 p5-date-simple					3.30.0_4
 p5-datemanip					6.700.0_1
-p5-datetime					1.460.0_1
+p5-datetime					2@1.460.0_1
 p5-datetime-calendar-christian			0.60.0_1
 p5-datetime-calendar-julian			0.40.0_1
-p5-datetime-format-builder			0.810.0_1
+p5-datetime-format-builder			1@0.810.0_1
 p5-datetime-format-dateparse			0.50.0_3
 p5-datetime-format-iso8601			0.80.0_1
 p5-datetime-format-mail				0.403.0_1
@@ -425,8 +443,8 @@ p5-datetime-format-pg				0.160.130_1
 p5-datetime-format-sqlite			0.110.0_5
 p5-datetime-format-strptime			1.750.0_1
 p5-datetime-format-w3cdtf			0.70.0_1
-p5-datetime-locale				1.170.0_1
-p5-datetime-timezone				2.170.0_1
+p5-datetime-locale				1@1.170.0_1
+p5-datetime-timezone				5@2.170.0_1
 p5-db_file					1.840.0_1
 p5-dbd-mock					1.450.0_2
 p5-dbd-mysql					4.46.0_1
@@ -472,7 +490,7 @@ p5-devel-partialdump				0.200.0_1
 p5-devel-ppport					3.360.0_1
 p5-devel-repl					1.3.28_1
 p5-devel-size					0.810.0_1
-p5-devel-stacktrace				2.30.0_1
+p5-devel-stacktrace				1@2.30.0_1
 p5-devel-stacktrace-ashtml			0.150.0_1
 p5-devel-symdump				2.180.0_1
 p5-device-serialport				1.40.0_3
@@ -554,7 +572,7 @@ p5-expect					1.350.0_1
 p5-expect-simple				0.40.0_1
 p5-exporter-lite				0.80.0_1
 p5-exporter-tiny				1.0.0_1
-p5-extutils-cbuilder				0.280.230_1
+p5-extutils-cbuilder				2@0.280.230_1
 p5-extutils-config				0.8.0_1
 p5-extutils-depends				0.405.0_1
 p5-extutils-f77					1.200.0_2
@@ -725,7 +743,7 @@ p5-html-template-compiled			1.3.0_1
 p5-html-tidy					1.600.0_1
 p5-html-tiny					1.50.0_5
 p5-html-tokeparser-simple			3.160.0_2
-p5-html-tree					5.70.0_1
+p5-html-tree					1@5.70.0_1
 p5-html-treebuilder-xpath			0.140.0_2
 p5-html-wikiconverter				0.680.0_4
 p5-html-wikiconverter-confluence		0.10.0_3
@@ -769,7 +787,7 @@ p5-http-tiny					0.70.0_1
 p5-http-tiny-mech				1.1.2_1
 p5-http-xscookies				0.0.14_1
 p5-http-xsheaders				0.400.3_1
-p5-ifeffit					1.2.13_1
+p5-ifeffit					1@1.2.13_1
 p5-ima-dbi					0.350.0_4
 p5-image-exiftool				10.820.0_1
 p5-image-imlib2					2.30.0_1
@@ -789,7 +807,7 @@ p5-inline-python				0.560.0_1
 p5-innotop					1.10.0_1
 p5-internals					1.100.0_4
 p5-io						1.250.0_5
-p5-io-aio					4.400.0_1
+p5-io-aio					1@4.400.0_1
 p5-io-all					0.870.0_1
 p5-io-capture					0.50.0_1
 p5-io-captureoutput				1.110.400_1
@@ -835,7 +853,7 @@ p5-json-dwiw					0.470.0_1
 p5-json-maybexs					1.3.10_1
 p5-json-parse					0.550.0_1
 p5-json-webtoken				0.100.0_1
-p5-json-xs					3.40.0_1
+p5-json-xs					1@3.40.0_1
 p5-lchown					1.10.0_2
 p5-lexical-persistence				1.23.0_1
 p5-lexical-sealrequirehints			0.11.0_1
@@ -977,7 +995,7 @@ p5-mldbm					2.50.0_2
 p5-mo						0.400.0_1
 p5-mock-config					0.30.0_1
 p5-modern-perl					1.201.701.170_1
-p5-module-build					0.422.400_1
+p5-module-build					2@0.422.400_1
 p5-module-build-ffi				0.470.0_1
 p5-module-build-tiny				0.39.0_2
 p5-module-build-xsutil				0.180.0_1
@@ -1001,7 +1019,7 @@ p5-module-versions-report			1.60.0_1
 p5-mogilefs-client				1.170.0_2
 p5-mogilefs-server				2.730.0_1
 p5-mogilefs-utils				2.300.0_1
-p5-mojolicious					7.700.0_1
+p5-mojolicious					2@7.700.0_1
 p5-mojolicious-plugin-chi			0.150.0_1
 p5-mojolicious-plugin-mason1renderer		0.30.0_1
 p5-mojolicious-plugin-mason2renderer		0.30.0_1
@@ -1184,7 +1202,7 @@ p5-parse-mediawikidump				1.0.6_2
 p5-parse-mime					1.3.0_1
 p5-parse-recdescent				1.967.15_1
 p5-parse-win32registry				1.0.0_2
-p5-parse-yapp					1.210.0_1
+p5-parse-yapp					1@1.210.0_1
 p5-patchreader					0.9.6_3
 p5-path-class					0.370.0_1
 p5-path-finddev					0.5.3_1
@@ -1204,7 +1222,7 @@ p5-pdl-io-hdf5					0.730.0_4
 p5-pdl-stats					0.750.0_2
 p5-pdl-transform-color				1.3.0_1
 p5-pegex					0.640.0_1
-p5-perl-critic					1.130.0_2
+p5-perl-critic					1@1.130.0_2
 p5-perl-ldap					0.650.0_1
 p5-perl-minimumversion				1.380.0_1
 p5-perl-ostype					1.10.0_1
@@ -1222,7 +1240,7 @@ p5-perlio-via-bzip2				0.20.0_4
 p5-perlio-via-dynamic				0.140.0_1
 p5-perlio-via-symlink				0.50.0_5
 p5-perlio-via-timeout				0.320.0_1
-p5-perlmagick					6.9.9-26_1
+p5-perlmagick					1@6.9.9-26_1
 p5-pgplot					2.210.0_3
 p5-pgtop					0.50.0_4
 p5-php-serialization				0.340.0_4
@@ -1330,7 +1348,7 @@ p5-sort-naturally				1.30.0_1
 p5-sort-versions				1.620.0_1
 p5-specio					0.420.0_1
 p5-spiffy					0.460.0_1
-p5-spreadsheet-parseexcel			0.650.0_2
+p5-spreadsheet-parseexcel			1@0.650.0_2
 p5-spreadsheet-writeexcel			2.400.0_1
 p5-sql-abstract					1.850.0_1
 p5-sql-abstract-limit				0.141.0_4
@@ -1369,7 +1387,7 @@ p5-sub-install					0.928.0_2
 p5-sub-name					0.210.0_1
 p5-sub-override					0.90.0_1
 p5-sub-quote					2.5.0_1
-p5-sub-uplevel					0.280.0_1
+p5-sub-uplevel					1@0.280.0_1
 p5-super					1.201.411.170_1
 p5-svg						2.840.0_1
 p5-svg-graph					0.40.0_1
@@ -1434,7 +1452,7 @@ p5-test-cpan-meta-yaml				0.250.0_1
 p5-test-deep					1.127.0_1
 p5-test-deep-json				0.40.0_1
 p5-test-deep-type				0.8.0_1
-p5-test-differences				0.640.0_1
+p5-test-differences				2@0.640.0_1
 p5-test-directory				0.41.0_1
 p5-test-eol					2.0.0_1
 p5-test-exception				0.430.0_1
@@ -1616,7 +1634,7 @@ p5-user-identity				0.990.0_1
 p5-utf8-all					0.24.0_1
 p5-uuid						0.270.0_1
 p5-variable-magic				0.620.0_1
-p5-version					0.991.800_1
+p5-version					2@0.991.800_1
 p5-want						0.290.0_1
 p5-warnings-unused				0.60.0_3
 p5-web-scraper					0.380.0_1
@@ -1638,14 +1656,14 @@ p5-wx						0.993.200_1
 p5-wx-demo					0.220.0_1
 p5-x11-protocol					0.560.0_4
 p5-xml-atom					0.420.0_1
-p5-xml-autowriter				0.400.0_4
+p5-xml-autowriter				1@0.400.0_4
 p5-xml-bare					0.530.0_1
 p5-xml-commonns					0.60.0_1
 p5-xml-dom					1.460.0_1
 p5-xml-dom-xpath				0.140.0_4
 p5-xml-doubleencodedentities			1.100.0_1
 p5-xml-entities					1.0.200_1
-p5-xml-feed					0.530.0_1
+p5-xml-feed					1@0.530.0_1
 p5-xml-filter-buffertext			1.10.0_5
 p5-xml-libxml					2.13.200_1
 p5-xml-libxml-simple				0.990.0_1

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -20,7 +20,12 @@ array set replacements {
 proc unknown args {
     upvar 1 replacements replacements
     set replaced_series [lassign $args superport version_string]
-    lassign [split $version_string _] ver rev
+    if [string match "*@*" $version_string] {
+        lassign [split $version_string {@ _}] epo ver rev
+    } else {
+        lassign [split $version_string _] ver rev
+        set epo 0
+    }
     if {$rev eq ""} {
         set rev 0
     }
@@ -30,22 +35,23 @@ proc unknown args {
         subport $replaced {
             version $ver
             revision $rev
+            epoch $epo
             replaced_by $replacement
         }
     }
 }
 
 # Please keep the list of ports sorted in alphabetical order. When adding a port
-# to the list, the version_revision listed must be greater than it was before,
+# to the list, the epoch@version_revision listed must be greater than it was before,
 # otherwise the port is not considered outdated and replacement does not occur.
 
-# SUPERPORT             VERSION_REV REPLACED BRANCHES
+# SUPERPORT             EPO@VER_REV REPLACED BRANCHES
 py-acor                 1.1.1_1     26 33
 py-acora                2.1_1       33
 py-alabaster            0.7.6_1     26 33
 py-appdirs              1.4.3_1     26 33
 py-argh                 0.24.1_1    33
-py-asn1                 0.1.9_2     26
+py-asn1                 1@0.1.9_2   26
 py-astlib               0.8.0_1     26 32
 py-astrolibcoords       0.37_1      26
 py-astropy              3.0.3_1     33
@@ -170,14 +176,16 @@ py-gflags               2.0_1       26
 py-gitdb                2.0.3_1     26
 py-gitpython            2.0.2_1     26
 py-gmpy                 1.17_1      25 26 31 32 33
-py-gmpy2                2.0.7_1     26 31 32 33
+py-gmpy2                1@2.0.7_1   26 31 32 33
 py-gnome                2.28.1_9    26
 py-gnuplot              1.8_3       26
-py-gobject              2.28.6_3    26 33
+py-gobject              20110613@2.28.6_3 \
+                                    26 33
 py-gobject3             3.28.1_1    33 34
 py-goocanvas            0.14.1_7    26
 py-google-apputils      0.4.2_1     26
-py-graph-tool           2.27_1      34
+py-graph-tool           20171109@2.27_1 \
+                                    34
 py-greenlet             0.4.14_1    26 33
 py-gst-python           0.10.22_3   26
 py-gtkhtml2             2.25.3_3    26
@@ -188,7 +196,7 @@ py-hat-trie             0.3_1       33
 py-hcluster             0.2.0_2     26
 py-hgsvn                0.1.9_1     26
 py-hiredis              0.2.0_1     33
-py-html5lib             @1.0b10_2   26 33
+py-html5lib             1.0b10_2    26 33
 py-htmldocs             3.3.99      26 31 32 33
 py-httplib2             2-0.11.3_1  26 33
 py-http-parser          0.8.3_1     26 31 32 33
@@ -284,7 +292,7 @@ py-prov                 1.1.5_1     34
 py-pyasdf               0.3.0_1     34
 py-pyaudio              0.2.8_1     26
 py-pyavm                0.9.2_1     26 33
-py-pybtex               0.21_2      26
+py-pybtex               1@0.21_2    26
 py-pycallgraph          1.0.1_1     33
 py-pycg                 0.14.1_12   26
 py-pycluster            1.50_2      26
@@ -369,7 +377,7 @@ py-shove                0.6.4_1     26
 py-simpy                3.0.5_1     33
 py-smmap                2.0.3_1     26
 py-snowballstemmer      1.2.0_1     26 33
-py-soaplib              1.0.0_1     26
+py-soaplib              1@1.0.0_1   26
 py-soappy               0.11.6_3    26
 py-socketpool           0.5.3_1     26 33
 py-socks                1.6.8_1     26
@@ -381,8 +389,10 @@ py-spectral             0.19_1      26
 py-sphinx-contrib       0.0.20151230 \
                                     26
 py-sphinx_rtd_theme     0.1.9_2     26 33
-py-spyder               2.3.7_1     33
-py-spyder-devel         2.3.4_1     33
+py-spyder               20111202@2.3.7_1 \
+                                    33
+py-spyder-devel         20161005@2.3.4_1 \
+                                    33
 py-sqlite               2.6.3_1     26
 py-storm                0.18_1      26
 py-subvertpy            0.10.1_1    26
@@ -419,7 +429,7 @@ py-visa                 1.4_1       26
 py-vobject              0.8.1c_1    26
 py-voeventlib           0.3_1       26
 py-watchdog             0.7.1_1     33
-py-webhelpers           1.3_1       26
+py-webhelpers           2@1.3_1     26
 py-webkitgtk            1.1.8_8     26
 py-werkzeug             0.14.1_1    26 33
 py-wordaxe              0.3.3_1     26


### PR DESCRIPTION
#### Description
As noted by @ryandesign in [this ticket](https://trac.macports.org/ticket/56858), replacements don't work correctly if the ```epoch``` value is higher than ```0```. This PR fixes that and adds support for ```epoch``` to py-graveyard and p5-graveyard. In addition, it adds the epoch value for py26-webhelpers (see [this commit](https://github.com/macports/macports-ports/commit/aa1d608282a2a58b3b9d3c4396a361832879448d#comments)).

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
