### PR TITLE
meson: remove obsoleted command scripts

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.48.0
 github.tarball_from releases
-revision            2
+revision            3
 license             Apache-2
 categories          devel python
 maintainers         {soap.za.net:git @SoapZA} openmaintainer
@@ -48,8 +48,6 @@ if {${os.platform} eq "darwin" && ${os.major} <= 9} {
 
 post-destroot {
     set python_prefix ${frameworks_dir}/Python.framework/Versions/${python.branch}
-    foreach bname {meson mesonconf mesonintrospect mesontest wraptool} {
-        ln -s  ${python_prefix}/bin/${bname} ${destroot}${prefix}/bin/${bname}
-        ln -s  ${python_prefix}/share/man/man1/${bname}.1 ${destroot}${prefix}/share/man/man1
-    }
+    ln -s  ${python_prefix}/bin/meson ${destroot}${prefix}/bin/meson
+    ln -s  ${python_prefix}/share/man/man1/meson.1 ${destroot}${prefix}/share/man/man1
 }


### PR DESCRIPTION
* These have been removed for 0.48.0:
  https://github.com/mesonbuild/meson/commit/b4c635a2e85a92bd0c3dd69c2d70612d09158bbd#diff-2eeaed663bd0d25b7e608891384b7298

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@mojca I forgot to remove those symlinks, as they have been fully removed for 0.48.0 from the installation.