### PR TITLE
node*: Use expansion operator instead of eval

### DIFF
--- a/devel/nodejs10/Portfile
+++ b/devel/nodejs10/Portfile
@@ -38,7 +38,7 @@ depends_lib             port:python27
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }

--- a/devel/nodejs4/Portfile
+++ b/devel/nodejs4/Portfile
@@ -25,7 +25,8 @@ master_sites            ${homepage}dist/v${version}
 use_xz                  yes
 
 checksums               rmd160  998037518261a3f701604dc4c1c7219583a34b2f \
-                        sha256  d7d1232f948391699c6e98780ac90bdf5889902d639bad41561ac29f03dad401
+                        sha256  d7d1232f948391699c6e98780ac90bdf5889902d639bad41561ac29f03dad401 \
+                        size    13250164
 
 distname                node-v${version}
 
@@ -38,7 +39,7 @@ depends_lib             port:icu \
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }

--- a/devel/nodejs5/Portfile
+++ b/devel/nodejs5/Portfile
@@ -25,7 +25,8 @@ homepage                http://nodejs.org/
 master_sites            ${homepage}dist/v${version}
 
 checksums               rmd160  c5fd1aa1c8b440ddc41647f2d90119a0796e3cca \
-                        sha256  250c12a561d7319e71e142ee92ab682494c7823d81ce24703c80eb52bdf9ba42
+                        sha256  250c12a561d7319e71e142ee92ab682494c7823d81ce24703c80eb52bdf9ba42 \
+                        size    22836343
 
 distname                node-v${version}
 
@@ -38,7 +39,7 @@ depends_lib             port:icu \
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }

--- a/devel/nodejs6/Portfile
+++ b/devel/nodejs6/Portfile
@@ -39,7 +39,7 @@ depends_lib             port:icu \
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }

--- a/devel/nodejs7/Portfile
+++ b/devel/nodejs7/Portfile
@@ -25,7 +25,8 @@ master_sites            ${homepage}dist/v${version}
 use_xz                  yes
 
 checksums               rmd160  98aeaae9756b7d9dc227afac0a350e11042701f1 \
-                        sha256  654db852149a1cc59ece68ec573b0486907e8febe8353cee097dd29ea5a56cfa
+                        sha256  654db852149a1cc59ece68ec573b0486907e8febe8353cee097dd29ea5a56cfa \
+                        size    16751504
 
 distname                node-v${version}
 
@@ -38,7 +39,7 @@ depends_lib             port:icu \
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }

--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -38,7 +38,7 @@ depends_lib             port:python27 \
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }

--- a/devel/nodejs9/Portfile
+++ b/devel/nodejs9/Portfile
@@ -38,7 +38,7 @@ depends_lib             port:python27 \
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
     foreach dir [glob -directory $basedir -nocomplain -type d *] {
-        eval lappend files [rec_glob $dir $pattern]
+        lappend files {*}[rec_glob $dir $pattern]
     }
     return $files
 }


### PR DESCRIPTION
#### Description

node*: Use expansion operator instead of eval and add size to checksums.
