### PR TITLE
port_cutleaves: Abandon port

### DIFF
--- a/sysutils/port_cutleaves/Portfile
+++ b/sysutils/port_cutleaves/Portfile
@@ -3,6 +3,7 @@ PortSystem          1.0
 name                port_cutleaves
 version             0.1.4
 categories          sysutils macports
+license             BSD
 maintainers         nomaintainer
 platforms           darwin
 supported_archs     noarch

--- a/sysutils/port_cutleaves/Portfile
+++ b/sysutils/port_cutleaves/Portfile
@@ -3,7 +3,7 @@ PortSystem          1.0
 name                port_cutleaves
 version             0.1.4
 categories          sysutils macports
-maintainers         {perry @lperry} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 supported_archs     noarch
 


### PR DESCRIPTION
#### Description

Changes the port's maintainer to nomaintainer, and adds license

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?