### PR TITLE
Golang portgroup & portfile generator

### DIFF
--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -1,0 +1,126 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# This PortGroup accommodates golang projects hosted at GitHub.
+#
+# Usage:
+#
+# PortGroup     golang 1.0
+#
+# github.setup  author project 1.0.0 v
+#
+# go.vendors    github.com/dep1/foo abcdef123456... \
+#               github.com/dep2/bar fedcba654321...
+#
+# checksums-append \
+#               dep1-foo-${foo.version}.tar.gz \
+#                   rmd160 abcdef123456... \
+#                   sha256 fedcba654321... \
+#                   size   1234 \
+#               dep2-bar-${bar.version}.tar.gz \
+#                   rmd160 abcdef123456... \
+#                   sha256 fedcba654321... \
+#                   size   4321
+#
+# The go.vendors option expects a list with 2-tuples consisting of package ID
+# and git SHA1.
+#
+# The list of vendors can be found in the Gopkg.lock, glide.lock, etc. file in
+# the upstream source code. The go2port tool (install via MacPorts) can be used
+# to generate a skeleton portfile with precomputed go.vendors and
+# checksums-append values.
+
+PortGroup               github 1.0
+
+options go.bin go.vendors
+
+default go.bin          {${prefix}/bin/go}
+default go.vendors      {}
+
+default platforms       darwin
+
+default use_configure   no
+default dist_subdir     go
+
+default depends_build   port:go
+
+set gopath              ${workpath}/gopath
+default worksrcdir      {${gopath}/src/github.com/${github.author}/${github.project}}
+
+default build.cmd       {"${go.bin} build"}
+build.args
+build.target
+default build.env       {"GOPATH=${gopath} CC=${configure.cc}"}
+
+# go.vendors name1 ver1 name2 ver2...
+# When a Gopkg.lock, glide.lock, etc. is present use go2port to generate values
+set go.vendors._internal {}
+option_proc go.vendors handle_go_vendors
+proc handle_go_vendors {option action {value ""}} {
+    global go.vendors._internal
+    if {${action} eq "set"} {
+        foreach {imp_name vers} ${value} {
+            set vlist [split ${imp_name} /]
+
+            set vdomain [lindex ${vlist} 0]
+            set vuser [lindex ${vlist} 1]
+            set vname [lindex ${vlist} 2]
+
+            switch -exact ${vdomain} {
+                github.com { set ghuser ${vuser} }
+                golang.org { set ghuser golang }
+                gopkg.in {
+                    if {$vname eq ""} {
+                        set vname [regsub -- \\..*$ ${vuser} ""]
+                        set ghuser go-${vname}
+                    } else {
+                        set vname [regsub -- \\..*$ ${vname} ""]
+                        set ghuser ${vuser}
+                    }
+                }
+            }
+
+            # Need to use the 7-character SHA-1 suffix later to identify
+            # the package when moving into the GOPATH, because the vuser
+            # here may be wrong (renamed on GitHub, etc.).
+            set sha1_short [string range ${vers} 0 6]
+            lappend go.vendors._internal [list ${sha1_short} ${imp_name} ${vers}]
+
+            global ${vname}.version
+            set ${vname}.version ${vers}
+
+            set fname ${ghuser}-${vname}
+            master_sites-append https://github.com/${ghuser}/${vname}/tarball/${vers}:${fname}
+            distfiles-append    ${fname}-${vers}.tar.gz:${fname}
+        }
+    }
+}
+
+# Setup build sources in GOPATH style:
+#   workpath/
+#       gopath/src/github.com/
+#           author1/project1/
+#           author2/project2/
+#             :
+post-extract {
+    file mkdir ${gopath}/src/github.com/${github.author}
+    move [glob ${workpath}/${github.author}-${github.project}-*] ${worksrcpath}
+
+    foreach vlist ${go.vendors._internal} {
+        set sha1_short [lindex ${vlist} 0]
+        set imp_name [lindex ${vlist} 1]
+        file mkdir ${gopath}/src/[file dirname ${imp_name}]
+        move [glob ${workpath}/*-${sha1_short}] ${gopath}/src/${imp_name}
+    }
+}
+
+destroot {
+    ui_error "No destroot phase in the Portfile!"
+    ui_msg "Here is an example destroot phase:"
+    ui_msg
+    ui_msg "destroot {"
+    ui_msg {    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/}
+    ui_msg "}"
+    ui_msg
+    ui_msg "Please check if there are additional files (configuration, documentation, etc.) that need to be installed."
+    error "destroot phase not implemented"
+}

--- a/sysutils/go2port/Portfile
+++ b/sysutils/go2port/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-github.setup        amake go2port 66629b0a45b49873a9554807e2c5426fa02fe3bb
+go.setup            github.com/amake/go2port 66629b0a45b49873a9554807e2c5426fa02fe3bb
 version             20180911
 categories          sysutils macports
 platforms           darwin
@@ -14,7 +14,7 @@ description         A go tool for creating MacPorts portfiles
 
 long_description    ${description}
 
-checksums           go2port-${github.version}.tar.gz \
+checksums           ${distname}${extract.suffix} \
                         rmd160  3256147a10337a3bf5c83cc468d7e6ffb9343584 \
                         sha256  110b5870be1e2cb956e7e54ea68ad9165ce6167ae2688972b7306e94239cf611 \
                         size    3957

--- a/sysutils/go2port/Portfile
+++ b/sysutils/go2port/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+github.setup        amake go2port 66629b0a45b49873a9554807e2c5426fa02fe3bb
+version             20180911
+categories          sysutils macports
+platforms           darwin
+maintainers         {amake @amake} openmaintainer
+license             BSD
+
+description         A go tool for creating MacPorts portfiles
+
+long_description    ${description}
+
+checksums           go2port-${github.version}.tar.gz \
+                        rmd160  3256147a10337a3bf5c83cc468d7e6ffb9343584 \
+                        sha256  110b5870be1e2cb956e7e54ea68ad9165ce6167ae2688972b7306e94239cf611 \
+                        size    3957
+
+go.vendors          github.com/BurntSushi/toml b26d9c308763d68093482582cea63d69be07a0f0 \
+                    github.com/urfave/cli cfb38830724cc34fedffe9a2a29fb54fa9169cd1 \
+                    golang.org/x/crypto 0e37d006457bf46f9e6692014ba72ef82c33022c \
+                    gopkg.in/yaml.v2 5420a8b6744d3b0345ab293f6fcba19c978f1183
+
+checksums-append    BurntSushi-toml-${toml.version}.tar.gz \
+                        rmd160 08c91052763fa884c7d88f6b10a03bfbcdea93e8 \
+                        sha256 360c150f4ec9f5450feee0009aba9555b6731ca0bbb2ce612c3b7b9173c0d896 \
+                        size 41567 \
+                    urfave-cli-${cli.version}.tar.gz \
+                        rmd160 b54f7232fbbfda640f7d9411a5dedab3adf6a888 \
+                        sha256 94f12754129bce1d3435efd84826a73fc8af70f61f9264c60c1f554d425d503a \
+                        size 58405 \
+                    golang-crypto-${crypto.version}.tar.gz \
+                        rmd160 dc6590753cf4472777b7a35a8ceacfb9a2316091 \
+                        sha256 ab5b09609da7722997b32a55b58703e90815e8a8c28668444df62b00cac93aab \
+                        size 1638395 \
+                    go-yaml-yaml-${yaml.version}.tar.gz \
+                        rmd160 56eb283b31feac8db4ede3e24768e0f9999913d2 \
+                        sha256 34dc73c7798abfa3bb96c46c25002ccc5b92543dc3e008a31e0ae94c2528e52b \
+                        size 70231
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description

New portgroup for golang. Handles dependencies similar to the [cargo_fetch portgroup](https://github.com/macports/macports-ports/blob/master/_resources/port1.0/group/cargo_fetch-1.0.tcl). Based heavily on the [peco port](https://github.com/macports/macports-ports/blob/master/sysutils/peco/Portfile).

Also includes a new tool, go2port, for generating portfiles from golang projects. When a supported lockfile (currently glide.lock only) is present in the project, the dependency values are generated automatically.

See also discussion here:
https://lists.macports.org/pipermail/macports-dev/2018-September/039283.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
