### PR TITLE
libvirt, py-libvirt: Update to 4.7.0

### DIFF
--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  3ae29c5ca20da92e5d96a1a9a8e7bc4b5e7d6e2c \
                     size    190330
 
 python.default_version  27
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 
 if {${name} ne ${subport}} {

--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
+# Remember to update libvirt and py-libvirt at the same time.
 name                py-libvirt
-version             4.5.0
+version             4.7.0
 platforms           darwin
 license             MIT
 maintainers         {danchr @danchr} openmaintainer
@@ -20,9 +21,9 @@ homepage            http://www.libvirt.org/
 distname            libvirt-python-${version}
 master_sites        ${homepage}sources/python
 
-checksums           rmd160  672c83e2dca72e4384be32df21f67aa6c42d50a0 \
-                    sha256  ef35ed6bc24d76563b1ba9b068ef5a048016726dba62a9d057fe6dfbea6b0f60 \
-                    size    190016
+checksums           rmd160  3ae29c5ca20da92e5d96a1a9a8e7bc4b5e7d6e2c \
+                    sha256  e36fee5898de3550ed7e63d5d0a8447f9d78f06574634855dee59eae27930908 \
+                    size    190330
 
 python.default_version  27
 python.versions     27 34 35 36

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem          1.0
 
+# Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
-version             4.5.0
+version             4.7.0
 categories          sysutils
 license             LGPL-2.1+
 platforms           darwin
@@ -18,9 +19,9 @@ homepage            https://libvirt.org
 master_sites        ${homepage}/sources/
 use_xz              yes
 
-checksums           rmd160  1e777d08609ad5fedab3141b211f14e4aa221464 \
-                    sha256  e7e95edc0ca553046761ed55a8d01a06a3a3a4238bbeaedb3ba34680a277ab09 \
-                    size    14743956
+checksums           rmd160  af153b67588bc9f7a5601d0606588d90446a1537 \
+                    sha256  92c279f7321624ac5a37a81f8bbe8c8d2a16781da04c63c99c92d3de035767e4 \
+                    size    14813352
 
 depends_build       port:pkgconfig \
                     port:bash-completion \


### PR DESCRIPTION
#### Description

Update libvirt and py-libvirt to 4.7.0.

Add py37-libvirt subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
