### PR TITLE
paraview:  fix python36 variant

### DIFF
--- a/science/paraview/files/patch-incomplete-types.patch
+++ b/science/paraview/files/patch-incomplete-types.patch
@@ -130,3 +130,15 @@ index a0ba740dbc..e44e0d43a5 100644
  class QItemSelection;
  class QItemSelectionModel;
  class QPoint;
+diff --git a/Qt/Python/pqPythonShell.cxx b/Qt/Python/pqPythonShell.cxx
+index 3d01fd0a96..7cb356fbc4 100644
+--- Qt/Python/pqPythonShell.cxx
++++ Qt/Python/pqPythonShell.cxx
+@@ -61,6 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <QTextCharFormat>
+ #include <QVBoxLayout>
+ #include <QtDebug>
++#include <QtWidgets>
+ 
+ QStringList pqPythonShell::Preamble;
+ 


### PR DESCRIPTION
* adds to patch for qt5 compatibility

Closes:  https://trac.macports.org/ticket/56981

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1408
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
