### PR TITLE
vim: fix test for SDK newer than 10.6

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -25,6 +25,9 @@ depends_lib         port:ncurses \
                     port:gettext \
                     port:libiconv
 
+# fix test macro for sdk check
+patchfiles-append   patch-vim-src-os_macosx-availability.diff
+
 post-patch {
     set features [open ${worksrcpath}/src/feature.h a+]
     puts $features "#define SYS_VIMRC_FILE \"${prefix}/etc/vimrc\""

--- a/editors/vim/files/patch-vim-src-os_macosx-availability.diff
+++ b/editors/vim/files/patch-vim-src-os_macosx-availability.diff
@@ -1,0 +1,40 @@
+diff --git src/os_macosx.m src/os_macosx.m
+index 752bdae..50ca361 100644
+--- src/os_macosx.m
++++ src/os_macosx.m
+@@ -63,7 +63,7 @@ clip_mch_request_selection(VimClipboard *cbd)
+     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+ 
+     NSPasteboard *pb = [NSPasteboard generalPasteboard];
+-#ifdef AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+     NSArray *supportedTypes = [NSArray arrayWithObjects:VimPboardType,
+ 	    NSPasteboardTypeString, nil];
+ #else
+@@ -99,7 +99,7 @@ clip_mch_request_selection(VimClipboard *cbd)
+     {
+ 	/* Use NSPasteboardTypeString.  The motion type is detected automatically.
+ 	 */
+-#ifdef AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+ 	NSMutableString *mstring =
+ 		[[pb stringForType:NSPasteboardTypeString] mutableCopy];
+ #else
+@@ -188,7 +188,7 @@ clip_mch_set_selection(VimClipboard *cbd)
+ 
+ 	/* See clip_mch_request_selection() for info on pasteboard types. */
+ 	NSPasteboard *pb = [NSPasteboard generalPasteboard];
+-#ifdef AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+ 	NSArray *supportedTypes = [NSArray arrayWithObjects:VimPboardType,
+ 		NSPasteboardTypeString, nil];
+ #else
+@@ -201,7 +201,7 @@ clip_mch_set_selection(VimClipboard *cbd)
+ 	NSArray *plist = [NSArray arrayWithObjects:motion, string, nil];
+ 	[pb setPropertyList:plist forType:VimPboardType];
+ 
+-#ifdef AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+ 	[pb setString:string forType:NSPasteboardTypeString];
+ #else
+ 	[pb setString:string forType:NSStringPboardType];


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/56994

Fixes build on 10.4 and 10.5. Confirmed to build correctly still on 10.14 with no deprecation warnings.

See <https://github.com/vim/vim/pull/3022> 