### PR TITLE
py-aiohttp: multiple changes

### DIFF
--- a/python/py-aiohttp/Portfile
+++ b/python/py-aiohttp/Portfile
@@ -5,11 +5,12 @@ PortGroup           python 1.0
 
 name                py-aiohttp
 version             3.3.2
+revision            1
 categories-append   devel
 platforms           darwin
 license             Apache-2
 
-python.versions     35 36 37
+python.versions     36 37
 
 maintainers         {ipglider.org:miguel @ipglider} openmaintainer
 
@@ -30,12 +31,16 @@ checksums           rmd160  bd2de873cd93a99aacf73280c2bab4130235b8ee \
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
-    depends_lib-append      port:py${python.version}-async-timeout \
+    depends_lib-append      port:py${python.version}-aiodns \
+                            port:py${python.version}-async-timeout \
                             port:py${python.version}-attrs \
+                            port:py${python.version}-chardet \
                             port:py${python.version}-cchardet \
                             port:py${python.version}-idna-ssl \
                             port:py${python.version}-multidict \
                             port:py${python.version}-yarl
+
+    livecheck.type          none
 } else {
     livecheck.type          pypi
 }


### PR DESCRIPTION
- Add py-aiodns as a dependency.
- Add py-chardet as a dependency.
- Remove Python 3.5 support.
- Disable livecheck when installing.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->