### PR TITLE
octave portgroup: move categories declaration to setup

### DIFF
--- a/_resources/port1.0/group/octave-1.0.tcl
+++ b/_resources/port1.0/group/octave-1.0.tcl
@@ -47,6 +47,7 @@ proc octave.setup {module version} {
     global octave.module
     octave.module               ${module}
     version                     ${version}
+    categories                  math science
 }
 
 option_proc octave.module octave.set_module
@@ -58,7 +59,6 @@ proc octave.set_module {opt action args} {
     }
 }
 
-default categories   {math science}
 default master_sites {sourceforge:octave}
 default distname     {${octave.module}-${version}}
 default worksrcdir   {${octave.module}}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/57118#ticket

`port lint` crashes when run against a number of octave packages; it seems as if "default" does not support multiple values.  This fix simply moves the declaration of categories to setup so that we don't have to use `default`.

Here are all the ports affected:

```
octave-audio
octave-benchmark
octave-bim
octave-bioinfo
octave-bsltl
octave-cgi
octave-civil-engineering
octave-communications
octave-control
octave-data-smoothing
octave-database
octave-dataframe
octave-divand
octave-doctest
octave-econometrics
octave-financial
octave-fits
octave-fl-core
octave-fpl
octave-fuzzy-logic-toolkit
octave-ga
octave-general
octave-generate_html
octave-geometry
octave-gsl
octave-ident
octave-image
octave-informationtheory
octave-integration
octave-interval
octave-io
octave-irsa
octave-linear-algebra
octave-ltfat
octave-mapping
octave-mechanics
octave-miscellaneous
octave-missing-functions
octave-msh
octave-multicore
octave-mvn
octave-nan
octave-ncarray
octave-netcdf
octave-nnet
octave-ocs
octave-octclip
octave-octproj
octave-odebvp
octave-optics
octave-optim
octave-optiminterp
octave-outliers
octave-parallel
octave-plot
octave-printpgf
octave-quaternion
octave-queueing
octave-secs1d
octave-signal
octave-sockets
octave-specfun
octave-special-matrix
octave-spline-gcvspl
octave-splines
octave-statistics
octave-stk
octave-strings
octave-struct
octave-symband
octave-symbolic
octave-tcl-octave
octave-tisean
octave-tsa
octave-video
octave-vrml
octave-windows
octave-zenity
octave-zeromq

```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2307
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`? **not fixing other lint issues, only ensuring lint no longer crashes**

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
