### PR TITLE
whois: tweak livecheck

### DIFF
--- a/net/whois/Portfile
+++ b/net/whois/Portfile
@@ -106,4 +106,4 @@ pre-activate {
 
 livecheck.type              regex
 livecheck.url               [lindex ${master_sites} 0]?C=M&O=D
-livecheck.regex             "${name}_(.+?)${extract.suffix}"
+livecheck.regex             "${name}_(\[^~\]+?)${extract.suffix}"


### PR DESCRIPTION
Ignore versions containing '~' to skip tags made for Debian packages,
such as "~deb" or "~bpo", and avoid false positives.

@ryandesign 