### PR TITLE
xorg-libXfont2: Fix build on OSX10.6

### DIFF
--- a/x11/xorg-libXfont2/Portfile
+++ b/x11/xorg-libXfont2/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       snowleopard_fixes 1.0
 
 name            xorg-libXfont2
 version         2.0.3
@@ -21,7 +22,7 @@ checksums       rmd160  0342f0c1264559ac6ab5a21ed200b4ae9d6d8d41 \
                 size    497085
 
 use_bzip2       yes
-
+snowleopard_fixes.addheader yes
 use_parallel_build  yes
 
 depends_build \


### PR DESCRIPTION
#### Description

xorg-libXfont2: Fix build on OSX10.6

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?