### PR TITLE
Remove sha512 checksums

### DIFF
--- a/aqua/jumpcut/Portfile
+++ b/aqua/jumpcut/Portfile
@@ -26,6 +26,8 @@ distname            ${name}_${version}-src
 extract.suffix      .tgz
 
 checksums           md5     8ea757ff5723c397be557618592e49bc \
-                    sha512  9dfdbf98a0906bf0efe1ec2f6a0d288bfd9e67b566f63d01bb84ffb08829072cb90541fbcb837b4cb243aa37a92423bb151acc321983f07cba75aa71e23c2799
+                    rmd160  ddf4f7fee02d84de62cec037a286d5f9c8a704f1 \
+                    sha256  48a0d44673138a97a2e734cd991bb065437ec66e1653a44d0e2679aa1087c9d9 \
+                    size    486246
 
 patchfiles          patch-AppController.m.diff

--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -21,9 +21,11 @@ platforms               darwin freebsd
 distname                apache-ant-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
-checksums               md5    565ffd791def7f22936311e9aa3f8058 \
-                        sha1   570005afd7c080436742e128b07eb97d50178d53 \
-                        sha512 3c0cc564c27483eb526e004b31b211dd689aa24a2aa7097fc11bc5304771e49124a657203eeec748a70a6bfa6f2c050d5647b37a69e5eb02843fff7a0f7646ea
+# Remember also to update the checksums in the source variant below.
+checksums               sha1    570005afd7c080436742e128b07eb97d50178d53 \
+                        rmd160  cc53e72de11b85d8825a11b8d5d0e801768fe5be \
+                        sha256  482059b1e54c9b64e0efec686cbee7acc2ad4905d04024b31864feb7b63fc72d \
+                        size    4414047
 
 worksrcdir              apache-ant-${version}
 set workTarget          ""
@@ -41,9 +43,10 @@ build.cmd               true
 variant source description "build from source; not recommended" {
         distname                        apache-ant-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       md5    c988158e101e7700b45c14b9804fd554 \
-                                        sha1   4c815a6f560cde94fc2b3d15e34393ebf6dbca52 \
-                                        sha512 27fe030f134e34d4e06ef32baf1e8cf392490745fa7a7f47cf3e123f1141499c059e317154c923a8d7dcb7af163eb0cc87636f5d6150e0ce54b6c0abc2d0a112
+        checksums                       sha1    4c815a6f560cde94fc2b3d15e34393ebf6dbca52 \
+                                        rmd160  755d736af7c20fb2273aa3761334952036e7aee3 \
+                                        sha256  69aa251ffb9f31312c21d67db197843e0b03b3c8cc3e0af6e6e92d98eb0f2ead \
+                                        size    3832876
         set workTarget                  /apache-ant
 
         build.cmd                       ./build.sh

--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -21,6 +21,7 @@ platforms               darwin freebsd
 distname                ${name}-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
+# Remember also to update the checksums in the source variant below.
 checksums               rmd160  e627aa699f3ed4399c4871126c6f5d6ef17d4b9f \
                         sha256  3fa4dfcc2f320f8dc01b443c1cb38e86cb85bcc94cc9460bc194342f55e5495a \
                         size    4582443
@@ -41,9 +42,10 @@ build.cmd               true
 variant source description "build from source; not recommended" {
         distname                        ${name}-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       md5    6413ed1cee16372d0fa215ffacca48b7 \
-                                        sha1   5f0d4f059cf7dc2620cde59e9c209663e99cad54 \
-                                        sha512 5a557e06b71c69ca61bbb4d2709edb41405cb22258a158f5645cf43b1087a692a0cc9829e356238c660ed9cd917ce3ce6d8accb1775b1642545c932a49676459
+        checksums                       sha1    9e5f2400205ef25ceee2820f05b7f5bd5bbe0b00 \
+                                        rmd160  eb7f949b52bbed51a38ad650224fe638cd3711d3 \
+                                        sha256  d5e3d87f0b4b42e0505b44215b4c4bbfaf6f49655c0a530136adfe4e724363b4 \
+                                        size    3842658
         set workTarget                  /${name}
 
         build.cmd                       ./build.sh

--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -21,8 +21,9 @@ platforms               darwin freebsd
 distname                ${name}-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
-checksums               rmd160 e627aa699f3ed4399c4871126c6f5d6ef17d4b9f \
-                        sha512 91992ae8ed122be8d5a6cc423149a8d0cef4e49ada60691c4802eab44bf65dc4d14b9cdfde61b3d4b705a24c7cdc8ab62502f93b4b8a1cbf0b3ffa580ff23738
+checksums               rmd160  e627aa699f3ed4399c4871126c6f5d6ef17d4b9f \
+                        sha256  3fa4dfcc2f320f8dc01b443c1cb38e86cb85bcc94cc9460bc194342f55e5495a \
+                        size    4582443
 
 worksrcdir              ${name}-${version}
 set workTarget          ""


### PR DESCRIPTION
#### Description

Remove sha512 checksums from ports. MacPorts doesn't verify them. Replace them with rmd160, sha256 and size. Remove md5 checksums. Also fix checksums of apache-ant's source variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->