### PR TITLE
hugo: update to 0.49

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        gohugoio hugo 0.48 v
+github.setup        gohugoio hugo 0.49 v
 revision            0
 categories          www
 platforms           darwin
@@ -12,23 +12,18 @@ maintainers         {isi.edu:calvin @cardi} openmaintainer
 description         A Fast and Flexible Static Site Generator built with love in GoLang
 long_description    ${description}
 
-checksums           rmd160  b83ec6c1cd1de366b51b4f27b2d8cba177005535 \
-                    sha256  a6a77166eed80ed4bfaa563254be788e65012fa369bae5f857ff1b95d3124549 \
-                    size    18883090
+checksums           rmd160  0a797ec25eee8031c9a3b569b2c6909008f220ea \
+                    sha256  c563aa8e1616af1a7b9a1f5a03b0e7749a708d18a06cad1a6a9334dbd6234ef8 \
+                    size    19727317
 
-depends_build-append port:dep \
-                    port:git \
+depends_build-append port:git \
                     port:go
+
+use_configure       no
 
 universal_variant   no
 
 worksrcdir          src/github.com/${github.author}/${github.project}
-
-configure.cmd       ${prefix}/bin/dep
-configure.pre_args  {}
-configure.args      ensure
-configure.post_args -vendor-only
-configure.env       GOPATH=${workpath}
 
 build.cmd           ${prefix}/bin/go
 build.target        install


### PR DESCRIPTION
#### Description

* Now uses Go Modules support (built in Go 1.11+) for dependencies.
  This removes the port's dependency on dep.

###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
