### PR TITLE
comix: Abandon port

### DIFF
--- a/graphics/comix/Portfile
+++ b/graphics/comix/Portfile
@@ -4,7 +4,7 @@ name                comix
 version             4.0.4
 revision            4
 categories          graphics
-maintainers         {perry @lperry} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 license             GPL-2
 


### PR DESCRIPTION
#### Description

Changes the port's maintainer to nomaintainer

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?