### PR TITLE
zinc: update to 0.3.15, use https

### DIFF
--- a/devel/zinc/Portfile
+++ b/devel/zinc/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    typesafehub zinc 0.3.5.3 v
+github.setup    typesafehub zinc 0.3.15 v
 categories      devel java
 license         Apache-2
 maintainers     openmaintainer {blair @blair}
@@ -12,15 +12,15 @@ long_description \
 platforms       darwin
 supported_archs noarch
 
-master_sites    http://downloads.typesafe.com/zinc/${version}
+master_sites    https://downloads.typesafe.com/zinc/${version}
 
 use_configure   no
 build           {}
 
 extract.suffix  .tgz
-checksums       md5    a1e71c996bfc875acaa32ea192ef8df8 \
-                sha1   ff91434ce32ba4fcfadb8621896edfd271a9bd21 \
-                sha256 92bdeb4d1ba1a08f8a3aa1a0b10d36a06060c47f16fc523856f3ada598362020
+checksums       rmd160  0b17dc840a84705bbc05be467d406f6a52d48ac7 \
+                sha256  5ec4df3fa2cbb271d65a5b478c940a9da6ef4902aa8c9d41a76dd253e3334ca7 \
+                size    24682167
 
 destroot {
     set sharedir ${destroot}${prefix}/share


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
