### PR TITLE
Updated digital_rf to 2.6.1

### DIFF
--- a/science/digital_rf/Portfile
+++ b/science/digital_rf/Portfile
@@ -5,8 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
-github.setup        MITHaystack digital_rf 2.6.0
-revision            1
+github.setup        MITHaystack digital_rf 2.6.1
 categories          science
 license             BSD
 platforms           darwin
@@ -20,9 +19,9 @@ long_description    ${description} The Digital RF project encompasses a standard
                     processing. For details on the format, refer to the 'documents' \
                     directory in the source tree.
 
-checksums           rmd160  f095ff1a80f7175f57a45048c826fe68b6dd56e9 \
-                    sha256  6468418a06c269964c9a5c5f145f7bfebf951226e3a85977226c7967fa50e691 \
-                    size    4528350
+checksums           rmd160  a8885c5e2976a6f904c59fa4debf4062ae8760c3 \
+                    sha256  c6e62d959b6716c953196dc33f47dc0dd81945379683b206762ca74e0888151e \
+                    size    4537334
 
 configure.ldflags-delete    -L${prefix}/lib
 


### PR DESCRIPTION
#### Description

Update digital_rf to 2.6.1. Fix to PR #2402

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
