### PR TITLE
http-parser: Use the right compiler and archs, add universal, fix Makefile

### DIFF
--- a/www/http-parser/Portfile
+++ b/www/http-parser/Portfile
@@ -23,8 +23,21 @@ patchfiles                  patch-Makefile.diff
 
 use_configure               no
 
-build.target                ""
-build.args                  CFLAGS="-DHTTP_PARSER_STRICT=0"
+universal_variant           yes
+
+configure.cflags-append     -DHTTP_PARSER_STRICT=0
+
+build.target                library
 build.post_args-delete      VERBOSE=ON
-build.env-append            PREFIX=${prefix}
-destroot.env-append         PREFIX=${prefix}
+build.env                   CC=${configure.cc} \
+                            PREFIX=${prefix}
+
+pre-build {
+    build.env-append        CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                            LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
+}
+
+test.run                    yes
+test.env                    {*}${build.env}
+
+destroot.env                {*}${build.env}

--- a/www/http-parser/files/patch-Makefile.diff
+++ b/www/http-parser/files/patch-Makefile.diff
@@ -1,6 +1,47 @@
---- Makefile
-+++ Makefile
-@@ -131,14 +131,14 @@
+Do not use -Werror because new compilers may include new warnings that the
+developer may not have anticipated.
+
+Use -dynamiclib on macOS instead of -shared.
+
+Fix the library target so that it only rebuilds the library if needed.
+
+Do not use install's -D option which is a GNU extension not supported on macOS.
+
+Mark the library target as phony.
+--- Makefile.orig	2018-03-31 01:07:55.000000000 -0500
++++ Makefile	2018-10-04 12:34:00.000000000 -0500
+@@ -52,13 +52,17 @@
+ CPPFLAGS_FAST += $(CPPFLAGS_FAST_EXTRA)
+ CPPFLAGS_BENCH = $(CPPFLAGS_FAST)
+ 
+-CFLAGS += -Wall -Wextra -Werror
++CFLAGS += -Wall -Wextra
+ CFLAGS_DEBUG = $(CFLAGS) -O0 -g $(CFLAGS_DEBUG_EXTRA)
+ CFLAGS_FAST = $(CFLAGS) -O3 $(CFLAGS_FAST_EXTRA)
+ CFLAGS_BENCH = $(CFLAGS_FAST) -Wno-unused-parameter
+ CFLAGS_LIB = $(CFLAGS_FAST) -fPIC
+ 
++ifeq (darwin,$(PLATFORM))
++LDFLAGS_LIB = $(LDFLAGS) -dynamiclib
++else
+ LDFLAGS_LIB = $(LDFLAGS) -shared
++endif
+ 
+ INSTALL ?= install
+ PREFIX ?= /usr/local
+@@ -109,8 +113,9 @@
+ libhttp_parser.o: http_parser.c http_parser.h Makefile
+ 	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_LIB) -c http_parser.c -o libhttp_parser.o
+ 
+-library: libhttp_parser.o
+-	$(CC) $(LDFLAGS_LIB) -o $(LIBNAME) $<
++library: $(LIBNAME)
++$(LIBNAME): libhttp_parser.o
++	$(CC) $(LDFLAGS_LIB) -o $@ $<
+ 
+ package: http_parser.o
+ 	$(AR) rcs libhttp_parser.a http_parser.o
+@@ -131,14 +136,14 @@
  	ctags $^
  
  install: library
@@ -19,3 +60,9 @@
  	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
  	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
  
+@@ -157,4 +162,4 @@
+ contrib/url_parser.c:	http_parser.h
+ contrib/parsertrace.c:	http_parser.h
+ 
+-.PHONY: clean package test-run test-run-timed test-valgrind install install-strip uninstall
++.PHONY: clean library package test-run test-run-timed test-valgrind install install-strip uninstall


### PR DESCRIPTION
#### Description

Use the right compiler and `-arch` flags and add a universal variant.

Closes https://trac.macports.org/ticket/57247

Only build the library in the build phase; don't run the tests.

Enable the test phase so that the tests can be run if desired.

Fix the Makefile:

* Don't use `-Werror`
* Don't rebuild the library unless that's needed
* Use `-dynamiclib` instead of `-shared` on macOS

**Note:** The Makefile fixes should probably be reported to the developer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
