### PR TITLE
py-barnaba: update to 0.1.6

### DIFF
--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -2,14 +2,11 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-version             0.1.5
+PortGroup           github 1.0
 
-homepage            https://github.com/srnas/barnaba
-
-master_sites        pypi:b/barnaba
-distname            barnaba-${version}
-
+github.setup        srnas barnaba 0.1.6
 name                py-barnaba
+
 platforms           darwin
 categories-append   science
 license             GPL-3
@@ -23,14 +20,17 @@ long_description    ${description} \
 
 supported_archs     noarch
 
-checksums           rmd160  385490c6c9c2e38738a3e64226c2316aad8c2dc2 \
-                    sha256  eb78ec5fd33b2fd8cb371bd073e2900950dbdaf2c5c8ce4d462439fcb9978d96
+checksums           rmd160  9b0906162ab6eca19ccfae9597c0c81a44c8d819 \
+                    sha256  6f4a76166f230ba1fa7f1a9669fd64909333cd71ea1c06afddb7024b56d9284a \
+                    size    30243004
 
-python.versions     27 34 35 36
+
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
 
-    depends_build-append port:py${python.version}-setuptools_scm
+    depends_build-append port:py${python.version}-setuptools_scm \
+                         port:py${python.version}-setuptools_scm_git_archive
 
     depends_lib-append  port:py${python.version}-mdtraj \
                         port:py${python.version}-scipy \

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -70,6 +70,7 @@ py-backports-ssl_match_hostname \
                         3.5.0.1_1   33
 py-backports_abc        0.5_1       33
 py-backports.weakref    1.0.post1   34
+py-barnaba              0.1.6       34 35
 py-beaker               1.10.0_1    26
 py-beautifulsoup        3.2.1_1     26
 py-beautifulsoup4       4.5.3_1     26 33


### PR DESCRIPTION
#### Description

Update to version 0.1.6.

I also changed the Portfile to download from github instead of pypi, using `setuptools_scm_git_archive`.

Following @pmetzger  recommendation I only added to `setuptools_scm_git_archive` support for python 27, 36, and 37. As a consequence, this update for `py-barnaba` port will only cover those python versions. I did the following:
- removed older versions (34 and 35) from line `python.versions` in`python/py-barnaba/Portfile`.
- added `py-barnaba 0.1.6 34 35` to `python/py-graveyard/Portfile`.

Hopefully this is the correct thing to do.

Thanks!

Giovanni

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

