### PR TITLE
groovy: update to 2.5.3

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.2
+version         2.5.3
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,9 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  df19ea9526acd19b0b515c799366ff12f65435d9 \
-                sha256  495f96f1be35ef838abb5f1c10fc6f642460cacd94c7095eb3a9f1fbf62b282e \
-                size    29598793
+checksums       rmd160  a06e9c08383864f2a95a5768fdd6a539d6373fb6 \
+                sha256  47942bdb31a9f7ebf0db5b324bc99a289fd6ff87723e21e06f4701fa7c8c85c7 \
+                size    29923371
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.3.

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?