### PR TITLE
php-uuid: Use MacPorts libuuid headers

### DIFF
--- a/php/php-uuid/Portfile
+++ b/php/php-uuid/Portfile
@@ -5,6 +5,7 @@ PortGroup               php 1.1
 
 name                    php-uuid
 version                 1.0.4
+revision                1
 categories-append       net www
 platforms               darwin
 maintainers             {pixilla @pixilla}
@@ -24,3 +25,10 @@ checksums               rmd160  5efc7fad2c43c029fa8a88e17356f3a8af9f5f8f \
 use_parallel_build      yes
 
 patchfiles              patch-osx_build.diff
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:libuuid
+
+    configure.args      --with-uuid=${prefix}
+}


### PR DESCRIPTION
#### Description

php-uuid: Use MacPorts libuuid headers

Fixes build failure on Mojave which doesn't have headers in /usr/include anymore.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
