### PR TITLE
sox: use curl instead of wget

### DIFF
--- a/audio/sox/Portfile
+++ b/audio/sox/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name             sox
 conflicts        play
 version          14.4.2
-revision         1
+revision         2
 categories       audio
 platforms        darwin
 maintainers      {stare.cz:hans @janstary}
@@ -27,6 +27,8 @@ checksums        sha1    dc9668256b9d81ef25d672f14f12ec026b0b4087 \
 
 depends_build	\
 		port:pkgconfig
+
+patchfiles      patch-curl.diff
 
 platform darwin 11 {
 	# System grep fails: "grep: Regular expression too big"
@@ -50,8 +52,6 @@ depends_lib	\
 		port:twolame		\
 		port:wavpack		\
 		port:zlib
-
-depends_run	port:wget
 
 configure.args	\
 		--enable-largefile	\

--- a/audio/sox/files/patch-curl.diff
+++ b/audio/sox/files/patch-curl.diff
@@ -1,0 +1,20 @@
+--- src/formats.c.orig	2018-08-18 10:05:14.000000000 +0200
++++ src/formats.c	2018-08-18 10:09:26.000000000 +0200
+@@ -353,7 +353,7 @@ static int sox_checkformat(sox_format_t 
+   return SOX_SUCCESS;
+ }
+ 
+-static sox_bool is_url(char const * text) /* detects only wget-supported URLs */
++static sox_bool is_url(char const * text)
+ {
+   return !(
+       strncasecmp(text, "http:" , (size_t)5) &&
+@@ -390,7 +390,7 @@ static FILE * xfopen(char const * identi
+   else if (is_url(identifier)) {
+     FILE * f = NULL;
+ #ifdef HAVE_POPEN
+-    char const * const command_format = "wget --no-check-certificate -q -O- \"%s\"";
++    char const * const command_format = "curl --no-cert-status -s -o - \"%s\"";
+     char * command = lsx_malloc(strlen(command_format) + strlen(identifier));
+     sprintf(command, command_format, identifier);
+     f = popen(command, POPEN_MODE);


### PR DESCRIPTION
This makes sox use `curl` instead of `wget` to play remote files,
which means we can drop the `wget` dependency.

- [x] enhancement

Tested on macOS 10.13.6 17G65 Xcode 9.4.1 9F2000.

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
