### PR TITLE
groovy: Update to 2.5.2

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.1
+version         2.5.2
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,9 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  18a02d9217047b0a24d4a89ea6e12be7fff795c8 \
-                sha256  7a7c1215620047f36ae66c8ca396864aa602cc90f7238851cd8714acb41418ff \
-                size    28300476
+checksums       rmd160  df19ea9526acd19b0b515c799366ff12f65435d9 \
+                sha256  495f96f1be35ef838abb5f1c10fc6f642460cacd94c7095eb3a9f1fbf62b282e \
+                size    29598793
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.2.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?