### PR TITLE
py-spyder-kernels[-devel]/py-corner/py-emcee: add py37 subports

### DIFF
--- a/python/py-corner/Portfile
+++ b/python/py-corner/Portfile
@@ -22,13 +22,15 @@ checksums           rmd160  6faff30d80a740db370d09363ac2de10300c198e \
                     sha256  102e22797ee75d1432b6dc66aa2850f61388996ece66fd6600508742d2a7b88f \
                     size    10534
 
-python.versions     27 36
+python.versions     27 36 37
 python.default_version 36
 
 if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-matplotlib
 
-    depends_build-append \
-                        port:py${python.version}-setuptools
+    livecheck.type      none
 }

--- a/python/py-corner/Portfile
+++ b/python/py-corner/Portfile
@@ -18,18 +18,17 @@ homepage            https://github.com/dfm/corner.py
 
 master_sites        pypi:c/corner
 distname            corner-${version}
-checksums   rmd160  6faff30d80a740db370d09363ac2de10300c198e \
-            sha256  102e22797ee75d1432b6dc66aa2850f61388996ece66fd6600508742d2a7b88f \
-            size    10534
+checksums           rmd160  6faff30d80a740db370d09363ac2de10300c198e \
+                    sha256  102e22797ee75d1432b6dc66aa2850f61388996ece66fd6600508742d2a7b88f \
+                    size    10534
 
 python.versions     27 36
 python.default_version 36
 
 if {${name} ne ${subport}} {
-
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-matplotlib
 
-    depends_build-append port:py${python.version}-setuptools
-
+    depends_build-append \
+                        port:py${python.version}-setuptools
 }

--- a/python/py-emcee/Portfile
+++ b/python/py-emcee/Portfile
@@ -27,7 +27,7 @@ license             MIT
 checksums           rmd160  9d877a80ce5a19b8c442d225a27a57fe548a14f0 \
                     sha256  afb252b304051ca7a936e81adfa69c92b37fdafd8d3be95e920059f08dcf2d00
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -35,6 +35,12 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-numpy
+
+    depends_test-append \
+                    port:py${python.version}-nose
+    test.run        yes
+    test.cmd        nosetests-${python.branch}
+    test.target
 
     livecheck.type  none
 }

--- a/python/py-spyder-kernels-devel/Portfile
+++ b/python/py-spyder-kernels-devel/Portfile
@@ -9,7 +9,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
 

--- a/python/py-spyder-kernels/Portfile
+++ b/python/py-spyder-kernels/Portfile
@@ -10,7 +10,7 @@ categories-append   devel
 platforms           darwin
 license             MIT
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
 


### PR DESCRIPTION
#### Description
- py-spyder-kernels/py-spyder-kernels-devel: add py37 subports
- py-corner: whitespace changes, add py37 subport
- py-emcee: add py37 subport, enable tests

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? only applicable for py-emcee
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
