### PR TITLE
ntpsec: removes lbschenkel as maintainer.

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -7,8 +7,7 @@ PortGroup           python 1.0
 name                ntpsec
 version             1.1.2
 categories          sysutils net
-maintainers         {lbschenkel @lbschenkel} {fwright.net:fw @fhgwright} \
-                    openmaintainer
+maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
 license             Permissive
 platforms           darwin


### PR DESCRIPTION
TESTED:
Ran "port info" and observed result.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
