### PR TITLE
mpv: update to 0.29.1

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -5,8 +5,7 @@ PortGroup               github 1.0
 PortGroup               waf 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
-github.setup            mpv-player mpv 0.28.2 v
-revision                1
+github.setup            mpv-player mpv 0.29.1 v
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic}
@@ -21,7 +20,7 @@ long_description        ${description} It plays most MPEG/VOB, AVI, Ogg/OGM, \
                         and even H.264 movies.
 homepage                http://www.mpv.io/
 
-set waf_version         1.9.8
+set waf_version         2.0.9
 set waf_distfile        waf-${waf_version}
 set mpv_distfile        ${distfiles}
 master_sites-append     https://waf.io/:waf
@@ -30,13 +29,13 @@ distfiles-append        ${waf_distfile}:waf
 extract.only-delete     ${waf_distfile}
 
 checksums               ${mpv_distfile} \
-                        rmd160  f74e0471685be85fafbb6548362997f146ff11a3 \
-                        sha256  9cac0613be59f766f5635da5380b0782d0141c9471c55815e8a1ddc9f2cb0b24 \
-                        size    2982853 \
+                        rmd160  10edd02cf12c4668c57317caf3042df30ae1128c \
+                        sha256  c7076df8c46f2696121d0b96cc5edfc472cbccc3b6a70d9b5c00a72b6a41c820 \
+                        size    3059829 \
                         ${waf_distfile} \
-                        rmd160  d1a5d0e0f42a0101f5832abb33cd71018505405f \
-                        sha256  167dc42bab6d5bd823b798af195420319cb5c9b571e00db7d83df2a0fe1f4dbf \
-                        size    100685
+                        rmd160  bbb01fa7c1d552c01e5a6531ed27aef710d668e7 \
+                        sha256  2a8e0816f023995e557f79ea8940d322bec18f286917c8f9a6fa2dc3875dfa48 \
+                        size    103104
 
 installs_libs           no
 
@@ -130,6 +129,13 @@ configure.cppflags-replace  -I${prefix}/include -isystem${prefix}/include
 
 build.args-append           -v
 
+# Clear CPATH and LIBRARY_PATH because a ncurses include file
+# conflicts with the one in MacPorts. It doesn't matter much anyway
+# because the swift module in mpv doesn't have any dependencies to
+# link against.
+compiler.cpath
+compiler.library_path
+
 platform macosx {
     if {${os.major} > 10} {
         # Force recent enough Xcode.
@@ -188,17 +194,6 @@ platform darwin {
     if {${os.major} > 11} {
         configure.args-delete   --disable-videotoolbox-gl
         configure.args-append   --enable-videotoolbox-gl
-    }
-
-    # It looks like mpv expects a CUDA API version 7050 or higher, which might mean >= 7.0.50.
-    # If that's the case, only 10.9+ have support for that.
-    # Current ffmpeg expects a CUDA version of 8.0.14.2 or higher, which is only available
-    # for 10.11+.
-    # Also, it might be necessary to have the CUDA SDK installed before installing ffmpeg.
-    # Let's hope for the best, for now.
-    if {${os.major} > 14} {
-        configure.args-replace   --disable-cuda-hwaccel \
-                                 --enable-cuda-hwaccel
     }
 
     if {${os.major} > 11} {


### PR DESCRIPTION
#### Description

Fixes two issues on Mojave:
* Black screens when playing videos
* Crashes if Accessibility access not allowed in System Preferences >
  Security & Privacy > Privacy

I dropped --enable-cuda-hwaccel as this option requires ffnvcodec
headers since version 0.29.0 [1], and those headers are not fully
compatibile with macOS yet [2].

Closes https://trac.macports.org/ticket/57246

[1] https://github.com/mpv-player/mpv/commit/07915b12273a36bc7f104a5f3fc949a407d243dc
[2] https://github.com/FFmpeg/nv-codec-headers/blob/n8.2.15.1/include/ffnvcodec/dynlink_nvcuvid.h#L229

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?