### PR TITLE
borgbackup: Update to 1.1.7 and add tab-completion

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                borgbackup
-version             1.1.6
+version             1.1.7
 categories          sysutils
 platforms           darwin
 license             BSD
-maintainers         loicp.eu:loic-github
+maintainers         {loicp.eu:loic-github @lpefferkorn} openmaintainer
 
 description         Deduplicating backup program
 long_description    BorgBackup (short: Borg) is a deduplicating backup \
@@ -23,9 +23,9 @@ long_description    BorgBackup (short: Borg) is a deduplicating backup \
 homepage            https://borgbackup.github.io/
 master_sites        pypi:b/borgbackup
 
-checksums           rmd160  f13b9a2428980b60c329431bb6c6a1170b1a0db2 \
-                    sha256  a1d2e474c85d3ad3d59b3f8209b5549653c88912082ea0159d27a2e80c910930 \
-                    size    3441523
+checksums           rmd160  3595743aa68582ea408939c83ab86f716dfbca9f \
+                    sha256  f7b51a132e9edfbe1cacb4f478b28caf3622d79fffcb369bdae9f92d8c8a7fdc \
+                    size    3446832
 
 patchfiles          patch-msgpack.diff
 
@@ -56,6 +56,18 @@ post-destroot {
     xinstall -m 0644 ${worksrcpath}/docs/_build/man/borg.1 \
         ${destroot}${prefix}/share/man/man1/
     file copy {*}[glob ${workpath}/${distname}/docs/_build/singlehtml/*] ${docdir}
+
+    # bash completion
+    set bash_compl_path ${prefix}/share/bash-completion/completions
+    xinstall -d ${destroot}${bash_compl_path}
+    xinstall -m 0644 ${worksrcpath}/scripts/shell_completions/bash/borg \
+        ${destroot}${bash_compl_path}
+
+    # zsh completion
+    set zsh_compl_path ${prefix}/share/zsh/site-functions
+    xinstall -d ${destroot}${zsh_compl_path}
+    xinstall -m 0644 ${worksrcpath}/scripts/shell_completions/zsh/_borg \
+        ${destroot}${zsh_compl_path}
 }
 
 livecheck.type      pypi


### PR DESCRIPTION
- Install upstream tab-completion files for bash and zsh

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->