### PR TITLE
sbt: fix warning when launching with Java 8+

### DIFF
--- a/devel/sbt/Portfile
+++ b/devel/sbt/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            sbt
 version         0.13.17
+revision        1
 categories      devel java
 license         BSD
 maintainers     {blair @blair} openmaintainer

--- a/devel/sbt/files/sbt.sh
+++ b/devel/sbt/files/sbt.sh
@@ -25,7 +25,13 @@ fi
 if [ -z "$JAVA_OPTS" ]; then
     # Ensure enough heap space is created for sbt.  These settings are
     # the default settings from Typesafe's sbt wrapper.
-    JAVA_OPTS="-XX:+CMSClassUnloadingEnabled -Xms1536m -Xmx1536m -XX:MaxPermSize=384m -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF8"
+    JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    if [ "$JAVA_VERSION" \< "1.8" ]; then
+        CLASS_METADATA_OPT="MaxPermSize"
+    else
+        CLASS_METADATA_OPT="MaxMetaspaceSize"
+    fi
+    JAVA_OPTS="-XX:+CMSClassUnloadingEnabled -Xms1536m -Xmx1536m -XX:$CLASS_METADATA_OPT=384m -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF8"
 fi
 
 # Assume java is already in the shell path.


### PR DESCRIPTION
#### Description

The sbt port contains a wrapper script that sets some memory options that are not compatible with Java 8+. This causes a warning on every invocation.

This PR changes the options depending on the Java version to be compatible. It is based on another sbt launch script here:
https://github.com/rtyley/sbt-launcher-package/blob/cb12ec1eaa6907273edd716356b33c6bec407fac/src/universal/bin/sbt-launch-lib.bash#L96

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
