### PR TITLE
py-markupsafe: Abandon port

### DIFF
--- a/python/py-markupsafe/Portfile
+++ b/python/py-markupsafe/Portfile
@@ -11,7 +11,7 @@ license             BSD
 
 python.versions     26 27 33 34 35 36 37
 
-maintainers         {perry @lperry} openmaintainer
+maintainers         nomaintainer
 
 description         Implements a XML/HTML/XHTML Markup safe string for Python
 long_description    ${description}


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?