### PR TITLE
py-django: Update to 1.11.16/2.1.2

### DIFF
--- a/python/py-django/Portfile
+++ b/python/py-django/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        django django 2.1.1
+github.setup        django django 2.1.2
 name                py-django
 categories-append   www
 platforms           darwin
@@ -23,17 +23,17 @@ supported_archs     noarch
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {
-        github.setup    django django 1.11.15
+        github.setup    django django 1.11.16
 
-        checksums       rmd160  38ccea19743ee393148f076bd806166bfad0b39a \
-                        sha256  58ddfa73a8c32c41fb2ca810dc79118dbaca6f4fbc251ec921e05a610fc911ef \
-                        size    7893007
+        checksums       rmd160  b6f63b057d8b3a693748be5db7191df1cadbe29f \
+                        sha256  bc2963c402806f23040f1d73cbefe2e038d68f53e52f8be0f6cc1774e7341b4f \
+                        size    7894144
 
         github.livecheck.regex  {(1\..+?)}
     } else {
-        checksums       rmd160  12ccde5448f7b8e9898bb04efc9cee4c275849ad \
-                        sha256  34b5771368fd9ca04d1340e0e6d948cd5f7e614dc0d5f7330bf415a6d2dec222 \
-                        size    8641387
+        checksums       rmd160  f1dbdd1441e42e87a1e3a3242d2d8ac51e5c69f4 \
+                        sha256  f218de943d47bbc33ae92609a67915762924f7ada3b06d8b8dcd55f664b8c02d \
+                        size    8656423
 
         livecheck.type  none
     }

--- a/python/py-django/Portfile
+++ b/python/py-django/Portfile
@@ -29,7 +29,7 @@ if {${name} ne ${subport}} {
                         sha256  58ddfa73a8c32c41fb2ca810dc79118dbaca6f4fbc251ec921e05a610fc911ef \
                         size    7893007
 
-        livecheck.regex {archive/(1[.].+?).tar.gz}
+        github.livecheck.regex  {(1\..+?)}
     } else {
         checksums       rmd160  12ccde5448f7b8e9898bb04efc9cee4c275849ad \
                         sha256  34b5771368fd9ca04d1340e0e6d948cd5f7e614dc0d5f7330bf415a6d2dec222 \


### PR DESCRIPTION
#### Description

py-django: Update to 1.11.16/2.1.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
