### PR TITLE
opusfile: update to 0.11

### DIFF
--- a/audio/opusfile/Portfile
+++ b/audio/opusfile/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                opusfile
-version             0.10
+version             0.11
 categories          audio
 license             BSD
 platforms           darwin
@@ -12,11 +12,12 @@ description         A library for decoding .opus files, including seeking suppor
 
 long_description    ${description}
 
-homepage            http://www.opus-codec.org
+homepage            https://opus-codec.org/
 master_sites        https://archive.mozilla.org/pub/opus/
 
-checksums           rmd160  b9fcc6fd243b45c853aa64137f006d71d0c7cc2b \
-                    sha256  48e03526ba87ef9cf5f1c47b5ebe3aa195bd89b912a57060c36184a6cd19412f
+checksums           rmd160  1698cdc450eaffc00aba4cc4912e6eb9b21bb565 \
+                    sha256  74ce9b6cf4da103133e7b5c95df810ceb7195471e1162ed57af415fabf5603bf \
+                    size    467420
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

* update to version 0.11
* use https for homepage

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1510
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
