### PR TITLE
fatsort: bump to 1.5.0.456

### DIFF
--- a/sysutils/fatsort/Portfile
+++ b/sysutils/fatsort/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                fatsort
-version             1.4.2.439
+version             1.5.0.456
 categories          sysutils
 platforms           darwin freebsd linux
 license             GPL-2+
@@ -23,9 +23,9 @@ depends_lib         port:libiconv
 
 master_sites        sourceforge:${name}
 use_xz              yes
-checksums           rmd160  b7c7ef2cb1df81089fd9bf6f89b6a60260b1fef0 \
-                    sha256  bdbcf99307baef3e76d99700691ac525c9a9cf96d8433b45c89314940cc6a1e0 \
-                    size    41852
+checksums           rmd160  667c8fe248d1008212c9e28e5faee168e6d3054b \
+                    sha256  a835b47814fd30d5bad464b839e9fc404bc1a6f5a5b1f6ed760ce9744915de95 \
+                    size    56100
 
 use_configure       no
 variant universal   {}


### PR DESCRIPTION
#### Description

###### Type(s)

###### Tested on
macOS 10.10.5 14F2511
Xcode 7.2 7C68

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] tested basic functionality of all binary files?