### PR TITLE
nnap: Update to 1.1 and clean up portfile

### DIFF
--- a/news/nnap/Portfile
+++ b/news/nnap/Portfile
@@ -3,7 +3,11 @@
 PortSystem          1.0
 
 name                nnap
-version             1.0
+version             1.1
+checksums           rmd160  de86591ccf20c6b5a0da8c4d290f2f8533d3aefb \
+                    sha256  7364c4f78a84bc481322daee121bc033e9b89793e28236a85c131f8ed0d52de7 \
+                    size    9438
+
 platforms           darwin
 categories          news
 maintainers         freebsdcluster.org:mich
@@ -15,22 +19,27 @@ long_description    A small program that implements just enough of the NNTP \
                     authentication client requests. After authentication nnap \
                     bounces the client TCP connection to an open NNTP server.
 
+homepage            http://www.freebsdcluster.org/~lasse/
 master_sites        http://www.freebsdcluster.org/~lasse/software/
-distname            ${name}
+livecheck.version   [string map {. _} ${version}]
+distname            ${name}-${livecheck.version}
 extract.suffix      .c
 
-checksums           md5     ea48d42df822cdcc566549638681f4e4
-
+extract.mkdir       yes
 extract {
-    system "cp ${distpath}/${name}.c ${workpath}/nnap.c"
+    copy ${distpath}/${distfiles} ${worksrcpath}
 }
 
 use_configure       no
 
+universal_variant   yes
+
 build {
-    system "cd ${workpath} && cc -o ${name} ${name}.c"
+    system -W ${worksrcpath} "${configure.cc} [get_canonical_archflags cc] -o ${name} ${distfiles}"
 }
 
 destroot {
-    system "cd ${workpath} && install ${name} ${destroot}${prefix}/sbin"
+    xinstall -W ${worksrcpath} ${name} ${destroot}${prefix}/sbin
 }
+
+livecheck.regex     ${name}-(\\d+(?:_\\d+)*)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
#### Description

Updates nnap to 1.1 and cleans up the portfile to follow current best-practices.

I don't know the maintainer's GitHub handle. I've sent him an email inquiring. Since this port is so old (version 1.1 is from 2004) the maintainer may be gone.

I don't know the software's license. I've sent the developer an email to find out.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
