### PR TITLE
libomp: Update to 7.0.0 release version.

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -53,16 +53,16 @@ if { ${subport} eq "libomp-devel" } {
             # these systems. https://trac.macports.org/ticket/52554
             configure.cflags-append -stdlib=libc++
         }
-        version                 6.0.1
+        version                 7.0.0
         revision                0
         master_sites            https://releases.llvm.org/${version}
         distname                openmp-${version}.src
         use_xz                  yes
         dist_subdir             openmp-release
         checksums \
-            rmd160  ae58847caeea529b3dfbfb42dee8812b3055374b \
-            sha256  66afca2b308351b180136cf899a3b22865af1a775efaf74dc8a10c96d4721c5a \
-            size    2048320
+            rmd160  12f4202372627ff41d57fc2ee2d7f9be0366bc54 \
+            sha256  30662b632f5556c59ee9215c1309f61de50b3ea8e89dcc28ba9a9494bba238ff \
+            size    910680
 
         worksrcdir              ${distname}
         set rtpath              "runtime/"


### PR DESCRIPTION
Updating to be in line with llvm 7.0 release.