### PR TITLE
py-gmpy: Add py37 subport

### DIFF
--- a/python/py-gmpy/Portfile
+++ b/python/py-gmpy/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-gmpy
 version             1.17
-maintainers         alluvialsw.com:md14-macports openmaintainer
+maintainers         {@mndavidoff alluvialsw.com:md14-macports} openmaintainer
 license             LGPL-2.1+
 platforms           darwin
 description         General multiple precision arithmetic module for Python
@@ -19,9 +19,10 @@ master_sites        pypi:g/gmpy
 distname            gmpy-${version}
 use_zip             yes
 checksums           rmd160  0465338605fa73695259082c973eab23d7d96cff \
-                    sha256  1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14
+                    sha256  1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14 \
+                    size    147636
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:gmp
@@ -33,7 +34,5 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 } else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/gmpy/json
-    livecheck.regex     {gmpy-(\d+(?:\.\d+)*)\.[tz]}
+    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description

* Add py37 subport
* Change maintainers to use GitHub username

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
