### PR TITLE
p5-future: update to version 0.39

### DIFF
--- a/perl/p5-future/Portfile
+++ b/perl/p5-future/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26
-perl5.setup         Future 0.38 ../by-authors/id/P/PE/PEVANS
+perl5.setup         Future 0.39 ../../authors/id/P/PE/PEVANS
 
 platforms           darwin
 maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
@@ -16,16 +16,17 @@ description         Future - represent an operation awaiting completion
 
 long_description    ${description}
 
-checksums           rmd160  3fdcebdc931fb5836b67f66fa08f1d268a917749 \
-                    sha256  68426ec98108b0d6311994b9201e8644cb25ee46497e6501b71a4555c9218463 \
-                    size    87772
+checksums           rmd160  71e4b0f8d20bbe35fe9cd9e791acc357228a9025 \
+                    sha256  1fdd988fabf477ad57156c8f9c1948c8037d7851830e8f37ae74e5a0ee4b6b45 \
+                    size    88840
 
 if {${perl5.major} != ""} {
-    depends_test-append \
+    depends_build-append \
                     port:p${perl5.major}-test-fatal \
                     port:p${perl5.major}-test-identity \
                     port:p${perl5.major}-test-pod \
                     port:p${perl5.major}-test-refcount
+
     depends_lib-append \
                     port:p${perl5.major}-test-simple \
                     port:p${perl5.major}-test-refcount \


### PR DESCRIPTION
Perl modules typically check all dependencies, including test dependencies,
during the configure phase.  Use depends_build instead of depends_test to
avoid spurious dependency errors during configure.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
