### PR TITLE
kotlin: update to 1.2.70

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.2.61 v
+github.setup        JetBrains kotlin 1.2.70 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,9 +21,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  984a30ca7572489667e2f6c9cb4d2b0cb08233a4 \
-                    sha256  be6d45385029ae99dee38fc77f554bddd49761067a532bfbf6bbf1b7348d5bbf \
-                    size    36305401
+checksums           rmd160  ea76b00af7b91feb1d8e498360d04ff2d975ba68 \
+                    sha256  a23a40a3505e78563100b9e6cfd7f535fbf6593b69a5c470800fbafbeccf8434 \
+                    size    37177896
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.2.70.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?