### PR TITLE
ghostscript: fix regression from 9.24

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -5,6 +5,7 @@ PortGroup           muniversal 1.0
 
 name                ghostscript
 version             9.24
+revision            1
 categories          print
 license             AGPL-3 BSD
 maintainers         nomaintainer
@@ -27,7 +28,10 @@ distfiles           ${distname}.tar.gz:source \
                     ghostscript-fonts-std-8.11.tar.gz:fonts \
                     ${mappingresources_commit}.zip:misc
 
-patchfiles          patch-base_unix-dll.mak.diff
+patchfiles          patch-base_unix-dll.mak.diff \
+                    patch-upstream-c8c01f8c4164.diff \
+                    patch-upstream-13418541a5ae.diff
+
 
 checksums           ${distname}.tar.gz \
                     rmd160  8489da8a20c11f525f7f325943ffe677926fe13a \

--- a/print/ghostscript/files/patch-upstream-13418541a5ae.diff
+++ b/print/ghostscript/files/patch-upstream-13418541a5ae.diff
@@ -1,0 +1,54 @@
+From 13418541a5ae19b15f51cbb87faf344902f5af98 Mon Sep 17 00:00:00 2001
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Thu, 6 Sep 2018 18:40:05 +0100
+Subject: [PATCH] Bug 699722 (2): add wildcards to the permissions paths.
+
+The temp and ICC profile paths need to finish with wildcards to work correctly.
+---
+ Resource/Init/gs_init.ps | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Resource/Init/gs_init.ps b/Resource/Init/gs_init.ps
+index 83918a9..5ff9f63 100644
+--- Resource/Init/gs_init.ps.orig
++++ Resource/Init/gs_init.ps
+@@ -2034,7 +2034,7 @@ readonly def
+     <<
+       /PermitFileReading [
+         currentuserparams /PermitFileReading get aload pop
+-        //tempfilepaths aload pop
++        [//tempfilepaths aload pop] (*) .generate_dir_list_templates
+         /FONTPATH .systemvar (*) .generate_dir_list_templates
+           % Library files :
+         /LIBPATH  .systemvar (*) .generate_dir_list_templates
+@@ -2049,15 +2049,15 @@ readonly def
+           [ currentsystemparams /GenericResourceDir get] (*) .file_name_separator (*)
+             concatstrings concatstrings .generate_dir_list_templates
+         } if
+-        currentuserparams /ICCProfilesDir known {currentuserparams /ICCProfilesDir get} if
++        currentuserparams /ICCProfilesDir known {[currentuserparams /ICCProfilesDir get] (*) .generate_dir_list_templates} if
+       ]
+       /PermitFileWriting [
+           currentuserparams /PermitFileWriting get aload pop
+-          //tempfilepaths aload pop
++          [//tempfilepaths aload pop] (*) .generate_dir_list_templates
+       ]
+       /PermitFileControl [
+           currentuserparams /PermitFileControl get aload pop
+-          //tempfilepaths aload pop
++          [//tempfilepaths aload pop] (*) .generate_dir_list_templates
+       ]
+       /LockFilePermissions //true
+     >> setuserparams
+@@ -2140,7 +2140,7 @@ SAFER { .setsafeglobal } if
+   /.setshapealpha            % transparency-example.ps
+   /.endtransparencygroup     % transparency-example.ps
+   /.setdotlength             % Bug687720.ps
+-  /.sort /.setdebug /.mementolistnewblocks /getenv
++  /.sort /.mementolistnewblocks /getenv
+ 
+   /.makeoperator /.setCPSImode              % gs_cet.ps, this won't work on cluster with -dSAFER
+ 
+-- 
+2.9.1
+

--- a/print/ghostscript/files/patch-upstream-c8c01f8c4164.diff
+++ b/print/ghostscript/files/patch-upstream-c8c01f8c4164.diff
@@ -1,0 +1,42 @@
+From c8c01f8c4164bc10281d9e8f87cf96314d93104b Mon Sep 17 00:00:00 2001
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Thu, 6 Sep 2018 14:08:41 +0100
+Subject: [PATCH] Bug 699722: Add the ICCProfilesDir to the PermitReading list
+
+There was also an issue that the string being returned from the graphics
+library was null terminated, and Postscript strings are not (and Ghostscript
+strings are not necessarily). We leave the null termination in place, but
+reduce the length returned by 1.
+---
+ Resource/Init/gs_init.ps | 1 +
+ base/gsicc_manage.c      | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Resource/Init/gs_init.ps b/Resource/Init/gs_init.ps
+index bc8b795..83918a9 100644
+--- Resource/Init/gs_init.ps.orig
++++ Resource/Init/gs_init.ps
+@@ -2049,6 +2049,7 @@ readonly def
+           [ currentsystemparams /GenericResourceDir get] (*) .file_name_separator (*)
+             concatstrings concatstrings .generate_dir_list_templates
+         } if
++        currentuserparams /ICCProfilesDir known {currentuserparams /ICCProfilesDir get} if
+       ]
+       /PermitFileWriting [
+           currentuserparams /PermitFileWriting get aload pop
+diff --git a/base/gsicc_manage.c b/base/gsicc_manage.c
+index 69f05c4..ff685e7 100644
+--- base/gsicc_manage.c.orig
++++ base/gsicc_manage.c
+@@ -2972,7 +2972,7 @@ gs_currenticcdirectory(const gs_gstate * pgs, gs_param_string * pval)
+         pval->persistent = true;
+     } else {
+         pval->data = (const byte *)(lib_ctx->profiledir);
+-        pval->size = lib_ctx->profiledir_len;
++        pval->size = lib_ctx->profiledir_len - 1;
+         pval->persistent = false;
+     }
+ }
+-- 
+2.9.1
+


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/57100

#### Description

Adds a few upstream commits to fix a relatively serious regression since version 9.23.
Patches picked up based on https://bugs.ghostscript.com/show_bug.cgi?id=699722

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
