### PR TITLE
gimp-app: fix build on macOS 10.14

### DIFF
--- a/aqua/gimp-app/Portfile
+++ b/aqua/gimp-app/Portfile
@@ -38,9 +38,11 @@ post-extract {
 patchfiles          patch-ScriptExec.xcodeproj-project.pbxproj.diff \
                     patch-ScriptExecController.m.diff
 
-pre-build {
-    # clean up old precompiled headers just in case
-    system -W ${worksrcpath} "${xcodebuildcmd} clean"
+# This is a temporary kludge. The new Xcode build system fails to
+# destroot this for reasons that are poorly understood.
+# Remove this when a better fix is known.
+if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    destroot.pre_args   -UseNewBuildSystem=NO
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

gimp-app fails to build on macOS 10.14 Mojave.

There were two issues:

1. The pre-build `${xcodebuildcmd} clean` failed. No other port seems to do this, so I removed it.
2. With no. 1 fixed, destroot failed due to the build system change. I adopted the kludge discussed [here](https://lists.macports.org/pipermail/macports-dev/2018-October/039438.html)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.14 18A391
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
