### PR TITLE
dblatex: Support external TeXLive (in addition to MacTeX).

### DIFF
--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -56,27 +56,57 @@ destroot.destdir    --root=${destroot} \
 # and installs dblatex's stylefiles to MacTeX's texmf (local)
 set dblatex.texmflocal ""
 set dblatex.mactex_bin ""
+set dblatex.temp       ""
 
-variant mactex description {Allow dblatex to use a MacTeX installation instead of Macports texlive tools.
-To install the mactex variant /Library/TeX/texbin must be added to binpath
-in macports.conf} {
-    # First, check if MacTeX actually seems to be there…
-    set dblatex.mactex_candidates { \
-       "/Library/TeX/texbin" \
-       "/usr/texbin" \
+variant mactex description {Allow dblatex to use MacTeX or another\
+    external TeXLive installation instead of MacPorts TeXLive tools.\
+    To install the 'mactex' variant the path to the TeX distribution's\
+    binary directory (for example '/Library/TeX/texbin') must be added\
+    to 'binpath' in 'macports.conf' *before* installing this port.} {
+
+    # Find the binary directory of the external TeX distribution by
+    # searching the kpsewhich program in the path.  We assume that all
+    # other binaries of the distribution are in this directory, too.
+    if {[auto_execok kpsewhich] ne ""} {
+        set dblatex.temp {*}[auto_execok kpsewhich]
     }
-    foreach dir ${dblatex.mactex_candidates} {
-        if [file executable "${dir}/kpsewhich"] {
-            set dblatex.mactex_bin ${dir}
-            break
+    set dblatex.mactex_bin \
+        [file dirname [file normalize ${dblatex.temp}]]
+    if {${dblatex.mactex_bin} eq "."} {
+        pre-fetch {
+            return -code error "Cannot find MacTeX or external TeXLive\
+                installation; aborting.  Have you added the path to\
+                your TeX distribution's binary directory to 'binpath'\
+                in 'macports.conf'?"
         }
-    }
-    if { ${dblatex.mactex_bin} != "" } {
+    } elseif {${dblatex.mactex_bin} eq \
+                  [file dirname [file normalize "${prefix}/bin/kpsewhich"]]} {
+        pre-fetch {
+            return -code error "Variant 'mactex' doesn't work with\
+                installed MacPorts TeXLive packages.  Either\
+                uninstall them or don't use the 'mactex' variant of\
+                dblatex."
+        }
+    } else {
         set dblatex.texmflocal \
             [exec ${dblatex.mactex_bin}/kpsewhich --expand-var='\$TEXMFLOCAL']
         regsub -all {'} ${dblatex.texmflocal} "" dblatex.texmflocal
+    }
+
+    # Make 'port notes dblatex +mactex' work even if neither the package
+    # nor an external TeXLive is installed.
+    if {${dblatex.texmflocal} eq ""} {
+        notes "The 'mactex' variant will install styles into your\
+            TeXLive's texmf-local tree (which is outside MacPorts'\
+            common directory structure)."
     } else {
-        return -code error "Cannot find MacTeX installation; aborting"
+        notes "\
+The 'mactex' variant will install styles into your TeXLive's texmf-local\
+tree at
+
+    ${dblatex.texmflocal}
+
+(which is outside MacPorts' common directory structure)."
     }
 
     depends_lib-delete \
@@ -84,13 +114,8 @@ in macports.conf} {
                     port:texlive-latex-recommended \
                     port:texlive-math-science
 
-    notes "The mactex variant will install styles to MacTeX's texmf-local
-        ${dblatex.texmflocal}
-    (which is outside macport's common directory structure).
-    For the mactex variant to work,
-    ${dblatex.mactex_bin} must also be added to binpath in macports.conf"
-
-    # AND, since we're installing files outside macports' normal directories
+    # AND, since we're installing files outside MacPorts' normal
+    # directories...
     destroot.violate_mtree  yes
 }
 
@@ -127,9 +152,6 @@ proc dblatex.mktexlsr {} {
     } else {
         global dblatex.mactex_bin
         system "${dblatex.mactex_bin}/mktexlsr"
-        if [file exists "${dblatex.mactex_bin}/mtxrun"] {
-            system "${dblatex.mactex_bin}/mtxrun --generate"
-        }
     }
 }
 


### PR DESCRIPTION
#### Description

This is a first try adding external TeXLive support in addition to MacTeX.  Both cases are handled by the `+mactex` variant for simplicity.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`? → only `-vs` works; option `-t` doesn't work with external TeXLive
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
