### PR TITLE
borgbackup: add fuse variant

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                borgbackup
 version             1.1.7
+revision            1
 categories          sysutils
 platforms           darwin
 license             BSD
@@ -36,6 +37,7 @@ depends_build-append    port:py${python.version}-setuptools_scm \
                         port:py${python.version}-sphinx_rtd_theme
 depends_lib-append      path:lib/libssl.dylib:openssl \
                         port:lz4 \
+                        port:py${python.version}-llfuse \
                         port:py${python.version}-msgpack \
                         port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

Add a fuse variant that installs the py-llfuse dependency. [Upstream recommends installing it as a requirement](https://github.com/borgbackup/borg/blob/master/setup.py#L56), but it seems that fa21d92 removed it from the port. I've added it as a variant, which seems like a decent compromise, though I'm interested to know why it was originally removed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.5
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->