### PR TITLE
gcc: Fix the conflicts between the production and devel ports

### DIFF
--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -48,9 +48,9 @@ depends_lib         port:cctools \
                     port:mpfr
 depends_run         port:gcc_select
 if { ${isLastSupported} } {
-depends_run-append  path:lib/libgcc/libgcc_s.1.dylib:libgcc
+    depends_run-append  path:lib/libgcc/libgcc_s.1.dylib:libgcc
 } else {
-depends_run-append  port:libgcc7
+    depends_run-append  port:libgcc7
 }
 
 depends_skip_archcheck-append gcc_select ld64 cctools
@@ -167,6 +167,11 @@ use_parallel_build  yes
 destroot.target     install install-info-host
 
 if {${subport} eq "libgcc7"} {
+
+    # If providing the primary runtime, add conflict against libgcc-devel
+    if { ${isLastSupported} } {
+        conflicts libgcc-devel
+    }
 
     # Activate hack for new libgcc
     # https://trac.macports.org/wiki/PortfileRecipes#deactivatehack

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -160,6 +160,9 @@ pre-fetch {
 
 if {${subport} eq "libgcc8"} {
 
+    # Always provides primary runtime so always in conflict
+    conflicts libgcc-devel
+
     # Activate hack for new libgcc
     # https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
     pre-activate {

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -149,7 +149,13 @@ pre-fetch {
 }
 
 if {${subport} eq "libgcc-devel"} {
-    conflicts       libgcc
+
+    # Set conflict against port providing primary runtime
+    if { ${os.major} < 10 } {
+        conflicts libgcc7
+    } else {
+        conflicts libgcc8
+    }
 
     # http://trac.macports.org/ticket/35770
     # http://trac.macports.org/ticket/38814

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -16,8 +16,6 @@ use_configure       no
 supported_archs     noarch
 platforms           darwin
 
-conflicts           libgcc-devel
-
 description         Provides the appropriate gcc runtime.
 long_description    ${description} \
                     Picks the version to use based on macOS version.


### PR DESCRIPTION
#### Description

Fixes some issues with the conflicts between the pro and devel gcc ports.

See https://trac.macports.org/ticket/57384

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
