### PR TITLE
security/mkcert: update to 1.1.2

### DIFF
--- a/security/mkcert/Portfile
+++ b/security/mkcert/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 
-github.setup        FiloSottile mkcert 1.1.1 v
+github.setup        FiloSottile mkcert 1.1.2 v
 
 platforms           darwin
 categories          security devel
@@ -29,9 +29,9 @@ long_description    mkcert is a simple tool for making locally-trusted \
                     the system root store, and generates locally-trusted \
                     certificates.
 
-checksums           rmd160  49d2950b187c95db442e6b7d266187c1635acdd3 \
-                    sha256  a545166f1154b215432d47e3901c578c04a68c5d288eb22f509d2adc0c3018e3 \
-                    size    375685
+checksums           rmd160  58f43d2362a1a19feb03dfaa15983616276b91da \
+                    sha256  4a7a4c364bd51cd1de0b173c4d5848587febaba2ff0cbde1949ca0c4d9aa8685 \
+                    size    374301
 
 depends_build       port:go
 use_configure       no
@@ -50,6 +50,5 @@ post-extract {
 }
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/${name}-${version} \
-        ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
 }


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2307
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? **port -vs install**
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
