### PR TITLE
wxgtk-3.0: accept '-stdlib=' option

### DIFF
--- a/graphics/wxWidgets-3.0/files/patch-configure.diff
+++ b/graphics/wxWidgets-3.0/files/patch-configure.diff
@@ -1,4 +1,5 @@
-This patch is needed for GTK to make sure that the port finds the right OpenGL library
+The first patch is needed for GTK to make sure that the port finds the right OpenGL library
+The second patch is for https://trac.macports.org/ticket/57092
 --- configure.orig
 +++ configure
 @@ -22047,48 +22047,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
@@ -51,3 +52,15 @@ This patch is needed for GTK to make sure that the port finds the right OpenGL l
  
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libraries directories" >&5
  $as_echo_n "checking for libraries directories... " >&6; }
+@@ -39278,6 +39242,11 @@ while test ${D}# -gt 0; do
+         args="${D}{args} ${D}1"
+         ;;
+
++       -stdlib*)
++        # collect these options
++        args="${D}{args} ${D}1"
++        ;;
++
+        -dynamiclib|-bundle)
+         linking_flag="${D}1"
+         ;;


### PR DESCRIPTION
#### Description

For details see https://trac.macports.org/ticket/57092

I would prefer if someone else (like @kencu) would check and test this patch first. I also asked @vslavik to try to fix it upstream (I wasn't sure where upstream of this file was), once that is done, we need an upstream fix in wxWidgets as well.

We probably also need to fix `wxgtk-3.2` and fix dependency on `webkit-gtk` (either always disable or always enable it) as a separate task.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->