### PR TITLE
ostinato: fix build against protobuf3-cpp

### DIFF
--- a/net/ostinato/Portfile
+++ b/net/ostinato/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           qt4 1.0
+PortGroup           qmake 1.0
+PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        pstavirs ostinato 0.9 v
-revision            1
+revision            2
 maintainers         {g5pw @g5pw} openmaintainer
 license             GPL-3+
 
@@ -22,18 +23,29 @@ depends_lib         port:qt4-mac \
                     port:protobuf3-cpp
 
 checksums           rmd160  e1984c471120a37ebe064ddb09df058a19c7481b \
-                    sha256  569172cac35a104d5c670304e11c2eec6dfa99f2786130da780173023bf6a56f
+                    sha256  569172cac35a104d5c670304e11c2eec6dfa99f2786130da780173023bf6a56f \
+                    size    413820
 
 worksrcdir          ${name}-${version}
 
-post-patch {
-    reinplace "s|/Applications/|${applications_dir}|" ${worksrcpath}/install.pri
+# doesn't build with clang-3.9 in c++11 mode
+# pcaptxthread.cpp:471:25: error: expected ')'
+# other clangs appear to work (3.4, 4.0, 6.0 tested)
+compiler.blacklist-append  macports-clang-3.9
+
+# protobuf3-cpp requires c++11
+configure.cxxflags-append -std=c++11
+
+# force protobuf3-cpp into the no_threadlocal mode
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    configure.cxxflags-append -DGOOGLE_PROTOBUF_NO_THREADLOCAL
 }
 
-# As per install instructions
-configure.cmd       qmake
-configure.pre_args  -spec macx-g++
+# qmake is not automatically passing in the stdlib on link
+if {[string match *clang* ${configure.cxx}]} {
+    configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+}
 
-# qmake doesn't recognize the --disable-dependency-tracking flag
-configure.universal_args-delete \
-                    --disable-dependency-tracking
+post-destroot {
+    move ${destroot}${prefix}/Ostinato ${destroot}${applications_dir}
+}


### PR DESCRIPTION
requires -std=c++11 added
qmake PG facilitates this most easily
but that requires a few other minor changes in Portfile wrt destrooting

This is one way to fix `ostinato`. Seems cleanest to me. Not the only way it could be fixed, however.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6, 10.13
Xcode 4.2, 9.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
