### PR TITLE
texlive-bin: Fix DSA-4299-1

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -11,7 +11,7 @@ PortGroup       muniversal 1.0
 
 name            texlive-bin
 version         2018.47642
-revision        4
+revision        5
 
 categories      tex
 maintainers     {dports @drkp}
@@ -78,6 +78,9 @@ depends_run     port:ghostscript
 depends_build-append \
                 path:bin/perl:perl5 \
                 port:pkgconfig
+
+# security patches
+patchfiles-append  patch-r48697.diff
 
 # patches related to changes in install paths
 patchfiles-append  patch-texk_chktex_Makefile.in.diff \

--- a/tex/texlive-bin/files/patch-r48697.diff
+++ b/tex/texlive-bin/files/patch-r48697.diff
@@ -1,0 +1,70 @@
+From 6ed0077520e2b0da1fd060c7f88db7b2e6068e4c Mon Sep 17 00:00:00 2001
+From: Norbert Preining <preining@logic.at>
+Date: Wed, 19 Sep 2018 04:02:06 +0000
+Subject: [PATCH] writet1 protection against buffer overflow
+
+git-svn-id: svn://tug.org/texlive/trunk/Build/source@48697 c570f23f-e606-0410-a88d-b1316a301751
+---
+ texk/dvipsk/ChangeLog               | 5 +++++
+ texk/dvipsk/writet1.c               | 2 ++
+ texk/web2c/luatexdir/ChangeLog      | 4 ++++
+ texk/web2c/luatexdir/font/writet1.w | 2 ++
+ texk/web2c/pdftexdir/ChangeLog      | 5 +++++
+ texk/web2c/pdftexdir/writet1.c      | 2 ++
+ 6 files changed, 20 insertions(+)
+
+diff --git texk/dvipsk/ChangeLog texk/dvipsk/ChangeLog
+index 88faea447..bbce8fb3f 100644
+--- texk/dvipsk/ChangeLog
++++ texk/dvipsk/ChangeLog
+@@ -1,3 +1,8 @@
++2018-09-18  Nick Roessler  <nicholas.e.roessler@gmail.com>
++
++	* writet1.c (t1_check_unusual_charstring): protect against buffer
++	overflow.
++
+ 2018-04-14  Karl Berry  <karl@tug.org>
+ 
+ 	* Version 5.998 for TeX Live 2018 release.
+diff --git texk/dvipsk/writet1.c texk/dvipsk/writet1.c
+index 0fcf26907..3b478b900 100644
+--- texk/dvipsk/writet1.c
++++ texk/dvipsk/writet1.c
+@@ -1449,7 +1449,9 @@ static void t1_check_unusual_charstring(void)
+         *(strend(t1_buf_array) - 1) = ' ';
+ 
+         t1_getline();
++        alloc_array(t1_buf, strlen(t1_line_array) + strlen(t1_buf_array) + 1, T1_BUF_SIZE);
+         strcat(t1_buf_array, t1_line_array);
++        alloc_array(t1_line, strlen(t1_buf_array) + 1, T1_BUF_SIZE);
+         strcpy(t1_line_array, t1_buf_array);
+         t1_line_ptr = eol(t1_line_array);
+     }
+diff --git texk/web2c/luatexdir/font/writet1.w texk/web2c/luatexdir/font/writet1.w
+index 0a0cadcfb..d3bf29341 100644
+--- texk/web2c/luatexdir/font/writet1.w
++++ texk/web2c/luatexdir/font/writet1.w
+@@ -1581,7 +1581,9 @@ static void t1_check_unusual_charstring(void)
+     if (sscanf(p, "%i", &i) != 1) {
+         strcpy(t1_buf_array, t1_line_array);
+         t1_getline();
++        alloc_array(t1_buf, strlen(t1_line_array) + strlen(t1_buf_array) + 1, T1_BUF_SIZE);
+         strcat(t1_buf_array, t1_line_array);
++        alloc_array(t1_line, strlen(t1_buf_array) + 1, T1_BUF_SIZE);
+         strcpy(t1_line_array, t1_buf_array);
+         t1_line_ptr = eol(t1_line_array);
+     }
+diff --git texk/web2c/pdftexdir/writet1.c texk/web2c/pdftexdir/writet1.c
+index d191b77ee..8cfc2616c 100644
+--- texk/web2c/pdftexdir/writet1.c
++++ texk/web2c/pdftexdir/writet1.c
+@@ -1598,7 +1598,9 @@ static void t1_check_unusual_charstring(void)
+         *(strend(t1_buf_array) - 1) = ' ';
+ 
+         t1_getline();
++        alloc_array(t1_buf, strlen(t1_line_array) + strlen(t1_buf_array) + 1, T1_BUF_SIZE);
+         strcat(t1_buf_array, t1_line_array);
++        alloc_array(t1_line, strlen(t1_buf_array) + 1, T1_BUF_SIZE);
+         strcpy(t1_line_array, t1_buf_array);
+         t1_line_ptr = eol(t1_line_array);
+     }


### PR DESCRIPTION
#### Description
Nick Roessler from the University of Pennsylvania has found a buffer overflow
in texlive-bin, the executables for TexLive, the popular distribution of TeX
document production system.

This buffer overflow can be used for arbitrary code execution by crafting a
special type1 font (.pfb) and provide it to users running pdf(la)tex, dvips or
luatex in a way that the font is loaded.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
