### PR TITLE
istioctl: new port submission (1.0.2)

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                istioctl
+
+github.setup        istio istio 1.0.2
+categories          sysutils
+platforms           darwin
+supported_archs     x86_64
+license             Apache-2
+
+maintainers         {vmware.com:nnikolay @nickolaev} openmaintainer
+
+description         Istio command line configuration utility
+long_description    Istio is an open, platform-independent service mesh designed \
+                    to manage communications between microservices and applications. \
+                    Without requiring changes to the underlying services, Istio \
+                    provides automated baseline traffic resilience, service metrics \
+                    collection, distributed tracing, traffic encryption, protocol \
+                    upgrades, and advanced routing functionality for all \
+                    service-to-service communication. \
+                    The port deploys the istioctl command line utility, \
+                    used to create, list, modify, and delete configuration \
+                    resources in a deployed Istio system.
+
+set goproj          istio.io/${github.project}
+
+depends_build       port:go
+use_configure       no
+worksrcdir          src/${goproj}
+
+checksums           rmd160  b6c61241b682a1b7f5676de60f3a4387bc057967 \
+                    sha256  12dc01cff8ebb335a08c62c9da95f9c71364d9dfab9c0c0baa5245f17202b057 \
+                    size    18824606
+
+post-extract {
+    xinstall -d ${workpath}/src/istio.io
+    move ${workpath}/${github.project}-${github.version} \
+        ${worksrcpath}
+}
+
+build {
+    system -W ${worksrcpath} "GOPATH=${workpath} \
+    TAG=${github.version} make istioctl"
+}
+
+
+destroot {
+    xinstall ${workpath}/out/darwin_amd64/release/istioctl ${destroot}${prefix}/bin/istioctl
+}


### PR DESCRIPTION
This port builds and installs the istioctl utility.

#### Description

Adding a new Portfile for istioctl CLI utility. The source code is downloaded and installed from the 1.0.2 release archive.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G2208
Xcode 9.4.1 9F2000

###### Verification

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
