### PR TITLE
compilers PG: keep -arch flags by default

### DIFF
--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -65,7 +65,7 @@ default compilers.required_f {}
 default compilers.required_some_f {}
 default compilers.variants_conflict {}
 default compilers.libfortran {}
-default compilers.clear_archflags yes
+default compilers.clear_archflags no
 
 # also set a default gcc version
 if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -241,8 +241,6 @@ compiler.blacklist-delete *gcc*
 #     see https://lists.gnu.org/archive/html/octave-maintainers/2016-02/msg00168.html
 compiler.blacklist macports-gcc-6
 
-compilers.clear_archflags no
-
 # for now, limit the number of variants
 # some of these compilers may work fine
 compilers.setup     \

--- a/math/petsc/Portfile
+++ b/math/petsc/Portfile
@@ -58,19 +58,6 @@ pre-configure {
     }
 
     configure.universal_args-delete --disable-dependency-tracking
-
-    if {![variant_isset universal]} {
-        # base does not quite handle Fortran flags correctly
-        if {${build_arch} eq "x86_64" || ${build_arch} eq "ppc64"} {
-            configure.fc_archflags   -m64
-            configure.f90_archflags  -m64
-            configure.fflags-append  -m64
-        } else {
-            configure.fc_archflags   -m32
-            configure.fflags-append  -m32
-            configure.f90_archflags  -m32
-        }
-    }
 }
 
 post-build {

--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -27,9 +27,6 @@ if {${name} ne ${subport}} {
 
 python.versions         26 27 33 34 35 36 37
 
-# respect ${build_arch} value
-compilers.clear_archflags  no
-
 # http://trac.macports.org/ticket/34562
 python.consistent_destroot yes
 

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -130,7 +130,6 @@ platform darwin {
 configure.optflags-delete   -O2 -Os
 configure.cppflags-delete   -I${prefix}/include
 configure.ldflags-delete    -L${prefix}/lib
-compilers.clear_archflags   no
 
 if {${subport} != ${name}} {
     set cname                   [lindex [split ${subport} -] end]

--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -109,7 +109,6 @@ configure.ccache no
 configure.optflags-delete   -O2 -Os
 configure.cppflags-delete   -I${prefix}/include
 configure.ldflags-delete    -L${prefix}/lib
-compilers.clear_archflags   no
 
 build.dir           ${configure.dir}
 destroot.dir        ${build.dir}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 10.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
