### PR TITLE
various py-ports: fix PyPI livecheck (DOAP issue) and other enhancements

### DIFF
--- a/python/py-astroML/Portfile
+++ b/python/py-astroML/Portfile
@@ -8,6 +8,7 @@ set realname        astroML
 
 name                py-${realname}
 version             0.3
+revision            1
 categories-append   science
 license             BSD
 platforms           darwin
@@ -27,19 +28,15 @@ long_description    AstroML is a Python module for machine learning and data \
                     and a large suite of examples of analyzing and visualizing \
                     astronomical datasets.
 
-homepage            http://www.astroml.org
+homepage            https://www.astroml.org
 master_sites        pypi:[string index ${realname} 0]/${realname}
 distname            ${realname}-${version}
 
-checksums           md5     56d5c281ca079eb569ef1898be1604db \
-                    sha1    dbf1a775f2dff6e3f3721d1b69a65a5d757bde95 \
-                    rmd160  2a029523b0fcc768acb4e2a3efe1050e24a32cc8
+checksums           rmd160  2a029523b0fcc768acb4e2a3efe1050e24a32cc8 \
+                    sha256  ea6d0119593aed0e0dadc79c613ac0bddad95e6f12151237562a4fd67552b2b8 \
+                    size    242925
 
-if {${name} eq ${subport}} {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi?:action=doap&name=${realname}
-    livecheck.regex     {<release><Version><revision>([^<]+)</revision></Version></release>}
-} else {
+if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-numpy \
                     port:py${python.version}-scipy \
@@ -47,12 +44,17 @@ if {${name} eq ${subport}} {
                     port:py${python.version}-scikit-learn \
                     port:py${python.version}-astropy
 
-    variant addons description "Install optional package ${name}_addons for faster C implementations of some algorithms" {
+    variant addons description "Install optional package py${python.version}-${realname}_addons for faster C implementations of some algorithms" {
         depends_run-append \
-                    port:${name}_addons
+                    port:py${python.version}-${realname}_addons
     }
-
     default_variants +addons
+
+    depends_test-append \
+                    port:py${python.version}-nose
+    test.run        yes
+    test.cmd        nosetests-${python.branch}
+    test.target
 
     livecheck.type  none
 }

--- a/python/py-astroML_addons/Portfile
+++ b/python/py-astroML_addons/Portfile
@@ -27,19 +27,15 @@ long_description    AstroML is a Python module for machine learning and data \
                     astronomical datasets. This package provides faster C \
                     implementations of some algorithms in astroML.
 
-homepage            http://www.astroml.org
+homepage            https://www.astroml.org
 master_sites        pypi:[string index ${realname} 0]/${realname}
 distname            ${realname}-${version}
 
-checksums           md5     9efd34f180766fbb3c58f989fd87e254 \
-                    sha1    a2dfd11a9dbaf52f6b88cd8e5ed8ce579a87cb4f \
-                    rmd160  b4d642a073c846bd66c902ada33079afd2abdd70
+checksums           rmd160  b4d642a073c846bd66c902ada33079afd2abdd70 \
+                    sha256  c4b6e9d9f86550e1a59b54ddedf6666c7293bd7ad7b99549170e3053e57cb0cb \
+                    size    51052
 
-if {${name} eq ${subport}} {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi?:action=doap&name=${realname}
-    livecheck.regex     {<release><Version><revision>([^<]+)</revision></Version></release>}
-} else {
+if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy
 
     livecheck.type  none

--- a/python/py-ephem/Portfile
+++ b/python/py-ephem/Portfile
@@ -1,4 +1,4 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
@@ -22,16 +22,18 @@ long_description \
 homepage            http://rhodesmill.org/pyephem/
 distname            ephem-${version}
 master_sites        pypi:e/ephem/
-checksums           md5     405a109f3017251ecd8c2890d850f649 \
-                    rmd160  32e5fcb0e74936706b68bd811a9dcdf55b97b1f8 \
-                    sha256  7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac
+
+checksums           rmd160  32e5fcb0e74936706b68bd811a9dcdf55b97b1f8 \
+                    sha256  7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac \
+                    size    739442
 
 python.versions     27 34 35 36
 
-if {${name} eq ${subport}} {
-    livecheck.type  regex
-    livecheck.url   {https://pypi.python.org/pypi?:action=doap&name=pyephem}
-    livecheck.regex {<release><Version><revision>([^<]+)</revision></Version></release>}
-} else {
+if {${name} ne ${subport}} {
     livecheck.type  none
+
+    test.dir        "${worksrcpath}/build/lib.macosx-${macosx_deployment_target}-${configure.build_arch}-${python.branch}"
+    test.run        yes
+    test.cmd        ${python.bin} -m unittest discover
+    test.target
 }

--- a/python/py-flask-script/Portfile
+++ b/python/py-flask-script/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
 name                py-flask-script
 set realname        Flask-Script
-version             2.0.5
+version             2.0.6
 python.versions     27 34 35 36
 license             BSD
 platforms           darwin
@@ -13,24 +13,26 @@ supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
 description         Scripting support for Flask
 long_description    Flask support for writing external scripts.
-homepage            http://flask-script.readthedocs.org/
+homepage            https://flask-script.readthedocs.org/
 master_sites        pypi:[string index ${realname} 0]/${realname}/
 distname            ${realname}-${version}
 
-checksums           md5     e5c73d3b7937f5b88942f342f9617029 \
-                    sha1    848706d0157fb05a45f3b78304d9f0f6b29452c5 \
-                    rmd160  734d7bc1a9ef996f9f13a2ef6d3f3b3b41997a6a
+checksums           rmd160  bfc8d52e970890f6f4875e4858873f3f911fadd5 \
+                    sha256  6425963d91054cfcc185807141c7314a9c5ad46325911bd24dcb489bd0161c65 \
+                    size    43146
 
-if {${name} eq ${subport}} {
-    livecheck.type      regex
-    livecheck.url       "https://pypi.python.org/pypi?:action=doap&name=${realname}"
-    livecheck.regex     {<release><Version><revision>([^<]+)</revision></Version></release>}
-} else {
+if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
     depends_lib-append \
                     port:py${python.version}-flask
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target     tests.py
 
     livecheck.type  none
 }

--- a/python/py-itsdangerous/Portfile
+++ b/python/py-itsdangerous/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-set realname        itsdangerous
-name                py-${realname}
+name                py-itsdangerous
 version             0.24
 python.versions     27 34 35 36 37
 license             BSD
@@ -13,21 +12,21 @@ supported_archs     noarch
 maintainers         {aronnax @lpsinger} openmaintainer
 description         Various helpers to pass trusted data to untrusted environments and back
 long_description    ${description}
-homepage            http://pythonhosted.org/itsdangerous/
-master_sites        pypi:[string index ${realname} 0]/${realname}/
-distname            ${realname}-${version}
+homepage            https://pythonhosted.org/itsdangerous/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
+distname            ${python.rootname}-${version}
 
-checksums           md5     a3d55aa79369aef5345c036a8a26307f \
-                    sha1    0a6ae9c20cd72e89d75314ebc7b0f390f93e6a0d \
-                    rmd160  870c1cef9d39c74f2d376be07b50d0e11f343018
+checksums           rmd160  870c1cef9d39c74f2d376be07b50d0e11f343018 \
+                    sha256  cbb3fcf8d3e33df861709ecaf89d9e6629cff0a217bc2848f1b41cd30d360519 \
+                    size    46541
 
-if {${name} eq ${subport}} {
-    livecheck.type      regex
-    livecheck.url       "https://pypi.python.org/pypi?:action=doap&name=${realname}"
-    livecheck.regex     {<release><Version><revision>([^<]+)</revision></Version></release>}
-} else {
+if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
+
+    test.run        yes
+    test.cmd        ${python.bin} tests.py
+    test.target
 
     livecheck.type  none
 }

--- a/python/py-linecache2/Portfile
+++ b/python/py-linecache2/Portfile
@@ -5,8 +5,9 @@ PortGroup           python 1.0
 
 name                py-linecache2
 version             1.0.0
+revision            1
 platforms           darwin
-license             unknown
+license             PSF
 maintainers         {khindenburg @kurthindenburg} openmaintainer
 
 description         A backport of linecache to older supported Pythons.
@@ -17,12 +18,14 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 checksums           rmd160  da6bcf3bd6f14c244a0b387c5b43fc9bab2fccdf \
-                    sha256  4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c
+                    sha256  4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c \
+                    size    11013
 
 python.versions     27 34 35 36
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-pbr
 
     livecheck.type  none
 } else {

--- a/python/py-traceback2/Portfile
+++ b/python/py-traceback2/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-traceback2
+version             1.4.0
+categories-append   devel
+platforms           darwin
+license             PSF
+
+python.versions     27 34
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         Backports of the traceback module
+long_description    ${description}
+
+homepage            https://github.com/testing-cabal/traceback2
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  3baf3da615360e8a4b773325102b49d2acbf5b5d \
+                    sha256  05acc67a09980c2ecfedd3423f7ae0104839eccb55fc645773e1caa0951c3030 \
+                    size    15872
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-pbr
+
+    depends_lib-append      port:py${python.version}-linecache2
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst ChangeLog AUTHORS \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type      none
+}

--- a/python/py-unittest2/Portfile
+++ b/python/py-unittest2/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-unittest2
-version             0.5.1
-revision            1
+version             1.1.0
 license             PSF
 maintainers         {aronnax @lpsinger} openmaintainer
 # do not add subports for python > 3.4
@@ -23,27 +22,26 @@ platforms           darwin
 supported_archs     noarch
 
 homepage            https://pypi.python.org/pypi/unittest2
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-if {${name} eq ${subport}} {
-    livecheck.type      regex
-    livecheck.url       {https://pypi.python.org/pypi?:action=doap&name=unittest2}
-    livecheck.regex     {<release><Version><revision>([^<]+)</revision></Version></release>}
-} else {
-    livecheck.type      none
+checksums           rmd160  b9294b1ef9a6f0f7d8d2419b3260fc27ba81777d \
+                    sha256  22882a0e418c284e1f718a822b3b022944d53d2d908e1690b319a9d3eb2c0579 \
+                    size    81432
 
-    if {${python.version} < 30} {
-        master_sites        pypi:u/unittest2/
-        distname            unittest2-${version}
+# see: last two commits in https://hg.python.org/unittest2, but also don't require argparse for setup
+patch.pre_args      -p1
+patchfiles          patch-traceback2-everywhere.diff \
+                    patch-argparse-dependency.diff
 
-        checksums           md5     a0af5cac92bbbfa0c3b0e99571390e0f \
-                            rmd160  aa83b1d6dedaa71a9e6d3bed4028e855bef04821 \
-                            sha256  aa5de8cdf654d843379c97bd1ee240e86356d3355a97b147a6f3f4d149247a71
-    } else {
-        master_sites        pypi:u/unittest2py3k/
-        distname            unittest2py3k-${version}
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-six \
+                    port:py${python.version}-traceback2
 
-        checksums           md5     8824ff92044310d9365f90d892bf0f09 \
-                            rmd160  119f837e7af015fc83e8967fa1388f8745d9895f \
-                            sha256  78249c5f1ac508a34d9d131d43a89d77bf154186f3ea5f7a6b993d3f3535d403
-    }
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
+
+    livecheck.type  none
 }

--- a/python/py-unittest2/files/patch-argparse-dependency.diff
+++ b/python/py-unittest2/files/patch-argparse-dependency.diff
@@ -1,0 +1,41 @@
+# HG changeset patch
+# User Robert Collins <rbtcollins@hp.com>
+# Date 1435721660 -43200
+# Node ID d091f0086b03f4610d41f45c8813c9402c209ccc
+# Parent  9badd4cde9ab5f70eff42777a00c038192a5541f
+Use PEP-426 markers to avoid installing argparse.
+
+diff --git a/README.txt b/README.txt
+--- a/README.txt
++++ b/README.txt
+@@ -169,6 +169,8 @@ CHANGELOG
+
+ - Use traceback2 consistently to get consistent output across all Pythons.
+
++- Use PEP-426 markers to avoid installing argparse on 2.7+ Pythons.
++
+ 2015-06-20 - 1.1.0
+ ------------------
+
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -57,7 +57,7 @@ KEYWORDS = "unittest testing tests".spli
+ # Both install and setup requires - because we read VERSION from within the
+ # package, and the package also exports all the APIs.
+ # six for compat helpers
+-REQUIRES = ['argparse', 'six>=1.4', 'traceback2'],
++REQUIRES = ['six>=1.4', 'traceback2']
+
+ params = dict(
+     name=NAME,
+@@ -71,7 +71,10 @@ params = dict(
+     classifiers=CLASSIFIERS,
+     keywords=KEYWORDS,
+     install_requires=REQUIRES,
+-    setup_requires=REQUIRES,
++    setup_requires=REQUIRES,
++    extras_require={
++        ':python_version<="2.6"': ['argparse'],
++        }
+ )

--- a/python/py-unittest2/files/patch-traceback2-everywhere.diff
+++ b/python/py-unittest2/files/patch-traceback2-everywhere.diff
@@ -1,0 +1,33 @@
+
+# HG changeset patch
+# User Robert Collins <rbtcollins@hp.com>
+# Date 1435721195 -43200
+# Node ID 9badd4cde9ab5f70eff42777a00c038192a5541f
+# Parent  4174bab908081fa41252f459dbc713246662f98b
+Use traceback2 everywhere.
+
+diff --git a/README.txt b/README.txt
+--- a/README.txt
++++ b/README.txt
+@@ -167,6 +167,8 @@ prevents it being fixed in unittest2.
+ CHANGELOG
+ =========
+ 
++- Use traceback2 consistently to get consistent output across all Pythons.
++
+ 2015-06-20 - 1.1.0
+ ------------------
+ 
+diff --git a/unittest2/loader.py b/unittest2/loader.py
+--- a/unittest2/loader.py
++++ b/unittest2/loader.py
+@@ -3,7 +3,7 @@
+ import os
+ import re
+ import sys
+-import traceback
++import traceback2 as traceback
+ import types
+ import unittest
+ import warnings
+


### PR DESCRIPTION
#### Description
For a variety of Python ports the livecheck on PyPI failed with the following error: ```The requested URL returned error: 410 DOAP is no longer supported.``` This PR updates these ports to make use of the default PyPI livecheck and at the same times adds the following enhancements (where possible/applicable):
- update to latest version (py-flask-script, py-unittest2)
- enable tests
- fix dependencies/variant (py-linecache2, py-astroML, and addition of new port py-traceback2)
- modernize checksums
- use https for homepage

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
Tests for py-astroML fail, likely due to syntax changes in py-numpy ; this was reported by others to upstream on GitHub, but it doesn't look like these are addressed. Of course, this has nothing to do with the current PR...
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
