### PR TITLE
py-roman: update to 3.0

### DIFF
--- a/python/py-roman/Portfile
+++ b/python/py-roman/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-roman
-version             2.0.0
+version             3.0
 categories-append   textproc
 license             PSF-2.1.1
 platforms           darwin
@@ -17,27 +17,19 @@ long_description    ${description}
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
 distname            ${python.rootname}-${version}
-use_zip             yes
 
-checksums           md5     aa71d131eec16d45c030fd06a27c9d17 \
-                    sha1    7fd136f80cf780bbf802ffe1c4989a64ff469c75 \
-                    rmd160  a8ca66d5fafd340986a45332d861d6bae259fe1e
+checksums           rmd160  39d72b580e07e5c49bdf3a7db9efe987f3ff8d60 \
+                    sha256  1cb1cfc9386ec39bd5dd3190c2c89c1b253140bccda16807aab3627cbb3f275d \
+                    size    5184
 
-python.versions     26 27 33 34 35 36
+python.versions     26 27 33 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    pre-activate {
-        if {[file exists ${python.pkgd}/roman.py]
-            && ![catch {set vers [lindex [registry_active py${python.version}-docutils] 0]}]
-            && [vercmp [lindex $vers 1] 0.6] < 0} {
-            registry_deactivate_composite py${python.version}-docutils "" [list ports_nodepcheck 1]
-        }
-    }
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.regex [format "%s-%s" ${python.rootname} {(\d+(?:\.\d+)*)}]
 }

--- a/python/py-roman/Portfile
+++ b/python/py-roman/Portfile
@@ -1,32 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-set realname        roman
-name                py-${realname}
+name                py-roman
 version             2.0.0
-python.versions     26 27 33 34 35 36
 categories-append   textproc
 license             PSF-2.1.1
 platforms           darwin
 supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
+
 description         Integer to Roman numerals converter
 long_description    ${description}
-homepage            https://pypi.python.org/pypi/${realname}/
-master_sites        pypi:[string index ${realname} 0]/${realname}/
-distname            ${realname}-${version}
+
+homepage            https://pypi.python.org/pypi/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
+distname            ${python.rootname}-${version}
 use_zip             yes
 
 checksums           md5     aa71d131eec16d45c030fd06a27c9d17 \
                     sha1    7fd136f80cf780bbf802ffe1c4989a64ff469c75 \
                     rmd160  a8ca66d5fafd340986a45332d861d6bae259fe1e
 
-if {${name} eq ${subport}} {
-    livecheck.type  regex
-    livecheck.regex [format "%s-%s" ${realname} {(\d+(?:\.\d+)*)}]
-} else {
+python.versions     26 27 33 34 35 36
+
+if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools
 
     pre-activate {
@@ -38,4 +37,7 @@ if {${name} eq ${subport}} {
     }
 
     livecheck.type  none
+} else {
+    livecheck.type  regex
+    livecheck.regex [format "%s-%s" ${python.rootname} {(\d+(?:\.\d+)*)}]
 }


### PR DESCRIPTION
#### Description
- adjust whitespaces and slightly reorganize so that it conforms more to the other Python Portfiles
- add py37 subport
- remove unneeded pre-activate statement (at least I think it's unnecessary, can @lpsinger confirm this?)
- enable tests
- update livecheck, modernize checksums

Closes: https://trac.macports.org/ticket/56913 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
