### PR TITLE
texlive: exclude dvisvgm

### DIFF
--- a/tex/texlive-bin-extra/Portfile
+++ b/tex/texlive-bin-extra/Portfile
@@ -5,7 +5,7 @@ PortGroup           texlive 1.0
 
 name                texlive-bin-extra
 version             47446
-revision            0
+revision            1
 
 categories          tex
 maintainers         {dports @drkp}
@@ -28,12 +28,13 @@ depends_lib         port:texlive-basic
 texlive.formats      \
     {0 mflua mflua-nowin - {mf.ini}}
 
-texlive.binaries    a2ping a5toa4 adhocfilelist arara arlatex bibtex8 bibtexu bundledoc checklistings chktex chkweb ctan-o-mat ctangle ctanify ctanupload ctie cweave de-macro depythontex deweb dt2dv dtxgen dv2dt dviasm dvibook dviconcat dvicopy dvidvi dvihp dviinfox dvilj dvilj2p dvilj4 dvilj4l dvilj6 dvipos dviselect dvisvgm dvitodvi dvitype e2pall findhyph fragmaster installfont-tl ketcindy lacheck latex-git-log latex-papersize latex2man latex2nemeth latexdef latexfileversion latexindent latexpand listings-ext.sh ltxfileinfo ltximg make4ht match_parens mflua mflua-nowin mfluajit mfluajit-nowin mkjobtexmf patgen pdfatfi pdfbook2 pdfclose pdfcrop pdflatexpicscale pdfopen pdftosrc pdfxup pfarrei pkfix pkfix-helper pooltype purifyeps pythontex rpdfcrop srcredact sty2dtx synctex tangle tex4ebook texcount texdef texdiff texdirflatten texdoc texdoctk texfot texliveonfly texloganalyser texosquery texosquery-jre5 texosquery-jre8 tie tlcockpit tlshell tpic2pdftex typeoutfileinfo weave
+texlive.binaries    a2ping a5toa4 adhocfilelist arara arlatex bibtex8 bibtexu bundledoc checklistings chktex chkweb ctan-o-mat ctangle ctanify ctanupload ctie cweave de-macro depythontex deweb dt2dv dtxgen dv2dt dviasm dvibook dviconcat dvicopy dvidvi dvihp dviinfox dvilj dvilj2p dvilj4 dvilj4l dvilj6 dvipos dviselect dvitodvi dvitype e2pall findhyph fragmaster installfont-tl ketcindy lacheck latex-git-log latex-papersize latex2man latex2nemeth latexdef latexfileversion latexindent latexpand listings-ext.sh ltxfileinfo ltximg make4ht match_parens mflua mflua-nowin mfluajit mfluajit-nowin mkjobtexmf patgen pdfatfi pdfbook2 pdfclose pdfcrop pdflatexpicscale pdfopen pdftosrc pdfxup pfarrei pkfix pkfix-helper pooltype purifyeps pythontex rpdfcrop srcredact sty2dtx synctex tangle tex4ebook texcount texdef texdiff texdirflatten texdoc texdoctk texfot texliveonfly texloganalyser texosquery texosquery-jre5 texosquery-jre8 tie tlcockpit tlshell tpic2pdftex typeoutfileinfo weave
 
 depends_run         port:latexmk \
                     port:detex \
                     port:latexdiff \
                     port:pdfjam \
-                    port:dvipng
+                    port:dvipng \
+                    port:dvisvgm
 
 texlive.texmfport

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -11,7 +11,7 @@ PortGroup       muniversal 1.0
 
 name            texlive-bin
 version         2018.47642
-revision        4
+revision        5
 
 categories      tex
 maintainers     {dports @drkp}
@@ -171,6 +171,7 @@ configure.args  --bindir=${texlive_bindir} \
                 --disable-detex \
                 --disable-dvi2tty \
                 --disable-dvipng \
+                --disable-dvisvgm \
                 --disable-lcdf-typetools \
                 --disable-ps2eps \
                 --disable-psutils \


### PR DESCRIPTION
The dvisvgm binary is available as a standalone port which depends on ghostscript.

Removing it from the TeX Live package has a number of benefits:
* No need to revbump `texlive-bin` after each `ghoscript` update.
* No need for a (missing) conflict between `texlive-bin-extra` and `dvisvgm`.
* Users of `texlive-bin-extra` get a newer version of `dvisvgm`.

See also: #2573, #2620.

#### Description

This looks to me like the correct thing to do instead of blindly (and uselessly) revbumping `texlive-bin` after each ghoscript update (#2573).

@l2dy: I would commit this together with #2620 and only do the revbump once. It could be a bit of a bordercase to do this quickly: this commit would generally not fall under openmaintainer policy to be committed under 72 hours, but @drkp did not respond to my request for review of #2573 and both cited PRs are security issues which do fall under "your-are-allowed-to-commit-immediately" policy. Commiting this at the same time would merely spare some CPU cycles. I leave it up to others to decide. I hope that @drkp responds quickly.

@RasmusWernerLarsen

###### Type(s)

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
  * commits would ideally be combined with #2620
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
  * two open pull requests referenced above
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?