### PR TITLE
py-notebook: Add ipaddress dep.

### DIFF
--- a/python/py-notebook/Portfile
+++ b/python/py-notebook/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-notebook
 version             5.6.0
-revision            1
+revision            2
 categories-append   devel science
 platforms           darwin
 license             BSD
@@ -41,6 +41,10 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-send2trash \
                         port:py${python.version}-terminado \
                         port:py${python.version}-prometheus_client
+
+    if {${python.version} == 27} {
+        depends_lib-append  port:py${python.version}-ipaddress
+    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
5.6.0 Added ipaddress as a dependency.

#### Description

I've dropped the form here as this is a simple dependency fix. 5.6.0 added (https://github.com/jupyter/notebook/commit/7f1bba613d94c20d09aeebc9b2bd9e26aa6cbb96) ipaddress as a dependency; catching that here.