### PR TITLE
X.Org Prototype packages. Adapt to upstream repackaging.

### DIFF
--- a/aqua/cotvnc/Portfile
+++ b/aqua/cotvnc/Portfile
@@ -6,6 +6,7 @@ PortGroup xcode     1.0
 name                cotvnc
 conflicts           cotvnc-devel
 version             2.2b2
+revision            1
 categories-append   vnc
 maintainers         nomaintainer
 license             GPL-2
@@ -28,7 +29,7 @@ depends_build-append \
 
 depends_lib-append \
                     lib:libz.1:zlib \
-                    port:xorg-xproto
+                    port:xorg-xorgproto
 
 worksrcdir          trunk/cotvnc
 

--- a/aqua/osx2x/Portfile
+++ b/aqua/osx2x/Portfile
@@ -6,7 +6,7 @@ PortGroup       xcode 1.0
 name            osx2x
 version         2.4.0
 set my_version  2.4
-revision        5
+revision        6
 set git_hash    3cc708236898ab789bb99a5fba7420ff76ede9f7
 license         BSD
 platforms       darwin
@@ -44,7 +44,7 @@ post-patch {
 }
 
 depends_lib     port:xorg-libXtst \
-                port:xorg-xproto \
+                port:xorg-xorgproto \
                 path:lib/libssl.dylib:openssl
 
 xcode.configuration Release

--- a/devel/gtkglext/Portfile
+++ b/devel/gtkglext/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 PortGroup  muniversal 1.0
 name		gtkglext
 version		1.2.0
-revision	9
+revision	10
 categories	devel
 license		LGPL-2.1+
 maintainers	lifehertz.com:jd
@@ -42,6 +42,6 @@ variant quartz {
 				patch-gdk-gdkglglext.h.diff
 
 	platform darwin 8 {
-			depends_lib-append port:xorg-glproto
+			depends_lib-append port:xorg-xorgproto
 	}
 }

--- a/emulators/scummvm/Portfile
+++ b/emulators/scummvm/Portfile
@@ -25,6 +25,7 @@ if {${subport} eq ${name}} {
         the ${name}-devel port.
 
     version             2.0.0
+    revision            1
     master_sites        http://scummvm.org/frs/${name}/${version}
     use_bzip2           yes
     checksums           sha256  46482e9f4eccd8590a86c70b024bdd0b319af8cbe8b7abaef592a9c52abbe1dc \
@@ -40,6 +41,7 @@ if {${subport} eq ${name}} {
     PortGroup           github 1.0
     github.setup        scummvm scummvm f99977255cf979568f0d57f977c10ac26f2ff4ac
     version             20180719
+    revision            1
     checksums           rmd160  666bbae9f3276a39f025a20255dd4f72b278e995 \
                         sha256  d79078791e3c84ef76e36c0e94a2c6d5aff4645be90e1d850fccc7c2f41a26f9 \
                         size    32852665
@@ -114,7 +116,7 @@ variant mpeg2 description {add mpeg2 support - has many dependencies} {
                     port:python2_select \
                     port:python_select \
                     port:sqlite3 \
-                    port:xorg-kbproto \
+                    port:xorg-xorgproto \
                     port:xorg-libX11 \
                     port:xorg-libXau \
                     port:xorg-libXdmcp \
@@ -125,12 +127,7 @@ variant mpeg2 description {add mpeg2 support - has many dependencies} {
                     port:xorg-libpthread-stubs \
                     port:xorg-libsm \
                     port:xorg-libxcb \
-                    port:xorg-randrproto \
-                    port:xorg-renderproto \
-                    port:xorg-videoproto \
                     port:xorg-xcb-proto \
-                    port:xorg-xextproto \
-                    port:xorg-xproto \
                     port:xrender \
                     port:xz
 

--- a/gnome/gnome-settings-daemon/Portfile
+++ b/gnome/gnome-settings-daemon/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                gnome-settings-daemon
 version             3.26.2
-revision            1
+revision            2
 license             GPL-2 LGPL-2.1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Gnome 3 settings daemon.
@@ -42,7 +42,7 @@ depends_lib         port:gtk3 \
                     port:policykit \
                     port:pulseaudio \
                     port:upower \
-                    port:xorg-kbproto \
+                    port:xorg-xorgproto \
                     port:xorg-libXi \
                     port:xorg-libXtst \
                     port:xorg-libXfixes \

--- a/net/nxcomp/Portfile
+++ b/net/nxcomp/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    nxcomp
 version                 3.5.99.14
-revision                0
+revision                1
 checksums               rmd160  b608df939adf4ffab56f4b16b5240a3ce6fb815f \
                         sha256  d6868702369cd852df0f111eea8734312dd085d88fe8e58da9d2e18a768fa54a \
                         size    725296
@@ -41,7 +41,7 @@ if {${name} eq ${subport}} {
     depends_lib-append  port:libpng \
                         path:lib/libjpeg.dylib:jpeg \
                         port:zlib \
-                        port:xorg-xproto
+                        port:xorg-xorgproto
 
     worksrcdir          nx-libs-${version}/nxcomp
 

--- a/x11/XawM/Portfile
+++ b/x11/XawM/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                XawM
 version             1.5u
+revision            1
 categories          x11
 platforms           darwin
 maintainers         nomaintainer
@@ -28,7 +29,7 @@ depends_build       port:xorg-libX11 \
                     port:xorg-libXext \
                     port:xorg-libXmu \
                     port:xorg-libXt \
-                    port:xorg-xproto
+                    port:xorg-xorgproto
 
 # Ancient configure script doesn't like it when CC contains multiple words.
 configure.ccache    no

--- a/x11/awesome/Portfile
+++ b/x11/awesome/Portfile
@@ -5,6 +5,7 @@ PortGroup           active_variants 1.1
 
 name                awesome
 version             3.5.6
+revision            1
 categories          x11 x11-wm
 platforms           darwin
 maintainers         nomaintainer
@@ -48,7 +49,7 @@ depends_lib         path:bin/dbus-daemon:dbus \
                     port:xorg-xcb-util-image \
                     port:xorg-xcb-util-keysyms \
                     port:xorg-xcb-util-wm \
-                    port:xorg-randrproto \
+                    port:xorg-xorgproto \
                     port:startup-notification \
                     port:libxdg-basedir \
                     port:imlib2 \

--- a/x11/fonttosfnt/Portfile
+++ b/x11/fonttosfnt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fonttosfnt
 version             1.0.5
-revision            1
+revision            2
 categories          x11 graphics
 maintainers         {jeremyhu @jeremyhu} openmaintainer
 license             X11
@@ -24,7 +24,7 @@ checksums           rmd160  0f8d356814b4df375e5dc4be80b53002f85fd116 \
                     size    141446
 
 depends_build       port:pkgconfig \
-                    port:xorg-xproto
+                    port:xorg-xorgproto
 
 depends_lib         port:xorg-libfontenc port:freetype
 

--- a/x11/imake/Portfile
+++ b/x11/imake/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name         imake
 version      1.0.7
+revision     1
 categories   x11 devel
 license      X11
 installs_libs no
@@ -22,7 +23,7 @@ checksums           rmd160  7a8d7b830463c1c429a8ad8349324e607ea255fb \
                     sha256  690c2c4ac1fad2470a5ea73156cf930b8040dc821a0da4e322014a42c045f37e
 
 depends_run    port:xorg-cf-files path:bin/perl:perl5
-depends_build  port:pkgconfig port:xorg-xproto
+depends_build  port:pkgconfig port:xorg-xorgproto
 
 if {${os.platform} eq "darwin" && ${os.major} >= 12} {
     depends_lib-append port:tradcpp

--- a/x11/lndir/Portfile
+++ b/x11/lndir/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                lndir
 version             1.0.3
+revision            1
 categories          x11 sysutils
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -20,7 +21,7 @@ checksums           sha1    fc71a6ff2cc0a1065cfb608796ffd6b4f0ce76fe \
 
 depends_build \
         port:pkgconfig \
-        port:xorg-xproto
+        port:xorg-xorgproto
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/x11/makedepend/Portfile
+++ b/x11/makedepend/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                makedepend
 version             1.0.5
+revision            1
 categories          x11 devel
 license             X11
 installs_libs       no
@@ -25,7 +26,7 @@ checksums           sha1    2599afa039d2070bae9df6ce43da288b3a4adf97 \
                     rmd160  d1ba5b107ae145608a5f3e932fa2794eec1ddd0a \
                     sha256  f7a80575f3724ac3d9b19eaeab802892ece7e4b0061dd6425b4b789353e25425
 
-depends_build       port:pkgconfig port:xorg-xproto
+depends_build       port:pkgconfig port:xorg-xorgproto
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -6,6 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                mesa
 epoch               1
 version             17.1.6
+revision            1
 categories          x11 graphics
 maintainers         {jeremyhu @jeremyhu} openmaintainer
 license             MIT
@@ -27,8 +28,7 @@ depends_build       port:pkgconfig \
                     port:bison \
                     port:gindent
 
-depends_lib         port:xorg-glproto \
-                    port:xorg-dri2proto \
+depends_lib         port:xorg-xorgproto \
                     port:xorg-libxcb \
                     port:xorg-libX11 \
                     port:xorg-libXext \

--- a/x11/mkfontscale/Portfile
+++ b/x11/mkfontscale/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mkfontscale
 version             1.1.2
-revision            1
+revision            2
 categories          x11
 license             X11
 platforms           darwin
@@ -23,7 +23,7 @@ use_parallel_build  yes
 depends_build \
 	port:xorg-util-macros \
 	port:pkgconfig \
-	port:xorg-xproto
+	port:xorg-xorgproto
 
 depends_lib \
 	port:xorg-libfontenc \

--- a/x11/rendercheck/Portfile
+++ b/x11/rendercheck/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                rendercheck
 version             1.5
+revision            1
 categories          x11
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -20,7 +21,7 @@ checksums           rmd160  e3cf47928162d4616e47bb44893c79b450311fc6 \
 depends_build       port:pkgconfig
 
 depends_lib         port:xorg-libX11 \
-                    port:xorg-xproto \
+                    port:xorg-xorgproto \
                     port:xrender
 
 livecheck.type      regex

--- a/x11/rgb/Portfile
+++ b/x11/rgb/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                rgb
 version             1.0.6
+revision            1
 categories          x11 sysutils
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -18,7 +19,7 @@ checksums           md5     eab5bbd7642e5c784429307ec210d198 \
                     sha1    542fade81a74f8a6beaea8cb517bdf1033fc6b71 \
                     rmd160  aaf1a6b1c96238a81b2b6a15648f93705a68f08f
 
-depends_build       port:pkgconfig port:xorg-xproto
+depends_build       port:pkgconfig port:xorg-xorgproto
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/x11/sessreg/Portfile
+++ b/x11/sessreg/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                sessreg
 version             1.1.0
+revision            1
 categories          x11
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -19,7 +20,7 @@ checksums           sha1    a27a476f7f39ae30a16dfa25ca07c12378cff7f0 \
                     rmd160  b5779a4f4bf7214fd186e41a81d4cf906f6b4443 \
                     sha256  551177657835e0902b5eee7b19713035beaa1581bbd3c6506baa553e751e017c
 
-depends_build       port:pkgconfig port:xorg-xproto
+depends_build       port:pkgconfig port:xorg-xorgproto
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/x11/wine-crossover/Portfile
+++ b/x11/wine-crossover/Portfile
@@ -18,6 +18,7 @@ name                        wine-crossover
 conflicts                   wine wine-devel
 set my_name                 wine
 version                     17.5.1
+revision                    1
 license                     LGPL-2.1+
 categories                  x11
 maintainers                 {ryandesign @ryandesign} {jeremyhu @jeremyhu} openmaintainer
@@ -183,7 +184,7 @@ variant x11 {
                                 port:xorg-libXrandr \
                                 port:xorg-libXxf86vm \
                                 port:xorg-libsm \
-                                port:xorg-xf86vidmodeproto \
+                                port:xorg-xorgproto \
                                 port:xrender
 
     configure.args-delete       --without-osmesa \

--- a/x11/wine-devel/Portfile
+++ b/x11/wine-devel/Portfile
@@ -15,7 +15,7 @@ name                        wine-devel
 conflicts                   wine wine-crossover
 set my_name                 wine
 version                     3.14
-revision                    1
+revision                    2
 set branch                  [lindex [split ${version} .] 0].x
 license                     LGPL-2.1+
 categories                  x11
@@ -180,7 +180,7 @@ variant x11 {
                                 port:xorg-libXrandr \
                                 port:xorg-libXxf86vm \
                                 port:xorg-libsm \
-                                port:xorg-xf86vidmodeproto \
+                                port:xorg-xorgproto \
                                 port:xrender
 
     configure.args-delete       --without-osmesa \

--- a/x11/wine/Portfile
+++ b/x11/wine/Portfile
@@ -15,6 +15,7 @@ name                        wine
 conflicts                   wine-devel wine-crossover
 set my_name                 wine
 version                     3.0.2
+revision                    1
 set branch                  [lindex [split ${version} .] 0].0
 license                     LGPL-2.1+
 categories                  x11
@@ -180,7 +181,7 @@ variant x11 {
                                 port:xorg-libXrandr \
                                 port:xorg-libXxf86vm \
                                 port:xorg-libsm \
-                                port:xorg-xf86vidmodeproto \
+                                port:xorg-xorgproto \
                                 port:xrender
 
     configure.args-delete       --without-osmesa \

--- a/x11/xfindproxy/Portfile
+++ b/x11/xfindproxy/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                xfindproxy
 version             1.0.4
+revision            1
 categories          x11
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -21,8 +22,7 @@ depends_build       port:pkgconfig
 
 depends_lib         port:xorg-libXt \
                     port:xorg-libICE \
-                    port:xorg-xproto \
-                    port:xorg-xproxymanagementprotocol
+                    port:xorg-xorgproto
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/x11/xkbutils/Portfile
+++ b/x11/xkbutils/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                xkbutils
 version             1.0.4
+revision            1
 categories          x11
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -18,7 +19,7 @@ checksums           md5     502b14843f610af977dffc6cbf2102d5 \
                     sha1    b09aef7cc3853eb12dbda332f55adec3add4447b \
                     rmd160  84ebc85a7289a501bf0c779e4d8f57a43fa55eb7
 
-depends_build       port:pkgconfig port:xorg-util-macros port:xorg-inputproto
+depends_build       port:pkgconfig port:xorg-util-macros port:xorg-xorgproto
 
 depends_lib         port:xorg-libXaw port:xorg-libxkbfile
 

--- a/x11/xorg-applewmproto/Portfile
+++ b/x11/xorg-applewmproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-applewmproto
 version		1.4.2
+revision    1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the AppleWM extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	applewmproto-${version}
-checksums           md5     c1d50749c3ac5215a1a9425818e856c1 \
-                    sha1    71dd2374e745a7db7ae0e94410e55ba721683d10 \
-                    rmd160  b6ba0eb3e12d783d73d18934587acd1b11fb3989
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex applewmproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-bigreqsproto/Portfile
+++ b/x11/xorg-bigreqsproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-bigreqsproto
 version		1.1.2
+revision    1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,43 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for BigReqs extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	bigreqsproto-${version}
-checksums           sha1    ef1765eeb5e9e38d080225fe6a64ed7cd2984b46 \
-                    rmd160  3bff3c4c05a0061e492181d4e687469e590b3900 \
-                    sha256  462116ab44e41d8121bfde947321950370b285a5316612b8fce8334d50751b1e
-use_bzip2	yes
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:fop \
-		port:xmlto \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		XMLTO="${prefix}/bin/xmlto" \
-		FOP="${prefix}/bin/fop"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex bigreqsproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-compositeproto/Portfile
+++ b/x11/xorg-compositeproto/Portfile
@@ -1,7 +1,12 @@
-PortSystem 1.0
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-compositeproto
 version		0.4.2
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -12,12 +17,3 @@ supported_archs	noarch
 long_description Prototype headers for Composite extension to X11
 master_sites 	xorg:individual/proto/
 
-distname	compositeproto-${version}
-checksums           md5     98482f65ba1e74a08bf5b056a4031ef0 \
-                    sha1    aa7b5abcfd5bbfad7cb681ce89dc1d6e381e3044 \
-                    rmd160  198d51821a3862718c656d8ccf3a8305e834f1c9
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex compositeproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-damageproto/Portfile
+++ b/x11/xorg-damageproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-damageproto
 version		1.2.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the Damage extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	damageproto-${version}
-checksums           md5     998e5904764b82642cc63d97b4ba9e95 \
-                    sha1    bd0f0f4dc8f37eaabd9279d10fe2889710507358 \
-                    rmd160  3354e2f38d443818ff7cd40fd19d72e8fd183043
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex damageproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-dmxproto/Portfile
+++ b/x11/xorg-dmxproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-dmxproto
 version		2.3.1
+revision        1
 categories	x11 devel
 license         MIT
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description X.org DMXProto protocol headers.
 master_sites 	xorg:individual/proto/
-
-distname	dmxproto-${version}
-checksums           md5     4ee175bbd44d05c34d43bb129be5098a \
-                    sha1    3b8b273b8ef3d8dbab998df9ec1dddf99edf4d91 \
-                    rmd160  d1ef4dcd268f85a935a63bdc4ff0dceb6b51aa8b
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex dmxproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-dri2proto/Portfile
+++ b/x11/xorg-dri2proto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-dri2proto
 version		2.8
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -13,11 +20,3 @@ long_description Prototype headers for DRI2
 master_sites 	xorg:individual/proto/
 distname	dri2proto-${version}
 use_bzip2	yes
-
-checksums           sha1    2bc4e8f00778b1f3fe58b4c4f93607ac2adafbbf \
-                    rmd160  61d47793b3abbb04016824c68decc1a313976f25 \
-                    sha256  f9b55476def44fc7c459b2537d17dbc731e36ed5d416af7ca0b1e2e676f8aa04
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex dri2proto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-dri3proto/Portfile
+++ b/x11/xorg-dri3proto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-dri3proto
 version		1.0
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -12,12 +19,3 @@ supported_archs	noarch
 long_description Prototype headers for DRI3
 master_sites 	xorg:individual/proto/
 distname	dri3proto-${version}
-use_bzip2	yes
-
-checksums           sha1    1007eaa2f83022653a224f7d2e676ea51cba2f2b \
-                    rmd160  e6cca0d2b5ca91c80de57ee1bc185a814ef397ba \
-                    sha256  01be49d70200518b9a6b297131f6cc71f4ea2de17436896af153226a774fc074
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex dri3proto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-fixesproto/Portfile
+++ b/x11/xorg-fixesproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-fixesproto
 version		5.0
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,17 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XFixes extension to X11.
 master_sites 	xorg:individual/proto/
-
-distname	fixesproto-${version}
-
-checksums           md5     e7431ab84d37b2678af71e29355e101d \
-                    sha1    ab605af5da8c98c0c2f8b2c578fed7c864ee996a \
-                    rmd160  e6733c26d84c58ba74263e90c79f2f6a1974c34a
-
-depends_lib     port:xorg-xextproto
-
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex fixesproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-fontsproto/Portfile
+++ b/x11/xorg-fontsproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-fontsproto
 version		2.1.3
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,43 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Font-related prototype header files for X11
 master_sites	 xorg:individual/proto/
-
-distname	fontsproto-${version}
-checksums           sha1    28c108bd6438c332122c10871c1fc6415591755f \
-                    rmd160  caa89b1818cc4ee5bd202faa25224aa6c89db1ed \
-                    sha256  259046b0dd9130825c4a4c479ba3591d6d0f17a33f54e294b56478729a6e5ab8
-use_bzip2	yes
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:fop \
-		port:xmlto \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		XMLTO="${prefix}/bin/xmlto" \
-		FOP="${prefix}/bin/fop"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex fontsproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-glproto/Portfile
+++ b/x11/xorg-glproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-glproto
 version		1.4.17
+revision    1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,14 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the GLX extension to X11
 master_sites	xorg:individual/proto/
-
-distname	glproto-${version}
-checksums           sha1    20e061c463bed415051f0f89e968e331a2078551 \
-                    rmd160  85ca52a3752d8618ed0e16dfb2b1020a464a83a8 \
-                    sha256  adaa94bded310a2bfcbb9deb4d751d965fcfe6fb3a2f6d242e2df2d6589dbe40
-
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex glproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-inputproto/Portfile
+++ b/x11/xorg-inputproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-inputproto
 version		2.3.2
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XInput extension to X11
 master_sites	xorg:individual/proto/
-
-distname	inputproto-${version}
-checksums           sha1    62b29a0c3b4ede9d129a0598cc6becf628a2158a \
-                    rmd160  907705001d5eb86641cf10d41ac5a45797880e7d \
-                    sha256  893a6af55733262058a27b38eeb1edc733669f01d404e8581b167f03c03ef31d
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex inputproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-kbproto/Portfile
+++ b/x11/xorg-kbproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-kbproto
 version		1.0.7
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,12 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for Xkb extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	kbproto-${version}
-checksums           rmd160  4fa5c2faf7e8558da2bab347c5027cc44fa678f8 \
-                    sha256  f882210b76376e3fa006b11dbd890e56ec0942bc56e65d1249ff4af86f90b857
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex kbproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-libAppleWM/Portfile
+++ b/x11/xorg-libAppleWM/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libAppleWM
 version         1.4.1
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -22,9 +23,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-applewmproto \
-                port:xorg-xextproto \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 configure.args \
     --disable-silent-rules

--- a/x11/xorg-libFS/Portfile
+++ b/x11/xorg-libFS/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libFS
 version         1.0.7
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -21,8 +22,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig \
 		port:xorg-xtrans
 
-depends_lib	port:xorg-fontsproto \
-                port:xorg-xproto
+depends_lib	port:xorg-xorgproto
 
 configure.args  --disable-silent-rules
 

--- a/x11/xorg-libX11/Portfile
+++ b/x11/xorg-libX11/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name        xorg-libX11
 version     1.6.6
+revision    1
 categories  x11 devel
 license     X11
 maintainers {jeremyhu @jeremyhu} openmaintainer
@@ -22,18 +23,13 @@ use_parallel_build      yes
 
 depends_build   port:pkgconfig \
                 port:xorg-xtrans \
-                port:xorg-bigreqsproto \
-                port:xorg-xcmiscproto \
-                port:xorg-xextproto \
-                port:xorg-xf86bigfontproto \
-                port:xorg-inputproto \
+                port:xorg-xorgproto \
                 port:xorg-util-macros
 
 depends_lib     port:xorg-libXdmcp \
                 port:xorg-libXau \
                 port:xorg-libxcb \
-                port:xorg-xproto \
-                port:xorg-kbproto
+                port:xorg-xorgproto 
 
 configure.env-append RAWCPP=${configure.cpp}
 

--- a/x11/xorg-libXScrnSaver/Portfile
+++ b/x11/xorg-libXScrnSaver/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXScrnSaver
 version         1.2.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -25,7 +26,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-scrnsaverproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXTrap/Portfile
+++ b/x11/xorg-libXTrap/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                xorg-libXTrap
 version             1.0.1
+revision            1
 categories          x11 devel
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -24,7 +25,7 @@ depends_build       port:pkgconfig
 depends_lib \
 	port:xorg-libXext \
 	port:xorg-libXt \
-	port:xorg-trapproto
+	port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXau/Portfile
+++ b/x11/xorg-libXau/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-libXau
 version		1.0.8
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -20,7 +21,7 @@ use_parallel_build      yes
 
 depends_build   port:pkgconfig
 
-depends_lib     port:xorg-xproto
+depends_lib     port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXcomposite/Portfile
+++ b/x11/xorg-libXcomposite/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXcomposite
 version         0.4.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -23,7 +24,7 @@ depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXfixes \
                 port:xorg-libXext \
-                port:xorg-compositeproto
+                port:xorg-xorgproto
 
 configure.args \
 	--without-xmlto

--- a/x11/xorg-libXcursor/Portfile
+++ b/x11/xorg-libXcursor/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXcursor
 version         1.1.15
+revision        1
 categories      x11 devel
 platforms       darwin macosx
 license         X11
@@ -25,8 +26,7 @@ use_parallel_build yes
 
 depends_build \
 	port:pkgconfig \
-	port:xorg-fixesproto \
-	port:xorg-renderproto \
+	port:xorg-xorgproto \
 	port:xorg-util-macros
 
 depends_lib \

--- a/x11/xorg-libXdamage/Portfile
+++ b/x11/xorg-libXdamage/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXdamage
 version         1.1.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -20,10 +21,10 @@ use_bzip2   yes
 use_parallel_build      yes
 
 depends_build   port:pkgconfig \
-                port:xorg-xextproto
+                port:xorg-xorgproto
 
 depends_lib     port:xorg-libXfixes \
-                port:xorg-damageproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXdmcp/Portfile
+++ b/x11/xorg-libXdmcp/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-libXdmcp
 version		1.1.2
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -19,7 +20,7 @@ checksums           sha1    3c09eabb0617c275b5ab09fae021d279a4832cac \
 use_bzip2	yes
 
 depends_build   port:pkgconfig \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 configure.args \
 	--without-xmlto \

--- a/x11/xorg-libXevie/Portfile
+++ b/x11/xorg-libXevie/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXevie
 version         1.0.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer

--- a/x11/xorg-libXext/Portfile
+++ b/x11/xorg-libXext/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXext
 version         1.3.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ depends_build   port:pkgconfig \
                 port:xorg-util-macros
 
 depends_lib     port:xorg-libX11 \
-                port:xorg-xextproto
+                port:xorg-xorgproto
 
 use_autoreconf  yes
 autoreconf.args -fvi

--- a/x11/xorg-libXfixes/Portfile
+++ b/x11/xorg-libXfixes/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXfixes
 version         5.0.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -20,10 +21,10 @@ use_bzip2   yes
 use_parallel_build      yes
 
 depends_build   port:pkgconfig \
-		port:xorg-xextproto
+		port:xorg-xorgproto
 
 depends_lib     port:xorg-libX11 \
-                port:xorg-fixesproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXfont/Portfile
+++ b/x11/xorg-libXfont/Portfile
@@ -5,6 +5,7 @@ PortGroup       snowleopard_fixes 1.0
 
 name		xorg-libXfont
 version		1.5.4
+revision    1
 categories	x11 devel
 license		X11 BSD
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -34,8 +35,7 @@ depends_lib \
 	port:xorg-libfontenc \
 	port:bzip2 \
 	port:zlib \
-	port:xorg-xproto \
-	port:xorg-fontsproto
+	port:xorg-xorgproto
 
 configure.args \
 	--with-bzip2 \

--- a/x11/xorg-libXfont2/Portfile
+++ b/x11/xorg-libXfont2/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXfont2
 version         2.0.3
+revision        1
 categories      x11 devel
 license         X11 BSD
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -33,8 +34,7 @@ depends_lib \
         port:xorg-libfontenc \
         port:bzip2 \
         port:zlib \
-        port:xorg-xproto \
-        port:xorg-fontsproto
+        port:xorg-xorgproto
 
 configure.args \
         --with-bzip2 \

--- a/x11/xorg-libXfontcache/Portfile
+++ b/x11/xorg-libXfontcache/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-libXfontcache
 version		1.0.5
+revision        1
 categories	x11 devel
 maintainers	{jeremyhu @jeremyhu} openmaintainer
 description	X.org libXfontcache

--- a/x11/xorg-libXi/Portfile
+++ b/x11/xorg-libXi/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXi
 version         1.7.9
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -26,7 +27,7 @@ depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
 		port:xorg-libXfixes \
-		port:xorg-inputproto
+		port:xorg-xorgproto
 
 configure.args \
 	--without-asciidoc \

--- a/x11/xorg-libXinerama/Portfile
+++ b/x11/xorg-libXinerama/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXinerama
 version         1.1.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -25,7 +26,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-xineramaproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXp/Portfile
+++ b/x11/xorg-libXp/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXp
 version         1.0.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer

--- a/x11/xorg-libXpresent/Portfile
+++ b/x11/xorg-libXpresent/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXpresent
 version         1.0.0
-revision        1
+revision        2
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -26,9 +26,7 @@ depends_lib     port:xorg-libX11 \
                 port:xorg-libXfixes \
                 port:xorg-libXext \
                 port:xorg-libXrandr \
-                port:xorg-xproto \
-                port:xorg-xextproto \
-                port:xorg-presentproto
+                port:xorg-xorgproto
 
 patch.pre_args  -p1
 patchfiles      0001-configure-xpresent.pc-require-xext-xfixes-and-xrandr.patch 

--- a/x11/xorg-libXrandr/Portfile
+++ b/x11/xorg-libXrandr/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-libXrandr
 version		1.5.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ depends_build   port:pkgconfig
 depends_lib	port:xorg-libX11 \
 		port:xorg-libXext \
 		port:xrender \
-                port:xorg-randrproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXres/Portfile
+++ b/x11/xorg-libXres/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXres
 version         1.2.0
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -23,7 +24,7 @@ use_bzip2   yes
 use_parallel_build      yes
 
 depends_build   port:pkgconfig \
-                port:xorg-resourceproto
+                port:xorg-xorgproto
 
 depends_lib     port:xorg-libXext
 

--- a/x11/xorg-libXtst/Portfile
+++ b/x11/xorg-libXtst/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXtst
 version         1.2.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -23,7 +24,7 @@ depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
                 port:xorg-libXi \
-                port:xorg-recordproto
+                port:xorg-xorgproto
 
 configure.args \
 	--without-xmlto \

--- a/x11/xorg-libXv/Portfile
+++ b/x11/xorg-libXv/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXv
 version         1.0.11
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-videoproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXxf86dga/Portfile
+++ b/x11/xorg-libXxf86dga/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXxf86dga
 version         1.1.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-xf86dgaproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXxf86misc/Portfile
+++ b/x11/xorg-libXxf86misc/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libXxf86misc
 version         1.0.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -25,7 +26,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-xf86miscproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libXxf86vm/Portfile
+++ b/x11/xorg-libXxf86vm/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name            xorg-libXxf86vm
 version         1.1.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-xf86vidmodeproto
+                port:xorg-xorgproto
 
 # Don't link with "-flat_namespace -undefined suppress" on Yosemite and
 # later (#45713).

--- a/x11/xorg-libdmx/Portfile
+++ b/x11/xorg-libdmx/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libdmx
 version         1.1.4
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -25,7 +26,7 @@ use_parallel_build      yes
 depends_build   port:pkgconfig
 
 depends_lib     port:xorg-libXext \
-                port:xorg-dmxproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libfontenc/Portfile
+++ b/x11/xorg-libfontenc/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-libfontenc
 version		1.1.3
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -18,7 +19,7 @@ use_bzip2	yes
 
 depends_build \
 	port:pkgconfig \
-	port:xorg-xproto
+	port:xorg-xorgproto
 
 depends_lib \
 	port:zlib

--- a/x11/xorg-libice/Portfile
+++ b/x11/xorg-libice/Portfile
@@ -2,6 +2,7 @@ PortSystem        1.0
 
 name              xorg-libice
 version           1.0.9
+revision          1
 categories        x11 devel
 license           X11
 maintainers       {jeremyhu @jeremyhu} openmaintainer
@@ -23,7 +24,7 @@ checksums           sha1    3c3a857a117ce48a1947a16860056e77cd494fdf \
 depends_build     port:pkgconfig \
                   port:xorg-xtrans
 
-depends_lib       port:xorg-xproto
+depends_lib       port:xorg-xorgproto
 
 configure.args \
 	--without-xmlto \

--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libxcb
 version         1.13
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer

--- a/x11/xorg-libxkbfile/Portfile
+++ b/x11/xorg-libxkbfile/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-libxkbfile
 version		1.0.9
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ depends_build \
 
 depends_lib \
 	port:xorg-libX11 \
-	port:xorg-kbproto
+	port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-libxshmfence/Portfile
+++ b/x11/xorg-libxshmfence/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-libxshmfence
 version         1.3
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -23,7 +24,7 @@ use_bzip2   yes
 use_parallel_build      yes
 
 depends_build   port:pkgconfig \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   http://xorg.freedesktop.org/archive/individual/lib/?C=M&O=D

--- a/x11/xorg-presentproto/Portfile
+++ b/x11/xorg-presentproto/Portfile
@@ -2,8 +2,13 @@
 
 PortSystem      1.0
 
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
+
 name            xorg-presentproto
 version         1.1
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -13,15 +18,3 @@ platforms       darwin
 supported_archs noarch
 long_description ${description}
 master_sites    xorg:individual/proto/
-
-distname        presentproto-${version}
-
-checksums       rmd160  e382eac1dcabef6cf031f4a12e0badb380ba15df \
-                sha256  f69b23a8869f78a5898aaf53938b829c8165e597cda34f06024d43ee1e6d26b9 \
-                size    116156
-
-use_bzip2       yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex presentproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-proto/Portfile
+++ b/x11/xorg-proto/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name		xorg-proto
-version		20081229
+version		20180829
 categories	x11 devel
 maintainers	{jeremyhu @jeremyhu} openmaintainer
 description	X.org proto meta-package
@@ -10,37 +10,11 @@ platforms	darwin macosx
 supported_archs	noarch
 long_description This package builds all of the x.org proto packages.
 
-depends_lib	port:xorg-applewmproto \
-		port:xorg-bigreqsproto \
-		port:xorg-compositeproto \
-		port:xorg-damageproto \
-		port:xorg-dmxproto \
-		port:xorg-dri2proto \
-		port:xorg-evieproto \
-		port:xorg-fixesproto \
+depends_lib	port:xorg-evieproto \
 		port:xorg-fontcacheproto \
-		port:xorg-fontsproto \
-		port:xorg-inputproto \
-		port:xorg-kbproto \
+		port:xorg-xorgproto \
 		port:xorg-printproto \
-		port:xorg-randrproto \
-		port:xorg-recordproto \
-		port:xorg-renderproto \
-		port:xorg-resourceproto \
-		port:xorg-scrnsaverproto \
-		port:xorg-trapproto \
-		port:xorg-videoproto \
-		port:xorg-xcb-proto \
-		port:xorg-xcmiscproto \
-		port:xorg-xextproto \
-		port:xorg-xf86bigfontproto \
-		port:xorg-xf86dgaproto \
-		port:xorg-xf86driproto \
-		port:xorg-xf86miscproto \
-		port:xorg-xf86vidmodeproto \
-		port:xorg-xineramaproto \
-		port:xorg-xproto \
-		port:xorg-xproxymanagementprotocol
+		port:xorg-xcb-proto 
 
 distfiles
 build           { }

--- a/x11/xorg-randrproto/Portfile
+++ b/x11/xorg-randrproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-randrproto
 version		1.5.0
+revision    1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -13,14 +20,3 @@ long_description The pkg-config program is used to retrieve information \
 		 about installed libraries in the system. It is typically \
 		 used to compile and link against one or more libraries.
 master_sites 	xorg:individual/proto/
-
-distname	randrproto-${version}
-
-checksums           rmd160  de8e411bf59e65ecece5a8a8e04dd63d93d9512b \
-                    sha256  4c675533e79cd730997d232c8894b6692174dce58d3e207021b8f860be498468
-
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex randrproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-recordproto/Portfile
+++ b/x11/xorg-recordproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-recordproto
 version		1.14.2
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,43 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the Record extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	recordproto-${version}
-checksums           sha1    1f48c4b0004d8b133efd0498e8d88d68d3b9199c \
-                    rmd160  7cf5ab53e3c06fcb917d67fdbfe235be5b019b23 \
-                    sha256  a777548d2e92aa259f1528de3c4a36d15e07a4650d0976573a8e2ff5437e7370
-use_bzip2	yes
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:fop \
-		port:xmlto \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		XMLTO="${prefix}/bin/xmlto" \
-		FOP="${prefix}/bin/fop"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex recordproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-renderproto/Portfile
+++ b/x11/xorg-renderproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-renderproto
 version		0.11.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the Render extension to X11
 master_sites	xorg:individual/proto/
-
-distname	renderproto-${version}
-checksums           md5     a914ccc1de66ddeb4b611c6b0686e274 \
-                    sha1    7ae9868a358859fe539482b02414aa15c2d8b1e4 \
-                    rmd160  ec176a258b707fa560f8f0190e31fed6478fec74
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url	http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex renderproto-(\[0-9.\]+)${extract.suffix}

--- a/x11/xorg-resourceproto/Portfile
+++ b/x11/xorg-resourceproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-resourceproto
 version		1.2.0
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype header files for the Resource extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	resourceproto-${version}
-checksums           md5     cfdb57dae221b71b2703f8e2980eaaf4 \
-                    sha1    9ff9bb9243b0474330959dc3853973523c9dd9ce \
-                    rmd160  651aa6eef3fd2c8e6e1b532eb48f81bddbdc1799
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex resourceproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-scrnsaverproto/Portfile
+++ b/x11/xorg-scrnsaverproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-scrnsaverproto
 version		1.2.2
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,43 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XScreenSaver extension to X11.
 master_sites 	xorg:individual/proto/
-
-distname	scrnsaverproto-${version}
-checksums           sha1    640a2cbef5893aacda74799e6fa4d973e629b753 \
-                    rmd160  7822f18bef696129485d86c83824e35f6ffbc0fa \
-                    sha256  8bb70a8da164930cceaeb4c74180291660533ad3cc45377b30a795d1b85bcd65
-use_bzip2	yes
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:fop \
-		port:xmlto \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		XMLTO="${prefix}/bin/xmlto" \
-		FOP="${prefix}/bin/fop"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex scrnsaverproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-server-devel/Portfile
+++ b/x11/xorg-server-devel/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 PortGroup       compiler_blacklist_versions 1.0
 

--- a/x11/xorg-server/Portfile
+++ b/x11/xorg-server/Portfile
@@ -7,7 +7,7 @@ name            xorg-server
 conflicts       xorg-server-devel
 set my_name     xorg-server
 version         1.18.4
-revision        2
+revision        3
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -33,24 +33,7 @@ use_parallel_build yes
 depends_build \
         port:pkgconfig \
         port:mesa \
-        port:xorg-applewmproto \
-        port:xorg-bigreqsproto \
-        port:xorg-damageproto \
-        port:xorg-fixesproto \
-        port:xorg-fontsproto \
-        port:xorg-glproto \
-        port:xorg-inputproto \
-        port:xorg-presentproto \
-        port:xorg-randrproto \
-        port:xorg-recordproto \
-        port:xorg-renderproto \
-        port:xorg-resourceproto \
-        port:xorg-scrnsaverproto \
-        port:xorg-videoproto \
-        port:xorg-xcmiscproto \
-        port:xorg-xproto \
-        port:xorg-xextproto \
-        port:xorg-xineramaproto \
+        port:xorg-xorgproto \
         port:xorg-xtrans
 
 # This xinit dependency needs to be port: not bin: because we specifically run ${prefix}/bin/startx from bundle-main.c

--- a/x11/xorg-trapproto/Portfile
+++ b/x11/xorg-trapproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-trapproto
 version		3.4.3
+revision        1
 categories	x11 devel
 license		MIT
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,11 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XTrap extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	trapproto-${version}
-checksums	sha1 b108aa39a7bfde530d5cd347fda7c58770d5b8da
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex trapproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-videoproto/Portfile
+++ b/x11/xorg-videoproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-videoproto
 version		2.3.3
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,14 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XVideo extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	videoproto-${version}
-checksums           md5     fe86de8ea3eb53b5a8f52956c5cd3174 \
-                    sha1    4556b5c2243a2ca290ea2140dc1a427c4bac8ba2 \
-                    rmd160  1c0b0e4b8bd6f205da9d8df3b4a2d477b9fde8be \
-                    sha256  c7803889fd08e6fcaf7b68cc394fb038b2325d1f315e571a6954577e07cca702
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex videoproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xcb-util-cursor/Portfile
+++ b/x11/xorg-xcb-util-cursor/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-xcb-util-cursor
 version		0.1.3
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -22,7 +23,7 @@ depends_build   port:pkgconfig \
 depends_lib	port:xorg-xcb-util \
                 port:xorg-xcb-util-image \
                 port:xorg-xcb-util-renderutil \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 # shape_to_id.gperf:2: error: type qualifiers ignored on function return type
 # shape_to_id.gperf:82: error: type qualifiers ignored on function return type

--- a/x11/xorg-xcb-util-image/Portfile
+++ b/x11/xorg-xcb-util-image/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-xcb-util-image
 version		0.4.0
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -20,7 +21,7 @@ use_parallel_build yes
 
 depends_build   port:pkgconfig
 depends_lib	port:xorg-xcb-util \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 livecheck.type  regex
 livecheck.url   ${master_sites}?C=M&O=D

--- a/x11/xorg-xcb-util/Portfile
+++ b/x11/xorg-xcb-util/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xorg-xcb-util
 version		0.4.0
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -20,7 +21,7 @@ use_parallel_build yes
 
 depends_build   port:pkgconfig
 depends_lib	port:xorg-libxcb \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 compiler.blacklist gcc-4.0
 

--- a/x11/xorg-xcmiscproto/Portfile
+++ b/x11/xorg-xcmiscproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xcmiscproto
 version		1.2.2
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,43 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XCMisc extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	xcmiscproto-${version}
-checksums           sha1    59ae9ec6414964440bf654b207618e5dd66a32fb \
-                    rmd160  06890647d88499b9533669837c0091e424b06ba2 \
-                    sha256  b13236869372256c36db79ae39d54214172677fb79e9cdc555dceec80bd9d2df
-use_bzip2	yes
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:fop \
-		port:xmlto \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		XMLTO="${prefix}/bin/xmlto" \
-		FOP="${prefix}/bin/fop"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xcmiscproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xextproto/Portfile
+++ b/x11/xorg-xextproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xextproto
 version		7.3.0
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -13,41 +20,3 @@ long_description Prototype headers for Xext
 master_sites 	xorg:individual/proto/
 distname	xextproto-${version}
 use_bzip2	yes
-
-checksums           sha1    b8d736342dcb73b71584d99a1cb9806d93c25ff8 \
-                    rmd160  241a3050c149fc00d308723fed10eed837406359 \
-                    sha256  f3f4b23ac8db9c3a9e0d8edb591713f3d70ef9c3b175970dd8823dfc92aa5bb0
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:xmlto \
-		port:fop \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		FOP="${prefix}/bin/fop" \
-		XMLTO="${prefix}/bin/xmlto"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xextproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xf86bigfontproto/Portfile
+++ b/x11/xorg-xf86bigfontproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name        xorg-xf86bigfontproto
 version     1.2.0
+revision    1
 categories  x11 devel
 license     X11
 maintainers nomaintainer
@@ -11,14 +18,3 @@ platforms   darwin
 supported_archs noarch
 long_description XF86BigFont extension headers
 master_sites    xorg:individual/proto/
-
-distname    xf86bigfontproto-${version}
-checksums           md5     120e226ede5a4687b25dd357cc9b8efe \
-                    sha1    312a2ea708b257520c1af4393b69d73a393a478f \
-                    rmd160  847c3ecfe705ede5e9292586835d0fe2bc7ccf45
-            
-use_bzip2   yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xf86bigfontproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xf86dgaproto/Portfile
+++ b/x11/xorg-xf86dgaproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xf86dgaproto
 version		2.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,14 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XF86DGA extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	xf86dgaproto-${version}
-use_bzip2	yes
-
-checksums           md5     a036dc2fcbf052ec10621fd48b68dbb1 \
-                    sha1    97a06120e7195c968875e8ba42e82c90ab54948b \
-                    rmd160  5fe5b3a2a8929c2a661b41fa733610917c7d74c5
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xf86dgaproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xf86driproto/Portfile
+++ b/x11/xorg-xf86driproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xf86driproto
 version		2.1.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for xf86dri
 master_sites 	xorg:individual/proto/
-distname	xf86driproto-${version}
-use_bzip2	yes
-
-checksums           md5     1d716d0dac3b664e5ee20c69d34bc10e \
-                    sha1    23e861f40ba0f0cbbfd7db7ba2ef623762ffca17 \
-                    rmd160  d7da476ce21b8e695d14e796daf1e25315798927
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xf86driproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xf86miscproto/Portfile
+++ b/x11/xorg-xf86miscproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xf86miscproto
 version		0.9.3
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Miscellaneous legacy XFree86 prototype headers for X11
 master_sites 	xorg:individual/proto/
-
-distname	xf86miscproto-${version}
-checksums           md5     ca63bbb31cf5b7f37b2237e923ff257a \
-                    sha1    52c54ed17e55f26b26654ff16d61da97f9fd36bc \
-                    rmd160  644b08dae757338464273be818e28414b99aeba5
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xf86miscproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xf86vidmodeproto/Portfile
+++ b/x11/xorg-xf86vidmodeproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xf86vidmodeproto
 version		2.3.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for the XF86Vidmode extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	xf86vidmodeproto-${version}
-checksums           md5     e793ecefeaecfeabd1aed6a01095174e \
-                    sha1    11d54c3210887631ea71e8f8030a77692e964fc4 \
-                    rmd160  200a5911d46be3306a85d9684ac5aea695bfc653
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xf86vidmodeproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xineramaproto/Portfile
+++ b/x11/xorg-xineramaproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xineramaproto
 version		1.2.1
+revision        1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,13 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description Prototype headers for Xinerama extension to X11
 master_sites 	xorg:individual/proto/
-
-distname	xineramaproto-${version}
-checksums           md5     9959fe0bfb22a0e7260433b8d199590a \
-                    sha1    818bffc16139d6e3de4344c83f00c495d3536753 \
-                    rmd160  ec5d4878b93766bf9e12bf981f4b419db5fa5853
-use_bzip2	yes
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xineramaproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xorgproto/Portfile
+++ b/x11/xorg-xorgproto/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             xorg-xorgproto
+version          2018.4
+categories       x11 devel
+license          X11
+maintainers      {jeremyhu @jeremyhu} {jonesc @cjones051073} openmaintainer
+description      X.org xorgproto
+homepage         https://www.x.org
+platforms        darwin
+supported_archs  noarch
+long_description X.Org combined prototype headers
+master_sites     xorg:individual/proto/
+
+distname         xorgproto-${version}
+
+checksums        rmd160  82de862ca473efd86c3d07e4aed4e7cdc993c88c \
+                 sha256  fee885e0512899ea5280c593fdb2735beb1693ad170c22ebcc844470eec415a0 \
+                 size    390293   
+
+use_bzip2        yes
+
+configure.args \
+	--without-xmlto \
+	--without-fop \
+	--disable-specs
+
+# Depending on ghostscript for the PDF documentation creates a dependency
+# loop, so you may want to install first without the docs variant
+variant docs description "Install extra documentation" {
+	depends_build-append \
+		port:fop \
+		port:xmlto \
+		port:xorg-sgml-doctools
+
+	configure.args-delete \
+		--without-xmlto \
+		--without-fop \
+		--disable-specs
+
+	configure.args-append \
+		--with-xmlto \
+		--with-fop \
+		--enable-specs
+
+	configure.env-append \
+		XMLTO="${prefix}/bin/xmlto" \
+		FOP="${prefix}/bin/fop"
+}
+
+livecheck.type   regex
+livecheck.url    http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
+livecheck.regex  xorgproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xproto/Portfile
+++ b/x11/xorg-xproto/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xproto
 version		7.0.31
+revision    1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -11,50 +18,3 @@ platforms	darwin
 supported_archs	noarch
 long_description The X.org xproto package contains miscellaneous X11 prototype headers.
 master_sites 	xorg:individual/proto/
-
-distname	xproto-${version}
-use_bzip2	yes
-
-checksums           rmd160  27350d33fd2bbc14201231d9fd30629f899b6005 \
-                    sha256  c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747
-
-post-destroot {
-    set docdir ${prefix}/share/doc/${name}-${version}
-    xinstall -d ${destroot}${docdir}
-    xinstall -m 0644 -W ${worksrcpath} AUTHORS COPYING ChangeLog \
-        ${destroot}${docdir}
-}
-
-configure.args \
-	--without-xmlto \
-	--without-fop \
-	--disable-specs
-
-build.args V=1
-
-# Depending on ghostscript for the PDF documentation creates a dependency
-# loop, so you may want to install first without the docs variant
-variant docs description "Install extra documentation" {
-	depends_build-append \
-		port:fop \
-		port:xmlto \
-		port:xorg-sgml-doctools
-
-	configure.args-delete \
-		--without-xmlto \
-		--without-fop \
-		--disable-specs
-
-	configure.args-append \
-		--with-xmlto \
-		--with-fop \
-		--enable-specs
-
-	configure.env-append \
-		XMLTO="${prefix}/bin/xmlto" \
-		FOP="${prefix}/bin/fop"
-}
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xproto-(\\d+(?:\\.\\d+)*)

--- a/x11/xorg-xproxymanagementprotocol/Portfile
+++ b/x11/xorg-xproxymanagementprotocol/Portfile
@@ -1,7 +1,14 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+# This port can be removed after 2019-08-29
+PortGroup       obsolete 1.0
+replaced_by     xorg-xorgproto
 
 name		xorg-xproxymanagementprotocol
-version		1.0.3
+version     1.0.3
+revision    1
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -13,11 +20,3 @@ long_description Prototype headers for xproxymanagement
 master_sites 	xorg:individual/proto/
 distname	xproxymanagementprotocol-${version}
 use_bzip2	yes
-
-checksums           md5     9de22ca1522008c28fb03dfc41ba2d30 \
-                    sha1    4abb036371670ecc25d32e48b3277fe203ae5203 \
-                    rmd160  b2a7ff26d7452dfa557185c4564958ec84c6191d
-
-livecheck.type  regex
-livecheck.url   http://xorg.freedesktop.org/archive/individual/proto/?C=M&O=D
-livecheck.regex xproxymanagementprotocol-(\\d+(?:\\.\\d+)*)

--- a/x11/xpm/Portfile
+++ b/x11/xpm/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name		xpm
 version		3.5.12
+revision        1
 categories	x11 devel graphics
 license		X11
 maintainers	 {jeremyhu @jeremyhu} openmaintainer
@@ -18,7 +19,7 @@ use_bzip2	yes
 use_parallel_build      yes
 
 depends_build	port:pkgconfig \
-                port:xorg-xproto
+                port:xorg-xorgproto
 
 depends_lib	port:xorg-libXt \
 		port:xorg-libXext \

--- a/x11/xrender/Portfile
+++ b/x11/xrender/Portfile
@@ -3,6 +3,7 @@ PortSystem			1.0
 name				xrender
 set my_name			libXrender
 version				0.9.10
+revision                        1
 categories			x11
 license				X11
 platforms			darwin
@@ -24,7 +25,7 @@ depends_build \
 
 depends_lib \
 	port:xorg-libX11 \
-	port:xorg-renderproto
+	port:xorg-xorgproto
 
 configure.args      --disable-silent-rules
 

--- a/x11/xscope/Portfile
+++ b/x11/xscope/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                xscope
 version             1.4.1
+revision            1
 categories          x11
 license             X11
 platforms           darwin
@@ -21,7 +22,7 @@ use_parallel_build  yes
 
 depends_build \
 	port:pkgconfig \
-	port:xorg-xproto \
+	port:xorg-xorgproto \
 	port:xorg-xtrans
 
 configure.args --disable-xtrans

--- a/x11/xterm/Portfile
+++ b/x11/xterm/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                xterm
 version             335
+revision            1
 categories          x11
 license             X11
 platforms           darwin
@@ -24,7 +25,7 @@ checksums           rmd160  8dcea07369b0c953c7ae3f2882dec536b1e911b2 \
 extract.suffix      .tgz
 
 depends_build \
-	port:xorg-xproto
+	port:xorg-xorgproto
 
 depends_run \
 	bin:luit:luit


### PR DESCRIPTION
 Upstream X.Org have merged a number of previously independent prototype packages into a single entity. This PR adapts to this, by providing a new xorg-xorgproto port that obsoletes those it replaces. Dependents are updated and rev-bumped to adapt.


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
