### PR TITLE
py-coloredlogs: new port

### DIFF
--- a/python/py-coloredlogs/Portfile
+++ b/python/py-coloredlogs/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-coloredlogs
+version             10.0
+checksums           rmd160  58d28b616c4d2ccb2bc8601f5a23979829e52b4e \
+                    sha256  b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36 \
+                    size    273273
+
+categories-append   devel
+platforms           darwin
+license             MIT
+maintainers         {ijackson @JacksonIsaac} openmaintainer
+supported_archs     noarch
+
+description         Colored terminal output for Python's logging module
+long_description    The coloredlogs package enables colored terminal \
+    output for Python’s logging module.
+homepage            https://coloredlogs.readthedocs.io/
+
+master_sites        pypi:c/${python.rootname}
+distname            ${python.rootname}-${version}
+
+python.versions     36 37
+
+if {${name} ne ${subport}} {
+    depends_lib-append  \
+        port:py${python.version}-humanfriendly \
+        port:py${python.version}-setuptools
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

py-coloredlogs: new port

Depends on #2645 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.3 9E145

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
