### PR TITLE
inchi-1, libinchi-1, stdinchi-1: Fix master_sites, livecheck, dist_subdir, checksums

### DIFF
--- a/devel/libinchi-1/Portfile
+++ b/devel/libinchi-1/Portfile
@@ -25,13 +25,13 @@ distname            INCHI-1-API
 distfiles-append    INCHI-1-DOC.zip
 
 checksums           INCHI-1-API.zip \
-                    md5     7dd26285418528172326aa32f9a19ba3 \
-                    sha1    9a9ac4b2f0a03638a97ffcd325b52c9992c777af \
                     rmd160  5a808be29e751c706b3ace7dfd8c1c7a0cdfb022 \
+                    sha256  d84ed63f71cba6c8622d36870085b7a2a7ea4abaf433808ea4f202d2e4637a69 \
+                    size    3642980 \
                     INCHI-1-DOC.zip \
-                    md5     6a380e9b1ac8b963b66304e1c16a31bb \
-                    sha1    4f2d2453573dd2ef22a70e190e9e2e90562959a7 \
-                    rmd160  1390a48cd691a5b4d00cc74152ac4df6fb4e836b
+                    rmd160  1390a48cd691a5b4d00cc74152ac4df6fb4e836b \
+                    sha256  434575d37eedc4a4e3e77fa512c5f9fe904fded6d25fff8587717b56abac05bf \
+                    size    2260288
 
 use_configure       no
 

--- a/devel/libinchi-1/Portfile
+++ b/devel/libinchi-1/Portfile
@@ -54,3 +54,7 @@ destroot {
         readme.txt \
         ${docdir}
 }
+
+livecheck.type      regex
+livecheck.url       https://www.inchi-trust.org/downloads/
+livecheck.regex     {InChI version 1 \(software version ([^)]+)\)}

--- a/devel/libinchi-1/Portfile
+++ b/devel/libinchi-1/Portfile
@@ -18,7 +18,7 @@ long_description    IUPAC library for standard and non-standard \
 
 homepage            http://www.iupac.org/inchi/
 master_sites        https://www.inchi-trust.org/download/[string map {. {}} ${version}]
-dist_subdir         inchi-1
+dist_subdir         inchi-1/${version}
 
 use_zip             yes
 distname            INCHI-1-API

--- a/devel/libinchi-1/Portfile
+++ b/devel/libinchi-1/Portfile
@@ -17,7 +17,7 @@ long_description    IUPAC library for standard and non-standard \
                     identifiers for chemical substances.
 
 homepage            http://www.iupac.org/inchi/
-master_sites        http://www.inchi-trust.org/download/[string map {. {}} $version]/
+master_sites        https://www.inchi-trust.org/download/[string map {. {}} ${version}]
 dist_subdir         inchi-1
 
 use_zip             yes

--- a/science/inchi-1/Portfile
+++ b/science/inchi-1/Portfile
@@ -16,7 +16,7 @@ long_description    IUPAC utility for standard and non-standard \
                     identifiers for chemical substances.
 
 homepage            http://www.iupac.org/inchi/
-master_sites        ${homepage}download/version${version}/
+master_sites        https://www.inchi-trust.org/download/[string map {. {}} ${version}]
 
 use_zip             yes
 distname            INCHI-1-API

--- a/science/inchi-1/Portfile
+++ b/science/inchi-1/Portfile
@@ -34,3 +34,7 @@ build.target        inchi-1
 destroot {
    xinstall -m 755 ${worksrcpath}/INCHI/gcc/inchi-1/inchi-1 ${destroot}${prefix}/bin/
 }
+
+livecheck.type      regex
+livecheck.url       https://www.inchi-trust.org/downloads/
+livecheck.regex     {InChI version 1 \(software version ([^)]+)\)}

--- a/science/inchi-1/Portfile
+++ b/science/inchi-1/Portfile
@@ -17,6 +17,7 @@ long_description    IUPAC utility for standard and non-standard \
 
 homepage            http://www.iupac.org/inchi/
 master_sites        https://www.inchi-trust.org/download/[string map {. {}} ${version}]
+dist_subdir         ${name}/${version}
 
 use_zip             yes
 distname            INCHI-1-API

--- a/science/inchi-1/Portfile
+++ b/science/inchi-1/Portfile
@@ -21,9 +21,9 @@ master_sites        ${homepage}download/version${version}/
 use_zip             yes
 distname            INCHI-1-API
 
-checksums           md5     7dd26285418528172326aa32f9a19ba3 \
-                    sha1    9a9ac4b2f0a03638a97ffcd325b52c9992c777af \
-                    rmd160  5a808be29e751c706b3ace7dfd8c1c7a0cdfb022
+checksums           rmd160  5a808be29e751c706b3ace7dfd8c1c7a0cdfb022 \
+                    sha256  d84ed63f71cba6c8622d36870085b7a2a7ea4abaf433808ea4f202d2e4637a69 \
+                    size    3642980
 
 use_configure       no
 

--- a/science/stdinchi-1/Portfile
+++ b/science/stdinchi-1/Portfile
@@ -16,7 +16,7 @@ long_description    IUPAC utility for standard International Chemical \
                     chemical substances.
 
 homepage            http://www.iupac.org/inchi/
-master_sites        http://www.iupac.org/inchi/download/
+master_sites        https://www.inchi-trust.org/download/[string map {. {}} ${version}]
 distname            STDINCHI-1-API
 use_zip             yes
 

--- a/science/stdinchi-1/Portfile
+++ b/science/stdinchi-1/Portfile
@@ -34,3 +34,7 @@ build.target        stdinchi-1
 destroot {
    xinstall -m 755 ${worksrcpath}/STDINCHI/gcc_makefile/stdinchi-1 ${destroot}${prefix}/bin/
 }
+
+livecheck.type      regex
+livecheck.url       https://www.inchi-trust.org/downloads/
+livecheck.regex     {InChI version 1 \(software version ([^)]+)\) for Standard InChI}

--- a/science/stdinchi-1/Portfile
+++ b/science/stdinchi-1/Portfile
@@ -20,11 +20,12 @@ master_sites        http://www.iupac.org/inchi/download/
 distname            STDINCHI-1-API
 use_zip             yes
 
-checksums           md5     aa8bab9424a4c9683b63706c18d55479 \
-                    sha1    8545bc26004db435edc56e58c2f74d9b424c0e26 \
-                    rmd160  02381c995b837a9bfe2eceadf3b5b9f5d7328360
+checksums           rmd160  02381c995b837a9bfe2eceadf3b5b9f5d7328360 \
+                    sha256  befa59c87b19a0249b84525a98ed574886acf890d8431b6587225eff221a1777 \
+                    size    5714027
 
 use_configure       no
+
 build.args          -C STDINCHI/gcc_makefile/ -f makefile
 build.target        stdinchi-1
 

--- a/science/stdinchi-1/Portfile
+++ b/science/stdinchi-1/Portfile
@@ -17,6 +17,8 @@ long_description    IUPAC utility for standard International Chemical \
 
 homepage            http://www.iupac.org/inchi/
 master_sites        https://www.inchi-trust.org/download/[string map {. {}} ${version}]
+dist_subdir         inchi-1/${version}
+
 distname            STDINCHI-1-API
 use_zip             yes
 


### PR DESCRIPTION
#### Description

* Update master_sites of libinchi-1 to use https.
* Fix master_sites of inchi-1 and stdinchi-1 to match.
* Add versioned dist_subdir to all three because the distfile's name is unversioned.
* Fix livecheck.
* Modernize checksums.

To do later:

* Make libinchi-1 and stdinchi-1 subports of inchi-1.
* Update inchi-1 and libinchi-1 1.05.
* Figure out if stdinchi-1 is still needed or if it has been superseded by inchi-1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
