### PR TITLE
Update dependency on llvm 3.5 to llvm 5.0.

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -8,7 +8,7 @@ name                ghc
 # When updating GHC, make sure to revbump all Haskell ports.
 # Also make sure to update the version in the Haskell PortGroup.
 version             7.8.3
-revision            6
+revision            7
 categories          lang haskell
 maintainers         {cal @neverpanic} openmaintainer
 license             BSD

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -51,7 +51,7 @@ depends_build   port:ghc-bootstrap \
 depends_lib     port:gmp           \
                 port:ncurses       \
                 port:libiconv      \
-                port:llvm-3.5       \
+                port:llvm-5.0      \
                 port:libffi
 
 patchfiles      patch-configure-workaround-bsdsed-incompatibility.diff \


### PR DESCRIPTION
#### Description

Update dependency on llvm 3.5 to llvm 5.0.  I also tested later versions of llvm, but settled on 5.0 as this gave the most interoperability with other ports and I dislike having half a dozen versions of llvm installed, if it's at all avoidable.

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B50c
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
