### PR TITLE
FScript: switch to GitHub PortGroup

### DIFF
--- a/aqua/FScript/Portfile
+++ b/aqua/FScript/Portfile
@@ -2,11 +2,13 @@
 
 PortSystem              1.0
 PortGroup               xcode 1.0
+PortGroup               github 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
+github.setup            pmougin F-Script e9aa94f2a5ec3409423f907c9423f7d1d845b893
 name                    FScript
 version                 2.1
-revision                1
+revision                2
 categories              aqua lang
 platforms               darwin
 license                 BSD
@@ -21,21 +23,9 @@ long_description        F-Script is an open-source interactive and scripting \
                         and experts, allowing interactively exploring, testing \
                         and using Cocoa-based objects and frameworks.
 
-homepage                http://www.fscript.org/
-
-master_sites            https://github.com/pmougin/F-Script/zipball/v${version}:fscript
-
-distfiles               pmougin-F-Script-v2.1-0-g25c850c.zip:fscript
-
-checksums               pmougin-F-Script-v2.1-0-g25c850c.zip \
-                        sha1    5f1afa244f41ab372953a616d27a72a1573f4a15 \
-                        rmd160  aa38b5e587bd3c0a8aeb1a8df8a38445d0036952
-
-use_zip                 yes
-
-post-extract {
-    file rename [glob ${workpath}/pmougin-F-Script-*] ${worksrcpath}
-}
+checksums               rmd160  bdb19590caa1e8fca0253bf5b287b9046d59bd7d \
+                        sha256  e4a793f292d1afab3f6cb699da2d095a76c253eea901bea53cb1aebc5a86f9cc \
+                        size    1087478
 
 patchfiles              patch-FScript.xcodeproj-project.pbxproj.diff
 
@@ -118,7 +108,3 @@ post-destroot {
             reinplace "s|/Library/Frameworks|${frameworks_dir}|g" "${destroot}/Library/Services/Inject F-Script into application.workflow/Contents/document.wflow"
         }
 }
-
-livecheck.type      regex
-livecheck.url       https://github.com/pmougin/F-Script/tags
-livecheck.regex     archive/v(\[^"\]+)${extract.suffix}


### PR DESCRIPTION
A hopefully non-invasive way to avoid the immediate build failure on ancient OSes. Untested.

See:
* #1760
* https://trac.macports.org/ticket/44345
* https://trac.macports.org/ticket/54839

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

NOT TESTED

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->