### PR TITLE
py-awscli: add bash and zsh completion variants

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-awscli
 version             1.15.16
+revision            1
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
@@ -50,6 +51,24 @@ if {${name} ne ${subport}} {
         reinplace \
             "s,@PYTHON_BRANCH@,${python.branch},g" \
              ${worksrcpath}/${subport}
+    }
+
+    post-destroot {
+        # bash completion
+        set bash_compl_path ${prefix}/etc/bash_completion.d
+        xinstall -d ${destroot}${bash_compl_path}
+        xinstall -m 0644 ${worksrcpath}/bin/aws_bash_completer \
+            ${destroot}${bash_compl_path}/aws_bash_completer-${python.branch}
+    }
+
+    variant zsh_completion {
+        post-destroot {
+            set zsh_compl_path ${prefix}/share/zsh/site-functions
+            xinstall -d ${destroot}${zsh_compl_path}
+            xinstall -m 0644 ${worksrcpath}/bin/aws_zsh_completer.sh \
+                ${filespath}/_aws \
+                ${destroot}${zsh_compl_path}
+        }
     }
 
     livecheck.type      none

--- a/python/py-awscli/files/_aws
+++ b/python/py-awscli/files/_aws
@@ -1,0 +1,6 @@
+#compdef aws
+_aws () {
+    local e
+    e=$(dirname ${funcsourcetrace[1]%:*})/aws_zsh_completer.sh
+    if [[ -f $e ]]; then source $e; fi
+}


### PR DESCRIPTION
#### Description

Add bash_completion and zsh_completion variants.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->