### PR TITLE
py-pylint/py-astroid: update to latest version

### DIFF
--- a/python/py-astroid/Portfile
+++ b/python/py-astroid/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-astroid
-version             1.6.5
-revision            0
+version             2.0.4
 categories-append   devel
 platforms           darwin
 license             LGPL-2.1+
@@ -23,27 +22,47 @@ long_description    The aim of this module is to provide a common \
                     Well, actually the development of this library is \
                     essentially governed by pylint's needs.
 
-homepage            http://bitbucket.org/logilab/astroid/
+homepage            https://github.com/pycqa/astroid
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  bba1d1e3582e557ecbe6a56ca83adef5b1d80506 \
-                    sha256  fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a \
-                    size    255688
+checksums           rmd160  4f525192794b7c408c719e4d9731801c2a697b96 \
+                    sha256  c7013d119ec95eb626f7a2011f0b63d0c9a095df9ad06d8507b37084eada1a8d \
+                    size    273871
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
+    if {${python.version} ne 27} {
+        depends_build-append \
+                        port:py${python.version}-pytest-runner
+    }
+
     depends_lib-append  port:py${python.version}-lazy_object_proxy \
                         port:py${python.version}-six \
                         port:py${python.version}-wrapt
 
-    if {${python.version} == 27} {
-        depends_lib-append  port:py${python.version}-enum34 \
-                            port:py${python.version}-singledispatch \
-                            port:py${python.version}-backports-functools_lru_cache
+    if {${python.version} eq 27} {
+        version         1.6.5
+        distname        ${python.rootname}-${version}
+        checksums       rmd160  bba1d1e3582e557ecbe6a56ca83adef5b1d80506 \
+                        sha256  fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a \
+                        size    255688
+
+        depends_lib-append \
+                        port:py${python.version}-enum34 \
+                        port:py${python.version}-singledispatch \
+                        port:py${python.version}-backports-functools_lru_cache
+    }
+    if {${python.version} ne 27 && ${python.version} ne 37} {
+        depends_lib-append \
+                        port:py${python.version}-typed-ast
+    }
+    if {${python.version} eq 34} {
+        depends_lib-append \
+                        port:py${python.version}-typing
     }
 
     post-destroot {

--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pylint
-version             1.9.2
+version             2.1.1
 categories-append   devel
 platforms           darwin
 license             GPL-2+
@@ -30,25 +30,30 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  9b682e1380ad5eea89fa6ffbc3fc61548ac52f20 \
-                    sha256  fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3 \
-                    size    516869
+checksums           rmd160  8caa95cd011b974fb0e450bc2f92ce6adbfa3736 \
+                    sha256  31142f764d2a7cd41df5196f9933b12b7ee55e73ef12204b648ad7e556c119fb \
+                    size    555770
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools \
                         port:py${python.version}-pytest-runner
 
-    depends_lib-append  port:py${python.version}-astroid \
-                        port:py${python.version}-six \
+    depends_lib-append  port:py${python.version}-setuptools \
+                        port:py${python.version}-astroid \
                         port:py${python.version}-isort \
                         port:py${python.version}-flake8-mccabe
 
     if {${python.version} eq 27} {
+        version             1.9.2
+        distname            ${python.rootname}-${version}
+        checksums           rmd160  9b682e1380ad5eea89fa6ffbc3fc61548ac52f20 \
+                            sha256  fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3 \
+                            size    516869
+
         depends_lib-append  port:py${python.version}-configparser \
                             port:py${python.version}-backports-functools_lru_cache \
-                            port:py${python.version}-enum34 \
-                            port:py${python.version}-singledispatch
+                            port:py${python.version}-singledispatch \
+                            port:py${python.version}-six
     }
 
     depends_run-append  port:pylint_select

--- a/python/py-typed-ast/Portfile
+++ b/python/py-typed-ast/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-typed-ast
+version             1.1.0
+categories-append   devel
+platforms           darwin
+license             Apache-2
+
+python.versions     34 35 36
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         A fork of Python 2 and 3 ast modules with type comment support.
+long_description    ${description}
+
+homepage            https://github.com/python/typed_ast
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            typed-ast-${version}
+
+checksums           rmd160  0b5c87b0360d7268ff407bfc18171c6e256343d1 \
+                    sha256  57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa \
+                    size    200587
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description
- py-astroid: update to 2.0.4 for Python 3 (pin at version 1.65 for Python 2), update dependencies
- py-pylint: update to 2.1.1 for Python 3 (pin at version 1.92 for Python 2), update dependencies
- py-typed-ast: new port, version 1.1.0 ; needed for py-astroid

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
