### PR TITLE
aquaterm: use old xcode build system on Xcode10+

### DIFF
--- a/aqua/aquaterm/Portfile
+++ b/aqua/aquaterm/Portfile
@@ -59,6 +59,12 @@ post-patch {
         ${worksrcpath}/adapters/pgplot/ReadMe
 }
 
+# this port does not build with the new xcode build system at present
+if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    build.pre_args      -UseNewBuildSystem=NO
+    destroot.pre_args   -UseNewBuildSystem=NO
+}
+
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/AquaTerm
     copy ${worksrcpath}/adapters ${destroot}${prefix}/share/AquaTerm


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/56895

This seems to do the right thing, and is much easier than the other kludgy fix I found before. Thanks to @pmetzger for the clue!