### PR TITLE
Gpsd updates

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    gpsd
 version                 3.17
-revision                1
+revision                2
 license                 BSD
 categories              net
 maintainers             {ryandesign @ryandesign} openmaintainer
@@ -36,6 +36,11 @@ depends_run             port:python27
 configure.python        ${prefix}/bin/python2.7
 
 patchfiles              patch-SConstruct.diff
+
+# change API to avoid conflict with mach's policy_t
+# gps policy_t -> gps_policy_t.
+# this change does not seem to conflict with dependent ports
+patchfiles-append       patch-fix_policy_t.diff
 
 use_configure           no
 
@@ -168,5 +173,5 @@ if {![variant_isset xgps]} {
 }
 
 livecheck.type          regex
-livecheck.url           https://download.savannah.gnu.org/releases/gpsd/
+livecheck.url           http://download.savannah.gnu.org/releases-noredirect/gpsd
 livecheck.regex         "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"

--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -7,7 +7,7 @@ version                 3.17
 revision                2
 license                 BSD
 categories              net
-maintainers             {ryandesign @ryandesign} openmaintainer
+maintainers             {ryandesign @ryandesign} {michaelld @michaelld} openmaintainer
 platforms               darwin
 
 description             GPS service daemon

--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -3,8 +3,7 @@
 PortSystem              1.0
 
 name                    gpsd
-version                 3.17
-revision                2
+
 license                 BSD
 categories              net
 maintainers             {ryandesign @ryandesign} {michaelld @michaelld} openmaintainer
@@ -20,10 +19,44 @@ long_description        GPSD is a service daemon that handles GPSes and other \
                         a local GPSD or a GPSD on another machine.
 
 homepage                http://www.catb.org/${name}/
-master_sites            savannah
 
-checksums               rmd160  7aeacd58b7374b392e691fc470dc9a644169ba8a \
-                        sha256  68e0dbecfb5831997f8b3d6ba48aed812eb465d8c0089420ab68f9ce4d85e77a
+subport gpsd-devel {}
+
+if {${subport} eq ${name}} {
+
+    # release
+    conflicts           gpsd-devel
+
+    version             3.17
+    revision            2
+    checksums           rmd160 7aeacd58b7374b392e691fc470dc9a644169ba8a \
+                        sha256 68e0dbecfb5831997f8b3d6ba48aed812eb465d8c0089420ab68f9ce4d85e77a \
+                        size   8755304
+
+    master_sites        savannah
+
+    # change API to avoid conflict with mach's policy_t
+    # gps policy_t -> gps_policy_t.
+    # this change does not seem to conflict with dependent ports
+    patchfiles-append   patch-fix_policy_t.diff
+
+    patchfiles-append   patch-SConstruct.diff
+
+} else {
+
+    # devel
+    conflicts           gpsd
+
+    version             20180911
+    set commit          ae73eda572e4bd8d8b5c222cf574f3913316354f
+    checksums           rmd160 21a3df870732ce654f4febff4e2e134bdac4e207 \
+                        sha256 390db8399d47ebdca19ff661295539d53cac8cbbb2550426d2e7de4cbef8ad36 \
+                        size   9724865
+
+    master_sites        http://git.savannah.gnu.org/cgit/gpsd.git/snapshot
+    distname            ${name}-${commit}
+
+}
 
 depends_lib-append      port:ncurses
 depends_build-append    port:scons port:pkgconfig
@@ -34,13 +67,6 @@ depends_build-append    port:scons port:pkgconfig
 #
 depends_run             port:python27
 configure.python        ${prefix}/bin/python2.7
-
-patchfiles              patch-SConstruct.diff
-
-# change API to avoid conflict with mach's policy_t
-# gps policy_t -> gps_policy_t.
-# this change does not seem to conflict with dependent ports
-patchfiles-append       patch-fix_policy_t.diff
 
 use_configure           no
 

--- a/net/gpsd/files/patch-fix_policy_t.diff
+++ b/net/gpsd/files/patch-fix_policy_t.diff
@@ -1,0 +1,128 @@
+--- gps.h.orig
++++ gps.h
+@@ -1902,7 +1902,7 @@
+     int driver_mode;    		/* is driver in native mode or not? */
+ };
+ 
+-struct policy_t {
++struct gps_policy_t {
+     bool watcher;			/* is watcher mode on? */
+     bool json;				/* requesting JSON? */
+     bool nmea;				/* requesting dumping as NMEA? */
+@@ -2038,7 +2038,7 @@
+ 
+     struct devconfig_t dev;	/* device that shipped last update */
+ 
+-    struct policy_t policy;	/* our listening policy */
++    struct gps_policy_t policy;	/* our listening policy */
+ 
+     struct {
+ 	timestamp_t time;
+--- gps_json.h.orig
++++ gps_json.h
+@@ -15,19 +15,19 @@
+ #endif
+ void json_data_report(const gps_mask_t,
+ 		      const struct gps_device_t *,
+-		      const struct policy_t *,
++		      const struct gps_policy_t *,
+ 		      char *, size_t);
+ char *json_stringify(char *, size_t, const char *);
+ void json_tpv_dump(const struct gps_device_t *,
+-		   const struct policy_t *, char *, size_t);
++		   const struct gps_policy_t *, char *, size_t);
+ void json_noise_dump(const struct gps_data_t *, char *, size_t);
+ void json_sky_dump(const struct gps_data_t *, char *, size_t);
+ void json_att_dump(const struct gps_data_t *, char *, size_t);
+ void json_oscillator_dump(const struct gps_data_t *, char *, size_t);
+ void json_subframe_dump(const struct gps_data_t *, char buf[], size_t);
+ void json_device_dump(const struct gps_device_t *, char *, size_t);
+-void json_watch_dump(const struct policy_t *, char *, size_t);
+-int json_watch_read(const char *, struct policy_t *,
++void json_watch_dump(const struct gps_policy_t *, char *, size_t);
++int json_watch_read(const char *, struct gps_policy_t *,
+ 		    const char **);
+ int json_device_read(const char *, struct devconfig_t *,
+ 		     const char **);
+--- gpsd.c.orig
++++ gpsd.c
+@@ -519,7 +519,7 @@
+ {
+     int fd;			/* client file descriptor. -1 if unused */
+     time_t active;		/* when subscriber last polled for data */
+-    struct policy_t policy;	/* configurable bits */
++    struct gps_policy_t policy;	/* configurable bits */
+     pthread_mutex_t mutex;	/* serialize access to fd */
+ };
+ 
+--- gpsd_json.c.orig
++++ gpsd_json.c
+@@ -133,7 +133,7 @@
+ 
+ 
+ void json_tpv_dump(const struct gps_device_t *session,
+-		   const struct policy_t *policy CONDITIONALLY_UNUSED,
++		   const struct gps_policy_t *policy CONDITIONALLY_UNUSED,
+ 		   char *reply, size_t replylen)
+ {
+     const struct gps_data_t *gpsdata = &session->gpsdata;
+@@ -372,7 +372,7 @@
+     (void)strlcat(reply, "}\r\n", replylen);
+ }
+ 
+-void json_watch_dump(const struct policy_t *ccp,
++void json_watch_dump(const struct gps_policy_t *ccp,
+ 		     char *reply, size_t replylen)
+ {
+     (void)snprintf(reply, replylen,
+@@ -3397,7 +3397,7 @@
+ 
+ void json_data_report(const gps_mask_t changed,
+ 		 const struct gps_device_t *session,
+-		 const struct policy_t *policy,
++		 const struct gps_policy_t *policy,
+ 		 char *buf, size_t buflen)
+ /* report a session state in JSON */
+ {
+--- gpsdecode.c.orig
++++ gpsdecode.c
+@@ -551,7 +551,7 @@
+ /* sensor data on fpin to dump format on fpout */
+ {
+     struct gps_device_t session;
+-    struct policy_t policy;
++    struct gps_policy_t policy;
+     size_t minima[PACKET_TYPES+1];
+ #if defined(SOCKET_EXPORT_ENABLE) || defined(AIVDM_ENABLE)
+     char buf[GPS_JSON_RESPONSE_MAX * 4];
+@@ -649,7 +649,7 @@
+ /* JSON format on fpin to JSON on fpout - idempotency test */
+ {
+     char inbuf[BUFSIZ];
+-    struct policy_t policy;
++    struct gps_policy_t policy;
+     struct gps_device_t session;
+     int lineno = 0;
+ 
+--- shared_json.c.orig
++++ shared_json.c
+@@ -74,7 +74,7 @@
+ }
+ 
+ int json_watch_read(const char *buf,
+-		    struct policy_t *ccp,
++		    struct gps_policy_t *ccp,
+ 		    const char **endptr)
+ {
+     bool dummy_pps_flag;
+--- test_libgps.c.orig
++++ test_libgps.c
+@@ -64,7 +64,7 @@
+ 		 sizeof(struct gps_data_t), sizeof(struct rtcm2_t),
+ 		 sizeof(struct rtcm3_t), sizeof(struct ais_t),
+ 		 sizeof(struct attitude_t), sizeof(struct rawdata_t),
+-		 sizeof(collect.devices), sizeof(struct policy_t),
++		 sizeof(collect.devices), sizeof(struct gps_policy_t),
+ 		 sizeof(struct version_t), sizeof(struct gst_t));
+ 	    exit(EXIT_SUCCESS);
+ #ifdef CLIENTDEBUG_ENABLE


### PR DESCRIPTION
#### Description

Fix gpsd to build using Boost 1.67.0+ via a patch that's already committed upstream. Add michaelld as comaintainer. Add gpsd-devel subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1510
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
