### PR TITLE
atom: fix build on macOS 10.14

### DIFF
--- a/editors/atom/Portfile
+++ b/editors/atom/Portfile
@@ -29,6 +29,18 @@ build.cmd           script/build
 build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \
                     CXX="${configure.cxx} [get_canonical_archflags cxx]" \
                     PYTHON="${prefix}/bin/python2.7"
+
+if {${os.major} > 17} {
+    # Make sure the compiler builds against libc++ for macOS 10.14 and newer (#57243)
+    build.env-append    CFLAGS="${configure.cflags} -mmacosx-version-min=10.9" \
+                        CXXFLAGS="${configure.cxxflags} -mmacosx-version-min=10.9" \
+                        LDFLAGS="${configure.ldflags} -mmacosx-version-min=10.9"
+} else {
+    build.env-append    CFLAGS="${configure.cflags}" \
+                        CXXFLAGS="${configure.cxxflags}" \
+                        LDFLAGS="${configure.ldflags}"
+}
+
 build.target-delete all
 
 universal_variant   no


### PR DESCRIPTION
#### Description
libstdc++ was removed in Mojave and we need to make sure that atom and its modules are built against libc++. We can do so by setting macOS 10.9 as minimum target in CFLAGS, CXXFLAGS and LDFLAGS.

While here, it may be a good idea to export these variables always with macports' default values.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
