### PR TITLE
stellarium* : use qt5.depends_component

### DIFF
--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -50,18 +50,14 @@ homepage        http://stellarium.org/
 # builds as 64-bit only, according to its top-level CMakeLists.txt file
 universal_variant no
 
+qt5.depends_component qtlocation qtmultimedia qtscript qtserialport qttools
+
 depends_lib-append \
     port:zlib \
     port:gpsd \
     port:gettext \
     port:doxygen \
-    port:python27 \
-    port:qt5-qtbase \
-    port:qt5-qtlocation \
-    port:qt5-qtmultimedia \
-    port:qt5-qtscript \
-    port:qt5-qtserialport \
-    port:qt5-qttools
+    port:python27
 
 # for libqcocoa.dylib (if not above)
 


### PR DESCRIPTION
works better across qt5 versions

I tried to install stellarium on `10.7.5` but the components didn't come in correctly. Marcus has previously indicated that the qt5 PG is meant to use this qt5.depends_component syntax, and indeed, switching it around to this did work on `10.7.5`. 

Apparently qtbase is implicit, as if I add that to the list, it comes up as specified twice.

So far I have only tested this on `10.7.5`, which is all I have available at the moment.