### PR TITLE
multimarkdown: fix build on macOS 10.14

### DIFF
--- a/textproc/multimarkdown/Portfile
+++ b/textproc/multimarkdown/Portfile
@@ -37,6 +37,7 @@ depends_lib-append  port:curl
 patchfiles-append   AppleClang.patch
 patchfiles-append   PATH.patch
 patchfiles-append   which.patch
+patchfiles-append   DeploymentTarget.patch
 
 # blacklist compilers that do not support C11
 compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 300}

--- a/textproc/multimarkdown/files/DeploymentTarget.patch
+++ b/textproc/multimarkdown/files/DeploymentTarget.patch
@@ -1,0 +1,25 @@
+From b9dc75f0b90970b31249a53e81315e3ac5ff55c3 Mon Sep 17 00:00:00 2001
+From: Aaron Madlon-Kay <aaron@madlon-kay.com>
+Date: Mon, 1 Oct 2018 23:53:24 +0900
+Subject: [PATCH] Remove hard-coded target of 10.4
+
+---
+ CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a738a35..220b8c4 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -396,9 +396,6 @@ endif()
+ # OS X Builds
+ if (APPLE)
+
+-	# Configure backwards-compatible support (if your project allows it)
+-	SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.4" CACHE STRING "Deployment target for OSX" FORCE)
+-
+ 	# Compile for x86_64 and i386.  ppc no longer supported
+ 	if(CMAKE_BUILD_TYPE MATCHES "Release")
+ 		SET (CMAKE_OSX_ARCHITECTURES x86_64;i386)
+--
+2.19.0


### PR DESCRIPTION
#### Description

I'm on macOS 10.14 and find that multimarkdown currently fails to build with the following error:

```
/usr/bin/clang -pipe -Os -DNDEBUG -I/opt/local/include -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -mmacosx-version-min=10.4 -dynamiclib -Wl,-headerpad_max_install_names -L/opt/local/lib -Wl,-headerpad_max_install_names -lcurl -Wl,-syslibroot,/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -o libMultiMarkdown.dylib -install_name /opt/local/var/macports/build/_Users_amake_Code_MacPorts_textproc_multimarkdown/multimarkdown/work/build/libMultiMarkdown.dylib CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/aho-corasick.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/beamer.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/char.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/critic_markup.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/d_string.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/epub.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/file.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/html.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/latex.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/lexer.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/memoir.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/miniz.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/mmd.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/object_pool.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/opendocument.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/opendocument-content.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/opml.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/opml-lexer.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/opml-parser.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/opml-reader.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/parser.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/rng.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/scanners.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/stack.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/textbundle.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/token.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/token_pairs.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/transclude.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/uuid.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/writer.c.o CMakeFiles/libMultiMarkdownShared.dir/Sources/libMultiMarkdown/zip.c.o 
/usr/bin/ranlib libMultiMarkdown.framework/Versions/A/libMultiMarkdown
ld: library not found for -lgcc_s.10.4
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libMultiMarkdown.dylib] Error 1
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
