### PR TITLE
new port: security/vault

### DIFF
--- a/security/vault/Portfile
+++ b/security/vault/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        hashicorp vault 0.11.1 v
+homepage            https://www.vaultproject.io/
+
+platforms           darwin
+categories          security
+license             MPL-2
+installs_libs       no
+
+# Vault's build process requires the git repository.
+fetch.type          git
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         A Tool for Managing Secrets
+
+long_description    HashiCorp Vault secures, stores, and tightly controls \
+                    access to tokens, passwords, certificates, API keys, and \
+                    other secrets in modern computing. Vault handles leasing, \
+                    key revocation, key rolling, and auditing. Through a \
+                    unified API, users can access an encrypted Key/Value \
+                    store and network encryption-as-a-service, or generate \
+                    AWS IAM/STS credentials, SQL/NoSQL databases, X.509 \
+                    certificates, SSH credentials, and more.
+
+depends_build       port:go
+
+set proj_dir "${workpath}/src/github.com/${github.author}/${github.project}"
+
+# The "dev" build target must be used to build just the binary for this
+# platform, instead of for ALL platforms
+# - https://www.vaultproject.io/docs/install/index.html#compiling-from-source
+build.target        bootstrap
+build.post_args     dev
+build.dir           ${proj_dir}
+build.env           GOPATH=${workpath} PATH=$env(PATH):${workpath}/bin
+use_configure       no
+# Bootstrap target must run before dev, so we disable parallel building.
+use_parallel_build  no
+
+post-extract {
+    file mkdir [file dirname ${proj_dir}]
+    move ${worksrcpath} ${proj_dir}
+}
+
+destroot {
+    xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
Adds Hashicorp Vault, version 0.11.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2307
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`? **port -vs install**
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
