### PR TITLE
mpv: fix mpv.app owner

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -6,6 +6,7 @@ PortGroup               waf 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.28.2 v
+revision                1
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic}
@@ -388,7 +389,7 @@ variant bundle description {Enable the optional macOS bundle of mpv} {
 
     post-destroot {
         xinstall -d -m 0755 ${destroot}${applications_dir}
-        move ${worksrcpath}/build/mpv.app ${destroot}${applications_dir}
+        copy ${worksrcpath}/build/mpv.app ${destroot}${applications_dir}
     }
 }
 


### PR DESCRIPTION
#### Description
`move` preserves owner of mpv.app, use `copy` instead.

```
drwxr-xr-x  0 macports admin       0 Feb 13  2018 ./Applications/MacPorts/mpv.app/
drwxr-xr-x  0 macports admin       0 Jul 23 04:49 ./Applications/MacPorts/mpv.app/Contents/
-rw-r--r--  0 macports admin   26524 Jul 23 04:49 ./Applications/MacPorts/mpv.app/Contents/Info.plist
drwxr-xr-x  0 macports admin       0 Jul 23 04:49 ./Applications/MacPorts/mpv.app/Contents/MacOS/
-rw-r--r--  0 macports admin       8 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/PkgInfo
drwxr-xr-x  0 macports admin       0 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/Resources/
-rw-r--r--  0 macports admin  311266 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/Resources/document.icns
-rw-r--r--  0 macports admin  742954 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/Resources/icon.icns
-rw-r--r--  0 macports admin      33 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/Resources/mpv.conf
-rw-r--r--  0 macports admin       0 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/MacOS/.gitkeep
drwxr-xr-x  0 macports admin       0 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/MacOS/lib/
-rwxr-xr-x  0 macports admin 3249948 Jul 23 04:49 ./Applications/MacPorts/mpv.app/Contents/MacOS/mpv
lrwxr-xr-x  0 macports admin       0 Jul 23 04:49 ./Applications/MacPorts/mpv.app/Contents/MacOS/mpv-bundle -> mpv
-rw-r--r--  0 macports admin       0 Feb 13  2018 ./Applications/MacPorts/mpv.app/Contents/MacOS/lib/.gitkeep
```