### PR TITLE
emacs-devel emacs-app-devel : Update to git commit 7946445962 

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -88,11 +88,11 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     epoch           1
-    version         20180621
+    version         20180928
 
     fetch.type      git
     git.url         http://git.savannah.gnu.org/r/emacs.git
-    git.branch      5583e6460c38c5d613e732934b066421349a5259
+    git.branch      7946445962372c4255180af45cb7c857f1b0b5fa
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"


### PR DESCRIPTION

Provides work around for emacs-app rendering issues seen on mac OS 10.14
Updates the devel ports to a recent git commit that fixes the issue. 

See discussion at

https://trac.macports.org/ticket/57217

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
