### PR TITLE
new port: net/consul

### DIFF
--- a/net/consul/Portfile
+++ b/net/consul/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        hashicorp consul 1.2.3 v
+homepage            https://www.consul.io
+
+platforms           darwin
+categories          net
+license             MPL-2
+installs_libs       no
+
+# Consul's build process requires the git repository.
+fetch.type          git
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         Consul is a distributed service mesh to connect, secure, \
+                    and configure services across any runtime platform and \
+                    public or private cloud.
+
+long_description    Consul is a service mesh solution providing a full \
+                    featured control plane with service discovery, \
+                    configuration, and segmentation functionality. Each of \
+                    these features can be used individually as needed, or \
+                    they can be used together to build a full service mesh. \
+                    Consul requires a data plane and supports both a proxy \
+                    and native integration model. Consul ships with a simple \
+                    built-in proxy so that everything works out of the box, \
+                    but also supports 3rd party proxy integrations such as \
+                    Envoy.
+
+depends_build       port:go
+
+set proj_dir "${workpath}/src/github.com/${github.author}/${github.project}"
+
+# The "dev" build target must be used to build just the binary for this
+# platform, instead of for ALL platforms
+# - https://www.consul.io/docs/install/index.html#compiling-from-source
+build.target        dev
+build.args          ""
+build.dir           ${proj_dir}
+build.env           GOPATH=${workpath} PATH=$env(PATH):${workpath}/bin
+use_configure       no
+
+post-extract {
+    file mkdir [file dirname ${proj_dir}]
+    move ${worksrcpath} ${proj_dir}
+}
+
+destroot {
+    xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
Adds a Portfile for Hashicorp Consul

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2307
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? **used -vs**
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
