### PR TITLE
mosh: fix build on older systems

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -46,6 +46,11 @@ platform darwin {
     configure.cxxflags-append -std=c++11
 }
 
+# force protobuf3-cpp into the no_threadlocal mode on older systems
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    configure.cppflags-append -DGOOGLE_PROTOBUF_NO_THREADLOCAL
+}
+
 # Apple commoncrypto available 10.8 or later
 if {${os.platform} eq "darwin" && ${os.major} > 11} {
     configure.args-append \


### PR DESCRIPTION
protobuf3-cpp builds without thread_local support
if a specific flag is added

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
