### PR TITLE
openjdk11: new submission

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+set build 28
+name             openjdk11
+version          11
+
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+license          GPL-2
+supported_archs  x86_64
+
+description      Open Java Development Kit 11
+
+long_description Production-ready, free and open-source build of the Java \
+                 Development Kit, an implementation of the Java Standard \
+                 Edition (SE) 11 Platform. OpenJDK is the official reference \
+                 implementation of Java SE. Included components are the \
+                 HotSpot virtual machine, the Java class library and the Java \
+                 compiler. 
+
+homepage         https://jdk.java.net/11/
+master_sites     https://download.java.net/java/GA/jdk${version}/${build}/GPL/
+distname         openjdk-${version}+${build}_osx-x64_bin
+
+checksums        rmd160  c914d38c78b2943c7b47ff2da4e8da89438f96cd \
+                 sha256  6b969d2df6a9758d9458f5ba47939250e848dfba8b49e41c935cf210606b6d38 \
+                 size    182717049
+
+worksrcdir       jdk-${version}.jdk
+
+use_configure    no
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+destroot {
+    set target ${destroot}/Library/Java/JavaVirtualMachines
+    xinstall -m 755 -d ${target}
+    copy ${worksrcpath} ${target}
+}
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     "version (\\d+(?:\\.\\d+)*)"
+livecheck.version   ${version}


### PR DESCRIPTION
#### Description

New port for OpenJDK 11.

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?