### PR TITLE
libomp: Disable universal on Mojave+

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -2,7 +2,9 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.0
-PortGroup               muniversal 1.0
+if {${os.major} <= 17} {
+    PortGroup               muniversal 1.0
+}
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github 1.0
 
@@ -98,7 +100,11 @@ foreach ver {3.8 3.9 4.0 5.0 6.0 devel} {
     }
 }
 
-default_variants        +universal
+if {${os.major} <= 17} {
+    default_variants        +universal
+} else {
+    universal_variant       no
+}
 
 # Do actual install into ${prefix}/(install|lib)/libomp
 # A little unorthodox, but to have clang automatically find the includes and


### PR DESCRIPTION
Can't recall if this route (switching a portgroup on and off) is kosher, but that's what review is for, right?

Trying to address https://trac.macports.org/ticket/56720 sooner than waiting for a new port update since libomp is a dependency for many (via the clangs) ports.