### PR TITLE
rclone: update to 1.43.1 and add bash/zsh completion

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -2,8 +2,8 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-github.setup        ncw rclone 1.41 v
-revision            0
+
+github.setup        ncw rclone 1.43.1 v
 
 homepage            http://rclone.org
 categories          net
@@ -14,11 +14,11 @@ long_description \
     Amazon S3, Openstack Swift / Rackspace cloud files / Memset, Memstore, \
     Dropbox, Google Cloud Storage, Amazon Drive, Microsoft One Drive, Hubic, \
     Backblaze B2, Yandex Disk, SFTP, and the local filesystem.
-license             mit
+license             MIT
 
-checksums \
-    rmd160  2b95bce1586da3aec5cd8ac267f72be60586e8a8 \
-    sha256  2dba19ffd56054888c78e7f14d6862eb591f631d7b7f14b177158a38394b5631
+checksums           rmd160  d2e8e08fd82b9307f619442c653686b1e2e7ea38 \
+                    sha256  0fcf9f4f9ee957c493f768983c7138a4104dfdc27672470d38672d51a7a19ce2 \
+                    size    15965138
 
 set goproj          github.com/${github.author}/${github.project}
 
@@ -50,3 +50,11 @@ destroot {
     xinstall -m 644 -W ${worksrcpath} rclone.1 ${destroot}${mandir}
 }
 
+post-destroot {
+    set bash_compl_path ${destroot}${prefix}/share/bash-completion/completions
+    set zsh_compl_path ${destroot}${prefix}/share/zsh/site-functions
+    set bin_path ${destroot}${prefix}/bin
+    xinstall -d ${bash_compl_path} ${zsh_compl_path}
+    system "${bin_path}/rclone genautocomplete bash ${bash_compl_path}/${name}"
+    system "${bin_path}/rclone genautocomplete zsh ${zsh_compl_path}/_${name}"
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.4.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->