### PR TITLE
sift: use golang-1.0 portgroup

### DIFF
--- a/sysutils/sift/Portfile
+++ b/sysutils/sift/Portfile
@@ -1,19 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           golang 1.0
+go.setup            github.com/svent/sift 0.9.0 v
 
-# this doesn't work directly because files need to be fetched from multiple repositories
-#
-# PortGroup         github 1.0
-# github.setup      svent sift 0.9.0 v
-
-name                sift
-version             0.9.0
-platforms           darwin
 categories          sysutils
 license             GPL-3+
 installs_libs       no
-maintainers         {gmail.com:esafak @esafak}
+maintainers         {gmail.com:esafak @esafak} openmaintainer
 description         A fast and powerful open source alternative to grep
 long_description    sift is an alternative that aims for both speed and flexibility, \
                     adding features while trying to reach (or even surpass) the performance \
@@ -21,71 +15,33 @@ long_description    sift is an alternative that aims for both speed and flexibil
                     conditions (e.g., match A only when preceded by B within X lines), \
                     full multi-core support and multiline matching.
 homepage            https://sift-tool.org
-platforms           darwin
-use_zip             yes
 
-set crypto_hash     2faea14
-set nbreader_hash   7cef48da76dca6a496faa7fe63e39ed665cbd219
-set flags_version   1.3.0
+checksums           ${distname}${extract.suffix} \
+                        rmd160  8980a7ca2580914ff03e4d5da15003923f4b9c61 \
+                        sha256  5039ac9fddf717a366f0e6d56a69ee54b4bcf460381f06f71b69774514d7ffb2 \
+                        size    37464
 
-master_sites        https://github.com/svent/sift/archive:sift \
-                    https://github.com/jessevdk/go-flags/archive:flags \
-                    https://github.com/svent/go-nbreader/archive:nbreader \
-                    https://raw.githubusercontent.com/golang/crypto/${crypto_hash}/ssh/terminal:crypto
-
-distfiles           v${version}.zip:sift \
-                    v${flags_version}.zip:flags \
-                    ${nbreader_hash}.zip:nbreader \
-                    terminal.go:crypto \
-                    util_bsd.go:crypto \
-                    util.go:crypto
-
-extract.only        v${version}.zip \
-                    v${flags_version}.zip \
-                    ${nbreader_hash}.zip
-
-checksums           v${version}.zip \
-                    rmd160  e1b1eae2e314510b852ee86f0152fa541b5b4af9 \
-                    sha256  00f4a57cd4140999443833b6bbf446a21ec5660613af5ce101d651a265152051 \
-                    v${flags_version}.zip \
-                    rmd160  0797467ba23c4c28ff8b13aa40b52bc8bad852a0 \
-                    sha256  be1356988abd183851b754a66a4171e370b952bee2dd3de5fc33f0370e534703 \
-                    ${nbreader_hash}.zip \
-                    rmd160  6bd004bdca7944c9ff523e479bd7814bc87aff34 \
-                    sha256  2f9c0c3b45bf04cb5ebc92b146d022b6a6e437258fc4d9936dfcd1a115af3578 \
-                    terminal.go \
-                    rmd160  ad3f5da181a2fa618e104b1deb79a869a9164cb2 \
-                    sha256  b35ec763e014dcc944989ff5ddea401c754bcc27c011f71012a2454eaca1b11a \
-                    util_bsd.go \
-                    rmd160  9a75a1dc87ad32232627302e266215cba35766a4 \
-                    sha256  fc3b7bafbded5b824b3b9c5d4c4d6730958cbeb9ae9cd2dde2132d670d2cc3f4 \
-                    util.go \
-                    rmd160  6f17dbf32422a7e43d9182137c0ebc2bc9704ef5 \
-                    sha256  c0506e16f0f7ec105437f35f2a7fb6c3b71a28f95102f3b5dec0d22f040cb727
-
-depends_build       port:go
-use_configure       no
-
-build.cmd           ${prefix}/bin/go
-build.target        build
-build.env           GOPATH=${worksrcpath}
+go.vendors          github.com/jessevdk/go-flags \
+                        lock    96dc06278ce32a0e9d957d590bb987c81ee66407 \
+                        rmd160  c5f8e8883c50d74d974f473287f8e89c3f76f80a \
+                        sha256  1981b872319a9496bb00d97b8cd10bed42518ee831a46538772dcfa999c701c6 \
+                        size    55455 \
+                    github.com/svent/go-nbreader \
+                        lock    7cef48da76dca6a496faa7fe63e39ed665cbd219 \
+                        rmd160  6fd0bad37adcf601cf22634cd58a66352651da03 \
+                        sha256  09ec2d65c7d95e9ecde248ff8edfaf52acaf375cb57c281c2fabb5efa682d4d3 \
+                        size    2782 \
+                    golang.org/x/crypto \
+                        lock    2faea1465de239e4babd8f5905cc25b781712442 \
+                        rmd160  45f15e1dad9af8b4b544c283fe7ed88a4001ff6a \
+                        sha256  af09f8a8b573cb6c18e026377b3359d7550edb3817863d46b3e50004fc77ef80 \
+                        size    1429256
 
 post-extract {
-    file mkdir ${worksrcpath}/src/github.com/svent/sift
-    file mkdir ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal
-
-    move ${worksrcpath}/gitignore                 ${worksrcpath}/src/github.com/svent/sift
-    move ${workpath}/go-nbreader-${nbreader_hash} ${worksrcpath}/src/github.com/svent/go-nbreader
-    move ${workpath}/go-flags-${flags_version}    ${worksrcpath}/src/github.com/svent/go-flags
-
-    ln -sf ${distpath}/terminal.go                ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal/terminal.go
-    ln -sf ${distpath}/util_bsd.go                ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal/util_bsd.go
-    ln -sf ${distpath}/util.go                    ${worksrcpath}/src/golang.org/x/crypto/ssh/terminal/util.go
+    # sift expects go-flags to be namespaced under svent for some reason.
+    move ${gopath}/src/github.com/jessevdk/go-flags ${gopath}/src/github.com/svent/go-flags
 }
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/${name}-${version} ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 }
-
-livecheck.url       https://github.com/svent/${name}/tags
-livecheck.regex     archive/v(\[^"\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

sift: simplify greatly by using golang-1.0 portgroup

I realize that this port is not openmaintainer, but I thought I would at least make the PR as a suggestion for the author of the kind of simplification that is possible with the golang-1.0 portgroup. If the change is not desired then please feel free to reject.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
