### PR TITLE
sox: Don't use flat namespace on OS X 10.10+

### DIFF
--- a/audio/sox/Portfile
+++ b/audio/sox/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name             sox
 conflicts        play
 version          14.4.2
-revision         2
+revision         3
 categories       audio
 platforms        darwin
 maintainers      {stare.cz:hans @janstary}
@@ -28,7 +28,8 @@ checksums        sha1    dc9668256b9d81ef25d672f14f12ec026b0b4087 \
 depends_build	\
 		port:pkgconfig
 
-patchfiles      patch-curl.diff
+patchfiles      patch-curl.diff \
+                yosemite-libtool.patch
 
 platform darwin 11 {
 	# System grep fails: "grep: Regular expression too big"

--- a/audio/sox/files/yosemite-libtool.patch
+++ b/audio/sox/files/yosemite-libtool.patch
@@ -1,0 +1,12 @@
+Don't accidentally create flat-namespace dylibs on Yosemite and later (#44596).
+--- configure.orig
++++ configure
+@@ -7601,7 +7601,7 @@
+       case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+ 	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+ 	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+-	10.[012]*)
++	10.[012][,.]*)
+ 	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+ 	10.*)
+ 	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;


### PR DESCRIPTION
#### Description

sox: Don't use flat namespace on OS X 10.10+

Before:

```
$ otool -hV /opt/local/lib/libsox.3.dylib
Mach header
      magic cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
MH_MAGIC_64  X86_64        ALL  0x00       DYLIB    29       2624 DYLDLINK NO_REEXPORTED_DYLIBS
```

After:

```
$ otool -hV /opt/local/lib/libsox.3.dylib
Mach header
      magic cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
MH_MAGIC_64  X86_64        ALL  0x00       DYLIB    29       2624   NOUNDEFS DYLDLINK TWOLEVEL NO_REEXPORTED_DYLIBS
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->