### PR TITLE
gpsd: fix livecheck

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -168,5 +168,5 @@ if {![variant_isset xgps]} {
 }
 
 livecheck.type          regex
-livecheck.url           https://download.savannah.gnu.org/releases-noredirect/gpsd
+livecheck.url           https://download.savannah.gnu.org/releases/gpsd/
 livecheck.regex         "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
@ryandesign: Previous livecheck URL was returning 404, fixed it. On my machine I am not getting redirected after dropping `-noredirect`.