### PR TITLE
glide: use golang-1.0 portgroup

### DIFF
--- a/devel/glide/Portfile
+++ b/devel/glide/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        Masterminds glide 0.13.1 v
+go.setup            github.com/Masterminds/glide 0.13.1 v
 categories          devel
-platforms           darwin
 maintainers         {@nareshov naresh.moe:macports} openmaintainer
 license             MIT
 
@@ -15,23 +14,14 @@ long_description    Are you used to tools such as Cargo, npm, Composer, Nuget, \
                     Pip, Maven, Bundler, or other modern package managers? If \
                     so, Glide is the comparable Go tool.
 
-depends_build       port:go
-use_configure       no
-
 checksums           rmd160  f31c2c0a192484b0c44245d002a06efbb382123c \
-                    sha256  6092afe0fdfe6c362e68ad6224bef2b133ac288c6a9ba6b3138efddfa6deb2ad
-
-worksrcdir          ${workpath}/src/github.com/Masterminds/glide
-post-extract {
-    file mkdir [file dirname ${worksrcdir}]
-    move [glob ${workpath}/glide-*] ${worksrcdir}
-}
+                    sha256  6092afe0fdfe6c362e68ad6224bef2b133ac288c6a9ba6b3138efddfa6deb2ad \
+                    size    269944
 
 build.cmd           make
+build.args          VERSION=${version}
 build.target        build
-build.env           GOPATH="${workpath}" DYLD_INSERT_LIBRARIES=''
 test.run            yes
-test.env            GOPATH="${workpath}"
 
 destroot {
     xinstall ${worksrcpath}/glide ${destroot}${prefix}/bin


### PR DESCRIPTION
This updates glide to use the golang-1.0 portgroup.

Also:
- add size checksum
- fix version reported by binary (-v flag)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
