### PR TITLE
freetype: Update to 2.9.1

### DIFF
--- a/print/freetype/Portfile
+++ b/print/freetype/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    freetype
-version                 2.8.1
+version                 2.9.1
 categories              print graphics
 maintainers             {ryandesign @ryandesign}
 license                 {FreeType GPL-2}
@@ -34,17 +34,20 @@ distfiles               ${distname}${extract.suffix}:source \
                         ${docdistname}${extract.suffix}:docs
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  4b31c73b38d1f03c431b12408f800569e0724cc4 \
-                        sha256  e5435f02e02d2b87bb8e4efdcaa14b1f78c9cf3ab1ed80f94b6382fb6acc7d78 \
-                        size    1886443 \
+                        rmd160  c01d82acf7062b07146f61f43a8d17d5805b9471 \
+                        sha256  db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d \
+                        size    1926385 \
                         ${docdistname}${extract.suffix} \
-                        rmd160  5ef58133218fa1ba8106cdaada4a3e6f56c793ad \
-                        sha256  e6251ab44adcb075c7ca4205163c43b6539cbe5265b8a24ec0afa07f8b9213f3 \
-                        size    2128376
+                        rmd160  44d57b5e54ad1792565b36f9324944035beabb8b \
+                        sha256  aa2f835ef8f50072630ddc48b9eb65f1f456014ffa3b5adddcb6bf390a3c5828 \
+                        size    2130292
 
 patchfiles \
+    freetype-config-no-pkg-config.patch \
     patch-src_base_ftrfork.c.diff \
     patch-modules.cfg.diff
+
+depends_build           port:pkgconfig
 
 depends_lib             port:bzip2 \
                         port:libpng \
@@ -58,6 +61,11 @@ configure.args          --with-bzip2 \
                         --with-zlib \
                         --without-harfbuzz \
                         ac_cv_prog_AWK=/usr/bin/awk
+
+variant no_freetype_config description {Don't install the freetype-config script} {}
+if {![variant_isset no_freetype_config]} {
+    configure.args-append --enable-freetype-config
+}
 
 configure.universal_args-delete --disable-dependency-tracking
 

--- a/print/freetype/files/freetype-config-no-pkg-config.patch
+++ b/print/freetype/files/freetype-config-no-pkg-config.patch
@@ -1,0 +1,13 @@
+Let's not have freetype-config giving different answers depending on
+whether or not pkg-config is installed.
+--- builds/unix/unix-def.in.orig	2018-04-22 04:41:36.000000000 -0500
++++ builds/unix/unix-def.in	2018-08-31 03:33:26.000000000 -0500
+@@ -104,7 +104,7 @@
+ $(OBJ_BUILD)/freetype-config: $(TOP_DIR)/builds/unix/freetype-config.in
+ 	rm -f $@ $@.tmp
+ 	sed -e 's|%LIBSSTATIC_CONFIG%|$(LIBSSTATIC_CONFIG)|'   \
+-	    -e 's|%PKG_CONFIG%|$(PKG_CONFIG)|'                 \
++	    -e 's|%PKG_CONFIG%|false|'                         \
+ 	    -e 's|%build_libtool_libs%|$(build_libtool_libs)|' \
+ 	    -e 's|%exec_prefix%|$(exec_prefix)|'               \
+ 	    -e 's|%ft_version%|$(ft_version)|'                 \

--- a/print/freetype/files/patch-modules.cfg.diff
+++ b/print/freetype/files/patch-modules.cfg.diff
@@ -1,7 +1,7 @@
---- modules.cfg.orig	2016-08-28 11:47:56.000000000 -0500
-+++ modules.cfg	2016-09-13 19:58:01.000000000 -0500
+--- modules.cfg.orig	2018-04-22 04:41:36.000000000 -0500
++++ modules.cfg	2018-08-30 03:05:50.000000000 -0500
 @@ -143,7 +143,7 @@
- # OpenType table validation.  Needs ftotval.c below.
+ # OpenType table validation.  Needs `ftotval.c' below.
  #
  # No FT_CONFIG_OPTION_PIC support.
 -# AUX_MODULES += otvalid

--- a/print/freetype/files/patch-src_base_ftrfork.c.diff
+++ b/print/freetype/files/patch-src_base_ftrfork.c.diff
@@ -1,6 +1,6 @@
---- src/base/ftrfork.c.orig	2013-06-05 16:56:56.000000000 -0500
-+++ src/base/ftrfork.c	2013-06-20 18:01:26.000000000 -0500
-@@ -533,29 +533,7 @@
+--- src/base/ftrfork.c.orig	2018-04-22 04:41:36.000000000 -0500
++++ src/base/ftrfork.c	2018-08-30 03:05:50.000000000 -0500
+@@ -596,29 +596,7 @@
      /*
        Only meaningful on systems with hfs+ drivers (or Macs).
       */


### PR DESCRIPTION
#### Description

Updates freetype to 2.9.1.

Let's not merge this yet, because this removes the `freetype-config` script on which some ports might still rely.

This PR is here so that others can test ports with freetype 2.9.1 and fix issues before we push the update out to everybody.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
