### PR TITLE
sysutils/terraform: update to 0.11.8

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                terraform
-version             0.11.7
+version             0.11.8
 
 categories          sysutils
 license             MPL-2
@@ -25,9 +25,9 @@ homepage            https://www.terraform.io/downloads.html
 master_sites        https://releases.hashicorp.com/${name}/${version}
 distname            ${name}_${version}_darwin_amd64
 
-checksums           rmd160 1337f0ae97afb165aa960e4ef3663f7c87815b2d \
-                    sha256 6514a8fe5a344c5b8819c7f32745cd571f58092ffc9bbe9ea3639799b97ced5f \
-                    size   17754416
+checksums           rmd160 0f12057ce54d69cf7c73c7b3083aeb1cb975bf45 \
+                    sha256 98c168b06e8b4058c66e044e3744d49956ce7bc3664dc1679a33f8fffc84564d \
+                    size   19269525
 
 use_configure       no
 use_zip             yes


### PR DESCRIPTION
#### Description

Update Hashicorp's Terraform to 0.11.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2208
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? **Used -vs**
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
