### PR TITLE
Upgrade ghc dependency on llvm from 3.5 to 5.0 (See description for rationale)

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -51,7 +51,7 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-5.0       \
+                port:llvm-6.0       \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -51,7 +51,7 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-3.5       \
+                port:llvm-6.0       \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -51,7 +51,7 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-3.5       \
+                port:llvm-5.0      \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -51,7 +51,7 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-6.0       \
+                port:llvm-5.0       \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -51,7 +51,7 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-6.0       \
+                port:llvm-3.5       \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \


### PR DESCRIPTION
#### Description

Update Haskell's somewhat stale dependency on llvm-3.5 to llvm-5.0 (I have not tested llvm-6 or llvm-7, but one step at a time).

###### Type(s)
Update dependency to llvm.5

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B50c
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X ] checked your Portfile with `port lint`?
- [ X] tried existing tests with `sudo port test`?
- [ X] tried a full install with `sudo port -vst install`?
- [ X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
