### PR TITLE
nawk: Update to 20180827

### DIFF
--- a/lang/nawk/Portfile
+++ b/lang/nawk/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        onetrueawk awk 20180827
+checksums           rmd160  aec269dbea4677b84a3dc36c4bf8fab242b50361 \
+                    sha256  aec3b4570bea6876f12c402ccae299520b758e017a194291ffaf0611aa80df3f \
+                    size    1824091
 
 name                nawk
-version             20121220
-revision            1
-checksums           rmd160  3872ef2407a4ad57f55c45dc60fc917eca7a614e \
-                    sha256  8dc092165c5a4e1449f964286483d06d0dbfba4b0bd003cb5dab30de8f6d9b83
-
 categories          lang
 platforms           darwin
 license             BSD
@@ -16,14 +17,6 @@ maintainers         toby openmaintainer
 description         the one true awk
 
 long_description    Kernighan's canonical implementation of awk.
-
-homepage            https://github.com/onetrueawk/awk
-master_sites        ${homepage}
-distname            awk
-
-dist_subdir         ${name}/${version}
-
-extract.mkdir       yes
 
 patchfiles          patch-makefile patch-run.c
 
@@ -39,5 +32,3 @@ destroot {
     xinstall ${worksrcpath}/a.out ${destroot}${prefix}/bin/nawk
     xinstall ${worksrcpath}/awk.1 ${destroot}${prefix}/share/man/man1/nawk.1
 }
-
-livecheck.type      none

--- a/lang/nawk/Portfile
+++ b/lang/nawk/Portfile
@@ -1,36 +1,43 @@
-PortSystem 1.0
-name             nawk
-version          20121220
-revision         1
-categories       lang
-license          BSD
-maintainers      toby openmaintainer
-description      the one true awk
-long_description Kernighan's canonical implementation of awk.
-homepage         https://github.com/onetrueawk/awk
-platforms        darwin
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-master_sites     ${homepage}
-distname         awk
-checksums        rmd160  3872ef2407a4ad57f55c45dc60fc917eca7a614e \
-                 sha256  8dc092165c5a4e1449f964286483d06d0dbfba4b0bd003cb5dab30de8f6d9b83
-dist_subdir      ${name}/${version}
+PortSystem          1.0
 
-extract.mkdir    yes
+name                nawk
+version             20121220
+revision            1
+checksums           rmd160  3872ef2407a4ad57f55c45dc60fc917eca7a614e \
+                    sha256  8dc092165c5a4e1449f964286483d06d0dbfba4b0bd003cb5dab30de8f6d9b83
 
-patchfiles       patch-makefile patch-run.c
+categories          lang
+platforms           darwin
+license             BSD
+maintainers         toby openmaintainer
+
+description         the one true awk
+
+long_description    Kernighan's canonical implementation of awk.
+
+homepage            https://github.com/onetrueawk/awk
+master_sites        ${homepage}
+distname            awk
+
+dist_subdir         ${name}/${version}
+
+extract.mkdir       yes
+
+patchfiles          patch-makefile patch-run.c
 
 configure {
-	reinplace "s|__CFLAGS__|${configure.cflags} [get_canonical_archflags]|" ${worksrcpath}/makefile
-	reinplace s|__CC__|${configure.cc}| ${worksrcpath}/makefile
+    reinplace "s|__CFLAGS__|${configure.cflags} [get_canonical_archflags]|" ${worksrcpath}/makefile
+    reinplace s|__CC__|${configure.cc}| ${worksrcpath}/makefile
 }
 
-use_parallel_build no
+use_parallel_build  no
 build.target
 
 destroot {
-	xinstall ${worksrcpath}/a.out ${destroot}${prefix}/bin/nawk
-	xinstall ${worksrcpath}/awk.1 ${destroot}${prefix}/share/man/man1/nawk.1
+    xinstall ${worksrcpath}/a.out ${destroot}${prefix}/bin/nawk
+    xinstall ${worksrcpath}/awk.1 ${destroot}${prefix}/share/man/man1/nawk.1
 }
 
-livecheck.type  none
+livecheck.type      none

--- a/lang/nawk/files/patch-makefile
+++ b/lang/nawk/files/patch-makefile
@@ -1,19 +1,23 @@
---- makefile.orig	2012-12-20 07:58:45.000000000 -0600
-+++ makefile	2013-06-25 22:47:15.000000000 -0500
-@@ -25,14 +25,15 @@
+--- makefile.orig	2018-08-28 15:05:48.000000000 -0500
++++ makefile	2018-10-11 06:24:02.000000000 -0500
+@@ -25,17 +25,18 @@
  CFLAGS = -g
- CFLAGS = -O2
  CFLAGS =
+ CFLAGS = -O2
 +CFLAGS = -DHAS_ISBLANK __CFLAGS__
  
- CC = gcc -Wall -g -Wwrite-strings
- CC = gcc -fprofile-arcs -ftest-coverage # then gcov f1.c; cat f1.c.gcov
+ # compiler options
+ #CC = gcc -Wall -g -Wwrite-strings
+ #CC = gcc -O4 -Wall -pedantic -fno-strict-aliasing
+ #CC = gcc -fprofile-arcs -ftest-coverage # then gcov f1.c; cat f1.c.gcov
  CC = gcc -g -Wall -pedantic 
- CC = gcc -O4 -Wall -pedantic -fno-strict-aliasing
 +CC = __CC__ -Wall -g
  
- YACC = bison -d -y
--YACC = yacc -d -S
+ # yacc options.  pick one; this varies a lot by system.
  #YFLAGS = -d -S
- 		# -S uses sprintf in yacc parser instead of sprint
+-#YACC = bison -d -y
+-YACC = yacc -d
++YACC = bison -d -y
+ #		-S uses sprintf in yacc parser instead of sprint
  
+ OFILES = b.o main.o parse.o proctab.o tran.o lib.o run.o lex.o

--- a/lang/nawk/files/patch-run.c
+++ b/lang/nawk/files/patch-run.c
@@ -1,7 +1,7 @@
---- run.c.orig	Tue Dec 28 23:53:45 2004
-+++ run.c	Tue Dec 28 23:53:57 2004
-@@ -903,7 +903,7 @@
- 			break;
+--- run.c.orig	2018-08-28 15:05:48.000000000 -0500
++++ run.c	2018-10-11 06:24:36.000000000 -0500
+@@ -930,7 +930,7 @@
+ 		case 'A':
  		case 'f':	sprintf(p, fmt, getfval(x)); break;
  		case 'd':	sprintf(p, fmt, (long) getfval(x)); break;
 -		case 'u':	sprintf(p, fmt, (int) getfval(x)); break;


### PR DESCRIPTION
#### Description

nawk: Update to 20180827

Switched to github portgroup, which also fixes the livecheck.

Portfile used a mix of tabs and spaces; added modeline and reformatted to our standard 4-spaces-per-indent style.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
