### PR TITLE
unixODBC: Update to 2.3.7 and clean up

### DIFF
--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 name                unixODBC
 conflicts           libiodbc virtuoso virtuoso-7
 version             2.3.5
+revision            1
 categories          databases
 platforms           darwin
 maintainers         nomaintainer

--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -4,8 +4,11 @@ PortSystem          1.0
 
 name                unixODBC
 conflicts           libiodbc virtuoso virtuoso-7
-version             2.3.5
-revision            1
+version             2.3.7
+checksums           rmd160  ebbd9e9cee6888779e572b8a32596f49a8bdad2d \
+                    sha256  45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77 \
+                    size    1669501
+
 categories          databases
 platforms           darwin
 maintainers         nomaintainer
@@ -31,9 +34,6 @@ long_description    The unixODBC project provides UNIX applications with the \
 homepage            http://www.unixodbc.org/
 master_sites        ${homepage} \
                     ftp://ftp.unixodbc.org/pub/unixODBC/
-
-checksums           rmd160  72ed87df0d59ce6a7c5459e1ca72e585c8619d51 \
-                    sha256  760972e05cc6361aee49d676fb7da8244e0f3a225cd4d3449a951378551b495b
 
 depends_lib         port:libiconv port:libtool port:readline
 

--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -45,29 +45,20 @@ use_parallel_build  yes
 post-destroot {
     # DOCS
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
-    
-    foreach doc [glob ${worksrcpath}/\[A-Z\]*\[A-Z\]\[A-Z\]\[A-Z\] ${worksrcpath}/doc/*.\[a-z\]\[a-z\]\[a-z\]*] {
-        xinstall -m 0644 $doc ${destroot}${prefix}/share/doc/${name}
-    }
-    
+    xinstall -m 0644 \
+        {*}[glob ${worksrcpath}/\[A-Z\]*\[A-Z\]\[A-Z\]\[A-Z\] ${worksrcpath}/doc/*.\[a-z\]\[a-z\]\[a-z\]*] \
+        ${destroot}${prefix}/share/doc/${name}
     foreach dir {AdministratorManual lst ProgrammerManual ProgrammerManual/Tutorial UserManual} {
-        xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}/$dir
-        
-        foreach file [glob ${worksrcpath}/doc/$dir/*.\[a-z\]\[a-z\]\[a-z\]*] {
-            xinstall -m 0644 $file ${destroot}${prefix}/share/doc/${name}/$dir
-        }
+        xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}/${dir}
+        xinstall -m 0644 \
+            {*}[glob ${worksrcpath}/doc/$dir/*.\[a-z\]\[a-z\]\[a-z\]*] \
+            ${destroot}${prefix}/share/doc/${name}/${dir}
     }
     
     # TEMPLATES
     xinstall -d -m 0755 ${destroot}${prefix}/share/${name}
-    
-    foreach template [glob ${filespath}/*.template] {
-        xinstall -m 0644 $template ${destroot}${prefix}/share/${name}
-    }
-    
-    foreach driver [glob ${destroot}${prefix}/share/${name}/*.driver.*] {
-        reinplace "s|__PREFIX__|${prefix}|g" $driver
-    }
+    xinstall -m 0644 {*}[glob ${filespath}/*.template] ${destroot}${prefix}/share/${name}
+    reinplace "s|__PREFIX__|${prefix}|g" {*}[glob ${destroot}${prefix}/share/${name}/*.driver.*]
     
     # CONFIG
     foreach ini [glob ${destroot}${prefix}/etc/*.ini] {

--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -71,7 +71,7 @@ post-destroot {
     
     # CONFIG
     foreach ini [glob ${destroot}${prefix}/etc/*.ini] {
-        system "mv $ini $ini.dist"
+        move ${ini} ${ini}.dist
     }
     
     destroot.keepdirs ${destroot}${prefix}/etc/ODBCDataSources

--- a/databases/unixODBC/Portfile
+++ b/databases/unixODBC/Portfile
@@ -47,10 +47,6 @@ post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
     
     foreach doc [glob ${worksrcpath}/\[A-Z\]*\[A-Z\]\[A-Z\]\[A-Z\] ${worksrcpath}/doc/*.\[a-z\]\[a-z\]\[a-z\]*] {
-        if {[string match "*.html" $doc]} {
-            reinplace "s|${homepage}doc/||g" $doc
-        }
-        
         xinstall -m 0644 $doc ${destroot}${prefix}/share/doc/${name}
     }
     
@@ -58,10 +54,6 @@ post-destroot {
         xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}/$dir
         
         foreach file [glob ${worksrcpath}/doc/$dir/*.\[a-z\]\[a-z\]\[a-z\]*] {
-            if {[string match "*.html" $file]} {
-                reinplace "s|${homepage}doc/||g" $file
-            }
-            
             xinstall -m 0644 $file ${destroot}${prefix}/share/doc/${name}/$dir
         }
     }

--- a/databases/unixODBC/files/nntp.driver.template
+++ b/databases/unixODBC/files/nntp.driver.template
@@ -1,4 +1,4 @@
 [NNTP]
 Description		= NNTP ODBC Driver
-Driver			= _DP_PREFIX/lib/libnn.so
-Setup			= _DP_PREFIX/lib/libodbcnnS.so
+Driver			= __PREFIX__/lib/libnn.so
+Setup			= __PREFIX__/lib/libodbcnnS.so

--- a/databases/unixODBC/files/tds.driver.template
+++ b/databases/unixODBC/files/tds.driver.template
@@ -1,4 +1,4 @@
 [TDS]
 Description		= TDS ODBC Driver
-Driver			= _DP_PREFIX/lib/libtdsodbc.so
-Setup			= _DP_PREFIX/lib/libtdsS.so
+Driver			= __PREFIX__/lib/libtdsodbc.so
+Setup			= __PREFIX__/lib/libtdsS.so


### PR DESCRIPTION
#### Description

* Update to 2.3.7
* Fix reinplace problems
* Simplify doc installation

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
