### PR TITLE
geant4.10.4: update to 4.10.04.p02, fix livecheck

### DIFF
--- a/science/geant4/Portfile
+++ b/science/geant4/Portfile
@@ -22,6 +22,9 @@ platforms           darwin
 
 master_sites        http://geant4.cern.ch/support/source/
 
+set geant.url_new   https://geant4.web.cern.ch/support/download
+set geant.url_old   https://geant4.web.cern.ch/support/download_archive
+
 # meaning of the fields:
 # - version
 # - revision (used internally in MacPorts to force updates)
@@ -30,14 +33,14 @@ master_sites        http://geant4.cern.ch/support/source/
 # - version string (used for fetching the source)
 #
 # if we start distributing betas, epoch will have to be added for the transition from version 4.x.y.b01 to 4.x.y
-set geant.versions_info {
-     9.6  2  0  4  4.9.6.p04    3dd8f6ac2e79929d26519e83fce113691a670788  997220a5386a43ac8f533fc7d5a8360aa1fd6338244d17deeaa583fb3a0f39fd
-    10.0  2  0  4  4.10.00.p04  bfd11977b55f316f5c38d82f09dc37e7c0f60ea7  f4e1fc6d5ea4d9761ba44fd7e50921ff6276e25c2f640c7615460235d8c77d74
-    10.1  1  0  3  4.10.01.p03  0b141adfceb4203f4855e0c6fb0d4c17036776ca  b198943b5bc4fd7968ef4eaa5bbe2fb094b8df1d907a05486dc05f4c92bbb174
-    10.2  1  1  3  4.10.02.p03  c45d91fb2def7143e6dcccb5d11907454be77386  e0bba0a9c937430e7dfac158873e218fafc0f167b12e7ff3d17ce13cbe550c4f
-    10.3  0  0  3  4.10.03.p03  e4e18181ab777811415b85341caec658d14f7427  a164f49c038859ab675eec474d08c9d02be8c4be9c0c2d3aa8e69adf89e1e138
-    10.4  1  0  0  4.10.04      740375629e95747af7c845bc876701bf989354b1  f6d883132f110eb036c69da2b21df51f13c585dc7b99d4211ddd32f4ccee1670
-}
+set geant.versions_info [list \
+     9.6  2  0  4  4.9.6.p04    3dd8f6ac2e79929d26519e83fce113691a670788  997220a5386a43ac8f533fc7d5a8360aa1fd6338244d17deeaa583fb3a0f39fd  25454650  ${geant.url_old}?page=4 \
+    10.0  2  0  4  4.10.00.p04  bfd11977b55f316f5c38d82f09dc37e7c0f60ea7  f4e1fc6d5ea4d9761ba44fd7e50921ff6276e25c2f640c7615460235d8c77d74  29655911  ${geant.url_old}?page=3 \
+    10.1  1  0  3  4.10.01.p03  0b141adfceb4203f4855e0c6fb0d4c17036776ca  b198943b5bc4fd7968ef4eaa5bbe2fb094b8df1d907a05486dc05f4c92bbb174  33538209  ${geant.url_old}?page=2 \
+    10.2  1  1  3  4.10.02.p03  c45d91fb2def7143e6dcccb5d11907454be77386  e0bba0a9c937430e7dfac158873e218fafc0f167b12e7ff3d17ce13cbe550c4f  32241693  ${geant.url_old}?page=1 \
+    10.3  0  0  3  4.10.03.p03  e4e18181ab777811415b85341caec658d14f7427  a164f49c038859ab675eec474d08c9d02be8c4be9c0c2d3aa8e69adf89e1e138  32517096  ${geant.url_old}?page=0 \
+    10.4  1  0  0  4.10.04      740375629e95747af7c845bc876701bf989354b1  f6d883132f110eb036c69da2b21df51f13c585dc7b99d4211ddd32f4ccee1670  34884065  ${geant.url_new} \
+]
 
 #   NAME               VERS  FILENAME             ENVVAR             md5                               rmd160                                    sha256
 set geant.data_versions_10.4 {
@@ -119,7 +122,7 @@ set geant.data_versions_9.6 {
     G4SAIDDATA         1.1   G4SAIDDATA           G4SAIDXSDATA       d88a31218fdf28455e5c5a3609f7216f  7f0c75c86eea3d227379d3dfe77e4600752f99a2  a38cd9a83db62311922850fe609ecd250d36adf264a88e88c82ba82b7da0ed7f
 }
 
-foreach {geant.version geant.revision geant.datarevision geant.patchlevel geant.version_full geant.rmd160 geant.sha256} ${geant.versions_info} {
+foreach {geant.version geant.revision geant.datarevision geant.patchlevel geant.version_full geant.rmd160 geant.sha256 geant.size geant.livecheck_url} ${geant.versions_info} {
 
     # this variable could/should come from a PortGroup one day
     # note that gmk files go to share/Geant4/Geant4-${geant.version}.${geant.patchlevel}
@@ -216,7 +219,7 @@ foreach {geant.version geant.revision geant.datarevision geant.patchlevel geant.
         version             ${geant.version_full}
         revision            ${geant.revision}
         distfiles           ${geant.distfilename}
-        checksums           ${geant.distfilename} rmd160 ${geant.rmd160} sha256 ${geant.sha256}
+        checksums           ${geant.distfilename} rmd160 ${geant.rmd160} sha256 ${geant.sha256} size ${geant.size}
 
         cmake.out_of_source yes
         worksrcdir          geant${version}
@@ -402,13 +405,8 @@ NOTE: Use 'sudo port select geant4 ${subport}'
         }
 
         set geant.version_full_no_patch [join [lrange [split ${geant.version_full} .] 0 2] \\.]
-        livecheck.type      regex
-        if {${geant.version} == "10.4"} {
-            livecheck.url   http://geant4.cern.ch/support/download.shtml
-        } else {
-            livecheck.url   http://geant4.cern.ch/support/source_archive.shtml
-        }
         # http://geant4.cern.ch/support/source/geant4.xx.xx[.pxx].tar.gz
+        livecheck.url       ${geant.livecheck_url}
         livecheck.regex     geant(${geant.version_full_no_patch}(\\.\[bp\]\[0-9\]+)?)\\.tar\\.gz
     }
 }


### PR DESCRIPTION
#### Description

Apart from updating geant4.10.4 this attempts to fix livecheck. I tried to use a trick to add a livecheck in a table, but this doesn't work. If anyone has an idea how to fix this, I would like to fix it, else I'll drop the idea and solve it with "if-elseif-elseif-...".

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? (yes, but `make test` fails for 4.10.4 for a mysterious reason)
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
