### PR TITLE
tinc-devel: update to 1.1.pre16

### DIFF
--- a/net/tinc/Portfile
+++ b/net/tinc/Portfile
@@ -43,8 +43,8 @@ post-destroot {
 subport tinc-devel {
     conflicts       tinc
 
-    version         1.1pre14
+    version         1.1pre16
     revision        0
-    checksums       rmd160  25f1edbf475a33e82527d62e40ba73b607aecd60 \
-                    sha256  e349e78f0e0d10899b8ab51c285bdb96c5ee322e847dfcf6ac9e21036286221f
+    checksums       rmd160  29a7953700515cc553c12662d0e93dd87c0a46c0 \
+                    sha256  9934c53f8b22bbcbfa0faae0cb7ea13875fe1990cce75af728a7f4ced2c0230b
 }


### PR DESCRIPTION
Updated tinc-devel to 1.1pre16.