### PR TITLE
cctools: xcode and universal variants conflict

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -40,8 +40,6 @@ patchfiles \
     cctools-895-OFILE_LLVM_BITCODE.patch \
     not-clang.patch
 
-variant universal {}
-
 if {${os.major} < 11} {
     patchfiles-append snowleopard-strnlen.patch
 }
@@ -109,7 +107,7 @@ if { ![some_llvm_variant_set] && ![variant_isset xcode] } {
 
 }
 
-variant xcode description "Use Xcode supplied toolkit" {
+variant xcode conflicts universal description "Use Xcode supplied toolkit" {
    supported_archs noarch
    patchfiles
    distfiles
@@ -138,6 +136,7 @@ destroot.args           RAW_DSTROOT=${destroot} DSTROOT=${destroot}${prefix} RC_
 
 if {![variant_isset xcode]} {
    depends_build           port:libunwind-headers
+    variant universal conflicts xcode {}
 }
 
 post-extract {

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -131,7 +131,6 @@ variant xcode conflicts universal description "Use Xcode supplied toolkit" {
    }
 }
 
-use_configure           no
 destroot.args           RAW_DSTROOT=${destroot} DSTROOT=${destroot}${prefix} RC_ProjectSourceVersion=${version}
 
 if {![variant_isset xcode]} {


### PR DESCRIPTION
#### Description

Make the xcode and universal variants conflict.

Don't even offer the universal variant if the xcode variant has already been selected. This avoids variant conflict messages for upgrading users who already had the universal variant installed, or those users who have +universal specified in variants.conf.

Remove duplicate `use_configure no` line.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
