### PR TITLE
vtk: Add hdf5/mpi variants and update version

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
+PortGroup           mpi 1.0
 PortGroup           muniversal 1.0
 
 name                vtk
-version             7.1.1
+version             8.1.1
 revision            0
 categories          graphics devel
 platforms           darwin
@@ -26,20 +27,24 @@ master_sites        http://www.vtk.org/files/release/${branch}
 
 distname            VTK-${version}
 
-checksums           rmd160  bfc1baf925ba1f497f14a4576fd0a7956ee42d29 \
-                    sha256  2d5cdd048540144d821715c718932591418bb48f5b6bb19becdae62339efa75a
+checksums           rmd160  aa711fbd3e7e8a60b300b0045233fdfe0110d7d7 \
+                    sha256  71a09b4340f0a9c58559fe946dc745ab68a866cf20636a41d97b6046cb736324 \
+                    size    33482287
 
 cmake.out_of_source yes
+mpi.setup 
 
 configure.args-delete \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
 
 configure.args-append \
                     ../${distname}/ \
+                    -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_EXAMPLES:BOOL=OFF \
                     -DVTK_WRAP_PYTHON:BOOL=OFF \
                     -DVTK_WRAP_JAVA:BOOL=OFF \
-                    -DVTK_WRAP_TCL:BOOL=OFF
+                    -DVTK_WRAP_TCL:BOOL=OFF \
+                    -DVTK_USE_COCOA=ON
 
 # As proposed at #46890
 if {${os.major} <= 10} {
@@ -87,6 +92,25 @@ variant python36 conflicts python27 python35 description {Add Python 3.6 support
                         -DVTK_WRAP_PYTHON:BOOL=ON \
                         -DPYTHON_EXECUTABLE:STRING=${prefix}/bin/python3.6 \
                         -DVTK_INSTALL_PYTHON_MODULE_DIR=${frameworks_dir}/Python.framework/Versions/3.6/lib/python3.6/site-packages
+}
+
+variant hdf5 description {Add hdf5 readers} {
+    depends_lib-append port:hdf5 port:boost port:netcdf-cxx
+    configure.args-append \
+    -DVTK_USE_SYSTEM_HDF5=ON \
+    -DVTK_USE_SYSTEM_NETCDF=ON \
+    -DNETCDF_DIR=${prefix} \
+    -DBOOST_ROOT=${prefix} \
+    -DModule_vtkIOXdmf2:BOOL=ON \
+    -DModule_vtkxdmf2:BOOL=ON \
+    -DModule_vtkxdmf3:BOOL=ON \
+    -DModule_vtkIOXdmf3:BOOL=ON 
+    
+    mpi.enforce_variant hdf5
+}
+
+if {[mpi_variant_isset]} {
+    configure.args-append -DVTK_Group_MPI:BOOL=ON
 }
 
 if {![variant_isset python35] && ![variant_isset python36]} {


### PR DESCRIPTION
#### Description
I added more flexibility allowing to select `hdf5` variant that compiles `xdmf` readers. Moreover I also added MPI capability.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
