### PR TITLE
1password-cli: add new port

### DIFF
--- a/security/1password-cli/Portfile
+++ b/security/1password-cli/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                1password-cli
+version             0.5.3
+
+categories          security
+license             Restrictive/Distributable
+maintainers         {gmail.com:newtonne.github @newtonne} openmaintainer
+platforms           darwin
+supported_archs     x86_64
+
+description         Official 1Password command-line tool
+
+long_description    View and manage 1password.com users, groups and objects \
+                    from the command-line.
+
+homepage            https://support.1password.com/command-line/
+
+set bin_name        op
+set archive         ${bin_name}_darwin_amd64_v
+
+use_zip             yes
+extract.mkdir       yes
+
+master_sites        https://cache.agilebits.com/dist/1P/op/pkg/v${version}/
+distfiles           ${archive}${version}${extract.suffix}
+
+checksums           rmd160 00306ee7172b5dcb300511b50b64a510a435f28f \
+                    sha256 2341376cd33760b89ba4bee82ddc5cf0de255ad2d12e3477f8442de00609b212 \
+                    size   3448707
+
+# Pre-built binary
+use_configure       no
+build               {}
+
+set share_dir       ${prefix}/share/${name}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${bin_name} ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${share_dir}
+    xinstall -m 644 ${worksrcpath}/${bin_name}.sig ${destroot}${share_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://app-updates.agilebits.com/product_history/CLI
+livecheck.regex     ${archive}(\\d+(\\.\\d+)+)${extract.suffix}
+
+# 1Password CLI team requested that this note be displayed
+notes "
+The GPG sigfile has been installed to ${share_dir}/${bin_name}.sig
+
+For instructions on verifying the binary, see:
+https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool
+"


### PR DESCRIPTION
#### Description

New port for the 1password command-line tool: https://support.1password.com/command-line/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->