### PR TITLE
wireguard-go: update to 0.0.20181001

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20180613
+version             0.0.20181001
 categories          net
 platforms           darwin
 license             GPL-2
@@ -23,9 +23,9 @@ homepage            https://www.wireguard.com/
 master_sites        https://git.zx2c4.com/wireguard-go/snapshot/
 use_xz              yes
 
-checksums           rmd160  eaca7df0a711c0f02f288c41bed6b0375f827773 \
-                    sha256  3e22e6f2a715f05f9bbc5b1a9c737ab2edc8f26b2af61f9cc31f83391cd663ff \
-                    size    53628
+checksums           rmd160  ce17aa151d2fe12128d2609823fec2227bc3e249 \
+                    sha256  46242e6ddc5f8e2cffbb5cf9634399e1d0f7b9d9634d09c35b65ac8f4bbe222a \
+                    size    54388
 
 depends_build       port:dep \
                     port:git \


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?