### PR TITLE
podofo: Fix build failure with cmake 3.12

### DIFF
--- a/graphics/podofo/Portfile
+++ b/graphics/podofo/Portfile
@@ -46,6 +46,7 @@ post-extract {
 }
 
 patchfiles          patch-cmake-modules-FindFREETYPE.cmake.diff
+patchfiles-append   podofo-cmake-3.12.patch
 
 configure.args-append \
                     -G \"Unix Makefiles\" \

--- a/graphics/podofo/files/podofo-cmake-3.12.patch
+++ b/graphics/podofo/files/podofo-cmake-3.12.patch
@@ -1,0 +1,15 @@
+Fix build failure with cmake 3.12.
+https://sourceforge.net/p/podofo/tickets/24/
+--- test/TokenizerTest/CMakeLists.txt.old	2018-07-20 18:26:02.921494293 +0200
++++ test/TokenizerTest/CMakeLists.txt	2018-07-20 18:34:53.727136443 +0200
+@@ -2,10 +2,3 @@
+ TARGET_LINK_LIBRARIES(TokenizerTest ${PODOFO_LIB} ${PODOFO_LIB_DEPENDS})
+ SET_TARGET_PROPERTIES(TokenizerTest PROPERTIES COMPILE_FLAGS "${PODOFO_CFLAGS}")
+ ADD_DEPENDENCIES(TokenizerTest ${PODOFO_DEPEND_TARGET})
+-
+-# Copy the test samples over to the build tree
+-ADD_CUSTOM_COMMAND(
+-    TARGET TokenizerTest
+-    POST_BUILD
+-    COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/objects" "${CMAKE_CURRENT_BINARY_DIR}/objects"
+-    )


### PR DESCRIPTION
#### Description

Fix build failure with cmake 3.12.

Thanks to @grumpybozo

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
