### PR TITLE
git-sizer: use golang-1.0 portgroup

### DIFF
--- a/devel/git-sizer/Portfile
+++ b/devel/git-sizer/Portfile
@@ -1,12 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               github 1.0
+PortGroup               golang 1.0
 
-github.setup            github git-sizer 1.2.0 v
+go.setup                github.com/github/git-sizer 1.2.0 v
 categories              devel
-platforms               darwin
-supported_archs         noarch
 maintainers             {@gerardsoleca gmail.com:g.sole.ca} openmaintainer
 license                 MIT
 
@@ -23,19 +21,7 @@ checksums               rmd160  8c6003f973ebaec06291d548c2ba7c471e7046dc \
                         sha256  3c021a5f73b52ea309940f3a964e129cd40741dbbfcbec611991de40a3c55953 \
                         size    102517
 
-depends_build           port:go
-use_configure           no
-use_parallel_build      no
-build.cmd               go
-build.target            build -a -tags production github.com/${github.author}/${name}
-build.env               GOPATH="${workpath}" DYLD_INSERT_LIBRARIES=''
-
-worksrcdir              ${workpath}/src/github.com/github/${name}
-
-post-extract {
-    file mkdir [file dirname ${worksrcdir}]
-    move [glob ${workpath}/${name}-*] ${worksrcdir}
-}
+build.args              -ldflags '-X main.BuildVersion=${version}'
 
 destroot {
     xinstall ${worksrcpath}/${name} ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description

This updates git-sizer to use the golang-1.0 portgroup.

There is a very minor behavior difference: previously the version reported by `git-sizer --version` was not set (empty string); now it is correctly set.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
