### PR TITLE
meson: add setuptools as runtime dependency

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.48.0
 github.tarball_from releases
+revision            1
 license             Apache-2
 categories          devel python
 maintainers         {soap.za.net:git @SoapZA} openmaintainer
@@ -35,6 +36,7 @@ depends_build-append \
                     port:py${python.version}-setuptools
 
 depends_lib-append \
+                    port:py${python.version}-setuptools \
                     port:ninja
 
 # requires a newer install_name_tool on older systems


### PR DESCRIPTION
* Since commit
  https://github.com/mesonbuild/meson/commit/86298f2109d215ad6b26d3462af7b685d52d0dd7#diff-2eeaed663bd0d25b7e608891384b7298
  Meson has a hard dependency on setuptools. This leads to
  `pkg_resources` failures without setuptools installed.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->