### PR TITLE
wireguard-tools: update to 0.0.20181007

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -9,7 +9,7 @@ name                wireguard-tools
 # the WireGuard repository and its updates primarily deals with the
 # Linux kernel module, which isn't useful or relevant for macOS (we're
 # just interested in its tools for manipulating WireGuard interfaces).
-version             0.0.20180925
+version             0.0.20181007
 categories          net
 platforms           darwin
 license             GPL-2
@@ -27,9 +27,9 @@ master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
 
-checksums           rmd160  a10067c1ba87d61589b2c903ae33929645cb8f80 \
-                    sha256  4a0488a07e40ec17e798f3e40a85cedf55f0560b1c3a8fd95806c7d4266cb0e8 \
-                    size    296460
+checksums           rmd160  0e7d122bb7328db488c3422ca8874e5ad0e47c6b \
+                    sha256  d26e0d1216594871b5947e76d64c2fa50e9b34b68cdcfa3fdad588cbb314af89 \
+                    size    299128
 
 depends_run         port:bash \
                     port:wireguard-go


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?