### PR TITLE
duti: pass in workable sdk root

### DIFF
--- a/sysutils/duti/Portfile
+++ b/sysutils/duti/Portfile
@@ -29,5 +29,12 @@ checksums           rmd160 99b928d040b98f3d164ec5967f694793a3b9c03b \
 
 use_autoreconf      yes
 
-configure.args-append \
-                    --with-macosx-sdk=${configure.sdkroot}
+# fix build on systems where XCode SDK doesn't match system version
+# eg XCode7 on 10.10 installs the 10.11.sdk
+
+if {${os.platform} eq "darwin" && ${os.major} > 13} {
+    if {![catch {set mysdk [exec xcrun --show-sdk-path 2> /dev/null]}]} {
+    configure.args-append \
+                    --with-macosx-sdk=${mysdk}
+    }
+}


### PR DESCRIPTION
fix build on systems where XCode SDK doesn't match system version
eg XCode7 on 10.10 installs the 10.11.sdk

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
