### PR TITLE
fontconfig: build static library/archive

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -5,6 +5,7 @@ PortGroup                   muniversal 1.0
 
 name                        fontconfig
 version                     2.13.0
+revision                    1
 categories                  graphics
 maintainers                 {ryandesign @ryandesign}
 license                     fontconfig
@@ -43,6 +44,7 @@ set docdir                  ${prefix}/share/doc/${name}
 patchfiles                  patch-docbook-4.2.diff
 
 configure.args              --disable-silent-rules \
+                            --enable-static \
                             --enable-iconv \
                             --with-expat=${prefix} \
                             --with-libiconv=${prefix} \


### PR DESCRIPTION
#### Description
Many other portfiles ship with this probably because it's turned on by default in ./configure. Many other portfiles also explicitly turn this one when it's not on by default.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
