### PR TITLE
apache-ant-1.9: Update to 1.9.13

### DIFF
--- a/devel/apache-ant-1.9/Portfile
+++ b/devel/apache-ant-1.9/Portfile
@@ -2,7 +2,8 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant-1.9
-version                 1.9.9
+version                 1.9.13
+set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              devel java
 license                 Apache-2 W3C
 maintainers             openmaintainer {blair @blair}
@@ -22,10 +23,9 @@ distname                apache-ant-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
 # Remember also to update the checksums in the source variant below.
-checksums               sha1    570005afd7c080436742e128b07eb97d50178d53 \
-                        rmd160  cc53e72de11b85d8825a11b8d5d0e801768fe5be \
-                        sha256  482059b1e54c9b64e0efec686cbee7acc2ad4905d04024b31864feb7b63fc72d \
-                        size    4414047
+checksums               rmd160  8834618ee8d4e951a8b0f370e1ec47125ef94d25 \
+                        sha256  e770c2ba77fd695734fa1945f887891a04524998f17e929d821f993ba3c5c73c \
+                        size    4485344
 
 worksrcdir              apache-ant-${version}
 set workTarget          ""
@@ -43,10 +43,9 @@ build.cmd               true
 variant source description "build from source; not recommended" {
         distname                        apache-ant-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       sha1    4c815a6f560cde94fc2b3d15e34393ebf6dbca52 \
-                                        rmd160  755d736af7c20fb2273aa3761334952036e7aee3 \
-                                        sha256  69aa251ffb9f31312c21d67db197843e0b03b3c8cc3e0af6e6e92d98eb0f2ead \
-                                        size    3832876
+        checksums                       rmd160  0d58a1dd1888fb3fe6c7504a31810d17283f370c \
+                                        sha256  fdefd01c909a69fbeab1c45a815e3a80d86351f61b992dfe2e2191d9b009aaaf \
+                                        size    3954912
         set workTarget                  /apache-ant
 
         build.cmd                       ./build.sh
@@ -89,4 +88,4 @@ universal_variant       no
 
 livecheck.type          regex
 livecheck.url           http://www.apache.org/dist/ant/binaries/
-livecheck.regex         {apache-ant-(\d+(?:\.\d+)*)-bin.tar.bz2}
+livecheck.regex         apache-ant-([quotemeta ${branch}](?:\\.\\d+)*)-bin\\.tar\\.bz2


### PR DESCRIPTION
#### Description

apache-ant-1.9: Update to 1.9.13

Also fix livecheck to only find 1.9.x versions, and to escape the literal periods.

I've updated the checksums of the +source variant but that variant does not build for me.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
