### PR TITLE
update tmux-pasteboard to version 2.7

### DIFF
--- a/sysutils/tmux-pasteboard/Portfile
+++ b/sysutils/tmux-pasteboard/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ChrisJohnsen tmux-MacOSX-pasteboard 2.6 v
+github.setup        ChrisJohnsen tmux-MacOSX-pasteboard 2.7 v
 name                tmux-pasteboard
 categories          sysutils
 platforms           darwin
@@ -15,8 +15,9 @@ long_description    ${description}
 
 depends_run         path:bin/tmux:tmux
 
-checksums           rmd160  647603906f23e3f1781c75b627c500d5f04b3391 \
-                    sha256  3472ff08a1250a20bfc955310bf5855175c60a109176bcefdd22ac517418af70
+checksums           rmd160  2cc454a397f3cc8b5b86a2140f85be97eee060e5 \
+                    sha256  e779a4a4f916484f15b9b384bbfa892030c70b65340da68f0d474df43889bcfd \
+                    size    16932
 
 use_configure       no
 variant universal {}


### PR DESCRIPTION
#### Description

@larryv 
Update tmux-pasteboard to suppress warning when ran under macOS Mojave.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
