### PR TITLE
py-rope: update to 0.11.0

### DIFF
--- a/python/py-rope/Portfile
+++ b/python/py-rope/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        python-rope rope 0.10.7
+github.setup        python-rope rope 0.11.0
 name                py-rope
 platforms           darwin
 license             GPL-2+
-maintainers         nomaintainer
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
 
 description         python refactoring library
 long_description    Rope is a Python refactoring library that can be used \
@@ -16,19 +16,25 @@ long_description    Rope is a Python refactoring library that can be used \
                     refactoring operations as well as forms of code \
                     assistance like auto-completion and access to \
                     documentation.
-homepage            http://rope.sourceforge.net/
 
 supported_archs     noarch
 
-checksums           rmd160  d7aa0ab0500845f6c03abafb60ab9ee877c6a239 \
-                    sha256  7f2499a7c6b6ede0505ea358f9c11dda412cf9da260d1441f2c66a54beeed82a
+checksums           rmd160  40a9a3f855e0867179410411e5b08c37a65b50b7 \
+                    sha256  8b72835c89ea549da578e8078eaa35cb243330a7f4bc433153427f2f4586ff22 \
+                    size    247423
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    post-destroot {
-        system "chmod -R a+r ${destroot}${prefix}"
-    }
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    livecheck.type      none
+    if {${python.version} < 35} {
+        depends_test-append \
+                    port:py${python.version}-unittest2
+    }
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
+
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to latest version
- enable tests
- remove homepage, already set by github portgroup
- remove unneeded post-destroot phase
- assume maintaintership

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? 
The py37 subport was perhaps added a bit premature in commit 941657f50b77262e5ecb2c383312e6178e9e4283 because not all tests pass, but for other Python versions they do pass.
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
