### PR TITLE
spring-boot-cli: update to 2.0.5

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.0.4
+version         2.0.5
 
 categories      java
 platforms       darwin
@@ -28,9 +28,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  1ff7f702d7aec3f223f3236e9c54297c8ebebe5d \
-                sha256  927a3816b4840066c135bea71f52285b6b0faea3acc381b371b0fc72f4662a5b \
-                size    9119158
+checksums       rmd160  50f0c1dc2d42593805ad17a861efb23e302cec1d \
+                sha256  6336b903cc21c49506a1e58544e84a5b4857dd85fae567a7c994ce43cf80947d \
+                size    9118621
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.0.5.RELEASE.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?