### PR TITLE
py-tox: update to 3.2.1

### DIFF
--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-tox
-version             3.0.0
+version             3.2.1
 categories-append   devel
 maintainers         {gmail.com:pedro.salgado @steenzout} openmaintainer
 platforms           darwin
@@ -20,20 +20,20 @@ master_sites        pypi:t/tox/
 
 distname            tox-${version}
 
-checksums           rmd160  b9eda9e6d0ba59b9b5f9ca83ee6e94c4e67bba0b \
-                    sha256  96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f \
-                    size    226055
+checksums           rmd160  e1f1b9ad6c8b39da6f45022a3e826f8689633314 \
+                    sha256  eb61aa5bcce65325538686f09848f04ef679b5cd9b83cc491272099b28739600 \
+                    size    268827
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm
 
     depends_lib-append \
                     port:py${python.version}-pluggy \
                     port:py${python.version}-py \
+                    port:py${python.version}-setuptools \
                     port:py${python.version}-six \
                     port:py${python.version}-virtualenv \
                     port:tox_select


### PR DESCRIPTION
#### Description
- update to version 3.2.1
- fix setuptools dependency type (runtime)
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
