### PR TITLE
spe/zim/unsermake/diffuse: remove obsolete python versions/variants

### DIFF
--- a/devel/diffuse/Portfile
+++ b/devel/diffuse/Portfile
@@ -1,8 +1,12 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
+PortGroup           python 1.0
 
 name                diffuse
 version             0.4.8
-categories          devel
+revision            1
+categories-prepend  devel
 platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
@@ -16,40 +20,29 @@ long_description    Diffuse is a small and simple text merge tool \
 homepage            http://diffuse.sourceforge.net
 master_sites        sourceforge
 
-checksums           sha1    473f7e82f57cc3a5ce0378eea8aede19a3f2a9df \
-                    sha256  c1d3b79bba9352fcb9aa4003537d3fece248fb824781c5e21f3fcccafd42df2b \
-                    rmd160  c424ba8e48a86d0eeab2b51b15bb6f81dd23e95d
+checksums           sha256  c1d3b79bba9352fcb9aa4003537d3fece248fb824781c5e21f3fcccafd42df2b \
+                    rmd160  c424ba8e48a86d0eeab2b51b15bb6f81dd23e95d \
+                    size    557966
 
 use_bzip2           yes
 
-set pythonexec ""
+python.default_version  27
 
-variant python26 conflicts python27 description {Use python26} {
-    depends_lib-append    port:py26-pygtk
-    set pythonexec        ${prefix}/bin/python2.6
-}
-
-variant python27 conflicts python26 description {Use python27} {
-    depends_lib-append    port:py27-pygtk
-    set pythonexec        ${prefix}/bin/python2.7
-}
-
-if {![variant_isset python26]} {
-    default_variants +python27
-}
+depends_lib-append  port:py${python.version}-pygtk
 
 use_configure       no
 
 post-patch {
-    reinplace "s|/usr/bin/env python|${pythonexec}|g" \
+    reinplace "s|/usr/bin/env python|${python.bin}|g" \
         ${worksrcpath}/src/usr/bin/diffuse
 }
 
 build {}
 
 destroot {
-    system "cd ${worksrcpath} && ${pythonexec} \
+    system -W "${worksrcpath}" "${python.bin} \
        ./install.py \
+       --pythonbin=${python.bin} \
        --prefix=${prefix} \
        --destdir=${destroot} \
        --sysconfdir=${prefix}/etc"

--- a/devel/unsermake/Portfile
+++ b/devel/unsermake/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       python 1.0
 
 name            unsermake
 version         0.4-20070824
-revision        2
+revision        3
 categories      devel
 license         GPL-2+
 maintainers     nomaintainer
@@ -15,18 +16,21 @@ long_description \
                 Unsermake is an automake replacement from the KDE project.
 platforms       darwin
 homepage        http://www.kde.me.uk/index.php?page=unsermake
-master_sites    http://ranger.befunk.com/fink \
-                http://astrange.ithinksw.net/~astrange/ranger-fink \
-                http://www.southofheaven.net/befunk
+master_sites    https://ranger.befunk.com/fink
 distfiles       ${name}-20070824.tar.bz2
 use_bzip2       yes
-checksums       md5 b794f83bdc3f6205d1fd731da4e96d89
+
+checksums       md5     b794f83bdc3f6205d1fd731da4e96d89 \
+                rmd160  edc5100fcd2b59065312967acf3ff8e96bb4f884 \
+                sha256  de84ea2e74149b0bcb4ce8cb25cb1e8c00fc39e386646d6d065033a25be5d7b3 \
+                size    66319
+
 worksrcdir      ${name}
 
-depends_run     port:python26
+python.default_version 27
 
 patch {
-    reinplace "s|exec python|exec ${prefix}/bin/python2.6|" ${worksrcpath}/unsermake
+    reinplace "s|exec python|exec ${python.bin}|" ${worksrcpath}/unsermake
 }
 
 use_configure   no

--- a/editors/spe/Portfile
+++ b/editors/spe/Portfile
@@ -6,34 +6,37 @@ PortGroup           wxWidgets 1.0
 
 name                spe
 version             0.8.4.h
-revision            1
+revision            2
 categories          editors python
 license             GPL-2+
 platforms           darwin
 supported_archs     noarch
 maintainers         nomaintainer
-description         spe - Stani's Python Editor 
+description         spe - Stani's Python Editor
 long_description    spe - Stani's Python Editor  \
                     Free Python IDE with Blender, Kiki, PyChecker,  \
-                    Remote Debugger, Uml and wxGlade support. 
+                    Remote Debugger, Uml and wxGlade support.
 
-homepage            http://pythonide.blogspot.com/
-master_sites        http://download.berlios.de/python/
+homepage            https://pythonide.blogspot.com/
+master_sites        macports_distfiles
 distname            spe-${version}-wx2.6.1.0
 checksums           rmd160  211c0465dce7aeab5b8a3d7fd9cf444b3efbe845 \
-                    sha256  e43d42c42d0f716fa7e6e4430295471786611873e47b39dfe2593f8aa2dc1576
+                    sha256  e43d42c42d0f716fa7e6e4430295471786611873e47b39dfe2593f8aa2dc1576 \
+                    size    1210145
 
-python.default_version 26
+python.default_version 27
 
-depends_lib-append  port:py26-wxpython-2.8
-depends_run         port:py26-checker
+depends_lib-append  port:py${python.version}-wxpython-2.8
+depends_run-append  port:py${python.version}-checker
 
 worksrcdir          spe-${version}
 
 patch {
-    reinplace "s|/usr/bin/env python|${prefix}/bin/pythonw2.6|1" ${worksrcpath}/_spe/spe
+    reinplace "s|/usr/bin/env python|${prefix}/bin/pythonw${python.branch}|1" ${worksrcpath}/_spe/spe
 }
 
 post-destroot {
     file delete ${destroot}${prefix}/bin/spe_wininst.py
 }
+
+livecheck.type      none

--- a/editors/zim/Portfile
+++ b/editors/zim/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           app 1.0
@@ -26,48 +28,31 @@ distname            zim-${version}
 checksums           rmd160  49d1d483942736c26db6a9ba55e09b12cb297416 \
                     sha256  b37cef3d4906aa263abccb1493929a7ea6b9e8d11a50ed92cd437e8f93ffabbd
 
-depends_run-append  port:desktop-file-utils
+python.default_version  27
+python.link_binaries    no
 
-use_configure       no
-build               {}
+depends_run-append  port:desktop-file-utils
 
 set app.icon        icons/zim48.png
 set app.executable  ${workpath}/zim-app
 
-python.link_binaries    no
-set python.bindir       ""
+depends_lib-append  port:py${python.version}-gobject \
+                    port:py${python.version}-pygtk \
+                    port:py${python.version}-xdg
 
-variant python27 conflicts python26 description {Configure to use Python version 2.7} {
-    python.default_version 27
-    set python.bindir   ${python.prefix}/bin
-    depends_lib-append  port:py27-gobject \
-                        port:py27-pygtk \
-                        port:py27-xdg
-    destroot.destdir-append     --install-data=${prefix} \
-                                --skip-xdg-cmd
-}
+use_configure       no
+build               {}
 
-variant python26 conflicts python27 description {Configure to use Python version 2.6} {
-    python.default_version 26
-    set python.bindir   ${python.prefix}/bin
-    depends_lib-append  port:py26-gobject \
-                        port:py26-gtk \
-                        port:py26-xdg
-    destroot.destdir-append     --install-data=${prefix} \
-                                --skip-xdg-cmd
-}
-
-if {![variant_isset python26] && ![variant_isset python27]} {
-    default_variants +python27
-}
+destroot.destdir-append --install-data=${prefix} \
+                        --skip-xdg-cmd
 
 pre-destroot {
     xinstall -m 755 ${filespath}/zim ${destroot}${prefix}/bin
     reinplace "s|__PREFIX__|${prefix}|g" ${destroot}${prefix}/bin/zim
-    reinplace "s|__PYTHON_BINDIR__|${python.bindir}|g" ${destroot}${prefix}/bin/zim
+    reinplace "s|__PYTHON_BINDIR__|${python.prefix}/bin|g" ${destroot}${prefix}/bin/zim
     file copy ${filespath}/zim-app ${workpath}/zim-app
     reinplace "s|__PREFIX__|${prefix}|g" ${workpath}/zim-app
-    reinplace "s|__PYTHON_BINDIR__|${python.bindir}|g" ${workpath}/zim-app
+    reinplace "s|__PYTHON_BINDIR__|${python.prefix}/bin|g" ${workpath}/zim-app
 }
 
 post-activate {

--- a/editors/zim/Portfile
+++ b/editors/zim/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           app 1.0
 
 name                zim
-version             0.67
+version             0.68
 platforms           darwin
 categories          editors
 maintainers         nomaintainer
@@ -25,8 +25,9 @@ homepage            http://zim-wiki.org
 master_sites        ${homepage}/downloads/
 distname            zim-${version}
 
-checksums           rmd160  49d1d483942736c26db6a9ba55e09b12cb297416 \
-                    sha256  b37cef3d4906aa263abccb1493929a7ea6b9e8d11a50ed92cd437e8f93ffabbd
+checksums           rmd160  9297468ff1caa0d9ea0936d30c34bb659938c48e \
+                    sha256  d91518e010f6a6e951a75314138b5545a4c51151fc99f513aa7768a18858df15 \
+                    size    2044224
 
 python.default_version  27
 python.link_binaries    no


### PR DESCRIPTION
#### Description
As part of an attempt to remove dependencies on Python 2.6, here some updates to the spe/zim/unsermake/diffuse ports. It removes the use of obsolete python versions (in variants), updates zim, and a variety of smaller changes (see the commit messages for more details).
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
