### PR TITLE
opus-tools: update to 0.2

### DIFF
--- a/audio/opus-tools/Portfile
+++ b/audio/opus-tools/Portfile
@@ -5,9 +5,9 @@ PortGroup       muniversal 1.0
 PortGroup       compiler_blacklist_versions 1.0
 
 name            opus-tools
-version         0.1.10
+version         0.2
 categories      audio
-license         BSD
+license         BSD GPL-2
 platforms       darwin
 maintainers     {jeremyhu @jeremyhu} openmaintainer
 description     The Opus Audio Codec (IETF RFC 6716), refrence implementation tools
@@ -18,14 +18,15 @@ long_description \
     all pre-existing codecs across the spectrum for voice, audio, archival, \
     and real-time uses.
 
-homepage        http://www.opus-codec.org
+homepage        https://opus-codec.org/
 master_sites    https://archive.mozilla.org/pub/opus/
 
-depends_lib     port:libopus port:libogg port:flac
+depends_lib     port:libopus port:libogg port:flac port:libopusenc port:opusfile
 depends_build   port:pkgconfig
 
-checksums           rmd160  74eb1bbd31f1cc6a9ad706069f6341bc5d807762 \
-                    sha256  a2357532d19471b70666e0e0ec17d514246d8b3cb2eb168f68bb0f6fd372b28c
+checksums           rmd160  236b05a0cfbb1e03340c0e99bcef888b01ecf36e \
+                    sha256  b4e56cb00d3e509acfba9a9b627ffd8273b876b4e2408642259f6da28fa0ff86 \
+                    size    457680
 
 compiler.blacklist  gcc-4.0 *gcc-4.2 {clang < 300}
 


### PR DESCRIPTION
#### Description

* update to version 0.2
* add new dependencies on libopusenc and opusfile
* use https for homepage
* correct license (opusenc/opusdec are BSD, opusinfo is GPL-2)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1510
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
