### PR TITLE
Updated digital_rf to 2.6.1

### DIFF
--- a/science/digital_rf/Portfile
+++ b/science/digital_rf/Portfile
@@ -5,13 +5,8 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
-github.setup        MITHaystack digital_rf 2.6.0
-revision            1
-categories          science
-license             BSD
-platforms           darwin
+github.setup        MITHaystack digital_rf 2.6.1
 maintainers         {mit.edu:rvolz @ryanvolz} {mit.edu:swoboj @jswoboda} openmaintainer
-
 description         Read, write, and interact with data in the Digital RF and Digital Metadata formats.
 long_description    ${description} The Digital RF project encompasses a standardized HDF5 format\
                     for reading and writing of radio frequency data and the software \
@@ -19,34 +14,38 @@ long_description    ${description} The Digital RF project encompasses a standard
                     for data archive and to allow rapid random access for data \
                     processing. For details on the format, refer to the 'documents' \
                     directory in the source tree.
+revision            1
+categories          science
+license             BSD
+platforms           darwin
+dist_subdir         digital_rf
 
-checksums           rmd160  f095ff1a80f7175f57a45048c826fe68b6dd56e9 \
-                    sha256  6468418a06c269964c9a5c5f145f7bfebf951226e3a85977226c7967fa50e691 \
-                    size    4528350
+checksums           rmd160  a8885c5e2976a6f904c59fa4debf4062ae8760c3 \
+                    sha256  c6e62d959b6716c953196dc33f47dc0dd81945379683b206762ca74e0888151e \
+                    size    4537334
 
-configure.ldflags-delete    -L${prefix}/lib
+configure.ldflags-delete -L${prefix}/lib
 
-depends_build-append \
-                    port:py27-pkgconfig
+depends_build-append  port:py27-pkgconfig
 
-depends_lib-append  port:hdf5 \
-                    port:py27-mako \
-                    port:py27-numpy
+depends_lib-append port:hdf5 \
+                   port:py27-mako \
+                   port:py27-numpy
 
-depends_run-append  port:boost \
-                    port:gnutls \
-                    port:py27-dateutil \
-                    port:py27-h5py \
-                    port:py27-matplotlib \
-                    port:py27-packaging \
-                    port:py27-pandas \
-                    port:py27-scipy \
-                    port:py27-six \
-                    port:py27-tz \
-                    port:py27-watchdog
+depends_run-append port:boost \
+                   port:gnutls \
+                   port:py27-dateutil \
+                   port:py27-h5py \
+                   port:py27-matplotlib \
+                   port:py27-packaging \
+                   port:py27-pandas \
+                   port:py27-scipy \
+                   port:py27-six \
+                   port:py27-tz \
+                   port:py27-watchdog
 
-depends_run-append  path:lib/libgnuradio-runtime.dylib:gnuradio \
-                    path:lib/libuhd.dylib:uhd
+depends_run-append path:lib/libgnuradio-runtime.dylib:gnuradio \
+                   path:lib/libuhd.dylib:uhd
 
 # CMAKE configuration
 configure.args-append \


### PR DESCRIPTION
#### Description

Updated digital_rf to 2.6.1. Port file is on revision 1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
