### PR TITLE
py-kivy: Fix patch-setup.py.diff to be compatible with version 1.10.1

### DIFF
--- a/python/py-kivy/files/patch-setup.py.diff
+++ b/python/py-kivy/files/patch-setup.py.diff
@@ -1,5 +1,5 @@
 --- setup.py.orig	2018-09-06 11:16:50.000000000 -0700
-+++ setup.py	2018-09-06 11:16:47.000000000 -0700
++++ setup.py	2018-09-18 10:29:16.000000000 -0700
 @@ -152,7 +152,7 @@
  c_options['use_egl'] = False
  c_options['use_opengl_es2'] = None
@@ -18,15 +18,12 @@
          # check the existence of frameworks
          sdl2_valid = True
          sdl2_flags = {
-@@ -1101,11 +1101,6 @@
-             ('Topic :: Software Development :: Libraries :: '
-              'Application Frameworks'),
-             'Topic :: Software Development :: User Interfaces'],
--        dependency_links=[
--            'https://github.com/kivy-garden/garden/archive/master.zip'],
--        install_requires=[
+@@ -1104,7 +1104,7 @@
+         dependency_links=[
+             'https://github.com/kivy-garden/garden/archive/master.zip'],
+         install_requires=[
 -            'Kivy-Garden>=0.1.4', 'docutils', 'pygments'
--        ],
++            'docutils', 'pygments'
+         ],
          extra_requires={
              'tuio': ['oscpy']
-         },

--- a/python/py-kivy/files/patch-setup.py.diff
+++ b/python/py-kivy/files/patch-setup.py.diff
@@ -1,6 +1,6 @@
---- setup.py.orig	2017-05-09 10:51:19.000000000 +0300
-+++ setup.py	2017-05-09 10:58:01.000000000 +0300
-@@ -140,7 +140,7 @@
+--- setup.py.orig	2018-09-06 11:16:50.000000000 -0700
++++ setup.py	2018-09-06 11:16:47.000000000 -0700
+@@ -152,7 +152,7 @@
  c_options['use_egl'] = False
  c_options['use_opengl_es2'] = None
  c_options['use_opengl_mock'] = environ.get('READTHEDOCS', None) == 'True'
@@ -9,7 +9,7 @@
  c_options['use_ios'] = False
  c_options['use_mesagl'] = False
  c_options['use_x11'] = False
-@@ -438,7 +438,7 @@
+@@ -451,7 +451,7 @@
          platform not in ('android',) and c_options['use_sdl2'] is None):
  
      sdl2_valid = False
@@ -18,13 +18,15 @@
          # check the existence of frameworks
          sdl2_valid = True
          sdl2_flags = {
-@@ -1052,9 +1052,6 @@
+@@ -1101,11 +1101,6 @@
              ('Topic :: Software Development :: Libraries :: '
               'Application Frameworks'),
              'Topic :: Software Development :: User Interfaces'],
 -        dependency_links=[
 -            'https://github.com/kivy-garden/garden/archive/master.zip'],
--        install_requires=['Kivy-Garden>=0.1.4', 'docutils', 'pygments'],
-         setup_requires=[
-             'cython>=' + MIN_CYTHON_STRING
-         ] if not skip_cython else [])
+-        install_requires=[
+-            'Kivy-Garden>=0.1.4', 'docutils', 'pygments'
+-        ],
+         extra_requires={
+             'tuio': ['oscpy']
+         },


### PR DESCRIPTION
#### Description
There were changes to `setup.py` in the latest version bump. The patch didn't get updated to reflect these changes.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
