### PR TITLE
py-qtpy: update to 1.5.1

### DIFF
--- a/python/py-qtpy/Portfile
+++ b/python/py-qtpy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        spyder-ide qtpy 1.5.0 v
+github.setup        spyder-ide qtpy 1.5.1 v
 name                py-qtpy
 
 categories-append   devel
@@ -13,20 +13,19 @@ platforms           darwin
 supported_archs     noarch
 maintainers         {eborisch @eborisch} openmaintainer
 
-description         Abtraction layer for PySide/PyQt4/PyQt5
+description         Abtraction layer for PyQt5/PyQt4/PySide2/PySide
 long_description    QtPy (pronounced 'cutie pie') is a small abstraction layer \
                     that lets you write applications using a single api call \
-                    to either PyQt or PySide. QtPy also provides a set of \
-                    additional QWidgets. \
-                    It provides support for PyQt5, PyQt4 and PySide using the \
-                    PyQt5 layout (where the QtGui module has been split into \
-                    QtGui and QtWidgets).
+                    to either PyQt or PySide. \
+                    It provides support for PyQt5, PyQt4, PySide2 and PySide \
+                    using the Qt5 layout (where the QtGui module has been split \
+                    into QtGui and QtWidgets).
 
-checksums           rmd160  ca11f9509244a1593431611f13c6ab3077a0cf97 \
-                    sha256  707f23e1636af51fb0d3a2049538bf55590038f29070eddee0516461c2de06f2 \
-                    size    31714
+checksums           rmd160  2ac1f3c4b7eed2f47b733247446436965d2c845e \
+                    sha256  9c6948c406c9dd483c2408a55e4b0f916d782fc23e8125605ff045c750d2a145 \
+                    size    31882
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     livecheck.type  none
@@ -43,9 +42,19 @@ if {${name} ne ${subport}} {
 
     default_variants        +qt5
 
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-mock
+    test.run                yes
+    test.cmd                py.test-${python.branch}
+    test.target
+
     post-destroot {
-        file mkdir ${destroot}${prefix}/share/doc/${subport}
-        copy ${worksrcpath}/LICENSE.txt \
-            ${destroot}${prefix}/share/doc/${subport}
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt ${destroot}${docdir}
     }
+
+    notes "QtPy will work with one of the following backends: pyqt5, pyqt4,\
+        pyside2, and pyside. If multiple backends are available on your system,\
+        pyqt5 will be used unless you set the QT_API environment variable."
 }


### PR DESCRIPTION
#### Description
- update to 1.5.1
- add py37 subport
- update post-destroot and description/long_description
- enable tests
- support all possible backends via variants: Qt5 is still the default, now also pyside and pyside2 are optional backends
- the pyside2 backend is only offered for python versions that are listed in the pyside2 port (i.e., py27/py36/py37).

The only current dependencies on py-qtpy use either the qt4 or qt5 variants; I think adding pyside and pyside2 could be useful though. Adding py34/py35 to pyside2 seems unnecessary, unless @pmetzger or @MarcusCalhoun-Lopez feel like this should be done.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
