### PR TITLE
py-scrapy, py-twisted: move 3.4 to graveyard

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -383,6 +383,7 @@ py-rope                 0.9.4_1     25 26 33
 py-roundup              1.4.21_1    26
 py-scientific           2.9.4_3     26
 py-scipy                1.1.0_1     26 33
+py-scrapy               1@1.5.0_1   34
 py-scgi                 1.14_1      26
 py-scikit-image         0.11.3_1    26 32 33
 py-scikit-learn         0.19.1_1    26 33

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -449,6 +449,7 @@ py-tvdb                 1.9_1       26
 py-tvnamer              2.3_1       26
 py-typing               3.6.4_1     33
 py-twill                0.9_1       26
+py-twisted              18.7.0_1    34
 py-tz                   2018.5_1    26 33
 py-uncertainties        2.4.6.1_1   26 33
 py-unidecode            0.04.20     33 34

--- a/python/py-scrapy/Portfile
+++ b/python/py-scrapy/Portfile
@@ -24,7 +24,7 @@ master_sites            https://files.pythonhosted.org/packages/source/S/Scrapy/
 checksums               rmd160  083f584cbe11a9382eef6314829f891f3b2a3b9d \
                         sha256  31a0bf05d43198afaf3acfb9b4fb0c09c1d7d7ff641e58c66e36117f26c4b755
 
-python.versions 27 34 35 36
+python.versions 27 35 36
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-twisted/Portfile
+++ b/python/py-twisted/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  97c7052cbad9d4a48eadccee974b5f19f4b3a64f \
                     sha256  95ae985716e8107816d8d0df249d558dbaabb677987cc2ace45272c166b267e4 \
                     size    3063847
 
-python.versions 27 34 35 36
+python.versions 27 35 36
 
 if {${name} ne ${subport}} {
     # uses "from pkg_resources import load_entry_point"


### PR DESCRIPTION
#### Description

Based on discussion in #2516 I'm attempting to move the two 3.4 subports to graveyard.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? (see #2516)
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->