### PR TITLE
atom: update to 1.31.2

### DIFF
--- a/editors/atom/Portfile
+++ b/editors/atom/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        atom atom 1.30.0 v
+github.setup        atom atom 1.31.2 v
 categories          editors
 platforms           darwin
 license             MIT
@@ -14,9 +14,9 @@ long_description    ${description}
 
 homepage            https://atom.io
 
-checksums           rmd160  8709874aee1d466e5456e5111f2f11f8ec57fe6c \
-                    sha256  09554ea124afb0867adcbde8f9fe2bbffc5798624d64899ce105499045e4adeb \
-                    size    11417767
+checksums           rmd160  e2ff226be405b3c9f5324da14b363b04a3bc9e06 \
+                    sha256  842089888a98712ace0f03eb840dda89fbfc24baa8dbea903345de078c480110 \
+                    size    11632654
 
 patchfiles          patch-install-prefix.diff
 
@@ -30,6 +30,7 @@ build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \
                     CXX="${configure.cxx} [get_canonical_archflags cxx]" \
                     PYTHON="${prefix}/bin/python2.7"
 build.target-delete all
+build.args-append   --ci
 
 universal_variant   no
 


### PR DESCRIPTION
#### Description
Use `--ci` added in Atom 1.31.0 for reproducible builds.

Potential security update: https://github.com/desktop/dugite/releases/tag/v1.78.0.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
