### PR TITLE
urw-core35-fonts: New port, version 2017-08-04

### DIFF
--- a/x11/urw-core35-fonts/Portfile
+++ b/x11/urw-core35-fonts/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                urw-core35-fonts
+version             2017-08-04
+set git_version     91edd6e
+categories          x11 fonts
+maintainers         {@lemzwerg gnu.org:wl} openmaintainer
+# the actual license is AGPL 3 with embedded font exception
+license             AGPL-3
+platforms           darwin
+supported_archs     noarch
+
+description         URW core35 fonts in various formats
+long_description    "Recent Ghostscript versions come with a new set\
+                    of URW fonts that have additional support for\
+                    the Greek and Cyrillic scripts (thus superseding\
+                    the fonts contained in the 'urw-fonts' port).\
+                    Ghostscript distributes the URW fonts in Type1\
+                    format; in addition to these files, this port\
+                    also contains the corresponding Type1 metrics\
+                    files (AFM), together with TrueType (TTF) and\
+                    OpenType (OTF) versions of the fonts."
+
+homepage            https://www.ghostscript.com
+master_sites        "https://git.ghostscript.com/?p=urw-core35-fonts.git;a=snapshot;h=${git_version};sf=tgz;dummy="
+distname            urw-core35-fonts-${git_version}
+checksums           rmd160 26447c6c906c2fe1320f033b4e3a8b27c015bb1a \
+                    sha256 1e8d2bf93c7aed3301e2a12c672cdcf44ef50f250a57db6534ff2fb298307fa0 \
+                    size 11128006
+
+depends_run         port:fontconfig
+
+extract.mkdir       yes
+
+use_configure       no
+
+build {}
+
+destroot {
+    set fontsdir ${destroot}${prefix}/share/fonts/${name}
+    xinstall -d -m 755 ${fontsdir}
+    foreach f {*.afm *.otf *.t1 *.ttf} {
+        xinstall -m 644 {*}[glob ${worksrcpath}/${distname}/${f}] ${fontsdir}
+    }
+}
+
+post-destroot {
+    xinstall -d -m 755 ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath}/${distname} \
+             COPYING LICENSE \
+             ${destroot}${prefix}/share/doc/${name}
+}
+
+post-activate {
+    # This approach is not so scalable.
+    system "${prefix}/bin/fc-cache -fv ${prefix}/share/fonts"
+}
+
+livecheck.type      regex
+livecheck.url       "http://git.ghostscript.com/?p=urw-core35-fonts.git;a=shortlog;dummy="
+livecheck.regex     <i>(\[0-9\-\]+)</i>


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
A follow-up to the withdrawn pull requests #2658 and #2663.