### PR TITLE
gnupg2: Make openldap dependency a variant

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -60,7 +60,6 @@ depends_lib         port:libiconv           \
                     port:libksba            \
                     port:libgcrypt          \
                     port:libgpg-error       \
-                    port:openldap           \
                     port:readline           \
                     port:gnutls             \
                     port:libusb-compat      \
@@ -81,6 +80,10 @@ variant pinentry_mac conflicts pinentry description {Handle user input via pinen
     configure.args-append   --with-pinentry-pgm=${applications_dir}/pinentry-mac.app/Contents/MacOS/pinentry-mac
 }
 
+variant openldap description {Build with openldap.} {
+    depends_lib-append      port:openldap
+}
+
 test.run            yes
 test.dir            ${worksrcpath}/tests
 test.target         check
@@ -88,3 +91,5 @@ test.target         check
 livecheck.type      regex
 livecheck.url       https://gnupg.org/ftp/gcrypt/${my_name}/
 livecheck.regex     ${my_name}-(\\d+(?:\\.\\d+)*)
+
+default_variants +openldap


### PR DESCRIPTION
#### Description

I install macports-base using --with-no-root-privileges.  gnupg2 depends on openldap, which could not be built due to this error:

Error: Failed to activate openldap: error renaming "/redacted.../etc/LaunchDaemons/org.macports.slapd.plist" to "/Library/LaunchDaemons/org.macports.slapd.plist": permission denied

It seems that gnupg2 builds fine without openldap.  With this patch 'port install gnupg2 -openldap' works for me on High Sierra.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
