### PR TITLE
openjdk10: Add openjdk11 sub-port

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -4,6 +4,13 @@ PortSystem       1.0
 
 name             openjdk10
 version          10.0.2
+set              openjdk_version 10
+
+subport openjdk11 {
+    version      11
+    set          openjdk_version 11
+    set          build 28
+}
 
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
@@ -11,22 +18,34 @@ platforms        darwin
 license          GPL-2
 supported_archs  x86_64
 
-description      Open Java Development Kit 10
+description      Open Java Development Kit ${openjdk_version}
 
 long_description Production-ready, free and open-source build of the Java \
                  Development Kit, an implementation of the Java Standard \
-                 Edition (SE) 10 Platform. OpenJDK is the official reference \
+                 Edition (SE) ${openjdk_version} Platform. OpenJDK is the official reference \
                  implementation of Java SE. Included components are the \
                  HotSpot virtual machine, the Java class library and the Java \
                  compiler. 
 
-homepage         http://jdk.java.net/10/
-master_sites     https://download.java.net/java/GA/jdk10/${version}/19aef61b38124481863b1413dce1855f/13/
-distname         openjdk-${version}_osx-x64_bin
+homepage         http://jdk.java.net/${openjdk_version}/
 
-checksums        rmd160  d29498411adc487bf8191adbc4276c72602022cf \
-                 sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
-                 size    200916897
+if {${subport} eq ${name}} {
+    # openjdk10
+    master_sites     https://download.java.net/java/GA/jdk10/${version}/19aef61b38124481863b1413dce1855f/13/
+    distname         openjdk-${version}_osx-x64_bin
+
+    checksums        rmd160  d29498411adc487bf8191adbc4276c72602022cf \
+                     sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
+                     size    200916897
+} else {
+    # openjdk11
+    master_sites     https://download.java.net/java/GA/jdk${version}/${build}/GPL/
+    distname         openjdk-${version}+${build}_osx-x64_bin
+
+    checksums        rmd160  c914d38c78b2943c7b47ff2da4e8da89438f96cd \
+                     sha256  6b969d2df6a9758d9458f5ba47939250e848dfba8b49e41c935cf210606b6d38 \
+                     size    182717049
+}
 
 worksrcdir       jdk-${version}.jdk
 
@@ -38,8 +57,10 @@ build {}
 destroot.violate_mtree yes
 
 destroot {
-    ui_msg "\nWarning: Support for OpenJDK 10.x has reached end of life and there will be no more updates."
-    ui_msg "         Please consider upgrading to a supported OpenJDK version.\n"
+    if {${subport} eq ${name}} {
+        ui_msg "\nWarning: Support for OpenJDK 10.x has reached end of life and there will be no more updates."
+        ui_msg "         Please consider upgrading to a supported OpenJDK version.\n"
+    }
     set target ${destroot}/Library/Java/JavaVirtualMachines
     xinstall -m 755 -d ${target}
     copy ${worksrcpath} ${target}


### PR DESCRIPTION
#### Description

openjdk10: Add openjdk11 sub-port

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->