### PR TITLE
parallel-netcdf 1.10.0: New port

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -6,6 +6,7 @@ PortGroup           github 1.0
 
 github.setup        mesonbuild meson 0.48.0
 github.tarball_from releases
+revision            1
 license             Apache-2
 categories          devel python
 maintainers         {soap.za.net:git @SoapZA} openmaintainer
@@ -35,6 +36,7 @@ depends_build-append \
                     port:py${python.version}-setuptools
 
 depends_lib-append \
+                    port:py${python.version}-setuptools \
                     port:ninja
 
 # requires a newer install_name_tool on older systems

--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               mpi 1.0
+PortGroup               active_variants 1.1
+
+name                    parallel-netcdf
+version                 1.10.0
+
+maintainers             {@thiagoveloso gmail.com:thiagoveloso} openmaintainer
+platforms               darwin
+categories              science devel
+license                 Permissive
+
+description             A Parallel I/O Library for NetCDF File Access.
+
+long_description        PnetCDF is a high-performance parallel I/O library \
+                        for accessing files in format compatibility with Unidata's \
+                        NetCDF, specifically the formats of CDF-1, 2, and 5. The \
+                        CDF-5 file format, an extension of CDF-2, supports unsigned \
+                        data types and uses 64-bit integers to allow users to define \
+                        large dimensions, attributes, and variables (> 2B array elements).
+
+homepage                http://cucis.ece.northwestern.edu/projects/PnetCDF
+
+master_sites            http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/
+
+checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
+                        sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
+                        size 	2089202
+
+mpi.setup               require -gcc7 -gfortran
+
+#compilers.choose        fc f77 f90 cc cxx
+
+depends_build-append    port:perl5 \
+                        port:autoconf \
+                        port:automake \
+                        port:libtool \
+                        port:m4                        
+
+default_variants        +gcc7 +mpich
+
+use_parallel_build      yes
+
+livecheck.type          regex
+livecheck.url           ${homepage}
+livecheck.regex         {New version \(([^)]+)\)}
+


### PR DESCRIPTION
#### Description
My second try for a (new) port for the Parallel netCDF library - http://cucis.ece.northwestern.edu/projects/PnetCDF/

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 9.0

###### Verification <!-- (delete not applicable items) -->
Have you:

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
