### PR TITLE
x86_64-elf-gcc: update to 8.2.0

### DIFF
--- a/cross/x86_64-elf-gcc/Portfile
+++ b/cross/x86_64-elf-gcc/Portfile
@@ -4,19 +4,14 @@ PortSystem          1.0
 PortGroup           crossgcc 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-crossgcc.setup      x86_64-elf 4.7.2
-revision            1
-crossgcc.setup_libc newlib 1.20.0
+crossgcc.setup      x86_64-elf 8.2.0
+crossgcc.setup_libc newlib 3.0.0
 
 maintainers         nomaintainer
 
-checksums           gcc-${version}.tar.bz2 \
-                    md5     cc308a0891e778cfda7a151ab8a6e762 \
-                    rmd160  fc281ade14b47d2a9c2ced4f7082c74bfbae31c1 \
-                    sha256  8a9283d7010fb9fe5ece3ca507e0af5c19412626384f8a5e9434251ae100b084 \
-                    newlib-${crossgcc.libc_version}.tar.gz \
-                    sha1    65e7bdbeda0cbbf99c8160df573fd04d1cbe00d1 \
-                    rmd160  e36c5337a74633456b47d09594974c7dd7a9cc3e
+# https://trac.macports.org/ticket/57153
+configure.args-append \
+                    --disable-libcc1
 
 # Failed to build with clang from Xcode 4.5
 # fatal error: error in backend: ran out of registers during register allocation


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/53802
See: https://trac.macports.org/ticket/57153

I did not test the resulting binary.

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
