### PR TITLE
python27: Fix uuid function on systems with 64-bit hardware IDs

### DIFF
--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -7,6 +7,7 @@ name                python27
 epoch               2
 # Remember to keep py27-tkinter and py27-gdbm's versions sync'd with this
 version             2.7.15
+revision            1
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -36,7 +37,8 @@ patchfiles          patch-Makefile.pre.in.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
                     patch-configure.diff \
                     patch-libedit.diff \
-                    enable-loadable-sqlite-extensions.patch
+                    enable-loadable-sqlite-extensions.patch \
+                    uuid-64bit.patch
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python27/files/uuid-64bit.patch
+++ b/lang/python27/files/uuid-64bit.patch
@@ -1,0 +1,42 @@
+Fix uuid failure on systems with 64-bit hardware addresses:
+https://bugs.python.org/issue32502
+Backported from:
+https://github.com/python/cpython/commit/d69794f4df81de731cc66dc82136e28bee691e1e#diff-9d2d23bf4362c9ec2b6dd4b64b73756c
+--- Lib/uuid.py.orig	2018-04-29 17:47:33.000000000 -0500
++++ Lib/uuid.py	2018-08-25 23:35:37.000000000 -0500
+@@ -522,6 +522,12 @@
+ 
+ _node = None
+ 
++_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++
++_NODE_GETTERS_UNIX = [_unixdll_getnode, _ifconfig_getnode, _arp_getnode,
++                      _lanscan_getnode, _netstat_getnode]
++
++
+ def getnode():
+     """Get the hardware address as a 48-bit positive integer.
+ 
+@@ -537,18 +543,18 @@
+ 
+     import sys
+     if sys.platform == 'win32':
+-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++        getters = _NODE_GETTERS_WIN32
+     else:
+-        getters = [_unixdll_getnode, _ifconfig_getnode, _arp_getnode,
+-                   _lanscan_getnode, _netstat_getnode]
++        getters = _NODE_GETTERS_UNIX
+ 
+     for getter in getters + [_random_getnode]:
+         try:
+             _node = getter()
+         except:
+             continue
+-        if _node is not None:
++        if (_node is not None) and (0 <= _node < (1 << 48)):
+             return _node
++    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+ 
+ _last_timestamp = None
+ 

--- a/lang/python31/Portfile
+++ b/lang/python31/Portfile
@@ -7,7 +7,8 @@ name                    python31
 epoch                   1
 # Remember to keep py31-tkinter and py31-gdbm's versions sync'd with this
 version                 3.1.5
-revision                6
+revision                7
+
 set major               [lindex [split $version .] 0]
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              lang
@@ -35,7 +36,8 @@ patchfiles              patch-setup.py.diff \
                         patch-setup.py-disabled_modules.diff \
                         patch-libedit.diff \
                         patch-Lib-site.py-omit_local_site_packages.diff \
-                        patch-Include-pyport.h.diff
+                        patch-Include-pyport.h.diff \
+                        uuid-64bit.patch
 
 # https://bugs.python.org/issue21811
 patchfiles-append       patch-configure_configure.ac-yosemite_configure_fixes.diff \

--- a/lang/python31/files/uuid-64bit.patch
+++ b/lang/python31/files/uuid-64bit.patch
@@ -1,0 +1,40 @@
+Fix uuid failure on systems with 64-bit hardware addresses:
+https://bugs.python.org/issue32502
+Backported from:
+https://github.com/python/cpython/commit/d69794f4df81de731cc66dc82136e28bee691e1e#diff-9d2d23bf4362c9ec2b6dd4b64b73756c
+--- Lib/uuid.py.orig	2012-04-09 18:25:36.000000000 -0500
++++ Lib/uuid.py	2018-08-26 02:33:28.000000000 -0500
+@@ -479,6 +479,11 @@
+ 
+ _node = None
+ 
++_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++
++_NODE_GETTERS_UNIX = [_unixdll_getnode, _ifconfig_getnode]
++
++
+ def getnode():
+     """Get the hardware address as a 48-bit positive integer.
+ 
+@@ -494,17 +499,18 @@
+ 
+     import sys
+     if sys.platform == 'win32':
+-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++        getters = _NODE_GETTERS_WIN32
+     else:
+-        getters = [_unixdll_getnode, _ifconfig_getnode]
++        getters = _NODE_GETTERS_UNIX
+ 
+     for getter in getters + [_random_getnode]:
+         try:
+             _node = getter()
+         except:
+             continue
+-        if _node is not None:
++        if (_node is not None) and (0 <= _node < (1 << 48)):
+             return _node
++    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+ 
+ _last_timestamp = None
+ 

--- a/lang/python32/Portfile
+++ b/lang/python32/Portfile
@@ -7,7 +7,7 @@ name                    python32
 epoch                   20120412
 # Remember to keep py32-tkinter and py32-gdbm's versions sync'd with this
 version                 3.2.6
-revision                6
+revision                7
 
 set major               [lindex [split $version .] 0]
 set branch              [join [lrange [split ${version} .] 0 1] .]
@@ -37,7 +37,8 @@ patchfiles              patch-setup.py.diff \
                         patch-setup.py-disabled_modules.diff \
                         patch-libedit.diff \
                         patch-Lib-site.py-omit_local_site_packages.diff \
-                        patch-Include-pyport.h.diff
+                        patch-Include-pyport.h.diff \
+                        uuid-64bit.patch
 
 # https://bugs.python.org/issue21811
 patchfiles-append       patch-configure_configure.ac-yosemite_configure_fixes.diff \

--- a/lang/python32/files/uuid-64bit.patch
+++ b/lang/python32/files/uuid-64bit.patch
@@ -1,0 +1,40 @@
+Fix uuid failure on systems with 64-bit hardware addresses:
+https://bugs.python.org/issue32502
+Backported from:
+https://github.com/python/cpython/commit/d69794f4df81de731cc66dc82136e28bee691e1e#diff-9d2d23bf4362c9ec2b6dd4b64b73756c
+--- Lib/uuid.py.orig	2014-10-12 01:52:03.000000000 -0500
++++ Lib/uuid.py	2018-08-26 02:34:07.000000000 -0500
+@@ -494,6 +494,11 @@
+ 
+ _node = None
+ 
++_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++
++_NODE_GETTERS_UNIX = [_unixdll_getnode, _ifconfig_getnode]
++
++
+ def getnode():
+     """Get the hardware address as a 48-bit positive integer.
+ 
+@@ -509,17 +514,18 @@
+ 
+     import sys
+     if sys.platform == 'win32':
+-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++        getters = _NODE_GETTERS_WIN32
+     else:
+-        getters = [_unixdll_getnode, _ifconfig_getnode]
++        getters = _NODE_GETTERS_UNIX
+ 
+     for getter in getters + [_random_getnode]:
+         try:
+             _node = getter()
+         except:
+             continue
+-        if _node is not None:
++        if (_node is not None) and (0 <= _node < (1 << 48)):
+             return _node
++    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+ 
+ _last_timestamp = None
+ 

--- a/lang/python33/Portfile
+++ b/lang/python33/Portfile
@@ -8,7 +8,7 @@ name                python33
 epoch               20141012
 # Remember to keep py33-tkinter and py33-gdbm's versions sync'd with this
 version             3.3.7
-revision            1
+revision            2
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -36,7 +36,8 @@ patchfiles          patch-setup.py.diff \
                     patch-configure.diff \
                     patch-libedit.diff \
                     omit-local-site-packages.patch \
-                    patch-Include-pyport.h.diff
+                    patch-Include-pyport.h.diff \
+                    uuid-64bit.patch
 
 # https://bugs.python.org/issue21811
 patchfiles-append   yosemite-configure-fixes.patch \

--- a/lang/python33/files/uuid-64bit.patch
+++ b/lang/python33/files/uuid-64bit.patch
@@ -1,0 +1,40 @@
+Fix uuid failure on systems with 64-bit hardware addresses:
+https://bugs.python.org/issue32502
+Backported from:
+https://github.com/python/cpython/commit/d69794f4df81de731cc66dc82136e28bee691e1e#diff-9d2d23bf4362c9ec2b6dd4b64b73756c
+--- Lib/uuid.py.orig	2017-09-19 02:32:02.000000000 -0500
++++ Lib/uuid.py	2018-08-26 02:34:44.000000000 -0500
+@@ -490,6 +490,11 @@
+ 
+ _node = None
+ 
++_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++
++_NODE_GETTERS_UNIX = [_unixdll_getnode, _ifconfig_getnode]
++
++
+ def getnode():
+     """Get the hardware address as a 48-bit positive integer.
+ 
+@@ -505,17 +510,18 @@
+ 
+     import sys
+     if sys.platform == 'win32':
+-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++        getters = _NODE_GETTERS_WIN32
+     else:
+-        getters = [_unixdll_getnode, _ifconfig_getnode]
++        getters = _NODE_GETTERS_UNIX
+ 
+     for getter in getters + [_random_getnode]:
+         try:
+             _node = getter()
+         except:
+             continue
+-        if _node is not None:
++        if (_node is not None) and (0 <= _node < (1 << 48)):
+             return _node
++    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+ 
+ _last_timestamp = None
+ 

--- a/lang/python34/Portfile
+++ b/lang/python34/Portfile
@@ -8,6 +8,7 @@ name                python34
 epoch               20170810
 # Remember to keep py34-tkinter and py34-gdbm's versions sync'd with this
 version             3.4.9
+revision            1
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -35,7 +36,8 @@ patchfiles          patch-setup.py.diff \
                     patch-Lib-ctypes-macholib-dyld.py.diff \
                     patch-libedit.diff \
                     omit-local-site-packages.patch \
-                    patch-Include-pyport.h.diff
+                    patch-Include-pyport.h.diff \
+                    uuid-64bit.patch
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python34/files/uuid-64bit.patch
+++ b/lang/python34/files/uuid-64bit.patch
@@ -1,0 +1,42 @@
+Fix uuid failure on systems with 64-bit hardware addresses:
+https://bugs.python.org/issue32502
+Backported from:
+https://github.com/python/cpython/commit/d69794f4df81de731cc66dc82136e28bee691e1e#diff-9d2d23bf4362c9ec2b6dd4b64b73756c
+--- Lib/uuid.py.orig	2018-04-29 17:47:33.000000000 -0500
++++ Lib/uuid.py	2018-08-25 23:35:37.000000000 -0500
+@@ -522,6 +522,12 @@
+ 
+ _node = None
+ 
++_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++
++_NODE_GETTERS_UNIX = [_unixdll_getnode, _ifconfig_getnode, _arp_getnode,
++                      _lanscan_getnode, _netstat_getnode]
++
++
+ def getnode():
+     """Get the hardware address as a 48-bit positive integer.
+ 
+@@ -537,18 +543,18 @@
+ 
+     import sys
+     if sys.platform == 'win32':
+-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++        getters = _NODE_GETTERS_WIN32
+     else:
+-        getters = [_unixdll_getnode, _ifconfig_getnode, _arp_getnode,
+-                   _lanscan_getnode, _netstat_getnode]
++        getters = _NODE_GETTERS_UNIX
+ 
+     for getter in getters + [_random_getnode]:
+         try:
+             _node = getter()
+         except:
+             continue
+-        if _node is not None:
++        if (_node is not None) and (0 <= _node < (1 << 48)):
+             return _node
++    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+ 
+ _last_timestamp = None
+ 

--- a/lang/python35/Portfile
+++ b/lang/python35/Portfile
@@ -8,6 +8,7 @@ name                python35
 epoch               20170810
 # Remember to keep py35-tkinter and py35-gdbm's versions sync'd with this
 version             3.5.6
+revision            1
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -36,7 +37,8 @@ patchfiles          patch-setup.py.diff \
                     patch-libedit.diff \
                     omit-local-site-packages.patch \
                     patch-xcode4bug.diff \
-                    Modules_posixmodule.c.diff
+                    Modules_posixmodule.c.diff \
+                    uuid-64bit.patch
 
 depends_build       port:pkgconfig
 depends_lib         port:bzip2 \

--- a/lang/python35/files/uuid-64bit.patch
+++ b/lang/python35/files/uuid-64bit.patch
@@ -1,0 +1,42 @@
+Fix uuid failure on systems with 64-bit hardware addresses:
+https://bugs.python.org/issue32502
+Backported from:
+https://github.com/python/cpython/commit/d69794f4df81de731cc66dc82136e28bee691e1e#diff-9d2d23bf4362c9ec2b6dd4b64b73756c
+--- lib/uuid.py.orig	2018-08-02 04:19:12.000000000 -0500
++++ lib/uuid.py	2018-08-26 02:26:30.000000000 -0500
+@@ -527,6 +527,12 @@
+ 
+ _node = None
+ 
++_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++
++_NODE_GETTERS_UNIX = [_unixdll_getnode, _ifconfig_getnode, _ip_getnode,
++                      _arp_getnode, _lanscan_getnode, _netstat_getnode]
++
++
+ def getnode():
+     """Get the hardware address as a 48-bit positive integer.
+ 
+@@ -542,18 +548,18 @@
+ 
+     import sys
+     if sys.platform == 'win32':
+-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
++        getters = _NODE_GETTERS_WIN32
+     else:
+-        getters = [_unixdll_getnode, _ifconfig_getnode, _ip_getnode,
+-                   _arp_getnode, _lanscan_getnode, _netstat_getnode]
++        getters = _NODE_GETTERS_UNIX
+ 
+     for getter in getters + [_random_getnode]:
+         try:
+             _node = getter()
+         except:
+             continue
+-        if _node is not None:
++        if (_node is not None) and (0 <= _node < (1 << 48)):
+             return _node
++    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
+ 
+ _last_timestamp = None
+ 


### PR DESCRIPTION
#### Description

This backports a fix from python 3 that fixes the `uuid` function on systems with 64-bit hardware IDs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->