### PR TITLE
bam: update to 0.5.1

### DIFF
--- a/devel/bam/Portfile
+++ b/devel/bam/Portfile
@@ -1,30 +1,30 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+PortGroup       github 1.0
+PortGroup       python 1.0
+
+github.setup    matricks bam 0.5.1 v
 
 name            bam
-version         0.4.0
 categories      devel
 platforms       darwin
 license         zlib
-maintainers     {raimue @raimue} \
-                openmaintainer
+maintainers     {raimue @raimue} openmaintainer
 
 description     A fast and flexible build system
 long_description \
     Bam is a fast and flexible build system. It uses Lua to describe the build \
     process.
 
-homepage        http://matricks.github.com/bam/
+checksums       rmd160  fba2bed2c2904f5bcb477c3a42f41a8c091221c6 \
+                sha256  a81c5217e2ccc86d9957819c08cbe730777cae9185776574cc0c5e708df9464b \
+                size    258770
 
-master_sites    https://github.com/downloads/matricks/bam/
-checksums       md5     2f8e8336b8884110e8a355b12c9fa58a \
-                sha1    c0f32ff9272d5552e02a9d68fbdd72106437ee69 \
-                rmd160  cbb8d56c891e650f0a14c9a55efc4e9cc96e0e28
+python.default_version  27
 
-depends_build   port:python26
-
-post-patch {
-    reinplace "s:^gcc:${configure.cc}:" ${worksrcpath}/make_unix.sh
-}
+patchfiles      patch-scripts_gendocs.py.diff
 
 use_configure   no
 use_parallel_build  no
@@ -33,11 +33,11 @@ build.cmd       ./make_unix.sh
 build.target
 
 post-build {
-    system "cd ${worksrcpath} && ${prefix}/bin/python2.6 scripts/gendocs.py"
+    system "cd ${worksrcpath} && ${python.bin} scripts/gendocs.py"
 }
 
 test.run        yes
-test.cmd        ${prefix}/bin/python2.6 scripts/test.py
+test.cmd        ${python.bin} scripts/test.py
 test.target
 
 # there is no install target
@@ -46,7 +46,3 @@ destroot {
     xinstall -m 644 ${worksrcpath}/docs/bam.html ${destroot}${prefix}/share/doc/bam/
     xinstall -m 755 ${worksrcpath}/bam ${destroot}${prefix}/bin/
 }
-
-livecheck.type  regex
-livecheck.url   ${homepage}
-livecheck.regex ${name}-(\\d+(?:\\.\\d+)+)\\.tar

--- a/devel/bam/files/patch-scripts_gendocs.py.diff
+++ b/devel/bam/files/patch-scripts_gendocs.py.diff
@@ -1,0 +1,20 @@
+--- scripts/gendocs.py.orig	2018-10-08 10:09:52.000000000 -0400
++++ scripts/gendocs.py	2018-10-08 10:09:59.000000000 -0400
+@@ -2,7 +2,7 @@
+ from tinydoc import *
+ import os
+ 
+-os.system("dot -Tpng docs/depgraph.dot > docs/depgraph.png")
++#os.system("dot -Tpng docs/depgraph.dot > docs/depgraph.png")
+ 
+ 
+ info = DocInfo()
+@@ -23,7 +23,7 @@
+ root.nodes += [ParseFile(Node("Function Reference"), "src/base.lua").Sorted()]
+ root.nodes += [ParseFile(Node("Tool Reference"), "src/tools.lua").Sorted()]
+ root.nodes += [ParseTextFile(Node("Quirks"), "docs/quirks.txt")]
+-root.nodes += [ParseTextFile(Node("License"), "license.txt", True)]
++#root.nodes += [ParseTextFile(Node("License"), "license.txt", True)]
+ #notes.nodes +=[Node("C/C++ Dependency Checker")]
+ #notes.nodes +=[Node("Spaces in Paths")]
+ 


### PR DESCRIPTION
#### Description
As part of an attempt to remove dependencies on Python 2.6, here an update to the bam port. In addition to switching to Python 2.7 for generating the documentation/tests, it also updates to version 0.5.1.

Changes:
- add modeline
- use github and python portgroups
- switch to Python 2.7
- patch gendocs.py for missing license.txt and not to generate the .png file (this was also not done in the previous version; would require the graphviz port to be installed)

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
