### PR TITLE
ffmpeg: Add variant for Secure Transport

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -147,6 +147,7 @@ configure.args      --enable-swscale \
                     --disable-audiotoolbox \
                     --disable-videotoolbox \
                     --disable-sdl2 \
+                    --disable-securetransport \
                     --mandir=${prefix}/share/man \
                     --enable-shared --enable-pthreads \
                     --cc=${configure.cc}
@@ -317,6 +318,12 @@ variant jack description {Enable jack library and indev support} {
     depends_lib-append      port:jack
     configure.args-delete   --disable-libjack \
                             --disable-indev=jack
+}
+
+variant darwinssl description {Enable https support using Apple built-in TLS library instead of GNU TLS} {
+    configure.args-delete   --disable-securetransport
+    configure.args-delete   --enable-gnutls
+    depends_lib-delete      port:gnutls
 }
 
 variant gpl2 description {Enable GPL code, license will be GPL-2+} {

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -148,6 +148,7 @@ configure.args      --enable-swscale \
                     --disable-audiotoolbox \
                     --disable-videotoolbox \
                     --disable-sdl2 \
+                    --disable-securetransport \
                     --mandir=${prefix}/share/man \
                     --enable-shared --enable-pthreads \
                     --cc=${configure.cc}
@@ -318,6 +319,12 @@ variant jack description {Enable jack library and indev support} {
     depends_lib-append      port:jack
     configure.args-delete   --disable-libjack \
                             --disable-indev=jack
+}
+
+variant darwinssl description {Enable https support using Apple built-in TLS library instead of GNU TLS} {
+    configure.args-delete   --disable-securetransport
+    configure.args-delete   --enable-gnutls
+    depends_lib-delete      port:gnutls
 }
 
 variant gpl2 description {Enable GPL code, license will be GPL-2+} {


### PR DESCRIPTION
#### Description

Adds a variant +darwinssl to ffmpeg and ffmpeg-devel to use Apple's built-in SSL library, instead of GNU TLS.

Moves the existing behavior (using GNU TLS) under the default variant +gnutls.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

(Tested building & https-seems-to-work-or-fail-as-expected with the three new possible variant combos.)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->