### PR TITLE
octave-1.0.tcl: Further default quoting fixes

### DIFF
--- a/_resources/port1.0/group/octave-1.0.tcl
+++ b/_resources/port1.0/group/octave-1.0.tcl
@@ -39,7 +39,11 @@ proc universal_setup {args} {
     } else {
         ui_debug "adding universal variant via PortGroup muniversal"
         uplevel "PortGroup muniversal 1.0"
+        if {[vercmp [macports_version] 2.5.3] <= 0} {
         uplevel "default universal_archs_supported {\"i386 x86_64\"}"
+        } else {
+        uplevel "default universal_archs_supported {i386 x86_64}"
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

Further `default` quoting fixes to go with 58369e469425fafca368aacb307b9234f6bc9022.

I *think* this is correct but I have not tested it because this is part of a large `if` statement and I don't know which octave ports would end up using this code.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
