### PR TITLE
openjdk10: add warning about EOL

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -38,7 +38,8 @@ build {}
 destroot.violate_mtree yes
 
 destroot {
-    ui_msg "\nWarning: Support for OpenJDK 10.x has reached end of life and there will be no more updates. Consider upgrading to a supported OpenJDK version.\n"
+    ui_msg "\nWarning: Support for OpenJDK 10.x has reached end of life and there will be no more updates."
+    ui_msg "         Please consider upgrading to a supported OpenJDK version.\n"
     set target ${destroot}/Library/Java/JavaVirtualMachines
     xinstall -m 755 -d ${target}
     copy ${worksrcpath} ${target}

--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -38,6 +38,7 @@ build {}
 destroot.violate_mtree yes
 
 destroot {
+    ui_msg "\nWarning: Support for OpenJDK 10.x has reached end of life and there will be no more updates. Consider upgrading to a supported OpenJDK version.\n"
     set target ${destroot}/Library/Java/JavaVirtualMachines
     xinstall -m 755 -d ${target}
     copy ${worksrcpath} ${target}
@@ -45,4 +46,5 @@ destroot {
 
 livecheck.type      regex
 livecheck.url       ${homepage}
-livecheck.regex     "Java Development Kit, version (\\d+(?:\\.\\d+)*(?:-\\d+)?)"
+livecheck.regex     "version (\\d+(?:\\.\\d+)*(?:-\\d+)?)"
+livecheck.version   ${version}


### PR DESCRIPTION
#### Description

OpenJDK 10 has reached end of life. It may still be useful to users for compatibility testing, etc. Installing/upgrading openjdk10 now prints a warning about the fact that there will be no more updates.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?