### PR TITLE
Remove cdeil as maintainer of py-iminuit

### DIFF
--- a/python/py-iminuit/Portfile
+++ b/python/py-iminuit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 name                py-iminuit
 version             1.2
-maintainers         {gmail.com:Deil.Christoph @cdeil} openmaintainer
+maintainers         nomaintainer
 
 dist_subdir         ${name}/${version}
 


### PR DESCRIPTION
I'm not using Macports anymore, so removing myself as maintainer here.

Just to note: the recent iminuit 1.3 releases changed from Numpy as a runtime dependency to Numpy as a build dependency (link against Numpy):
https://pypi.org/project/iminuit/#history
So if someone tries to update to 1.3, it might or might not be trivial to configure that via the Portfile.