### PR TITLE
openjdk10: simplified Portfile

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -9,7 +9,6 @@ set              openjdk_version 10
 subport openjdk11 {
     version      11
     set          openjdk_version 11
-    set          build 28
 }
 
 categories       java devel
@@ -31,22 +30,21 @@ homepage         https://jdk.java.net/${openjdk_version}/
 
 if {${subport} eq ${name}} {
     # openjdk10
-    master_sites     https://download.java.net/java/GA/jdk10/${version}/19aef61b38124481863b1413dce1855f/13/
-    distname         openjdk-${version}_osx-x64_bin
+    master_sites     https://download.java.net/java/GA/jdk${openjdk_version}/${version}/19aef61b38124481863b1413dce1855f/13/
 
     checksums        rmd160  d29498411adc487bf8191adbc4276c72602022cf \
                      sha256  77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7 \
                      size    200916897
 } else {
     # openjdk11
-    master_sites     https://download.java.net/java/GA/jdk${version}/${build}/GPL/
-    distname         openjdk-${version}+${build}_osx-x64_bin
+    master_sites     https://download.java.net/java/ga/jdk${openjdk_version}/
 
     checksums        rmd160  c914d38c78b2943c7b47ff2da4e8da89438f96cd \
                      sha256  6b969d2df6a9758d9458f5ba47939250e848dfba8b49e41c935cf210606b6d38 \
                      size    182717049
 }
 
+distname         openjdk-${version}_osx-x64_bin
 worksrcdir       jdk-${version}.jdk
 
 use_configure    no


### PR DESCRIPTION
#### Description

OpenJDK 11 is available at a simplified URL without a build number, which allows for a simplified Portfile with less subport customisation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?