### PR TITLE
py-codestyle/py-pyflakes/py-flake8: update to latest

### DIFF
--- a/python/py-codestyle/Portfile
+++ b/python/py-codestyle/Portfile
@@ -12,7 +12,7 @@ name                py-codestyle
 # Please DO NOT update without cross-checking version compatibility and
 # perform updates in a coordinated way.
 
-version             2.3.1
+version             2.4.0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -25,26 +25,19 @@ long_description    \
     conventions in PEP 8 (https://www.python.org/dev/peps/pep-0008/). \
     This package used to be called pep8, but was renamed.
 
-homepage            https://pypi.python.org/pypi/${_name}/
+homepage            https://pycodestyle.readthedocs.io
 
 master_sites        pypi:[string index ${_name} 0]/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     240e342756af30cae0983b16303a2055 \
-                    rmd160  beb5e00fdd74e3811a180959bac9c2abfb7cbea0 \
-                    sha256  682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766
+checksums           rmd160  1a0281bb62c0a409e2318b6eb3b25e84c9840f8e \
+                    sha256  cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a \
+                    size    96665
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-setuptools
-
-    # fix wrong file permissions of the distfile
-    post-extract {
-        fs-traverse f ${worksrcpath} {
-            file attributes ${f} -permissions a+r
-        }
-    }
 
     depends_run-append      port:${_name}_select
 
@@ -57,9 +50,12 @@ when you execute the commands without a version suffix, e.g. '${_name}', run:
 port select --set ${select.group} [file tail ${select.file}]
 "
 
+    test.run        yes
+    test.cmd        ${python.bin} pycodestyle.py --testsuite testsuite
+    test.target
+
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}"
+    livecheck.type  pypi
+    livecheck.name  pycodestyle
 }

--- a/python/py-flake8/Portfile
+++ b/python/py-flake8/Portfile
@@ -9,6 +9,7 @@ set _n              [string index ${_name} 0]
 
 name                py-${_name}
 version             3.5.0
+revision            1
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -30,18 +31,22 @@ homepage            http://flake8.readthedocs.org/
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-
-checksums           md5     7e5fe39d578a2c2d0962b61b35b8c3fc \
-                    rmd160  4533c09c33394ca31ab081ed09f370dfac415882 \
-                    sha256  7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0
+checksums           rmd160  4533c09c33394ca31ab081ed09f370dfac415882 \
+                    sha256  7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0 \
+                    size    140608
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools \
-                            port:py${python.version}-pytest-runner
+    # apply upstream patches so that flake8 works with latest versions of
+    # pycodestyle and py-flakes [remove when new version is released]
+    patchfiles-append       patch-pr230.diff \
+                            patch-pr239.diff
 
-    depends_lib-append      port:py${python.version}-pyflakes \
+    depends_build-append    port:py${python.version}-pytest-runner
+
+    depends_lib-append      port:py${python.version}-setuptools \
+                            port:py${python.version}-pyflakes \
                             port:py${python.version}-codestyle \
                             port:py${python.version}-flake8-mccabe
 
@@ -73,9 +78,17 @@ port select --set ${select.group} [file tail ${select.file}]
                 ${dest_doc}
     }
 
+    depends_test-append \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-mock
+
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
+    livecheck.type  pypi
+    livecheck.name  flake8
 }

--- a/python/py-flake8/files/patch-pr230.diff
+++ b/python/py-flake8/files/patch-pr230.diff
@@ -1,0 +1,33 @@
+--- setup.py.orig	2018-08-17 12:10:13.000000000 -0400
++++ setup.py	2018-08-17 12:11:22.000000000 -0400
+@@ -22,7 +22,7 @@
+     # And in which releases we will update those ranges here:
+     # http://flake8.pycqa.org/en/latest/internal/releases.html#releasing-flake8
+     "pyflakes >= 1.5.0, < 1.7.0",
+-    "pycodestyle >= 2.0.0, < 2.4.0",
++    "pycodestyle >= 2.0.0, < 2.5.0",
+     "mccabe >= 0.6.0, < 0.7.0",
+     "setuptools >= 30",
+ ]
+@@ -108,7 +108,8 @@
+             PEP8_PLUGIN('module_imports_on_top_of_file'),
+             PEP8_PLUGIN('compound_statements'),
+             PEP8_PLUGIN('explicit_line_join'),
+-            PEP8_PLUGIN('break_around_binary_operator'),
++            PEP8_PLUGIN('break_after_binary_operator'),
++            PEP8_PLUGIN('break_before_binary_operator'),
+             PEP8_PLUGIN('comparison_to_singleton'),
+             PEP8_PLUGIN('comparison_negative'),
+             PEP8_PLUGIN('comparison_type'),
+
+--- setup.cfg.orig	2018-08-17 12:10:05.000000000 -0400
++++ setup.cfg	2018-08-17 12:10:31.000000000 -0400
+@@ -9,7 +9,7 @@
+ 	enum34; python_version<"3.4"
+ 	configparser; python_version<"3.2"
+ 	pyflakes >= 1.5.0, < 1.7.0
+-	pycodestyle >= 2.0.0, < 2.4.0
++	pycodestyle >= 2.0.0, < 2.5.0
+ 	mccabe >= 0.6.0, < 0.7.0
+ 
+ [egg_info]

--- a/python/py-flake8/files/patch-pr239.diff
+++ b/python/py-flake8/files/patch-pr239.diff
@@ -1,0 +1,65 @@
+--- setup.py.orig	2018-08-17 12:14:39.000000000 -0400
++++ setup.py	2018-08-17 12:15:09.000000000 -0400
+@@ -21,7 +21,7 @@
+     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
+     # And in which releases we will update those ranges here:
+     # http://flake8.pycqa.org/en/latest/internal/releases.html#releasing-flake8
+-    "pyflakes >= 1.5.0, < 1.7.0",
++    "pyflakes >= 2.0.0, < 2.1.0",
+     "pycodestyle >= 2.0.0, < 2.5.0",
+     "mccabe >= 0.6.0, < 0.7.0",
+     "setuptools >= 30",
+
+--- setup.cfg.orig	2018-08-17 12:14:51.000000000 -0400
++++ setup.cfg	2018-08-17 12:15:24.000000000 -0400
+@@ -8,7 +8,7 @@
+ requires-dist = 
+ 	enum34; python_version<"3.4"
+ 	configparser; python_version<"3.2"
+-	pyflakes >= 1.5.0, < 1.7.0
++	pyflakes >= 2.0.0, < 2.1.0
+ 	pycodestyle >= 2.0.0, < 2.5.0
+ 	mccabe >= 0.6.0, < 0.7.0
+ 
+--- docs/source/user/error-codes.rst.orig	2018-08-17 12:19:12.000000000 -0400
++++ docs/source/user/error-codes.rst	2018-08-17 12:18:49.000000000 -0400
+@@ -54,6 +54,10 @@
+ +------+---------------------------------------------------------------------+
+ | F707 | an ``except:`` block as not the last exception handler              |
+ +------+---------------------------------------------------------------------+
++| F721 | doctest syntax error                                                |
+++------+---------------------------------------------------------------------+
++| F722 | syntax error in forward type annotation                             |
+++------+---------------------------------------------------------------------+
+ +------+---------------------------------------------------------------------+
+ | F811 | redefinition of unused ``name`` from line ``N``                     |
+ +------+---------------------------------------------------------------------+
+@@ -69,6 +73,9 @@
+ +------+---------------------------------------------------------------------+
+ | F841 | local variable ``name`` is assigned to but never used               |
+ +------+---------------------------------------------------------------------+
+++------+---------------------------------------------------------------------+
++| F901 | ``raise NotImplemented`` should be ``raise NotImplementedError``    |
+++------+---------------------------------------------------------------------+
+ 
+ Note that some of these entries behave differently on Python 2 and Python 3,
+ for example F812 is specific to Python 2 only.
+
+--- src/flake8/plugins/pyflakes.py.orig	2018-08-17 12:21:07.000000000 -0400
++++ src/flake8/plugins/pyflakes.py	2018-08-17 12:21:48.000000000 -0400
+@@ -38,6 +38,7 @@
+     'ReturnOutsideFunction': 'F706',
+     'DefaultExceptNotLast': 'F707',
+     'DoctestSyntaxError': 'F721',
++    'ForwardAnnotationSyntaxError': 'F722',
+     'RedefinedWhileUnused': 'F811',
+     'RedefinedInListComp': 'F812',
+     'UndefinedName': 'F821',
+@@ -45,6 +46,7 @@
+     'UndefinedLocal': 'F823',
+     'DuplicateArgument': 'F831',
+     'UnusedVariable': 'F841',
++    'RaiseNotImplemented': 'F901',
+ }
+ 
+ 

--- a/python/py-pyflakes/Portfile
+++ b/python/py-pyflakes/Portfile
@@ -10,8 +10,7 @@ name                py-pyflakes
 # Please DO NOT update without cross-checking version compatibility and
 # perform updates in a coordinated way.
 
-version             1.6.0
-revision            0
+version             2.0.0
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -32,8 +31,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            pyflakes-${version}
 
-checksums           rmd160  c0ec8b750e590295e875ac820fdbeb660c9c8af6 \
-                    sha256  8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805
+checksums           rmd160  9a04c07af00adf6772a5777e12d8c4ef0d38245c \
+                    sha256  9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49 \
+                    size    49002
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools
@@ -49,6 +49,9 @@ when you execute the commands without a version suffix, e.g. 'pyflakes', run:
 
 port select --set ${select.group} [file tail ${select.file}]
 "
+
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
This PR updates ```py-codestyle``` and ```py-pyflakes``` to their latest versions  and applies two patches to ```py-flake8``` to support these newer versions. Both patches are from upstream and are merged into their codebase already, but for some reason they don't seem eager to release a new version.... with the added patches all tests pass.

Changes:
- py-codestyle: update to 2.4.0, enable tests, remove no longer needed post-extract phase, and update livecheck and homepage
- py-pyflakes: update to 2.0.0, enable tests
- py-flake8: patches for latest pycodestyle and pyflakes, fix setuptools dependency type (runtime), enable tests, update livecheck
 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
