### PR TITLE
nmap: Don't prevent the use of nawk

### DIFF
--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -26,7 +26,8 @@ master_sites	https://nmap.org/dist/
 checksums	md5	84eb6fbe788e0d4918c2b1e39421bf79 \
 		sha1	71057361a0953bba5967dc0385de77f3eed792de \
 		rmd160	39b176e3b515bb5bf95503e3cb431a0dcd9e97ed \
-		sha256	847b068955f792f4cc247593aca6dc3dc4aae12976169873247488de147a6e18
+		sha256	847b068955f792f4cc247593aca6dc3dc4aae12976169873247488de147a6e18 \
+		size	10467371
 
 depends_lib	port:libpcap \
 		port:zlib \
@@ -42,8 +43,7 @@ configure.args	--without-zenmap --without-ndiff \
 		
 
 # nmap's configure script in nselib-bin does not respect --with-liblua=included
-# as with many ports, configure fails if nawk is installed, force use of system awk
-configure.env ac_cv_header_lua_h=no ac_cv_prog_AWK=awk
+configure.env ac_cv_header_lua_h=no
 
 use_parallel_build	no
 configure.ccache	no


### PR DESCRIPTION
#### Description

nmap: Don't prevent the use of nawk

The nawk port was broken but has been fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
