### PR TITLE
py-autopep8: update to 1.4

### DIFF
--- a/python/py-autopep8/Portfile
+++ b/python/py-autopep8/Portfile
@@ -5,9 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-autopep8
-set realname        autopep8
-version             1.3.5
-revision            1
+version             1.4
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -23,28 +21,28 @@ long_description    autopep8 automatically formats Python code to \
                     capable of fixing most of the formatting issues \
                     that can be reported by pycodestyle.
 
-homepage            https://pypi.python.org/pypi/${realname}
+homepage            https://github.com/hhatto/autopep8
 
-master_sites        pypi:a/${realname}
-distname            ${realname}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5     9d0dfe251d003edb8f6a95dc4929b7b7 \
-                    rmd160  98c2eeb12ae464628d0b1e2ae5ba090be11ee94b \
-                    sha256  2284d4ae2052fedb9f466c09728e30d2e231cfded5ffd7b1a20c34123fdc4ba4 \
-                    size    109415
+checksums           rmd160  faadbda8660fe14c088533a062dc53851601df42 \
+                    sha256  655e3ee8b4545be6cfed18985f581ee9ecc74a232550ee46e9797b6fbf4f336d \
+                    size    107925
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append    port:py${python.version}-setuptools
-    depends_run-append    port:${realname}_select \
+
+    depends_run-append    port:${python.rootname}_select \
                           port:py${python.version}-codestyle
 
     test.run              yes
     test.cmd              ${python.bin} setup.py
 
-    select.group          ${realname}
-    select.file           ${filespath}/${realname}-${python.version}
+    select.group          ${python.rootname}
+    select.file           ${filespath}/${python.rootname}-${python.version}
     notes "
 To make the Python ${python.branch} version of autopep8 the one that is run\
 when you execute the commands without a version suffix, e.g. 'autopep8', run:
@@ -53,6 +51,4 @@ when you execute the commands without a version suffix, e.g. 'autopep8', run:
 "
 
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- update to latest version
- make use of python.rootname variable
- modernize checksums and update homepage
- use default PyPI livecheck

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
