### PR TITLE
capstone: Build for the right architectures

### DIFF
--- a/devel/capstone/Portfile
+++ b/devel/capstone/Portfile
@@ -29,7 +29,8 @@ use_configure       no
 build.env           CC=${configure.cc} \
                     CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
                     LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]" \
-                    PREFIX=${prefix}
+                    PREFIX=${prefix} \
+                    V=1
 
 eval destroot.env   ${build.env}
 

--- a/devel/capstone/Portfile
+++ b/devel/capstone/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        aquynh capstone 3.0.5
+revision            1
 categories          devel
 platforms           darwin
-maintainers         gmail.com:aquynh
+maintainers         {gmail.com:aquynh @aquynh}
 license             BSD
 
 description         Capstone disassembly engine
@@ -22,15 +23,20 @@ checksums           rmd160  a10436a751acd5f78aba6279787d46a22bd4a744 \
 patch.pre_args      -p1
 patchfiles          patch-Makefile.diff
 
-variant universal {}
-
 use_configure       no
 
+universal_variant   yes
+
 build.env           CC=${configure.cc} \
-                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
-                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]" \
+                    CFLAGS="${configure.cflags}" \
+                    LDFLAGS="${configure.ldflags}" \
                     PREFIX=${prefix} \
                     V=1
+
+pre-build {
+    build.args-append \
+                    LIBARCHS="[get_canonical_archs]"
+}
 
 eval destroot.env   ${build.env}
 


### PR DESCRIPTION
#### Description

capstone:

* Build for the right architectures.
* Disable silent rules.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
