### PR TITLE
ace, tao: update to 6.5.2

### DIFF
--- a/devel/ace/Portfile
+++ b/devel/ace/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ace
 set name_package    ACE
-version             6.4.8
+version             6.5.2
 distname            ${name_package}-${version}
 categories          devel
 maintainers         {gmail.com:tlockhart1976 @lockhart} openmaintainer
@@ -25,7 +25,7 @@ long_description    The ADAPTIVE Communication Environment (ACE) is a freely ava
 
 conflicts           tao
 
-homepage            http://www.cs.wustl.edu/~schmidt/ACE.html
+homepage            http://www.dre.vanderbilt.edu/~schmidt/ACE.html
 master_sites        http://download.dre.vanderbilt.edu/previous_versions
 
 universal_variant   yes
@@ -34,15 +34,15 @@ use_bzip2           yes
 
 worksrcdir          ACE_wrappers
 
-patch.pre_args      -p1
 patchfiles          patch-ace-config.h.diff \
-                    patch-include-makeinclude-platform_macros.GNU.diff
+                    patch-include-makeinclude-platform_macros.GNU.diff \
+                    patch-archflags.diff
 
-checksums           rmd160  0b8a65df846331bec1d69ce781d22508cf67f37f \
-                    sha256  0f8121a8e3f49e217644a353d439d148f1d6fe52487ae6bd80572a2bb4f30ca4 \
-                    size    8381452
+checksums           rmd160  20c75a6e764d4896f946e35350c1b579c6537c07 \
+                    sha256  f0393d6df25ee92e0cbc6539c68ccf122caae0ffd5ae9a786163403bb2306cc5 \
+                    size    8074873
 
-set os.name "sierra"
+set os.name "highsierra"
 array set os.names {
      7  panther
      8  tiger
@@ -55,6 +55,7 @@ array set os.names {
     15  elcapitan
     16  sierra
     17  highsierra
+    18  mojave
 }
 foreach {key value} [array get os.names]  {
     if {${key} == ${os.major}} {
@@ -70,31 +71,15 @@ post-patch {
     reinplace "s|@MACOSX@|${os.name}|g" \
         ${worksrcpath}/ace/config.h \
         ${worksrcpath}/include/makeinclude/platform_macros.GNU
+    reinplace "s|@@CFLAGS@@|[get_canonical_archflags cc]|g" \
+        ${worksrcpath}/include/makeinclude/platform_macosx_common.GNU
+    reinplace "s|@@LDFLAGS@@|[get_canonical_archflags ld] -stdlib=${configure.cxx_stdlib}|g" \
+        ${worksrcpath}/include/makeinclude/platform_macosx_common.GNU
+    reinplace "s|@@CXXFLAGS@@|[get_canonical_archflags cc] -stdlib=${configure.cxx_stdlib}|g" \
+        ${worksrcpath}/include/makeinclude/platform_macosx_common.GNU
 }
 
 depends_lib-append  path:bin/perl:perl5
-
-proc setuniversalflags {fname cxxflags ldflags} {
-    set apat "-arch \[ \]*\[a-z\]\[_a-z0-9\]*"
-    if {[file exists ${fname}]} {
-        reinplace "s|^\\(\[ \]*FLAGS_C_CC\[ \]*+=\[ \]*\\)${apat}\\(\[ \]*${apat}\\)*|\\1${cxxflags}|g" \
-            ${fname}
-        reinplace "s|^\\(\[ \]*LDFLAGS\[ \]*+=\[ \]*\\)${apat}\\(\[ \]*${apat}\\)*|\\1${ldflags}|g" \
-            ${fname}
-    } else {
-        ui_warn "File ${fname} not found for patching"
-    }
-}
-
-variant universal {
-    post-patch {
-        ui_info "patching platform_macros.GNU"
-        reinplace "s|buildbits=64|buildbits=universal|g" \
-            ${worksrcpath}/include/makeinclude/platform_macros.GNU
-        setuniversalflags ${worksrcpath}/include/makeinclude/platform_macosx_${os.name}.GNU \
-            ${configure.universal_cxxflags} ${configure.universal_ldflags}
-    }
-}
 
 variant ssl description {Enable SSL} {
     depends_lib-append path:lib/libssl.dylib:openssl

--- a/devel/ace/files/patch-ace-config.h.diff
+++ b/devel/ace/files/patch-ace-config.h.diff
@@ -1,5 +1,5 @@
---- ACE_wrappers.orig/ace/config.h	1969-12-31 16:00:00.000000000 -0800
-+++ ACE_wrappers/ace/config.h	2012-02-10 20:59:39.000000000 -0800
+--- ace/config.h.orig
++++ ace/config.h
 @@ -0,0 +1,8 @@
 +// ACE_LACKS_CLOCKID_T and ACE_LACKS_CLOCK_MONOTONIC were needed sometime before Mountain Lion
 +// but are not needed for Sierra. Do not yet have info for releases in between.

--- a/devel/ace/files/patch-archflags.diff
+++ b/devel/ace/files/patch-archflags.diff
@@ -1,0 +1,63 @@
+--- include/makeinclude/platform_macosx_common.GNU.orig
++++ include/makeinclude/platform_macosx_common.GNU
+@@ -47,7 +47,6 @@ endif
+ 
+ LDFLAGS         += -flat_namespace
+ 
+-ifeq ($(universal),1)
+-  CFLAGS += -arch i386 -arch ppc
+-  LDFLAGS += -arch i386 -arch ppc
+-endif
++CFLAGS += @@CFLAGS@@
++LDFLAGS += @@LDFLAGS@@
++FLAGS_C_CC += @@CXXFLAGS@@
+--- include/makeinclude/platform_macosx_lion.GNU.orig
++++ include/makeinclude/platform_macosx_lion.GNU
+@@ -1,27 +1,6 @@
+ 
+ INSLIB?=$(ACE_ROOT)/lib
+ 
+-ifeq ($(buildbits),32)
+-  FLAGS_C_CC += -m32
+-  LDFLAGS    += -m32
+-endif
+-ifeq ($(buildbits),64)
+-  FLAGS_C_CC += -m64
+-  LDFLAGS    += -m64
+-endif
+-ifeq ($(buildbits),universal)
+-  FLAGS_C_CC += -arch i386 -arch x86_64
+-  LDFLAGS    += -arch i386 -arch x86_64
+-endif
+-
+-ifeq (,$(buildbits))
+-  FLAGS_C_CC += -m64
+-  LDFLAGS    += -m64
+-endif
+-
+-CC:=clang
+-CXX:=clang++
+-
+ PLATFORM_NDDS_FLAGS=-ppPath cpp-4.2 -I.
+ 
+ include $(ACE_ROOT)/include/makeinclude/platform_macosx_common.GNU
+--- include/makeinclude/platform_macosx_snowleopard.GNU.orig
++++ include/makeinclude/platform_macosx_snowleopard.GNU
+@@ -1,17 +1,4 @@
+ 
+-ifeq ($(buildbits),32)
+-  FLAGS_C_CC += -m32
+-  LDFLAGS    += -m32
+-endif
+-ifeq ($(buildbits),64)
+-  FLAGS_C_CC += -m64
+-  LDFLAGS    += -m64
+-endif
+-ifeq ($(buildbits),universal)
+-  FLAGS_C_CC += -arch i386 -arch x86_64
+-  LDFLAGS    += -arch i386 -arch x86_64
+-endif
+-
+ PLATFORM_NDDS_FLAGS="-ppPath cpp-4.2 -I."
+ 
+ include $(ACE_ROOT)/include/makeinclude/platform_macosx_common.GNU

--- a/devel/ace/files/patch-include-makeinclude-platform_macros.GNU.diff
+++ b/devel/ace/files/patch-include-makeinclude-platform_macros.GNU.diff
@@ -1,5 +1,5 @@
---- ACE_wrappers.orig/include/makeinclude/platform_macros.GNU	1969-12-31 16:00:00.000000000 -0800
-+++ ACE_wrappers/include/makeinclude/platform_macros.GNU	2012-02-10 22:47:24.000000000 -0800
+--- include/makeinclude/platform_macros.GNU.orig
++++ include/makeinclude/platform_macros.GNU
 @@ -0,0 +1,12 @@
 +buildbits=64
 +universal=0

--- a/devel/tao/Portfile
+++ b/devel/tao/Portfile
@@ -11,7 +11,7 @@ PortSystem          1.0
 
 name                tao
 set name_package    ACE+TAO
-version             6.4.8
+version             6.5.2
 distname            ${name_package}-${version}
 categories          devel
 platforms           darwin
@@ -28,9 +28,8 @@ long_description    The ACE ORB (TAO) is a real-time implementation of CORBA bui
 
 conflicts           ace
 
-homepage            http://www.cs.wustl.edu/~schmidt/TAO.html
-master_sites        http://download.dre.vanderbilt.edu/previous_versions \
-                    ftp://download.dre.vanderbilt.edu/previous_versions
+homepage            http://www.dre.vanderbilt.edu/~schmidt/TAO.html
+master_sites        http://download.dre.vanderbilt.edu/previous_versions
 
 universal_variant   yes
 default_variants    +server
@@ -39,16 +38,16 @@ use_bzip2           yes
 
 worksrcdir          ACE_wrappers
 
-patch.pre_args      -p1
 patchfiles          patch-ace-config.h.diff \
                     patch-ace-config-macosx-sierra.h.diff \
-                    patch-include-makeinclude-platform_macros.GNU.diff
+                    patch-include-makeinclude-platform_macros.GNU.diff \
+                    patch-archflags.diff
 
-checksums           rmd160  011c4bce5cde3cf0fa617133b18b31ee465318ea \
-                    sha256  5d0592e0d06bcdc79bf59372ea6302a1ccc72fc3c733de5f738dfc0c83f1c6c8 \
-                    size    23464186
+checksums           rmd160  5f2877aa12727ec1f8b26c9965c0e6b97158f44d \
+                    sha256  033e4d119db3f3a5da98dbfc0754b02e2dbe73b17c2927c95711d8b15f4cc86f \
+                    size    21636691
 
-set os.name "sierra"
+set os.name "highsierra"
 array set os.names {
      7  panther
      8  tiger
@@ -61,6 +60,7 @@ array set os.names {
     15  elcapitan
     16  sierra
     17  highsierra
+    18  mojave
 }
 foreach {key value} [array get os.names]  {
     if {${key} == ${os.major}} {
@@ -80,25 +80,17 @@ post-patch {
     reinplace "s|@MACOSX@|${os.name}|g" \
         ${worksrcpath}/ace/config.h \
         ${worksrcpath}/include/makeinclude/platform_macros.GNU
+    reinplace "s|@@CFLAGS@@|[get_canonical_archflags cc]|g" \
+        ${worksrcpath}/include/makeinclude/platform_macosx_common.GNU
+    reinplace "s|@@LDFLAGS@@|[get_canonical_archflags ld] -stdlib=${configure.cxx_stdlib}|g" \
+        ${worksrcpath}/include/makeinclude/platform_macosx_common.GNU
+    reinplace "s|@@CXXFLAGS@@|[get_canonical_archflags cc] -stdlib=${configure.cxx_stdlib}|g" \
+        ${worksrcpath}/include/makeinclude/platform_macosx_common.GNU
 }
 
 depends_lib-append  path:bin/perl:perl5 \
                     port:tcl \
                     port:zlib
-
-variant universal {
-    post-patch {
-        ui_info "patching platform_macros.GNU"
-        reinplace "s|buildbits=64|buildbits=universal|g" \
-            ${worksrcpath}/include/makeinclude/platform_macros.GNU
-        set apat "-arch \[ \]*\[a-z\]\[_a-z0-9\]*"
-        reinplace "s|${apat}\\(\[ \]*${apat}\\)*|${configure.universal_cxxflags}|g" \
-            ${worksrcpath}/include/makeinclude/platform_macosx_lion.GNU
-        ui_info "patching platform_macosx_snowleopard.GNU"
-        reinplace "s|${apat}\\(\[ \]*${apat}\\)*|${configure.universal_cxxflags}|g" \
-            ${worksrcpath}/include/makeinclude/platform_macosx_snowleopard.GNU
-    }
-}
 
 variant ssl description {Enable SSL} {
     depends_lib-append path:lib/libssl.dylib:openssl

--- a/devel/tao/files/patch-ace-config-macosx-sierra.h.diff
+++ b/devel/tao/files/patch-ace-config-macosx-sierra.h.diff
@@ -1,5 +1,5 @@
---- ACE_wrappers/ace/config-macosx-sierra.h.orig	2017-09-07 00:02:07.000000000 -0700
-+++ ACE_wrappers/ace/config-macosx-sierra.h	2017-09-17 12:47:10.000000000 -0700
+--- ace/config-macosx-sierra.h.orig
++++ ace/config-macosx-sierra.h
 @@ -3,4 +3,8 @@
  
  #include "ace/config-macosx-elcapitan.h"

--- a/devel/tao/files/patch-ace-config.h.diff
+++ b/devel/tao/files/patch-ace-config.h.diff
@@ -1,5 +1,5 @@
---- ACE_wrappers.orig/ace/config.h	1969-12-31 16:00:00.000000000 -0800
-+++ ACE_wrappers/ace/config.h	2012-02-10 20:59:39.000000000 -0800
+--- ace/config.h.orig
++++ ace/config.h
 @@ -0,0 +1,8 @@
 +// ACE_LACKS_CLOCKID_T and ACE_LACKS_CLOCK_MONOTONIC were needed sometime before Mountain Lion
 +// but are not needed for Sierra. Do not yet have info for releases in between.

--- a/devel/tao/files/patch-archflags.diff
+++ b/devel/tao/files/patch-archflags.diff
@@ -1,0 +1,63 @@
+--- include/makeinclude/platform_macosx_common.GNU.orig
++++ include/makeinclude/platform_macosx_common.GNU
+@@ -47,7 +47,6 @@ endif
+ 
+ LDFLAGS         += -flat_namespace
+ 
+-ifeq ($(universal),1)
+-  CFLAGS += -arch i386 -arch ppc
+-  LDFLAGS += -arch i386 -arch ppc
+-endif
++CFLAGS += @@CFLAGS@@
++LDFLAGS += @@LDFLAGS@@
++FLAGS_C_CC += @@CXXFLAGS@@
+--- include/makeinclude/platform_macosx_lion.GNU.orig
++++ include/makeinclude/platform_macosx_lion.GNU
+@@ -1,27 +1,6 @@
+ 
+ INSLIB?=$(ACE_ROOT)/lib
+ 
+-ifeq ($(buildbits),32)
+-  FLAGS_C_CC += -m32
+-  LDFLAGS    += -m32
+-endif
+-ifeq ($(buildbits),64)
+-  FLAGS_C_CC += -m64
+-  LDFLAGS    += -m64
+-endif
+-ifeq ($(buildbits),universal)
+-  FLAGS_C_CC += -arch i386 -arch x86_64
+-  LDFLAGS    += -arch i386 -arch x86_64
+-endif
+-
+-ifeq (,$(buildbits))
+-  FLAGS_C_CC += -m64
+-  LDFLAGS    += -m64
+-endif
+-
+-CC:=clang
+-CXX:=clang++
+-
+ PLATFORM_NDDS_FLAGS=-ppPath cpp-4.2 -I.
+ 
+ include $(ACE_ROOT)/include/makeinclude/platform_macosx_common.GNU
+--- include/makeinclude/platform_macosx_snowleopard.GNU.orig
++++ include/makeinclude/platform_macosx_snowleopard.GNU
+@@ -1,17 +1,4 @@
+ 
+-ifeq ($(buildbits),32)
+-  FLAGS_C_CC += -m32
+-  LDFLAGS    += -m32
+-endif
+-ifeq ($(buildbits),64)
+-  FLAGS_C_CC += -m64
+-  LDFLAGS    += -m64
+-endif
+-ifeq ($(buildbits),universal)
+-  FLAGS_C_CC += -arch i386 -arch x86_64
+-  LDFLAGS    += -arch i386 -arch x86_64
+-endif
+-
+ PLATFORM_NDDS_FLAGS="-ppPath cpp-4.2 -I."
+ 
+ include $(ACE_ROOT)/include/makeinclude/platform_macosx_common.GNU

--- a/devel/tao/files/patch-include-makeinclude-platform_macros.GNU.diff
+++ b/devel/tao/files/patch-include-makeinclude-platform_macros.GNU.diff
@@ -1,5 +1,5 @@
---- ACE_wrappers.orig/include/makeinclude/platform_macros.GNU	1969-12-31 16:00:00.000000000 -0800
-+++ ACE_wrappers/include/makeinclude/platform_macros.GNU	2012-02-10 22:47:24.000000000 -0800
+--- include/makeinclude/platform_macros.GNU.orig
++++ include/makeinclude/platform_macros.GNU
 @@ -0,0 +1,13 @@
 +buildbits=64
 +universal=0


### PR DESCRIPTION
I browsed the tickets on Trac and found two for updates of ace & tao, but since the time the maintainer submitted them, the versions were already outdated. Please don't merge before the maintainer approves. @ryandesign said tao did not build for him. I only tested the latest version (6.5.2 rather than 6.5.0) and the build succeeded on 10.13.

* Update homepage (broken url)
* Add support for Mojave
* Livecheck does not work from two URLs at the same time (bugfix)

Closes: https://trac.macports.org/ticket/56699
Closes: https://trac.macports.org/ticket/56700

###### Tested on

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
