### PR TITLE
clang-devel: Update to svn revision 340138

### DIFF
--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -9,8 +9,8 @@ PortGroup cmake         1.0
 
 set llvm_version        devel
 set llvm_version_no_dot devel
-set clang_executable_version 7
-set lldb_executable_version 7.0.0
+set clang_executable_version 8
+set lldb_executable_version 8.0.0
 name                    llvm-${llvm_version}
 subport                 clang-${llvm_version} {}
 subport                 lldb-${llvm_version} {}
@@ -81,7 +81,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 }
 
 fetch.type              svn
-svn.revision            337717
+svn.revision            340138
 
 depends_extract-append  port:subversion
 


### PR DESCRIPTION
#### Description

Updates clang-devel port to build a more recent svn revision.
( Scratches an itch to get an updated clang-format ... )

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
