### PR TITLE
nheko: use qt5 portgroup for dependencies

### DIFF
--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -3,8 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           qt5 1.0
 PortGroup           cxx11 1.1
 PortGroup           compiler_blacklist_versions 1.0
+
 #NOTE: requires C++14
 
 github.setup        mujx nheko 0.5.2 v
@@ -45,12 +47,13 @@ depends_lib-append  port:boost \
                     port:fontconfig \
                     port:libsodium \
                     port:lmdb \
-                    port:qt5-qtbase \
-                    port:qt5-qtmacextras \
-                    port:qt5-qtmultimedia \
-                    port:qt5-qtsvg \
-                    port:qt5-qttools \
                     port:spdlog
+
+qt5.depends_component qtbase \
+                    qtmacextras \
+                    qtmultimedia \
+                    qtsvg \
+                    qttools
 
 destroot {
     copy ${workpath}/build/nheko.app ${destroot}${applications_dir}/Nheko.app


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A365a
Xcode 10.0 10L201y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
