### PR TITLE
wireguard-tools: update to 0.0.20180918

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -9,7 +9,7 @@ name                wireguard-tools
 # the WireGuard repository and its updates primarily deals with the
 # Linux kernel module, which isn't useful or relevant for macOS (we're
 # just interested in its tools for manipulating WireGuard interfaces).
-version             0.0.20180910
+version             0.0.20180918
 categories          net
 platforms           darwin
 license             GPL-2
@@ -27,9 +27,9 @@ master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
 
-checksums           rmd160  10c6bccb3f1f442fc39cddad13bfced6a41ac7a4 \
-                    sha256  43481ac82d4889491e1ae761d4ef10688410975cc861db5d2ac1845ac62eae39 \
-                    size    271596
+checksums           rmd160  4b8cecc55cb950c5dbd6a8e3717ff0624b9146ef \
+                    sha256  c0d931bdfce139a3678592ada463042c24f12dd01ba75badd3eeb0aee2211302 \
+                    size    282204
 
 depends_run         port:bash \
                     port:wireguard-go


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?>
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?