### PR TITLE
screen: enable login patch

### DIFF
--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                screen
 version             4.6.2
+revision            1
 homepage            https://www.gnu.org/software/screen/
 description         Screen manager with VT100/ANSI terminal emulation
 long_description    \
@@ -52,6 +53,7 @@ configure.args      --mandir=${prefix}/share/man \
                     --enable-telnet \
                     --enable-colors256 \
                     --enable-rxvt_osc
+configure.cflags-append -DRUN_LOGIN
 
 post-destroot {
     xinstall -m 644 ${workpath}/18 ${destroot}${prefix}/share/${name}/utf8encodings


### PR DESCRIPTION
Apple defines RUN_LOGIN in their build, I forgot to do it with macports.
I was able to validate that login gets run and wtmp is updated.

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?