### PR TITLE
stellarium-qt4: new port

### DIFF
--- a/science/stellarium-qt4/Portfile
+++ b/science/stellarium-qt4/Portfile
@@ -1,0 +1,74 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           qt4 1.0
+PortGroup           github 1.0
+
+conflicts           stellarium-devel stellarium
+github.setup        Stellarium stellarium 2d593b8d4d49280f0a3c31147e9d30e7c435abaa
+
+name                stellarium-qt4
+version             0.12.9-20171229
+categories          science
+platforms           darwin
+license             GPL-2+
+maintainers         {kencu @kencu} openmaintainer
+
+description         Stellarium is a free open source planetarium for your computer. \
+                    This older version is the last version based on qt4 which may \
+                    run, or run more efficiently, on older or less powerful systems.
+long_description    ${description} It has been updated with some fixes and features \
+                    found in later versions of Stellarium.
+
+homepage            http://stellarium.org/
+
+checksums           rmd160  0b7e70a913e190f76d2f6330584faa04b42760bb \
+                    sha256  8f409882f0a64e7478a0e98ccdf4de34e9ff080ae5609a705308e368e679335e \
+                    size    111785017
+
+depends_lib-append  port:freetype \
+                    port:zlib \
+                    port:libiconv \
+                    path:lib/libssl.dylib:openssl \
+                    port:phonon
+
+post-patch {
+    reinplace "s:SET(CMAKE_INSTALL_PREFIX \"\$\{PROJECT_BINARY_DIR\}/:SET(CMAKE_INSTALL_PREFIX \"${applications_dir}/:" ${worksrcpath}/CMakeLists.txt
+
+    # be more liberal with the allowed system versions
+    reinplace "s:10.6.0:10.4.11:" ${worksrcpath}/data/Info.plist
+
+    # Determine which archs to build
+    if {[variant_isset universal]} {
+        set archs ${configure.universal_archs}
+    } else {
+        set archs ${configure.build_arch}
+    }
+    reinplace "s:SET(CMAKE_OSX_ARCHITECTURES \".*\"):SET(CMAKE_OSX_ARCHITECTURES \"${archs}\"):" ${worksrcpath}/CMakeLists.txt
+}
+
+# This post-destroot phase is similar to the 'make macosx_bundle' target,
+# but it does not copy libraries into the bundle and does not require perl as
+# another dependency
+post-destroot {
+    set appdir ${destroot}${applications_dir}/Stellarium.app/Contents
+
+    move ${appdir}/bin ${appdir}/MacOS
+    move ${appdir}/share ${appdir}/Resources
+    move {*}[glob ${appdir}/Resources/stellarium/*] ${appdir}/Resources/
+    delete ${appdir}/Resources/stellarium
+
+    # copy .app-specific files
+    copy ${worksrcpath}/data/Info.plist ${appdir}
+    copy ${worksrcpath}/data/PkgInfo ${appdir}
+    copy ${worksrcpath}/data/Icon.icns ${appdir}/Resources/
+
+    # copy other useful file(s)
+    copy ${worksrcpath}/util/qt.conf ${appdir}/Resources/
+}
+
+# Supports universal builds through cmake, archs are set in post-patch
+variant universal {}
+
+livecheck none

--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -23,7 +23,7 @@ if {${name} eq ${subport}} {
 
     # release
 
-    conflicts       stellarium-devel
+    conflicts       stellarium-devel stellarium-qt4
     github.setup    Stellarium stellarium 0.18.2 v
     checksums       rmd160  7eb375e9c1cfa57e81bf35ce40c36fe3a81f95b5 \
                     sha256  dac3d71fd24df72cfd3f3e69e4d24498999359c0e5f6bb4e5b29c04aaeb399a4 \
@@ -36,7 +36,7 @@ if {${name} eq ${subport}} {
     long_description  ${long_description}: \
         This port is kept up with the Stellarium GIT master branch, which is typically updated daily to weekly.
 
-    conflicts       stellarium
+    conflicts       stellarium stellarium-qt4
     github.setup    Stellarium stellarium 756f5febd8c0b7549b80c17d1eaad1451fb2b75e
     version         20180815
     checksums       rmd160 ba97e08db21eb581b75fb228409296add13d5fc4 \


### PR DESCRIPTION
based on stellarium 0.12.9
last version to support qt4
has been maintained along the way with
some fixes from the newer versions
runs on less powerful or older systems

update conflicts for other stellarium ports

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5, 10.6, 10.7, 10.13
Xcode 3 - 9

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
