### PR TITLE
unibilium: update to 2.0.0

### DIFF
--- a/devel/unibilium/Portfile
+++ b/devel/unibilium/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup github 1.0
 
-github.setup        mauke unibilium 1.2.1 v
+github.setup        mauke unibilium 2.0.0 v
 categories          devel
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -17,13 +17,11 @@ long_description \
     any other library. It also doesn't use global variables, so it should be \
     thread-safe.
 
-checksums           rmd160  85817faa6df4d8afad85764020e7aec19ece9f9a \
-                    sha256  006d2e6765fe3c6b508affc51ea11b7afb6622683a61a36ed9ef8be0b6ffb1ac
+checksums           rmd160  7dcb792282fbe353c145cb8727a97bf0927fda99 \
+                    sha256  dc9e6ba177d5ded698abcade77a8546b70d14c6eb47e9e040e94c15d4580e2c1 \
+                    size    112610
 
 depends_build       port:libtool
-
-patchfiles          patch-Makefile.diff
-patch.pre_args      -p1
 
 use_configure no
 

--- a/devel/unibilium/files/patch-Makefile.diff
+++ b/devel/unibilium/files/patch-Makefile.diff
@@ -1,11 +1,14 @@
-diff --git a/Makefile b/Makefile
---- a/Makefile
-+++ b/Makefile
-@@ -33,7 +33,7 @@
+--- a/Makefile.orig	2018-02-08 16:14:10.000000000 +0100
++++ b/Makefile	2018-09-14 22:39:48.000000000 +0200
+@@ -33,11 +33,7 @@
  MAN3DIR=$(MANDIR)/man3
  
  ifneq ($(OS),Windows_NT)
--  TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo"
+-  TERMINFO_DIRS="$(shell ncursesw6-config --terminfo-dirs 2>/dev/null || \
+-                         ncurses6-config  --terminfo-dirs 2>/dev/null || \
+-                         ncursesw5-config --terminfo-dirs 2>/dev/null || \
+-                         ncurses5-config  --terminfo-dirs 2>/dev/null || \
+-                         echo "/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo")"
 +  TERMINFO_DIRS="/etc/terminfo:$(PREFIX)/share/terminfo:/usr/local/share/terminfo:/usr/share/terminfo"
  else
    TERMINFO_DIRS=""

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -5,6 +5,7 @@ PortGroup github 1.0
 PortGroup cmake 1.0
 
 github.setup            neovim neovim 0.3.1 v
+revision                1
 categories              editors
 platforms               darwin
 maintainers             {raimue @raimue} \


### PR DESCRIPTION
#### Description

```
unibilium: update to 2.0.0

    Refresh Makefile patch: TERMINFO_DIRS is kept hardcoded in order to
    avoid a dependency on ncurses and to support multiple simultaneous
    terminfo databases.

neovim: bump revision, unibilium updated
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
