### PR TITLE
portaudio: support for jack, test/example binaries

### DIFF
--- a/audio/portaudio/Portfile
+++ b/audio/portaudio/Portfile
@@ -61,6 +61,23 @@ platform darwin {
     }
 }
 
+variant jack description {Enable JACK support} {
+    depends_lib-append \
+                    port:jack
+    configure.args-replace \
+                    --without-jack \
+                    --with-jack
+}
+
+variant tools description {Install the example and test utilities to ${prefix}/libexec/${name}} {
+    post-destroot {
+        set utildir ${destroot}${prefix}/libexec/${name}
+        xinstall -m 755 -d ${utildir}
+        # avoid installing any .dSYM directories that might have been created
+        xinstall -m 755 {*}[glob -type f ${build.dir}/bin/.libs/pa*] ${utildir}
+    }
+}
+
 use_parallel_build  no
 
 post-destroot {


### PR DESCRIPTION
@RJVB: This is what seems remaining of https://trac.macports.org/ticket/54125 (according to my understanding) after #1678 was merged. Please let me know if I should put your name as the author.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
