### PR TITLE
processing: update to 3.4 (maintainer)

### DIFF
--- a/lang/processing/Portfile
+++ b/lang/processing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        processing processing 3.3.7 processing-0264-
+github.setup        processing processing 3.4 processing-0265-
 
 categories          lang
 platforms           darwin
@@ -24,8 +24,8 @@ long_description    \
 
 homepage            https://processing.org
 
-checksums           rmd160  e699981b6195f7ce4954e1d73e9e95702d769211 \
-                    sha256  b6791bab7cf4f29e251825e45a87195d1515028e7b9cd29265b67c4bc8029a45
+checksums           rmd160  985a58038d7da6a6a9b6d99d82bd12f903e7d735 \
+                    sha256  ff8e3711e6424e9c3842ace051a5ddfdf144ea3066e2107423f5d7c4ac9ba63f
 
 depends_build       port:apache-ant
 


### PR DESCRIPTION
To build on OS X, you must install Oracle's JDK 8u181
http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html

#### Description

Update processing Portfile to 3.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
