### PR TITLE
ragel: Allow building with clang

### DIFF
--- a/lang/ragel/Portfile
+++ b/lang/ragel/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
 
 name                ragel
 version             7.0.0.11
-revision            0
+revision            1
 categories          lang devel
 platforms           darwin
 license             MIT
@@ -30,9 +29,8 @@ checksums           rmd160  5f357270929cd5de16e81451b396e7605d2ec6b0 \
 
 depends_lib-append  port:colm
 
-# Force a compatible compiler
-compiler.blacklist *clang* *llvm-gcc* *apple-gcc* gcc gcc-3.3 gcc-4.0 gcc-4.2
-compiler.whitelist macports-gcc-7 macports-gcc-6 macports-gcc-5 macports-gcc-4.9 macports-gcc-4.8 macports-gcc-4.7
+# fatal error: 'ext/stdio_filebuf.h' file not found
+configure.cxx_stdlib libstdc++
 
 livecheck.type      regex
 livecheck.url       ${homepage}


### PR DESCRIPTION
#### Description

This allows building with clang, by using libstdc++ instead of libc++. This should not cause any problems since ragel does not install any C++ libraries and does not use any other port's C++ libraries.

The code generated by ragel's dependency colm requires (or at least tries to `#include`) the header `ext/stdio_filebuf.h` which appears to be for libstdc++ only.

The developers of colm/ragel should be informed of this problem. I couldn't find a bug tracker, and I couldn't find a mention of the problem on their [mailing lists](http://www.colm.net/cgi-bin/mailman/listinfo/).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
