### PR TITLE
gptfdisk: Update to 1.0.4 and cleanup

### DIFF
--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -3,8 +3,11 @@
 PortSystem              1.0
 
 name                    gptfdisk
-version                 1.0.3
-revision                1
+version                 1.0.4
+checksums               rmd160  69e0885c90c732ff1147ddb2c59cf82034a8dc23 \
+                        sha256  b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d \
+                        size    204075
+
 categories              sysutils
 platforms               darwin
 license                 GPL-2+
@@ -17,11 +20,6 @@ long_description        GPT fdisk (gdisk) is a disk partitioning tool loosely mo
 
 homepage                http://www.rodsbooks.com/gdisk/
 master_sites            sourceforge:project/gptfdisk/gptfdisk/${version}
-
-checksums               md5 07b625a583b66c8c5840be5923f3e3fe \
-                        sha1 9a74bbe7805d562316e92417f71e4b03155308e6 \
-                        sha256 89fd5aec35c409d610a36cb49c65b442058565ed84042f767bba614b8fc91b5c \
-                        rmd160 9bf949224cb5fa4fe7df4f332c22a7106a2cfa0c
 
 patchfiles              patch-Makefile.mac.diff
 

--- a/sysutils/gptfdisk/Portfile
+++ b/sysutils/gptfdisk/Portfile
@@ -42,15 +42,8 @@ build.args              -f Makefile.mac \
                         FATBINFLAGS="[get_canonical_archflags]"
 
 destroot {
-    xinstall -m 0755 -d ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/gdisk ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/sgdisk ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/cgdisk ${destroot}${prefix}/bin
-    xinstall -m 0755 ${worksrcpath}/fixparts ${destroot}${prefix}/bin
+    xinstall -m 0755 -W ${worksrcpath} cgdisk fixparts gdisk sgdisk ${destroot}${prefix}/bin
 
     xinstall -m 0755 -d ${destroot}${prefix}/share/man/man8
-    xinstall -m 0644 ${worksrcpath}/gdisk.8 ${destroot}${prefix}/share/man/man8
-    xinstall -m 0644 ${worksrcpath}/sgdisk.8 ${destroot}${prefix}/share/man/man8
-    xinstall -m 0644 ${worksrcpath}/cgdisk.8 ${destroot}${prefix}/share/man/man8
-    xinstall -m 0644 ${worksrcpath}/fixparts.8 ${destroot}${prefix}/share/man/man8
+    xinstall -m 0644 -W ${worksrcpath} cgdisk.8 fixparts.8 gdisk.8 sgdisk.8 ${destroot}${prefix}/share/man/man8
 }

--- a/sysutils/gptfdisk/files/patch-Makefile.mac.diff
+++ b/sysutils/gptfdisk/files/patch-Makefile.mac.diff
@@ -1,29 +1,30 @@
---- Makefile.mac.orig	2017-07-27 20:41:20.000000000 -0500
-+++ Makefile.mac	2018-05-31 21:57:18.000000000 -0500
-@@ -1,9 +1,9 @@
+--- Makefile.mac.orig	2018-07-05 15:19:46.000000000 -0500
++++ Makefile.mac	2018-08-26 21:03:02.000000000 -0500
+@@ -1,10 +1,11 @@
 +prefix=__PREFIX__
  CC=gcc
  CXX=clang++
  FATBINFLAGS=-arch x86_64 -arch i386 -mmacosx-version-min=10.4
+ THINBINFLAGS=-arch x86_64 -mmacosx-version-min=10.4
 -CFLAGS=$(FATBINFLAGS) -O2 -D_FILE_OFFSET_BITS=64 -g
--#CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
--CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -I /usr/local/include -I/opt/local/include -g
 +CFLAGS=$(FATBINFLAGS) -D_FILE_OFFSET_BITS=64 -g
+ #CXXFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D USE_UTF16 -I/opt/local/include -I/usr/local/include -I/opt/local/include -g
+-CXXFLAGS=$(FATBINFLAGS) -O2 -Wall -D_FILE_OFFSET_BITS=64 -I/opt/local/include -I /usr/local/include -I/opt/local/include -g
 +CXXFLAGS=$(FATBINFLAGS) -Wall -D_FILE_OFFSET_BITS=64 -I$(prefix)/include -g
  LIB_NAMES=crc32 support guid gptpart mbrpart basicmbr mbr gpt bsd parttypes attributes diskio diskio-unix
  MBR_LIBS=support diskio diskio-unix basicmbr mbrpart
  #LIB_SRCS=$(NAMES:=.cc)
-@@ -19,12 +19,11 @@
+@@ -20,12 +21,12 @@
  #	$(CXX) $(LIB_OBJS) -L/usr/lib -licucore gpttext.o gdisk.o -o gdisk
  
  cgdisk: $(LIB_OBJS) cgdisk.o gptcurses.o
--	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /opt/local/lib/libncurses.a $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
+-	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /usr/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
 +	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(prefix)/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
  #	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(LDFLAGS) -licucore -lncurses -o cgdisk
  
  sgdisk: $(LIB_OBJS) gptcl.o sgdisk.o
--#	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o /opt/local/lib/libiconv.a /opt/local/lib/libintl.a /opt/local/lib/libpopt.a $(FATBINFLAGS) -o sgdisk
--	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/opt/local/lib -lpopt $(FATBINFLAGS) -o sgdisk
+ #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o /opt/local/lib/libiconv.a /opt/local/lib/libintl.a /opt/local/lib/libpopt.a $(FATBINFLAGS) -o sgdisk
+-	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/usr/local/lib -lpopt $(THINBINFLAGS) -o sgdisk
 +	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L$(prefix)/lib -lpopt $(FATBINFLAGS) -o sgdisk
  #	$(CXX) $(LIB_OBJS) gptcl.o sgdisk.o -L/sw/lib -licucore -lpopt -o sgdisk
  


### PR DESCRIPTION
#### Description

Updates to 1.0.4.

With this version the developer made sgdisk build for only 64-bit because he had trouble building it universal. I had no such trouble on my system so I reverted that change.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
