### PR TITLE
libopusenc: new port

### DIFF
--- a/audio/libopusenc/Portfile
+++ b/audio/libopusenc/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libopusenc
+version             0.2
+categories          audio
+license             BSD
+platforms           darwin
+maintainers         {gmail.com:mark.hsj @mark4o} openmaintainer
+description         High-level API for encoding .opus files
+
+long_description    ${description}
+
+homepage            https://opus-codec.org/
+master_sites        https://archive.mozilla.org/pub/opus/
+
+checksums           rmd160  6a88129293cddda162a1633b2fca43319de59349 \
+                    sha256  c79e95eeee43a0b965e9b2c59a243763a8f8b0a7e71441df2aa9084f6171c73a \
+                    size    388027
+
+depends_build       port:pkgconfig
+
+depends_lib         port:libopus
+
+configure.args      --disable-silent-rules
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
#### Description

The libopusenc library provides a high-level API for encoding .opus files.  It is also a new dependency of the recently released opus-tools 0.2.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1510
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
