### PR TITLE
mkcert: new port, version 1.1.0

### DIFF
--- a/security/mkcert/Portfile
+++ b/security/mkcert/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+
+github.setup        FiloSottile mkcert 1.1.0 v
+
+platforms           darwin
+categories          security devel
+license             permissive
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         A simple zero-config tool to make locally trusted \
+                    development certificates with any names you'd like
+
+long_description    mkcert is a simple tool for making locally-trusted \
+                    development certificates. It requires no configuration. \
+                    Using certificates from real certificate authorities (CAs)\
+                    for development can be dangerous or impossible (for hosts \
+                    like localhost or 127.0.0.1), but self-signed certificates\
+                    cause trust errors. Managing your own CA is the best \
+                    solution, but usually involves arcane commands, \
+                    specialized knowledge and manual steps. \
+                    \
+                    mkcert automatically creates and installs a local CA in \
+                    the system root store, and generates locally-trusted \
+                    certificates.
+
+checksums   rmd160  e3e148b80b2122242a3bf20d3e96a82e69e04d50 \
+            sha256  2f18b5152019a50ffe0df2dd2468a67f9765f43b3d57209458b04c432651a2c6 \
+            size    1710218
+
+depends_build       port:go
+use_configure       no
+
+build.cmd           ${prefix}/bin/go
+build.target        build
+build.env           GOPATH=${workpath}
+
+post-extract {
+    file mkdir ${workpath}/src/
+
+    ln -sf ${worksrcpath}/vendor/golang.org ${workpath}/src/golang.org
+    ln -sf ${worksrcpath}/vendor/github.com ${workpath}/src/github.com
+    ln -sf ${worksrcpath}/vendor/software.sslmate.com \
+        ${workpath}/src/software.sslmate.com
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name}-${version} \
+        ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

mkcert is a simple zero-config tool to make locally trusted development certificates with any names you'd like

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2208

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?  ***Used `sudo port -vs install`, tracing does not seem to work because golang***
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
