### PR TITLE
llvm-7.0: fix build on 10.6

### DIFF
--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -268,6 +268,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
         # libfuzzer uses TLS, so disable it on Snow Leopard and earlier
 	configure.args-append \
 	    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
+
+        # XRAY uses TLS, so disable it on Snow Leopard and earlier
+	configure.args-append \
+	    -DCOMPILER_RT_BUILD_XRAY=OFF
     }
 } elseif {${subport} eq "lldb-${llvm_version}"} {
     #select.group        lldb

--- a/lang/llvm-7.0/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
+++ b/lang/llvm-7.0/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
@@ -65,6 +65,28 @@ index fa81ce974ec..1e86f820437 100644
  
  using namespace llvm;
  
--- 
-2.17.1 (Apple Git-112)
+--- a/tools/llvm-readobj/ObjDumper.cpp.orig	2018-09-03 23:25:13.000000000 -0700
++++ b/tools/llvm-readobj/ObjDumper.cpp	2018-09-03 23:26:25.000000000 -0700
+@@ -27,6 +27,20 @@
+ ObjDumper::~ObjDumper() {
+ }
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
+ static void printAsPrintable(raw_ostream &W, const uint8_t *Start, size_t Len) {
+   for (size_t i = 0; i < Len; i++)
+     W << (isPrint(Start[i]) ? static_cast<char>(Start[i]) : '.');
+
 


### PR DESCRIPTION
also fixes build of clang-7.0

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 

built with clang-3.9 configured with LibcxxOnOlderSystems
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
