### PR TITLE
py-libvirt: Update to 4.5.0

### DIFF
--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-libvirt
-version             4.1.0
+version             4.5.0
 platforms           darwin
 license             MIT
 maintainers         {danchr @danchr} openmaintainer
@@ -20,9 +20,9 @@ homepage            http://www.libvirt.org/
 distname            libvirt-python-${version}
 master_sites        ${homepage}sources/python
 
-checksums           rmd160  e42219ddd3b9127657d9519511f5181097e9a152 \
-                    sha256  dec2a33d68779672b4688b296d6de18c9c41b89d8c74c9d3dc887e366587b8c7 \
-                    size    186312
+checksums           rmd160  672c83e2dca72e4384be32df21f67aa6c42d50a0 \
+                    sha256  ef35ed6bc24d76563b1ba9b068ef5a048016726dba62a9d057fe6dfbea6b0f60 \
+                    size    190016
 
 python.default_version  27
 python.versions     27 34 35 36


### PR DESCRIPTION
#### Description

py-libvirt is currently at version 4.1.0 and it does not build. This updates py-libvirt to 4.5.0 which does build.

We probably need to update libvirt and py-libvirt at the same time in the future. It might make sense to list both of us as maintainers of both ports.

4.6.0 is available but I'm skipping this version for the libvirt port, because 4.6.0 included a change that the developers have already decided to revert for the next version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
