### PR TITLE
urw-fonts: Update to version used by Ghostscript.

### DIFF
--- a/x11/urw-fonts/Portfile
+++ b/x11/urw-fonts/Portfile
@@ -1,51 +1,59 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
+PortSystem          1.0
 
-name            urw-fonts
-version         1.0.7pre44
-categories      x11 fonts
-maintainers     nomaintainer
-license             GPL-2+
-description     Cyrillized free URW fonts
-long_description \
-                These fonts were made from the free URW fonts distributed with ghostcript. \
-                There are NO changes in the latin part of them (I hope). \
-                Cyrillic glyphs were added by copying suitable latin ones \
-                and painting oulines of unique cyrillic glyphs in same style as the others.
-platforms       darwin
-supported_archs noarch
-homepage        ftp://ftp.gnome.ru/fonts/urw/release/
-master_sites    macports \
-                ftp://ftp.gnome.ru/fonts/urw/release/
-use_bzip2       yes
-checksums       md5 51c6c2690593cd9bd92f197a6f2ff8bd \
-                sha1 465fd5faab9ba9e7590f1bf761015862eb09748d \
-                rmd160 52bddb1e267e6aa3cace9197293718e4919384bd
+name                urw-fonts
+version             2017-07-27
+set git_version     91edd6e
+categories          x11 fonts
+maintainers         {@lemzwerg gnu.org:wl} openmaintainer
+license             AGPL-3-with-embedded-font-exception
+platforms           darwin
+supported_archs     noarch
 
-depends_run     port:fontconfig
+description         URW fonts in various formats
+long_description    The Ghostscript distribution comes with the URW \
+                    fonts in Type1 format (containing support for \
+                    Latin, Greek, and Cyrillic scripts). In addition \
+                    to those files, this port also contains the \
+                    corresponding Type1 metrics files (AFM), \
+                    together with TrueType (TTF) and OpenType (OTF) \
+                    versions of the fonts.
 
-extract.mkdir   yes
+homepage            https://www.ghostscript.com
+master_sites        "https://git.ghostscript.com/?p=urw-core35-fonts.git;a=snapshot;h=${git_version};sf=tgz;dummy="
+distname            urw-core35-fonts-${git_version}
+checksums           rmd160 26447c6c906c2fe1320f033b4e3a8b27c015bb1a \
+                    sha256 1e8d2bf93c7aed3301e2a12c672cdcf44ef50f250a57db6534ff2fb298307fa0 \
+                    size 11128006
 
-use_configure   no
+depends_run         port:fontconfig
+
+extract.mkdir       yes
+
+use_configure       no
 
 build {}
 
 destroot {
     set fontsdir ${destroot}${prefix}/share/fonts/${name}
     xinstall -d -m 755 ${fontsdir}
-    foreach f {*.afm *.pfb *.pfm fonts.*} {
-        xinstall -m 644 {*}[glob ${worksrcpath}/${f}] ${fontsdir}
+    foreach f {*.afm *.otf *.t1 *.ttf} {
+        xinstall -m 644 {*}[glob ${worksrcpath}/${distname}/${f}] ${fontsdir}
     }
 }
+
 post-destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} COPYING ChangeLog README README.tweaks ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath}/${distname} \
+             COPYING LICENSE \
+             ${destroot}${prefix}/share/doc/${name}
 }
+
 post-activate {
-    #though this approach is not so scalable.
+    # though this approach is not so scalable.
     system "${prefix}/bin/fc-cache -fv ${prefix}/share/fonts"
 }
 
-#livecheck.name urw-fonts-cyrillic
-livecheck.type  none
+# TODO
+livecheck.type      none


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
Please have a look at this; I'm not sure everything is correct.  Note that ghostscript doesn't offer a tarball for those files.

One place in the portfile is marked with 'TODO', namely how to correctly set up the livecheck feature from a git repository – I haven't found a proper (working!) template in the repository that I could use.