### PR TITLE
peco: use golang portgroup

### DIFF
--- a/sysutils/peco/Portfile
+++ b/sysutils/peco/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       github 1.0
+PortGroup       golang 1.0
 
-github.setup    peco peco 0.5.3 v
-revision        0
+go.setup        github.com/peco/peco 0.5.3 v
 categories      sysutils
 homepage        https://peco.github.io
 description     Simplistic interactive filtering tool
@@ -15,118 +14,59 @@ long_description \
 license         MIT
 
 maintainers     {kimuraw @kimuraw} openmaintainer
-platforms       darwin
-
-depends_build   port:go
-use_configure   no
-dist_subdir     go
 
 # peco
 checksums       peco-${version}.tar.gz \
-                    md5 42804cb50a16a40524de7dc0e1fa8746 \
-                    sha1 f499d639ea09ac375410748b96344a5e18d9cfed \
-                    sha256 4553ce77c6c7fb218b1ff513ec052badb946482833c3ea88c47ae788e4a48a9e
-
-# utility for go-vendoring codes
-set go.vendors {}
-# go.vendors-append name1 ver1 name2 ver2...
-proc go.vendors-append {args} {
-    global go.vendors
-
-    foreach {imp_name vers} ${args} {
-        set vlist [split ${imp_name} /]
-
-        set vdomain [lindex ${vlist} 0]
-        set vuser [lindex ${vlist} 1]
-        set vname [lindex ${vlist} 2]
-
-        # NOTE: now expects github.com or golang.org
-        switch -exact ${vdomain} {
-            github.com { set ghuser ${vuser} }
-            golang.org { set ghuser golang }
-        }
-
-        set fname ${ghuser}-${vname}
-        lappend go.vendors [list ${fname} ${imp_name} ${vers}]
-
-        global ${vname}.version
-        set ${vname}.version ${vers}
-
-        master_sites-append https://github.com/${ghuser}/${vname}/tarball/${vers}:${fname}
-        distfiles-append    ${fname}-${vers}.tar.gz:${fname}
-    }
-}
+                    rmd160  921c181f383d355d109597d7fa0fce8e0b88d6ae \
+                    sha256  4553ce77c6c7fb218b1ff513ec052badb946482833c3ea88c47ae788e4a48a9e \
+                    size    77427
 
 # dependencies to build. remember revbump when you change version of dependencies.
 # https://github.com/peco/peco/blob/master/glide.lock
 # $ curl https://raw.githubusercontent.com/peco/peco/v${version}/glide.lock |
 #   ruby2.5 -r yaml -e 'YAML.load(ARGF)["imports"].each{|d| puts d["name"]+" "+d["version"]}'
-go.vendors-append   github.com/davecgh/go-spew    346938d642f2ec3594ed81d874461961cd0faa76 \
-                    github.com/google/btree       0c3044bc8bada22db67b93f5760fe3f05d6a5c25 \
-                    github.com/jessevdk/go-flags  8bc97d602c3bfeb5fc6fc9b5a9c898f245495637 \
-                    github.com/lestrrat/go-pdebug 2e6eaaa5717f81bda41d27070d3c966f40a1e75f \
-                    github.com/mattn/go-runewidth 737072b4e32b7a5018b4a7125da8d12de90e8045 \
-                    github.com/nsf/termbox-go     e2050e41c8847748ec5288741c0b19a8cb26d084 \
-                    github.com/pkg/errors         248dadf4e9068a0b3e79f02ed0a610d935de5302 \
-                    github.com/stretchr/testify   18a02ba4a312f95da08ff4cfc0055750ce50ae9e
+go.vendors      github.com/davecgh/go-spew \
+                    lock    346938d642f2ec3594ed81d874461961cd0faa76 \
+                    rmd160  8276b22029bd408decd9af5e56b421eaacce865a \
+                    sha256  81515ee3b5afb35147ab25a534cbf5fd18e27281f54cf8c1ee8d6545ef8ff820 \
+                    size    42359 \
+                github.com/google/btree \
+                    lock    0c3044bc8bada22db67b93f5760fe3f05d6a5c25 \
+                    rmd160  7f1d03590d10cb90822ca1f9b3dde9eb485621ff \
+                    sha256  3c5559d88337ac1a34b43b23363a96630b1cd34eb234a2cb44f532cebb894743 \
+                    size    14147 \
+                github.com/jessevdk/go-flags \
+                    lock    8bc97d602c3bfeb5fc6fc9b5a9c898f245495637 \
+                    rmd160  b4f5d02550f77f5b1ab67d8c9e56314f20cb00dd \
+                    sha256  364bc7a9704c3de622caec67da953a0633dec6386297afa2b90b9b255c026bc7 \
+                    size    54387 \
+                github.com/lestrrat/go-pdebug \
+                    lock    2e6eaaa5717f81bda41d27070d3c966f40a1e75f \
+                    rmd160  c24faf02940348fa142152c37505d8a9660c0732 \
+                    sha256  7c1574a70158def432a1a3d6306592e2b89cc1668467e599cd71f818b6084bcf \
+                    size    5177 \
+                github.com/mattn/go-runewidth \
+                    lock    737072b4e32b7a5018b4a7125da8d12de90e8045 \
+                    rmd160  2c94fdedf9cbf54b4b10a0263517aacbe81c6108 \
+                    sha256  4c3a2f1d5a44b54442bed374b41b18f37983f2dce7637289f498d79b115d8018 \
+                    size    6864 \
+                github.com/nsf/termbox-go \
+                    lock    e2050e41c8847748ec5288741c0b19a8cb26d084 \
+                    rmd160  4a7a1929c16bc6c9f54821f142ec904f4ba653a9 \
+                    sha256  a9a4d39c6aef0aed62015ee01a85e1e4059aec4cdef9bc7ee978386eade92583 \
+                    size    31449 \
+                github.com/pkg/errors \
+                    lock    248dadf4e9068a0b3e79f02ed0a610d935de5302 \
+                    rmd160  b958ee3a78c873759c67e103ee5800559690b5b4 \
+                    sha256  4ba9cfcd163ddba8c52f10f6934f4767d2f727a3b4c5f66384252a46992507df \
+                    size    11339 \
+                github.com/stretchr/testify \
+                    lock    18a02ba4a312f95da08ff4cfc0055750ce50ae9e \
+                    rmd160  31183020e6c1c9cde5d76adfaffa5989f06b426d \
+                    sha256  1a362b9430d82e3e28b4525bdfa45515e26642b046f8c81f6c114b346d415d55 \
+                    size    83495
 
-checksums-append    davecgh-go-spew-${go-spew.version}.tar.gz \
-                        md5 40113f77febc1bdf8207c2c8c9f67293 \
-                        sha1 b02ca0e6655fe8db4658ac265df87ae8cb52a44a \
-                        sha256 81515ee3b5afb35147ab25a534cbf5fd18e27281f54cf8c1ee8d6545ef8ff820 \
-                    google-btree-${btree.version}.tar.gz \
-                        md5 68ec2402eb1ccb68ff1f231c7bc15ac5 \
-                        sha1 9b7ba01bf1abe50342d88a0d3cf66f7f6cfafe46 \
-                        sha256 3c5559d88337ac1a34b43b23363a96630b1cd34eb234a2cb44f532cebb894743 \
-                    jessevdk-go-flags-${go-flags.version}.tar.gz \
-                        md5 c6710dfa23916db4e22c8a8a81016bc3 \
-                        sha1 56bf799a5070466d2818e5369480a9a434d06e98 \
-                        sha256 364bc7a9704c3de622caec67da953a0633dec6386297afa2b90b9b255c026bc7 \
-                    lestrrat-go-pdebug-${go-pdebug.version}.tar.gz \
-                        md5 a7a00fd430599d9af79ae9958492a3ab \
-                        sha1 b6f890f2690012c5ac973f1a5bc3ffc64b9d9912 \
-                        sha256 7c1574a70158def432a1a3d6306592e2b89cc1668467e599cd71f818b6084bcf \
-                    mattn-go-runewidth-${go-runewidth.version}.tar.gz \
-                        md5 e11a6a8f6d7b2a7bade05375ad199cca \
-                        sha1 8f12ee73a43b40fa903f98fcffb4bedcc8dc52da \
-                        sha256 4c3a2f1d5a44b54442bed374b41b18f37983f2dce7637289f498d79b115d8018 \
-                    nsf-termbox-go-${termbox-go.version}.tar.gz \
-                        md5 8eb4914b69384658a7c1f8a0797a11b0 \
-                        sha1 a40cf4da7a7f6eb543ba30558abce5d45503f794 \
-                        sha256 a9a4d39c6aef0aed62015ee01a85e1e4059aec4cdef9bc7ee978386eade92583 \
-                    pkg-errors-${errors.version}.tar.gz \
-                        md5 7d63087f27182aacb966cdfa9d2f4e17 \
-                        sha1 1840a1704460959adc3b44d82f3c07f214d85fe2 \
-                        sha256 4ba9cfcd163ddba8c52f10f6934f4767d2f727a3b4c5f66384252a46992507df \
-                    stretchr-testify-${testify.version}.tar.gz \
-                        md5 657d01f1005dd842e9c6c8a0a921beb8 \
-                        sha1 144550c2cffa1936c9ecd669aca103c9072f3710 \
-                        sha256 1a362b9430d82e3e28b4525bdfa45515e26642b046f8c81f6c114b346d415d55
-
-# setup build sources as gopath style:
-#   workpath/
-#       peco-0.4.1/
-#       gopath/src/github.com/
-#           peco/peco/
-#           jessevdk/go-flags-v/
-#             :
-set gopath      ${workpath}/gopath
-post-extract {
-    file mkdir ${gopath}/src/github.com/peco
-    ln -s ${worksrcpath} ${gopath}/src/github.com/peco/peco
-
-    foreach vlist ${go.vendors} {
-        set fname [lindex ${vlist} 0]
-        set imp_name [lindex ${vlist} 1]
-        file mkdir ${gopath}/src/[file dirname ${imp_name}]
-        move [glob ${workpath}/${fname}-*] ${gopath}/src/${imp_name}
-    }
-}
-
-build.cmd       go
-build.target    build
-build.args      cmd/peco/peco.go
-build.env       GOPATH="${gopath}"
+build.target    cmd/peco/peco.go
 
 destroot {
     xinstall ${worksrcpath}/peco ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description

I have created a new portgroup for golang projects. It is heavily inspired by this port. I would love to get some feedback on what, if anything, still might need improvement.

Documentation is available in the [portfile](https://github.com/macports/macports-ports/blob/master/_resources/port1.0/group/golang-1.0.tcl) or at macports/macports-guide#22.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
