### PR TITLE
scribus-devel: Update poppler patch and revbump

### DIFF
--- a/print/scribus-devel/Portfile
+++ b/print/scribus-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup           qt5 1.0
 
 name                scribus-devel
 version             1.5.4
-revision            5
+revision            6
 categories          print
 license             LGPL-2+ BSD MIT
 platforms           darwin

--- a/print/scribus-devel/files/poppler.patch
+++ b/print/scribus-devel/files/poppler.patch
@@ -1026,3 +1026,73 @@ index 7317cae210..b8497d94de 100644
 +};
 +
 +#endif
+diff --git a/scribus/plugins/import/pdf/importpdf.cpp b/scribus/plugins/import/pdf/importpdf.cpp
+index a5ce57fdfc..e3690cca8b 100644
+--- scribus/plugins/import/pdf/importpdf.cpp
++++ scribus/plugins/import/pdf/importpdf.cpp
+@@ -548,10 +548,21 @@ bool PdfPlug::convert(const QString& fn)
+ 									}
+ 									else
+ 									{
+-										GooList *ocgs;
+-										int i;
+-										ocgs = ocg->getOCGs ();
+-										for (i = 0; i < ocgs->getLength (); ++i)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(0, 69, 0)
++										const auto& ocgs = ocg->getOCGs ();
++										for (const auto& ocg : ocgs)
++										{
++											OptionalContentGroup *oc = ocg.second.get();
++											QString ocgName = UnicodeParsedString(oc->getName());
++											if (!ocgNames.contains(ocgName))
++											{
++												ocgGroups.prepend(oc);
++												ocgNames.append(ocgName);
++											}
++										}
++#else
++										GooList *ocgs = ocg->getOCGs ();
++										for (int i = 0; i < ocgs->getLength (); ++i)
+ 										{
+ 											OptionalContentGroup *oc = (OptionalContentGroup *)ocgs->get(i);
+ 											QString ocgName = UnicodeParsedString(oc->getName());
+@@ -561,15 +572,27 @@ bool PdfPlug::convert(const QString& fn)
+ 												ocgNames.append(ocgName);
+ 											}
+ 										}
++#endif
+ 									}
+ 								}
+ 							}
+ 							else
+ 							{
+-								GooList *ocgs;
+-								int i;
+-								ocgs = ocg->getOCGs ();
+-								for (i = 0; i < ocgs->getLength (); ++i)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(0, 69, 0)
++								const auto& ocgs = ocg->getOCGs ();
++								for (const auto& ocg : ocgs)
++								{
++									OptionalContentGroup *oc = ocg.second.get();
++									QString ocgName = UnicodeParsedString(oc->getName());
++									if (!ocgNames.contains(ocgName))
++									{
++										ocgGroups.prepend(oc);
++										ocgNames.append(ocgName);
++									}
++								}
++#else
++								GooList *ocgs = ocg->getOCGs ();
++								for (int i = 0; i < ocgs->getLength (); ++i)
+ 								{
+ 									OptionalContentGroup *oc = (OptionalContentGroup *)ocgs->get(i);
+ 									QString ocgName = UnicodeParsedString(oc->getName());
+@@ -579,6 +602,7 @@ bool PdfPlug::convert(const QString& fn)
+ 										ocgNames.append(ocgName);
+ 									}
+ 								}
++#endif
+ 							}
+ 						}
+ 					}


### PR DESCRIPTION
Fixing scribus-devel build with poppler 0.69.0.

This adds the upstream patch found here: https://github.com/scribusproject/scribus/commit/8e05d26c19097ac2ad5b4ebbf40a3771ee6faf9c