### PR TITLE
openjdk10: use same installation directory per major version

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -4,6 +4,7 @@ PortSystem       1.0
 
 name             openjdk10
 version          10.0.2
+revision         1
 set              openjdk_version 10
 
 subport openjdk11 {
@@ -57,7 +58,7 @@ destroot.violate_mtree yes
 destroot {
     set target ${destroot}/Library/Java/JavaVirtualMachines
     xinstall -m 755 -d ${target}
-    copy ${worksrcpath} ${target}
+    copy ${worksrcpath} ${target}/openjdk${openjdk_version}
 }
 
 if {${subport} eq ${name}} {


### PR DESCRIPTION
#### Description

Use consistent installation directory per OpenJDK major version, so users don't need to update the location of the JDK in their IDE after MacPorts updates OpenJDK to a new minor or patch version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?