### PR TITLE
librecad-devel: fix for qt-5.11

### DIFF
--- a/cad/LibreCAD/Portfile
+++ b/cad/LibreCAD/Portfile
@@ -31,6 +31,9 @@ if {${subport} eq "${name}"} {
     checksums           rmd160  ad84d422534a69c49a85017e0f04ba050115fb89 \
                         sha256  c23e6a1ccd0368c089e74772c02a420a5b475fdeb205ae6be39a93b3abeda965 \
                         size    13578523
+    
+    patchfiles          qt511.patch
+    patch.pre_args      -p1
 }
 
 pre-fetch {

--- a/cad/LibreCAD/files/qt511.patch
+++ b/cad/LibreCAD/files/qt511.patch
@@ -1,0 +1,52 @@
+From 6c392e903e162b9283e88f53006e929663f2e883 Mon Sep 17 00:00:00 2001
+From: Jiri Slaby <jslaby@suse.cz>
+Date: Mon, 11 Jun 2018 10:44:00 +0200
+Subject: [PATCH] fix build with Qt 5.11
+
+The new Qt removed some implicit inclusions of headers. To avoid build
+errors, add explicit includes of those we use in the sources.
+
+Signed-off-by: Jiri Slaby <jslaby@suse.cz>
+---
+ librecad/src/ui/forms/qg_commandwidget.cpp | 1 +
+ librecad/src/ui/generic/colorwizard.cpp    | 1 +
+ librecad/src/ui/generic/widgetcreator.cpp  | 2 ++
+ 3 files changed, 4 insertions(+)
+
+diff --git a/librecad/src/ui/forms/qg_commandwidget.cpp b/librecad/src/ui/forms/qg_commandwidget.cpp
+index 835e47d67..2c878e833 100644
+--- a/librecad/src/ui/forms/qg_commandwidget.cpp
++++ b/librecad/src/ui/forms/qg_commandwidget.cpp
+@@ -27,6 +27,7 @@
+ 
+ #include <algorithm>
+ 
++#include <QAction>
+ #include <QKeyEvent>
+ #include <QFileDialog>
+ #include <QSettings>
+diff --git a/librecad/src/ui/generic/colorwizard.cpp b/librecad/src/ui/generic/colorwizard.cpp
+index 2beaceb9c..84068ad75 100644
+--- a/librecad/src/ui/generic/colorwizard.cpp
++++ b/librecad/src/ui/generic/colorwizard.cpp
+@@ -27,6 +27,7 @@
+ #include "colorwizard.h"
+ #include "ui_colorwizard.h"
+ 
++#include <QAction>
+ #include <QColorDialog>
+ #include <QLineEdit>
+ #include <QListWidget>
+diff --git a/librecad/src/ui/generic/widgetcreator.cpp b/librecad/src/ui/generic/widgetcreator.cpp
+index 7c35144ff..d51190842 100644
+--- a/librecad/src/ui/generic/widgetcreator.cpp
++++ b/librecad/src/ui/generic/widgetcreator.cpp
+@@ -27,6 +27,8 @@
+ #include "widgetcreator.h"
+ #include "ui_widgetcreator.h"
+ 
++#include <QAction>
++#include <QActionGroup>
+ #include <QSettings>
+ #include <QLineEdit>
+ #include <QPushButton>


### PR DESCRIPTION
* patch for qt-5.11
* librecad (not devel) still broken

#### Description

LibreCAD sources need to be patched to work with qt-5.11. This PR does this for librecad-devel, but the source patch does not apply cleanly to librecad @2.1.3 (not devel). A different patch or using earlier versions of qt5 are potential solutions.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.12.6 16G1510
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
