### PR TITLE
compilers PG: return libgcc7 dep in gfortran variant

### DIFF
--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -148,7 +148,8 @@ set cdb(gfortran,variant)  gfortran
 set cdb(gfortran,compiler) gfortran
 set cdb(gfortran,descrip)  "$cdb(${compilers.gcc_default},descrip) Fortran"
 set cdb(gfortran,depends)  $cdb(${compilers.gcc_default},depends)
-set cdb(gfortran,dependsl) $cdb(${compilers.gcc_default},dependsl)
+# see https://trac.macports.org/ticket/57284 for inclusion of port:libgcc7
+set cdb(gfortran,dependsl) "$cdb(${compilers.gcc_default},dependsl) port:libgcc7"
 set cdb(gfortran,libfortran) $cdb(${compilers.gcc_default},libfortran)
 set cdb(gfortran,dependsd) $cdb(${compilers.gcc_default},dependsd)
 set cdb(gfortran,dependsa) $cdb(${compilers.gcc_default},dependsa)


### PR DESCRIPTION
See https://trac.macports.org/ticket/57284

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.0 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
