### PR TITLE
libfreehand: minimal build fixes

### DIFF
--- a/graphics/libfreehand/Portfile
+++ b/graphics/libfreehand/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 
+# requires support for C++11
+PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
+
 name                libfreehand
 version             0.1.2
 categories          graphics
@@ -30,8 +34,12 @@ depends_lib         port:librevenge \
                     port:lcms2 \
                     port:zlib
 
+# blacklist compilers with known problems on older systems
+compiler.blacklist-append  *gcc-3.* *gcc-4.* {clang < 300}
+
 configure.args      --disable-werror \
                     --disable-silent-rules \
+                    --disable-tests \
                     --without-docs
 
 variant docs description {Build API documentation} {


### PR DESCRIPTION
* requires support for C++11, use cxx11 1.1 PortGroup
* blacklist compilers with known problems on older systems
* disable tests which require cppunit since Portfile doesn't run them

See: https://trac.macports.org/ticket/57068

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
