### PR TITLE
openjdk10: use notes instead of ui_msg for EOL warning

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -38,12 +38,15 @@ build {}
 destroot.violate_mtree yes
 
 destroot {
-    ui_msg "\nWarning: Support for OpenJDK 10.x has reached end of life and there will be no more updates."
-    ui_msg "         Please consider upgrading to a supported OpenJDK version.\n"
     set target ${destroot}/Library/Java/JavaVirtualMachines
     xinstall -m 755 -d ${target}
     copy ${worksrcpath} ${target}
 }
+
+notes "
+Warning: Support for OpenJDK 10.x has reached end of life and there will be no more updates.
+         Please consider upgrading to a supported OpenJDK version.
+"
 
 livecheck.type      regex
 livecheck.url       ${homepage}


### PR DESCRIPTION
#### Description

Use the `notes` keyword instead of `ui_msg` as recommended here: 
https://github.com/macports/macports-ports/commit/14aced4308cf6a09c4fc960074bf207259903034#r30687100

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?