### PR TITLE
BGHUDAppKit: fix build with XCode 10

### DIFF
--- a/aqua/BGHUDAppKit/Portfile
+++ b/aqua/BGHUDAppKit/Portfile
@@ -25,6 +25,14 @@ if {[vercmp $xcodeversion 5] >=0} {
     patchfiles-append xcode5.patch
 }
 
+# This is a temporary kludge. The new Xcode build system fails to
+# build and destroot this for reasons that are poorly understood.
+# Remove this when a better fix is known.
+if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    build.pre_args      -UseNewBuildSystem=NO
+    destroot.pre_args   -UseNewBuildSystem=NO
+}
+
 post-destroot {
     move ${destroot}${frameworks_dir}/BGHUDAppKitPlugin.ibplugin ${destroot}${frameworks_dir}/BGHUDAppKit.framework/Resources
 }


### PR DESCRIPTION
#### Description

XCode's new build system does not work for this port for reasons
not yet understood. As a workaround, switch to the old build system.

This issue was discussed under
https://lists.macports.org/pipermail/macports-dev/2018-October/039438.html
and is tracked for several ports as #57234.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.0 10A25

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
