### PR TITLE
py-asteval: update to 0.9.13

### DIFF
--- a/python/py-asteval/Portfile
+++ b/python/py-asteval/Portfile
@@ -1,44 +1,44 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
-PortGroup               python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name                    py-asteval
-version                 0.9.12
-categories-append       math
-license                 BSD
-maintainers             {@reneeotten gmail.com:ottenr.work} openmaintainer
-description             Minimalistic evaluator of python expression using ast module
-long_description        ASTEVAL is a safe(ish) evaluator of Python expressions and \
-                        statements, using Python's ast module. The idea is to provide \
-                        a simple, safe, and robust miniature mathematical language that \
-                        can handle user-input. The emphasis here is on mathematical \
-                        expressions, and so many functions from numpy are imported and \
-                        used if available.
-platforms               darwin
-homepage                https://github.com/newville/asteval
-master_sites            pypi:a/asteval/
-distname                asteval-${version}
+name                py-asteval
+version             0.9.12
+categories-append   math
+license             BSD
+maintainers         {@reneeotten gmail.com:ottenr.work} openmaintainer
+description         Minimalistic evaluator of python expression using ast module
+long_description    ASTEVAL is a safe(ish) evaluator of Python expressions and \
+                    statements, using Python's ast module. The idea is to provide \
+                    a simple, safe, and robust miniature mathematical language that \
+                    can handle user-input. The emphasis here is on mathematical \
+                    expressions, and so many functions from numpy are imported and \
+                    used if available.
+platforms           darwin
+homepage            https://github.com/newville/asteval
+master_sites        pypi:a/asteval/
+distname            asteval-${version}
 
-checksums               rmd160  68782a598a9532d5384151796883fb42f1138b8a \
-                        sha256  38f3b0592cae7e7f65adc687e37aad1824a8e518245603a29ec33258277e779b \
-                        size    50686
+checksums           rmd160  68782a598a9532d5384151796883fb42f1138b8a \
+                    sha256  38f3b0592cae7e7f65adc687e37aad1824a8e518245603a29ec33258277e779b \
+                    size    50686
 
-python.versions         27 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {$subport ne $name} {
-    depends_build-append       port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools
 
-    depends_lib-append         port:py${python.version}-numpy \
-                               port:py${python.version}-six
+    depends_lib-append      port:py${python.version}-numpy \
+                            port:py${python.version}-six
 
-    depends_test-append        port:py${python.version}-pytest
-    test.run                   yes
-    test.cmd                   py.test-${python.branch}
+    depends_test-append     port:py${python.version}-pytest
+    test.run                yes
+    test.cmd                py.test-${python.branch}
     test.target
-    test.env                   PYTHONPATH=${worksrcpath}/build/lib
+    test.env                PYTHONPATH=${worksrcpath}/build/lib
 
-    livecheck.type      none
+    livecheck.type          none
 } else {
-    livecheck.type      pypi
+    livecheck.type          pypi
 }

--- a/python/py-asteval/Portfile
+++ b/python/py-asteval/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-asteval
-version             0.9.12
+version             0.9.13
 categories-append   math
 license             BSD
 maintainers         {@reneeotten gmail.com:ottenr.work} openmaintainer
@@ -20,13 +20,13 @@ homepage            https://github.com/newville/asteval
 master_sites        pypi:a/asteval/
 distname            asteval-${version}
 
-checksums           rmd160  68782a598a9532d5384151796883fb42f1138b8a \
-                    sha256  38f3b0592cae7e7f65adc687e37aad1824a8e518245603a29ec33258277e779b \
-                    size    50686
+checksums           rmd160  36f24c2c4509ba66e3a532686393b838e4ae12b4 \
+                    sha256  8faf9f92b2b0d2ed376dc149d6bab2e01f614f6994722be9c16f982cbdd07c99 \
+                    size    51640
 
 python.versions     27 34 35 36 37
 
-if {$subport ne $name} {
+if {${subport} ne ${name}} {
     depends_build-append    port:py${python.version}-setuptools
 
     depends_lib-append      port:py${python.version}-numpy \
@@ -39,6 +39,4 @@ if {$subport ne $name} {
     test.env                PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type          none
-} else {
-    livecheck.type          pypi
 }


### PR DESCRIPTION
#### Description
- whitespace changes
- update to latest version, use default PyPI livecheck
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
