### PR TITLE
osxfuse: Apply gen_bridge_metadata workaround on Mojave

### DIFF
--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -127,19 +127,22 @@ post-extract {
             move ${workpath}/osxfuse-${mp.comp}-${mp.rev} ${workpath}/${worksrcdir}/${mp.comp}
         }
     }
+}
 
-    if {${os.major} == 17 && [catch {system "/usr/bin/gen_bridge_metadata --version > /dev/null 2>&1"}]} {
-        ui_msg "If building this port fails, consider applying the following workaround:"
-        ui_msg ""
-        ui_msg "    cd /usr/local/lib"
-        ui_msg "    sudo ln -s \$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
-        ui_msg ""
-        ui_msg "or"
-        ui_msg ""
-        ui_msg "    cd \$(xcode-select -p)/Toolchains"
-        ui_msg "    sudo ln -s XcodeDefault.xctoolchain OSX10.13.xctoolchain"
-        ui_msg ""
-        ui_msg "See https://trac.macports.org/ticket/54939 for more information."
+pre-build {
+    if {${os.major} >= 17 && [catch {system "/usr/bin/gen_bridge_metadata --version > /dev/null 2>&1"}]} {
+        ui_error "This port will fail to build because of a bug in macOS,"
+        ui_error "unless you apply one of the following two workarounds:"
+        ui_error ""
+        ui_error "    sudo mkdir -p /usr/local/lib"
+        ui_error "    sudo ln -s \$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib /usr/local/lib"
+        ui_error ""
+        ui_error "or:"
+        ui_error ""
+        ui_error "    sudo ln -s XcodeDefault.xctoolchain \$(xcode-select -p)/Toolchains/OSX10.13.xctoolchain"
+        ui_error ""
+        ui_error "See https://trac.macports.org/ticket/54939 for more information."
+        return -code error "gen_bridge_metadata workaround not performed"
     }
 }
 


### PR DESCRIPTION
#### Description

The problem still exists on Mojave, so include that in the check.

The problem will cause a build failure, so don't even try to build if the workaround has not been performed.

Clean up the suggested workaround commands.

Move the detection of the problem from post-extract to pre-build since that's where it's actually needed.

See: https://trac.macports.org/ticket/54939

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->