### PR TITLE
Update to net/librdkafka port to v0.11.5

### DIFF
--- a/net/librdkafka/Portfile
+++ b/net/librdkafka/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-version             0.11.3
+version             0.11.5
 github.setup        edenhill librdkafka ${version} v
 categories          net
 platforms           darwin
@@ -13,8 +13,8 @@ description         The Apache Kafka C/C++ library
 long_description    Full Apache Kafka protocol support, including producer and consumer
 homepage            https://github.com/edenhill/librdkafka
 
-checksums           sha256 79587c89a571b9db30635d9a4a55de624891ec34bcc1e5e5fd8736f05b17efa2 \
-                    rmd160 a624b87d5da3eb3bdb0182ebccf9376ee99f4773
+checksums           sha256 f0567b6abcdc597769995416d81f2e7ccf75ed8e69f2ed268b52ce120fd760c2 \
+                    rmd160 7c8ae28c27d5948e8b1e468b03492a9806af6e8b
 
 configure.args      --enable-ssl --enable-sasl
 


### PR DESCRIPTION
#### Description

This updates the net/librdkafka port to the latest release.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.3 17D102
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
