### PR TITLE
py-pyhamcrest: new port as a dependency of py-twisted

### DIFF
--- a/python/py-pyhamcrest/Portfile
+++ b/python/py-pyhamcrest/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyhamcrest
+version             1.9.0
+platforms           darwin
+license             BSD
+maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+
+description         Hamcrest framework for matcher objects
+long_description    ${description}
+
+homepage            https://github.com/hamcrest/PyHamcrest
+master_sites        pypi:P/PyHamcrest
+distname            PyHamcrest-${version}
+
+checksums           rmd160  f5fa85ec3e29c3ec41e28ae8e690700fbf2025a1 \
+                    sha256  8ffaa0a53da57e89de14ced7185ac746227a8894dbd5a3c718bf05ddbd1d56cd \
+                    size    376623
+
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}

--- a/python/py-twisted/Portfile
+++ b/python/py-twisted/Portfile
@@ -5,7 +5,7 @@ PortGroup  python 1.0
 
 name                py-twisted
 version             18.7.0
-#revision            0
+revision            1
 categories-append   devel net
 license             MIT
 platforms           darwin
@@ -29,7 +29,7 @@ checksums           rmd160  97c7052cbad9d4a48eadccee974b5f19f4b3a64f \
                     sha256  95ae985716e8107816d8d0df249d558dbaabb677987cc2ace45272c166b267e4 \
                     size    3063847
 
-python.versions 27 35 36
+python.versions 27 35 36 37
 
 if {${name} ne ${subport}} {
     # uses "from pkg_resources import load_entry_point"
@@ -39,6 +39,8 @@ if {${name} ne ${subport}} {
         port:py${python.version}-incremental \
         port:py${python.version}-hyperlink \
         port:py${python.version}-constantly
+    depends_run-append \
+        port:py${python.version}-pyhamcrest
 
     post-destroot {
         # update the plugin cache


### PR DESCRIPTION
#### Description

While trying to install buildbot slave I discovered a problem that prevented me from running the build slave:
```
pkg_resources.DistributionNotFound: The 'PyHamcrest>=1.9.0' distribution was not found and is required by Twisted
```

See: https://github.com/twisted/twisted/blob/trunk/src/twisted/python/_setup.py#L241

Questions:
* Not sure about what the best name should be for pyhamcrest. The upstream name is `PyHamcrest`.
* Not sure whether to remove 3.4 support from `py-twisted` or to add it to `py-hamcrest`. Other dependencies are missing in order to be able to add `py37-twisted`.
* There might be other dependencies missing (automat, attrs).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->