### PR TITLE
github portgroup: add archive download source

### DIFF
--- a/_resources/port1.0/group/github-1.0.tcl
+++ b/_resources/port1.0/group/github-1.0.tcl
@@ -37,6 +37,9 @@ proc handle_tarball_from {option action args} {
             releases {
                 github.master_sites ${github.homepage}/releases/download/${git.branch}
             }
+            archive {
+                github.master_sites ${github.homepage}/archive/${git.branch}
+            }
             tags {
                 github.master_sites ${github.homepage}/tarball/${git.branch}
             }


### PR DESCRIPTION
A non-trivial amount of Github repositories generate **archive** URLs for their releases.

This is an issue when trying to use the `github` portgroup because there is no automatic redirection happening between the "modern" **releases** URL and the **archive** one.

This PR adds a new option for the `github.tarball_from` parameter, `archives`, that allows port authors to properly download from repositories like these when using this portgroup.

Related Trac tickets:
- https://trac.macports.org/ticket/47895
- https://trac.macports.org/ticket/40518

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G2307
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
