### PR TITLE
osxfuse: add the old workaround back

### DIFF
--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -134,6 +134,11 @@ post-extract {
         ui_msg "    cd /usr/local/lib"
         ui_msg "    sudo ln -s \$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
         ui_msg ""
+        ui_msg "or"
+        ui_msg ""
+        ui_msg "    cd \$(xcode-select -p)/Toolchains"
+        ui_msg "    sudo ln -s XcodeDefault.xctoolchain OSX10.13.xctoolchain"
+        ui_msg ""
         ui_msg "See https://trac.macports.org/ticket/54939 for more information."
     }
 }


### PR DESCRIPTION
#### Description

As reported in https://trac.macports.org/ticket/57126#comment:8, the
original workaround works in some cases.

Closes: https://trac.macports.org/ticket/57126

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10L232m

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?