### PR TITLE
upgrade various py26-only ports

### DIFF
--- a/python/py-appdirs/Portfile
+++ b/python/py-appdirs/Portfile
@@ -20,13 +20,18 @@ homepage            https://github.com/ActiveState/appdirs
 master_sites        pypi:a/appdirs
 distname            ${python.rootname}-${version}
 
-checksums           md5     44c679904082a2133f5566c8a0d3ab42 \
-                    rmd160  5c20593d89aa579dc571d533efeeb8ee72eb0d58 \
-                    sha256  9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92
+checksums           rmd160  5c20593d89aa579dc571d533efeeb8ee72eb0d58 \
+                    sha256  9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+                    size    12700
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {$subport ne $name} {
+    depends_test-append \
+                    port:py${python.version}-pytest
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}

--- a/python/py-carrot/Portfile
+++ b/python/py-carrot/Portfile
@@ -1,36 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
 name                py-carrot
+replaced_by         py-kombu
 version             0.10.7
-categories-append   devel
+revision            1
+categories-append   python devel
 license             BSD
-platforms           darwin
-supported_archs     noarch
-maintainers         {stromnov @stromnov} openmaintainer
 
-description         AMQP Messaging Framework for Python.
-
-long_description    ${description}
-
-homepage            http://ask.github.com/carrot/
-master_sites        pypi:c/carrot/
-
-distname            carrot-${version}
-
-checksums           md5     530a0614de3a669314c3acd4995c54d5 \
-                    sha1    3295a79a93ac6d77f41d830057af3ee8df97567b \
-                    rmd160  be0cce6da09f2acf106e1d3a4947b8b587d02edd
-
-python.versions     26
-
-if {${name} ne ${subport}} {
-    depends_build       port:py${python.version}-setuptools
-    livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/carrot/json
-    livecheck.regex     "carrot-(\\d+(?:\\.\\d+)*)${extract.suffix}"
-}
+subport py26-carrot "replaced_by py27-kombu"
+# remove after August 18, 2019

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -302,6 +302,7 @@ py-pyds9                1.1_1       26
 py-pyfftw               0.10.4_1    33
 py-pyfftw3              0.2.2_1     26
 py-pyflakes             1.6.0_1     26 33
+py-pyfsevents           0.2b1_1     26
 py-pygeocoder           1.1.4_1     26
 py-pyglet               1.2.4_1     26
 py-pygments             2.2.0_2     26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -315,6 +315,7 @@ py-pygrib               2.0.2       33
 py-pygtk                2.24.0_4    26
 py-pygtkhelpers         0.4.3_1     26
 py-pygtksourceview      2.10.1_4    26
+py-pyhyphen             0.9.3_1     26
 py-pyinstaller          3.1_2       33
 py-pyke                 1.1.1_1     26 32 33
 py-pykerberos           1.1-10616_1 26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -266,6 +266,7 @@ py-ntplib               0.3.1_1     26
 py-numexpr              2.6.6_1     26 33
 py-obspy                1.1.0       34
 py-openbabel            2.3.2_1     26
+py-openopt              0.29_2      26
 py-openssl              0.15.1_6    26 33
 py-packaging            17.1_1      26 33
 py-parsing              2.2.0_1     26 33

--- a/python/py-openopt/Portfile
+++ b/python/py-openopt/Portfile
@@ -1,11 +1,10 @@
-# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openopt
-version             0.29
-revision            1
+version             0.5628
 categories-append   math science
 maintainers         nomaintainer
 description         Numerical optimization framework for python
@@ -16,23 +15,24 @@ long_description    OpenOpt is a free optimization framework for python. \
 platforms           darwin
 license             BSD
 
-homepage            http://openopt.org
-#the checksums (inevitably) mismatch with upstream as of 2013-07-6
-#master_sites        http://openopt.org/images/3/33/
-master_sites        http://distfiles.macports.org/python/
-distname            OpenOpt
+homepage            https://pypi.org/project/openopt/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5     e2cf031a18616c26cdd7d0a4615ef8d8 \
-                    sha1    f60213b5c01e133b3c06a9698b34484fe1948f2e \
-                    rmd160  c7e23f95fdfd4af7c5df960e23641fc1d6a784ba
+checksums           rmd160  c8112116454ab50659ce29d6d3d35f48757b0515 \
+                    sha256  a24d4dc8f7ec84d1b7799e78e3a6e471c75f8e6b2dafe933387cb9392aecdc71 \
+                    size    282544
 
-python.versions     26
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
-    use_zip             yes
-    depends_lib-append  port:py${python.version}-numpy
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-setproctitle \
+                    port:py${python.version}-sortedcontainers
+
     livecheck.type      none
-} else {
-    livecheck.url       ${master_sites}
-    livecheck.regex     OpenOpt(.*).zip
 }

--- a/python/py-pyfsevents/Portfile
+++ b/python/py-pyfsevents/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
@@ -18,11 +20,11 @@ homepage            https://pypi.python.org/pypi/pyfsevents
 master_sites        pypi:p/pyfsevents/
 distname            pyfsevents-${version}
 
-checksums           md5     41b41d336ed402b9ad1486f441b51de4 \
-                    sha1    b80645f726fd59544bc757b362ace0afd8ed26fd \
-                    rmd160  a5f9486dc6ffd08e502aba7dd444c8aa7b9026dc
+checksums           rmd160  a5f9486dc6ffd08e502aba7dd444c8aa7b9026dc \
+                    sha256  3ce90f5c235f413178dfd78e8bef878077193a16ef3b38402a85e06f946c45c1 \
+                    size    11992
 
-python.versions     26
+python.versions     27
 
 if {$subport ne $name} {
     post-destroot {
@@ -34,8 +36,6 @@ if {$subport ne $name} {
     }
     livecheck.type      none
 } else {
-    livecheck.type      regex
-    livecheck.url       [lindex ${master_sites} 0]
     livecheck.regex     pyfsevents-(\[\\w.\]+)${extract.suffix}
 }
 

--- a/python/py-pyhyphen/Portfile
+++ b/python/py-pyhyphen/Portfile
@@ -1,12 +1,14 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyhyphen
-version                 0.9.3
+version                 3.0.1
 categories-append       textproc
-license                 {MPL-1.1 LGPL-2.1+}
+license                 Apache-2
 maintainers             nomaintainer
-description             Python wrapper for the Mozilla hyphenation library hyphen-2.4
+description             The hyphenation library of LibreOffice and FireFox wrapped for Python
 long_description        PyHyphen is a wrapper around the high quality \
                         hyphenation library hyphen-2.4 (May 2008) that ships \
                         with OpenOffice.org and Mozilla products. Hence, all \
@@ -18,13 +20,21 @@ long_description        PyHyphen is a wrapper around the high quality \
 
 platforms               darwin
 
-homepage                https://code.google.com/p/pyhyphen/
+homepage                https://bitbucket.org/fhaxbox66/pyhyphen
 master_sites            pypi:P/PyHyphen/
 distname                PyHyphen-${version}
-use_zip                 yes
 
-checksums               md5 e511a331f698ba21d78f45a00daf2876 \
-                        sha1 78febbe9141be03b7f0188a38cdfa146f4192ae3 \
-                        rmd160 2e61675914b90c3ed602c25f6465e89a610b92e4
+checksums               rmd160  06d5cf7859443b40c8a380b7ad3b1ec74b25056b \
+                        sha256  379a78c49cadd8653d5634951bf243a0d99704eee496d8b23ddb00dc81a0e1fb \
+                        size    31174
 
-python.versions         26
+python.versions         27 36 37
+
+if {$subport ne $name} {
+    depends_lib-append \
+                        port:py${python.version}-appdirs \
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-six
+
+    livecheck.type      none
+}

--- a/python/py-recaptcha-client/Portfile
+++ b/python/py-recaptcha-client/Portfile
@@ -1,30 +1,14 @@
-PortSystem              1.0
-PortGroup               python 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name                    py-recaptcha-client
-version                 1.0.6
-maintainers             nomaintainer
-platforms               darwin
-supported_archs         noarch
+PortSystem           1.0
+PortGroup            obsolete 1.0
 
-description             Provides a CAPTCHA for Python using the reCAPTCHA \
-                        service.
-long_description        ${description}
-license                 MIT
-homepage                https://pypi.python.org/pypi/recaptcha-client/
+name                 py-recaptcha-client
+replaced_by          py-recaptcha
+version              1.0.6
+categories-append    python graphics
+revision             1
+license              MIT
 
-distname                recaptcha-client-${version}
-master_sites            pypi:r/recaptcha-client/
-
-checksums               rmd160 7dffe66b7fd37f5be2a7d7b2bf24c3978f46c8e9
-
-python.versions         26
-
-if {$subport ne $name} {
-    depends_build-append    port:py${python.version}-setuptools
-    livecheck.type          none
-} else {
-    livecheck.regex         {>recaptcha-client (.+) :}
-    livecheck.type          regex
-    livecheck.url           ${homepage}
-}
+subport py26-recaptcha-client "replaced_by py27-recaptcha"
+# remove after August 22, 2019

--- a/python/py-recaptcha/Portfile
+++ b/python/py-recaptcha/Portfile
@@ -26,9 +26,11 @@ homepage            https://pypi.python.org/pypi/recaptcha-client
 
 master_sites        pypi:r/recaptcha-client/
 distname            recaptcha-client-${version}
-checksums           md5     74228180f7e1fb76c4d7089160b0d919 \
-                    sha1    661317355af7a2985c9011b6efa026b7178e9917 \
-                    rmd160  7dffe66b7fd37f5be2a7d7b2bf24c3978f46c8e9
+
+checksums           rmd160  7dffe66b7fd37f5be2a7d7b2bf24c3978f46c8e9 \
+                    sha256  28c6853c1d13d365b7dc71a6b05e5ffb56471f70a850de318af50d3d7c0dea2f \
+                    size    7389
+
 
 python.versions     27
 
@@ -41,7 +43,5 @@ if {${name} ne ${subport}} {
     }
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex {recaptcha-client&amp;version=(\d+(\.\d+)*)}
+    livecheck.name  recaptcha-client
 }


### PR DESCRIPTION
#### Description
This PR takes care of five py26-only ports and two updates to dependencies/replacements:

- py-carrot: replaced by py-kombu as mentioned by upstream
- py-openopt: update to 0.5628, obsolete py26 subport, various other small fixes
- py-pyfsevents: obsolete py26 and add py27 subport
- py-pyhyphen: update to 3.0.1, obsolete py26 and add py36/py37 subport
- py-recaptcha-client: obsolete port, replaced by py-recaptcha 

- py-recaptcha: fix livecheck, modernize checksums
- py-appdirs: add py37 subport, enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
