### PR TITLE
amtk: use gobject_introspection portgroup, rebuild

### DIFF
--- a/gnome/amtk/Portfile
+++ b/gnome/amtk/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gobject_introspection 1.0
 
 name                amtk
 version             5.0.0
+revision            1
 license             GPL-2.1+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         ${name} is a companion library to GLib and Gtk+.
@@ -25,14 +27,13 @@ checksums           rmd160  e5b6550a395dd43908db2b0b2e4e91a6ebaa2441 \
                     sha256  12a996978a30b7b69a810ac0c5656d5cf2f58d9787b98a0c028ff1b64e8f31ff \
                     size    368524
 
-depends_build-append \
-                    port:pkgconfig \
-                    port:gobject-introspection
+depends_build       port:pkgconfig
 
 depends_lib-append  port:gtk3
 
+gobject_introspection yes
+
 configure.args-append \
-                    --enable-introspection \
                     --disable-dependency-tracking \
                     --disable-silent-rules
 


### PR DESCRIPTION
The PortGroup declares gobject-introspection as depends_lib
since it installs basic typelib dependencies required
at run time. Rebuild to pick up the dependency change.

Closes: https://trac.macports.org/ticket/56931.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
