### PR TITLE
istioctl: use golang-1.0 portgroup

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
 name                istioctl
 
-github.setup        istio istio 1.0.2
+go.setup            github.com/istio/istio 1.0.2
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
@@ -25,28 +25,16 @@ long_description    Istio is an open, platform-independent service mesh designed
                     used to create, list, modify, and delete configuration \
                     resources in a deployed Istio system.
 
-set goproj          istio.io/${github.project}
-
-depends_build       port:go
-use_configure       no
-worksrcdir          src/${goproj}
+go.package          istio.io/istio
 
 checksums           rmd160  b6c61241b682a1b7f5676de60f3a4387bc057967 \
                     sha256  12dc01cff8ebb335a08c62c9da95f9c71364d9dfab9c0c0baa5245f17202b057 \
                     size    18824606
 
-post-extract {
-    xinstall -d ${workpath}/src/istio.io
-    move ${workpath}/${github.project}-${github.version} \
-        ${worksrcpath}
-}
-
-build {
-    system -W ${worksrcpath} "GOPATH=${workpath} \
-    TAG=${github.version} make istioctl"
-}
-
+build.cmd           make
+build.target        ${name}
+build.env-append    TAG=${version}
 
 destroot {
-    xinstall ${workpath}/out/darwin_amd64/release/istioctl ${destroot}${prefix}/bin/istioctl
+    xinstall ${workpath}/out/${goos}_${goarch}/release/${name} ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

istioctl: use golang-1.0 portgroup

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
