### PR TITLE
extractpdfmark: New port, version 1.0.2

### DIFF
--- a/textproc/extractpdfmark/Portfile
+++ b/textproc/extractpdfmark/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+PortGroup           cxx11 1.1
+
+github.setup        trueroad extractpdfmark 1.0.2 v
+categories          textproc
+platforms           darwin
+license             GPL-3+
+maintainers         {@lemzwerg gnu.org:wl} \
+                    openmaintainer
+
+description         Extract page mode and named destinations as PDFmark from PDF.
+
+long_description    This tool helps ghostscript circumvent a bug while \
+                    embedding PDF files in another PDF document \
+                    (https://bugs.ghostscript.com/show_bug.cgi?id=695760). \
+                    If you have control over font embedding in all PDF \
+                    files, the resulting PDF can become *much* smaller \
+                    and still fully functional.
+
+github.tarball_from releases
+
+checksums           rmd160  1f1bac62afac8b52e54a796084d5b6c87453122e \
+                    sha256  63f3ababd5b1081ef92ff7a417597302327c1db3902cdb9827fade147558e6db \
+                    size    295003
+
+depends_lib         port:libiconv \
+                    port:pkgconfig \
+                    port:poppler
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}-${version}
+    set mandir ${prefix}/share/man/man1
+
+    xinstall -d ${destroot}${docdir}
+    xinstall -d ${destroot}${mandir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        README.md \
+        README.ja.md \
+        ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        man/${name}.1 \
+        ${destroot}${mandir}
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (no tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
This is a first step in updating lilypond-devel.  For documentation generation, lilypond uses extractpdftext to create smaller PDFs.