### PR TITLE
cvs2svn: remove obsolete python26 variant, update to 

### DIFF
--- a/devel/cvs2svn/Portfile
+++ b/devel/cvs2svn/Portfile
@@ -27,7 +27,10 @@ checksums       md5     4b93192e66302af9e537c6e33d80acc5 \
                 sha1	1194ac6ec70004409eea1fb2f0fce745318f1767 \
                 rmd160	62db8eb7b5d70ed42b47679bcb21237312e62135
 
+python.default_version 27
+
 test.run        yes
+test.cmd        ${python.bin}
 test.target     run-tests.py
 
 post-destroot {
@@ -37,18 +40,4 @@ post-destroot {
         cvs2svn-example.options HACKING README doc/design-notes.txt \
         ${destroot}${prefix}/share/doc/${name}
     file copy ${worksrcpath}/www ${destroot}${prefix}/share/doc/${name}
-}
-
-variant python26 description {Use python 2.6} {
-    python.default_version 26
-    test.cmd ${python.bin}
-}
-
-variant python27 description {Use python 2.7} {
-    python.default_version 27
-    test.cmd ${python.bin}
-}
-
-if {![variant_isset python26]} {
-    default_variants +python27
 }

--- a/devel/cvs2svn/Portfile
+++ b/devel/cvs2svn/Portfile
@@ -4,8 +4,7 @@ PortSystem      1.0
 PortGroup       python 1.0
 
 name            cvs2svn
-version         2.4.0
-revision        1
+version         2.5.0
 categories      devel python
 maintainers     {geeklair.net:dluke @danielluke}
 description     Tool for converting from CVS to subversion
@@ -22,10 +21,11 @@ long_description \
 
 platforms       darwin
 homepage        http://cvs2svn.tigris.org
-master_site     http://cvs2svn.tigris.org/files/documents/1462/49237/
-checksums       md5     4b93192e66302af9e537c6e33d80acc5 \
-                sha1	1194ac6ec70004409eea1fb2f0fce745318f1767 \
-                rmd160	62db8eb7b5d70ed42b47679bcb21237312e62135
+master_sites    http://cvs2svn.tigris.org/files/documents/1462/49543/
+
+checksums       rmd160  0ec03a846b20128ebffa8ab0590219152588d4fa \
+                sha256  6409d118730722f439760d41c08a5bfd05e5d3ff4a666050741e4a5dc2076aea \
+                size    539332
 
 python.default_version 27
 
@@ -41,3 +41,7 @@ post-destroot {
         ${destroot}${prefix}/share/doc/${name}
     file copy ${worksrcpath}/www ${destroot}${prefix}/share/doc/${name}
 }
+
+livecheck.type  regex
+livecheck.url   http://cvs2svn.tigris.org/servlets/ProjectDocumentList?folderID=2976
+livecheck.regex /${name}-(\[0-9.\]+)${extract.suffix}

--- a/devel/cvs2svn/Portfile
+++ b/devel/cvs2svn/Portfile
@@ -1,52 +1,54 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortGroup		python 1.0
+PortSystem      1.0
+PortGroup       python 1.0
 
-name			cvs2svn
-version			2.4.0
-revision		1
-categories		devel python
-maintainers		{geeklair.net:dluke @danielluke}
-description		Tool for converting from CVS to subversion
+name            cvs2svn
+version         2.4.0
+revision        1
+categories      devel python
+maintainers     {geeklair.net:dluke @danielluke}
+description     Tool for converting from CVS to subversion
 #Actually it's CollabNet/Tigris.org Apache-style license
 #which is the same as the Apache license, but with CollabNet as the copyright holder
 #see http://cvs2svn.tigris.org/servlets/LicenseDetails?licenseID=9
-license			Apache
+license         Apache
 
-long_description	cvs2svn is a Python script that converts a CVS \
-			repository to a Subversion repository. It is designed \
-			for one-time conversions, not for repeated \
-			synchronizations between CVS and Subversion.
+long_description \
+                cvs2svn is a Python script that converts a CVS \
+                repository to a Subversion repository. It is designed \
+                for one-time conversions, not for repeated \
+                synchronizations between CVS and Subversion.
 
-platforms		darwin
-homepage		http://cvs2svn.tigris.org
-master_sites		http://cvs2svn.tigris.org/files/documents/1462/49237/
-checksums	md5	4b93192e66302af9e537c6e33d80acc5 \
-		sha1	1194ac6ec70004409eea1fb2f0fce745318f1767 \
-		rmd160	62db8eb7b5d70ed42b47679bcb21237312e62135
+platforms       darwin
+homepage        http://cvs2svn.tigris.org
+master_site     http://cvs2svn.tigris.org/files/documents/1462/49237/
+checksums       md5     4b93192e66302af9e537c6e33d80acc5 \
+                sha1	1194ac6ec70004409eea1fb2f0fce745318f1767 \
+                rmd160	62db8eb7b5d70ed42b47679bcb21237312e62135
 
-test.run		yes
-test.target		run-tests.py
+test.run        yes
+test.target     run-tests.py
 
 post-destroot {
-	xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-	xinstall -m 644 -W ${worksrcpath} BUGS CHANGES COMMITTERS COPYING \
-		cvs2bzr-example.options cvs2git-example.options cvs2hg-example.options \
-		cvs2svn-example.options HACKING README doc/design-notes.txt \
-		${destroot}${prefix}/share/doc/${name}
-	file copy ${worksrcpath}/www ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} BUGS CHANGES COMMITTERS COPYING \
+        cvs2bzr-example.options cvs2git-example.options cvs2hg-example.options \
+        cvs2svn-example.options HACKING README doc/design-notes.txt \
+        ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/www ${destroot}${prefix}/share/doc/${name}
 }
 
-variant python26 description {Use python 2.6} { 
-	python.default_version 26 
-	test.cmd ${python.bin} 
+variant python26 description {Use python 2.6} {
+    python.default_version 26
+    test.cmd ${python.bin}
 }
- 
-variant python27 description {Use python 2.7} { 
-	python.default_version 27 
-	test.cmd ${python.bin} 
-} 
 
-if {![variant_isset python26]} { 
-	default_variants +python27 
+variant python27 description {Use python 2.7} {
+    python.default_version 27
+    test.cmd ${python.bin}
+}
+
+if {![variant_isset python26]} {
+    default_variants +python27
 }


### PR DESCRIPTION
#### Description
As part of an attempt to remove dependencies on Python 2.6, here an update to the cvs2svn port. In addition to removing the Python 2.6, it also updates the port to version 2.5.0.

Changes:
- add/conform to modeline
- remove Python 2.6 variant
- update to 2.5.0
- modernize checksums
- fix livecheck
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
Yes, but they fail - just as for the previous version... so nothing has changed.
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? 
The Python scripts do seem to work and it seems all good to me..

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
