### PR TITLE
py-gwosc: new submission

### DIFF
--- a/python/py-gwosc/Portfile
+++ b/python/py-gwosc/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-gwosc
+version             0.3.3
+
+categories-append   science
+maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+
+platforms           darwin
+license             GPL-3
+
+description         A python interface to the GW Open Science data archive
+long_description    The `gwosc` package provides an interface to querying \
+                    the open data releases hosted on <https://losc.ligo.org> \
+                    from the LIGO and Virgo gravitational-wave observatories.
+homepage            https://gwosc.readthedocs.io
+
+master_sites        pypi:g/gwosc
+distname            gwosc-${version}
+checksums           rmd160  45a7437f7cbd62393af7d293ff8b35ae484e9002 \
+                    sha256  863a67296763ec9be79fa057b6ee0b3cb4f91c768b97b769840fa91f2f3b4e2c \
+                    size    31201
+
+python.versions     27 36 37
+python.default_version 36
+
+if {${name} ne ${subport}} {
+    depends_build-append port:py${python.version}-setuptools
+    depends_lib-append   port:py${python.version}-six
+    livecheck.type      none
+} else {
+    livecheck.type      pypi
+}


### PR DESCRIPTION
#### Description

This PR introduces ports for the [`gwosc`](//gwosc.readthedocs.io) Python package.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-pxrts/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
