### PR TITLE
py-pykerberos: update to 1.1.14 for python3

### DIFF
--- a/python/py-pykerberos/Portfile
+++ b/python/py-pykerberos/Portfile
@@ -2,41 +2,31 @@ PortSystem         1.0
 PortGroup          python 1.0
 
 name               py-pykerberos
-set my_name        pykerberos
-version            1.1-10616
+version            1.1.14
 categories-append  devel
 license            Apache-2
 platforms          darwin
 maintainers        nomaintainer
 description        A GSSAPI interface module for Python
 
-set major          [lindex [split [lindex [split ${version} {-}] 0] {.}] 0]
-set minor          [lindex [split [lindex [split ${version} {-}] 0] {.}] 1]
-set rev            [lindex [split ${version} {-}] 1]
-set my_version     ${major}.${minor}+svn${rev}
-
 long_description   ${description}
 
-homepage           http://packages.debian.org/source/unstable/${my_name}
-master_sites       debian:p/${my_name}
-distname           ${my_name}_${my_version}
-extract.suffix     .orig.tar.gz
-worksrcdir         PyKerberos-${major}.${minor}
+homepage           https://pypi.org/project/pykerberos/
+master_sites       pypi:p/pykerberos
+distname           pykerberos-${version}
 
-python.versions    27
+python.versions    27 36 37
 
-checksums          rmd160 8d95d2797b86ef670a17d99f70f7cc71a5cdb516 \
-                   sha256 e82bb0508cc21ce4281af7e6fd9243cd1a8b4052b9b948781297aa9d8c183d28
+checksums          rmd160 ab5464d07a89cfc3a894400bf0a670113aa45c0a \
+                   sha256 60f84e1b606d58cc457b186914c195072ebebf5d5a05e75c0136541808e06523 \
+                   size   20454
 
 if {${name} ne ${subport}} {
-  depends_lib-append port:kerberos5
-}
-
-if {${name} eq ${subport}} {
-  livecheck.type     regex
-  livecheck.url      ${homepage}
-  livecheck.version  ${my_version}
-  livecheck.regex    {(\d+\.\d+\+svn\d+)}
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append port:kerberos5
+    livecheck.type  none
 } else {
-  livecheck.type     none
+    livecheck.type  regex
+    livecheck.url   ${homepage}
+    livecheck.regex {pykerberos (\d+(?:\.\d+)*)}
 }


### PR DESCRIPTION
#### Description

This PR the pykerberos port to [pypi release 1.1.14](https://pypi.org/project/pykerberos/1.1.14/), which provides python3 support. In the process I reworked the Portfile to point only at pypi, which simplifies things a wee bit.

I am not a pykerberos developer so don't really understand the consequences of having modified this Portfile, especially the `livecheck` stuff (which I have never understood). However, the port builds and seems to run on python3.6.

##### Why not pykerberos-1.2.1?

pykerberos-1.2.1 is the latest release, however, while that does build on my machine, I get the following error when trying to use it:

```
$ python -c "import kerberos; print(kerberos)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: dlopen(/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/kerberos.cpython-36m-darwin.so, 2): Symbol not found: _mempcpy
  Referenced from: /opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/kerberos.cpython-36m-darwin.so
  Expected in: flat namespace
 in /opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/kerberos.cpython-36m-darwin.so
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
