### PR TITLE
x48: Add pkgconfig/xorg-libXt build dependencies

### DIFF
--- a/emulators/x48/Portfile
+++ b/emulators/x48/Portfile
@@ -27,12 +27,15 @@ patchfiles          patch-src-debugger.c.diff \
                     patch-src-emulate.c.diff
 
 checksums           ${distname}${extract.suffix} \
-                    sha1    dfc82fe84f0c793a5f7b8024127e16d341ad2899 \
                     rmd160  a5d7ddb4eb47426c639941d8cf53926bd3451ef5 \
-                    sha256  dd42fb3dfde860abb758f8e6d5ccd01845bbf0dcd808b87786eec3ef7091067f
+                    sha256  dd42fb3dfde860abb758f8e6d5ccd01845bbf0dcd808b87786eec3ef7091067f \
+                    size    227991
 
 depends_build       port:autoconf \
-                    port:automake
+                    port:automake \
+                    port:pkgconfig \
+                    port:xorg-libXt
+
 depends_lib         port:readline \
                     port:xorg-libXext
 
@@ -58,15 +61,15 @@ default_variants    +roms
 variant roms description "download and install ROM images" {
     distfiles-append ${gxrom}.bz2
     checksums-append ${gxrom}.bz2 \
-        sha1    c60a83cd57681c3cb359f0cd2505ede686fdb4c8 \
         rmd160  1dafce5902310161cb60f3dde401941565fd031c \
-        sha256  f89eb7bf979e62db53d436e3218b963c693f66c52797218c01d6552f1bbe014f
+        sha256  f89eb7bf979e62db53d436e3218b963c693f66c52797218c01d6552f1bbe014f \
+        size    332316
 
     distfiles-append ${sxrom}.bz2
     checksums-append ${sxrom}.bz2 \
-        sha1    660252ec34357bf0e3c4f2ba78eab3409f1c6fe8 \
         rmd160  8fb5f6f1284fb2dc15aa5d7603bbe3bfb8f30638 \
-        sha256  abd7f59cc07dcd22d1ac62bff901172d37e1ea4f01e1afdd099aa4bcf77e14a8
+        sha256  abd7f59cc07dcd22d1ac62bff901172d37e1ea4f01e1afdd099aa4bcf77e14a8 \
+        size    193349
 
     post-destroot {
         xinstall -d ${destroot}${romdir}
@@ -90,6 +93,4 @@ Check ${docdir}/README for details
 "
 }
 
-livecheck.type  regex
-livecheck.url   http://developer.berlios.de/project/showfiles.php?group_id=3335
-livecheck.regex {x48-(\d+\.\d+\.\d+)\.tar\.bz2}
+livecheck.distname  ${name}


### PR DESCRIPTION
#### Description

pkgconfig is needed to prevent configure failure.

Add size to checksums.

Remove references to the defunct berliOS service.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
