### PR TITLE
py-async-timeout: update to 3.0.1

### DIFF
--- a/python/py-async-timeout/Portfile
+++ b/python/py-async-timeout/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-async-timeout
-version             3.0.0
+version             3.0.1
 categories-append   devel
 platforms           darwin
 license             Apache-2
@@ -25,12 +25,14 @@ master_sites        pypi:a/async-timeout
 
 distname            async-timeout-${version}
 
-checksums           rmd160  8948ebeadcc3a5206c04cf8642e9a539c734e766 \
-                    sha256  b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287 \
-                    size    10803
+checksums           rmd160  6dc15c02bc3565772a71ebcdbccc368e6c3db87b \
+                    sha256  0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f \
+                    size    9724
 
 if {${name} ne ${subport}} {
-    depends_build       port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type          none
 } else {
-    livecheck.type      pypi
+    livecheck.type          pypi
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- [skip notification] Use "skip notification" (surrounded with []) to avoid notifying maintainers -->