### PR TITLE
parallel-netcdf 1.10.0: New port

### DIFF
--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -4,6 +4,10 @@ PortSystem              1.0
 PortGroup               mpi 1.0
 PortGroup               active_variants 1.1
 
+compilers.choose        f90 cxx
+
+mpi.setup
+
 name                    parallel-netcdf
 version                 1.10.0
 
@@ -29,26 +33,22 @@ checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
                         sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
                         size 	2089202
 
-compilers.setup         default
-
-mpi.setup               require
-
 depends_lib             port:autoconf \
                         port:automake \
                         port:libtool \
                         port:m4                        
 
 # Setting environment variables
-#configure.flags-append  -fPIC
-#configure.cc            ${prefix}/bin/mpicc
-#configure.cxx           ${prefix}/bin/mpicxx
-#configure.fc            ${prefix}/bin/mpifort
-#configure.f77           ${prefix}/bin/mpifort
-#configure.f90           ${prefix}/bin/mpifort
-#configure.env-append    MPICC=${prefix}/bin/mpicc \
-                        MPICXX=${prefix}/bin/mpicxx \
-                        MPIF77=${prefix}/bin/mpifort \
-                        MPIF90=${prefix}/bin/mpifort
+configure.flags-append  -fPIC
+configure.cc 			${prefix}/bin/mpicc
+configure.cxx 			${prefix}/bin/mpicxx
+configure.fc 			${prefix}/bin/mpifort
+configure.f77 			${prefix}/bin/mpifort
+configure.f90 			${prefix}/bin/mpifort
+configure.env-append 	MPICC=${prefix}/bin/mpicc \
+						MPICXX=${prefix}/bin/mpicxx \
+						MPIF77=${prefix}/bin/mpifort \
+						MPIF90=${prefix}/bin/mpifort
 
 default_variants        +gcc7 +mpich
 

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -44,7 +44,7 @@ depends_lib             port:autoconf \
                         port:m4                        
 
 # Setting environment variables
-configure.flags-append  -fPIC
+configure.cflags-append -fPIC
 configure.cc            ${prefix}/bin/mpicc
 configure.cxx           ${prefix}/bin/mpicxx
 configure.fc            ${prefix}/bin/mpifort

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -10,8 +10,8 @@ mpi.setup
 
 name                    parallel-netcdf
 version                 1.10.0
-revision                1
-maintainers             gmail.com:thiagoveloso openmaintainer
+
+maintainers             {@thiagoveloso gmail.com:thiagoveloso} openmaintainer
 platforms               darwin
 categories              science devel
 license                 Permissive
@@ -28,8 +28,6 @@ long_description        PnetCDF is a high-performance parallel I/O library \
 homepage                https://parallel-netcdf.github.io/
 
 master_sites            http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/
-
-distfiles               parallel-netcdf-${version}.tar.gz
 
 checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
                         sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -33,19 +33,24 @@ checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
                         sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
                         size 	2089202
 
+compilers.setup         default
+
+mpi.setup               require
+
+
 depends_lib             port:autoconf \
                         port:automake \
                         port:libtool \
                         port:m4                        
 
 # Setting environment variables
-configure.flags-append  -fPIC
-configure.cc 			${prefix}/bin/mpicc
-configure.cxx 			${prefix}/bin/mpicxx
-configure.fc 			${prefix}/bin/mpifort
-configure.f77 			${prefix}/bin/mpifort
-configure.f90 			${prefix}/bin/mpifort
-configure.env-append 	MPICC=${prefix}/bin/mpicc \
+#configure.flags-append  -fPIC
+#configure.cc 			${prefix}/bin/mpicc
+#configure.cxx 			${prefix}/bin/mpicxx
+#configure.fc 			${prefix}/bin/mpifort
+#configure.f77 			${prefix}/bin/mpifort
+#configure.f90 			${prefix}/bin/mpifort
+#configure.env-append 	MPICC=${prefix}/bin/mpicc \
 						MPICXX=${prefix}/bin/mpicxx \
 						MPIF77=${prefix}/bin/mpifort \
 						MPIF90=${prefix}/bin/mpifort

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -44,16 +44,16 @@ depends_lib             port:autoconf \
                         port:m4                        
 
 # Setting environment variables
-#configure.flags-append  -fPIC
-#configure.cc 			${prefix}/bin/mpicc
-#configure.cxx 			${prefix}/bin/mpicxx
-#configure.fc 			${prefix}/bin/mpifort
-#configure.f77 			${prefix}/bin/mpifort
-#configure.f90 			${prefix}/bin/mpifort
-#configure.env-append 	MPICC=${prefix}/bin/mpicc \
-						MPICXX=${prefix}/bin/mpicxx \
-						MPIF77=${prefix}/bin/mpifort \
-						MPIF90=${prefix}/bin/mpifort
+configure.flags-append  -fPIC
+configure.cc            ${prefix}/bin/mpicc
+configure.cxx           ${prefix}/bin/mpicxx
+configure.fc            ${prefix}/bin/mpifort
+configure.f77           ${prefix}/bin/mpifort
+configure.f90           ${prefix}/bin/mpifort
+configure.env-append    MPICC=${prefix}/bin/mpicc \
+                        MPICXX=${prefix}/bin/mpicxx \
+                        MPIF77=${prefix}/bin/mpifort \
+                        MPIF90=${prefix}/bin/mpifort
 
 default_variants        +gcc7 +mpich
 

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -4,10 +4,6 @@ PortSystem              1.0
 PortGroup               mpi 1.0
 PortGroup               active_variants 1.1
 
-compilers.choose        f90 cxx
-
-mpi.setup
-
 name                    parallel-netcdf
 version                 1.10.0
 
@@ -33,22 +29,26 @@ checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
                         sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
                         size 	2089202
 
+compilers.setup         default
+
+mpi.setup               require
+
 depends_lib             port:autoconf \
                         port:automake \
                         port:libtool \
                         port:m4                        
 
 # Setting environment variables
-configure.flags-append  -fPIC
-configure.cc 			${prefix}/bin/mpicc
-configure.cxx 			${prefix}/bin/mpicxx
-configure.fc 			${prefix}/bin/mpifort
-configure.f77 			${prefix}/bin/mpifort
-configure.f90 			${prefix}/bin/mpifort
-configure.env-append 	MPICC=${prefix}/bin/mpicc \
-						MPICXX=${prefix}/bin/mpicxx \
-						MPIF77=${prefix}/bin/mpifort \
-						MPIF90=${prefix}/bin/mpifort
+#configure.flags-append  -fPIC
+#configure.cc            ${prefix}/bin/mpicc
+#configure.cxx           ${prefix}/bin/mpicxx
+#configure.fc            ${prefix}/bin/mpifort
+#configure.f77           ${prefix}/bin/mpifort
+#configure.f90           ${prefix}/bin/mpifort
+#configure.env-append    MPICC=${prefix}/bin/mpicc \
+                        MPICXX=${prefix}/bin/mpicxx \
+                        MPIF77=${prefix}/bin/mpifort \
+                        MPIF90=${prefix}/bin/mpifort
 
 default_variants        +gcc7 +mpich
 

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               mpi 1.0
+PortGroup               active_variants 1.1
+
+compilers.choose        f90 cxx
+
+mpi.setup
+
+name                    parallel-netcdf
+version                 1.10.0
+revision                1
+maintainers             gmail.com:thiagoveloso openmaintainer
+platforms               darwin
+categories              science devel
+license                 Permissive
+
+description             A Parallel I/O Library for NetCDF File Access.
+
+long_description        PnetCDF is a high-performance parallel I/O library \
+                        for accessing files in format compatibility with Unidata's \
+                        NetCDF, specifically the formats of CDF-1, 2, and 5. The \
+                        CDF-5 file format, an extension of CDF-2, supports unsigned \
+                        data types and uses 64-bit integers to allow users to define \
+                        large dimensions, attributes, and variables (> 2B array elements).
+
+homepage                https://parallel-netcdf.github.io/
+
+master_sites            http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/
+
+distfiles               parallel-netcdf-${version}.tar.gz
+
+checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
+                        sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
+                        size 	2089202
+
+default_variants        +gcc7 +mpich
+
+use_parallel_build      yes
+
+livecheck.type          regex
+livecheck.url           ${homepage}
+livecheck.regex         {New version \(([^)]+)\)}

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -33,6 +33,11 @@ checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
                         sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
                         size 	2089202
 
+depends_lib             port:autoconf \
+                        port:automake \
+                        port:libtool \
+                        port:m4                        
+
 default_variants        +gcc7 +mpich
 
 use_parallel_build      yes

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -38,6 +38,18 @@ depends_lib             port:autoconf \
                         port:libtool \
                         port:m4                        
 
+# Setting environment variables
+configure.flags-append  -fPIC
+configure.cc 			${prefix}/bin/mpicc
+configure.cxx 			${prefix}/bin/mpicxx
+configure.fc 			${prefix}/bin/mpifort
+configure.f77 			${prefix}/bin/mpifort
+configure.f90 			${prefix}/bin/mpifort
+configure.env-append 	MPICC=${prefix}/bin/mpicc \
+						MPICXX=${prefix}/bin/mpicxx \
+						MPIF77=${prefix}/bin/mpifort \
+						MPIF90=${prefix}/bin/mpifort
+
 default_variants        +gcc7 +mpich
 
 use_parallel_build      yes


### PR DESCRIPTION
This is a (new) port for the Parallel netCDF library - https://parallel-netcdf.github.io/

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1
Xcode 10.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
