### PR TITLE
py-typing: update to 3.6.6

### DIFF
--- a/python/py-typing/Portfile
+++ b/python/py-typing/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typing
-version             3.6.4
+version             3.6.6
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -24,10 +24,11 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 
 master_sites        pypi:t/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           md5     5b2ade08d83be488f17b5fe587c27c74 \
-                    rmd160  0c03e1a2972bc8ed83494ef5a92f06a76d32e7d9 \
-                    sha256  d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2
+checksums           rmd160  104c60a95f09e7ebc036e2426184af97e67f320d \
+                    sha256  4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d \
+                    size    71799
 
+# do not add subports for python 3.5 and later; module is in stdlib.
 python.versions     27 34
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description
Update port and added comment that this is not needed for python 3.5 and later.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->