### PR TITLE
ntpsec: update to 1.1.2

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,7 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.1
+version             1.1.2
 categories          sysutils net
 maintainers         {lbschenkel @lbschenkel} {fwright.net:fw @fhgwright} \
                     openmaintainer
@@ -19,9 +19,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  6c11e9993f6f24402b8afd6021628f4bfd2627cc \
-                    sha256  d06052b662ca3948841b7767a962cb8935c3da9deca7cabdba6b1bd689803262 \
-                    size    2451415
+checksums           rmd160  b876eca0fca5cd92fd813fa9520f1c110e5df320 \
+                    sha256  9dfaf1d791109160b3632a203bd75c784c54902442cea36983d5131b9f3b0111 \
+                    size    2458805
 
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}
@@ -38,7 +38,8 @@ use_configure       yes
 configure.args      --alltests \
                     --define=CONFIG_FILE=${prefix}/etc/ntp.conf \
                     --disable-manpage \
-                    --pythondir=${python.pkgd}
+                    --pythondir=${python.pkgd} \
+                    --pythonarchdir=${python.pkgd}
 destroot.cmd        ${build.cmd}
 
 default_variants    +doc

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,6 +1,6 @@
---- attic/digest-timing.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ attic/digest-timing.c	2018-06-19 23:14:59.000000000 -0700
-@@ -33,6 +33,8 @@
+--- ./attic/digest-timing.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./attic/digest-timing.c	2018-08-29 15:03:46.000000000 -0700
+@@ -34,6 +34,8 @@
  #include <openssl/rand.h>
  #include <openssl/objects.h>
  
@@ -9,7 +9,7 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
-@@ -43,6 +45,23 @@
+@@ -44,6 +46,23 @@
  #define EVP_MD_CTX_reset(ctx) EVP_MD_CTX_init(ctx)
  #endif
  
@@ -33,7 +33,7 @@
  
  /* Get timing for old slower way too.  Pre Feb 2018 */
  #define DoSLOW 1
-@@ -144,21 +163,21 @@
+@@ -146,21 +165,21 @@ static void DoDigest(
  
    if (NULL == digest) return;
  
@@ -59,7 +59,7 @@
    slow = (stop.tv_sec-start.tv_sec)*1E9 + (stop.tv_nsec-start.tv_nsec);
    printf("   %6.0f  %2.0f %4.0f",
      slow/NUM, (slow-fast)*100.0/slow, (slow-fast)/NUM);
-@@ -183,11 +202,11 @@
+@@ -185,11 +204,11 @@ static void DoCMAC(
  
    if (NULL == cipher) return;
  
@@ -73,8 +73,8 @@
    fast = (stop.tv_sec-start.tv_sec)*1E9 + (stop.tv_nsec-start.tv_nsec);
    printf("%10s  %2d %2d %2lu %6.0f  %6.3f",
      name, keylength, pktlength, digestlength, fast/NUM,  fast/1E9);
---- include/ntp_machine.h.orig	2018-06-11 21:36:09.000000000 -0700
-+++ include/ntp_machine.h	2018-06-19 23:14:59.000000000 -0700
+--- ./include/ntp_machine.h.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./include/ntp_machine.h	2018-08-29 15:03:46.000000000 -0700
 @@ -13,14 +13,53 @@
  
  #ifndef CLOCK_REALTIME
@@ -134,9 +134,9 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- include/ntp_stdlib.h.orig	2018-06-11 21:36:09.000000000 -0700
-+++ include/ntp_stdlib.h	2018-06-19 23:14:59.000000000 -0700
-@@ -113,7 +113,9 @@
+--- ./include/ntp_stdlib.h.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./include/ntp_stdlib.h	2018-08-29 15:03:46.000000000 -0700
+@@ -98,7 +98,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
  extern	const char * res_access_flags(unsigned short);
@@ -145,9 +145,9 @@
 +#endif
  extern	char *	statustoa	(int, int);
  extern	sockaddr_u * netof6	(sockaddr_u *);
- extern	char *	numtoa		(uint32_t);
---- include/ntp_syscall.h.orig	2018-06-11 21:36:09.000000000 -0700
-+++ include/ntp_syscall.h	2018-06-19 23:14:59.000000000 -0700
+ extern	const char * socktoa	(const sockaddr_u *);
+--- ./include/ntp_syscall.h.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./include/ntp_syscall.h	2018-08-29 15:03:46.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -160,8 +160,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- libntp/clockwork.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ libntp/clockwork.c	2018-06-19 23:14:59.000000000 -0700
+--- ./libntp/clockwork.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./libntp/clockwork.c	2018-08-29 15:03:46.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -175,7 +175,7 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
-@@ -77,14 +79,10 @@
+@@ -77,14 +79,10 @@ ntp_set_tod(
  	int		saved_errno;
  
  	TPRINT(1, ("In ntp_set_tod\n"));
@@ -190,8 +190,8 @@
  	errno = saved_errno;	/* for %m below */
  	TPRINT(1, ("ntp_set_tod: Final result: clock_settime: %d %m\n", rc));
  
---- libntp/statestr.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ libntp/statestr.c	2018-06-19 23:14:59.000000000 -0700
+--- ./libntp/statestr.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./libntp/statestr.c	2018-08-29 15:03:46.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -202,7 +202,7 @@
  
  
  /*
-@@ -186,23 +188,50 @@
+@@ -186,23 +188,50 @@ static const struct codestring res_acces
  	/* not used with getcode(), no terminating entry needed */
  };
  
@@ -253,7 +253,7 @@
  # ifdef STA_NANO
  	{ STA_NANO,			"nano" },
  # endif
-@@ -214,6 +243,7 @@
+@@ -214,6 +243,7 @@ static const struct codestring k_st_bits
  # endif
  	/* not used with getcode(), no terminating entry needed */
  };
@@ -261,10 +261,12 @@
  
  /* Forwards */
  static const char *	getcode(int, const struct codestring *);
-@@ -315,9 +345,11 @@
+@@ -314,10 +344,12 @@ decode_bitflags(
+ 		 "decode_bitflags(%s) can't decode 0x%x in %d bytes",
  		 (tab == peer_st_bits)
  		     ? "peer_st"
- 		     : 
+-		     :
++		     : 
 +#ifdef HAVE_KERNEL_PLL
  		       (tab == k_st_bits)
  			   ? "kern_st"
@@ -273,7 +275,7 @@
  			     "",
  		 (unsigned)bits, (int)LIB_BUFLENGTH);
  	errno = saved_errno;
-@@ -356,6 +388,7 @@
+@@ -356,6 +388,7 @@ res_access_flags(
  }
  
  
@@ -281,7 +283,7 @@
  const char *
  k_st_flags(
  	uint32_t st
-@@ -363,6 +396,8 @@
+@@ -363,6 +396,8 @@ k_st_flags(
  {
  	return decode_bitflags((int)st, " ", k_st_bits, COUNTOF(k_st_bits));
  }
@@ -290,9 +292,9 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ntpd/ntp_control.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ ntpd/ntp_control.c	2018-06-19 23:14:59.000000000 -0700
-@@ -1469,6 +1469,7 @@
+--- ./ntpd/ntp_control.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./ntpd/ntp_control.c	2018-08-29 15:03:46.000000000 -0700
+@@ -1464,6 +1464,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
  	const char *ss;
@@ -300,7 +302,7 @@
  	static struct timex ntx;
  	static unsigned long ntp_adjtime_time;
  
-@@ -1483,6 +1484,7 @@
+@@ -1478,6 +1479,7 @@ ctl_putsys(
  		else
  			ntp_adjtime_time = current_time;
  	}
@@ -308,7 +310,7 @@
  
  	switch (varid) {
  
-@@ -1856,50 +1858,93 @@
+@@ -1866,50 +1868,93 @@ ctl_putsys(
  		break;
  
  		/*
@@ -414,8 +416,8 @@
  		break;
  
  	case CS_K_PPS_FREQ:
---- ntpd/ntp_loopfilter.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ ntpd/ntp_loopfilter.c	2018-06-19 23:14:59.000000000 -0700
+--- ./ntpd/ntp_loopfilter.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2018-08-29 15:03:46.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -427,7 +429,7 @@
  
  /*
   * This is an implementation of the clock discipline algorithm described
-@@ -122,13 +124,16 @@
+@@ -122,13 +124,16 @@ double	drift_comp;		/* frequency (s/s) *
  static double init_drift_comp; /* initial frequency (PPM) */
  double	clock_stability;	/* frequency stability (wander) (s/s) */
  unsigned int	sys_tai;		/* TAI offset from UTC */
@@ -445,7 +447,7 @@
  #ifndef PATH_MAX
  # define PATH_MAX MAX_PATH
  #endif
-@@ -144,6 +149,7 @@
+@@ -144,6 +149,7 @@ static unsigned int loop_tai;		/* last T
  #endif /* ENABLE_LOCKCLOCK */
  static	void	start_kern_loop(void);
  static	void	stop_kern_loop(void);
@@ -453,7 +455,7 @@
  
  /*
   * Clock state machine control flags
-@@ -160,7 +166,9 @@
+@@ -160,7 +166,9 @@ struct clock_control_flags clock_ctl = {
  int	freq_cnt;		/* initial frequency clamp */
  
  static int freq_set;		/* initial set frequency switch */
@@ -463,7 +465,7 @@
  
  /*
   * Clock state machine variables
-@@ -180,6 +188,7 @@
+@@ -180,6 +188,7 @@ static int sys_hufflen;		/* huff-n'-puff
  static int sys_huffptr;		/* huff-n'-puff filter pointer */
  static double sys_mindly;	/* huff-n'-puff filter min delay */
  
@@ -471,7 +473,7 @@
  /* Emacs cc-mode goes nuts if we split the next line... */
  #define MOD_BITS (MOD_OFFSET | MOD_MAXERROR | MOD_ESTERROR | \
      MOD_STATUS | MOD_TIMECONST)
-@@ -189,7 +198,9 @@
+@@ -189,7 +198,9 @@ static struct sigaction sigsys;	/* curre
  static struct sigaction newsigsys; /* new sigaction status */
  static sigjmp_buf env;		/* environment var. for pll_trap() */
  #endif /* SIGSYS */
@@ -481,7 +483,7 @@
  #ifndef ENABLE_LOCKCLOCK
  static void
  sync_status(const char *what, int ostatus, int nstatus)
-@@ -215,6 +226,7 @@
+@@ -215,6 +226,7 @@ static char *file_name(void)
  	}
  	return this_file;
  }
@@ -489,7 +491,7 @@
  
  /*
   * init_loopfilter - initialize loop filter data
-@@ -230,6 +242,7 @@
+@@ -230,6 +242,7 @@ init_loopfilter(void)
  	freq_cnt = (int)clock_minstep;
  }
  
@@ -497,7 +499,7 @@
  /*
   * ntp_adjtime_error_handler - process errors from ntp_adjtime
   */
-@@ -428,6 +441,7 @@
+@@ -428,6 +441,7 @@ or, from ntp_adjtime():
  	}
  	return;
  }
@@ -505,7 +507,7 @@
  
  /*
   * local_clock - the NTP logical clock loop filter.
-@@ -453,7 +467,9 @@
+@@ -453,7 +467,9 @@ local_clock(
  #else
  	int	rval;		/* return code */
  	int	osys_poll;	/* old system poll */
@@ -515,7 +517,7 @@
  	double	mu;		/* interval since last update */
  	double	clock_frequency; /* clock frequency */
  	double	dtemp, etemp;	/* double temps */
-@@ -722,6 +738,7 @@
+@@ -722,6 +738,7 @@ local_clock(
  		}
  	}
  
@@ -523,7 +525,7 @@
  	/*
  	 * This code segment works when clock adjustments are made using
  	 * precision time kernel support and the ntp_adjtime() system
-@@ -837,6 +854,7 @@
+@@ -837,6 +854,7 @@ local_clock(
  		}
  #endif /* STA_NANO */
  	}
@@ -531,7 +533,7 @@
  
  	/*
  	 * Clamp the frequency within the tolerance range and calculate
-@@ -950,8 +968,10 @@
+@@ -950,8 +968,10 @@ adj_host_clock(
  	} else if (freq_cnt > 0) {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(1));
  		freq_cnt--;
@@ -542,7 +544,7 @@
  	} else {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(sys_poll));
  	}
-@@ -962,9 +982,11 @@
+@@ -962,9 +982,11 @@ adj_host_clock(
  	 * set_freq().  Otherwise it is a component of the adj_systime()
  	 * offset.
  	 */
@@ -554,7 +556,7 @@
  		freq_adj = drift_comp;
  
  	/* Bound absolute value of total adjustment to NTP_MAXFREQ. */
-@@ -1056,6 +1078,7 @@
+@@ -1056,6 +1078,7 @@ set_freq(
  
  	drift_comp = freq;
  	loop_desc = "ntpd";
@@ -562,7 +564,7 @@
  	if (clock_ctl.pll_control) {
  		int ntp_adj_ret;
  		ZERO(ntv);
-@@ -1068,11 +1091,13 @@
+@@ -1068,11 +1091,13 @@ set_freq(
  		    ntp_adjtime_error_handler(__func__, &ntv, ntp_adj_ret, errno, false, false, __LINE__ - 1);
  		}
  	}
@@ -576,7 +578,7 @@
  static void
  start_kern_loop(void)
  {
-@@ -1133,8 +1158,10 @@
+@@ -1133,8 +1158,10 @@ start_kern_loop(void)
  	  	    "kernel time sync enabled");
  	}
  }
@@ -587,7 +589,7 @@
  static void
  stop_kern_loop(void)
  {
-@@ -1142,6 +1169,7 @@
+@@ -1142,6 +1169,7 @@ stop_kern_loop(void)
  		report_event(EVNT_KERN, NULL,
  		    "kernel time sync disabled");
  }
@@ -595,7 +597,7 @@
  
  
  /*
-@@ -1154,17 +1182,21 @@
+@@ -1154,17 +1182,21 @@ select_loop(
  {
  	if (clock_ctl.kern_enable == use_kern_loop)
  		return;
@@ -618,7 +620,7 @@
  	if (clock_ctl.pll_control && loop_started)
  		set_freq(drift_comp);
  #endif
-@@ -1215,10 +1247,12 @@
+@@ -1215,10 +1247,12 @@ loop_config(
  	 */
  	case LOOP_DRIFTINIT:
  #ifndef ENABLE_LOCKCLOCK
@@ -631,7 +633,7 @@
  
  		/*
  		 * Initialize frequency if given; otherwise, begin frequency
-@@ -1236,13 +1270,16 @@
+@@ -1236,13 +1270,16 @@ loop_config(
  			rstclock(EVNT_FSET, 0);
  		else
  			rstclock(EVNT_NSET, 0);
@@ -648,7 +650,7 @@
  		if (clock_ctl.pll_control && clock_ctl.kern_enable) {
  			memset((char *)&ntv, 0, sizeof(ntv));
  			ntv.modes = MOD_STATUS;
-@@ -1252,6 +1289,7 @@
+@@ -1252,6 +1289,7 @@ loop_config(
  				pll_status,
  				ntv.status);
  		   }
@@ -656,7 +658,7 @@
  #endif /* ENABLE_LOCKCLOCK */
  #endif
  		break;
-@@ -1331,7 +1369,7 @@
+@@ -1331,7 +1369,7 @@ loop_config(
  }
  
  
@@ -665,14 +667,14 @@
  /*
   * _trap - trap processor for undefined syscalls
   *
-@@ -1349,4 +1387,4 @@
+@@ -1349,4 +1387,4 @@ pll_trap(
  	clock_ctl.pll_control = false;
  	siglongjmp(env, 1);
  }
 -#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL && SIGSYS */
---- ntpd/ntp_timer.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ ntpd/ntp_timer.c	2018-06-19 23:14:59.000000000 -0700
+--- ./ntpd/ntp_timer.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./ntpd/ntp_timer.c	2018-08-29 15:03:46.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -683,7 +685,7 @@
  
  #ifdef HAVE_TIMER_CREATE
  /* TC_ERR represents the timer_create() error return value. */
-@@ -373,7 +375,11 @@
+@@ -373,7 +375,11 @@ check_leapsec(
  
  	leap_result_t lsdata;
  	uint32_t       lsprox;
@@ -695,9 +697,9 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ntpd/refclock_local.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ ntpd/refclock_local.c	2018-06-19 23:14:59.000000000 -0700
-@@ -131,6 +131,9 @@
+--- ./ntpd/refclock_local.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./ntpd/refclock_local.c	2018-08-29 15:03:46.000000000 -0700
+@@ -131,6 +131,9 @@ local_poll(
  	struct peer *peer
  	)
  {
@@ -707,7 +709,7 @@
  	struct refclockproc *pp;
  
  	UNUSED_ARG(unit);
-@@ -156,8 +159,7 @@
+@@ -156,8 +159,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
  	 */
@@ -717,7 +719,7 @@
  	memset(&ntv,  0, sizeof ntv);
  	switch (ntp_adjtime(&ntv)) {
  	case TIME_OK:
-@@ -181,11 +183,11 @@
+@@ -181,11 +183,11 @@ local_poll(
  	}
  	pp->disp = 0;
  	pp->jitter = 0;
@@ -731,8 +733,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ntpfrob/precision.c.orig	2018-06-11 21:36:09.000000000 -0700
-+++ ntpfrob/precision.c	2018-06-19 23:14:59.000000000 -0700
+--- ./ntpfrob/precision.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./ntpfrob/precision.c	2018-08-29 15:03:46.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -741,9 +743,31 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- wafhelpers/options.py.orig	2018-06-11 21:36:09.000000000 -0700
-+++ wafhelpers/options.py	2018-06-19 23:14:59.000000000 -0700
-@@ -21,6 +21,8 @@
+--- ./tests/libntp/statestr.c.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./tests/libntp/statestr.c	2018-08-29 15:03:46.000000000 -0700
+@@ -4,7 +4,9 @@
+ #include "unity.h"
+ #include "unity_fixture.h"
+ 
++#ifdef HAVE_SYS_TIMEX_H
+ #include <sys/timex.h>
++#endif
+ 
+ TEST_GROUP(statestr);
+ 
+@@ -29,7 +31,9 @@ TEST(statestr, ResAccessFlags) {
+ 
+ // k_st_flags()
+ TEST(statestr, KSTFlags) {
++#ifdef STA_PPSFREQ
+ 	TEST_ASSERT_EQUAL_STRING("ppsfreq", k_st_flags(STA_PPSFREQ));
++#endif
+ }
+ 
+ // statustoa
+--- ./wafhelpers/options.py.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./wafhelpers/options.py	2018-08-29 15:03:46.000000000 -0700
+@@ -21,6 +21,8 @@ def options_cmd(ctx, config):
                     default=False, help="Enable seccomp (restricts syscalls).")
      grp.add_option('--disable-dns-lookup', action='store_true',
                     default=False, help="Disable DNS lookups.")
@@ -752,9 +776,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- wscript.orig	2018-06-11 21:36:09.000000000 -0700
-+++ wscript	2018-06-19 23:14:59.000000000 -0700
-@@ -562,13 +562,13 @@
+--- ./wscript.orig	2018-08-28 22:18:48.000000000 -0700
++++ ./wscript	2018-08-29 15:03:46.000000000 -0700
+@@ -562,13 +562,13 @@ int main(int argc, char **argv) {
          ctx.define("__EXTENSIONS__", "1", quote=False)
  
      structures = (
@@ -774,7 +798,7 @@
  
      # waf's SNIP_FIELD should likely include this header itself
      # This is needed on some systems to get size_t for following checks
-@@ -625,8 +625,6 @@
+@@ -626,8 +626,6 @@ int main(int argc, char **argv) {
          ('adjtimex', ["sys/time.h", "sys/timex.h"]),
          ('backtrace_symbols_fd', ["execinfo.h"]),
          ('closefrom', ["stdlib.h"]),
@@ -783,7 +807,7 @@
          ('ntp_adjtime', ["sys/time.h", "sys/timex.h"]),     # BSD
          ('ntp_gettime', ["sys/time.h", "sys/timex.h"]),     # BSD
          ('res_init', ["netinet/in.h", "arpa/nameser.h", "resolv.h"]),
-@@ -771,6 +769,21 @@
+@@ -772,6 +770,21 @@ int main(int argc, char **argv) {
      ctx.define("HAVE_WORKING_FORK", 1,
                 comment="Whether a working fork() exists")
  


### PR DESCRIPTION
This includes the changes for compatibility with macOS<10.13,
which can also be seen at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_1_2

NOTE:
The 'ntptime' utility is currently not included prior to 10.13.
Whether this is easily fixed is a matter for further study.

This now includes the -p option when generating the patchfile.  This
results in some additional "metadiffs" against the previous patchfile.

TESTED:
Built and ran on MacPro 10.9, MacBookPro 10.9, PowerBook 10.5,
and VMs for 10.5-10.13.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
