### PR TITLE
jmol: update to 14.29.22 (maintainer)

### DIFF
--- a/science/jmol/Portfile
+++ b/science/jmol/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                jmol
-version             14.29.12
+version             14.29.22
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science
 platforms           darwin
@@ -23,9 +23,9 @@ master_sites        sourceforge:project/jmol/Jmol/Version%20${branch}/Jmol%20${v
 
 distname            Jmol-${version}-binary
 
-checksums           rmd160  a4028ebe365726d4202363fdfba40afcd6bbafd8 \
-                    sha256  7b8d89aea3607fe1f6551688bbc81cd0571b3e19c3886933d456c972aa4ab8d9 \
-                    size    70470520
+checksums           rmd160  1799d0d28adaaae58063d387b4d6f36d4aedadcf \
+                    sha256  fb3a1109cbe888fb0920bf13e910265d8be17048e17555ee323fa9cf85cdd9f2 \
+                    size    66351584
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
Bug fixes, and new features, see https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.29/Jmol%2014.29.22/README-14.29.22.properties/download for details.

#### Description

Upstream update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Java 1.8.0_152

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
