### PR TITLE
sbcl: use proper macosx_deployment_target

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -6,6 +6,7 @@ name            sbcl
 
 # Please revbump maxima and maxima-devel when this port changes
 version         1.4.9
+revision        1
 
 categories      lang
 license         BSD
@@ -90,7 +91,7 @@ post-patch {
 use_configure   no
 
 build {
-    system "ulimit -s 8192 && export SBCL_MACOSX_VERSION_MIN=10.5 && cd ${worksrcpath} && export CC && CC=${configure.cc} && export CXX && CXX=${configure.cxx} && export CPP && CPP==${configure.cpp} && sh ./make.sh ${make_sh_options} --prefix=${prefix} --xc-host=${host_lisp}"
+    system "ulimit -s 8192 && export SBCL_MACOSX_VERSION_MIN=${macosx_deployment_target} && cd ${worksrcpath} && export CC && CC=${configure.cc} && export CXX && CXX=${configure.cxx} && export CPP && CPP==${configure.cpp} && sh ./make.sh ${make_sh_options} --prefix=${prefix} --xc-host=${host_lisp}"
 }
 
 post-build {


### PR DESCRIPTION
Mojave / XCode10 does not accept 10.5 as a
deployment target.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255 
