### PR TITLE
py-gwdatafind: update to 1.0.2

### DIFF
--- a/python/py-gwdatafind/Portfile
+++ b/python/py-gwdatafind/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-gwdatafind
-version             1.0.0
+version             1.0.2
 
 categories-append   science
 maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
@@ -22,9 +22,9 @@ homepage            https://gwdatafind.readthedocs.io
 
 master_sites        pypi:g/gwdatafind
 distname            gwdatafind-${version}
-checksums           rmd160  d6ee9ee4ab579341543458acef32b6a12cf6d628 \
-                    sha256  1441ad9dc445fc906bd3f589a059b878976958870cfad9ef20b9e2b8255378f4 \
-                    size    31273
+checksums           rmd160  0ab3223d8526bae8bcaadb942ee28cd4e0334483 \
+                    sha256  1c26a2abf912c25c214c08da304328042ca2945e8acc92923b8eba03b838bc2b \
+                    size    31397
 
 python.versions     27 36 37
 python.default_version 36


### PR DESCRIPTION
#### Description

This PR updates `py-gwdatafind` to [1.0.2](https://pypi.org/project/gwdatafind/1.0.2).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
