### PR TITLE
rancid: update to 3.8

### DIFF
--- a/net/rancid/Portfile
+++ b/net/rancid/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                rancid
-version             3.7
+version             3.8
 categories          net
 license             BSD-old
 maintainers         nomaintainer
@@ -19,9 +19,9 @@ long_description    Rancid maintains a CVS/SVN/git repository of router and \
 homepage            http://www.shrubbery.net/rancid
 master_sites        ftp://ftp.shrubbery.net/pub/rancid/
 
-checksums           rmd160  dda06111afbd28fc2ee06780fb1ac451f0d62732 \
-                    sha256  9c6befff78d49d8d0757a2b57b6cfdfef55cadcbc1fa6fbe1ab9424335d51f7b \
-                    size    503424
+checksums           rmd160  456fb1a9a262dd61c15f7351040940fdfffac8e2 \
+                    sha256  cecdeed2379c832fb5988f4dc8c45fbbbb382723882a9ffea577e54f5ab8cc5f \
+                    size    523950
 
 perl5.branches      5.26
 depends_lib-append  port:perl${perl5.major} \
@@ -29,7 +29,8 @@ depends_lib-append  port:perl${perl5.major} \
                     path:lib/libssl.dylib:openssl
 
 patchfiles          patch-etc-Makefile.am.diff \
-                    patch-bin-Makefile.in.diff
+                    patch-bin-Makefile.in.diff \
+                    patch-bin-fxlogin.in.diff
 
 post-patch {
 # Set path for lg.conf.sample so Looking Glass will work

--- a/net/rancid/files/patch-bin-fxlogin.in.diff
+++ b/net/rancid/files/patch-bin-fxlogin.in.diff
@@ -1,0 +1,11 @@
+--- bin/fxlogin.in.orig	2018-08-14 16:47:55.000000000 -0400
++++ bin/fxlogin.in	2018-08-14 16:52:05.000000000 -0400
+@@ -397,7 +397,7 @@
+ 	    -re "^\[^\n\r]*$reprompt."		{ send_user -- "$expect_out(buffer)"
+ 						  exp_continue
+ 						}
+-	    -re "^[^-]*--More--\[^\r\n]*[\r\n]+"	{ # fxos FTP pager
++	    -re "^\[^-]*--More--\[^\r\n]*\[\r\n]+"	{ # fxos FTD pager
+ 						  send " "
+ 						  exp_continue
+ 						}


### PR DESCRIPTION
#### Description

Update to new upstream release 3.8, and fix for a typo in that release.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G1510
Xcode 9.2 9C40b 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
