### PR TITLE
libressl-devel: update to 2.8.1

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libressl-devel
-version             2.8.0
+version             2.8.1
 distname            libressl-${version}
 
 categories          security devel
@@ -23,9 +23,9 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160 92cbbe323ae16197e8ae90fb8e7e5d783910b7d0 \
-                    sha256 af2bba965b06063518eec6f192d411631dfe1d07713760c67c3c29d348789dc3 \
-                    size   3377310
+checksums           rmd160 fcc1241815c094f0e16dd5cd2e4de90e18eb0689 \
+                    sha256 334bf7050f1db4087feebb30571ec13d9fa975bf05d6003ce3ab6d7d2452cf42 \
+                    size   3375642
 
 patchfiles \
     openssldir-cert.pem.patch


### PR DESCRIPTION
This updates the libressl-devel to the latest LibreSSL 2.8.1

- [x] bugfix
- [x] enhancement
- [x] security fix

Tested on macOS 10.13.6 17G65 with Xcode 10.0 10A255.

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

See release notes at https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.8.1-relnotes.txt .

Did I mention already that we are really missing out keeping the libressl port (as opposed to the libressl-devel port) at 2.5.5? Including > 20yo security bugs?