### PR TITLE
apache-ant: Update to 1.10.5

### DIFF
--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant
-version                 1.10.1
+version                 1.10.5
 categories              devel java
 license                 Apache-2 W3C
 maintainers             openmaintainer {blair @blair}
@@ -22,9 +22,9 @@ distname                ${name}-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
 # Remember also to update the checksums in the source variant below.
-checksums               rmd160  e627aa699f3ed4399c4871126c6f5d6ef17d4b9f \
-                        sha256  3fa4dfcc2f320f8dc01b443c1cb38e86cb85bcc94cc9460bc194342f55e5495a \
-                        size    4582443
+checksums               rmd160  bc2823d7ce5a83ff3078f6997c147efe33872643 \
+                        sha256  3f762e16c4b5446e64869d146efe76be865a1d83062eede2d0a8fc11d1e20b2d \
+                        size    4730768
 
 worksrcdir              ${name}-${version}
 set workTarget          ""
@@ -42,10 +42,9 @@ build.cmd               true
 variant source description "build from source; not recommended" {
         distname                        ${name}-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       sha1    9e5f2400205ef25ceee2820f05b7f5bd5bbe0b00 \
-                                        rmd160  eb7f949b52bbed51a38ad650224fe638cd3711d3 \
-                                        sha256  d5e3d87f0b4b42e0505b44215b4c4bbfaf6f49655c0a530136adfe4e724363b4 \
-                                        size    3842658
+        checksums                       rmd160  3f03bfeed5c95136b2aa5a5df87680c9803fe002 \
+                                        sha256  71a5cdd45a54901b6321d5a140d882f7580c38f766a4e4959bcc36555da9f3ac \
+                                        size    4465063
         set workTarget                  /${name}
 
         build.cmd                       ./build.sh
@@ -88,4 +87,4 @@ universal_variant       no
 
 livecheck.type          regex
 livecheck.url           http://www.apache.org/dist/ant/binaries/
-livecheck.regex         {apache-ant-(\d+(?:\.\d+)*)-bin.tar.bz2}
+livecheck.regex         {apache-ant-(\d+(?:\.\d+)*)-bin\.tar\.bz2}


### PR DESCRIPTION
#### Description

apache-ant: Update to 1.10.5

I have also updated the checksums of the non-recommended +source variant, but that variant does not build for me.

I've also tweaked the livecheck to escape the literal periods.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
