### PR TITLE
py-olefile: update to 0.45.1

### DIFF
--- a/python/py-olefile/Portfile
+++ b/python/py-olefile/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-olefile
-version             0.44
-revision            0
+version             0.45.1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -24,15 +23,26 @@ homepage            https://www.decalage.info/python/olefileio
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
+use_zip             yes
 
-checksums           rmd160  e85ff631ac1992b5b59dcf98ced566c7778d2ea4 \
-                    sha256  61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad
+checksums           rmd160  1eb05371bc3368f755d5a70103e289690d474c8d \
+                    sha256  2b6575f5290de8ab1086f8c5490591f7e0885af682c7c1793bdaf6e64078d385 \
+                    size    112359
 
 if {${name} ne ${subport}} {
+    if {[lsearch {26 33} ${python.version}] != -1} {
+        version     0.44
+        checksums   rmd160  e85ff631ac1992b5b59dcf98ced566c7778d2ea4 \
+                    sha256  61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad \
+                    size    74147
+        distname    ${python.rootname}-${version}
+    }
+
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
 
-    use_zip             yes
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
 
-    livecheck.type      none
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to latest version (0.45.1)
- pin py26/py33 subports to version 0.44 [removing these subports is not possible as there are still dependencies]
- enable tests
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
