### PR TITLE
rrdtool: Move python bindings to new py-rrdtool port

### DIFF
--- a/net/ntop/Portfile
+++ b/net/ntop/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name			ntop
 version			5.0.1
-revision        5
+revision        6
 categories		net
 maintainers		nomaintainer
 # COPYING is GPL 3 but the source files say GPL 2 or later
@@ -33,6 +33,7 @@ depends_lib		port:libpcap \
 			port:gdbm \
 			port:libgeoip \
 			port:rrdtool \
+			port:py27-rrdtool \
 			port:python27
 
 post-extract {

--- a/net/rrdtool/Portfile
+++ b/net/rrdtool/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                rrdtool
 version             1.7.0
-revision            1
+revision            2
 categories          net
 license             GPL-2+
 platforms           darwin
@@ -63,11 +63,4 @@ post-destroot {
             }
         }
     }
-}
-
-variant python27 description {Python 2.7 bindings for RRDtool} {
-    depends_lib-append      port:python27
-    configure.python        ${prefix}/bin/python2.7
-    configure.args-delete   --disable-python
-    configure.args-append   --enable-python
 }

--- a/python/py-rrdtool/Portfile
+++ b/python/py-rrdtool/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rrdtool
+version             0.1.14
+platforms           darwin
+license             LGPL-2.1+
+maintainers         nomaintainer
+
+description         Python bindings for rrdtool
+long_description    ${description}
+
+homepage            https://github.com/commx/python-rrdtool
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            rrdtool-${version}
+
+checksums           rmd160  c2580ed4aacb431a98b4f030ac99fd744f960c64 \
+                    sha256  32c8f0a6b2622052564387a7eb5228be8eb45753bb51695cbf7a36338a63c36d \
+                    size    12341
+
+python.versions     27 37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:rrdtool
+
+    post-patch {
+        if {${prefix} ne "/usr/local"} {
+            reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/setup.py
+        }
+    }
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description

rrdtool 1.7.0 bundles version 0.1.10 of the python bindings. This PR removes the python27 variant from the rrdtool port and adds a new port py-rrdtool. This change allows us to use the most up-to-date version of the bindings, currently 0.1.14; allows us to update them independent of rrdtool; and allows the user to install them after installing rrdtool, without having to rebuild rrdtool.

The ports that depend on rrdtool that also mention python are collectd, honeyd, and ntop. Of those, as far as I can tell, only ntop uses the rrdtool python bindings, so I added the `port:py27-rrdtool` dependency to that port and increased its revision to record that change in the registry. [ntop does not currently build](https://trac.macports.org/ticket/55550); I am working on fixing that separately. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->