### PR TITLE
devel/boost: update to 1.68.0

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -8,12 +8,12 @@ PortGroup       active_variants 1.1
 
 name            boost
 
-version         1.66.0
+version         1.68.0
 # Revision is set below in the `if {$subport eq $name} { ... }` statement
 # The boost-numpy subport has its own revision number
-checksums       rmd160  ee5dafdfa49adf50a5333cef1f55dac4f70b4c14 \
-                sha256  5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9 \
-                size    85995778
+checksums       rmd160  39c7f40eafd4de2c12c639534ef07df8bb520df0 \
+                sha256  7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7 \
+                size    92155315
 
 license         Boost-1
 categories      devel


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2307
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? **Not supported**
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
