### PR TITLE
tesseract: update to 3.05.02, fix missing config & man files

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 
 PortGroup           github 1.0
-PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
 github.setup        tesseract-ocr tesseract 3.05.02
@@ -30,14 +29,20 @@ checksums           rmd160  c31e95c288d9ecfa893bebe467dc5cc5f0edce5a \
                     size    3571750
 
 if {${name} eq ${subport}} {
-    depends_build-append    port:pkgconfig
+    depends_build-append    port:pkgconfig \
+                            port:autoconf \
+                            port:automake \
+                            port:libtool \
+                            port:asciidoc
 
     depends_lib             port:zlib \
                             port:libpng \
                             port:leptonica \
                             port:jpeg
 
-    cmake.out_of_source     yes
+    use_autoreconf          yes
+    autoreconf.cmd          ./autogen.sh
+    autoreconf.args
 
     patchfiles              patch-fix-library-name.diff \
                             patch-fix-mtree-violation-by-cmake-files.diff

--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -6,8 +6,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
-github.setup        tesseract-ocr tesseract 3.05.01
-revision            1
+github.setup        tesseract-ocr tesseract 3.05.02
 categories          textproc graphics pdf
 platforms           darwin
 license             Apache-2
@@ -26,8 +25,9 @@ long_description    The Tesseract OCR engine was one of the top  3  engines in \
 
 github.master_sites ${github.homepage}/archive/${git.branch}
 
-checksums           rmd160  11fae540fdd0ec4f6f9388fae4bbde790b17ee4d \
-                    sha256  05898f93c5d057fada49b9a116fc86ad9310ff1726a0f499c3e5211b3af47ec1
+checksums           rmd160  c31e95c288d9ecfa893bebe467dc5cc5f0edce5a \
+                    sha256  494d64ffa7069498a97b909a0e65a35a213989e0184f1ea15332933a90d43445 \
+                    size    3571750
 
 if {${name} eq ${subport}} {
     depends_build-append    port:pkgconfig


### PR DESCRIPTION
#### Description

1. Update tesseract to 3.05.02, a bugfix release
2. Address [Trac #56226](https://trac.macports.org/ticket/56226): `${PREFIX}/share/tessdata`, which should contain important config files needed for some basic features of tesseract, is not populated when built with cmake.

The update to 3.05.01 switched to cmake, but I note that the [official documentation](https://github.com/tesseract-ocr/tesseract/wiki/Compiling-%E2%80%93-GitInstallation#installing-with-autoconf-tools) appears to recommend using autoconf when building from source, whereas cmake is only mentioned in the context of [Windows builds](https://github.com/tesseract-ocr/tesseract/wiki/Compiling).

It may be possible to get the cmake build to output the config files; I don't know enough about it to even attempt to do so.

Diff of `port contents tesseract` from 3.05.01 to 3.05.02:

```
--- tesseract-3.05.01.txt	2018-09-01 23:26:28.000000000 +0900
+++ tesseract-3.05.02.txt	2018-09-01 23:30:43.000000000 +0900
@@ -27,10 +27,44 @@
   /opt/local/include/tesseract/unichar.h
   /opt/local/include/tesseract/unicharmap.h
   /opt/local/include/tesseract/unicharset.h
-  /opt/local/lib/cmake/tesseract/TesseractConfig-version.cmake
-  /opt/local/lib/cmake/tesseract/TesseractConfig.cmake
-  /opt/local/lib/cmake/tesseract/TesseractTargets-macports.cmake
-  /opt/local/lib/cmake/tesseract/TesseractTargets.cmake
-  /opt/local/lib/libtesseract.3.0.5.dylib
+  /opt/local/lib/libtesseract.3.dylib
+  /opt/local/lib/libtesseract.a
   /opt/local/lib/libtesseract.dylib
   /opt/local/lib/pkgconfig/tesseract.pc
+  /opt/local/share/man/man1/ambiguous_words.1.gz
+  /opt/local/share/man/man1/cntraining.1.gz
+  /opt/local/share/man/man1/combine_tessdata.1.gz
+  /opt/local/share/man/man1/dawg2wordlist.1.gz
+  /opt/local/share/man/man1/mftraining.1.gz
+  /opt/local/share/man/man1/shapeclustering.1.gz
+  /opt/local/share/man/man1/tesseract.1.gz
+  /opt/local/share/man/man1/unicharset_extractor.1.gz
+  /opt/local/share/man/man1/wordlist2dawg.1.gz
+  /opt/local/share/man/man5/unicharambigs.5.gz
+  /opt/local/share/man/man5/unicharset.5.gz
+  /opt/local/share/tessdata/configs/ambigs.train
+  /opt/local/share/tessdata/configs/api_config
+  /opt/local/share/tessdata/configs/bigram
+  /opt/local/share/tessdata/configs/box.train
+  /opt/local/share/tessdata/configs/box.train.stderr
+  /opt/local/share/tessdata/configs/digits
+  /opt/local/share/tessdata/configs/hocr
+  /opt/local/share/tessdata/configs/inter
+  /opt/local/share/tessdata/configs/kannada
+  /opt/local/share/tessdata/configs/linebox
+  /opt/local/share/tessdata/configs/logfile
+  /opt/local/share/tessdata/configs/makebox
+  /opt/local/share/tessdata/configs/pdf
+  /opt/local/share/tessdata/configs/quiet
+  /opt/local/share/tessdata/configs/rebox
+  /opt/local/share/tessdata/configs/strokewidth
+  /opt/local/share/tessdata/configs/tsv
+  /opt/local/share/tessdata/configs/txt
+  /opt/local/share/tessdata/configs/unlv
+  /opt/local/share/tessdata/pdf.ttf
+  /opt/local/share/tessdata/tessconfigs/batch
+  /opt/local/share/tessdata/tessconfigs/batch.nochop
+  /opt/local/share/tessdata/tessconfigs/matdemo
+  /opt/local/share/tessdata/tessconfigs/msdemo
+  /opt/local/share/tessdata/tessconfigs/nobatch
+  /opt/local/share/tessdata/tessconfigs/segdemo
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
