### PR TITLE
xsv: Add new port

### DIFF
--- a/textproc/xsv/Portfile
+++ b/textproc/xsv/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo 1.0
+PortGroup           github 1.0
+
+github.setup        BurntSushi xsv 0.13.0
+categories          textproc
+description         A fast CSV command line toolkit written in Rust
+long_description    xsv is a command line program for indexing, slicing, \
+                    analyzing, splitting and joining CSV files.
+license             MIT
+platforms           darwin
+maintainers         {@lperry perry} \
+                    openmaintainer
+
+cargo.crates \
+    aho-corasick                     0.6.4  d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4 \
+    bitflags                         1.0.3  d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789 \
+    byteorder                        1.2.2  73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87 \
+    cfg-if                           0.1.3  405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18 \
+    chan                            0.1.21  9af7c487bb99c929ba2715b1a3a7bf45f5062bf5b6eae5d32b292a96c5865172 \
+    csv                              1.0.0  71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3 \
+    csv-core                         0.1.4  4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105 \
+    csv-index                        0.1.5  7b27beef016f9d0d43fd1f6097a469d1ccccd2191888f5dfeb4e7be7dbc8bfc6 \
+    docopt                           1.0.0  e67fb750c36fc6fffbd3575cf8f2b46790fc0b05096ae3c03a36cf71b55e1e2b \
+    filetime                        0.1.15  714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    lazy_static                      1.0.0  c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d \
+    libc                            0.2.40  6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b \
+    log                              0.4.1  89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2 \
+    memchr                           2.0.1  796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d \
+    num-traits                       0.2.4  775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28 \
+    num_cpus                         1.8.0  c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30 \
+    proc-macro2                      0.3.8  1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7 \
+    quickcheck                       0.6.2  c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7 \
+    quote                            0.5.2  9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8 \
+    rand                            0.3.22  15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1 \
+    rand                             0.4.2  eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5 \
+    redox_syscall                   0.1.37  0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd \
+    regex                            1.0.0  75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3 \
+    regex-syntax                     0.6.0  8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b \
+    serde                           1.0.54  db9c1726bdebaed7ac8afb7028672e068e12cf1b0b97cddd742a3a7939159699 \
+    serde_derive                    1.0.54  5121751b76f5a2e6f51b4c0d07976f4f04e33ae7a981467c2845e7cd4b67a114 \
+    streaming-stats                  0.2.0  4f233aa550ceeb22c47cff12e167f7bc89c03e265e7fcff64b8359bb6799e0f4 \
+    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    syn                             0.13.9  505550dded6ff93eb63bd9d0ada380ffccd9f51c046a5e80a3078d53fcef0038 \
+    tabwriter                        1.0.4  56ab9ac71e2a71d113e4568ab0a89e2182f0fc214d2e4952c6e5655cb8eac4dd \
+    thread_local                     0.3.5  279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963 \
+    threadpool                       1.7.1  e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865 \
+    ucd-util                         0.1.1  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
+    unicode-width                    0.1.4  bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+    utf8-ranges                      1.0.0  662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122 \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    winapi                           0.3.4  04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+
+checksums-append    ${distname}${extract.suffix} \
+                    rmd160  7a82208d831582841b2d8bd2faa78c9acab0032c \
+                    sha256  fd333294b3a21d3d090238c169e8825b7b9d0e6fc206f5b455c8d8371e312538 \
+                    size    60542
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/xsv ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

xsv is a command line program for indexing, slicing, analyzing, splitting and joining CSV files.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?