### PR TITLE
py-gmpy2: Add py37 subport

### DIFF
--- a/python/py-gmpy2/Portfile
+++ b/python/py-gmpy2/Portfile
@@ -7,7 +7,7 @@ name                py-gmpy2
 epoch               1
 version             2.0.8
 revision            1
-maintainers         alluvialsw.com:md14-macports openmaintainer
+maintainers         {@mndavidoff alluvialsw.com:md14-macports} openmaintainer
 license             LGPL-2.1+
 platforms           darwin
 description         General multiple precision arithmetic module for Python
@@ -22,9 +22,10 @@ master_sites        pypi:g/gmpy2
 distname            gmpy2-${version}
 use_zip             yes
 checksums           rmd160  d7a4f6d8fe370e4565f0af00b903d6b6740e4718 \
-                    sha256  dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f
+                    sha256  dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f \
+                    size    280551
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:gmp port:libmpc port:mpfr
@@ -42,7 +43,5 @@ if {${name} ne ${subport}} {
 
     livecheck.type      none
 } else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/gmpy2/json
-    livecheck.regex     {gmpy2-(\d+(?:\.\d+)*)\.[tz]}
+    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description

* Add py37 subport
* Change maintainers to use GitHub username

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
