### PR TITLE
py-scikit-learn: update to 0.19.2

### DIFF
--- a/python/py-scikit-learn/Portfile
+++ b/python/py-scikit-learn/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-scikit-learn
-version             0.19.1
+version             0.19.2
 revision            0
 categories-append   science
 platforms           darwin
 license             BSD
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -27,8 +27,10 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  dfb92fedadc1fecd9934f85321156f3f5d197a2e \
-                    sha256  5ca0ad32ee04abe0d4ba02c8d89d501b4e5e0304bdf4d45c2e9875a735b323a0
+checksums           rmd160  c6ded64cadf7ba3d3a40abc28835d5d1b852e5cf \
+                    sha256  b276739a5f863ccacb61999a3067d0895ee291c95502929b2ae56ea1f882e888 \
+                    size    9680746
+
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION

#### Description

Added version 0.19.2 and support for python 3.7. Notice that travis-ci is not able to complete the installation in the maximum time for this Portfile for some Xcode versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? __this Portfile has no tests__
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
