### PR TITLE
Update py-regions to v0.3

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -374,6 +374,7 @@ py-rabbyt               0.8.3_1     26
 py-raven                5.32.0_1    33
 py-rdflib               4.2.2_1     26 33 34
 py-redis                2.10.6_1    26 33
+py-regions              0.3         34
 py-reproject            0.4         34
 py-requests             2.16.5_1    26
 py-requests-unixsocket  0.1.5_1     26

--- a/python/py-regions/Portfile
+++ b/python/py-regions/Portfile
@@ -7,7 +7,7 @@ set _name           regions
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.2
+version             0.3
 categories-append   science
 platforms           darwin
 maintainers         {gmail.com:Deil.Christoph @cdeil} openmaintainer
@@ -19,12 +19,12 @@ homepage            https://github.com/astropy/regions
 master_sites        pypi:${_n}/${_name}/
 distname            ${_name}-${version}
 
-checksums           md5     48597dc17906e478292040dae2df5596 \
-                    rmd160  06d84c11af473fee0e6816c8fb2b692df8e811fa \
-                    sha256  980b8091d935484dde5907ff1631f624c5c0b99f5c1790c6c7879bb1f4d51009
+checksums           md5     b2f0b08cdaa2b40519de665f9af2a25a \
+                    rmd160  59106aea117ad23b7c67dc6064802980d30b5752 \
+                    sha256  ec98751880020a3e0c861e43412c750240576b09882bd71cdeb67dbcb0ed7618
 
 
-python.versions     27 34 35 36
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
 
@@ -36,11 +36,8 @@ if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools
 
     depends_run-append    port:py${python.version}-numpy \
-                          port:py${python.version}-astropy
+                          port:py${python.version}-astropy \
+                          port:py${python.version}-astropy-healpix
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   [lindex ${master_sites} 0]
-    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
 }


### PR DESCRIPTION
This PR updates `py-regions` to v0.3.

https://pypi.org/project/regions/0.3/

I didn't do any tests locally, I no longer have Macports installed.