### PR TITLE
paraview @5.5.2_0: Bump version and fix qt5 compatibility

### DIFF
--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 
 PortGroup           cmake 1.0
-PortGroup           qt4 1.0
+PortGroup           qt5 1.0
 PortGroup           mpi 1.0
 
 name                paraview
-version             5.5.0
-revision            1
+version             5.5.2
 
 categories          science graphics
 platforms           darwin
@@ -32,13 +31,15 @@ master_sites        ${homepage}/files/v${branch}/
 
 distname            ParaView-v${version}
 
-checksums           sha256  1b619e326ff574de808732ca9a7447e4cd14e94ae6568f55b6581896cd569dff \
-                    rmd160  3d8b47989bba8664aa781425731088754c0cd35d \
-                    size    51414419
+checksums           sha256  64561f34c4402b88f3cb20a956842394dde5838efd7ebb301157a837114a0e2d \
+                    rmd160  b8bb2f50615e9db85dc986e108531ffffad1c96e \
+                    size    51418473
 
 depends_build-append    port:readline \
     port:netcdf \
-    port:qt4-mac-sqlite3-plugin port:qt5-qttools
+    port:qt5-sqlite-plugin port:qt5-qttools 
+
+patchfiles patch-incomplete-types.patch
 
 cmake.out_of_source yes
 
@@ -55,7 +56,11 @@ configure.args-delete \
 configure.args-append \
     -DBUILD_TESTING:BOOL=OFF \
     -DMACOSX_APP_INSTALL_PREFIX=${destroot}${applications_dir} \
-    -DBUILD_SHARED_LIBS:BOOL=ON
+    -DBUILD_SHARED_LIBS:BOOL=ON \
+    -DPARAVIEW_QT_VERSION=5 \
+    -DQt5_DIR=${qt_dir} \
+    -DQT_HELP_GENERATOR=${qt_bins_dir}/qhelpgenerator \
+    -DQT_XMLPATTERNS_EXECUTABLE=${qt_bins_dir}/xmlpatterns
 
 pre-configure {
     configure.args-append -DCMAKE_CXX_COMPILER=${configure.cxx} \

--- a/science/paraview/files/patch-incomplete-types.patch
+++ b/science/paraview/files/patch-incomplete-types.patch
@@ -1,0 +1,132 @@
+diff --git Plugins/SLACTools/pqSLACDataLoadManager.cxx Plugins/SLACTools/pqSLACDataLoadManager.cxx
+index 3ba019c26b..ce38396f68 100644
+--- Plugins/SLACTools/pqSLACDataLoadManager.cxx
++++ Plugins/SLACTools/pqSLACDataLoadManager.cxx
+@@ -34,6 +34,7 @@
+ #include "vtkSMProperty.h"
+ #include "vtkSMSourceProxy.h"
+ 
++#include <QAction>
+ #include <QPushButton>
+ #include <QtDebug>
+ 
+diff --git Plugins/StreamLinesRepresentation/CMakeLists.txt Plugins/StreamLinesRepresentation/CMakeLists.txt
+index 5d656a54b8..86c24964fe 100644
+--- Plugins/StreamLinesRepresentation/CMakeLists.txt
++++ Plugins/StreamLinesRepresentation/CMakeLists.txt
+@@ -41,7 +41,6 @@ encode_files_as_strings(ENCODED_STRING_FILES
+ 
+ add_paraview_plugin(
+   StreamLinesRepresentation "0.1"
+-  DOCUMENTATION_DIR "${CMAKE_CURRENT_SOURCE_DIR}/doc"
+   SERVER_MANAGER_XML StreamLinesRepresentation.xml
+   SERVER_MANAGER_SOURCES
+     vtkStreamLinesRepresentation.cxx
+diff --git Qt/ApplicationComponents/pqColorMapEditor.cxx Qt/ApplicationComponents/pqColorMapEditor.cxx
+index 0395185e0a..88b56745eb 100644
+--- Qt/ApplicationComponents/pqColorMapEditor.cxx
++++ Qt/ApplicationComponents/pqColorMapEditor.cxx
+@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <QDebug>
+ #include <QKeyEvent>
+ #include <QPointer>
++#include <QStyle>
+ #include <QVBoxLayout>
+ 
+ class pqColorMapEditor::pqInternals
+diff --git Qt/ApplicationComponents/pqDoubleRangeSliderPropertyWidget.cxx Qt/ApplicationComponents/pqDoubleRangeSliderPropertyWidget.cxx
+index 908e4598e0..820361a2b3 100644
+--- Qt/ApplicationComponents/pqDoubleRangeSliderPropertyWidget.cxx
++++ Qt/ApplicationComponents/pqDoubleRangeSliderPropertyWidget.cxx
+@@ -43,6 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include "vtkSMUncheckedPropertyHelper.h"
+ 
+ #include <QGridLayout>
++#include <QStyle>
+ 
+ class pqDoubleRangeSliderPropertyWidget::pqInternals
+ {
+diff --git Qt/ApplicationComponents/pqStandardViewFrameActionsImplementation.cxx Qt/ApplicationComponents/pqStandardViewFrameActionsImplementation.cxx
+index c297dc3d9e..501633f63a 100644
+--- Qt/ApplicationComponents/pqStandardViewFrameActionsImplementation.cxx
++++ Qt/ApplicationComponents/pqStandardViewFrameActionsImplementation.cxx
+@@ -69,6 +69,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <QPushButton>
+ #include <QSet>
+ #include <QShortcut>
++#include <QStyle>
+ 
+ //-----------------------------------------------------------------------------
+ pqStandardViewFrameActionsImplementation::pqStandardViewFrameActionsImplementation(
+diff --git Qt/ApplicationComponents/pqTimeInspectorWidget.cxx Qt/ApplicationComponents/pqTimeInspectorWidget.cxx
+index 6774c2e48e..3430f70376 100644
+--- Qt/ApplicationComponents/pqTimeInspectorWidget.cxx
++++ Qt/ApplicationComponents/pqTimeInspectorWidget.cxx
+@@ -51,6 +51,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <QLineF>
+ #include <QPainter>
++#include <QStyle>
+ #include <QVariant>
+ #include <QtDebug>
+ 
+diff --git Qt/ApplicationComponents/pqTransferFunctionWidgetPropertyDialog.cxx Qt/ApplicationComponents/pqTransferFunctionWidgetPropertyDialog.cxx
+index 55d3146447..225879cd4c 100644
+--- Qt/ApplicationComponents/pqTransferFunctionWidgetPropertyDialog.cxx
++++ Qt/ApplicationComponents/pqTransferFunctionWidgetPropertyDialog.cxx
+@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include "pqTransferFunctionWidgetPropertyWidget.h"
+ #include "vtkPiecewiseFunction.h"
++#include <qvalidator>
+ #include <QString>
+ 
+ class pqTransferFunctionWidgetPropertyDialog::pqInternals
+diff --git Qt/ApplicationComponents/pqViewResolutionPropertyWidget.cxx Qt/ApplicationComponents/pqViewResolutionPropertyWidget.cxx
+index 6d2865431e..8d2c4b61cd 100644
+--- Qt/ApplicationComponents/pqViewResolutionPropertyWidget.cxx
++++ Qt/ApplicationComponents/pqViewResolutionPropertyWidget.cxx
+@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include "vtkSMProxy.h"
+ 
+ #include <QIntValidator>
++#include <QStyle>
+ 
+ class pqViewResolutionPropertyWidget::pqInternals
+ {
+diff --git Qt/Widgets/pqAnimationWidget.h Qt/Widgets/pqAnimationWidget.h
+index 283493a276..1c9a678cfe 100644
+--- Qt/Widgets/pqAnimationWidget.h
++++ Qt/Widgets/pqAnimationWidget.h
+@@ -36,10 +36,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include "pqWidgetsModule.h"
+ 
+ #include <QAbstractScrollArea>
++#include <QHeaderView>
+ #include <QStandardItemModel>
+ 
+ class QGraphicsView;
+-class QHeaderView;
+ class pqAnimationModel;
+ class pqAnimationTrack;
+ 
+diff --git Qt/Widgets/pqFlatTreeView.h Qt/Widgets/pqFlatTreeView.h
+index a0ba740dbc..e44e0d43a5 100644
+--- Qt/Widgets/pqFlatTreeView.h
++++ Qt/Widgets/pqFlatTreeView.h
+@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #define _pqFlatTreeView_h
+ 
+ #include "pqWidgetsModule.h"
++#include <QHeaderView>
+ #include <QAbstractScrollArea>
+ #include <QModelIndex>          // Needed for return type
+ #include <QStyleOptionViewItem> // Needed for return type
+@@ -50,7 +51,6 @@ class pqFlatTreeViewInternal;
+ class QAbstractItemModel;
+ class QColor;
+ class QFontMetrics;
+-class QHeaderView;
+ class QItemSelection;
+ class QItemSelectionModel;
+ class QPoint;


### PR DESCRIPTION
#### Description
Paraview was not compiling anymore with, I think, new QT5 version. Ref: [Ticket 56981](https://trac.macports.org/ticket/56981)

I imagine that in new QT5 they rearranged classes so some of them resulted in incomplete types during Paraview build. 
I patched all the source files with explicit includes. 

Moreover there was an error with `directory_copy` a directory that is not present in the sources (dunno if it's generated by cmake at build time or what), so I patched the related `CMakeLists.txt` in order to remove the reference to that unexistent directory.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
