### PR TITLE
mkcert 1.1.0: correct license to BSD

### DIFF
--- a/security/mkcert/Portfile
+++ b/security/mkcert/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-
 github.setup        FiloSottile mkcert 1.1.0 v
 
 platforms           darwin
 categories          security devel
-license             permissive
+license             BSD
 installs_libs       no
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer


### PR DESCRIPTION
#### Description

Correcting license and spacing for mkcert as per comments from @neverpanic and @pmetzger on #2381 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2208
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
