### PR TITLE
postgresql10*: version bump to 10.5

### DIFF
--- a/databases/postgresql10-doc/Portfile
+++ b/databases/postgresql10-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql10-doc
 conflicts           postgresql92-doc postgresql93-doc postgresql94-doc \
                     postgresql95-doc postgresql96-doc
-version             10.4
+version             10.5
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql10
 
-checksums           rmd160  0a9246b31ae9786e9f7e486b66ebabb6fd8fd4bf \
-                    sha256  1b60812310bd5756c62d93a9f93de8c28ea63b0df254f428cd1cf1a4d9020048 \
-                    size    20201838
+checksums           rmd160  2427223152e54ba048b3881380091530f4887b58 \
+                    sha256  6c8e616c91a45142b85c0aeb1f29ebba4a361309e86469e0fb4617b6a73c4011 \
+                    size    20284578
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql10-server/Portfile
+++ b/databases/postgresql10-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql10-server
-version             10.4
+version             10.5
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql10/Portfile
+++ b/databases/postgresql10/Portfile
@@ -7,7 +7,7 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql10
-version             10.4
+version             10.5
 
 categories          databases
 platforms           darwin
@@ -25,9 +25,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  0a9246b31ae9786e9f7e486b66ebabb6fd8fd4bf \
-                    sha256  1b60812310bd5756c62d93a9f93de8c28ea63b0df254f428cd1cf1a4d9020048 \
-                    size    20201838
+checksums           rmd160  2427223152e54ba048b3881380091530f4887b58 \
+                    sha256  6c8e616c91a45142b85c0aeb1f29ebba4a361309e86469e0fb4617b6a73c4011 \
+                    size    20284578
 
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

Update postgresql10, postgresql10-doc and postgresql10-server to 10.5, latest upstream stable release.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

I didn't test _all_ binary files (there are 34 of them), but I did test the main ones (spinning up the DB server, connecting to it with psql and running some queries, running vacuumdb, and running pg_upgrade to migrate an old 9.4 cluster, which internally runs pg_dump and pg_restore), and all appears well.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
