### PR TITLE
git-lfs: update to 2.5.2, use golang 1.0 PortGroup

### DIFF
--- a/devel/git-lfs/Portfile
+++ b/devel/git-lfs/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               github 1.0
+PortGroup               golang 1.0
 
-github.setup            git-lfs git-lfs 2.4.2 v
+go.setup                github.com/git-lfs/git-lfs 2.5.2 v
 maintainers             {raimue @raimue} \
                         openmaintainer
 platforms               darwin
@@ -15,24 +15,19 @@ long_description        ${description} is an extension for versioning large file
 homepage                https://git-lfs.github.com/
 license                 MIT
 
-checksums               rmd160  bdf7b71221ec5edf2ebd4b332002e5a6145d6afd \
-                        sha256  245a57c688aded74bd2c6326e251fdaaafa93594429be6de2a83ea65ceea0367 \
-                        size    790767
-
-patchfiles              patch-ronn.diff
+checksums               rmd160  ff92bcb4d03b93ee640a36cd7ad780eaaa948933 \
+                        sha256  1fb0b6951b8a5094d6f07e112f9fe2a1f4abd45cc7b07ed7faa4d6fd9c433cfa \
+                        size    946475
 
 depends_build           port:go \
                         port:rb19-ronn
 depends_run             port:git
 
-post-patch {
-    reinplace "s:@@PREFIX@@:${prefix}:" ${worksrcpath}/script/man
-}
-
 use_configure no
 
-build.cmd               ./script/bootstrap && ./script/man
-build.target
+build.cmd               make
+build.target            bin/git-lfs man
+build.args              RONN=${prefix}/bin/ronn-1.9
 
 destroot {
     set bindir ${destroot}${prefix}/bin

--- a/devel/git-lfs/files/patch-ronn.diff
+++ b/devel/git-lfs/files/patch-ronn.diff
@@ -1,9 +1,0 @@
---- script/man.orig	2015-10-01 21:36:42.000000000 +0200
-+++ script/man	2015-10-01 21:37:20.000000000 +0200
-@@ -1,5 +1,5 @@
- #!/usr/bin/env bash
--ronn=`which ronn`
-+ronn=@@PREFIX@@/bin/ronn-1.9
- 
- if [ -x "$ronn" ]; then
-   mkdir -p man


### PR DESCRIPTION
#### Description
Fixes: https://trac.macports.org/ticket/56905

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
