### PR TITLE
osxfuse: update to 3.8.2

### DIFF
--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                osxfuse
 epoch               1
-version             3.8.0
+version             3.8.2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          fuse devel
 platforms           macosx
@@ -47,12 +47,12 @@ if {${kernel_arch} ne "x86_64"} {
 distfiles
 dist_subdir ${name}/${version}
 set mp.dist {
-    osxfuse     19b3fb7
-    kext        93017b5
+    osxfuse     120c6ce
+    kext        60c55dd
     framework   8b79906
     prefpane    095ba9c
-    fuse        5abbc87
-    support     587d243
+    fuse        5de6743
+    support     2cdc560
 }
 
 depends_build       port:autoconf \
@@ -73,14 +73,14 @@ if { $use_signed_kext } {
     distfiles-append ${name}-${version}.dmg
 }
 
-checksums           osxfuse-19b3fb7.tar.gz \
-                    rmd160  9f584fe05f9ba28089980d4a74f5cadcb8d8255f \
-                    sha256  0997b4a46c253dc47bd298ac68474006013a8ecc33c5171005340385fa28510b \
-                    size    32332 \
-                    kext-93017b5.tar.gz \
-                    rmd160  2ca07a81e26d5263cd0e43bdc977490bd11c665c \
-                    sha256  6679f629cc3de74b69bed52bc3a9a4834f9bd7db36c6a73ce6e29f99efae79bf \
-                    size    118892 \
+checksums           osxfuse-120c6ce.tar.gz \
+                    rmd160  50c93857d53649e6fb1bfad918f153e3de35f98f \
+                    sha256  0e83540afed7c5efa6878538e0645cc453ed2bf4ef93ce49ffa02e558e7db679 \
+                    size    32355 \
+                    kext-60c55dd.tar.gz \
+                    rmd160  7b33e3d0069f448097272b4f1fb08f21e90729ed \
+                    sha256  e0fb92ee033da07c9e60d902c0d722ea8971683a00bbdf97c390a2783481c147 \
+                    size    119156 \
                     framework-8b79906.tar.gz \
                     rmd160  d3ad907fc8ed42fb7ca5cdf08ceb8aa09ba1ec74 \
                     sha256  f08a2e063aa6b3299e4edc4cd898a557c20b6d6c85eb26cd489eb6a642d682e6 \
@@ -89,18 +89,18 @@ checksums           osxfuse-19b3fb7.tar.gz \
                     rmd160  c7794cd3d644cf1f036b248d21a83901d93187ca \
                     sha256  2426c4669aeb1c1179e5e89af46f2d9a30743f6929419c6414c7eeb8b3212fae \
                     size    5346030 \
-                    fuse-5abbc87.tar.gz \
-                    rmd160  b68cde9bbbc915e869359aa83568f65268923672 \
-                    sha256  c439c57436a623a8160658763fd768bf02c3ad54877b6ed9e1cc0c7c2bf145c9 \
-                    size    231403 \
-                    support-587d243.tar.gz \
-                    rmd160  8c304cebd0e1e35be0c4ec6626bf7b68f499b3d9 \
-                    sha256  5e708f831d63dfb38be9abf461f93863639265a47ebeab1fdef1924f0d4bf4a6 \
-                    size    3391241 \
-                    osxfuse-3.8.0.dmg \
-                    rmd160  1ad2ab21611508e541e5c61481c4ca75e6fa14c4 \
-                    sha256  4661f160e678e46d83a9a63fd0b7eb10903f688f7d37ea066c543a37781a0007 \
-                    size    6943979
+                    fuse-5de6743.tar.gz \
+                    rmd160  fdc52f04c0b345ae3ffde57a355fbb96f907f5c3 \
+                    sha256  e487fac223060caea4bbbaeca861ea35c1d99b98aac75ab393cdfbb97c72b031 \
+                    size    231697 \
+                    support-2cdc560.tar.gz \
+                    rmd160  096fc6f329f626ca63d9ec5901004173357327bd \
+                    sha256  1c65b389628d5a675d700330143c55c60854faafd791a0743a05cf310721fcf8 \
+                    size    3391234 \
+                    osxfuse-3.8.2.dmg \
+                    rmd160  2aa7fea8104f62f4f2bb7c21027a9fba3f4831d7 \
+                    sha256  03a3e561803cdf9fa797c146dc33f0ec0d665cc2bf41cf2b68b3c5b34b03b758 \
+                    size    6945638
 
 # extract phase will just extract the dmg; post-extract will expand
 # the tarballs
@@ -131,8 +131,8 @@ post-extract {
     if {${os.major} == 17 && [catch {system "/usr/bin/gen_bridge_metadata --version > /dev/null 2>&1"}]} {
         ui_msg "If building this port fails, consider applying the following workaround:"
         ui_msg ""
-        ui_msg "    cd \$(xcode-select -p)/Toolchains"
-        ui_msg "    sudo ln -s XcodeDefault.xctoolchain OSX10.13.xctoolchain"
+        ui_msg "    cd /usr/local/lib"
+        ui_msg "    sudo ln -s \$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
         ui_msg ""
         ui_msg "See https://trac.macports.org/ticket/54939 for more information."
     }
@@ -140,6 +140,12 @@ post-extract {
 
 if { ! $use_signed_kext } {
     patchfiles      patch-build.d_targets_packagemanager.sh.diff
+}
+
+patchfiles-append       patch-IDECustomDerivedData.diff
+
+post-patch {
+    reinplace "s|@@WORKSRCPATH@@|${worksrcpath}|" ${worksrcpath}/build.sh
 }
 
 use_configure   no

--- a/fuse/osxfuse/files/patch-IDECustomDerivedData.diff
+++ b/fuse/osxfuse/files/patch-IDECustomDerivedData.diff
@@ -1,0 +1,10 @@
+--- build.sh.orig	2018-09-10 15:28:54.000000000 +0800
++++ build.sh	2018-09-10 15:30:22.000000000 +0800
+@@ -353,6 +353,7 @@
+ 
+     local -a command=(/usr/bin/xcodebuild
+                       -configuration "${BUILD_TARGET_OPTION_BUILD_CONFIGURATION}"
++                      -IDECustomDerivedDataLocation="@@WORKSRCPATH@@/IDECustomDerivedData"
+                       CONFIGURATION_BUILD_DIR="`build_target_get_build_directory "${BUILD_TARGET_NAME}"`"
+                       SDKROOT="macosx${BUILD_TARGET_OPTION_SDK}"
+                       ARCHS="`array_join BUILD_TARGET_OPTION_ARCHITECTURES " "`"


### PR DESCRIPTION
#### Description

The original libclang.dylib workaround is not compatible with osxfuse
3.8.2, so I choose another way.

This version also fixes building with Xcode 10 beta.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10L232m

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?