### PR TITLE
qlandkartegt: fix compilation failures on Mojave

### DIFF
--- a/gis/qlandkartegt/Portfile
+++ b/gis/qlandkartegt/Portfile
@@ -6,7 +6,7 @@ PortGroup        qt4 1.0
 
 name             qlandkartegt
 version          1.8.1
-revision         5
+revision         6
 categories       gis
 platforms        darwin
 maintainers      {puffin.lb.shuttle.de:michael.klein @mklein-de}
@@ -33,7 +33,12 @@ depends_lib      port:libexif \
                  bin:gpsbabel:gpsbabel
 
 patchfiles       patch-src-main.cpp.diff \
-                 patch-cmake-modules-findproj.cmake.diff
+                 patch-cmake-modules-findproj.cmake.diff \
+                 patch-mojave-fix.diff \
+                 patch-src-locale-qlandkartegt_en.ts.diff \
+                 patch-provide-default-osm-tile-config.diff
+
+configure.cxxflags-append   -std=c++11
 
 cmake.out_of_source yes
 

--- a/gis/qlandkartegt/files/patch-mojave-fix.diff
+++ b/gis/qlandkartegt/files/patch-mojave-fix.diff
@@ -1,0 +1,107 @@
+diff -Nur ../a/3rdparty/cache2gtiff/main.cpp ./3rdparty/cache2gtiff/main.cpp
+--- ../a/3rdparty/cache2gtiff/main.cpp	2014-08-08 10:53:46.000000000 +0100
++++ ./3rdparty/cache2gtiff/main.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -35,7 +35,7 @@
+ #define _MKSTR(x)           _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR             _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR             _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ #define WHAT_STR            "cache2gtiff, Version " VER_STR
+ 
+ 
+diff -Nur ../a/3rdparty/getopt/CGetOpt.cpp ./3rdparty/getopt/CGetOpt.cpp
+--- ../a/3rdparty/getopt/CGetOpt.cpp	2014-08-08 10:53:45.000000000 +0100
++++ ./3rdparty/getopt/CGetOpt.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -330,7 +330,7 @@
+ 			qWarning( "Too many arguments" );
+ 			return false;
+ 		    }
+-		} else if ( numOptArgs = 9999 ) {
++		} else if ( numOptArgs == 9999 ) {
+ 		    optArg.listValue->append( a );
+ 		} else if ( numOptArgs > 0 ) {
+ 		    if ( optArg.stringValue->isNull() ) { // ###
+diff -Nur ../a/3rdparty/map2gcm/main.cpp ./3rdparty/map2gcm/main.cpp
+--- ../a/3rdparty/map2gcm/main.cpp	2014-08-08 10:53:46.000000000 +0100
++++ ./3rdparty/map2gcm/main.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -40,7 +40,7 @@
+ #define _MKSTR(x)           _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR             _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR             _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ #define WHAT_STR            "map2gcm, Version " VER_STR
+ 
+ #define MAX_TILE_SIZE   1024
+diff -Nur ../a/3rdparty/map2jnx/main.cpp ./3rdparty/map2jnx/main.cpp
+--- ../a/3rdparty/map2jnx/main.cpp	2014-08-08 10:53:42.000000000 +0100
++++ ./3rdparty/map2jnx/main.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -51,7 +51,7 @@
+ #define _MKSTR(x)           _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR             _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR             _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ #define WHAT_STR            "map2jnx, Version " VER_STR
+ 
+ #define JNX_MAX_TILES       50000 //6250
+diff -Nur ../a/3rdparty/map2rmap/main.cpp ./3rdparty/map2rmap/main.cpp
+--- ../a/3rdparty/map2rmap/main.cpp	2014-08-08 10:53:42.000000000 +0100
++++ ./3rdparty/map2rmap/main.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -33,7 +33,7 @@
+ #define _MKSTR(x)           _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR             _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR             _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ #define WHAT_STR            "map2rmap, Version " VER_STR
+ 
+ 
+diff -Nur ../a/3rdparty/map2rmp/CFileGenerator.cpp ./3rdparty/map2rmp/CFileGenerator.cpp
+--- ../a/3rdparty/map2rmp/CFileGenerator.cpp	2014-08-08 10:53:46.000000000 +0100
++++ ./3rdparty/map2rmp/CFileGenerator.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -27,7 +27,7 @@
+ #define _MKSTR(x)           _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR             _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR             _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ 
+ 
+ extern "C"
+diff -Nur ../a/3rdparty/map2rmp/main.cpp ./3rdparty/map2rmp/main.cpp
+--- ../a/3rdparty/map2rmp/main.cpp	2014-08-08 10:53:46.000000000 +0100
++++ ./3rdparty/map2rmp/main.cpp	2018-10-14 17:13:17.000000000 +0100
+@@ -32,7 +32,7 @@
+ #define _MKSTR(x)           _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR             _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR             _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ #define WHAT_STR            "map2rmp, Version " VER_STR
+ 
+ int main(int argc, char ** argv)
+diff -Nur ../a/src/CRoute.h ./src/CRoute.h
+--- ../a/src/CRoute.h	2015-01-19 14:36:35.000000000 +0000
++++ ./src/CRoute.h	2018-10-14 17:13:17.000000000 +0100
+@@ -52,7 +52,7 @@
+ 
+             QString action;
+ 
+-            operator const projXY ()
++            operator projXY() const
+             {
+                 projXY p;
+                 p.u = lon;
+diff -Nur ../a/src/version.h ./src/version.h
+--- ../a/src/version.h	2014-08-08 10:53:29.000000000 +0100
++++ ./src/version.h	2018-10-14 17:13:17.000000000 +0100
+@@ -23,6 +23,6 @@
+ #define _MKSTR(x)      _MKSTR_1(x)
+ #endif
+ 
+-#define VER_STR       _MKSTR(VER_MAJOR)"."_MKSTR(VER_MINOR)"."_MKSTR(VER_STEP)
++#define VER_STR       _MKSTR(VER_MAJOR) "." _MKSTR(VER_MINOR) "." _MKSTR(VER_STEP)
+ #define WHAT_STR      "QLandkarte GT, Version " VER_STR
+ #endif                           //VERSION_H

--- a/gis/qlandkartegt/files/patch-provide-default-osm-tile-config.diff
+++ b/gis/qlandkartegt/files/patch-provide-default-osm-tile-config.diff
@@ -1,0 +1,213 @@
+diff -Nur ../a/src/CDlgEditWpt.cpp ./src/CDlgEditWpt.cpp
+--- ../a/src/CDlgEditWpt.cpp	2015-02-03 08:38:09.000000000 +0000
++++ ./src/CDlgEditWpt.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -27,6 +27,7 @@
+ #include "IMap.h"
+ #include "IUnit.h"
+ #include "CSettings.h"
++#include "version.h"
+ 
+ #include "config.h"
+ 
+@@ -670,7 +671,7 @@
+     pendingRequests.clear();
+ 
+     QNetworkRequest request;
+-
++    request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+     request.setUrl(wpt.link);
+     networkAccessManager->get(request);
+ }
+@@ -755,7 +756,7 @@
+             QString url  = re0.cap(1);
+ 
+             QNetworkRequest request;
+-
++            request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+             request.setUrl(url);
+             networkAccessManager->get(request);
+             return;
+@@ -775,7 +776,7 @@
+                 QString text = re2.cap(2);
+ 
+                 QNetworkRequest request;
+-
++                request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+                 request.setUrl(url);
+                 pendingRequests[networkAccessManager->get(request)] = text;
+ 
+diff -Nur ../a/src/CDlgMapWmsConfig.cpp ./src/CDlgMapWmsConfig.cpp
+--- ../a/src/CDlgMapWmsConfig.cpp	2014-08-08 10:53:40.000000000 +0100
++++ ./src/CDlgMapWmsConfig.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -21,6 +21,7 @@
+ #include "CMapDB.h"
+ #include "CResources.h"
+ #include "CMainWindow.h"
++#include "version.h"
+ 
+ #include <QtGui>
+ #include <QtXml>
+@@ -150,7 +151,7 @@
+         this, SLOT(slotProxyAuthenticationRequired(const QNetworkProxy&, QAuthenticator*)));
+ 
+     QNetworkRequest request;
+-
++    request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+     QUrl url(map.urlstr);
+ #ifdef QK_QT5_PORT
+     QUrlQuery urlQuery;
+diff -Nur ../a/src/CMapDB.cpp ./src/CMapDB.cpp
+--- ../a/src/CMapDB.cpp	2014-08-08 10:53:14.000000000 +0100
++++ ./src/CMapDB.cpp	2018-10-15 13:07:46.000000000 +0100
+@@ -128,6 +128,23 @@
+     {
+         map_t m;
+ 
++        m.description   = "OpenStreetMap";
++        //http://a.tile.openstreetmap.de/tiles/osmde/&#37;1/&#37;2/&#37;3.png
++        m.filename      = "https://a.tile.openstreetmap.org/%1/%2/%3.png";
++        m.type          = IMap::eTMS;
++        m.key           = QString::number(qHash(m.filename));
++        m.copyright     = "Open Street Map, Creative Commons Attribution-ShareAlike 2.0 license";
++        knownMaps[m.key] = m;
++        builtInKeys << m.key;
++
++        m.description   = "OpenCycleMap";
++        m.filename      = "http://b.tile.opencyclemap.org/cycle/%1/%2/%3.png";
++        m.type          = IMap::eTMS;
++        m.key           = QString::number(qHash(m.filename));
++        m.copyright     = "Open Street Map, Creative Commons Attribution-ShareAlike 2.0 license";
++        knownMaps[m.key] = m;
++        builtInKeys << m.key;
++
+         QStringList keys = cfg.value("tms/knownMaps").toString().split("|",QString::SkipEmptyParts);
+         foreach(const QString& key, keys)
+         {
+@@ -156,7 +173,7 @@
+         }
+     }
+ 
+-    maps = cfg.value("maps/visibleMaps","").toString().split("|",QString::SkipEmptyParts);
++    maps = cfg.value("maps/visibleMaps","https://a.tile.openstreetmap.org/%1/%2/%3.png").toString().split("|",QString::SkipEmptyParts);
+     cfg.setValue("maps/visibleMaps","");
+     cfg.sync();
+ 
+diff -Nur ../a/src/CMapTms.cpp ./src/CMapTms.cpp
+--- ../a/src/CMapTms.cpp	2014-08-08 10:53:14.000000000 +0100
++++ ./src/CMapTms.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -26,6 +26,7 @@
+ #include "CDlgMapTmsConfig.h"
+ #include "CMapSelectionRaster.h"
+ #include "CSettings.h"
++#include "version.h"
+ 
+ #include <QtGui>
+ #include <QtNetwork>
+@@ -607,7 +608,7 @@
+         }
+ 
+         QNetworkRequest request;
+-
++        request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+         request.setUrl(req.url);
+         foreach(const rawHeaderItem_t& item, rawHeaderItems)
+         {
+diff -Nur ../a/src/CMapWms.cpp ./src/CMapWms.cpp
+--- ../a/src/CMapWms.cpp	2014-08-08 10:53:14.000000000 +0100
++++ ./src/CMapWms.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -24,6 +24,7 @@
+ #include "CDlgMapWmsConfig.h"
+ #include "CMapSelectionRaster.h"
+ #include "CSettings.h"
++#include "version.h"
+ 
+ #include <QtGui>
+ #include <QtXml>
+@@ -637,7 +638,7 @@
+         }
+ 
+         QNetworkRequest request;
+-
++        request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+         request.setUrl(req.url);
+         req.reply = accessManager->get(request);
+ 
+@@ -673,7 +674,7 @@
+             QUrl url(urlRedir);
+ 
+             QNetworkRequest request;
+-
++            request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+             request.setUrl(url);
+             req.reply = accessManager->get(request);
+ 
+diff -Nur ../a/src/CRouteToolWidget.cpp ./src/CRouteToolWidget.cpp
+--- ../a/src/CRouteToolWidget.cpp	2015-02-16 10:34:56.000000000 +0000
++++ ./src/CRouteToolWidget.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -524,7 +524,7 @@
+     url.setPath("/qlandkarte/route");
+ 
+     QNetworkRequest request;
+-
++    request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+     request.setUrl(url);
+ 
+     QNetworkReply* reply = m_networkAccessManager->post(request, array);
+@@ -972,7 +972,7 @@
+     //    qDebug() << url.toString();
+ 
+     QNetworkRequest request;
+-
++    request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+     request.setUrl(url);
+     m_networkAccessManager->get(request);
+ 
+diff -Nur ../a/src/CSearchDB.cpp ./src/CSearchDB.cpp
+--- ../a/src/CSearchDB.cpp	2014-08-08 10:53:29.000000000 +0100
++++ ./src/CSearchDB.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -23,6 +23,7 @@
+ #include "CCanvas.h"
+ #include "CMapDB.h"
+ #include "IMap.h"
++#include "version.h"
+ 
+ #include <QtGui>
+ #include <QtXml>
+@@ -100,7 +101,7 @@
+     url.addQueryItem("sensor","false");
+ #endif
+     QNetworkRequest request;
+-
++    request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+     request.setUrl(url);
+     QNetworkReply * reply = networkAccessManager.get(request);
+     pendingRequests[reply] = eGoogle;
+@@ -167,7 +168,7 @@
+     url.setPath("/qlandkarte/geocode");
+ 
+     QNetworkRequest request;
+-
++    request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+     request.setUrl(url);
+     QNetworkReply * reply = networkAccessManager.post(request, array);
+     pendingRequests[reply] = eOpenRouteService;
+diff -Nur ../a/src/CTrack.cpp ./src/CTrack.cpp
+--- ../a/src/CTrack.cpp	2014-12-08 07:15:44.000000000 +0000
++++ ./src/CTrack.cpp	2018-10-15 13:07:40.000000000 +0100
+@@ -26,6 +26,7 @@
+ #include "CWptDB.h"
+ #include "CTrackDB.h"
+ #include "CSettings.h"
++#include "version.h"
+ 
+ #include <QtGui>
+ #include <QNetworkProxy>
+@@ -1025,7 +1026,7 @@
+ #endif
+ 
+         QNetworkRequest request;
+-
++        request.setRawHeader("User-Agent", "QLandkarteGT/" VER_STR " (MacPorts)");
+         request.setUrl(url);
+         QNetworkReply * reply = networkAccessManager->get(request);
+ 

--- a/gis/qlandkartegt/files/patch-src-locale-qlandkartegt_en.ts.diff
+++ b/gis/qlandkartegt/files/patch-src-locale-qlandkartegt_en.ts.diff
@@ -1,0 +1,9146 @@
+--- ./src/locale/qlandkartegt_en.ts.orig	1970-01-01 01:00:00.000000000 +0100
++++ ./src/locale/qlandkartegt_en.ts	2016-10-17 13:58:48.000000000 +0100
+@@ -0,0 +1,9143 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!DOCTYPE TS>
++<TS version="2.0" language="en_US">
++<context>
++    <name>CActions</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>+</source>
++        <translation>+</translation>
++    </message>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++    <message>
++        <source>F1</source>
++        <translation>F1</translation>
++    </message>
++    <message>
++        <source>F2</source>
++        <translation>F2</translation>
++    </message>
++    <message>
++        <source>F3</source>
++        <translation>F3</translation>
++    </message>
++    <message>
++        <source>F4</source>
++        <translation>F4</translation>
++    </message>
++    <message>
++        <source>F5</source>
++        <translation>F5</translation>
++    </message>
++    <message>
++        <source>F6</source>
++        <translation>F6</translation>
++    </message>
++    <message>
++        <source>F7</source>
++        <translation>F7</translation>
++    </message>
++    <message>
++        <source>F8</source>
++        <translation>F8</translation>
++    </message>
++    <message>
++        <source>F9</source>
++        <translation>F9</translation>
++    </message>
++    <message>
++        <source>F10</source>
++        <translation>F10</translation>
++    </message>
++    <message>
++        <source>ESC</source>
++        <translation>ESC</translation>
++    </message>
++    <message>
++        <source>Toggle between first person view and rotation mode.</source>
++        <translation>Toggle between first person view and rotation mode.</translation>
++    </message>
++    <message>
++        <source>&amp;Back</source>
++        <translation>&amp;Back</translation>
++    </message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;Copy</translation>
++    </message>
++    <message>
++        <source>&amp;Main</source>
++        <translation>&amp;Main</translation>
++    </message>
++    <message>
++        <source>&amp;Maps</source>
++        <translation>&amp;Maps</translation>
++    </message>
++    <message>
++        <source>&amp;Redo</source>
++        <translation>&amp;Redo</translation>
++    </message>
++    <message>
++        <source>&amp;Undo</source>
++        <translation>&amp;Undo</translation>
++    </message>
++    <message>
++        <source>&amp;Overlay ...</source>
++        <translation>&amp;Overlay ...</translation>
++    </message>
++    <message>
++        <source>Track</source>
++        <translation>Track</translation>
++    </message>
++    <message>
++        <source>Split a track into pieces.</source>
++        <translation>Split a track into pieces.</translation>
++    </message>
++    <message>
++        <source>&amp;Waypoints</source>
++        <translation>&amp;Waypoints</translation>
++    </message>
++    <message>
++        <source>&amp;Main (More)</source>
++        <translation>&amp;Main (More)</translation>
++    </message>
++    <message>
++        <source>Toggle track edit dialog.</source>
++        <translation>Toggle track edit dialog.</translation>
++    </message>
++    <message>
++        <source>Add &amp;Waypoint</source>
++        <translation>Add &amp;Waypoint</translation>
++    </message>
++    <message>
++        <source>Go back to overlay menu.</source>
++        <translation>Go back to overlay menu.</translation>
++    </message>
++    <message>
++        <source>&amp;Live Log</source>
++        <translation>&amp;Live Log</translation>
++    </message>
++    <message>
++        <source>Turn on/off lighting.</source>
++        <translation>Turn on/off lighting.</translation>
++    </message>
++    <message>
++        <source>&amp;Zoom in</source>
++        <translation>&amp;Zoom in</translation>
++    </message>
++    <message>
++        <source>Action with name &apos;%1&apos; not found. %2</source>
++        <translation>Action with name &apos;%1&apos; not found. %2</translation>
++    </message>
++    <message>
++        <source>Upload all data to device.</source>
++        <translation>Upload all data to device.</translation>
++    </message>
++    <message>
++        <source>From &amp;Images...</source>
++        <translation>From &amp;Images...</translation>
++    </message>
++    <message>
++        <source>Download routes from device.</source>
++        <translation>Download routes from device.</translation>
++    </message>
++    <message>
++        <source>Join Distance PolyLines</source>
++        <translation>Join Distance PolyLines</translation>
++    </message>
++    <message>
++        <source>Live &amp;Log ...</source>
++        <translation>Live &amp;Log ...</translation>
++    </message>
++    <message>
++        <source>Add text on the map.</source>
++        <translation>Add text on the map.</translation>
++    </message>
++    <message>
++        <source>Manage maps.</source>
++        <translation>Manage maps.</translation>
++    </message>
++    <message>
++        <source>Download tracks from device.</source>
++        <translation>Download tracks from device.</translation>
++    </message>
++    <message>
++        <source>&amp;Close</source>
++        <translation>&amp;Close</translation>
++    </message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;Paste</translation>
++    </message>
++    <message>
++        <source>FPV / Rot.</source>
++        <translation>FPV / Rot.</translation>
++    </message>
++    <message>
++        <source>Hide/Show Selection</source>
++        <translation>Hide/Show Selection</translation>
++    </message>
++    <message>
++        <source>Show 3D map</source>
++        <translation>Show 3D map</translation>
++    </message>
++    <message>
++        <source>Start / stop live log recording.</source>
++        <translation>Start / stop live log recording.</translation>
++    </message>
++    <message>
++        <source>&amp;Map ...</source>
++        <translation>&amp;Map ...</translation>
++    </message>
++    <message>
++        <source>Download all data from device.</source>
++        <translation>Download all data from device.</translation>
++    </message>
++    <message>
++        <source>Manage tracks.</source>
++        <translation>Manage tracks.</translation>
++    </message>
++    <message>
++        <source>Create waypoints from geo-referenced images in a path.</source>
++        <translation>Create waypoints from geo-referenced images in a path.</translation>
++    </message>
++    <message>
++        <source>Move Map to &amp;Pos.</source>
++        <translation>Move Map to &amp;Pos.</translation>
++    </message>
++    <message>
++        <source>&amp;New Waypoint</source>
++        <translation>&amp;New Waypoint</translation>
++    </message>
++    <message>
++        <source>&amp;Move up</source>
++        <translation>&amp;Move up</translation>
++    </message>
++    <message>
++        <source>Zoom&apos;s into the Map.</source>
++        <translation>Zoom&apos;s into the Map.</translation>
++    </message>
++    <message>
++        <source>Mor&amp;e ...</source>
++        <translation>Mor&amp;e ...</translation>
++    </message>
++    <message>
++        <source>&amp;Split Track</source>
++        <translation>&amp;Split Track</translation>
++    </message>
++    <message>
++        <source>Select area of map to export. Select area by pressing down the left mouse button and move the mouse.</source>
++        <translation>Select area of map to export. Select area by pressing down the left mouse button and move the mouse.</translation>
++    </message>
++    <message>
++        <source>Close 3D view.</source>
++        <translation>Close 3D view.</translation>
++    </message>
++    <message>
++        <source>U&amp;pload all</source>
++        <translation>U&amp;pload all</translation>
++    </message>
++    <message>
++        <source>3&amp;D Map...</source>
++        <translation>3&amp;D Map...</translation>
++    </message>
++    <message>
++        <source>Upload routes to device.</source>
++        <translation>Upload routes to device.</translation>
++    </message>
++    <message>
++        <source>&amp;Waypoint ...</source>
++        <translation>&amp;Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Join multiple selected tracks to one.</source>
++        <translation>Join multiple selected tracks to one.</translation>
++    </message>
++    <message>
++        <source>Distance &amp;Polyline</source>
++        <translation>Distance &amp;Polyline</translation>
++    </message>
++    <message>
++        <source>Add Distance &amp;Polyline</source>
++        <translation>Add Distance &amp;Polyline</translation>
++    </message>
++    <message>
++        <source>Action with the name &apos;%1&apos; already registered. Please choose another name.</source>
++        <translation>Action with the name &apos;%1&apos; already registered. Please choose another name.</translation>
++    </message>
++    <message>
++        <source>&amp;Zoom out</source>
++        <translation>&amp;Zoom out</translation>
++    </message>
++    <message>
++        <source>&amp;Zoom Map</source>
++        <translation>&amp;Zoom Map</translation>
++    </message>
++    <message>
++        <source>&amp;Edit Track</source>
++        <translation>&amp;Edit Track</translation>
++    </message>
++    <message>
++        <source>Send current workspace to Open Cache Manager.</source>
++        <translation>Send current workspace to Open Cache Manager.</translation>
++    </message>
++    <message>
++        <source>Move up.</source>
++        <translation>Move up.</translation>
++    </message>
++    <message>
++        <source>&amp;Overlay</source>
++        <translation>&amp;Overlay</translation>
++    </message>
++    <message>
++        <source>Overlay</source>
++        <translation>Overlay</translation>
++    </message>
++    <message>
++        <source>Add &amp;Geo-Ref. Text Box</source>
++        <translation>Add &amp;Geo-Ref. Text Box</translation>
++    </message>
++    <message>
++        <source>Add a waypoint at current position.</source>
++        <translation>Add a waypoint at current position.</translation>
++    </message>
++    <message>
++        <source>Move the map. Press down the left mouse button and move the mouse.</source>
++        <translation>Move the map. Press down the left mouse button and move the mouse.</translation>
++    </message>
++    <message>
++        <source>&amp;Move right</source>
++        <translation>&amp;Move right</translation>
++    </message>
++    <message>
++        <source>Download waypoints from device.</source>
++        <translation>Download waypoints from device.</translation>
++    </message>
++    <message>
++        <source>3D / 2D</source>
++        <translation>3D / 2D</translation>
++    </message>
++    <message>
++        <source>Move down.</source>
++        <translation>Move down.</translation>
++    </message>
++    <message>
++        <source>&amp;Track ...</source>
++        <translation>&amp;Track ...</translation>
++    </message>
++    <message>
++        <source>Trackmode</source>
++        <translation>Trackmode</translation>
++    </message>
++    <message>
++        <source>U&amp;pload</source>
++        <translation>U&amp;pload</translation>
++    </message>
++    <message>
++        <source>Zoom&apos;s out of the Map.</source>
++        <translation>Zoom&apos;s out of the Map.</translation>
++    </message>
++    <message>
++        <source>What to do?</source>
++        <translation>What to do?</translation>
++    </message>
++    <message>
++        <source>Select &amp;Sub Map</source>
++        <translation>Select &amp;Sub Map</translation>
++    </message>
++    <message>
++        <source>Maps ...</source>
++        <translation>Maps ...</translation>
++    </message>
++    <message>
++        <source>&amp;Search Map</source>
++        <translation>&amp;Search Map</translation>
++    </message>
++    <message>
++        <source>Find your map by jumping to it&apos;s center.</source>
++        <translation>Find your map by jumping to it&apos;s center.</translation>
++    </message>
++    <message>
++        <source>Move to the right side.</source>
++        <translation>Move to the right side.</translation>
++    </message>
++    <message>
++        <source>&amp;Edit / Create Map</source>
++        <translation>&amp;Edit / Create Map</translation>
++    </message>
++    <message>
++        <source>Select waypoints in a radius</source>
++        <translation>Select waypoints in a radius</translation>
++    </message>
++    <message>
++        <source>Glue point of view to track.</source>
++        <translation>Glue point of view to track.</translation>
++    </message>
++    <message>
++        <source>Add a textbox on the map.</source>
++        <translation>Add a textbox on the map.</translation>
++    </message>
++    <message>
++        <source>&amp;Overlay Distance</source>
++        <translation>&amp;Overlay Distance</translation>
++    </message>
++    <message>
++        <source>Lighting On/Off</source>
++        <translation>Lighting On/Off</translation>
++    </message>
++    <message>
++        <source>&amp;Start / Stop</source>
++        <translation>&amp;Start / Stop</translation>
++    </message>
++    <message>
++        <source>&amp;Center Map</source>
++        <translation>&amp;Center Map</translation>
++    </message>
++    <message>
++        <source>Upload tracks to device.</source>
++        <translation>Upload tracks to device.</translation>
++    </message>
++    <message>
++        <source>Create a new user waypoint. The default position will be the current cursor position.</source>
++        <translation>Create a new user waypoint. The default position will be the current cursor position.</translation>
++    </message>
++    <message>
++        <source>Move the map to keep the positon cursor centered.</source>
++        <translation>Move the map to keep the position cursor centered.</translation>
++    </message>
++    <message>
++        <source>&amp;Export to OCM</source>
++        <translation>&amp;Export to OCM</translation>
++    </message>
++    <message>
++        <source>&amp;Clear all</source>
++        <translation>&amp;Clear all</translation>
++    </message>
++    <message>
++        <source>ctrl+Del</source>
++        <translation>ctrl+Del</translation>
++    </message>
++    <message>
++        <source>&amp;Routes</source>
++        <translation>&amp;Routes</translation>
++    </message>
++    <message>
++        <source>Find symbols on a map via image recognition.</source>
++        <translation>Find symbols on a map via image recognition.</translation>
++    </message>
++    <message>
++        <source>&amp;Tracks</source>
++        <translation>&amp;Tracks</translation>
++    </message>
++    <message>
++        <source>Toggle live log recording.</source>
++        <translation>Toggle live log recording.</translation>
++    </message>
++    <message>
++        <source>Manage overlays, such as textboxes</source>
++        <translation>Manage overlays, such as textboxes</translation>
++    </message>
++    <message>
++        <source>I do not know what to copy. Please select:</source>
++        <translation>I do not know what to copy. Please select:</translation>
++    </message>
++    <message>
++        <source>Add Static &amp;Text Box</source>
++        <translation>Add Static &amp;Text Box</translation>
++    </message>
++    <message>
++        <source>&amp;Move down</source>
++        <translation>&amp;Move down</translation>
++    </message>
++    <message>
++        <source>&amp;Move left</source>
++        <translation>&amp;Move left</translation>
++    </message>
++    <message>
++        <source>Manage waypoints.</source>
++        <translation>Manage waypoints.</translation>
++    </message>
++    <message>
++        <source>Select track points by rectangle.</source>
++        <translation>Select track points by rectangle.</translation>
++    </message>
++    <message>
++        <source>&amp;Route ...</source>
++        <translation>&amp;Route ...</translation>
++    </message>
++    <message>
++        <source>&amp;Select Points</source>
++        <translation>&amp;Select Points</translation>
++    </message>
++    <message>
++        <source>Extended functions.</source>
++        <translation>Extended functions.</translation>
++    </message>
++    <message>
++        <source>Mo&amp;ve Map</source>
++        <translation>Mo&amp;ve Map</translation>
++    </message>
++    <message>
++        <source>Upload waypoints to device.</source>
++        <translation>Upload waypoints to device.</translation>
++    </message>
++    <message>
++        <source>&amp;Radius Select</source>
++        <translation>&amp;Radius Select</translation>
++    </message>
++    <message>
++        <source>Remove all waypoints, tracks, ...</source>
++        <translation>Remove all waypoints, tracks, ...</translation>
++    </message>
++    <message>
++        <source>Go back to main menu.</source>
++        <translation>Go back to main menu.</translation>
++    </message>
++    <message>
++        <source>Down&amp;load</source>
++        <translation>Down&amp;load</translation>
++    </message>
++    <message>
++        <source>Down&amp;load all</source>
++        <translation>Down&amp;load all</translation>
++    </message>
++    <message>
++        <source>Add a polyline to measure distances.</source>
++        <translation>Add a polyline to measure distances.</translation>
++    </message>
++    <message>
++        <source>Select area for zoom.</source>
++        <translation>Select area for zoom.</translation>
++    </message>
++    <message>
++        <source>Join &amp;Tracks</source>
++        <translation>Join &amp;Tracks</translation>
++    </message>
++    <message>
++        <source>Redo a command.</source>
++        <translation>Redo a command.</translation>
++    </message>
++    <message>
++        <source>Undo a command.</source>
++        <translation>Undo a command.</translation>
++    </message>
++    <message>
++        <source>Join distance polylines to one.</source>
++        <translation>Join distance polylines to one.</translation>
++    </message>
++    <message>
++        <source>Move to the left side.</source>
++        <translation>Move to the left side.</translation>
++    </message>
++    <message>
++        <source>Toggle between 3D and 2D map.</source>
++        <translation>Toggle between 3D and 2D map.</translation>
++    </message>
++    <message>
++        <source>Upload map selection to device.</source>
++        <translation>Upload map selection to device.</translation>
++    </message>
++    <message>
++        <source>Toggle visibility of the selected track points.</source>
++        <translation>Toggle visibility of the selected track points.</translation>
++    </message>
++    <message>
++        <source>Add Area Polygon</source>
++        <translation type="unfinished">Add Area Polygon</translation>
++    </message>
++    <message>
++        <source>Mark an area with a polygon.</source>
++        <translation type="unfinished">Mark an area with a polygon.</translation>
++    </message>
++    <message>
++        <source>Area Polygon</source>
++        <translation type="unfinished">Area Polygon</translation>
++    </message>
++    <message>
++        <source>&amp;Overlay Area</source>
++        <translation type="unfinished">&amp;Overlay Area</translation>
++    </message>
++</context>
++<context>
++    <name>CCanvas</name>
++    <message>
++        <source>[Grid: %1] </source>
++        <translation>[Grid: %1] </translation>
++    </message>
++    <message>
++        <source>[Grid: %1m, %2m] </source>
++        <translation type="obsolete">[Grid: %1m, %2m] </translation>
++    </message>
++    <message>
++        <source>[Grid: N %1m, E %2m] </source>
++        <translation>[Grid: N %1m, E %2m] </translation>
++    </message>
++</context>
++<context>
++    <name>CCopyright</name>
++    <message>
++        <source>
++GDAL Environment
++</source>
++        <translation>
++GDAL Environment
++</translation>
++    </message>
++    <message>
++        <source>running gdal_translate failed!</source>
++        <translation>running gdal_translate failed!</translation>
++    </message>
++    <message>
++        <source>&lt;p&gt;&amp;#169; 2007 Oliver Eichler (oliver.eichler@gmx.de)&lt;/p&gt;&lt;p&gt;Thanks for contributing to the project:&lt;/p&gt;&lt;p&gt;Andrew Vagin&lt;br/&gt;Fabrice Crohas&lt;br/&gt;Marc Feld&lt;br/&gt;Joerg Wunsch&lt;br/&gt;Albrecht Dre&amp;szlig;&lt;br&gt;Christian Ehrlicher&lt;br/&gt;Christian Treffs&lt;br/&gt;Michael Klein&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Translation:&lt;br&gt;Sarah Neumann (German)&lt;br&gt;Fabrice Crohas (French)&lt;br&gt;Alessandro Briosi (Italian)&lt;br&gt;Mike Markov (Russian)&lt;br&gt;Oscar A. and Luis Llorente (Spanish)&lt;br&gt;Harrie Klomp (Dutch)&lt;br&gt;&lt;/p&gt;&lt;p&gt;Icons and eye candy are from the &lt;b&gt;KDE&lt;/b&gt; icon set, the &lt;b&gt;Nuvola&lt;/b&gt; icon set and the &lt;b&gt;Oxygen&lt;/b&gt; icon set.See &lt;b&gt;http://www.kde.org/&lt;/b&gt;,&lt;b&gt;http://www.icon-king.com/&lt;/b&gt; and &lt;b&gt;http://www.oxygen-icons.org/&lt;/b&gt;. Waypoint icons are copied from &lt;b&gt;GPSMan&lt;/b&gt;. See &lt;b&gt;http://www.ncc.up.pt/gpsman/&lt;/b&gt;. Cursor icons are from the &apos;Polar Cursor Theme&apos;. See &lt;b&gt;http://www.kde-look.org/content/show.php?content=27913&lt;/b&gt;.Geocache icons are taken from the OpenCacheManager project. See &lt;b&gt;http://opencachemanage.sourceforge.net/&lt;/b&gt;.&lt;/p&gt; &lt;p&gt;Some of the 2D polygon math is copied from &lt;b&gt;http://local.wasp.uwa.edu.au/~pbourke/geometry/&lt;/b&gt;. The geodesic distance calculation by Thaddeus Vincenty is copied from &lt;b&gt;http://www.movable-type.co.uk/scripts/LatLongVincenty.html&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Typ file decoding is done with the help of the source code published at http://ati.land.cz/gps/typedit//&lt;p&gt;</source>
++        <translation>&lt;p&gt;&amp;#169; 2007 Oliver Eichler (oliver.eichler@gmx.de)&lt;/p&gt;&lt;p&gt;Thanks for contributing to the project:&lt;/p&gt;&lt;p&gt;Andrew Vagin&lt;br/&gt;Fabrice Crohas&lt;br/&gt;Marc Feld&lt;br/&gt;Joerg Wunsch&lt;br/&gt;Albrecht Dre&amp;szlig;&lt;br&gt;Christian Ehrlicher&lt;br/&gt;Christian Treffs&lt;br/&gt;Michael Klein&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Translation:&lt;br&gt;Sarah Neumann (German)&lt;br&gt;Fabrice Crohas (French)&lt;br&gt;Alessandro Briosi (Italian)&lt;br&gt;Mike Markov (Russian)&lt;br&gt;Oscar A. and Luis Llorente (Spanish)&lt;br&gt;Harrie Klomp (Dutch)&lt;br&gt;&lt;/p&gt;&lt;p&gt;Icons and eye candy are from the &lt;b&gt;KDE&lt;/b&gt; icon set, the &lt;b&gt;Nuvola&lt;/b&gt; icon set and the &lt;b&gt;Oxygen&lt;/b&gt; icon set.See &lt;b&gt;http://www.kde.org/&lt;/b&gt;,&lt;b&gt;http://www.icon-king.com/&lt;/b&gt; and &lt;b&gt;http://www.oxygen-icons.org/&lt;/b&gt;. Waypoint icons are copied from &lt;b&gt;GPSMan&lt;/b&gt;. See &lt;b&gt;http://www.ncc.up.pt/gpsman/&lt;/b&gt;. Cursor icons are from the &apos;Polar Cursor Theme&apos;. See &lt;b&gt;http://www.kde-look.org/content/show.php?content=27913&lt;/b&gt;.Geocache icons are taken from the OpenCacheManager project. See &lt;b&gt;http://opencachemanage.sourceforge.net/&lt;/b&gt;.&lt;/p&gt; &lt;p&gt;Some of the 2D polygon math is copied from &lt;b&gt;http://local.wasp.uwa.edu.au/~pbourke/geometry/&lt;/b&gt;. The geodesic distance calculation by Thaddeus Vincenty is copied from &lt;b&gt;http://www.movable-type.co.uk/scripts/LatLongVincenty.html&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Typ file decoding is done with the help of the source code published at http://ati.land.cz/gps/typedit//&lt;p&gt;</translation>
++    </message>
++</context>
++<context>
++    <name>CCreateMapFineTune</name>
++    <message>
++        <source>Open map file...</source>
++        <translation>Open map file...</translation>
++    </message>
++    <message>
++        <source>Referenced file (*.tif *.tiff *.png *.gif)</source>
++        <translation>Referenced file (*.tif *.tiff *.png *.gif)</translation>
++    </message>
++</context>
++<context>
++    <name>CCreateMapGeoTiff</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>square pixels (2 Ref. Pts.)</source>
++        <translation>square pixels (2 Ref. Pts.)</translation>
++    </message>
++    <message>
++        <source>Save result as...</source>
++        <translation>Save result as...</translation>
++    </message>
++    <message>
++        <source>quadratic (6 Ref. Pts.)</source>
++        <translation>quadratic (6 Ref. Pts.)</translation>
++    </message>
++    <message>
++        <source>Add Reference Points</source>
++        <translation>Add Reference Points</translation>
++    </message>
++    <message>
++        <source>&lt;enter coord&gt;</source>
++        <translation>&lt;enter coord&gt;</translation>
++    </message>
++    <message>
++        <source>Ref %1</source>
++        <translation>Ref %1</translation>
++    </message>
++    <message utf8="true">
++        <source>The next stage is to add known reference points. Simply add reference points to the map and enter their latitude / longitude (WGS84) or the easting and northing [m] in the table. Next you move the point to the correct location on the map.
++
++coordinate formats:
++• &quot;N49° 10.234 E12° 01.456&quot;
++• &quot;46.575377   12.193172&quot;
++• &quot;285000 5162000&quot;</source>
++        <translation type="obsolete">The next stage is to add known reference points. Simply add reference points to the map and enter their latitude / longitude (WGS84) or the easting and northing [m] in the table. Next you move the point to the correct location on the map.
++
++coordinate formats:
++• &quot;N49° 10.234 E12° 01.456&quot;
++• &quot;46.575377   12.193172&quot;
++• &quot;285000 5162000&quot;</translation>
++    </message>
++    <message>
++        <source>Sorry...</source>
++        <translation>Sorry...</translation>
++    </message>
++    <message>
++        <source>This dialog allows you to georeference raster map files. As pre-requisite you need a set of reference points and the projection for those points. You will get best results if the projection of the points is also the projection of the map. In most cases this is mercator. It is recommended to shift the reference point to WGS84 datum, right from the beginning.</source>
++        <translation>This dialog allows you to georeference raster map files. As pre-requisite you need a set of reference points and the projection for those points. You will get best results if the projection of the points is also the projection of the map. In most cases this is mercator. It is recommended to shift the reference point to WGS84 datum, right from the beginning.</translation>
++    </message>
++    <message>
++        <source>Load reference points...</source>
++        <translation>Load reference points...</translation>
++    </message>
++    <message>
++        <source>--- finished ---
++</source>
++        <translation>--- finished ---
++</translation>
++    </message>
++    <message>
++        <source>Save reference points...</source>
++        <translation>Save reference points...</translation>
++    </message>
++    <message>
++        <source>Failed!
++</source>
++        <translation>Failed!
++</translation>
++    </message>
++    <message>
++        <source>Error ...</source>
++        <translation>Error ...</translation>
++    </message>
++    <message>
++        <source>thin plate (4 Ref. Pts.)</source>
++        <translation>thin plate (4 Ref. Pts.)</translation>
++    </message>
++    <message>
++        <source>Reference points are too close.</source>
++        <translation>Reference points are too close.</translation>
++    </message>
++    <message>
++        <source>linear (3 Ref. Pts.)</source>
++        <translation>linear (3 Ref. Pts.)</translation>
++    </message>
++    <message>
++        <source>Reference Map</source>
++        <translation>Reference Map</translation>
++    </message>
++    <message>
++        <source>Open map file...</source>
++        <translation>Open map file...</translation>
++    </message>
++    <message>
++        <source>Now QLandkarte GT will reference your file with the help of the GDAL tools. Watch the progress in the output browser.</source>
++        <translation>Now QLandkarte GT will reference your file with the help of the GDAL tools. Watch the progress in the output browser.</translation>
++    </message>
++    <message>
++        <source>GeoTiff (*.tif *.tiff)</source>
++        <translation>GeoTiff (*.tif *.tiff)</translation>
++    </message>
++    <message>
++        <source>Load Raster Map</source>
++        <translation>Load Raster Map</translation>
++    </message>
++    <message>
++        <source>No Mapinfo TAB file support yet.</source>
++        <translation>No Mapinfo TAB file support yet.</translation>
++    </message>
++    <message>
++        <source>Grid Tool</source>
++        <translation>Grid Tool</translation>
++    </message>
++    <message utf8="true">
++        <source>The next stage is to add known reference points. Simply add reference points to the map and enter their latitude / longitude (WGS84) or the easting and northing [m] in the table. Next you move the point to the correct location on the map.
++
++coordinate formats:
++• &quot;N49° 10.234 E12° 01.456&quot; (dd mm.mmm)
++• &quot;46.575377   12.193172&quot;  (dd.dddddd)
++• &quot;285000 5162000&quot;</source>
++        <translation>The next stage is to add known reference points. Simply add reference points to the map and enter their latitude / longitude (WGS84) or the easting and northing [m] in the table. Next you move the point to the correct location on the map.
++
++coordinate formats:
++• &quot;N49° 10.234 E12° 01.456&quot; (dd mm.mmm)
++• &quot;46.575377   12.193172&quot;  (dd.dddddd)
++• &quot;285000 5162000&quot;</translation>
++    </message>
++    <message>
++        <source>Raw bitmaps (*.tif *.tiff *.png *.gif *.jpg)</source>
++        <translation>Raw bitmaps (*.tif *.tiff *.png *.gif *.jpg)</translation>
++    </message>
++</context>
++<context>
++    <name>CCreateMapGridTool</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>%1</source>
++        <translation>%1</translation>
++    </message>
++    <message>
++        <source>Place Reference Points</source>
++        <translation>Place Reference Points</translation>
++    </message>
++    <message>
++        <source>Failed to setup projection. Bad syntax?</source>
++        <translation>Failed to setup projection. Bad syntax?</translation>
++    </message>
++    <message>
++        <source>Failed to calculate transformation for ref. points. Are all 4 points placed propperly?</source>
++        <translation>Failed to calculate transformation for ref. points. Are all 4 points placed propperly?</translation>
++    </message>
++    <message>
++        <source>Do you want to take the existing reference points to calculate additional points on the grid?</source>
++        <translation>Do you want to take the existing reference points to calculate additional points on the grid?</translation>
++    </message>
++    <message>
++        <source>Error ...</source>
++        <translation>Error ...</translation>
++    </message>
++    <message>
++        <source>Reference points found.</source>
++        <translation>Reference points found.</translation>
++    </message>
++    <message>
++        <source>Create grid</source>
++        <translation>Create grid</translation>
++    </message>
++    <message>
++        <source>On ok, the grid tool will add equally spaced reference points over your map. Keep in mind to manually fine tune the location of each point to get good results.</source>
++        <translation>On ok, the grid tool will add equally spaced reference points over your map. Keep in mind to manually fine tune the location of each point to get good results.</translation>
++    </message>
++    <message>
++        <source>The grid tool will place reference points with calculated longitude and latitude to the line crossings of a linear map grid. To do so you have to place the 4 initial reference points to the grid as shown in the example.
++
++Altenatively you might have chosen to use already existing reference points. In this case you simply have to define the grid step size.</source>
++        <translation>The grid tool will place reference points with calculated longitude and latitude to the line crossings of a linear map grid. To do so you have to place the 4 initial reference points to the grid as shown in the example.
++
++Altenatively you might have chosen to use already existing reference points. In this case you simply have to define the grid step size.</translation>
++    </message>
++    <message>
++        <source>Next you might want to add a source projection to do a grid shift to WGS84. And you have to define the longitude and the latitude of the top left reference point. And the spacing between point 1 and 2, and 1 and 4.</source>
++        <translation>Next you might want to add a source projection to do a grid shift to WGS84. And you have to define the longitude and the latitude of the top left reference point. And the spacing between point 1 and 2, and 1 and 4.</translation>
++    </message>
++    <message>
++        <source>Add Source projection</source>
++        <translation>Add Source projection</translation>
++    </message>
++</context>
++<context>
++    <name>CCreateMapQMAP</name>
++    <message>
++        <source>Define Map</source>
++        <translation>Define Map</translation>
++    </message>
++    <message>
++        <source>Select map definition file...</source>
++        <translation>Select map definition file...</translation>
++    </message>
++    <message>
++        <source>You can edit or create QLandkarte GT map definition files (*.qmap). A map definition defines what files to show at a certain zoom level. The comment will be used to list the map collection as known map in the map tool view. You can choose between a linear or quadratic zoom level increment.
++Once you created a map set you can attach DEM data to it via the context menu in the lefthand map tool view.</source>
++        <translation>You can edit or create QLandkarte GT map definition files (*.qmap). A map definition defines what files to show at a certain zoom level. The comment will be used to list the map collection as known map in the map tool view. You can choose between a linear or quadratic zoom level increment.
++Once you created a map set you can attach DEM data to it via the context menu in the lefthand map tool view.</translation>
++    </message>
++    <message>
++        <source>Failed to load file %1.</source>
++        <translation>Failed to load file %1.</translation>
++    </message>
++    <message>
++        <source>Bottom/right corner:	%1
++</source>
++        <translation>Bottom/right corner:	%1
++</translation>
++    </message>
++    <message>
++        <source>Width x Height [m] x [m]:	 %1 x %2</source>
++        <translation>Width x Height [m] x [m]:	 %1 x %2</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>All maps in a level must have the same projection.</source>
++        <translation>All maps in a level must have the same projection.</translation>
++    </message>
++    <message>
++        <source>Add Maps</source>
++        <translation>Add Maps</translation>
++    </message>
++    <message>
++        <source>You can stack maps of different detail as layer. For each detail layer you can define the number of zoom levels. Several map files can be grouped into a detail layer. All map files in a layer must have the same projection and scale. You need at least one layer with one file.</source>
++        <translation>You can stack maps of different detail as layer. For each detail layer you can define the number of zoom levels. Several map files can be grouped into a detail layer. All map files in a layer must have the same projection and scale. You need at least one layer with one file.</translation>
++    </message>
++    <message>
++        <source>Top/left corner:	%1
++</source>
++        <translation>Top/left corner:	%1
++</translation>
++    </message>
++    <message>
++        <source>Define a map collection file...</source>
++        <translation>Define a map collection file...</translation>
++    </message>
++</context>
++<context>
++    <name>CCreateMapWMS</name>
++    <message>
++        <source>Error...</source>
++        <translation type="obsolete">Error...</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceGPSD</name>
++    <message>
++        <source>GPSD: Download screenshots is not implemented.</source>
++        <translation>GPSD: Download screenshots is not implemented.</translation>
++    </message>
++    <message>
++        <source>GPSD: Download tracks is not implemented.</source>
++        <translation>GPSD: Download tracks is not implemented.</translation>
++    </message>
++    <message>
++        <source>GPSD: Upload maps is not implemented.</source>
++        <translation>GPSD: Upload maps is not implemented.</translation>
++    </message>
++    <message>
++        <source>GPSD: Download waypoints is not implemented.</source>
++        <translation>GPSD: Download waypoints is not implemented.</translation>
++    </message>
++    <message>
++        <source>GPSD: Upload routes is not implemented.</source>
++        <translation>GPSD: Upload routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>GPSD: Upload waypoints is not implemented.</source>
++        <translation>GPSD: Upload waypoints is not implemented.</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>GPSD: Upload tracks is not implemented.</source>
++        <translation>GPSD: Upload tracks is not implemented.</translation>
++    </message>
++    <message>
++        <source>GPSD: Download routes is not implemented.</source>
++        <translation>GPSD: Download routes is not implemented.</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceGarmin</name>
++    <message>
++        <source>Upload maps finished!</source>
++        <translation>Upload maps finished!</translation>
++    </message>
++    <message>
++        <source>Download tracks finished!</source>
++        <translation>Download tracks finished!</translation>
++    </message>
++    <message>
++        <source>Download routes finished!</source>
++        <translation>Download routes finished!</translation>
++    </message>
++    <message>
++        <source>Failed to create image file.</source>
++        <translation>Failed to create image file.</translation>
++    </message>
++    <message>
++        <source>Device Link Error</source>
++        <translation>Device Link Error</translation>
++    </message>
++    <message>
++        <source>Error ...</source>
++        <translation>Error ...</translation>
++    </message>
++    <message>
++        <source>The version of your driver plugin &quot;%1&quot; does not match the version QLandkarteGT expects (&quot;%2&quot;).</source>
++        <translation>The version of your driver plugin &quot;%1&quot; does not match the version QLandkarteGT expects (&quot;%2&quot;).</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Download waypoints finished!</source>
++        <translation>Download waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Driver version mismatch.</source>
++        <translation>Driver version mismatch.</translation>
++    </message>
++    <message>
++        <source>Upload routes finished!</source>
++        <translation>Upload routes finished!</translation>
++    </message>
++    <message>
++        <source>Upload tracks finished!</source>
++        <translation>Upload tracks finished!</translation>
++    </message>
++    <message>
++        <source>Upload waypoints finished!</source>
++        <translation>Upload waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Failed to load driver.</source>
++        <translation>Failed to load driver.</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceGarminBulk</name>
++    <message>
++        <source>waypoints</source>
++        <translation>waypoints</translation>
++    </message>
++    <message>
++        <source>Download tracks finished!</source>
++        <translation>Download tracks finished!</translation>
++    </message>
++    <message>
++        <source>Download routes finished!</source>
++        <translation>Download routes finished!</translation>
++    </message>
++    <message>
++        <source>routes</source>
++        <translation>routes</translation>
++    </message>
++    <message>
++        <source>tracks</source>
++        <translation>tracks</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Missing...</source>
++        <translation>Missing...</translation>
++    </message>
++    <message>
++        <source>Download waypoints finished!</source>
++        <translation>Download waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Upload routes finished!</source>
++        <translation>Upload routes finished!</translation>
++    </message>
++    <message>
++        <source>Upload tracks finished!</source>
++        <translation>Upload tracks finished!</translation>
++    </message>
++    <message>
++        <source>Upload waypoints finished!</source>
++        <translation>Upload waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Path to Garmin device...</source>
++        <translation>Path to Garmin device...</translation>
++    </message>
++    <message>
++        <source>Garmin Mass Storage: Upload maps is not implemented.</source>
++        <translation>Garmin Mass Storage: Upload maps is not implemented.</translation>
++    </message>
++    <message>
++        <source>Garmin Mass Storage: Download screenshots is not implemented.</source>
++        <translation>Garmin Mass Storage: Download screenshots is not implemented.</translation>
++    </message>
++    <message>
++        <source>Garmin Mass Storage: Live log is not implemented.</source>
++        <translation>Garmin Mass Storage: Live log is not implemented.</translation>
++    </message>
++    <message>
++        <source>Error</source>
++        <translation>Error</translation>
++    </message>
++    <message>
++        <source>The selected path must have a subdirectory &apos;%1&apos;. Should I create the path?
++
++%2</source>
++        <translation>The selected path must have a subdirectory &apos;%1&apos;. Should I create the path?
++
++%2</translation>
++    </message>
++    <message>
++        <source>The selected path must have a subdirectory &apos;%1. Should I create the path?
++
++%2</source>
++        <translation>The selected path must have a subdirectory &apos;%1. Should I create the path?
++
++%2</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceMagellan</name>
++    <message>
++        <source>Path to Magellan device...</source>
++        <translation>Path to Magellan device...</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>waypoints</source>
++        <translation>waypoints</translation>
++    </message>
++    <message>
++        <source>Error</source>
++        <translation>Error</translation>
++    </message>
++    <message>
++        <source>Upload waypoints finished!</source>
++        <translation>Upload waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Download waypoints finished!</source>
++        <translation>Download waypoints finished!</translation>
++    </message>
++    <message>
++        <source>tracks</source>
++        <translation>tracks</translation>
++    </message>
++    <message>
++        <source>Upload tracks finished!</source>
++        <translation>Upload tracks finished!</translation>
++    </message>
++    <message>
++        <source>Download tracks finished!</source>
++        <translation>Download tracks finished!</translation>
++    </message>
++    <message>
++        <source>Magellan: Upload routes is not implemented.</source>
++        <translation>Magellan: Upload routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>Magellan: Download routes is not implemented.</source>
++        <translation>Magellan: Download routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>Magellan: Upload maps is not implemented.</source>
++        <translation>Magellan: Upload maps is not implemented.</translation>
++    </message>
++    <message>
++        <source>Magellan: Live log is not supported.</source>
++        <translation>Magellan: Live log is not supported.</translation>
++    </message>
++    <message>
++        <source>Magellan: Screen shot is not supported.</source>
++        <translation>Magellan: Screen shot is not supported.</translation>
++    </message>
++    <message>
++        <source>I need a path with &apos;Track&apos;, &apos;Waypoints&apos;, &apos;Routes&apos; and &apos;Geocaches&apos; as subdirectory</source>
++        <translation>I need a path with &apos;Track&apos;, &apos;Waypoints&apos;, &apos;Routes&apos; and &apos;Geocaches&apos; as subdirectory</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceMikrokopter</name>
++    <message>
++        <source>Error...</source>
++        <translation type="obsolete">Error...</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Failed to open serial port.</source>
++        <translation type="obsolete">Mikrokopter: Failed to open serial port.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Upload waypoints is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Upload waypoints is not implemented.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Upload tracks is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Upload tracks is not implemented.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Download tracks is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Download tracks is not implemented.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Upload routes is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Upload routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Download routes is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Download routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Upload maps is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Upload maps is not implemented.</translation>
++    </message>
++    <message>
++        <source>Mikrokopter: Download screenschots is not implemented.</source>
++        <translation type="obsolete">Mikrokopter: Download screenschots is not implemented.</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceNMEA</name>
++    <message>
++        <source>NMEA: Upload tracks is not implemented.</source>
++        <translation>NMEA: Upload tracks is not implemented.</translation>
++    </message>
++    <message>
++        <source>NMEA: Download waypoints is not implemented.</source>
++        <translation>NMEA: Download waypoints is not implemented.</translation>
++    </message>
++    <message>
++        <source>NMEA: Download tracks is not implemented.</source>
++        <translation>NMEA: Download tracks is not implemented.</translation>
++    </message>
++    <message>
++        <source>NMEA: Download screenshots is not implemented.</source>
++        <translation>NMEA: Download screenshots is not implemented.</translation>
++    </message>
++    <message>
++        <source>NMEA: Upload waypoints is not implemented.</source>
++        <translation>NMEA: Upload waypoints is not implemented.</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>NMEA: Download routes is not implemented.</source>
++        <translation>NMEA: Download routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>NMEA: Upload routes is not implemented.</source>
++        <translation>NMEA: Upload routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>NMEA: Upload maps is not implemented.</source>
++        <translation>NMEA: Upload maps is not implemented.</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceQLandkarteM</name>
++    <message>
++        <source>QLandkarteM: No device found. Is it connected to the network?</source>
++        <translation>QLandkarteM: No device found. Is it connected to the network?</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Failed to transfer waypoints.</source>
++        <translation>QLandkarteM: Failed to transfer waypoints.</translation>
++    </message>
++    <message>
++        <source>Connect to device.</source>
++        <translation>Connect to device.</translation>
++    </message>
++    <message>
++        <source>%1
++%2 of %3</source>
++        <translation>%1
++%2 of %3</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Failed to download screenshot from device.</source>
++        <translation>QLandkarteM: Failed to download screenshot from device.</translation>
++    </message>
++    <message>
++        <source>Download tracks ...</source>
++        <translation>Download tracks ...</translation>
++    </message>
++    <message>
++        <source>Download track: %1</source>
++        <translation>Download track: %1</translation>
++    </message>
++    <message>
++        <source>Download waypoint: %1</source>
++        <translation>Download waypoint: %1</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Download routes is not implemented.</source>
++        <translation>QLandkarteM: Download routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Upload map is not implemented.</source>
++        <translation>QLandkarteM: Upload map is not implemented.</translation>
++    </message>
++    <message>
++        <source>Download screenshot ...</source>
++        <translation>Download screenshot ...</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Query list of tracks from the device</source>
++        <translation>Query list of tracks from the device</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Failed to query waypoints from device.</source>
++        <translation>QLandkarteM: Failed to query waypoints from device.</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Failed to query tracks from device.</source>
++        <translation>QLandkarteM: Failed to query tracks from device.</translation>
++    </message>
++    <message>
++        <source>Uplaod tracks ...</source>
++        <translation>Uplaod tracks ...</translation>
++    </message>
++    <message>
++        <source>Query list of waypoints from the device</source>
++        <translation>Query list of waypoints from the device</translation>
++    </message>
++    <message>
++        <source>Download waypoints ...</source>
++        <translation>Download waypoints ...</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Failed to transfer tracks.</source>
++        <translation>QLandkarteM: Failed to transfer tracks.</translation>
++    </message>
++    <message>
++        <source>QLandkarteM: Failed to connect to device.</source>
++        <translation>QLandkarteM: Failed to connect to device.</translation>
++    </message>
++    <message>
++        <source>Upload waypoints ...</source>
++        <translation>Upload waypoints ...</translation>
++    </message>
++</context>
++<context>
++    <name>CDeviceTwoNav</name>
++    <message>
++        <source>Download tracks finished!</source>
++        <translation>Download tracks finished!</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Download waypoints finished!</source>
++        <translation>Download waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Upload tracks finished!</source>
++        <translation>Upload tracks finished!</translation>
++    </message>
++    <message>
++        <source>Upload waypoints finished!</source>
++        <translation>Upload waypoints finished!</translation>
++    </message>
++    <message>
++        <source>Path to TwoNav device...</source>
++        <translation>Path to TwoNav device...</translation>
++    </message>
++    <message>
++        <source>I need a path with &apos;TwoNavData/Data&apos; as subdirectory</source>
++        <translation>I need a path with &apos;TwoNavData/Data&apos; as subdirectory</translation>
++    </message>
++    <message>
++        <source>waypoints</source>
++        <translation>waypoints</translation>
++    </message>
++    <message>
++        <source>tracks</source>
++        <translation>tracks</translation>
++    </message>
++    <message>
++        <source>TwoNav: Upload routes is not implemented.</source>
++        <translation>TwoNav: Upload routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>TwoNav: Download routes is not implemented.</source>
++        <translation>TwoNav: Download routes is not implemented.</translation>
++    </message>
++    <message>
++        <source>TwoNav: Upload maps is not implemented.</source>
++        <translation>TwoNav: Upload maps is not implemented.</translation>
++    </message>
++    <message>
++        <source>TwoNav: Download screenshots is not implemented.</source>
++        <translation>TwoNav: Download screenshots is not implemented.</translation>
++    </message>
++    <message>
++        <source>Only support lon/lat WGS 84 format.</source>
++        <translation>Only support lon/lat WGS 84 format.</translation>
++    </message>
++</context>
++<context>
++    <name>CDiary</name>
++    <message>
++        <source>Diary</source>
++        <translation>Diary</translation>
++    </message>
++</context>
++<context>
++    <name>CDiaryEdit</name>
++    <message>
++        <source>Cu&amp;t</source>
++        <translation>Cu&amp;t</translation>
++    </message>
++    <message>
++        <source>Info</source>
++        <translation>Info</translation>
++    </message>
++    <message>
++        <source>&amp;Bold</source>
++        <translation>&amp;Bold</translation>
++    </message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;Copy</translation>
++    </message>
++    <message>
++        <source>Failed...</source>
++        <translation>Failed...</translation>
++    </message>
++    <message>
++        <source>&amp;Redo</source>
++        <translation>&amp;Redo</translation>
++    </message>
++    <message>
++        <source>&amp;Undo</source>
++        <translation>&amp;Undo</translation>
++    </message>
++    <message>
++        <source>Waypoints</source>
++        <translation>Waypoints</translation>
++    </message>
++    <message>
++        <source>Add your own text here...</source>
++        <translation>Add your own text here...</translation>
++    </message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;Paste</translation>
++    </message>
++    <message>
++        <source>The diary is modified. Do you want to save it?</source>
++        <translation>The diary is modified. Do you want to save it?</translation>
++    </message>
++    <message>
++        <source>Tracks</source>
++        <translation>Tracks</translation>
++    </message>
++    <message>
++        <source>Print Diary</source>
++        <translation>Print Diary</translation>
++    </message>
++    <message>
++        <source>&amp;Color...</source>
++        <translation>&amp;Color...</translation>
++    </message>
++    <message>
++        <source>Diary - %1 *</source>
++        <translation>Diary - %1 *</translation>
++    </message>
++    <message>
++        <source>Diary modified...</source>
++        <translation>Diary modified...</translation>
++    </message>
++    <message>
++        <source>&lt;b&gt;Owner:&lt;/b&gt; %1 &lt;b&gt;Size:&lt;/b&gt; %2 &lt;b&gt;Difficulty:&lt;/b&gt; %3 &lt;b&gt;Terrain:&lt;/b&gt; %4</source>
++        <translation>&lt;b&gt;Owner:&lt;/b&gt; %1 &lt;b&gt;Size:&lt;/b&gt; %2 &lt;b&gt;Difficulty:&lt;/b&gt; %3 &lt;b&gt;Terrain:&lt;/b&gt; %4</translation>
++    </message>
++    <message>
++        <source>Diary - %1</source>
++        <translation>Diary - %1</translation>
++    </message>
++    <message>
++        <source>Comment</source>
++        <translation>Comment</translation>
++    </message>
++    <message>
++        <source>&amp;Underline</source>
++        <translation>&amp;Underline</translation>
++    </message>
++    <message>
++        <source>&amp;Italic</source>
++        <translation>&amp;Italic</translation>
++    </message>
++    <message>
++        <source>Failed to save diary to database. Probably because it was not created from a database project.</source>
++        <translation>Failed to save diary to database. Probably because it was not created from a database project.</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgConfig</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>GPSD</source>
++        <translation>GPSD</translation>
++    </message>
++    <message>
++        <source>NMEA</source>
++        <translation>NMEA</translation>
++    </message>
++    <message>
++        <source>Garmin Mass Storage</source>
++        <translation>Garmin Mass Storage</translation>
++    </message>
++    <message>
++        <source>No plugins found. I expect them in: %1</source>
++        <translation>No plugins found. I expect them in: %1</translation>
++    </message>
++    <message>
++        <source>Garmin</source>
++        <translation>Garmin</translation>
++    </message>
++    <message>
++        <source>QLandkarte M</source>
++        <translation>QLandkarte M</translation>
++    </message>
++    <message>
++        <source>TwoNav</source>
++        <translation>TwoNav</translation>
++    </message>
++    <message>
++        <source>Mikrokopter</source>
++        <translation type="obsolete">Mikrokopter</translation>
++    </message>
++    <message>
++        <source>Pass something like &quot;COM1:&quot; or &quot;\\.\COM13&quot; or &quot;\\.\com13&quot; for serial Garmin devices or NMEA devices. For Garmin USB devices leave blank.</source>
++        <translation type="obsolete">Pass something like &quot;COM1:&quot; or &quot;\\.\COM13&quot; or &quot;\\.\com13&quot; for serial Garmin devices or NMEA devices. For Garmin USB devices leave blank.</translation>
++    </message>
++    <message>
++        <source>Open Directory</source>
++        <translation>Open Directory</translation>
++    </message>
++    <message>
++        <source>Magellan</source>
++        <translation>Magellan</translation>
++    </message>
++    <message>
++        <source>Pass something like &quot;COM1&quot; or &quot;\\.\COM13&quot; or &quot;\\.\com13&quot; for serial Garmin devices or NMEA devices. For Garmin USB devices leave blank.</source>
++        <translation type="unfinished">Pass something like &quot;COM1&quot; or &quot;\\.\COM13&quot; or &quot;\\.\com13&quot; for serial Garmin devices or NMEA devices. For Garmin USB devices leave blank.</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgConfig3D</name>
++    <message>
++        <source>fine</source>
++        <translation>fine</translation>
++    </message>
++    <message>
++        <source>coarse</source>
++        <translation>coarse</translation>
++    </message>
++    <message>
++        <source>medium</source>
++        <translation>medium</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgConvertToTrack</name>
++    <message>
++        <source>1 km</source>
++        <translation>1 km</translation>
++    </message>
++    <message>
++        <source>10 m</source>
++        <translation>10 m</translation>
++    </message>
++    <message>
++        <source>20 m</source>
++        <translation>20 m</translation>
++    </message>
++    <message>
++        <source>30 m</source>
++        <translation>30 m</translation>
++    </message>
++    <message>
++        <source>50 m</source>
++        <translation>50 m</translation>
++    </message>
++    <message>
++        <source>none</source>
++        <translation>none</translation>
++    </message>
++    <message>
++        <source>100 m</source>
++        <translation>100 m</translation>
++    </message>
++    <message>
++        <source>200 m</source>
++        <translation>200 m</translation>
++    </message>
++    <message>
++        <source>300 m</source>
++        <translation>300 m</translation>
++    </message>
++    <message>
++        <source>500 m</source>
++        <translation>500 m</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgCropMap</name>
++    <message>
++        <source>Close</source>
++        <translation>Close</translation>
++    </message>
++    <message>
++        <source>Step %1/%2,</source>
++        <translation>Step %1/%2,</translation>
++    </message>
++    <message>
++        <source>Cancel</source>
++        <translation>Cancel</translation>
++    </message>
++    <message>
++        <source>!!! failed !!!
++</source>
++        <translation>!!! failed !!!
++</translation>
++    </message>
++    <message>
++        <source>Failed. See &quot;Details&quot; for more information.</source>
++        <translation>Failed. See &quot;Details&quot; for more information.</translation>
++    </message>
++    <message>
++        <source>*** done ***
++</source>
++        <translation>*** done ***
++</translation>
++    </message>
++    <message>
++        <source>
++Canceled by user&apos;s request.
++</source>
++        <translation>
++Canceled by user&apos;s request.
++</translation>
++    </message>
++    <message>
++        <source>Warnings. See &quot;Details&quot; for more information.
++</source>
++        <translation>Warnings. See &quot;Details&quot; for more information.
++</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgDeviceExportPath</name>
++    <message>
++        <source>Where should I place all %1?</source>
++        <translation>Where should I place all %1?</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgEditFolder</name>
++    <message>
++        <source>Group</source>
++        <translation>Group</translation>
++    </message>
++    <message>
++        <source>Project</source>
++        <translation>Project</translation>
++    </message>
++    <message>
++        <source>Other data</source>
++        <translation>Other data</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgEditMapLevel</name>
++    <message>
++        <source>Select &lt;b&gt;all&lt;/b&gt; files for that level.</source>
++        <translation>Select &lt;b&gt;all&lt;/b&gt; files for that level.</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgEditWpt</name>
++    <message>
++        <source>%1
++</source>
++        <translation>%1
++</translation>
++    </message>
++    <message>
++        <source>None</source>
++        <translation>None</translation>
++    </message>
++    <message>
++        <source>Error</source>
++        <translation>Error</translation>
++    </message>
++    <message>
++        <source>no image</source>
++        <translation>no image</translation>
++    </message>
++    <message>
++        <source>Edit link ...</source>
++        <translation>Edit link ...</translation>
++    </message>
++    <message>
++        <source>Select image file</source>
++        <translation>Select image file</translation>
++    </message>
++    <message>
++        <source>You must provide a waypoint position.</source>
++        <translation>You must provide a waypoint position.</translation>
++    </message>
++    <message>
++        <source>Select output file</source>
++        <translation>Select output file</translation>
++    </message>
++    <message>
++        <source>comment</source>
++        <translation>comment</translation>
++    </message>
++    <message>
++        <source>Link: &apos;http://...&apos;</source>
++        <translation>Link: &apos;http://...&apos;</translation>
++    </message>
++    <message>
++        <source>Add comment ...</source>
++        <translation>Add comment ...</translation>
++    </message>
++    <message>
++        <source>(proj.)</source>
++        <translation>(proj.)</translation>
++    </message>
++    <message>
++        <source>You must provide a waypoint identifier.</source>
++        <translation>You must provide a waypoint identifier.</translation>
++    </message>
++    <message>
++        <source>Delete images...</source>
++        <translation>Delete images...</translation>
++    </message>
++    <message>
++        <source>Remove all other images first?</source>
++        <translation>Remove all other images first?</translation>
++    </message>
++    <message>
++        <source>No spoilers...</source>
++        <translatorcomment>Pas d&apos;indice trouvé</translatorcomment>
++        <translation>No spoilers...</translation>
++    </message>
++    <message>
++        <source>No spoilers found.</source>
++        <translation>No spoilers found.</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgExport</name>
++    <message>
++        <source>Waypoints</source>
++        <translation>Waypoints</translation>
++    </message>
++    <message>
++        <source>Routes</source>
++        <translation>Routes</translation>
++    </message>
++    <message>
++        <source>Tracks</source>
++        <translation>Tracks</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgImportImages</name>
++    <message>
++        <source>Select path...</source>
++        <translation>Select path...</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgLoadOnlineMap</name>
++    <message>
++        <source>Target path is %1</source>
++        <translation type="obsolete">Target path is %1</translation>
++    </message>
++    <message>
++        <source>Open Directory</source>
++        <translation>Open Directory</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgMapWmsConfig</name>
++    <message>
++        <source>File: %1</source>
++        <translation>File: %1</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgProjWizzard</name>
++    <message>
++        <source>north</source>
++        <translation>north</translation>
++    </message>
++    <message>
++        <source>south</source>
++        <translation>south</translation>
++    </message>
++    <message>
++        <source>The value
++&apos;%1&apos;
++is not a valid coordinate system definition:
++%2</source>
++        <translation>The value
++&apos;%1&apos;
++is not a valid coordinate system definition:
++%2</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgProxy</name>
++    <message>
++        <source>&lt;qt&gt;Connect to proxy &quot;%1&quot; using:&lt;/qt&gt;</source>
++        <translation>&lt;qt&gt;Connect to proxy &quot;%1&quot; using:&lt;/qt&gt;</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgScreenshot</name>
++    <message>
++        <source>Select output file</source>
++        <translation>Select output file</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgSetupGarminIcons</name>
++    <message>
++        <source>: Bad icon format</source>
++        <translation>: Bad icon format</translation>
++    </message>
++    <message>
++        <source>Format Error</source>
++        <translation>Format Error</translation>
++    </message>
++    <message>
++        <source>Device Link Error</source>
++        <translation>Device Link Error</translation>
++    </message>
++    <message>
++        <source>select icon</source>
++        <translation>select icon</translation>
++    </message>
++    <message>
++        <source>reset icon</source>
++        <translation>reset icon</translation>
++    </message>
++    <message>
++        <source>Select icon ...</source>
++        <translation>Select icon ...</translation>
++    </message>
++</context>
++<context>
++    <name>CDlgTrackFilter</name>
++    <message>
++        <source>Abort filter</source>
++        <translation>Abort filter</translation>
++    </message>
++    <message>
++        <source>Smooth profile (Median filter, %1 tabs)</source>
++        <translation>Smooth profile (Median filter, %1 tabs)</translation>
++    </message>
++    <message>
++        <source>Filter track...</source>
++        <translation>Filter track...</translation>
++    </message>
++</context>
++<context>
++    <name>CGarminExport</name>
++    <message>
++        <source>Creating image from maps:
++</source>
++        <translation>Creating image from maps:
++</translation>
++    </message>
++    <message>
++        <source>Failed to read file structure: </source>
++        <translation>Failed to read file structure: </translation>
++    </message>
++    <message>
++        <source>Initialize %1</source>
++        <translation>Initialize %1</translation>
++    </message>
++    <message>
++        <source>Map: %1</source>
++        <translation>Map: %1</translation>
++    </message>
++    <message>
++        <source>contains a duplicate internal filename. Skipped!</source>
++        <translation>contains a duplicate internal filename. Skipped!</translation>
++    </message>
++    <message>
++        <source>Failed to read: </source>
++        <translation>Failed to read: </translation>
++    </message>
++    <message>
++        <source>Block count: %1 (of %2)</source>
++        <translation>Block count: %1 (of %2)</translation>
++    </message>
++    <message>
++        <source>Failed to open: </source>
++        <translation>Failed to open: </translation>
++    </message>
++    <message>
++        <source>Too many tiles.</source>
++        <translation>Too many tiles.</translation>
++    </message>
++    <message>
++        <source>Write header...</source>
++        <translation>Write header...</translation>
++    </message>
++    <message>
++        <source>FAT entries: %1 (of %2) Failed!</source>
++        <translation>FAT entries: %1 (of %2) Failed!</translation>
++    </message>
++    <message>
++        <source>Block count: %1 (of %2) Failed!</source>
++        <translation>Block count: %1 (of %2) Failed!</translation>
++    </message>
++    <message>
++        <source>Copy typ files...</source>
++        <translation>Copy typ files...</translation>
++    </message>
++    <message>
++        <source>Select output path...</source>
++        <translation>Select output path...</translation>
++    </message>
++    <message>
++        <source>    %1 (%2 MB)</source>
++        <translation>    %1 (%2 MB)</translation>
++    </message>
++    <message>
++        <source>FAT entries: %1 (of %2) </source>
++        <translation>FAT entries: %1 (of %2) </translation>
++    </message>
++    <message>
++        <source>    Copy %1...</source>
++        <translation>    Copy %1...</translation>
++    </message>
++    <message>
++        <source>File size: %1 MB (of %2 MB)</source>
++        <translation>File size: %1 MB (of %2 MB)</translation>
++    </message>
++    <message>
++        <source>Bad file format: </source>
++        <translation>Bad file format: </translation>
++    </message>
++    <message>
++        <source>Copy tile data...</source>
++        <translation>Copy tile data...</translation>
++    </message>
++    <message>
++        <source>Map: %1 (Key: %2)</source>
++        <translation>Map: %1 (Key: %2)</translation>
++    </message>
++    <message>
++        <source>Abort due to errors.</source>
++        <translation>Abort due to errors.</translation>
++    </message>
++    <message>
++        <source>Write map lookup table...</source>
++        <translation>Write map lookup table...</translation>
++    </message>
++    <message>
++        <source>File size: %1 MB (of %2 MB) Failed!</source>
++        <translation>File size: %1 MB (of %2 MB) Failed!</translation>
++    </message>
++</context>
++<context>
++    <name>CGarminIndex</name>
++    <message>
++        <source>Create index... %1</source>
++        <translation>Create index... %1</translation>
++    </message>
++    <message>
++        <source>Done</source>
++        <translation>Done</translation>
++    </message>
++</context>
++<context>
++    <name>CGarminTile</name>
++    <message>
++        <source>Failed to read file structure: </source>
++        <translation>Failed to read file structure: </translation>
++    </message>
++    <message>
++        <source>Failed to read: </source>
++        <translation>Failed to read: </translation>
++    </message>
++    <message>
++        <source>Failed to open: </source>
++        <translation>Failed to open: </translation>
++    </message>
++    <message>
++        <source>Bad file format: </source>
++        <translation>Bad file format: </translation>
++    </message>
++    <message>
++        <source>File is NT format. QLandkarte GT is unable to read map files with NT format: </source>
++        <translation>File is NT format. QLandkarte GT is unable to read map files with NT format: </translation>
++    </message>
++    <message>
++        <source>File contains locked / encypted data. Garmin does not want you to use this file with any other software than the one supplied by Garmin.</source>
++        <translation>File contains locked / encypted data. Garmin does not want you to use this file with any other software than the one supplied by Garmin.</translation>
++    </message>
++</context>
++<context>
++    <name>CGeoDB</name>
++    <message>
++        <source>New</source>
++        <translation>New</translation>
++    </message>
++    <message>
++        <source>Copy</source>
++        <translation>Copy</translation>
++    </message>
++    <message>
++        <source>Edit</source>
++        <translation>Edit</translation>
++    </message>
++    <message>
++        <source>Move</source>
++        <translation>Move</translation>
++    </message>
++    <message>
++        <source>Waypoints</source>
++        <translation>Waypoints</translation>
++    </message>
++    <message>
++        <source>Loading items from database.</source>
++        <translation>Loading items from database.</translation>
++    </message>
++    <message>
++        <source>Map Selection</source>
++        <translation>Map Selection</translation>
++    </message>
++    <message>
++        <source>All items that lost their parent folder as you deleted it.</source>
++        <translation>All items that lost their parent folder as you deleted it.</translation>
++    </message>
++    <message>
++        <source>Show/hide diary</source>
++        <translation>Show/hide diary</translation>
++    </message>
++    <message>
++        <source>Loading workspace. Please wait.</source>
++        <translation>Loading workspace. Please wait.</translation>
++    </message>
++    <message>
++        <source>Manage your Geo Data Base</source>
++        <translation>Manage your Geo Data Base</translation>
++    </message>
++    <message>
++        <source>Map Selections</source>
++        <translation>Map Selections</translation>
++    </message>
++    <message>
++        <source>Delete diary</source>
++        <translation>Delete diary</translation>
++    </message>
++    <message>
++        <source>Saving workspace. Please wait.</source>
++        <translation>Saving workspace. Please wait.</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Export</source>
++        <translation>Export</translation>
++    </message>
++    <message>
++        <source>Routes</source>
++        <translation>Routes</translation>
++    </message>
++    <message>
++        <source>Tracks</source>
++        <translation>Tracks</translation>
++    </message>
++    <message>
++        <source>Add diary</source>
++        <translation>Add diary</translation>
++    </message>
++    <message>
++        <source>Lost &amp; Found (%1)</source>
++        <translation>Lost &amp; Found (%1)</translation>
++    </message>
++    <message>
++        <source>Migrating database from version 5 to 6.</source>
++        <translation>Migrating database from version 5 to 6.</translation>
++    </message>
++    <message>
++        <source>Check-out as copy</source>
++        <translation>Check-out as copy</translation>
++    </message>
++    <message>
++        <source>All your data grouped by folders.</source>
++        <translation>All your data grouped by folders.</translation>
++    </message>
++    <message>
++        <source>Copy items.</source>
++        <translation>Copy items.</translation>
++    </message>
++    <message>
++        <source>Save items.</source>
++        <translation>Save items.</translation>
++    </message>
++    <message>
++        <source>Move items.</source>
++        <translation>Move items.</translation>
++    </message>
++    <message>
++        <source>Migrating database from version 4 to 5.</source>
++        <translation>Migrating database from version 4 to 5.</translation>
++    </message>
++    <message>
++        <source>Update workspace.</source>
++        <translation>Update workspace.</translation>
++    </message>
++    <message>
++        <source>Database</source>
++        <translation>Database</translation>
++    </message>
++    <message>
++        <source>Migrating database from version 7 to 8.</source>
++        <translation>Migrating database from version 7 to 8.</translation>
++    </message>
++    <message>
++        <source>Workspace</source>
++        <translation>Workspace</translation>
++    </message>
++    <message>
++        <source>All items you see on the map.</source>
++        <translation>All items you see on the map.</translation>
++    </message>
++    <message>
++        <source>Migrating database from version 6 to 7.</source>
++        <translation>Migrating database from version 6 to 7.</translation>
++    </message>
++    <message>
++        <source>Export data to...</source>
++        <translation>Export data to...</translation>
++    </message>
++    <message>
++        <source>Add items to database.</source>
++        <translation>Add items to database.</translation>
++    </message>
++    <message>
++        <source>You are sure you want to delete &apos;%1&apos; and all items below?</source>
++        <translation>You are sure you want to delete &apos;%1&apos; and all items below?</translation>
++    </message>
++    <message>
++        <source>Save changes</source>
++        <translation>Save changes</translation>
++    </message>
++    <message>
++        <source>Overlays</source>
++        <translation>Overlays</translation>
++    </message>
++    <message>
++        <source>Lost &amp; Found</source>
++        <translation>Lost &amp; Found</translation>
++    </message>
++    <message>
++        <source>Delete items.</source>
++        <translation>Delete items.</translation>
++    </message>
++    <message>
++        <source>Delete folder...</source>
++        <translation>Delete folder...</translation>
++    </message>
++    <message>
++        <source>Add to database</source>
++        <translation>Add to database</translation>
++    </message>
++    <message>
++        <source>Delete diary...</source>
++        <translation>Delete diary...</translation>
++    </message>
++    <message>
++        <source>Do you really want to delete the diary?</source>
++        <translation>Do you really want to delete the diary?</translation>
++    </message>
++    <message>
++        <source>Lock</source>
++        <translation>Lock</translation>
++    </message>
++    <message>
++        <source>Migrating database from version 8 to 9.</source>
++        <translation>Migrating database from version 8 to 9.</translation>
++    </message>
++</context>
++<context>
++    <name>CGpx</name>
++    <message>
++        <source>Not a GPX file: </source>
++        <translation>Not a GPX file: </translation>
++    </message>
++    <message>
++        <source>GPX schema violation: no &quot;creator&quot; attribute.</source>
++        <translation>GPX schema violation: no &quot;creator&quot; attribute.</translation>
++    </message>
++    <message>
++        <source>The file exists and it has not been created by QLandkarte GT. If you press &apos;yes&apos; all data in this file will be lost. Even if this file contains GPX data, QLandkarte GT might not load and store all elements of this file. Those elements will be lost. I recommend to use another file. &lt;b&gt;Do you really want to overwrite the file?&lt;/b&gt;</source>
++        <translation>The file exists and it has not been created by QLandkarte GT. If you press &apos;yes&apos; all data in this file will be lost. Even if this file contains GPX data, QLandkarte GT might not load and store all elements of this file. Those elements will be lost. I recommend to use another file. &lt;b&gt;Do you really want to overwrite the file?&lt;/b&gt;</translation>
++    </message>
++    <message>
++        <source>Failed to open: </source>
++        <translation>Failed to open: </translation>
++    </message>
++    <message>
++        <source>Failed to read: %1
++line %2, column %3:
++ %4</source>
++        <translation>Failed to read: %1
++line %2, column %3:
++ %4</translation>
++    </message>
++    <message>
++        <source>File exists ...</source>
++        <translation>File exists ...</translation>
++    </message>
++    <message>
++        <source>bad application</source>
++        <translation>bad application</translation>
++    </message>
++    <message>
++        <source>Failed to create %1</source>
++        <translation>Failed to create %1</translation>
++    </message>
++    <message>
++        <source>Failed to write %1</source>
++        <translation>Failed to write %1</translation>
++    </message>
++</context>
++<context>
++    <name>CGridDB</name>
++    <message>
++        <source>Grid</source>
++        <translation>Grid</translation>
++    </message>
++    <message>
++        <source>Configure grid color and projection.
++Cur. proj.: %1</source>
++        <translation>Configure grid color and projection.
++Cur. proj.: %1</translation>
++    </message>
++</context>
++<context>
++    <name>CImageSelect</name>
++    <message>
++        <source>leave right</source>
++        <translation>leave right</translation>
++    </message>
++    <message>
++        <source>leave left</source>
++        <translation>leave left</translation>
++    </message>
++    <message>
++        <source>straight on</source>
++        <translation>straight on</translation>
++    </message>
++    <message>
++        <source>turn right</source>
++        <translation>turn right</translation>
++    </message>
++    <message>
++        <source>turn left</source>
++        <translation>turn left</translation>
++    </message>
++    <message>
++        <source>hard right turn</source>
++        <translation>hard right turn</translation>
++    </message>
++    <message>
++        <source>hard left turn</source>
++        <translation>hard left turn</translation>
++    </message>
++    <message>
++        <source>go left</source>
++        <translation>go left</translation>
++    </message>
++    <message>
++        <source>go right</source>
++        <translation>go right</translation>
++    </message>
++    <message>
++        <source>take right</source>
++        <translation>take right</translation>
++    </message>
++    <message>
++        <source>take left</source>
++        <translation>take left</translation>
++    </message>
++    <message>
++        <source>turn right @x-ing</source>
++        <translation>turn right @x-ing</translation>
++    </message>
++    <message>
++        <source>turn left @x-ing</source>
++        <translation>turn left @x-ing</translation>
++    </message>
++    <message>
++        <source>u-turn right</source>
++        <translation>u-turn right</translation>
++    </message>
++    <message>
++        <source>u-turn left</source>
++        <translation>u-turn left</translation>
++    </message>
++    <message>
++        <source>river</source>
++        <translation>river</translation>
++    </message>
++    <message>
++        <source>attention</source>
++        <translation>attention</translation>
++    </message>
++</context>
++<context>
++    <name>CLiveLogDB</name>
++    <message>
++        <source>%1</source>
++        <translation>%1</translation>
++    </message>
++    <message>
++        <source>%1 %2</source>
++        <translation>%1 %2</translation>
++    </message>
++    <message>
++        <source>%1° T</source>
++        <translation type="obsolete">%1° T</translation>
++    </message>
++    <message>
++        <source>LiveLog</source>
++        <translation>LiveLog</translation>
++    </message>
++    <message>
++        <source>GPS signal low (%1)</source>
++        <translation>GPS signal low (%1)</translation>
++    </message>
++    <message>
++        <source>2D (%1)</source>
++        <translation>2D (%1)</translation>
++    </message>
++    <message>
++        <source>GPS connection receiving %1 bytes</source>
++        <translation>GPS connection receiving %1 bytes</translation>
++    </message>
++    <message>
++        <source>3D (%1)</source>
++        <translation>3D (%1)</translation>
++    </message>
++    <message>
++        <source>GPS connection failed</source>
++        <translation>GPS connection failed</translation>
++    </message>
++    <message>
++        <source>DR (%1)</source>
++        <translation>DR (%1)</translation>
++    </message>
++    <message>
++        <source>GPS connection established</source>
++        <translation>GPS connection established</translation>
++    </message>
++    <message>
++        <source>GPS off</source>
++        <translation>GPS off</translation>
++    </message>
++    <message>
++        <source>%1%2 T</source>
++        <translation type="unfinished">%1%2 T</translation>
++    </message>
++</context>
++<context>
++    <name>CLiveLogToolWidget</name>
++    <message>
++        <source>Live Log</source>
++        <translation>Live Log</translation>
++    </message>
++</context>
++<context>
++    <name>CMainWindow</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>Map</source>
++        <translation>Map</translation>
++    </message>
++    <message>
++        <source>&amp;Map</source>
++        <translation>&amp;Map</translation>
++    </message>
++    <message>
++        <source>GPSD</source>
++        <translation>GPSD</translation>
++    </message>
++    <message>
++        <source>Exit</source>
++        <translation>Exit</translation>
++    </message>
++    <message>
++        <source>NMEA</source>
++        <translation>NMEA</translation>
++    </message>
++    <message>
++        <source>Garmin Mass Storage</source>
++        <translation>Garmin Mass Storage</translation>
++    </message>
++    <message>
++        <source>&amp;Edit</source>
++        <translation>&amp;Edit</translation>
++    </message>
++    <message>
++        <source>&amp;File</source>
++        <translation>&amp;File</translation>
++    </message>
++    <message>
++        <source>&amp;Help</source>
++        <translation>&amp;Help</translation>
++    </message>
++    <message>
++        <source>Error</source>
++        <translation>Error</translation>
++    </message>
++    <message>
++        <source>Mor&amp;e</source>
++        <translation>Mor&amp;e</translation>
++    </message>
++    <message>
++        <source>Print Map</source>
++        <translation>Print Map</translation>
++    </message>
++    <message>
++        <source>Add Geo Data</source>
++        <translation>Add Geo Data</translation>
++    </message>
++    <message>
++        <source>&amp;Live Log</source>
++        <translation>&amp;Live Log</translation>
++    </message>
++    <message>
++        <source> %1 &lt;a href=&apos;Tracks&apos;&gt;tracks&lt;/a&gt;, </source>
++        <translation> %1 &lt;a href=&apos;Tracks&apos;&gt;tracks&lt;/a&gt;, </translation>
++    </message>
++    <message>
++        <source>Select map...</source>
++        <translation>Select map...</translation>
++    </message>
++    <message>
++        <source>http://Support</source>
++        <translation>http://Support</translation>
++    </message>
++    <message>
++        <source>Failed ...</source>
++        <translation>Failed ...</translation>
++    </message>
++    <message>
++        <source>&amp;Route</source>
++        <translation>&amp;Route</translation>
++    </message>
++    <message>
++        <source>&amp;Setup</source>
++        <translation>&amp;Setup</translation>
++    </message>
++    <message>
++        <source>&amp;Track</source>
++        <translation>&amp;Track</translation>
++    </message>
++    <message>
++        <source>Clear all...</source>
++        <translation>Clear all...</translation>
++    </message>
++    <message>
++        <source>This will erase all project data like waypoints and tracks.</source>
++        <translation type="obsolete">This will erase all project data like waypoints and tracks.</translation>
++    </message>
++    <message>
++        <source>Save Geo Data</source>
++        <translation>Save Geo Data</translation>
++    </message>
++    <message>
++        <source>http://FAQ</source>
++        <translation>http://FAQ</translation>
++    </message>
++    <message>
++        <source>Print Map ...</source>
++        <translation>Print Map ...</translation>
++    </message>
++    <message>
++        <source>quadratic zoom</source>
++        <translation>quadratic zoom</translation>
++    </message>
++    <message>
++        <source> %1 &lt;a href=&apos;Routes&apos;&gt;route&lt;/a&gt; and </source>
++        <translation> %1 &lt;a href=&apos;Routes&apos;&gt;route&lt;/a&gt; and </translation>
++    </message>
++    <message>
++        <source>QLandkarte M</source>
++        <translation>QLandkarte M</translation>
++    </message>
++    <message>
++        <source>Load Map</source>
++        <translation>Load Map</translation>
++    </message>
++    <message>
++        <source>Select input files</source>
++        <translation>Select input files</translation>
++    </message>
++    <message>
++        <source>TwoNav</source>
++        <translation>TwoNav</translation>
++    </message>
++    <message>
++        <source>About &amp;QLandkarte GT</source>
++        <translation>About &amp;QLandkarte GT</translation>
++    </message>
++    <message>
++        <source>Currently there is %1 &lt;a href=&apos;Waypoints&apos;&gt;waypoint&lt;/a&gt;, </source>
++        <translation>Currently there is %1 &lt;a href=&apos;Waypoints&apos;&gt;waypoint&lt;/a&gt;, </translation>
++    </message>
++    <message>
++        <source>Mikrokopter</source>
++        <translation type="obsolete">Mikrokopter</translation>
++    </message>
++    <message>
++        <source>Currently there are %1 &lt;a href=&apos;Waypoints&apos;&gt;waypoints&lt;/a&gt;, </source>
++        <translation>Currently there are %1 &lt;a href=&apos;Waypoints&apos;&gt;waypoints&lt;/a&gt;, </translation>
++    </message>
++    <message>
++        <source>&amp;Overlay</source>
++        <translation>&amp;Overlay</translation>
++    </message>
++    <message>
++        <source> %1 &lt;a href=&apos;Overlay&apos;&gt;overlays&lt;/a&gt;. </source>
++        <translation> %1 &lt;a href=&apos;Overlay&apos;&gt;overlays&lt;/a&gt;. </translation>
++    </message>
++    <message>
++        <source>There are no waypoints, </source>
++        <translation>There are no waypoints, </translation>
++    </message>
++    <message>
++        <source>no tracks, </source>
++        <translation>no tracks, </translation>
++    </message>
++    <message>
++        <source>Select output file</source>
++        <translation>Select output file</translation>
++    </message>
++    <message>
++        <source>&lt;b&gt;GPS Device:&lt;/b&gt;</source>
++        <translation>&lt;b&gt;GPS Device:&lt;/b&gt;</translation>
++    </message>
++    <message>
++        <source>&amp;Waypoint</source>
++        <translation>&amp;Waypoint</translation>
++    </message>
++    <message>
++        <source>Device Screenshot ...</source>
++        <translation>Device Screenshot ...</translation>
++    </message>
++    <message>
++        <source>Load Online Map</source>
++        <translation>Load Online Map</translation>
++    </message>
++    <message>
++        <source>Load Geo Data</source>
++        <translation>Load Geo Data</translation>
++    </message>
++    <message>
++        <source> %1 &lt;a href=&apos;Tracks&apos;&gt;track&lt;/a&gt;, </source>
++        <translation> %1 &lt;a href=&apos;Tracks&apos;&gt;track&lt;/a&gt;, </translation>
++    </message>
++    <message>
++        <source>Save geo data?</source>
++        <translation>Save geo data?</translation>
++    </message>
++    <message>
++        <source>Toggle toolview</source>
++        <translation>Toggle toolview</translation>
++    </message>
++    <message>
++        <source>Failed to start OCM.</source>
++        <translation>Failed to start OCM.</translation>
++    </message>
++    <message>
++        <source>&lt;div style=&apos;float: left;&apos;&gt;&lt;b&gt;Project Summary (&lt;a href=&apos;Clear&apos;&gt;clear&lt;/a&gt; project):&lt;/b&gt;&lt;/div&gt;</source>
++        <translation type="obsolete">&lt;div style=&apos;float: left;&apos;&gt;&lt;b&gt;Project Summary (&lt;a href=&apos;Clear&apos;&gt;clear&lt;/a&gt; project):&lt;/b&gt;&lt;/div&gt;</translation>
++    </message>
++    <message>
++        <source> %1 &lt;a href=&apos;Routes&apos;&gt;routes&lt;/a&gt; and </source>
++        <translation> %1 &lt;a href=&apos;Routes&apos;&gt;routes&lt;/a&gt; and </translation>
++    </message>
++    <message>
++        <source>New QLandkarte GT %1 available</source>
++        <translation>New QLandkarte GT %1 available</translation>
++    </message>
++    <message>
++        <source>Convert error</source>
++        <translation>Convert error</translation>
++    </message>
++    <message>
++        <source>Load most recent...</source>
++        <translation>Load most recent...</translation>
++    </message>
++    <message>
++        <source>Save map as image ...</source>
++        <translation>Save map as image ...</translation>
++    </message>
++    <message>
++        <source>no routes and </source>
++        <translation>no routes and </translation>
++    </message>
++    <message>
++        <source>Export Geo Data</source>
++        <translation>Export Geo Data</translation>
++    </message>
++    <message>
++        <source>http://Help</source>
++        <translation>http://Help</translation>
++    </message>
++    <message>
++        <source>&amp;General</source>
++        <translation>&amp;General</translation>
++    </message>
++    <message>
++        <source>no overlays. </source>
++        <translation>no overlays. </translation>
++    </message>
++    <message>
++        <source> %1 &lt;a href=&apos;Overlay&apos;&gt;overlay&lt;/a&gt;. </source>
++        <translation> %1 &lt;a href=&apos;Overlay&apos;&gt;overlay&lt;/a&gt;. </translation>
++    </message>
++    <message>
++        <source>The loaded data has been modified.
++Do you want to save your changes?</source>
++        <translation>The loaded data has been modified.
++Do you want to save your changes?</translation>
++    </message>
++    <message>
++        <source>Profiling</source>
++        <translatorcomment>What is it about ? Track&apos;s height profile ?</translatorcomment>
++        <translation type="obsolete">Profiling</translation>
++    </message>
++    <message>
++        <source>Magellan</source>
++        <translation>Magellan</translation>
++    </message>
++    <message>
++        <source>This will erase all workspace data like waypoints and tracks.</source>
++        <translation>This will erase all workspace data like waypoints and tracks.</translation>
++    </message>
++    <message>
++        <source>&lt;div style=&apos;float: left;&apos;&gt;&lt;b&gt;Workspace Summary (&lt;a href=&apos;Clear&apos;&gt;clear&lt;/a&gt; workspace):&lt;/b&gt;&lt;/div&gt;</source>
++        <translation>&lt;div style=&apos;float: left;&apos;&gt;&lt;b&gt;Workspace Summary (&lt;a href=&apos;Clear&apos;&gt;clear&lt;/a&gt; workspace):&lt;/b&gt;&lt;/div&gt;</translation>
++    </message>
++    <message>
++        <source>QLandkarte GT can query for new versions on start-up. If there is a new version available, it will display a short notice in the statusbar. To query for a new version QLandkarte GT has to connect to the server
++
++http://www.qlandkarte.org/webservice/qlandkartegt.php
++
++It won&apos;t transmit any private data other than needed for requesting a HTML page.
++
++If you want QLandkarte GT to do this query now and in the future press &apos;Ok&apos;. Else press &apos;No&apos;.
++
++You won&apos;t be bugged a second time unless you erase QLandkarte&apos;s configuration data.</source>
++        <translation>QLandkarte GT can query for new versions on start-up. If there is a new version available, it will display a short notice in the statusbar. To query for a new version QLandkarte GT has to connect to the server
++
++http://www.qlandkarte.org/webservice/qlandkartegt.php
++
++It won&apos;t transmit any private data other than needed for requesting a HTML page.
++
++If you want QLandkarte GT to do this query now and in the future press &apos;Ok&apos;. Else press &apos;No&apos;.
++
++You won&apos;t be bugged a second time unless you erase QLandkarte&apos;s configuration data.</translation>
++    </message>
++    <message>
++        <source>Query for new version...</source>
++        <translation>Query for new version...</translation>
++    </message>
++</context>
++<context>
++    <name>CMap3D</name>
++    <message>
++        <source>FPV / Rot.</source>
++        <translation>FPV / Rot.</translation>
++    </message>
++    <message>
++        <source>Config</source>
++        <translation>Config</translation>
++    </message>
++    <message>
++        <source>Track on map</source>
++        <translation>Track on map</translation>
++    </message>
++    <message>
++        <source>POV on track</source>
++        <translation>POV on track</translation>
++    </message>
++    <message>
++        <source>Reset Light</source>
++        <translation>Reset Light</translation>
++    </message>
++    <message>
++        <source>3D / 2D</source>
++        <translation>3D / 2D</translation>
++    </message>
++    <message>
++        <source>:/skybox/%1.bmp</source>
++        <translation>:/skybox/%1.bmp</translation>
++    </message>
++    <message>
++        <source>Help 3d</source>
++        <translation>Help 3d</translation>
++    </message>
++</context>
++<context>
++    <name>CMap3DWidget</name>
++    <message>
++        <source>Flat / 3D Mode</source>
++        <translation>Flat / 3D Mode</translation>
++    </message>
++    <message>
++        <source>Show Track</source>
++        <translation>Show Track</translation>
++    </message>
++    <message>
++        <source>Track on Map</source>
++        <translation>Track on Map</translation>
++    </message>
++    <message>
++        <source>Inc. Elevation</source>
++        <translation>Inc. Elevation</translation>
++    </message>
++    <message>
++        <source>Dec. Elevation</source>
++        <translation>Dec. Elevation</translation>
++    </message>
++    <message>
++        <source>Reset Elevation</source>
++        <translation>Reset Elevation</translation>
++    </message>
++    <message>
++        <source>Reset light source</source>
++        <translation>Reset light source</translation>
++    </message>
++    <message>
++        <source>Add Waypoint ...</source>
++        <translation>Add Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Copy Pos. Waypoint</source>
++        <translation>Copy Pos. Waypoint</translation>
++    </message>
++    <message>
++        <source>Edit Waypoint...</source>
++        <translation>Edit Waypoint...</translation>
++    </message>
++    <message>
++        <source>Delete Waypoint</source>
++        <translation>Delete Waypoint</translation>
++    </message>
++    <message>
++        <source>:/skybox/%1.bmp</source>
++        <translation>:/skybox/%1.bmp</translation>
++    </message>
++</context>
++<context>
++    <name>CMapCropStateCrop</name>
++    <message>
++        <source>Cut area from files...</source>
++        <translation>Cut area from files...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapCropStateOptimize</name>
++    <message>
++        <source>nothing to do
++</source>
++        <translation>nothing to do
++</translation>
++    </message>
++    <message>
++        <source>Optimize file...</source>
++        <translation>Optimize file...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapDB</name>
++    <message>
++        <source>This map does not support this feature.</source>
++        <translation>This map does not support this feature.</translation>
++    </message>
++    <message>
++        <source>Map 3D...</source>
++        <translation>Map 3D...</translation>
++    </message>
++    <message>
++        <source>QLandkarte GT was terminated with a crash. This is really bad. A common reason for that is a bad map. Do you really want to load the last map?</source>
++        <translation>QLandkarte GT was terminated with a crash. This is really bad. A common reason for that is a bad map. Do you really want to load the last map?</translation>
++    </message>
++    <message>
++        <source>Only vector maps are valid overlays.</source>
++        <translation>Only vector maps are valid overlays.</translation>
++    </message>
++    <message>
++        <source>Sorry...</source>
++        <translation>Sorry...</translation>
++    </message>
++    <message>
++        <source>Search Map</source>
++        <translation>Search Map</translation>
++    </message>
++    <message>
++        <source>You can&apos;t select subareas from single file maps. Create a collection with F1-&gt;F6.</source>
++        <translation>You can&apos;t select subareas from single file maps. Create a collection with F1-&gt;F6.</translation>
++    </message>
++    <message>
++        <source>Crash detected....</source>
++        <translation>Crash detected....</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Edit Map</source>
++        <translation>Edit Map</translation>
++    </message>
++    <message>
++        <source>--- No map ---</source>
++        <translation>--- No map ---</translation>
++    </message>
++</context>
++<context>
++    <name>CMapDEM</name>
++    <message>
++        <source>Failed to load file: %1
++
++</source>
++        <translation>Failed to load file: %1
++
++</translation>
++    </message>
++    <message>
++        <source>Failed to load file: %1</source>
++        <translation>Failed to load file: %1</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapDEMSlopeSetup</name>
++    <message>
++        <source>Grade %1</source>
++        <translation>Grade %1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapEditWidget</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>Create map collection from existing geo-referenced files.</source>
++        <translation>Create map collection from existing geo-referenced files.</translation>
++    </message>
++    <message>
++        <source>&lt;b style=&apos;color: red;&apos;&gt;Can&apos;t find the GDAL tools in your path. Make sure you have Installed GDAL and all related command line applications.&lt;/b&gt;</source>
++        <translation>&lt;b style=&apos;color: red;&apos;&gt;Can&apos;t find the GDAL tools in your path. Make sure you have Installed GDAL and all related command line applications.&lt;/b&gt;</translation>
++    </message>
++    <message>
++        <source>Fine tune offset of referenced file.</source>
++        <translation>Fine tune offset of referenced file.</translation>
++    </message>
++    <message>
++        <source>Convert a TIFF into GeoTiff by geo referencing it.</source>
++        <translation>Convert a TIFF into GeoTiff by geo referencing it.</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateCombineFiles</name>
++    <message>
++        <source>Combine files for each level...</source>
++        <translation>Combine files for each level...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateConvColor</name>
++    <message>
++        <source>Reduce color bands to 3 (RGB)...</source>
++        <translation>Reduce color bands to 3 (RGB)...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateCutFiles</name>
++    <message>
++        <source>Cut area from files...</source>
++        <translation>Cut area from files...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateGCM</name>
++    <message>
++        <source>Create Garmin Custom Map...</source>
++        <translation>Create Garmin Custom Map...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateJNX</name>
++    <message>
++        <source>Create Garmin JNX Map...</source>
++        <translation>Create Garmin JNX Map...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateOptimize</name>
++    <message>
++        <source>nothing to do
++</source>
++        <translation>nothing to do
++</translation>
++    </message>
++    <message>
++        <source>Optimize files...</source>
++        <translation>Optimize files...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateRMAP</name>
++    <message>
++        <source>Create TwoNav RMAP...</source>
++        <translation>Create TwoNav RMAP...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateRMP</name>
++    <message>
++        <source>Create Magellan RMP Map...</source>
++        <translation>Create Magellan RMP Map...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateReadTileCache</name>
++    <message>
++        <source>Create GeoTiff from map cache...</source>
++        <translation>Create GeoTiff from map cache...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapExportStateReproject</name>
++    <message>
++        <source>Re-project files...</source>
++        <translation>Re-project files...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapGeoTiff</name>
++    <message>
++        <source>Overzoom x%1</source>
++        <translation>Overzoom x%1</translation>
++    </message>
++    <message>
++        <source>No georeference information found.</source>
++        <translation>No georeference information found.</translation>
++    </message>
++    <message>
++        <source>File must be 8 bit palette or gray indexed.</source>
++        <translation>File must be 8 bit palette or gray indexed.</translation>
++    </message>
++    <message>
++        <source>Failed to load file: %1</source>
++        <translation>Failed to load file: %1</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Zoom level x%1</source>
++        <translation>Zoom level x%1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapJnx</name>
++    <message>
++        <source>Area</source>
++        <translation>Area</translation>
++    </message>
++    <message>
++        <source>Info</source>
++        <translation>Info</translation>
++    </message>
++    <message>
++        <source>Level</source>
++        <translation>Level</translation>
++    </message>
++    <message>
++        <source>Scale</source>
++        <translation>Scale</translation>
++    </message>
++    <message>
++        <source>Value</source>
++        <translation type="obsolete">Value</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>#Tiles</source>
++        <translation>#Tiles</translation>
++    </message>
++    <message>
++        <source>Top/Left</source>
++        <translation>Top/Left</translation>
++    </message>
++    <message>
++        <source>Parameter</source>
++        <translation type="obsolete">Parameter</translation>
++    </message>
++    <message>
++        <source>Bottom/Right</source>
++        <translation>Bottom/Right</translation>
++    </message>
++    <message>
++        <source>Z-Order</source>
++        <translation>Z-Order</translation>
++    </message>
++    <message>
++        <source>Product ID</source>
++        <translation>Product ID</translation>
++    </message>
++</context>
++<context>
++    <name>CMapQMAP</name>
++    <message>
++        <source>Area</source>
++        <translation>Area</translation>
++    </message>
++    <message>
++        <source>Files</source>
++        <translation>Files</translation>
++    </message>
++    <message>
++        <source>Value</source>
++        <translation type="obsolete">Value</translation>
++    </message>
++    <message>
++        <source>disabled</source>
++        <translation>disabled</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Overzoom x%1</source>
++        <translation>Overzoom x%1</translation>
++    </message>
++    <message>
++        <source>Map Level</source>
++        <translation>Map Level</translation>
++    </message>
++    <message>
++        <source>Top/Left</source>
++        <translation>Top/Left</translation>
++    </message>
++    <message>
++        <source>Parameter</source>
++        <translation type="obsolete">Parameter</translation>
++    </message>
++    <message>
++        <source>Quadratic zoom %1</source>
++        <translation>Quadratic zoom %1</translation>
++    </message>
++    <message>
++        <source>Zoom level x%1</source>
++        <translation>Zoom level x%1</translation>
++    </message>
++    <message>
++        <source>enabled</source>
++        <translation>enabled</translation>
++    </message>
++    <message>
++        <source>Bottom/Right</source>
++        <translation>Bottom/Right</translation>
++    </message>
++    <message>
++        <source>Zoom Level</source>
++        <translation>Zoom Level</translation>
++    </message>
++</context>
++<context>
++    <name>CMapQMAPExport</name>
++    <message>
++        <source>Close</source>
++        <translation>Close</translation>
++    </message>
++    <message>
++        <source>Unknown map format.</source>
++        <translation>Unknown map format.</translation>
++    </message>
++    <message>
++        <source>Step %1/%2,</source>
++        <translation>Step %1/%2,</translation>
++    </message>
++    <message>
++        <source>Failed to read %1</source>
++        <translation>Failed to read %1</translation>
++    </message>
++    <message>
++        <source>Cancel</source>
++        <translation>Cancel</translation>
++    </message>
++    <message>
++        <source>Job %1/%2 - </source>
++        <translation>Job %1/%2 - </translation>
++    </message>
++    <message>
++        <source>!!! failed !!!
++</source>
++        <translation>!!! failed !!!
++</translation>
++    </message>
++    <message>
++        <source>Failed. See &quot;Details&quot; for more information.</source>
++        <translation>Failed. See &quot;Details&quot; for more information.</translation>
++    </message>
++    <message>
++        <source>Select output path...</source>
++        <translation>Select output path...</translation>
++    </message>
++    <message>
++        <source>*** done ***
++</source>
++        <translation>*** done ***
++</translation>
++    </message>
++    <message>
++        <source>Error ...</source>
++        <translation>Error ...</translation>
++    </message>
++    <message>
++        <source>
++Canceled by user&apos;s request.
++</source>
++        <translation>
++Canceled by user&apos;s request.
++</translation>
++    </message>
++    <message>
++        <source>Warnings. See &quot;Details&quot; for more information.
++</source>
++        <translation>Warnings. See &quot;Details&quot; for more information.
++</translation>
++    </message>
++    <message>
++        <source>Please enter a string</source>
++        <translation>Please enter a string</translation>
++    </message>
++    <message>
++        <source>Select copyright notice...</source>
++        <translation>Select copyright notice...</translation>
++    </message>
++    <message>
++        <source>text file (*.txt)</source>
++        <translation>text file (*.txt)</translation>
++    </message>
++</context>
++<context>
++    <name>CMapRaster</name>
++    <message>
++        <source>Overzoom x%1</source>
++        <translation>Overzoom x%1</translation>
++    </message>
++    <message>
++        <source>File must be 8 bit palette or gray indexed.</source>
++        <translation>File must be 8 bit palette or gray indexed.</translation>
++    </message>
++    <message>
++        <source>Failed to load file: %1</source>
++        <translation>Failed to load file: %1</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Zoom level x%1</source>
++        <translation>Zoom level x%1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapRmap</name>
++    <message>
++        <source>Overzoom x%1</source>
++        <translation>Overzoom x%1</translation>
++    </message>
++    <message>
++        <source>Unknown sub-format.</source>
++        <translation>Unknown sub-format.</translation>
++    </message>
++    <message>
++        <source>This is not a TwoNav RMAP file.</source>
++        <translation>This is not a TwoNav RMAP file.</translation>
++    </message>
++    <message>
++        <source>Failed to read reference point.</source>
++        <translation>Failed to read reference point.</translation>
++    </message>
++    <message>
++        <source>Unknown projection and datum (%1%2).</source>
++        <translation>Unknown projection and datum (%1%2).</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Unknown version.</source>
++        <translation>Unknown version.</translation>
++    </message>
++    <message>
++        <source>Zoom level x%1</source>
++        <translation>Zoom level x%1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapRmp</name>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Failed to open: %1.</source>
++        <translation>Failed to open: %1.</translation>
++    </message>
++    <message>
++        <source>This is not a Magellan RMP file: %1</source>
++        <translation>This is not a Magellan RMP file: %1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapSearchThread</name>
++    <message>
++        <source>Canceled!</source>
++        <translation>Canceled!</translation>
++    </message>
++    <message>
++        <source>Done! Found %1 items.</source>
++        <translation>Done! Found %1 items.</translation>
++    </message>
++    <message>
++        <source>Parsing...</source>
++        <translation>Parsing...</translation>
++    </message>
++    <message>
++        <source>Start...</source>
++        <translation>Start...</translation>
++    </message>
++    <message>
++        <source>Error. This only works on a *.qmap map collection.</source>
++        <translation>Error. This only works on a *.qmap map collection.</translation>
++    </message>
++</context>
++<context>
++    <name>CMapSearchWidget</name>
++    <message>
++        <source>%2 %1</source>
++        <translation>%2 %1</translation>
++    </message>
++    <message>
++        <source>Please provide a symbol name to save the symbol.</source>
++        <translation>Please provide a symbol name to save the symbol.</translation>
++    </message>
++    <message>
++        <source>no mask</source>
++        <translation>no mask</translation>
++    </message>
++    <message>
++        <source>No area selected.</source>
++        <translation>No area selected.</translation>
++    </message>
++    <message>
++        <source>No mask selected.</source>
++        <translation>No mask selected.</translation>
++    </message>
++    <message>
++        <source>Symbols</source>
++        <translation>Symbols</translation>
++    </message>
++    <message>
++        <source>Missing name...</source>
++        <translation>Missing name...</translation>
++    </message>
++</context>
++<context>
++    <name>CMapSelectionRaster</name>
++    <message>
++        <source>Tiles: #%1</source>
++        <translation>Tiles: #%1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapTDB</name>
++    <message>
++        <source></source>
++        <translation></translation>
++    </message>
++    <message>
++        <source>???</source>
++        <translation>???</translation>
++    </message>
++    <message>
++        <source>Day</source>
++        <translation>Day</translation>
++    </message>
++    <message>
++        <source>Sea</source>
++        <translation>Sea</translation>
++    </message>
++    <message>
++        <source>Area</source>
++        <translation>Area</translation>
++    </message>
++    <message>
++        <source>Flat</source>
++        <translation>Flat</translation>
++    </message>
++    <message>
++        <source>Name</source>
++        <translation>Name</translation>
++    </message>
++    <message>
++        <source>Type</source>
++        <translation>Type</translation>
++    </message>
++    <message>
++        <source>none</source>
++        <translation>none</translation>
++    </message>
++    <message>
++        <source>Parking lot</source>
++        <translation>Parking lot</translation>
++    </message>
++    <message>
++        <source>Czech</source>
++        <translation>Czech</translation>
++    </message>
++    <message>
++        <source>Dutch</source>
++        <translation>Dutch</translation>
++    </message>
++    <message>
++        <source>Error</source>
++        <translation>Error</translation>
++    </message>
++    <message>
++        <source>Ferry</source>
++        <translation>Ferry</translation>
++    </message>
++    <message>
++        <source>Greek</source>
++        <translation>Greek</translation>
++    </message>
++    <message>
++        <source>Night</source>
++        <translation>Night</translation>
++    </message>
++    <message>
++        <source>Ocean</source>
++        <translation>Ocean</translation>
++    </message>
++    <message>
++        <source>River</source>
++        <translation>River</translation>
++    </message>
++    <message>
++        <source>Scrub</source>
++        <translation>Scrub</translation>
++    </message>
++    <message>
++        <source>Trail</source>
++        <translation>Trail</translation>
++    </message>
++    <message>
++        <source>Welsh</source>
++        <translation>Welsh</translation>
++    </message>
++    <message>
++        <source>Pipeline</source>
++        <translation>Pipeline</translation>
++    </message>
++    <message>
++        <source>Collector road</source>
++        <translation>Collector road</translation>
++    </message>
++    <message>
++        <source>Highway ramp, low speed</source>
++        <translation>Highway ramp, low speed</translation>
++    </message>
++    <message>
++        <source>Italian</source>
++        <translation>Italian</translation>
++    </message>
++    <message>
++        <source>Shopping center</source>
++        <translation>Shopping center</translation>
++    </message>
++    <message>
++        <source>Major depth contour</source>
++        <translation>Major depth contour</translation>
++    </message>
++    <message>
++        <source>Intermittent water</source>
++        <translation>Intermittent water</translation>
++    </message>
++    <message>
++        <source>Albanian</source>
++        <translation>Albanian</translation>
++    </message>
++    <message>
++        <source>Latvian</source>
++        <translation>Latvian</translation>
++    </message>
++    <message>
++        <source>Bulgarian</source>
++        <translation>Bulgarian</translation>
++    </message>
++    <message>
++        <source>Small lake</source>
++        <translation>Small lake</translation>
++    </message>
++    <message>
++        <source>National park</source>
++        <translation>National park</translation>
++    </message>
++    <message>
++        <source>Time zone</source>
++        <translation>Time zone</translation>
++    </message>
++    <message>
++        <source>Point of Interest</source>
++        <translation>Point of Interest</translation>
++    </message>
++    <message>
++        <source>missing</source>
++        <translation>missing</translation>
++    </message>
++    <message>
++        <source>Major River</source>
++        <translation>Major River</translation>
++    </message>
++    <message>
++        <source>Basque</source>
++        <translation>Basque</translation>
++    </message>
++    <message>
++        <source>Roundabout</source>
++        <translation>Roundabout</translation>
++    </message>
++    <message>
++        <source>Danish</source>
++        <translation>Danish</translation>
++    </message>
++    <message>
++        <source>Principal highway</source>
++        <translation>Principal highway</translation>
++    </message>
++    <message>
++        <source>Highway ramp, high speed</source>
++        <translation>Highway ramp, high speed</translation>
++    </message>
++    <message>
++        <source>&lt;p&gt;Failed to load file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;However, if the basemap is still old format I am able to let you select the map tiles for upload&lt;/p&gt;</source>
++        <translation>&lt;p&gt;Failed to load file:&lt;/p&gt;&lt;p&gt;%1&lt;/p&gt;&lt;p&gt;However, if the basemap is still old format I am able to let you select the map tiles for upload&lt;/p&gt;</translation>
++    </message>
++    <message>
++        <source>Forest</source>
++        <translation>Forest</translation>
++    </message>
++    <message>
++        <source>Gaelic</source>
++        <translation>Gaelic</translation>
++    </message>
++    <message>
++        <source>Hungarian</source>
++        <translation>Hungarian</translation>
++    </message>
++    <message>
++        <source>French</source>
++        <translation>French</translation>
++    </message>
++    <message>
++        <source>German</source>
++        <translation>German</translation>
++    </message>
++    <message>
++        <source>Marina</source>
++        <translation>Marina</translation>
++    </message>
++    <message>
++        <source>No basemap projection. That shouldn&apos;t happen.</source>
++        <translation>No basemap projection. That shouldn&apos;t happen.</translation>
++    </message>
++    <message>
++        <source>Polish</source>
++        <translation>Polish</translation>
++    </message>
++    <message>
++        <source>Slovak</source>
++        <translation>Slovak</translation>
++    </message>
++    <message>
++        <source>Stream</source>
++        <translation>Stream</translation>
++    </message>
++    <message>
++        <source>Tundra</source>
++        <translation>Tundra</translation>
++    </message>
++    <message>
++        <source>Romanian</source>
++        <translation>Romanian</translation>
++    </message>
++    <message>
++        <source>Major lake</source>
++        <translation>Major lake</translation>
++    </message>
++    <message>
++        <source>University/College</source>
++        <translation>University/College</translation>
++    </message>
++    <message>
++        <source>Hazard boundary</source>
++        <translation>Hazard boundary</translation>
++    </message>
++    <message>
++        <source>Shoreline</source>
++        <translation>Shoreline</translation>
++    </message>
++    <message>
++        <source>Hospital</source>
++        <translation>Hospital</translation>
++    </message>
++    <message>
++        <source>Slovenian</source>
++        <translation>Slovenian</translation>
++    </message>
++    <message>
++        <source>County/parish border</source>
++        <translation>County/parish border</translation>
++    </message>
++    <message>
++        <source>Golf course</source>
++        <translation>Golf course</translation>
++    </message>
++    <message>
++        <source>Large River</source>
++        <translation>Large River</translation>
++    </message>
++    <message>
++        <source>Airport runway</source>
++        <translation>Airport runway</translation>
++    </message>
++    <message>
++        <source>Rural housing area</source>
++        <translation>Rural housing area</translation>
++    </message>
++    <message>
++        <source>POI labels</source>
++        <translation>POI labels</translation>
++    </message>
++    <message>
++        <source>Intermittent stream</source>
++        <translation>Intermittent stream</translation>
++    </message>
++    <message>
++        <source>Railroad</source>
++        <translation>Railroad</translation>
++    </message>
++    <message>
++        <source>Airport</source>
++        <translation>Airport</translation>
++    </message>
++    <message>
++        <source>Galician</source>
++        <translation>Galician</translation>
++    </message>
++    <message>
++        <source>Other highway</source>
++        <translation>Other highway</translation>
++    </message>
++    <message>
++        <source>Residential street</source>
++        <translation>Residential street</translation>
++    </message>
++    <message>
++        <source>Intermediate land contour</source>
++        <translation>Intermediate land contour</translation>
++    </message>
++    <message>
++        <source>Minor depth contour</source>
++        <translation>Minor depth contour</translation>
++    </message>
++    <message>
++        <source>Blue (unknown)</source>
++        <translation>Blue (unknown)</translation>
++    </message>
++    <message>
++        <source>Orchard/Plantation</source>
++        <translation>Orchard/Plantation</translation>
++    </message>
++    <message>
++        <source>Industrial complex</source>
++        <translation>Industrial complex</translation>
++    </message>
++    <message>
++        <source>State/province border</source>
++        <translation>State/province border</translation>
++    </message>
++    <message>
++        <source>&lt;p&gt;&lt;b&gt;However ...&lt;/b&gt;&lt;/p&gt;&lt;p&gt;as I can read the basemap, and the information from the *tdb file,&lt;br&gt;I am able to let you select the map tiles for upload. To do this I&lt;br/&gt;need the unlock key (25 digits) for this map, as it has to be uploaded&lt;br/&gt;to the unit together with the map.&lt;/p&gt;</source>
++        <translation>&lt;p&gt;&lt;b&gt;However ...&lt;/b&gt;&lt;/p&gt;&lt;p&gt;as I can read the basemap, and the information from the *tdb file,&lt;br&gt;I am able to let you select the map tiles for upload. To do this I&lt;br/&gt;need the unlock key (25 digits) for this map, as it has to be uploaded&lt;br/&gt;to the unit together with the map.&lt;/p&gt;</translation>
++    </message>
++    <message>
++        <source>Croatian</source>
++        <translation>Croatian</translation>
++    </message>
++    <message>
++        <source>Bosnian</source>
++        <translation>Bosnian</translation>
++    </message>
++    <message>
++        <source>Catalan</source>
++        <translation>Catalan</translation>
++    </message>
++    <message>
++        <source>Reservation</source>
++        <translation>Reservation</translation>
++    </message>
++    <message>
++        <source>Serbian</source>
++        <translation>Serbian</translation>
++    </message>
++    <message>
++        <source>Russian</source>
++        <translation>Russian</translation>
++    </message>
++    <message>
++        <source>Norwegian</source>
++        <translation>Norwegian</translation>
++    </message>
++    <message>
++        <source>Man-made area</source>
++        <translation>Man-made area</translation>
++    </message>
++    <message>
++        <source>International border</source>
++        <translation>International border</translation>
++    </message>
++    <message>
++        <source>Medium River</source>
++        <translation>Medium River</translation>
++    </message>
++    <message>
++        <source>Spanish</source>
++        <translation>Spanish</translation>
++    </message>
++    <message>
++        <source>State park</source>
++        <translation>State park</translation>
++    </message>
++    <message>
++        <source>Detail  0</source>
++        <translation>Detail  0</translation>
++    </message>
++    <message>
++        <source>Detail  1</source>
++        <translation>Detail  1</translation>
++    </message>
++    <message>
++        <source>Detail  2</source>
++        <translation>Detail  2</translation>
++    </message>
++    <message>
++        <source>Detail  3</source>
++        <translation>Detail  3</translation>
++    </message>
++    <message>
++        <source>Detail  4</source>
++        <translation>Detail  4</translation>
++    </message>
++    <message>
++        <source>Detail  5</source>
++        <translation>Detail  5</translation>
++    </message>
++    <message>
++        <source>Detail -1</source>
++        <translation>Detail -1</translation>
++    </message>
++    <message>
++        <source>Detail -2</source>
++        <translation>Detail -2</translation>
++    </message>
++    <message>
++        <source>Detail -3</source>
++        <translation>Detail -3</translation>
++    </message>
++    <message>
++        <source>Detail -4</source>
++        <translation>Detail -4</translation>
++    </message>
++    <message>
++        <source>Detail -5</source>
++        <translation>Detail -5</translation>
++    </message>
++    <message>
++        <source>Alley/Private road</source>
++        <translation>Alley/Private road</translation>
++    </message>
++    <message>
++        <source>Estonian</source>
++        <translation>Estonian</translation>
++    </message>
++    <message>
++        <source>Swedish</source>
++        <translation>Swedish</translation>
++    </message>
++    <message>
++        <source>Medium lake</source>
++        <translation>Medium lake</translation>
++    </message>
++    <message>
++        <source>Macedonian</source>
++        <translation>Macedonian</translation>
++    </message>
++    <message>
++        <source>City park</source>
++        <translation>City park</translation>
++    </message>
++    <message>
++        <source>Level: %1 Bits: %2 On basmap: %3</source>
++        <translation>Level: %1 Bits: %2 On basmap: %3</translation>
++    </message>
++    <message>
++        <source>Portuguese</source>
++        <translation>Portuguese</translation>
++    </message>
++    <message>
++        <source>Unspecified</source>
++        <translation>Unspecified</translation>
++    </message>
++    <message>
++        <source>Turkish</source>
++        <translation>Turkish</translation>
++    </message>
++    <message>
++        <source>Cemetery</source>
++        <translation>Cemetery</translation>
++    </message>
++    <message>
++        <source>English</source>
++        <translation>English</translation>
++    </message>
++    <message>
++        <source>Unknown</source>
++        <translation>Unknown</translation>
++    </message>
++    <message>
++        <source>Large urban area (&amp;gt;200K)</source>
++        <translation>Large urban area (&amp;gt;200K)</translation>
++    </message>
++    <message>
++        <source>Wetland/Swamp</source>
++        <translation>Wetland/Swamp</translation>
++    </message>
++    <message>
++        <source>Select Base Map for </source>
++        <translation>Select Base Map for </translation>
++    </message>
++    <message>
++        <source>However ...</source>
++        <translation>However ...</translation>
++    </message>
++    <message>
++        <source>Small urban area (&amp;lt;200K)</source>
++        <translation>Small urban area (&amp;lt;200K)</translation>
++    </message>
++    <message>
++        <source>Finnish</source>
++        <translation>Finnish</translation>
++    </message>
++    <message>
++        <source>Large lake</source>
++        <translation>Large lake</translation>
++    </message>
++    <message>
++        <source>Major highway</source>
++        <translation>Major highway</translation>
++    </message>
++    <message>
++        <source>Military base</source>
++        <translation>Military base</translation>
++    </message>
++    <message>
++        <source>Powerline</source>
++        <translation>Powerline</translation>
++    </message>
++    <message>
++        <source>Intermediate depth contour</source>
++        <translation>Intermediate depth contour</translation>
++    </message>
++    <message>
++        <source>Small River</source>
++        <translation>Small River</translation>
++    </message>
++    <message>
++        <source>Glacier</source>
++        <translation>Glacier</translation>
++    </message>
++    <message>
++        <source>Parking garage</source>
++        <translation>Parking garage</translation>
++    </message>
++    <message>
++        <source>Minor land contour</source>
++        <translation>Minor land contour</translation>
++    </message>
++    <message>
++        <source>Major land contour</source>
++        <translation>Major land contour</translation>
++    </message>
++    <message>
++        <source>Unpaved road</source>
++        <translation>Unpaved road</translation>
++    </message>
++    <message>
++        <source>Major highway connector</source>
++        <translation>Major highway connector</translation>
++    </message>
++    <message>
++        <source>Sports complex</source>
++        <translation>Sports complex</translation>
++    </message>
++    <message>
++        <source>Arterial road</source>
++        <translation>Arterial road</translation>
++    </message>
++    <message>
++        <source>Lithuanian</source>
++        <translation>Lithuanian</translation>
++    </message>
++    <message>
++        <source>Marine boundary</source>
++        <translation>Marine boundary</translation>
++    </message>
++</context>
++<context>
++    <name>CMapTms</name>
++    <message>
++        <source>%1 %2</source>
++        <translation>%1 %2</translation>
++    </message>
++    <message>
++        <source>Copyright notice is missing.</source>
++        <translation>Copyright notice is missing.</translation>
++    </message>
++    <message>
++        <source>Overzoom x%1</source>
++        <translation>Overzoom x%1</translation>
++    </message>
++    <message>
++        <source>Map loaded.</source>
++        <translation>Map loaded.</translation>
++    </message>
++    <message>
++        <source>Failed to read: %1
++line %2, column %3:
++ %4</source>
++        <translation>Failed to read: %1
++line %2, column %3:
++ %4</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Zoom level x%1</source>
++        <translation>Zoom level x%1</translation>
++    </message>
++    <message>
++        <source>Wait for %1 tiles.</source>
++        <translation>Wait for %1 tiles.</translation>
++    </message>
++    <message>
++        <source>Failed to open %1</source>
++        <translation>Failed to open %1</translation>
++    </message>
++</context>
++<context>
++    <name>CMapToolWidget</name>
++    <message>
++        <source>Maps</source>
++        <translation>Maps</translation>
++    </message>
++    <message>
++        <source>Garmin/TDB/IMG</source>
++        <translation>Garmin/TDB/IMG</translation>
++    </message>
++    <message>
++        <source>use a single click to deactivate map as overlay</source>
++        <translation>use a single click to deactivate map as overlay</translation>
++    </message>
++    <message>
++        <source>map stack/QMAP</source>
++        <translation>map stack/QMAP</translation>
++    </message>
++    <message>
++        <source>use a single click to activate map as overlay</source>
++        <translation>use a single click to activate map as overlay</translation>
++    </message>
++    <message>
++        <source>various projections</source>
++        <translation>various projections</translation>
++    </message>
++    <message>
++        <source>Info/Config</source>
++        <translation>Info/Config</translation>
++    </message>
++    <message>
++        <source>Error export maps...</source>
++        <translation>Error export maps...</translation>
++    </message>
++    <message>
++        <source>Add DEM...</source>
++        <translation>Add DEM...</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Del. DEM...</source>
++        <translation>Del. DEM...</translation>
++    </message>
++    <message>
++        <source>Export</source>
++        <translation>Export</translation>
++    </message>
++    <message>
++        <source>Raster</source>
++        <translation>Raster</translation>
++    </message>
++    <message>
++        <source>Stream</source>
++        <translation>Stream</translation>
++    </message>
++    <message>
++        <source>Vector</source>
++        <translation>Vector</translation>
++    </message>
++    <message>
++        <source>map server</source>
++        <translation>map server</translation>
++    </message>
++    <message>
++        <source>tile server</source>
++        <translation>tile server</translation>
++    </message>
++    <message>
++        <source>BirdsEye/JNX</source>
++        <translation>BirdsEye/JNX</translation>
++    </message>
++    <message>
++        <source>TwoNav/RMAP</source>
++        <translation>TwoNav/RMAP</translation>
++    </message>
++    <message>
++        <source>You need to have the GDAL toolchain installed in your path.</source>
++        <translation>You need to have the GDAL toolchain installed in your path.</translation>
++    </message>
++    <message>
++        <source>selected map</source>
++        <translation>selected map</translation>
++    </message>
++    <message>
++        <source>Add TMS map...</source>
++        <translation>Add TMS map...</translation>
++    </message>
++    <message>
++        <source>Select DEM file...</source>
++        <translation>Select DEM file...</translation>
++    </message>
++    <message>
++        <source>Reload map...</source>
++        <translation>Reload map...</translation>
++    </message>
++    <message>
++        <source>Magellan/RMP</source>
++        <translation>Magellan/RMP</translation>
++    </message>
++    <message>
++        <source>16bit Srtm Data (*.tif *.tiff *.hgt *.blx *.vrt)</source>
++        <translation>16bit Srtm Data (*.tif *.tiff *.hgt *.blx *.vrt)</translation>
++    </message>
++</context>
++<context>
++    <name>CMapWms</name>
++    <message>
++        <source>%1 %2</source>
++        <translation>%1 %2</translation>
++    </message>
++    <message>
++        <source>Overzoom x%1</source>
++        <translation>Overzoom x%1</translation>
++    </message>
++    <message>
++        <source>Map loaded.</source>
++        <translation>Map loaded.</translation>
++    </message>
++    <message>
++        <source>Copyright notice is missing. Use &lt;copyright&gt; tag in &lt;service&gt; secton to supply a copyright notice.</source>
++        <translation>Copyright notice is missing. Use &lt;copyright&gt; tag in &lt;service&gt; secton to supply a copyright notice.</translation>
++    </message>
++    <message>
++        <source>Failed to read: %1
++line %2, column %3:
++ %4</source>
++        <translation>Failed to read: %1
++line %2, column %3:
++ %4</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>Zoom level x%1</source>
++        <translation>Zoom level x%1</translation>
++    </message>
++    <message>
++        <source>Wait for %1 tiles.</source>
++        <translation>Wait for %1 tiles.</translation>
++    </message>
++    <message>
++        <source>Failed to open %1</source>
++        <translation>Failed to open %1</translation>
++    </message>
++    <message>
++        <source>Unknown projection %1</source>
++        <translation>Unknown projection %1</translation>
++    </message>
++</context>
++<context>
++    <name>CMegaMenu</name>
++    <message>
++        <source>%1 ...</source>
++        <translation>%1 ...</translation>
++    </message>
++</context>
++<context>
++    <name>CMenus</name>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++    <message>
++        <source>F%1</source>
++        <translation>F%1</translation>
++    </message>
++    <message>
++        <source>Esc</source>
++        <translation>Esc</translation>
++    </message>
++    <message>
++        <source>ActionGroup %1 not defined. Please fix.</source>
++        <translation>ActionGroup %1 not defined. Please fix.</translation>
++    </message>
++</context>
++<context>
++    <name>CMouseMoveMap</name>
++    <message>
++        <source>Crop map: %1x%2 w:%3 h:%4</source>
++        <translation>Crop map: %1x%2 w:%3 h:%4</translation>
++    </message>
++    <message>
++        <source>Map: N %1m E %2m</source>
++        <translation>Map: N %1m E %2m</translation>
++    </message>
++    <message>
++        <source>Grid: N %1m E %2m</source>
++        <translation>Grid: N %1m E %2m</translation>
++    </message>
++    <message>
++        <source>Pixel %1x%2 (%3)</source>
++        <translation>Pixel %1x%2 (%3)</translation>
++    </message>
++    <message>
++        <source>Split Track ...</source>
++        <translation>Split Track ...</translation>
++    </message>
++    <message>
++        <source>Crop: set pos. 1</source>
++        <translation>Crop: set pos. 1</translation>
++    </message>
++    <message>
++        <source>Reload Map</source>
++        <translation>Reload Map</translation>
++    </message>
++    <message>
++        <source>Move map</source>
++        <translation>Move map</translation>
++    </message>
++    <message>
++        <source>Grid: %1</source>
++        <translation>Grid: %1</translation>
++    </message>
++    <message>
++        <source>Add Waypoint ...</source>
++        <translation>Add Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Edit Waypoint ...</source>
++        <translation>Edit Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Delete Waypoint</source>
++        <translation>Delete Waypoint</translation>
++    </message>
++    <message>
++        <source>Edit Track ...</source>
++        <translation>Edit Track ...</translation>
++    </message>
++    <message>
++        <source>Copy Pos. Waypoint</source>
++        <translation>Copy Pos. Waypoint</translation>
++    </message>
++    <message>
++        <source>Open Pos. with Google Maps</source>
++        <translation>Open Pos. with Google Maps</translation>
++    </message>
++    <message>
++        <source>Move Waypoint</source>
++        <translation>Move Waypoint</translation>
++    </message>
++    <message>
++        <source>Copy Pos. Trackpoint</source>
++        <translation>Copy Pos. Trackpoint</translation>
++    </message>
++    <message>
++        <source>N %1m E %2m</source>
++        <translation>N %1m E %2m</translation>
++    </message>
++</context>
++<context>
++    <name>CMouseRefPoint</name>
++    <message>
++        <source>%1</source>
++        <translation>%1</translation>
++    </message>
++    <message>
++        <source>Pos1 -&gt; Pos %1x%2 w:%3 h:%4</source>
++        <translation>Pos1 -&gt; Pos %1x%2 w:%3 h:%4</translation>
++    </message>
++    <message>
++        <source>Set as Pos1</source>
++        <translation>Set as Pos1</translation>
++    </message>
++    <message>
++        <source>Pixel %1x%2</source>
++        <translation>Pixel %1x%2</translation>
++    </message>
++</context>
++<context>
++    <name>CMouseSelMap</name>
++    <message>
++        <source>Select no tiles</source>
++        <translation>Select no tiles</translation>
++    </message>
++    <message>
++        <source>Select all tiles</source>
++        <translation>Select all tiles</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayArea</name>
++    <message>
++        <source>Area %1</source>
++        <translation type="unfinished">Area %1</translation>
++    </message>
++    <message>
++        <source>Overlay</source>
++        <translation type="unfinished">Overlay</translation>
++    </message>
++    <message>
++        <source>Edit...</source>
++        <translation type="unfinished">Edit...</translation>
++    </message>
++    <message>
++        <source>Show</source>
++        <translation type="unfinished">Show</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayAreaEditWidget</name>
++    <message>
++        <source>Delete</source>
++        <translation type="unfinished">Delete</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayDB</name>
++    <message>
++        <source>Geo ref. text</source>
++        <translation>Geo ref. text</translation>
++    </message>
++    <message>
++        <source>Overlay</source>
++        <translation>Overlay</translation>
++    </message>
++    <message>
++        <source>Static text</source>
++        <translation>Static text</translation>
++    </message>
++    <message>
++        <source>Area</source>
++        <translation type="unfinished">Area</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayDistance</name>
++    <message>
++        <source>%1:</source>
++        <translation>%1:</translation>
++    </message>
++    <message>
++        <source>Show</source>
++        <translation>Show</translation>
++    </message>
++    <message>
++        <source>Revert</source>
++        <translation>Revert</translation>
++    </message>
++    <message>
++        <source>Overlay</source>
++        <translation>Overlay</translation>
++    </message>
++    <message>
++        <source>Make Route</source>
++        <translation>Make Route</translation>
++    </message>
++    <message>
++        <source>Make Track</source>
++        <translation>Make Track</translation>
++    </message>
++    <message>
++        <source>Tour %1</source>
++        <translation>Tour %1</translation>
++    </message>
++    <message>
++        <source>Edit...</source>
++        <translation>Edit...</translation>
++    </message>
++    <message>
++        <source>Show Bullets</source>
++        <translation>Show Bullets</translation>
++    </message>
++    <message>
++        <source>Length: %1 %2</source>
++        <translation>Length: %1 %2</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayDistanceEditWidget</name>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayText</name>
++    <message>
++        <source>no text</source>
++        <translation>no text</translation>
++    </message>
++</context>
++<context>
++    <name>COverlayToolWidget</name>
++    <message>
++        <source>Draw</source>
++        <translation>Draw</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Zoom to fit</source>
++        <translation>Zoom to fit</translation>
++    </message>
++</context>
++<context>
++    <name>CPlot</name>
++    <message>
++        <source>No or bad data.</source>
++        <translation>No or bad data.</translation>
++    </message>
++    <message>
++        <source>Add Waypoint...</source>
++        <translation>Add Waypoint...</translation>
++    </message>
++    <message>
++        <source>Select output file</source>
++        <translation>Select output file</translation>
++    </message>
++    <message>
++        <source>Save...</source>
++        <translation>Save...</translation>
++    </message>
++    <message>
++        <source>Vertical zoom</source>
++        <translation>Vertical zoom</translation>
++    </message>
++    <message>
++        <source>Reset zoom</source>
++        <translation>Reset zoom</translation>
++    </message>
++</context>
++<context>
++    <name>CResources</name>
++    <message>
++        <source>You have to select a device in Setup-&gt;Config-&gt;Device &amp; Xfer</source>
++        <translation>You have to select a device in Setup-&gt;Config-&gt;Device &amp; Xfer</translation>
++    </message>
++    <message>
++        <source>No device.</source>
++        <translation>No device.</translation>
++    </message>
++</context>
++<context>
++    <name>CRoute</name>
++    <message>
++        <source>
++time: </source>
++        <translation>
++time: </translation>
++    </message>
++    <message>
++        <source>
++time: %1:</source>
++        <translation>
++time: %1:</translation>
++    </message>
++    <message>
++        <source>
++length: %1 %2</source>
++        <translation>
++length: %1 %2</translation>
++    </message>
++</context>
++<context>
++    <name>CRouteDB</name>
++    <message>
++        <source>Route%1</source>
++        <translation>Route%1</translation>
++    </message>
++    <message>
++        <source>Unnamed</source>
++        <translation>Unnamed</translation>
++    </message>
++</context>
++<context>
++    <name>CRouteToolWidget</name>
++    <message>
++        <source>Edit</source>
++        <translation>Edit</translation>
++    </message>
++    <message>
++        <source>Failed...</source>
++        <translation>Failed...</translation>
++    </message>
++    <message>
++        <source>Calc. route</source>
++        <translation>Calc. route</translation>
++    </message>
++    <message>
++        <source>Czech</source>
++        <translation>Czech</translation>
++    </message>
++    <message>
++        <source>Dutch</source>
++        <translation>Dutch</translation>
++    </message>
++    <message>
++        <source>Reset</source>
++        <translation>Reset</translation>
++    </message>
++    <message>
++        <source>Italian</source>
++        <translation>Italian</translation>
++    </message>
++    <message>
++        <source>de - Ruhrpott</source>
++        <translation>de - Ruhrpott</translation>
++    </message>
++    <message>
++        <source>created from route</source>
++        <translation>created from route</translation>
++    </message>
++    <message>
++        <source>Dutch (belgium)</source>
++        <translation>Dutch (belgium)</translation>
++    </message>
++    <message>
++        <source>de - Bavarian</source>
++        <translation>de - Bavarian</translation>
++    </message>
++    <message>
++        <source>Bulgarian</source>
++        <translation>Bulgarian</translation>
++    </message>
++    <message>
++        <source>Make Overlay</source>
++        <translation>Make Overlay</translation>
++    </message>
++    <message>
++        <source>Danish</source>
++        <translation>Danish</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Hungarian</source>
++        <translation>Hungarian</translation>
++    </message>
++    <message>
++        <source>French</source>
++        <translation>French</translation>
++    </message>
++    <message>
++        <source>German</source>
++        <translation>German</translation>
++    </message>
++    <message>
++        <source>Portuguese (brazil)</source>
++        <translation>Portuguese (brazil)</translation>
++    </message>
++    <message>
++        <source>Routes</source>
++        <translation>Routes</translation>
++    </message>
++    <message>
++        <source>Romanian</source>
++        <translation>Romanian</translation>
++    </message>
++    <message>
++        <source>Esperanto</source>
++        <translation>Esperanto</translation>
++    </message>
++    <message>
++        <source>Pedestrian/pub. transp.</source>
++        <translation>Pedestrian/pub. transp.</translation>
++    </message>
++    <message>
++        <source>Make Track</source>
++        <translation>Make Track</translation>
++    </message>
++    <message>
++        <source>Zoom to fit</source>
++        <translation>Zoom to fit</translation>
++    </message>
++    <message>
++        <source>de - Op Platt</source>
++        <translation>de - Op Platt</translation>
++    </message>
++    <message>
++        <source>Bicycle safest</source>
++        <translation>Bicycle safest</translation>
++    </message>
++    <message>
++        <source>Japanese</source>
++        <translation>Japanese</translation>
++    </message>
++    <message>
++        <source>Bicycle</source>
++        <translation>Bicycle</translation>
++    </message>
++    <message>
++        <source>Croatian</source>
++        <translation>Croatian</translation>
++    </message>
++    <message>
++        <source>Catalan</source>
++        <translation>Catalan</translation>
++    </message>
++    <message>
++        <source>Russian</source>
++        <translation>Russian</translation>
++    </message>
++    <message>
++        <source>Norwegian</source>
++        <translation>Norwegian</translation>
++    </message>
++    <message>
++        <source>Spanish</source>
++        <translation>Spanish</translation>
++    </message>
++    <message>
++        <source>Svenska</source>
++        <translation>Svenska</translation>
++    </message>
++    <message>
++        <source>Swedish</source>
++        <translation>Swedish</translation>
++    </message>
++    <message>
++        <source>Bad response from server:
++%1</source>
++        <translation>Bad response from server:
++%1</translation>
++    </message>
++    <message>
++        <source>Vietnamese</source>
++        <translation>Vietnamese</translation>
++    </message>
++    <message>
++        <source>Route request timed out. Please try again later.</source>
++        <translation>Route request timed out. Please try again later.</translation>
++    </message>
++    <message>
++        <source>Turkish</source>
++        <translation>Turkish</translation>
++    </message>
++    <message>
++        <source>de - great Austrian dialect</source>
++        <translation>de - great Austrian dialect</translation>
++    </message>
++    <message>
++        <source>US English</source>
++        <translation>US English</translation>
++    </message>
++    <message>
++        <source>English</source>
++        <translation>English</translation>
++    </message>
++    <message>
++        <source>Mountain bike</source>
++        <translation>Mountain bike</translation>
++    </message>
++    <message>
++        <source>de - Swabian</source>
++        <translation>de - Swabian</translation>
++    </message>
++    <message>
++        <source>Fastest</source>
++        <translation>Fastest</translation>
++    </message>
++    <message>
++        <source>Pedestrian</source>
++        <translation>Pedestrian</translation>
++    </message>
++    <message>
++        <source>British English</source>
++        <translation>British English</translation>
++    </message>
++    <message>
++        <source>Finnish</source>
++        <translation>Finnish</translation>
++    </message>
++    <message>
++        <source>de - Berlin dialect</source>
++        <translation>de - Berlin dialect</translation>
++    </message>
++    <message>
++        <source>de - Rhenish</source>
++        <translation>de - Rhenish</translation>
++    </message>
++    <message>
++        <source>Norwegian-bokmal</source>
++        <translation>Norwegian-bokmal</translation>
++    </message>
++    <message>
++        <source>Shortest</source>
++        <translation>Shortest</translation>
++    </message>
++    <message>
++        <source>Bicycle racer</source>
++        <translation>Bicycle racer</translation>
++    </message>
++    <message>
++        <source>Bicycle route</source>
++        <translation>Bicycle route</translation>
++    </message>
++</context>
++<context>
++    <name>CSearchDB</name>
++    <message>
++        <source>finished</source>
++        <translation>finished</translation>
++    </message>
++    <message>
++        <source>Failed. No location because of legal matters.</source>
++        <translation type="obsolete">Failed. No location because of legal matters.</translation>
++    </message>
++    <message>
++        <source>Failed. No location found.</source>
++        <translation type="obsolete">Failed. No location found.</translation>
++    </message>
++    <message>
++        <source>Failed. Missing query string.</source>
++        <translation type="obsolete">Failed. Missing query string.</translation>
++    </message>
++    <message>
++        <source>no result</source>
++        <translation>no result</translation>
++    </message>
++    <message>
++        <source>Failed. Bad API key.</source>
++        <translation type="obsolete">Failed. Bad API key.</translation>
++    </message>
++    <message>
++        <source>Failed. Reason unknown.</source>
++        <translation type="obsolete">Failed. Reason unknown.</translation>
++    </message>
++    <message>
++        <source>Success.</source>
++        <translation type="obsolete">Success.</translation>
++    </message>
++    <message>
++        <source>Unknown host.</source>
++        <translation>Unknown host.</translation>
++    </message>
++    <message>
++        <source>Bad number of return parameters</source>
++        <translation type="obsolete">Bad number of return parameters</translation>
++    </message>
++    <message>
++        <source>start searching...</source>
++        <translation>start searching...</translation>
++    </message>
++    <message>
++        <source>Unknown response</source>
++        <translation>Unknown response</translation>
++    </message>
++    <message>
++        <source>Error: </source>
++        <translation>Error: </translation>
++    </message>
++</context>
++<context>
++    <name>CSearchToolWidget</name>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Google</source>
++        <translation>Google</translation>
++    </message>
++    <message>
++        <source>Search</source>
++        <translation>Search</translation>
++    </message>
++    <message>
++        <source>OpenRouteService</source>
++        <translation>OpenRouteService</translation>
++    </message>
++    <message>
++        <source>Add Waypoint ...</source>
++        <translation>Add Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Copy Position</source>
++        <translation>Copy Position</translation>
++    </message>
++</context>
++<context>
++    <name>CTextEditWidget</name>
++    <message>
++        <source>Cu&amp;t</source>
++        <translation>Cu&amp;t</translation>
++    </message>
++    <message>
++        <source>&amp;Bold</source>
++        <translation>&amp;Bold</translation>
++    </message>
++    <message>
++        <source>&amp;Copy</source>
++        <translation>&amp;Copy</translation>
++    </message>
++    <message>
++        <source>&amp;Left</source>
++        <translation>&amp;Left</translation>
++    </message>
++    <message>
++        <source>&amp;Redo</source>
++        <translation>&amp;Redo</translation>
++    </message>
++    <message>
++        <source>&amp;Undo</source>
++        <translation>&amp;Undo</translation>
++    </message>
++    <message>
++        <source>&amp;Justify</source>
++        <translation>&amp;Justify</translation>
++    </message>
++    <message>
++        <source>&amp;Paste</source>
++        <translation>&amp;Paste</translation>
++    </message>
++    <message>
++        <source>&amp;Right</source>
++        <translation>&amp;Right</translation>
++    </message>
++    <message>
++        <source>C&amp;enter</source>
++        <translation>C&amp;enter</translation>
++    </message>
++    <message>
++        <source>&amp;Color...</source>
++        <translation>&amp;Color...</translation>
++    </message>
++    <message>
++        <source>&amp;Underline</source>
++        <translation>&amp;Underline</translation>
++    </message>
++    <message>
++        <source>&amp;Italic</source>
++        <translation>&amp;Italic</translation>
++    </message>
++</context>
++<context>
++    <name>CTrack</name>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++    <message>
++        <source>elevation: %1 %2</source>
++        <translation type="obsolete">elevation: %1 %2</translation>
++    </message>
++    <message>
++        <source>
++time: </source>
++        <translation>
++time: </translation>
++    </message>
++    <message>
++        <source>
++time: %1:</source>
++        <translation>
++time: %1:</translation>
++    </message>
++    <message>
++        <source>Warning...</source>
++        <translation>Warning...</translation>
++    </message>
++    <message>
++        <source>
++moving: %1:</source>
++        <translation>
++moving: %1:</translation>
++    </message>
++    <message>
++        <source>
++moving: </source>
++        <translation>
++moving: </translation>
++    </message>
++    <message>
++        <source>, points: %1 (%2)</source>
++        <translation>, points: %1 (%2)</translation>
++    </message>
++    <message>
++        <source>
++ %1: %2 </source>
++        <translation>
++ %1: %2 </translation>
++    </message>
++    <message>
++        <source>
++start: %1</source>
++        <translation>
++start: %1</translation>
++    </message>
++    <message>
++        <source>, speed: %1 %2</source>
++        <translation>, speed: %1 %2</translation>
++    </message>
++    <message>
++        <source>
++end: %1</source>
++        <translation>
++end: %1</translation>
++    </message>
++    <message>
++        <source>%5 %4 %1%2 (%3%)</source>
++        <translation>%5 %4 %1%2 (%3%)</translation>
++    </message>
++    <message>
++        <source>
++%1%2 %3, %4%5 %6</source>
++        <translation>
++%1%2 %3, %4%5 %6</translation>
++    </message>
++    <message>
++        <source>
++length: %1 %2</source>
++        <translation>
++length: %1 %2</translation>
++    </message>
++    <message>
++        <source>You are trying to find waypoints along a track with %1 waypoints and a track of size %2. This can be a very time consuming operation. Go on?
++
++Your selection will be stored in the track&apos;s data. You can save it along with the data. To change the selection use the checkbox in the track edit dialog.</source>
++        <translation>You are trying to find waypoints along a track with %1 waypoints and a track of size %2. This can be a very time consuming operation. Go on?
++
++Your selection will be stored in the track&apos;s data. You can save it along with the data. To change the selection use the checkbox in the track edit dialog.</translation>
++    </message>
++    <message>
++        <source> %3 %1 %2</source>
++        <translation> %3 %1 %2</translation>
++    </message>
++    <message>
++        <source>Start</source>
++        <translation>Start</translation>
++    </message>
++    <message>
++        <source>End</source>
++        <translation>End</translation>
++    </message>
++    <message>
++        <source> %3 %1 %2 </source>
++        <translation> %3 %1 %2 </translation>
++    </message>
++    <message>
++        <source>| %3 %1 %2</source>
++        <translation>| %3 %1 %2</translation>
++    </message>
++    <message>
++        <source> %1 %2</source>
++        <translation> %1 %2</translation>
++    </message>
++    <message>
++        <source> %1 :%2</source>
++        <translation> %1 :%2</translation>
++    </message>
++    <message>
++        <source>%5 %4 %1:%2:%3 (%6%)</source>
++        <translation>%5 %4 %1:%2:%3 (%6%)</translation>
++    </message>
++    <message>
++        <source>%4 %1:%2:%3 (%5%)</source>
++        <translation>%4 %1:%2:%3 (%5%)</translation>
++    </message>
++    <message>
++        <source>%4 %1%2 (%3%)</source>
++        <translation>%4 %1%2 (%3%)</translation>
++    </message>
++    <message>
++        <source>elevation: %1%2</source>
++        <translation>elevation: %1%2</translation>
++    </message>
++    <message>
++        <source>heart rate: %1bpm</source>
++        <translation>heart rate: %1bpm</translation>
++    </message>
++    <message>
++        <source>cadence: %1rpm</source>
++        <translation>cadence: %1rpm</translation>
++    </message>
++    <message>
++        <source> .. (%6%) %1:%2:%3 %4 %5</source>
++        <translation> .. (%6%) %1:%2:%3 %4 %5</translation>
++    </message>
++    <message>
++        <source> .. (%5%) %1:%2:%3 %4</source>
++        <translation> .. (%5%) %1:%2:%3 %4</translation>
++    </message>
++    <message>
++        <source> .. (%3%) %1%2 %4 %5</source>
++        <translation> .. (%3%) %1%2 %4 %5</translation>
++    </message>
++    <message>
++        <source> .. (%3%) %1%2 %4</source>
++        <translation> .. (%3%) %1%2 %4</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>This track has no valid start timestamp. Use the &apos;Date/Time&apos; track filter to set one.</source>
++        <translation>This track has no valid start timestamp. Use the &apos;Date/Time&apos; track filter to set one.</translation>
++    </message>
++    <message>
++        <source>Slope [°]</source>
++        <translation>Slope [°]</translation>
++    </message>
++    <message>
++        <source>Elevation [m]</source>
++        <translation>Elevation [m]</translation>
++    </message>
++    <message>
++        <source>solid</source>
++        <translation>solid</translation>
++    </message>
++    <message>
++        <source>slope</source>
++        <translation>slope</translation>
++    </message>
++    <message>
++        <source>elevation</source>
++        <translation>elevation</translation>
++    </message>
++    <message>
++        <source>slope: %1°</source>
++        <translation>slope: %1°</translation>
++    </message>
++    <message>
++        <source>Speed [km/h]</source>
++        <translation>Speed [km/h]</translation>
++    </message>
++    <message>
++        <source>speed</source>
++        <translation>speed</translation>
++    </message>
++    <message>
++        <source>speed: %1%2</source>
++        <translation>speed: %1%2</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackDB</name>
++    <message>
++        <source>_rev</source>
++        <translation>_rev</translation>
++    </message>
++    <message>
++        <source>Hmin=%1%2</source>
++        <translation>Hmin=%1%2</translation>
++    </message>
++    <message>
++        <source>Failed...</source>
++        <translation>Failed...</translation>
++    </message>
++    <message>
++        <source>Failed to copy track. You must select a track or track points of a track.</source>
++        <translation>Failed to copy track. You must select a track or track points of a track.</translation>
++    </message>
++    <message>
++        <source>Hmax=%1%2</source>
++        <translation>Hmax=%1%2</translation>
++    </message>
++    <message>
++        <source>Vmax=%1%2</source>
++        <translation>Vmax=%1%2</translation>
++    </message>
++    <message>
++        <source>Track%1</source>
++        <translation>Track%1</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackEditWidget</name>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++    <message>
++        <source>Name</source>
++        <translation>Name</translation>
++    </message>
++    <message>
++        <source>Pic.</source>
++        <translation>Pic.</translation>
++    </message>
++    <message>
++        <source>%1 %2</source>
++        <translation>%1 %2</translation>
++    </message>
++    <message>
++        <source>Remove track points ...</source>
++        <translation>Remove track points ...</translation>
++    </message>
++    <message>
++        <source>Prox.</source>
++        <translation>Prox.</translation>
++    </message>
++    <message>
++        <source>Split</source>
++        <translation>Split</translation>
++    </message>
++    <message>
++        <source>Total</source>
++        <translation>Total</translation>
++    </message>
++    <message>
++        <source>Profile/Dist.</source>
++        <translation>Profile/Dist.</translation>
++    </message>
++    <message>
++        <source>%1 %2 </source>
++        <translation>%1 %2 </translation>
++    </message>
++    <message>
++        <source>no extensions elements in this file</source>
++        <translation>no extensions elements in this file</translation>
++    </message>
++    <message>
++        <source>Dist./Time</source>
++        <translation>Dist./Time</translation>
++    </message>
++    <message>
++        <source>Profile/Time</source>
++        <translation>Profile/Time</translation>
++    </message>
++    <message>
++        <source>Speed/Dist.</source>
++        <translation>Speed/Dist.</translation>
++    </message>
++    <message>
++        <source>%1:%2 h</source>
++        <translation>%1:%2 h</translation>
++    </message>
++    <message>
++        <source>Comment</source>
++        <translation>Comment</translation>
++    </message>
++    <message>
++        <source>To Next</source>
++        <translation>To Next</translation>
++    </message>
++    <message>
++        <source>Speed/Time</source>
++        <translation>Speed/Time</translation>
++    </message>
++    <message>
++        <source>Trainee</source>
++        <translation>Trainee</translation>
++    </message>
++    <message>
++        <source>Elevation</source>
++        <translation>Elevation</translation>
++    </message>
++    <message>
++        <source>You are about to remove hidden track points permanently. If you press &apos;yes&apos;, all information will be lost.</source>
++        <translation>You are about to remove hidden track points permanently. If you press &apos;yes&apos;, all information will be lost.</translation>
++    </message>
++    <message>
++        <source>wpt</source>
++        <translation>wpt</translation>
++    </message>
++    <message>
++        <source>trk</source>
++        <translation>trk</translation>
++    </message>
++    <message>
++        <source>Start</source>
++        <translation>Start</translation>
++    </message>
++    <message>
++        <source>Start of track.</source>
++        <translation>Start of track.</translation>
++    </message>
++    <message>
++        <source>End</source>
++        <translation>End</translation>
++    </message>
++    <message>
++        <source>End of track.</source>
++        <translation>End of track.</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackFilterWidget</name>
++    <message>
++        <source>Edit name...</source>
++        <translation>Edit name...</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Filter name ...</source>
++        <translation>Filter name ...</translation>
++    </message>
++    <message>
++        <source>Please enter a name for the filter list to store.</source>
++        <translation>Please enter a name for the filter list to store.</translation>
++    </message>
++    <message>
++        <source>Delete track filter...</source>
++        <translation>Delete track filter...</translation>
++    </message>
++    <message>
++        <source>Do you really want to delete &apos;%1&apos;?</source>
++        <translation>Do you really want to delete &apos;%1&apos;?</translation>
++    </message>
++    <message>
++        <source>Abort filter</source>
++        <translation>Abort filter</translation>
++    </message>
++    <message>
++        <source> (local)</source>
++        <translation> (local)</translation>
++    </message>
++    <message>
++        <source> (remote)</source>
++        <translation> (remote)</translation>
++    </message>
++    <message>
++        <source>Reset</source>
++        <translatorcomment>Réinitialiser</translatorcomment>
++        <translation>Reset</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackStatDistanceWidget</name>
++    <message>
++        <source>time [h]</source>
++        <translation>time [h]</translation>
++    </message>
++    <message>
++        <source>distance [m]</source>
++        <translation>distance [m]</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackStatExtensionWidget</name>
++    <message>
++        <source>time [h]</source>
++        <translation>time [h]</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackStatProfileWidget</name>
++    <message>
++        <source>time [h]</source>
++        <translation>time [h]</translation>
++    </message>
++    <message>
++        <source>distance [m]</source>
++        <translation>distance [m]</translation>
++    </message>
++    <message>
++        <source>distance [%1]</source>
++        <translation>distance [%1]</translation>
++    </message>
++    <message>
++        <source>alt. [m]</source>
++        <translation>alt. [m]</translation>
++    </message>
++    <message>
++        <source>alt. [%1]</source>
++        <translation>alt. [%1]</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackStatSpeedWidget</name>
++    <message>
++        <source>time [h]</source>
++        <translation>time [h]</translation>
++    </message>
++    <message>
++        <source>speed</source>
++        <translation>speed</translation>
++    </message>
++    <message>
++        <source>med. speed</source>
++        <translation>med. speed</translation>
++    </message>
++    <message>
++        <source>distance [m]</source>
++        <translation>distance [m]</translation>
++    </message>
++    <message>
++        <source>distance [%1]</source>
++        <translation>distance [%1]</translation>
++    </message>
++    <message>
++        <source>speed [km/h]</source>
++        <translation>speed [km/h]</translation>
++    </message>
++    <message>
++        <source>speed [%1]</source>
++        <translation>speed [%1]</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackStatTraineeWidget</name>
++    <message>
++        <source>distance [m]</source>
++        <translation>distance [m]</translation>
++    </message>
++    <message>
++        <source>distance [%1]</source>
++        <translation>distance [%1]</translation>
++    </message>
++    <message>
++        <source>heart rate [bpm]</source>
++        <translation>heart rate [bpm]</translation>
++    </message>
++</context>
++<context>
++    <name>CTrackToolWidget</name>
++    <message>
++        <source>Show</source>
++        <translation>Show</translation>
++    </message>
++    <message>
++        <source>Track</source>
++        <translation>Track</translation>
++    </message>
++    <message>
++        <source>created from track</source>
++        <translation>created from track</translation>
++    </message>
++    <message>
++        <source>You have to select a track first.</source>
++        <translation>You have to select a track first.</translation>
++    </message>
++    <message>
++        <source>Filter...</source>
++        <translation type="obsolete">Filter...</translation>
++    </message>
++    <message>
++        <source>Make Overlay</source>
++        <translation>Make Overlay</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Filter</source>
++        <translation>Filter</translation>
++    </message>
++    <message>
++        <source>Revert</source>
++        <translation>Revert</translation>
++    </message>
++    <message>
++        <source>Tracks</source>
++        <translation>Tracks</translation>
++    </message>
++    <message>
++        <source>Show Min/Max</source>
++        <translation>Show Min/Max</translation>
++    </message>
++    <message>
++        <source>Zoom to fit</source>
++        <translation>Zoom to fit</translation>
++    </message>
++    <message>
++        <source>Edit...</source>
++        <translation>Edit...</translation>
++    </message>
++    <message>
++        <source>Show Bullets</source>
++        <translation>Show Bullets</translation>
++    </message>
++    <message>
++        <source>Edit track ...</source>
++        <translation>Edit track ...</translation>
++    </message>
++</context>
++<context>
++    <name>CWpt</name>
++    <message>
++        <source>elevation: %1 %2</source>
++        <translation>elevation: %1 %2</translation>
++    </message>
++    <message>
++        <source>proximity: %1 %2</source>
++        <translation>proximity: %1 %2</translation>
++    </message>
++    <message>
++        <source>&lt;b&gt;D:&lt;/b&gt; %1 &lt;b&gt;T:&lt;/b&gt; %2 </source>
++        <translation>&lt;b&gt;D:&lt;/b&gt; %1 &lt;b&gt;T:&lt;/b&gt; %2 </translation>
++    </message>
++    <message>
++        <source>&lt;div&gt;&lt;b&gt;Type:&lt;/b&gt; %1 &lt;b&gt;Container:&lt;/b&gt; %2 </source>
++        <translation>&lt;div&gt;&lt;b&gt;Type:&lt;/b&gt; %1 &lt;b&gt;Container:&lt;/b&gt; %2 </translation>
++    </message>
++    <message>
++        <source>Parent: %1</source>
++        <translation>Parent: %1</translation>
++    </message>
++    <message>
++        <source>No additional information.</source>
++        <translation>No additional information.</translation>
++    </message>
++    <message>
++        <source>direction: %1%2</source>
++        <translation>direction: %1%2</translation>
++    </message>
++</context>
++<context>
++    <name>CWptDB</name>
++    <message>
++        <source>Abort</source>
++        <translation>Abort</translation>
++    </message>
++    <message>
++        <source>Unable to find libexif-12.dll.</source>
++        <translation>Unable to find libexif-12.dll.</translation>
++    </message>
++    <message>
++        <source>Unable to find libexif.so.</source>
++        <translation>Unable to find libexif.so.</translation>
++    </message>
++    <message>
++        <source>Missing libexif</source>
++        <translation>Missing libexif</translation>
++    </message>
++    <message>
++        <source>Select path...</source>
++        <translation type="obsolete">Select path...</translation>
++    </message>
++    <message>
++        <source>Read EXIF tags from pictures.</source>
++        <translation>Read EXIF tags from pictures.</translation>
++    </message>
++    <message>
++        <source>Delete sticky waypoint ...</source>
++        <translation>Delete sticky waypoint ...</translation>
++    </message>
++    <message>
++        <source>Do you really want to delete the sticky waypoint &apos;%1&apos;</source>
++        <translation>Do you really want to delete the sticky waypoint &apos;%1&apos;</translation>
++    </message>
++    <message>
++        <source>Reference pictures by timestamp.</source>
++        <translation>Reference pictures by timestamp.</translation>
++    </message>
++</context>
++<context>
++    <name>CWptToolWidget</name>
++    <message>
++        <source>Waypoints</source>
++        <translation>Waypoints</translation>
++    </message>
++    <message>
++        <source>Distance [%1]</source>
++        <translation>Distance [%1]</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Make Route ...</source>
++        <translation>Make Route ...</translation>
++    </message>
++    <message>
++        <source>enter valid position</source>
++        <translation>enter valid position</translation>
++    </message>
++    <message>
++        <source>Proximity ...</source>
++        <translation>Proximity ...</translation>
++    </message>
++    <message>
++        <source>Delete non-selected</source>
++        <translation>Delete non-selected</translation>
++    </message>
++    <message>
++        <source>Zoom to fit</source>
++        <translation>Zoom to fit</translation>
++    </message>
++    <message>
++        <source>Show Names</source>
++        <translation>Show Names</translation>
++    </message>
++    <message>
++        <source>Icon ...</source>
++        <translation>Icon ...</translation>
++    </message>
++    <message>
++        <source> (sticky)</source>
++        <translation> (sticky)</translation>
++    </message>
++    <message>
++        <source>Reset selection</source>
++        <translation>Reset selection</translation>
++    </message>
++    <message>
++        <source>Edit...</source>
++        <translation>Edit...</translation>
++    </message>
++    <message>
++        <source>Delete by ...</source>
++        <translation>Delete by ...</translation>
++    </message>
++    <message>
++        <source>Copy Position</source>
++        <translation>Copy Position</translation>
++    </message>
++    <message>
++        <source>Parent Waypoint ...</source>
++        <translation>Parent Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Proximity distance ...</source>
++        <translation>Proximity distance ...</translation>
++    </message>
++</context>
++<context>
++    <name>ICopyright</name>
++    <message>
++        <source>GPL</source>
++        <translation>GPL</translation>
++    </message>
++    <message>
++        <source>QT Library</source>
++        <translation>QT Library</translation>
++    </message>
++    <message>
++        <source>Formats supported by GDAL:</source>
++        <translation>Formats supported by GDAL:</translation>
++    </message>
++    <message>
++        <source>Proj4 Library</source>
++        <translation>Proj4 Library</translation>
++    </message>
++    <message>
++        <source>GDAL Library</source>
++        <translation>GDAL Library</translation>
++    </message>
++    <message>
++        <source>Copyright...</source>
++        <translation>Copyright...</translation>
++    </message>
++    <message>
++        <source>Version</source>
++        <translation>Version</translation>
++    </message>
++    <message>
++        <source>Formats</source>
++        <translation>Formats</translation>
++    </message>
++    <message>
++        <source>QLandkarte GT</source>
++        <translation>QLandkarte GT</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation>TextLabel</translation>
++    </message>
++    <message utf8="true">
++        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;title&gt;GNU General Public License v3.0 - GNU Project - Free Software Foundation (FSF)&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;GNU GENERAL PUBLIC LICENSE&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Version 3, 29 June 2007 &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Copyright © 2007 Free Software Foundation, Inc. &amp;lt;&lt;a href=&quot;http://fsf.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://fsf.org/&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;preamble&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;P&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;reamble&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The GNU General Public License is a free, copyleft license for software and other kinds of works. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;For the developers&apos; and authors&apos; protection, the GPL clearly explains that there is no warranty for this free software. For both users&apos; and authors&apos; sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users&apos; freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The precise terms and conditions for copying, distribution and modification follow. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;terms&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;T&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;ERMS AND CONDITIONS&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section0&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;0&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Definitions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“This License” refers to version 3 of the GNU General Public License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “covered work” means either the unmodified Program or a work based on the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section1&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Source Code.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work&apos;s System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Corresponding Source for a work in source code form is that same work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section2&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;2&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Basic Permissions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section3&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;3&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Protecting Users&apos; Legal Rights From Anti-Circumvention Law.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work&apos;s users, your or third parties&apos; legal rights to forbid circumvention of technological measures. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section4&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;4&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Verbatim Copies.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey verbatim copies of the Program&apos;s source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section5&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;5&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Modified Source Versions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) The work must carry prominent notices stating that you modified it, and giving a relevant date. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation&apos;s users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section6&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;6&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Non-Source Forms.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM). &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section7&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;7&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Additional Terms.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) Limiting the use for publicity purposes of names of licensors or authors of the material; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section8&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;8&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Termination.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11). &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section9&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;9&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Acceptance Not Required for Having Copies.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section10&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;0. Automatic Licensing of Downstream Recipients.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party&apos;s predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section11&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1. Patents.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor&apos;s “contributor version”. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A contributor&apos;s “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor&apos;s essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient&apos;s use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section12&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;2. No Surrender of Others&apos; Freedom.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section13&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;3. Use with the GNU Affero General Public License.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section14&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;4. Revised Versions of this License.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy&apos;s public statement of acceptance of a version permanently authorizes you to choose that version for the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section15&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;5. Disclaimer of Warranty.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section16&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;6. Limitation of Liability.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section17&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;7. Interpretation of Sections 15 and 16.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;END OF TERMS AND CONDITIONS &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;howto&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;H&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;ow to Apply These Terms to Your New Programs&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    &amp;lt;one line to give the program&apos;s name and a brief idea of what it does.&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    Copyright (C) &amp;lt;year&amp;gt;  &amp;lt;name of author&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program is free software: you can redistribute it and/or modify&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    it under the terms of the GNU General Public License as published by&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    the Free Software Foundation, either version 3 of the License, or&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program is distributed in the hope that it will be useful,&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    but WITHOUT ANY WARRANTY; without even the implied warranty of&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    GNU General Public License for more details.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    You should have received a copy of the GNU General Public License&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    along with this program.  If not, see &amp;lt;http://www.gnu.org/licenses/&amp;gt;. &lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Also add information on how to contact you by electronic and paper mail. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode: &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    &amp;lt;program&amp;gt;  Copyright (C) &amp;lt;year&amp;gt;  &amp;lt;name of author&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w&apos;.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This is free software, and you are welcome to redistribute it&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    under certain conditions; type `show c&apos; for details. &lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The hypothetical commands `show w&apos; and `show c&apos; should show the appropriate parts of the General Public License. Of course, your program&apos;s commands might be different; for a GUI interface, you would use an “about box”. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see &amp;lt;&lt;a href=&quot;http://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://www.gnu.org/licenses/&lt;/span&gt;&lt;/a&gt;&amp;gt;. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read &amp;lt;&lt;a href=&quot;http://www.gnu.org/philosophy/why-not-lgpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://www.gnu.org/philosophy/why-not-lgpl.html&lt;/span&gt;&lt;/a&gt;&amp;gt;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translatorcomment>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;title&gt;GNU General Public License v3.0 - GNU Project - Free Software Foundation (FSF)&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;GNU GENERAL PUBLIC LICENSE&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Version 3, 29 June 2007 &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Copyright © 2007 Free Software Foundation, Inc. &amp;lt;&lt;a href=&quot;http://fsf.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://fsf.org/&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;preamble&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;P&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;reamble&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The GNU General Public License is a free, copyleft license for software and other kinds of works. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;For the developers&apos; and authors&apos; protection, the GPL clearly explains that there is no warranty for this free software. For both users&apos; and authors&apos; sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users&apos; freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The precise terms and conditions for copying, distribution and modification follow. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;terms&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;T&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;ERMS AND CONDITIONS&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section0&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;0&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Definitions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“This License” refers to version 3 of the GNU General Public License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “covered work” means either the unmodified Program or a work based on the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section1&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Source Code.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work&apos;s System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Corresponding Source for a work in source code form is that same work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section2&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;2&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Basic Permissions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section3&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;3&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Protecting Users&apos; Legal Rights From Anti-Circumvention Law.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work&apos;s users, your or third parties&apos; legal rights to forbid circumvention of technological measures. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section4&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;4&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Verbatim Copies.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey verbatim copies of the Program&apos;s source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section5&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;5&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Modified Source Versions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) The work must carry prominent notices stating that you modified it, and giving a relevant date. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation&apos;s users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section6&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;6&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Non-Source Forms.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM). &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section7&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;7&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Additional Terms.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) Limiting the use for publicity purposes of names of licensors or authors of the material; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section8&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;8&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Termination.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11). &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section9&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;9&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Acceptance Not Required for Having Copies.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section10&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;0. Automatic Licensing of Downstream Recipients.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party&apos;s predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section11&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1. Patents.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor&apos;s “contributor version”. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A contributor&apos;s “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor&apos;s essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient&apos;s use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section12&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;2. No Surrender of Others&apos; Freedom.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section13&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;3. Use with the GNU Affero General Public License.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section14&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;4. Revised Versions of this License.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy&apos;s public statement of acceptance of a version permanently authorizes you to choose that version for the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section15&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;5. Disclaimer of Warranty.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section16&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;6. Limitation of Liability.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section17&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;7. Interpretation of Sections 15 and 16.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;END OF TERMS AND CONDITIONS &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;howto&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;H&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;ow to Apply These Terms to Your New Programs&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    &amp;lt;one line to give the program&apos;s name and a brief idea of what it does.&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    Copyright (C) &amp;lt;year&amp;gt;  &amp;lt;name of author&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program is free software: you can redistribute it and/or modify&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    it under the terms of the GNU General Public License as published by&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    the Free Software Foundation, either version 3 of the License, or&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program is distributed in the hope that it will be useful,&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    but WITHOUT ANY WARRANTY; without even the implied warranty of&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    GNU General Public License for more details.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    You should have received a copy of the GNU General Public License&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    along with this program.  If not, see &amp;lt;http://www.gnu.org/licenses/&amp;gt;. &lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Also add information on how to contact you by electronic and paper mail. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode: &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    &amp;lt;program&amp;gt;  Copyright (C) &amp;lt;year&amp;gt;  &amp;lt;name of author&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w&apos;.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This is free software, and you are welcome to redistribute it&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    under certain conditions; type `show c&apos; for details. &lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The hypothetical commands `show w&apos; and `show c&apos; should show the appropriate parts of the General Public License. Of course, your program&apos;s commands might be different; for a GUI interface, you would use an “about box”. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see &amp;lt;&lt;a href=&quot;http://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://www.gnu.org/licenses/&lt;/span&gt;&lt;/a&gt;&amp;gt;. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read &amp;lt;&lt;a href=&quot;http://www.gnu.org/philosophy/why-not-lgpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://www.gnu.org/philosophy/why-not-lgpl.html&lt;/span&gt;&lt;/a&gt;&amp;gt;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translatorcomment>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;title&gt;GNU General Public License v3.0 - GNU Project - Free Software Foundation (FSF)&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;GNU GENERAL PUBLIC LICENSE&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Version 3, 29 June 2007 &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Copyright © 2007 Free Software Foundation, Inc. &amp;lt;&lt;a href=&quot;http://fsf.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://fsf.org/&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;preamble&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;P&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;reamble&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The GNU General Public License is a free, copyleft license for software and other kinds of works. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;For the developers&apos; and authors&apos; protection, the GPL clearly explains that there is no warranty for this free software. For both users&apos; and authors&apos; sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users&apos; freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The precise terms and conditions for copying, distribution and modification follow. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;terms&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;T&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;ERMS AND CONDITIONS&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section0&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;0&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Definitions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“This License” refers to version 3 of the GNU General Public License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “covered work” means either the unmodified Program or a work based on the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section1&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Source Code.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work&apos;s System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Corresponding Source for a work in source code form is that same work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section2&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;2&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Basic Permissions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section3&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;3&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Protecting Users&apos; Legal Rights From Anti-Circumvention Law.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work&apos;s users, your or third parties&apos; legal rights to forbid circumvention of technological measures. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section4&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;4&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Verbatim Copies.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey verbatim copies of the Program&apos;s source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section5&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;5&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Modified Source Versions.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) The work must carry prominent notices stating that you modified it, and giving a relevant date. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation&apos;s users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section6&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;6&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Conveying Non-Source Forms.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements. &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM). &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section7&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;7&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Additional Terms.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms: &lt;/p&gt;
++&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;d) Limiting the use for publicity purposes of names of licensors or authors of the material; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or &lt;/li&gt;
++&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors. &lt;/li&gt;&lt;/ul&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section8&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;8&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Termination.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11). &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section9&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;9&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;. Acceptance Not Required for Having Copies.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section10&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;0. Automatic Licensing of Downstream Recipients.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party&apos;s predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section11&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1. Patents.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor&apos;s “contributor version”. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A contributor&apos;s “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor&apos;s essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient&apos;s use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section12&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;2. No Surrender of Others&apos; Freedom.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section13&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;3. Use with the GNU Affero General Public License.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section14&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;4. Revised Versions of this License.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy&apos;s public statement of acceptance of a version permanently authorizes you to choose that version for the Program. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section15&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;5. Disclaimer of Warranty.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section16&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;6. Limitation of Liability.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;section17&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;1&lt;/span&gt;&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;7. Interpretation of Sections 15 and 16.&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;END OF TERMS AND CONDITIONS &lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a name=&quot;howto&quot;&gt;&lt;/a&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;H&lt;/span&gt;&lt;span style=&quot; font-size:large; font-weight:600;&quot;&gt;ow to Apply These Terms to Your New Programs&lt;/span&gt; &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    &amp;lt;one line to give the program&apos;s name and a brief idea of what it does.&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    Copyright (C) &amp;lt;year&amp;gt;  &amp;lt;name of author&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program is free software: you can redistribute it and/or modify&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    it under the terms of the GNU General Public License as published by&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    the Free Software Foundation, either version 3 of the License, or&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program is distributed in the hope that it will be useful,&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    but WITHOUT ANY WARRANTY; without even the implied warranty of&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    GNU General Public License for more details.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Courier New,courier&apos;;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    You should have received a copy of the GNU General Public License&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    along with this program.  If not, see &amp;lt;http://www.gnu.org/licenses/&amp;gt;. &lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Also add information on how to contact you by electronic and paper mail. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode: &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    &amp;lt;program&amp;gt;  Copyright (C) &amp;lt;year&amp;gt;  &amp;lt;name of author&amp;gt;&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w&apos;.&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    This is free software, and you are welcome to redistribute it&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Courier New,courier&apos;;&quot;&gt;    under certain conditions; type `show c&apos; for details. &lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The hypothetical commands `show w&apos; and `show c&apos; should show the appropriate parts of the General Public License. Of course, your program&apos;s commands might be different; for a GUI interface, you would use an “about box”. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see &amp;lt;&lt;a href=&quot;http://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://www.gnu.org/licenses/&lt;/span&gt;&lt;/a&gt;&amp;gt;. &lt;/p&gt;
++&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read &amp;lt;&lt;a href=&quot;http://www.gnu.org/philosophy/why-not-lgpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;http://www.gnu.org/philosophy/why-not-lgpl.html&lt;/span&gt;&lt;/a&gt;&amp;gt;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++</context>
++<context>
++    <name>ICreateMapFineTune</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Save</source>
++        <translation>Save</translation>
++    </message>
++    <message>
++        <source>Input</source>
++        <translation>Input</translation>
++    </message>
++    <message>
++        <source>Output</source>
++        <translation>Output</translation>
++    </message>
++    <message>
++        <source>Control</source>
++        <translation>Control</translation>
++    </message>
++    <message>
++        <source>Open File</source>
++        <translation>Open File</translation>
++    </message>
++    <message>
++        <source>Load a referenced file together with waypoints or tracks. You can move the map until it fits best all overlay elements. Finally you can save a copy of the file with the new offset.</source>
++        <translation>Load a referenced file together with waypoints or tracks. You can move the map until it fits best all overlay elements. Finally you can save a copy of the file with the new offset.</translation>
++    </message>
++</context>
++<context>
++    <name>ICreateMapGeoTiff</name>
++    <message>
++        <source>x</source>
++        <translation>x</translation>
++    </message>
++    <message>
++        <source>y</source>
++        <translation>y</translation>
++    </message>
++    <message>
++        <source>2x</source>
++        <translation>2x</translation>
++    </message>
++    <message>
++        <source>4x</source>
++        <translation>4x</translation>
++    </message>
++    <message>
++        <source>8x</source>
++        <translation>8x</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>16x</source>
++        <translation>16x</translation>
++    </message>
++    <message>
++        <source>32x</source>
++        <translation>32x</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Help</source>
++        <translation>Help</translation>
++    </message>
++    <message>
++        <source>Mode</source>
++        <translation>Mode</translation>
++    </message>
++    <message>
++        <source>Step1</source>
++        <translation>Step1</translation>
++    </message>
++    <message>
++        <source>Step2</source>
++        <translation>Step2</translation>
++    </message>
++    <message>
++        <source>open input file</source>
++        <translation>open input file</translation>
++    </message>
++    <message>
++        <source>label</source>
++        <translation>label</translation>
++    </message>
++    <message>
++        <source>Output file:</source>
++        <translation>Output file:</translation>
++    </message>
++    <message>
++        <source>Coord.</source>
++        <translation>Coord.</translation>
++    </message>
++    <message>
++        <source>Input file:</source>
++        <translation>Input file:</translation>
++    </message>
++    <message>
++        <source>Load Ref.</source>
++        <translation>Load Ref.</translation>
++    </message>
++    <message>
++        <source>Process</source>
++        <translation>Process</translation>
++    </message>
++    <message>
++        <source>Map projection</source>
++        <translation>Map projection</translation>
++    </message>
++    <message>
++        <source>Ref. projection</source>
++        <translation>Ref. projection</translation>
++    </message>
++    <message>
++        <source>Delete Ref.</source>
++        <translation>Delete Ref.</translation>
++    </message>
++    <message>
++        <source>Add Ref.</source>
++        <translation>Add Ref.</translation>
++    </message>
++    <message>
++        <source>reload input file</source>
++        <translation>reload input file</translation>
++    </message>
++    <message>
++        <source>Clear All</source>
++        <translation>Clear All</translation>
++    </message>
++    <message>
++        <source>Save Ref.</source>
++        <translation>Save Ref.</translation>
++    </message>
++    <message>
++        <source>Overviews</source>
++        <translation>Overviews</translation>
++    </message>
++    <message>
++        <source>Start process</source>
++        <translation>Start process</translation>
++    </message>
++    <message>
++        <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;URW Gothic L&apos;; font-size:9pt; font-weight:200; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Projection Wizard&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;URW Gothic L&apos;; font-size:9pt; font-weight:200; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Projection Wizard&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>Use the n and b key to step between reference points while fine tuning the points on the map.</source>
++        <translation>Use the n and b key to step between reference points while fine tuning the points on the map.</translation>
++    </message>
++    <message>
++        <source>Projection Wizard</source>
++        <translation>Projection Wizard</translation>
++    </message>
++    <message>
++        <source>select output file</source>
++        <translation>select output file</translation>
++    </message>
++    <message>
++        <source>Grid Tool</source>
++        <translation>Grid Tool</translation>
++    </message>
++</context>
++<context>
++    <name>ICreateMapGridTool</name>
++    <message>
++        <source>Ok</source>
++        <translation>Ok</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Help</source>
++        <translation>Help</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Cancel</source>
++        <translation>Cancel</translation>
++    </message>
++    <message>
++        <source>Northing</source>
++        <translation>Northing</translation>
++    </message>
++    <message>
++        <source>y - spacing</source>
++        <translation>y - spacing</translation>
++    </message>
++    <message>
++        <source>x - spacing</source>
++        <translation>x - spacing</translation>
++    </message>
++    <message>
++        <source>Easting</source>
++        <translation>Easting</translation>
++    </message>
++    <message>
++        <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;URW Gothic L&apos;; font-size:9pt; font-weight:200; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Projection Wizard&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;URW Gothic L&apos;; font-size:9pt; font-weight:200; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Projection Wizard&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation>TextLabel</translation>
++    </message>
++    <message>
++        <source>Did you notice the orange rectangle at the border of your map? The calculated reference points will be inside this rectangle. You can move the lines with your mouse to limit the area. This comes very handy if you have maps with more than on UTM zone. You apply the grid tool to the one zone first. And in a second run to the other.</source>
++        <translation>Did you notice the orange rectangle at the border of your map? The calculated reference points will be inside this rectangle. You can move the lines with your mouse to limit the area. This comes very handy if you have maps with more than on UTM zone. You apply the grid tool to the one zone first. And in a second run to the other.</translation>
++    </message>
++</context>
++<context>
++    <name>ICreateMapQMAP</name>
++    <message>
++        <source>up</source>
++        <translation>up</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>add</source>
++        <translation>add</translation>
++    </message>
++    <message>
++        <source>del</source>
++        <translation>del</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Help</source>
++        <translation>Help</translation>
++    </message>
++    <message>
++        <source>Save</source>
++        <translation>Save</translation>
++    </message>
++    <message>
++        <source>down</source>
++        <translation>down</translation>
++    </message>
++    <message>
++        <source>edit</source>
++        <translation>edit</translation>
++    </message>
++    <message>
++        <source>Step1</source>
++        <translation>Step1</translation>
++    </message>
++    <message>
++        <source>Step2</source>
++        <translation>Step2</translation>
++    </message>
++    <message>
++        <source>files</source>
++        <translation>files</translation>
++    </message>
++    <message>
++        <source>min. zoom</source>
++        <translation>min. zoom</translation>
++    </message>
++    <message>
++        <source>quadratic zoom</source>
++        <translation>quadratic zoom</translation>
++    </message>
++    <message>
++        <source>Create new *.qmap definition</source>
++        <translation>Create new *.qmap definition</translation>
++    </message>
++    <message>
++        <source>Open existing *.qmap definition</source>
++        <translation>Open existing *.qmap definition</translation>
++    </message>
++    <message>
++        <source>map definition</source>
++        <translation>map definition</translation>
++    </message>
++    <message>
++        <source>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>comment</source>
++        <translation>comment</translation>
++    </message>
++    <message>
++        <source>Summary</source>
++        <translation>Summary</translation>
++    </message>
++    <message>
++        <source>Detail Layer</source>
++        <translation>Detail Layer</translation>
++    </message>
++    <message>
++        <source>max. zoom</source>
++        <translation>max. zoom</translation>
++    </message>
++</context>
++<context>
++    <name>ICreateMapWMS</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Server:</source>
++        <translation>Server:</translation>
++    </message>
++    <message>
++        <source>Load Capabilities</source>
++        <translation>Load Capabilities</translation>
++    </message>
++    <message>
++        <source>Title:</source>
++        <translation>Title:</translation>
++    </message>
++    <message>
++        <source>Format:</source>
++        <translation>Format:</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Layers:</source>
++        <translation>Layers:</translation>
++    </message>
++    <message>
++        <source>File</source>
++        <translation>File</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Save</source>
++        <translation>Save</translation>
++    </message>
++</context>
++<context>
++    <name>IDevice</name>
++    <message>
++        <source>Abort</source>
++        <translation>Abort</translation>
++    </message>
++    <message>
++        <source>Upload finished.</source>
++        <translation>Upload finished.</translation>
++    </message>
++    <message>
++        <source>Your device does not support live log.</source>
++        <translation>Your device does not support live log.</translation>
++    </message>
++    <message>
++        <source>Download finished.</source>
++        <translation>Download finished.</translation>
++    </message>
++    <message>
++        <source>Sorry... </source>
++        <translation>Sorry... </translation>
++    </message>
++</context>
++<context>
++    <name>IDiaryEdit</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Exit</source>
++        <translation>Exit</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Save</source>
++        <translation>Save</translation>
++    </message>
++    <message>
++        <source>Print</source>
++        <translation>Print</translation>
++    </message>
++    <message>
++        <source>show profiles</source>
++        <translation>show profiles</translation>
++    </message>
++    <message>
++        <source>Reload</source>
++        <translation>Reload</translation>
++    </message>
++    <message>
++        <source>show geocaches</source>
++        <translation>show geocaches</translation>
++    </message>
++    <message>
++        <source>add map view  when printing</source>
++        <translation>add map view  when printing</translation>
++    </message>
++</context>
++<context>
++    <name>IDlg3DHelp</name>
++    <message>
++        <source>Help for 3D view...</source>
++        <translation>Help for 3D view...</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;How to control the 3D view&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt; font-weight:600;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;The view and the point of view (POV) are moved by several keys together with mouse movements. &lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;FPV/Rotate:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;There are two basic modes: The first person view (FPV) mode and the rotation mode. In FPV mode your POV is moving freely in the screen. In rotation mode your POV is circling around the map center.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Track mode:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;In track mode the POV is tied to a point within a selected track. You can use the &apos;w&apos; and &apos;s&apos; key to move along the track. You can use the mouse (left button pressed) to look around.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouse:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can control your POV by mouse movements. You have to press the left mouse button while moving the mouse. Moving the mouse up and down will make your POV look up and down. Moving your map left and right will depend on the mode:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;FPV: you turn around your own axis. Rotate: you rotate the complete screen&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouse wheel:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can zoom in and out from the sceen by the mouse wheel. If you keep the shift key pressed while scrolling you change the elevation of the 3D sceen only.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can use the keyboard, too:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;strg + +: zoom in&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;strg + -: zoom out&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + +: raise elevation&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + -: lower elevation&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Keys:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can move your  POV in the sceen by key. This is independent of the chosen mode.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;w: move forward&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;s: move backward&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;a: strafe left&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;d: strafe right&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + w: move up&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + s: move down&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Light:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;To move the light source you have to press down the &apos;L&apos; key, the left mouse button and move the mouse.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;up: move light source north&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;down: move light source south&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;left: move light source west&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;right: move light source east&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;How to control the 3D view&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt; font-weight:600;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;The view and the point of view (POV) are moved by several keys together with mouse movements. &lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;FPV/Rotate:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;There are two basic modes: The first person view (FPV) mode and the rotation mode. In FPV mode your POV is moving freely in the screen. In rotation mode your POV is circling around the map center.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Track mode:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;In track mode the POV is tied to a point within a selected track. You can use the &apos;w&apos; and &apos;s&apos; key to move along the track. You can use the mouse (left button pressed) to look around.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouse:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can control your POV by mouse movements. You have to press the left mouse button while moving the mouse. Moving the mouse up and down will make your POV look up and down. Moving your map left and right will depend on the mode:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;FPV: you turn around your own axis. Rotate: you rotate the complete screen&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouse wheel:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can zoom in and out from the sceen by the mouse wheel. If you keep the shift key pressed while scrolling you change the elevation of the 3D sceen only.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can use the keyboard, too:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;strg + +: zoom in&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;strg + -: zoom out&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + +: raise elevation&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + -: lower elevation&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Keys:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;You can move your  POV in the sceen by key. This is independent of the chosen mode.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;w: move forward&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;s: move backward&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;a: strafe left&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;d: strafe right&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + w: move up&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;shift + s: move down&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Light:&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;To move the light source you have to press down the &apos;L&apos; key, the left mouse button and move the mouse.&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;up: move light source north&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;down: move light source south&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;left: move light source west&lt;/span&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;right: move light source east&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgCombineDistOvl</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Move overlay up in list</source>
++        <translation>Move overlay up in list</translation>
++    </message>
++    <message>
++        <source>Move overlay down in list</source>
++        <translation>Move overlay down in list</translation>
++    </message>
++    <message>
++        <source>Add overlay to list</source>
++        <translation>Add overlay to list</translation>
++    </message>
++    <message>
++        <source>Remove overlay from list</source>
++        <translation>Remove overlay from list</translation>
++    </message>
++    <message>
++        <source>New Distance</source>
++        <translation>New Distance</translation>
++    </message>
++    <message>
++        <source>Selected Overlays</source>
++        <translation>Selected Overlays</translation>
++    </message>
++    <message>
++        <source>Combine Overlays ...</source>
++        <translation>Combine Overlays ...</translation>
++    </message>
++    <message>
++        <source>New Overlay Name</source>
++        <translation>New Overlay Name</translation>
++    </message>
++    <message>
++        <source>Available Overlays</source>
++        <translation>Available Overlays</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgCombineTracks</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Add track to list</source>
++        <translation>Add track to list</translation>
++    </message>
++    <message>
++        <source>Remove track from list</source>
++        <translation>Remove track from list</translation>
++    </message>
++    <message>
++        <source>Sort by timestamp</source>
++        <translation>Sort by timestamp</translation>
++    </message>
++    <message>
++        <source>New Track Name</source>
++        <translation>New Track Name</translation>
++    </message>
++    <message>
++        <source>Available Tracks</source>
++        <translation>Available Tracks</translation>
++    </message>
++    <message>
++        <source>Selected Tracks</source>
++        <translation>Selected Tracks</translation>
++    </message>
++    <message>
++        <source>New Track</source>
++        <translation>New Track</translation>
++    </message>
++    <message>
++        <source>Combine Tracks ...</source>
++        <translation>Combine Tracks ...</translation>
++    </message>
++    <message>
++        <source>Move track up in list</source>
++        <translation>Move track up in list</translation>
++    </message>
++    <message>
++        <source>Move track down in list</source>
++        <translation>Move track down in list</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgConfig</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>4242</source>
++        <translation>4242</translation>
++    </message>
++    <message>
++        <source>8080</source>
++        <translation type="obsolete">8080</translation>
++    </message>
++    <message>
++        <source>Flip</source>
++        <translation>Flip</translation>
++    </message>
++    <message>
++        <source>Font</source>
++        <translation>Font</translation>
++    </message>
++    <message>
++        <source>Host</source>
++        <translation>Host</translation>
++    </message>
++    <message>
++        <source>Keys</source>
++        <translation>Keys</translation>
++    </message>
++    <message>
++        <source>Play</source>
++        <translation>Play</translation>
++    </message>
++    <message>
++        <source>Port</source>
++        <translation>Port</translation>
++    </message>
++    <message>
++        <source>Type</source>
++        <translation>Type</translation>
++    </message>
++    <message>
++        <source>Proxy</source>
++        <translation>Proxy</translation>
++    </message>
++    <message>
++        <source>Units</source>
++        <translation>Units</translation>
++    </message>
++    <message>
++        <source>Waypoints</source>
++        <translation>Waypoints</translation>
++    </message>
++    <message>
++        <source>Define custom icons for Garmin Devices.</source>
++        <translation>Define custom icons for Garmin Devices.</translation>
++    </message>
++    <message>
++        <source>Download All</source>
++        <translation>Download All</translation>
++    </message>
++    <message>
++        <source>The compass rose in the bottom right corner</source>
++        <translation>The compass rose in the bottom right corner</translation>
++    </message>
++    <message>
++        <source>Customize Waypoint Icons...</source>
++        <translation>Customize Waypoint Icons...</translation>
++    </message>
++    <message>
++        <source>Character Set</source>
++        <translation>Character Set</translation>
++    </message>
++    <message>
++        <source>Sound after Transfer</source>
++        <translation>Sound after Transfer</translation>
++    </message>
++    <message>
++        <source>00000; </source>
++        <translation type="obsolete">00000; </translation>
++    </message>
++    <message>
++        <source>ABCDEFGHabcdefgh123456789</source>
++        <translation>ABCDEFGHabcdefgh123456789</translation>
++    </message>
++    <message>
++        <source>Baud rate for Serial Port</source>
++        <translation>Baud rate for Serial Port</translation>
++    </message>
++    <message>
++        <source>Device &amp;&amp; Xfer</source>
++        <translation>Device &amp;&amp; Xfer</translation>
++    </message>
++    <message>
++        <source>Imperial</source>
++        <translation>Imperial</translation>
++    </message>
++    <message>
++        <source>If your device is accessed by TCP/IP you can give a hard coded address. Leave blank for &quot;QLandkarte M&quot; as the driver will query the device by UDP broadcast.</source>
++        <translation>If your device is accessed by TCP/IP you can give a hard coded address. Leave blank for &quot;QLandkarte M&quot; as the driver will query the device by UDP broadcast.</translation>
++    </message>
++    <message>
++        <source>Map Canvas</source>
++        <translation>Map Canvas</translation>
++    </message>
++    <message>
++        <source>Device</source>
++        <translation>Device</translation>
++    </message>
++    <message>
++        <source>Pass something like &quot;/dev/ttyS0&quot; or &quot;/dev/rfcomm0&quot; for serial Garmin devices or NMEA devices. For Garmin USB devices leave blank.</source>
++        <translation>Pass something like &quot;/dev/ttyS0&quot; or &quot;/dev/rfcomm0&quot; for serial Garmin devices or NMEA devices. For Garmin USB devices leave blank.</translation>
++    </message>
++    <message>
++        <source>Metric</source>
++        <translation>Metric</translation>
++    </message>
++    <message>
++        <source>Nautic</source>
++        <translation>Nautic</translation>
++    </message>
++    <message>
++        <source>Upload All</source>
++        <translation>Upload All</translation>
++    </message>
++    <message>
++        <source>Routes</source>
++        <translation>Routes</translation>
++    </message>
++    <message>
++        <source>Tracks</source>
++        <translation>Tracks</translation>
++    </message>
++    <message>
++        <source>Mouse Wheel</source>
++        <translation>Mouse Wheel</translation>
++    </message>
++    <message>
++        <source>IP Address</source>
++        <translation>IP Address</translation>
++    </message>
++    <message>
++        <source>Serial Port</source>
++        <translation>Serial Port</translation>
++    </message>
++    <message>
++        <source>Save workspace on exit</source>
++        <translation>Save workspace on exit</translation>
++    </message>
++    <message>
++        <source>Select your Garmin device from list. If your device is not supported use &quot;whatGarmin&quot; and download waypoints to create a protocol query.</source>
++        <translation>Select your Garmin device from list. If your device is not supported use &quot;whatGarmin&quot; and download waypoints to create a protocol query.</translation>
++    </message>
++    <message>
++        <source>Environment</source>
++        <translation>Environment</translation>
++    </message>
++    <message>
++        <source>Show north</source>
++        <translation>Show north</translation>
++    </message>
++    <message>
++        <source>Show scale</source>
++        <translation>Show scale</translation>
++    </message>
++    <message>
++        <source>Anti-aliasing</source>
++        <translation>Anti-aliasing</translation>
++    </message>
++    <message>
++        <source>The scale bar in the bottom right corner</source>
++        <translation>The scale bar in the bottom right corner</translation>
++    </message>
++    <message>
++        <source>Add TCP/IP port for Device. Set to 0 for &quot;QLandkarte M&quot;.</source>
++        <translation>Add TCP/IP port for Device. Set to 0 for &quot;QLandkarte M&quot;.</translation>
++    </message>
++    <message>
++        <source>Baud rate</source>
++        <translation>Baud rate</translation>
++    </message>
++    <message>
++        <source>Geo Database</source>
++        <translation>Geo Database</translation>
++    </message>
++    <message>
++        <source>Preferences</source>
++        <translation>Preferences</translation>
++    </message>
++    <message>
++        <source>Select the device you want to setup.</source>
++        <translation>Select the device you want to setup.</translation>
++    </message>
++    <message>
++        <source>Use database</source>
++        <translation>Use database</translation>
++    </message>
++    <message>
++        <source>You have to restart QLandkarte GT to make the database changes taking effect.</source>
++        <translation>You have to restart QLandkarte GT to make the database changes taking effect.</translation>
++    </message>
++    <message>
++        <source>manual configuration</source>
++        <translation>manual configuration</translation>
++    </message>
++    <message>
++        <source>Waypoint text color</source>
++        <translation>Waypoint text color</translation>
++    </message>
++    <message>
++        <source>Database path:</source>
++        <translation>Database path:</translation>
++    </message>
++    <message>
++        <source>The profile graph for the active track in the bottom left corner</source>
++        <translation>The profile graph for the active track in the bottom left corner</translation>
++    </message>
++    <message>
++        <source>Show track profile preview</source>
++        <translation>Show track profile preview</translation>
++    </message>
++    <message>
++        <source>Show information as tooltip for items under cursor in vector maps.</source>
++        <translation>Show information as tooltip for items under cursor in vector maps.</translation>
++    </message>
++    <message>
++        <source>Rendering the map with anti-aliasing uses a lot of CPU power. Best to disable it for weak CPUs.</source>
++        <translation>Rendering the map with anti-aliasing uses a lot of CPU power. Best to disable it for weak CPUs.</translation>
++    </message>
++    <message>
++        <source>Show zoom level in the top left corner</source>
++        <translation>Show zoom level in the top left corner</translation>
++    </message>
++    <message>
++        <source>Show zoom level</source>
++        <translation>Show zoom level</translation>
++    </message>
++    <message>
++        <source>Services &amp;&amp; Paths</source>
++        <translation>Services &amp;&amp; Paths</translation>
++    </message>
++    <message>
++        <source>Streaming Map Cache</source>
++        <translation>Streaming Map Cache</translation>
++    </message>
++    <message>
++        <source>Cache Path: </source>
++        <translation>Cache Path: </translation>
++    </message>
++    <message>
++        <source>Size</source>
++        <translation>Size</translation>
++    </message>
++    <message>
++        <source>MB</source>
++        <translation>MB</translation>
++    </message>
++    <message>
++        <source>Expire in</source>
++        <translation>Expire in</translation>
++    </message>
++    <message>
++        <source>Days</source>
++        <translation>Days</translation>
++    </message>
++    <message>
++        <source> and every </source>
++        <translation> and every </translation>
++    </message>
++    <message>
++        <source> min</source>
++        <translation> min</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouseless control&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; &lt;/span&gt;&lt;/p&gt;
++&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + right&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to east&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + left&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to west&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + up&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to north&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + down&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to south&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;+&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	zoom in&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;-&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	zoom out&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouse control&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;wheel		zoom in / out&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;left button		select&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;right button	context menu&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt+move mouse	move map&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouseless control&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; &lt;/span&gt;&lt;/p&gt;
++&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + right&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to east&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + left&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to west&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + up&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to north&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt + down&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	move map view to south&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;+&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	zoom in&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;
++&lt;tr&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;-&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;
++&lt;td&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;	zoom out&lt;/span&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
++&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Mouse control&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;wheel		zoom in / out&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;left button		select&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;right button	context menu&lt;/span&gt;&lt;/p&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;alt+move mouse	move map&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>Show track elevation info</source>
++        <translation>Show track elevation info</translation>
++    </message>
++    <message>
++        <source>Time</source>
++        <translation>Time</translation>
++    </message>
++    <message>
++        <source>UTC</source>
++        <translation>UTC</translation>
++    </message>
++    <message>
++        <source>Local</source>
++        <translation>Local</translation>
++    </message>
++    <message>
++        <source>Automatic</source>
++        <translation>Automatic</translation>
++    </message>
++    <message>
++        <source>Show clock</source>
++        <translation>Show clock</translation>
++    </message>
++    <message>
++        <source>Vector Maps</source>
++        <translation>Vector Maps</translation>
++    </message>
++    <message>
++        <source>Tooltips</source>
++        <translation>Tooltips</translation>
++    </message>
++    <message>
++        <source>Element Info</source>
++        <translation>Element Info</translation>
++    </message>
++    <message>
++        <source>Reduce POI icons</source>
++        <translation>Reduce POI icons</translation>
++    </message>
++    <message>
++        <source>Zoom level threshold for POIs:</source>
++        <translation>Zoom level threshold for POIs:</translation>
++    </message>
++    <message>
++        <source>Defines at which zoom level POIs are drawn.</source>
++        <translation>Defines at which zoom level POIs are drawn.</translation>
++    </message>
++    <message>
++        <source>Zoom level threshold for POI labels:</source>
++        <translation>Zoom level threshold for POI labels:</translation>
++    </message>
++    <message>
++        <source>Defines at which zoom level POIs are labeled.</source>
++        <translation>Defines at which zoom level POIs are labeled.</translation>
++    </message>
++    <message>
++        <source>00000</source>
++        <translation type="obsolete">00000</translation>
++    </message>
++    <message>
++        <source>Watch Dog</source>
++        <translatorcomment>Chien de garde (watchdog)</translatorcomment>
++        <translation>Watch Dog</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgConfig3D</name>
++    <message>
++        <source>3D View Options...</source>
++        <translation>3D View Options...</translation>
++    </message>
++    <message>
++        <source>Couple Elevation/POV</source>
++        <translation>Couple Elevation/POV</translation>
++    </message>
++    <message>
++        <source>Model Quality</source>
++        <translation>Model Quality</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgConvertToTrack</name>
++    <message>
++        <source>add no elevation data</source>
++        <translation>add no elevation data</translation>
++    </message>
++    <message>
++        <source>add elevation from www.geonames.org</source>
++        <translation>add elevation from www.geonames.org</translation>
++    </message>
++    <message>
++        <source>add elevation from loaded DEM data</source>
++        <translation>add elevation from loaded DEM data</translation>
++    </message>
++    <message>
++        <source>Intermediate track points...</source>
++        <translation>Intermediate track points...</translation>
++    </message>
++    <message>
++        <source>Select interval to place additional trackpoints. &quot;none&quot; will just use the available points.</source>
++        <translation>Select interval to place additional trackpoints. &quot;none&quot; will just use the available points.</translation>
++    </message>
++    <message>
++        <source>Username:</source>
++        <translation>Username:</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgCropMap</name>
++    <message>
++        <source>Close</source>
++        <translation>Close</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation>TextLabel</translation>
++    </message>
++    <message>
++        <source>Crop map...</source>
++        <translation>Crop map...</translation>
++    </message>
++    <message>
++        <source>Input:</source>
++        <translation>Input:</translation>
++    </message>
++    <message>
++        <source>Output:</source>
++        <translation>Output:</translation>
++    </message>
++    <message>
++        <source>Overview</source>
++        <translation>Overview</translation>
++    </message>
++    <message>
++        <source>x2</source>
++        <translation>x2</translation>
++    </message>
++    <message>
++        <source>x4</source>
++        <translation>x4</translation>
++    </message>
++    <message>
++        <source>x8</source>
++        <translation>x8</translation>
++    </message>
++    <message>
++        <source>x16</source>
++        <translation>x16</translation>
++    </message>
++    <message>
++        <source>Start</source>
++        <translation>Start</translation>
++    </message>
++    <message>
++        <source>Details</source>
++        <translation>Details</translation>
++    </message>
++    <message>
++        <source>Press &quot;Start&quot;</source>
++        <translation>Press &quot;Start&quot;</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgDelWpt</name>
++    <message>
++        <source>type</source>
++        <translation>type</translation>
++    </message>
++    <message>
++        <source>Delete waypoint by ...</source>
++        <translation>Delete waypoint by ...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgDeviceExportPath</name>
++    <message>
++        <source>Select output path...</source>
++        <translation>Select output path...</translation>
++    </message>
++    <message>
++        <source>Where to place..?</source>
++        <translation>Where to place..?</translation>
++    </message>
++    <message>
++        <source>Select a sub-directory from above or enter a new one</source>
++        <translation>Select a sub-directory from above or enter a new one</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgEditFolder</name>
++    <message>
++        <source>Name</source>
++        <translation>Name</translation>
++    </message>
++    <message>
++        <source>Type</source>
++        <translation>Type</translation>
++    </message>
++    <message>
++        <source>Comment</source>
++        <translation>Comment</translation>
++    </message>
++    <message>
++        <source>Edit folder ...</source>
++        <translation>Edit folder ...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgEditMapLevel</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>files</source>
++        <translation>files</translation>
++    </message>
++    <message>
++        <source>Select files</source>
++        <translation>Select files</translation>
++    </message>
++    <message>
++        <source>zoom levels</source>
++        <translation>zoom levels</translation>
++    </message>
++    <message>
++        <source>Add files to list</source>
++        <translation>Add files to list</translation>
++    </message>
++    <message>
++        <source>Delete file from list</source>
++        <translation>Delete file from list</translation>
++    </message>
++    <message>
++        <source>Edit map level ...</source>
++        <translation>Edit map level ...</translation>
++    </message>
++    <message>
++        <source>Move file up in list</source>
++        <translation>Move file up in list</translation>
++    </message>
++    <message>
++        <source>Move file down in list</source>
++        <translation>Move file down in list</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgEditRoute</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Edit Route ...</source>
++        <translation>Edit Route ...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgEditWpt</name>
++    <message>
++        <source>+</source>
++        <translation>+</translation>
++    </message>
++    <message>
++        <source>m</source>
++        <translation>m</translation>
++    </message>
++    <message>
++        <source>m,</source>
++        <translation>m,</translation>
++    </message>
++    <message utf8="true">
++        <source>°</source>
++        <translation>°</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Add</source>
++        <translation>Add</translation>
++    </message>
++    <message>
++        <source>Data</source>
++        <translation>Data</translation>
++    </message>
++    <message>
++        <source>None</source>
++        <translation>None</translation>
++    </message>
++    <message>
++        <source>Save</source>
++        <translation>Save</translation>
++    </message>
++    <message>
++        <source>no image</source>
++        <translation>no image</translation>
++    </message>
++    <message>
++        <source>Altitude</source>
++        <translation>Altitude</translation>
++    </message>
++    <message>
++        <source>Delete</source>
++        <translation>Delete</translation>
++    </message>
++    <message>
++        <source>Images</source>
++        <translation>Images</translation>
++    </message>
++    <message>
++        <source>Update</source>
++        <translation>Update</translation>
++    </message>
++    <message>
++        <source>Position</source>
++        <translation>Position</translation>
++    </message>
++    <message>
++        <source>sticky</source>
++        <translation>sticky</translation>
++    </message>
++    <message>
++        <source>about:blank</source>
++        <translation>about:blank</translation>
++    </message>
++    <message>
++        <source>Description</source>
++        <translation>Description</translation>
++    </message>
++    <message>
++        <source>Symbol &amp; Name</source>
++        <translation>Symbol &amp; Name</translation>
++    </message>
++    <message>
++        <source>Comment</source>
++        <translation>Comment</translation>
++    </message>
++    <message>
++        <source>Edit Waypoint ...</source>
++        <translation>Edit Waypoint ...</translation>
++    </message>
++    <message>
++        <source>Webpage</source>
++        <translation>Webpage</translation>
++    </message>
++    <message>
++        <source>Proximity Dist.</source>
++        <translation>Proximity Dist.</translation>
++    </message>
++    <message>
++        <source>Parent waypoint. Attach this waypoint to a geocache.</source>
++        <translation>Parent waypoint. Attach this waypoint to a geocache.</translation>
++    </message>
++    <message>
++        <source>More</source>
++        <translation>More</translation>
++    </message>
++    <message>
++        <source>Show hidden information</source>
++        <translation>Show hidden information</translation>
++    </message>
++    <message>
++        <source>If you use the word &quot;Spoiler&quot; in the comment, the image might be treated special on your GPSr. 
++
++For modern Garmin device select &quot;Garmin Mass Storage&quot; device to exchange pictures and spoilers.</source>
++        <translation>If you use the word &quot;Spoiler&quot; in the comment, the image might be treated special on your GPSr. 
++
++For modern Garmin device select &quot;Garmin Mass Storage&quot; device to exchange pictures and spoilers.</translation>
++    </message>
++    <message>
++        <source>Transparent</source>
++        <translation>Transparent</translation>
++    </message>
++    <message>
++        <source>Barcode</source>
++        <translation>Barcode</translation>
++    </message>
++    <message>
++        <source>xx</source>
++        <translation>xx</translation>
++    </message>
++    <message>
++        <source>Create Buddies</source>
++        <translation>Create Buddies</translation>
++    </message>
++    <message>
++        <source>Get spoilers!</source>
++        <translation>Get spoilers!</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgExport</name>
++    <message>
++        <source>All</source>
++        <translation>All</translation>
++    </message>
++    <message>
++        <source>Export data...</source>
++        <translation>Export data...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgImportImages</name>
++    <message>
++        <source>Import pictures from</source>
++        <translation>Import pictures from</translation>
++    </message>
++    <message>
++        <source>./</source>
++        <translation>./</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translatorcomment>...</translatorcomment>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Create local copy</source>
++        <translation>Create local copy</translation>
++    </message>
++    <message>
++        <source>~600x400</source>
++        <translation>~600x400</translation>
++    </message>
++    <message>
++        <source>~1024x700</source>
++        <translation>~1024x700</translation>
++    </message>
++    <message>
++        <source>just link external file</source>
++        <translation>just link external file</translation>
++    </message>
++    <message>
++        <source>original size</source>
++        <translation>original size</translation>
++    </message>
++    <message>
++        <source>Reference source</source>
++        <translation>Reference source</translation>
++    </message>
++    <message>
++        <source>From EXIF header</source>
++        <translation>From EXIF header</translation>
++    </message>
++    <message>
++        <source>Time reference</source>
++        <translation>Time reference</translation>
++    </message>
++    <message>
++        <source>Position reference</source>
++        <translation>Position reference</translation>
++    </message>
++    <message>
++        <source>Select a picture from the list and enter the timestamp</source>
++        <translation>Select a picture from the list and enter the timestamp</translation>
++    </message>
++    <message>
++        <source>dd.MM.yy HH:mm:ss</source>
++        <translation>dd.MM.yy HH:mm:ss</translation>
++    </message>
++    <message>
++        <source>Select a picture from the list and enter the position</source>
++        <translation>Select a picture from the list and enter the position</translation>
++    </message>
++    <message>
++        <source>The position has to be in WGS84 datum. The position format is: N|Sdd mm.mmm E|Wddd mm.mmm</source>
++        <translation>The position has to be in WGS84 datum. The position format is: N|Sdd mm.mmm E|Wddd mm.mmm</translation>
++    </message>
++    <message>
++        <source>Import pictures</source>
++        <translation>Import pictures</translation>
++    </message>
++    <message>
++        <source>Take a picture of the GPS time display as the first photo in the series. Double-click that picture in the above list and enter the GPS time in the text box. QLandkarte GT will derive the delta time between camera
++and GPS and adjust all image time-stamps before correlating them with loaded track points.</source>
++        <translation>Take a picture of the GPS time display as the first photo in the series. Double-click that picture in the above list and enter the GPS time in the text box. QLandkarte GT will derive the delta time between camera
++and GPS and adjust all image time-stamps before correlating them with loaded track points.</translation>
++    </message>
++    <message>
++        <source>Take a picture of the GPS position display as the first photo in the series. Double-click that picture in the above list and enter the GPS position. QLandkarte GT will locate the closest track point and derive the delta time between camera and GPS and adjust all image time-stamps before correlating them with loaded track points.</source>
++        <translation>Take a picture of the GPS position display as the first photo in the series. Double-click that picture in the above list and enter the GPS position. QLandkarte GT will locate the closest track point and derive the delta time between camera and GPS and adjust all image time-stamps before correlating them with loaded track points.</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgLoadOnlineMap</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Target path is %1</source>
++        <translation type="obsolete">Target path is %1</translation>
++    </message>
++    <message>
++        <source>Available Online Map ...</source>
++        <translation>Available Online Map ...</translation>
++    </message>
++    <message>
++        <source>Download map file to:</source>
++        <translation>Download map file to:</translation>
++    </message>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMapJNXConfig</name>
++    <message>
++        <source>about:blank</source>
++        <translation>about:blank</translation>
++    </message>
++    <message>
++        <source>Information...</source>
++        <translation>Information...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMapQMAPConfig</name>
++    <message>
++        <source>about:blank</source>
++        <translation>about:blank</translation>
++    </message>
++    <message>
++        <source>Information...</source>
++        <translation>Information...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMapRMPConfig</name>
++    <message>
++        <source>Information...</source>
++        <translation>Information...</translation>
++    </message>
++    <message>
++        <source>about:blank</source>
++        <translation>about:blank</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMapTDBConfig</name>
++    <message>
++        <source>Configure Garmin Map...</source>
++        <translation>Configure Garmin Map...</translation>
++    </message>
++    <message>
++        <source>about:blank</source>
++        <translation>about:blank</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMapTmsConfig</name>
++    <message>
++        <source>URL</source>
++        <translation>URL</translation>
++    </message>
++    <message>
++        <source>Name</source>
++        <translation>Name</translation>
++    </message>
++    <message>
++        <source>Config TMS</source>
++        <translation>Config TMS</translation>
++    </message>
++    <message>
++        <source>Placeholders to be used inside &quot;Path&quot; definition: %1 = zoom; %2 = x; %3 = y</source>
++        <translation>Placeholders to be used inside &quot;Path&quot; definition: %1 = zoom; %2 = x; %3 = y</translation>
++    </message>
++    <message>
++        <source>Copyright</source>
++        <translation>Copyright</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMapWmsConfig</name>
++    <message>
++        <source>Map</source>
++        <translation>Map</translation>
++    </message>
++    <message>
++        <source>Value</source>
++        <translation>Value</translation>
++    </message>
++    <message>
++        <source>Config WMS</source>
++        <translation>Config WMS</translation>
++    </message>
++    <message>
++        <source>File:</source>
++        <translation>File:</translation>
++    </message>
++    <message>
++        <source>Property</source>
++        <translation>Property</translation>
++    </message>
++    <message>
++        <source>Server</source>
++        <translation>Server</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgMultiColorConfig</name>
++    <message>
++        <source>Multi Color Setup...</source>
++        <translation>Multi Color Setup...</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation>TextLabel</translation>
++    </message>
++    <message>
++        <source>Auto</source>
++        <translation>Auto</translation>
++    </message>
++    <message>
++        <source>Min</source>
++        <translation>Min</translation>
++    </message>
++    <message>
++        <source>Max</source>
++        <translation>Max</translation>
++    </message>
++    <message>
++        <source>Min Color</source>
++        <translation>Min Color</translation>
++    </message>
++    <message>
++        <source>Max Color</source>
++        <translation>Max Color</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgNoMapConfig</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Map Setup...</source>
++        <translation>Map Setup...</translation>
++    </message>
++    <message>
++        <source>restore default</source>
++        <translation>restore default</translation>
++    </message>
++    <message>
++        <source>projection wizzard</source>
++        <translation>projection wizzard</translation>
++    </message>
++    <message>
++        <source>Scale x</source>
++        <translation>Scale x</translation>
++    </message>
++    <message>
++        <source>Scale y</source>
++        <translation>Scale y</translation>
++    </message>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgParentWpt</name>
++    <message>
++        <source>Select Parent Waypoint ...</source>
++        <translation>Select Parent Waypoint ...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgProjWizzard</name>
++    <message>
++        <source>UTM</source>
++        <translation>UTM</translation>
++    </message>
++    <message>
++        <source>zone</source>
++        <translation>zone</translation>
++    </message>
++    <message>
++        <source>Datum</source>
++        <translation>Datum</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Lon/Lat</source>
++        <translation>Lon/Lat</translation>
++    </message>
++    <message>
++        <source>Result:</source>
++        <translation>Result:</translation>
++    </message>
++    <message>
++        <source>Proj4 Wizzard</source>
++        <translation>Proj4 Wizzard</translation>
++    </message>
++    <message>
++        <source>Mercator</source>
++        <translation>Mercator</translation>
++    </message>
++    <message>
++        <source>user defined</source>
++        <translation>user defined</translation>
++    </message>
++    <message>
++        <source>World Mercator (OSM)</source>
++        <translation>World Mercator (OSM)</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgScreenshot</name>
++    <message>
++        <source>Save</source>
++        <translation>Save</translation>
++    </message>
++    <message>
++        <source>Screenshot...</source>
++        <translation>Screenshot...</translation>
++    </message>
++    <message>
++        <source>This will take a screen shot from your connected GPSr. Simply press &apos;Acquire&apos; to download the current screen. In addition, it will copy the image to your clipboard.</source>
++        <translation>This will take a screen shot from your connected GPSr. Simply press &apos;Acquire&apos; to download the current screen. In addition, it will copy the image to your clipboard.</translation>
++    </message>
++    <message>
++        <source>Acquire</source>
++        <translation>Acquire</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgSelGeoDBFolder</name>
++    <message>
++        <source>Select folder...</source>
++        <translation>Select folder...</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgSetupGarminIcons</name>
++    <message>
++        <source>Name</source>
++        <translation>Name</translation>
++    </message>
++    <message>
++        <source>Garmin Waypoint Icons</source>
++        <translation>Garmin Waypoint Icons</translation>
++    </message>
++    <message>
++        <source>Source</source>
++        <translation>Source</translation>
++    </message>
++    <message>
++        <source>Send to device</source>
++        <translation>Send to device</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgSetupGrid</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Setup Grid...</source>
++        <translation>Setup Grid...</translation>
++    </message>
++    <message>
++        <source>restore default</source>
++        <translation>restore default</translation>
++    </message>
++    <message>
++        <source>Get projection from current map.</source>
++        <translation>Get projection from current map.</translation>
++    </message>
++    <message>
++        <source>projection wizzard</source>
++        <translation>projection wizzard</translation>
++    </message>
++    <message>
++        <source>Grid color</source>
++        <translatorcomment>Paramétrer la couleur de la grille</translatorcomment>
++        <translation>Grid color</translation>
++    </message>
++    <message>
++        <source>setup grid color</source>
++        <translation>setup grid color</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgTrackFilter</name>
++    <message utf8="true">
++        <source>°</source>
++        <translation>°</translation>
++    </message>
++    <message>
++        <source>UTC</source>
++        <translation>UTC</translation>
++    </message>
++    <message>
++        <source>SplitTrack into chunks of </source>
++        <translation>SplitTrack into chunks of </translation>
++    </message>
++    <message>
++        <source>Time from previous point less than</source>
++        <translation>Time from previous point less than</translation>
++    </message>
++    <message>
++        <source>Change time deltas to 1 second per trackpoint</source>
++        <translation>Change time deltas to 1 second per trackpoint</translation>
++    </message>
++    <message>
++        <source>buttonGroupTDelta</source>
++        <translation>buttonGroupTDelta</translation>
++    </message>
++    <message>
++        <source>Track Filter...</source>
++        <translation>Track Filter...</translation>
++    </message>
++    <message>
++        <source>Distance to previous point less than</source>
++        <translation>Distance to previous point less than</translation>
++    </message>
++    <message>
++        <source>Split track on &quot;Ok&quot;</source>
++        <translation>Split track on &quot;Ok&quot;</translation>
++    </message>
++    <message>
++        <source>Leave time deltas as in original track</source>
++        <translation>Leave time deltas as in original track</translation>
++    </message>
++    <message>
++        <source>Split Track</source>
++        <translation>Split Track</translation>
++    </message>
++    <message>
++        <source>Reset to 1970-01-01, 00:00 UTC</source>
++        <translation>Reset to 1970-01-01, 00:00 UTC</translation>
++    </message>
++    <message>
++        <source>chunks</source>
++        <translation>chunks</translation>
++    </message>
++    <message>
++        <source>Change the track&apos;s starting time (anonymize track) to:</source>
++        <translation>Change the track&apos;s starting time (anonymize track) to:</translation>
++    </message>
++    <message>
++        <source>buttonGroupTZ</source>
++        <translation>buttonGroupTZ</translation>
++    </message>
++    <message>
++        <source>points</source>
++        <translation>points</translation>
++    </message>
++    <message>
++        <source>Local time</source>
++        <translation>Local time</translation>
++    </message>
++    <message>
++        <source>Split the track into </source>
++        <translation>Split the track into </translation>
++    </message>
++    <message>
++        <source>Perform dataset reduction on &quot;OK&quot;</source>
++        <translation>Perform dataset reduction on &quot;OK&quot;</translation>
++    </message>
++    <message>
++        <source>Timestamps</source>
++        <translation>Timestamps</translation>
++    </message>
++    <message>
++        <source>If you select to split the track, the above will apply to the newly created fragments.</source>
++        <translation>If you select to split the track, the above will apply to the newly created fragments.</translation>
++    </message>
++    <message>
++        <source>Reset to 1st of month, hour 00</source>
++        <translation>Reset to 1st of month, hour 00</translation>
++    </message>
++    <message>
++        <source>Modify timestamps on &quot;OK&quot;</source>
++        <translation>Modify timestamps on &quot;OK&quot;</translation>
++    </message>
++    <message>
++        <source>Filter Track</source>
++        <translation>Filter Track</translation>
++    </message>
++    <message>
++        <source>Hide track points if:</source>
++        <translation>Hide track points if:</translation>
++    </message>
++    <message>
++        <source>buttonGroup</source>
++        <translation>buttonGroup</translation>
++    </message>
++    <message>
++        <source>Azimuth from previous point less than</source>
++        <translation>Azimuth from previous point less than</translation>
++    </message>
++    <message>
++        <source>Change track point data:</source>
++        <translation>Change track point data:</translation>
++    </message>
++    <message>
++        <source>Smooth profile (Median filter, 5 tabs)</source>
++        <translation>Smooth profile (Median filter, 5 tabs)</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgWpt2Rte</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Route from waypoints...</source>
++        <translation>Route from waypoints...</translation>
++    </message>
++    <message>
++        <source>Available Waypoints</source>
++        <translation>Available Waypoints</translation>
++    </message>
++    <message>
++        <source>Selected Waypoints</source>
++        <translation>Selected Waypoints</translation>
++    </message>
++    <message>
++        <source>New Route Name</source>
++        <translation>New Route Name</translation>
++    </message>
++    <message>
++        <source>New Route</source>
++        <translation>New Route</translation>
++    </message>
++</context>
++<context>
++    <name>IDlgWptIcon</name>
++    <message>
++        <source>Select icon ...</source>
++        <translation>Select icon ...</translation>
++    </message>
++</context>
++<context>
++    <name>IGarminExport</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Create gmapsupp.img</source>
++        <translation>Create gmapsupp.img</translation>
++    </message>
++    <message>
++        <source>Close</source>
++        <translation>Close</translation>
++    </message>
++    <message>
++        <source>Output Path:</source>
++        <translation>Output Path:</translation>
++    </message>
++    <message>
++        <source>Export</source>
++        <translation>Export</translation>
++    </message>
++    <message>
++        <source>File Prefix</source>
++        <translation>File Prefix</translation>
++    </message>
++</context>
++<context>
++    <name>IGarminTyp</name>
++    <message>
++        <source>This is a typ file with unknown polyline encoding. Please report!</source>
++        <translation>This is a typ file with unknown polyline encoding. Please report!</translation>
++    </message>
++    <message>
++        <source>Warning...</source>
++        <translation>Warning...</translation>
++    </message>
++    <message>
++        <source>This is a typ file with unknown polygon encoding. Please report!</source>
++        <translation>This is a typ file with unknown polygon encoding. Please report!</translation>
++    </message>
++</context>
++<context>
++    <name>IGeoToolWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++</context>
++<context>
++    <name>IHelpDialog</name>
++    <message>
++        <source>Help</source>
++        <translation>Help</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation>TextLabel</translation>
++    </message>
++</context>
++<context>
++    <name>IImageSelect</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++</context>
++<context>
++    <name>IImageViewer</name>
++    <message>
++        <source>Dialog</source>
++        <translation>Dialog</translation>
++    </message>
++</context>
++<context>
++    <name>ILiveLogToolWidget</name>
++    <message>
++        <source>-</source>
++        <translation>-</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Error vert.:</source>
++        <translation>Error vert.:</translation>
++    </message>
++    <message>
++        <source>Satellites:</source>
++        <translation>Satellites:</translation>
++    </message>
++    <message>
++        <source>Error horiz.:</source>
++        <translation>Error horiz.:</translation>
++    </message>
++    <message>
++        <source>GPS Time:</source>
++        <translation>GPS Time:</translation>
++    </message>
++    <message>
++        <source>Speed:</source>
++        <translation>Speed:</translation>
++    </message>
++    <message>
++        <source>Position:</source>
++        <translation>Position:</translation>
++    </message>
++    <message>
++        <source>Status:</source>
++        <translation>Status:</translation>
++    </message>
++    <message>
++        <source>Altitude:</source>
++        <translation>Altitude:</translation>
++    </message>
++    <message>
++        <source>Heading:</source>
++        <translation>Heading:</translation>
++    </message>
++    <message>
++        <source>GPS off</source>
++        <translation>GPS off</translation>
++    </message>
++    <message>
++        <source>use small arrow</source>
++        <translation>use small arrow</translation>
++    </message>
++</context>
++<context>
++    <name>IMap</name>
++    <message>
++        <source>This map does not support this feature.</source>
++        <translation>This map does not support this feature.</translation>
++    </message>
++    <message>
++        <source>No basemap projection. That shouldn&apos;t happen.</source>
++        <translation>No basemap projection. That shouldn&apos;t happen.</translation>
++    </message>
++    <message>
++        <source>Error...</source>
++        <translation>Error...</translation>
++    </message>
++    <message>
++        <source>DEM projection does not match the projection of the basemap.
++
++Map: %1
++
++DEM: %2
++
++In my point of view this is bad. But if you think I am wrong just go on with &apos;Apply&apos;. Else abort operation.</source>
++        <translation>DEM projection does not match the projection of the basemap.
++
++Map: %1
++
++DEM: %2
++
++In my point of view this is bad. But if you think I am wrong just go on with &apos;Apply&apos;. Else abort operation.</translation>
++    </message>
++    <message>
++        <source>Changing the offset is not supported by this map.</source>
++        <translation>Changing the offset is not supported by this map.</translation>
++    </message>
++    <message>
++        <source>DEM projection does not match the projection of the basemap.
++
++Map: %1
++
++DEM: %2</source>
++        <translation>DEM projection does not match the projection of the basemap.
++
++Map: %1
++
++DEM: %2</translation>
++    </message>
++</context>
++<context>
++    <name>IMapDEMSlopeSetup</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translatorcomment>Label textuel</translatorcomment>
++        <translation>TextLabel</translation>
++    </message>
++</context>
++<context>
++    <name>IMapEditWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Select a source for the map to create.</source>
++        <translation>Select a source for the map to create.</translation>
++    </message>
++    <message>
++        <source>Source:</source>
++        <translation>Source:</translation>
++    </message>
++</context>
++<context>
++    <name>IMapQMAPExport</name>
++    <message>
++        <source>1 </source>
++        <translation>1 </translation>
++    </message>
++    <message>
++        <source>2x</source>
++        <translation>2x</translation>
++    </message>
++    <message>
++        <source>4x</source>
++        <translation>4x</translation>
++    </message>
++    <message>
++        <source>8x</source>
++        <translation>8x</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>16x</source>
++        <translation>16x</translation>
++    </message>
++    <message>
++        <source>411</source>
++        <translation>411</translation>
++    </message>
++    <message>
++        <source>422</source>
++        <translation>422</translation>
++    </message>
++    <message>
++        <source>444</source>
++        <translation>444</translation>
++    </message>
++    <message>
++        <source>Close</source>
++        <translation>Close</translation>
++    </message>
++    <message>
++        <source>Projection</source>
++        <translation>Projection</translation>
++    </message>
++    <message>
++        <source>Output path:</source>
++        <translation>Output path:</translation>
++    </message>
++    <message>
++        <source>Device</source>
++        <translation>Device</translation>
++    </message>
++    <message>
++        <source>Export</source>
++        <translation>Export</translation>
++    </message>
++    <message>
++        <source>File prefix</source>
++        <translation>File prefix</translation>
++    </message>
++    <message>
++        <source>Description</source>
++        <translation>Description</translation>
++    </message>
++    <message>
++        <source>Garmin Custom Map</source>
++        <translation>Garmin Custom Map</translation>
++    </message>
++    <message>
++        <source>Overviews</source>
++        <translation>Overviews</translation>
++    </message>
++    <message>
++        <source>Export map ...</source>
++        <translation>Export map ...</translation>
++    </message>
++    <message>
++        <source>Z-Order</source>
++        <translation>Z-Order</translation>
++    </message>
++    <message>
++        <source>You want to export a map from a streaming map server. QLandkarte GT will only export those parts of the map that are anyway in the cache. In other words, &lt;b&gt;you have to view the whole area at the selected zoom levels with QLandkarte GT before you can export it&lt;/b&gt;. Keep in mind that QLandkarte is not a ripper tool for streaming maps. &lt;b&gt;Please respect the copyrights and terms of use of the particular server.&lt;/b&gt; </source>
++        <translation>You want to export a map from a streaming map server. QLandkarte GT will only export those parts of the map that are anyway in the cache. In other words, &lt;b&gt;you have to view the whole area at the selected zoom levels with QLandkarte GT before you can export it&lt;/b&gt;. Keep in mind that QLandkarte is not a ripper tool for streaming maps. &lt;b&gt;Please respect the copyrights and terms of use of the particular server.&lt;/b&gt; </translation>
++    </message>
++    <message>
++        <source>Streaming</source>
++        <translation>Streaming</translation>
++    </message>
++    <message>
++        <source>Levels to export</source>
++        <translation>Levels to export</translation>
++    </message>
++    <message>
++        <source>Give a list of zoom levels you want to export. Like: 1 4 8 16</source>
++        <translation>Give a list of zoom levels you want to export. Like: 1 4 8 16</translation>
++    </message>
++    <message>
++        <source>GeoTiff</source>
++        <translation>GeoTiff</translation>
++    </message>
++    <message>
++        <source>Garmin BirdsEye</source>
++        <translation>Garmin BirdsEye</translation>
++    </message>
++    <message>
++        <source>TwoNav RMAP</source>
++        <translation>TwoNav RMAP</translation>
++    </message>
++    <message>
++        <source>Tile selection is only supported by Garmin Custom Map. All other formats will export the whole area as is.</source>
++        <translation>Tile selection is only supported by Garmin Custom Map. All other formats will export the whole area as is.</translation>
++    </message>
++    <message>
++        <source>BirdsEye</source>
++        <translation>BirdsEye</translation>
++    </message>
++    <message>
++        <source>Product name</source>
++        <translation>Product name</translation>
++    </message>
++    <message>
++        <source>Copyright notice</source>
++        <translation>Copyright notice</translation>
++    </message>
++    <message>
++        <source>None</source>
++        <translation>None</translation>
++    </message>
++    <message>
++        <source>Product ID</source>
++        <translation>Product ID</translation>
++    </message>
++    <message>
++        <source>JPEG</source>
++        <translation>JPEG</translation>
++    </message>
++    <message>
++        <source>Quality</source>
++        <translation>Quality</translation>
++    </message>
++    <message>
++        <source>Chroma subsampling</source>
++        <translation>Chroma subsampling</translation>
++    </message>
++    <message>
++        <source>RMAP</source>
++        <translation>RMAP</translation>
++    </message>
++    <message>
++        <source>Projection </source>
++        <translation>Projection </translation>
++    </message>
++    <message>
++        <source>Single File</source>
++        <translation>Single File</translation>
++    </message>
++    <message>
++        <source>Get projection from current map.</source>
++        <translation>Get projection from current map.</translation>
++    </message>
++    <message>
++        <source>Projection Wizard</source>
++        <translation>Projection Wizard</translation>
++    </message>
++    <message>
++        <source>Details</source>
++        <translation>Details</translation>
++    </message>
++    <message>
++        <source>Step -/-</source>
++        <translation>Step -/-</translation>
++    </message>
++    <message>
++        <source>File -/-</source>
++        <translation>File -/-</translation>
++    </message>
++    <message>
++        <source>Make your selections and press &quot;Export&quot;</source>
++        <translation>Make your selections and press &quot;Export&quot;</translation>
++    </message>
++    <message>
++        <source>Magellan RMP</source>
++        <translation>Magellan RMP</translation>
++    </message>
++    <message>
++        <source>Provider </source>
++        <translation>Provider </translation>
++    </message>
++    <message>
++        <source>Product</source>
++        <translation>Product</translation>
++    </message>
++    <message>
++        <source>Copyright</source>
++        <translation>Copyright</translation>
++    </message>
++</context>
++<context>
++    <name>IMapSearchWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Gray Threshold</source>
++        <translation>Gray Threshold</translation>
++    </message>
++    <message>
++        <source>Area:</source>
++        <translation>Area:</translation>
++    </message>
++    <message>
++        <source>Cancel</source>
++        <translation>Cancel</translation>
++    </message>
++    <message>
++        <source>Search...</source>
++        <translation>Search...</translation>
++    </message>
++    <message>
++        <source>No mask selected</source>
++        <translation>No mask selected</translation>
++    </message>
++    <message>
++        <source>No area selected.</source>
++        <translation>No area selected.</translation>
++    </message>
++    <message>
++        <source>Symbols</source>
++        <translation>Symbols</translation>
++    </message>
++</context>
++<context>
++    <name>IMapToolWidget</name>
++    <message>
++        <source>M</source>
++        <translation>M</translation>
++    </message>
++    <message>
++        <source>T</source>
++        <translation>T</translation>
++    </message>
++    <message>
++        <source>Map</source>
++        <translation>Map</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Page</source>
++        <translation>Page</translation>
++    </message>
++    <message>
++        <source>The map&apos;s name</source>
++        <translation>The map&apos;s name</translation>
++    </message>
++    <message>
++        <source>Tab 1</source>
++        <translation>Tab 1</translation>
++    </message>
++    <message>
++        <source>Tab 2</source>
++        <translation>Tab 2</translation>
++    </message>
++    <message>
++        <source>Mode - show active map and active overlays</source>
++        <translation>Mode - show active map and active overlays</translation>
++    </message>
++    <message>
++        <source>Export Map</source>
++        <translation>Export Map</translation>
++    </message>
++    <message>
++        <source>Type of map</source>
++        <translation>Type of map</translation>
++    </message>
++    <message>
++        <source>Selected Maps:</source>
++        <translation>Selected Maps:</translation>
++    </message>
++</context>
++<context>
++    <name>IMouse</name>
++    <message>
++        <source>too many...</source>
++        <translation>too many...</translation>
++    </message>
++    <message>
++        <source>Left click to lock circles.
++Then select function from circle.
++Left click on canvas to un-lock circles.</source>
++        <translation>Left click to lock circles.
++Then select function from circle.
++Left click on canvas to un-lock circles.</translation>
++    </message>
++</context>
++<context>
++    <name>IOverlay</name>
++    <message>
++        <source>No info set</source>
++        <translation>No info set</translation>
++    </message>
++</context>
++<context>
++    <name>IOverlayAreaEditWidget</name>
++    <message>
++        <source>Form</source>
++        <translation type="unfinished">Form</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation type="unfinished">TextLabel</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation type="unfinished">...</translation>
++    </message>
++    <message>
++        <source>Color</source>
++        <translation type="unfinished">Color</translation>
++    </message>
++    <message>
++        <source>Comment</source>
++        <translation type="unfinished">Comment</translation>
++    </message>
++    <message>
++        <source>Name</source>
++        <translation type="unfinished">Name</translation>
++    </message>
++    <message>
++        <source>Style</source>
++        <translation type="unfinished">Style</translation>
++    </message>
++    <message>
++        <source>Border Width</source>
++        <translation type="unfinished">Border Width</translation>
++    </message>
++    <message>
++        <source>Opacity</source>
++        <translation type="unfinished">Opacity</translation>
++    </message>
++    <message>
++        <source>Apply</source>
++        <translation type="unfinished">Apply</translation>
++    </message>
++    <message>
++        <source>Position</source>
++        <translation type="unfinished">Position</translation>
++    </message>
++</context>
++<context>
++    <name>IOverlayDistanceEditWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Name</source>
++        <translation>Name</translation>
++    </message>
++    <message>
++        <source>Speed</source>
++        <translation>Speed</translation>
++    </message>
++    <message>
++        <source>Position</source>
++        <translation>Position</translation>
++    </message>
++    <message>
++        <source>Comment</source>
++        <translation>Comment</translation>
++    </message>
++    <message>
++        <source>TextLabel</source>
++        <translation>TextLabel</translation>
++    </message>
++    <message>
++        <source>Apply</source>
++        <translation type="unfinished">Apply</translation>
++    </message>
++</context>
++<context>
++    <name>IOverlayToolWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++</context>
++<context>
++    <name>IRouteToolWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Ferry</source>
++        <translation>Ferry</translation>
++    </message>
++    <message>
++        <source>Setup</source>
++        <translation>Setup</translation>
++    </message>
++    <message>
++        <source>Country Border</source>
++        <translation>Country Border</translation>
++    </message>
++    <message>
++        <source>Toll Road</source>
++        <translation>Toll Road</translation>
++    </message>
++    <message>
++        <source>Lim. Access</source>
++        <translation>Lim. Access</translation>
++    </message>
++    <message>
++        <source>Avoid:</source>
++        <translation>Avoid:</translation>
++    </message>
++    <message>
++        <source>Routes</source>
++        <translation>Routes</translation>
++    </message>
++    <message>
++        <source>Seasonal</source>
++        <translation>Seasonal</translation>
++    </message>
++    <message>
++        <source>Sort by time</source>
++        <translation>Sort by time</translation>
++    </message>
++    <message>
++        <source>Sort by name</source>
++        <translation>Sort by name</translation>
++    </message>
++    <message>
++        <source>Unpaved</source>
++        <translation>Unpaved</translation>
++    </message>
++    <message>
++        <source>Highways</source>
++        <translation>Highways</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;table border=&quot;0&quot; style=&quot;-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;&quot;&gt;
++&lt;tr&gt;
++&lt;td style=&quot;border: none;&quot;&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;How to add a route?&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Routes can be created from waypoints or distance polylines. &lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To create a route from waypoints you have to select at least two waypoints in the waypoint tool view. After you made your selection you summon the menu by a right mouse button click and select &amp;quot;Make Route&amp;quot;. &lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To create a route from a distance polyline you select the line and summon the menu by a right mouse button click and select &amp;quot;Make Route&amp;quot;.&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;In the &amp;quot;Setup&amp;quot; tab you can select settings for auto routing. To calculate a secondary, autorouted route to your primary route definition you  summon the menu by a right mouse button click and select &amp;quot;Calc. route&amp;quot;.&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;table border=&quot;0&quot; style=&quot;-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;&quot;&gt;
++&lt;tr&gt;
++&lt;td style=&quot;border: none;&quot;&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;How to add a route?&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Routes can be created from waypoints or distance polylines. &lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To create a route from waypoints you have to select at least two waypoints in the waypoint tool view. After you made your selection you summon the menu by a right mouse button click and select &amp;quot;Make Route&amp;quot;. &lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;To create a route from a distance polyline you select the line and summon the menu by a right mouse button click and select &amp;quot;Make Route&amp;quot;.&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
++&lt;p align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;In the &amp;quot;Setup&amp;quot; tab you can select settings for auto routing. To calculate a secondary, autorouted route to your primary route definition you  summon the menu by a right mouse button click and select &amp;quot;Calc. route&amp;quot;.&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++</context>
++<context>
++    <name>ISearchToolWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Host:</source>
++        <translation>Host:</translation>
++    </message>
++    <message>
++        <source>Search:</source>
++        <translation>Search:</translation>
++    </message>
++</context>
++<context>
++    <name>IStatusDEM</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>none</source>
++        <translation>none</translation>
++    </message>
++    <message>
++        <source>shading</source>
++        <translation>shading</translation>
++    </message>
++    <message>
++        <source>contour</source>
++        <translation>contour</translation>
++    </message>
++    <message>
++        <source>slope</source>
++        <translation>slope</translation>
++    </message>
++</context>
++<context>
++    <name>ITextEditWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++</context>
++<context>
++    <name>ITrackEditWidget</name>
++    <message>
++        <source>#</source>
++        <translation>#</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>time</source>
++        <translation>time</translation>
++    </message>
++    <message>
++        <source>delta</source>
++        <translation>delta</translation>
++    </message>
++    <message>
++        <source>speed</source>
++        <translation>speed</translation>
++    </message>
++    <message>
++        <source>distance</source>
++        <translation>distance</translation>
++    </message>
++    <message>
++        <source>Reset all changes (hidden track points and filters)</source>
++        <translation type="obsolete">Reset all changes (hidden track points and filters)</translation>
++    </message>
++    <message>
++        <source>Use &apos;return&apos; key to change name permanently.</source>
++        <translation>Use &apos;return&apos; key to change name permanently.</translation>
++    </message>
++    <message>
++        <source>altitude</source>
++        <translation>altitude</translation>
++    </message>
++    <message>
++        <source>Remove hidden track points permanently.</source>
++        <translation type="obsolete">Remove hidden track points permanently.</translation>
++    </message>
++    <message>
++        <source>Stages</source>
++        <translation>Stages</translation>
++    </message>
++    <message>
++        <source>ascend</source>
++        <translation>ascend</translation>
++    </message>
++    <message>
++        <source>position</source>
++        <translation>position</translation>
++    </message>
++    <message>
++        <source>Tracklist</source>
++        <translation>Tracklist</translation>
++    </message>
++    <message>
++        <source>Toggle extensions statistics view over time</source>
++        <translation>Toggle extensions statistics view over time</translation>
++    </message>
++    <message>
++        <source>Toggle statistics view for trainings data.</source>
++        <translation>Toggle statistics view for trainings data.</translation>
++    </message>
++    <message>
++        <source>Toggle track statistics view over time.</source>
++        <translation>Toggle track statistics view over time.</translation>
++    </message>
++    <message>
++        <source>azimuth</source>
++        <translation>azimuth</translation>
++    </message>
++    <message>
++        <source>Standard</source>
++        <translation>Standard</translation>
++    </message>
++    <message>
++        <source>descend</source>
++        <translation>descend</translation>
++    </message>
++    <message>
++        <source>Toggle track statistics view over distance.</source>
++        <translation>Toggle track statistics view over distance.</translation>
++    </message>
++    <message>
++        <source>Extensions</source>
++        <translation>Extensions</translation>
++    </message>
++    <message>
++        <source>Settings</source>
++        <translation>Settings</translation>
++    </message>
++    <message>
++        <source>Choose here which columns are shown in the tracklist view</source>
++        <translation>Choose here which columns are shown in the tracklist view</translation>
++    </message>
++    <message>
++        <source>Show the track on Google Maps</source>
++        <translation>Show the track on Google Maps</translation>
++    </message>
++    <message>
++        <source>row number (#)</source>
++        <translation>row number (#)</translation>
++    </message>
++    <message>
++        <source>Filter track points.</source>
++        <translation type="obsolete">Filter track points.</translation>
++    </message>
++    <message>
++        <source>Filter</source>
++        <translation>Filter</translation>
++    </message>
++    <message>
++        <source>Multicolor</source>
++        <translation>Multicolor</translation>
++    </message>
++    <message>
++        <source>If checked, the map is centered map on selected trackpoint.</source>
++        <translation>If checked, the map is centered map on selected trackpoint.</translation>
++    </message>
++    <message>
++        <source>Center map</source>
++        <translation>Center map</translation>
++    </message>
++</context>
++<context>
++    <name>ITrackFilterWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Points</source>
++        <translation>Points</translation>
++    </message>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Reduce Points</source>
++        <translation>Reduce Points</translation>
++    </message>
++    <message>
++        <source>Hide track points if:</source>
++        <translation>Hide track points if:</translation>
++    </message>
++    <message>
++        <source>Distance to previous point less than</source>
++        <translation>Distance to previous point less than</translation>
++    </message>
++    <message>
++        <source>Azimuth from previous point less than</source>
++        <translation>Azimuth from previous point less than</translation>
++    </message>
++    <message utf8="true">
++        <source>°</source>
++        <translation>°</translation>
++    </message>
++    <message>
++        <source>Smooth Profile</source>
++        <translation>Smooth Profile</translation>
++    </message>
++    <message>
++        <source>Change elevation data of track:</source>
++        <translation>Change elevation data of track:</translation>
++    </message>
++    <message>
++        <source>Median filter over</source>
++        <translation>Median filter over</translation>
++    </message>
++    <message>
++        <source>points</source>
++        <translation>points</translation>
++    </message>
++    <message>
++        <source>Delete hidden points</source>
++        <translation>Delete hidden points</translation>
++    </message>
++    <message>
++        <source>Delete hidden track points for ever. No way back!</source>
++        <translation>Delete hidden track points for ever. No way back!</translation>
++    </message>
++    <message>
++        <source>Split</source>
++        <translation>Split</translation>
++    </message>
++    <message>
++        <source>Split into equal chunks</source>
++        <translation>Split into equal chunks</translation>
++    </message>
++    <message>
++        <source>Split the track into </source>
++        <translation>Split the track into </translation>
++    </message>
++    <message>
++        <source>chunks</source>
++        <translation>chunks</translation>
++    </message>
++    <message>
++        <source>Split by number of points</source>
++        <translation>Split by number of points</translation>
++    </message>
++    <message>
++        <source>SplitTrack into chunks of </source>
++        <translation>SplitTrack into chunks of </translation>
++    </message>
++    <message>
++        <source>Split by distance</source>
++        <translation>Split by distance</translation>
++    </message>
++    <message>
++        <source>m</source>
++        <translation>m</translation>
++    </message>
++    <message>
++        <source>length</source>
++        <translation>length</translation>
++    </message>
++    <message>
++        <source>Split by ascend</source>
++        <translation>Split by ascend</translation>
++    </message>
++    <message>
++        <source>SplitTrack into chunks with </source>
++        <translation>SplitTrack into chunks with </translation>
++    </message>
++    <message>
++        <source>ascend</source>
++        <translation>ascend</translation>
++    </message>
++    <message>
++        <source>Split track</source>
++        <translation>Split track</translation>
++    </message>
++    <message>
++        <source>Add only waypoints for stages</source>
++        <translation>Add only waypoints for stages</translation>
++    </message>
++    <message>
++        <source>reset filter list</source>
++        <translation>reset filter list</translation>
++    </message>
++    <message>
++        <source>save filter list</source>
++        <translation>save filter list</translation>
++    </message>
++    <message>
++        <source>apply filter</source>
++        <translation>apply filter</translation>
++    </message>
++    <message>
++        <source>Apply</source>
++        <translation>Apply</translation>
++    </message>
++    <message>
++        <source>Profile</source>
++        <translation>Profile</translation>
++    </message>
++    <message>
++        <source>Replace elevation data</source>
++        <translation>Replace elevation data</translation>
++    </message>
++    <message>
++        <source>Use elevation from loaded DEM data</source>
++        <translation>Use elevation from loaded DEM data</translation>
++    </message>
++    <message>
++        <source>Use elevation from www.geonames.org</source>
++        <translation>Use elevation from www.geonames.org</translation>
++    </message>
++    <message>
++        <source>Username:</source>
++        <translation>Username:</translation>
++    </message>
++    <message>
++        <source>apply now</source>
++        <translation>apply now</translation>
++    </message>
++    <message>
++        <source>add to list</source>
++        <translation>add to list</translation>
++    </message>
++    <message>
++        <source>Douglas-Peucker</source>
++        <translation>Douglas-Peucker</translation>
++    </message>
++    <message>
++        <source>Distance of a point to a straight line between neighbor points is less than</source>
++        <translation>Distance of a point to a straight line between neighbor points is less than</translation>
++    </message>
++    <message>
++        <source>Change the track&apos;s starting time (anonymize track) to:</source>
++        <translation type="obsolete">Change the track&apos;s starting time (anonymize track) to:</translation>
++    </message>
++    <message>
++        <source>Local time</source>
++        <translation type="obsolete">Local time</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; color:#c00000;&quot;&gt;The filters will only apply to the selected part of the track.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
++&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
++p, li { white-space: pre-wrap; }
++&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
++&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; color:#c00000;&quot;&gt;The filters will only apply to the selected part of the track.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>Reset all changes</source>
++        <translation>Reset all changes</translation>
++    </message>
++    <message>
++        <source>Offset elevation data</source>
++        <translation>Offset elevation data</translation>
++    </message>
++    <message>
++        <source>Add offset of</source>
++        <translation>Add offset of</translation>
++    </message>
++    <message>
++        <source>Split at stages</source>
++        <translation>Split at stages</translation>
++    </message>
++    <message>
++        <source>Split track at stage waypoints</source>
++        <translation>Split track at stage waypoints</translation>
++    </message>
++    <message>
++        <source>Time</source>
++        <translation>Time</translation>
++    </message>
++    <message>
++        <source>Date/Time of track</source>
++        <translation>Date/Time of track</translation>
++    </message>
++    <message>
++        <source>New date/time of track</source>
++        <translation>New date/time of track</translation>
++    </message>
++    <message>
++        <source>dd.MMMM.yyyy HH:mm:ss</source>
++        <translation>dd.MMMM.yyyy HH:mm:ss</translation>
++    </message>
++    <message>
++        <source>Speed of track</source>
++        <translation>Speed of track</translation>
++    </message>
++    <message>
++        <source>Speed</source>
++        <translation>Speed</translation>
++    </message>
++    <message>
++        <source>km/h</source>
++        <translation>km/h</translation>
++    </message>
++    <message>
++        <source>Unify timestamps</source>
++        <translation>Unify timestamps</translation>
++    </message>
++    <message>
++        <source>Increase timestamp by</source>
++        <translation>Increase timestamp by</translation>
++    </message>
++    <message>
++        <source>sec.</source>
++        <translation>sec.</translation>
++    </message>
++    <message>
++        <source>0 will remove timestamps</source>
++        <translation>0 will remove timestamps</translation>
++    </message>
++</context>
++<context>
++    <name>ITrackStatWidget</name>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++</context>
++<context>
++    <name>ITrackToolWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Sort by name</source>
++        <translation>Sort by name</translation>
++    </message>
++    <message>
++        <source>Sort by time (start)</source>
++        <translation>Sort by time (start)</translation>
++    </message>
++</context>
++<context>
++    <name>IWptToolWidget</name>
++    <message>
++        <source>...</source>
++        <translation>...</translation>
++    </message>
++    <message>
++        <source>Form</source>
++        <translation>Form</translation>
++    </message>
++    <message>
++        <source>Sort by position</source>
++        <translation>Sort by position</translation>
++    </message>
++    <message>
++        <source>Sort by comment</source>
++        <translation>Sort by comment</translation>
++    </message>
++    <message>
++        <source>Add position to sort waypoints by distance to that position.</source>
++        <translation>Add position to sort waypoints by distance to that position.</translation>
++    </message>
++    <message>
++        <source>Sort by alphanumerical order</source>
++        <translation>Sort by alphanumerical order</translation>
++    </message>
++    <message>
++        <source>Sort by icon</source>
++        <translation>Sort by icon</translation>
++    </message>
++    <message>
++        <source>Sort by time</source>
++        <translation>Sort by time</translation>
++    </message>
++</context>
++<context>
++    <name>ProxyDialog</name>
++    <message>
++        <source>Proxy Authentication</source>
++        <translation>Proxy Authentication</translation>
++    </message>
++    <message>
++        <source>ICON</source>
++        <translation>ICON</translation>
++    </message>
++    <message>
++        <source>Connect to proxy</source>
++        <translation>Connect to proxy</translation>
++    </message>
++    <message>
++        <source>Username:</source>
++        <translation>Username:</translation>
++    </message>
++    <message>
++        <source>Password:</source>
++        <translation>Password:</translation>
++    </message>
++</context>
++<context>
++    <name>QObject</name>
++    <message>
++        <source>Error</source>
++        <translation>Error</translation>
++    </message>
++    <message>
++        <source>
++
++Estimated finish: %02i:%02i:%02i [hh:mm:ss]</source>
++        <translation>
++
++Estimated finish: %02i:%02i:%02i [hh:mm:ss]</translation>
++    </message>
++    <message>
++        <source>Number of trackpoints is not equal the number of extended data trackpoints.</source>
++        <translation>Number of trackpoints is not equal the number of extended data trackpoints.</translation>
++    </message>
++    <message>
++        <source>Zoom in</source>
++        <translation>Zoom in</translation>
++    </message>
++    <message>
++        <source>Select Trackpoints</source>
++        <translation>Select Trackpoints</translation>
++    </message>
++    <message>
++        <source>Unselect Trackpoints</source>
++        <translation>Unselect Trackpoints</translation>
++    </message>
++    <message>
++        <source>delete track</source>
++        <translation>delete track</translation>
++    </message>
++    <message>
++        <source>Number of trackpoints is not equal the number of shadow data trackpoints.</source>
++        <translation>Number of trackpoints is not equal the number of shadow data trackpoints.</translation>
++    </message>
++    <message>
++        <source>Cancel</source>
++        <translation>Cancel</translation>
++    </message>
++    <message>
++        <source>Failed to setup projection. Bad syntax?
++%1</source>
++        <translation>Failed to setup projection. Bad syntax?
++%1</translation>
++    </message>
++    <message>
++        <source>Bad position format. Must be: &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot; or &quot;[N|S] ddd.ddd [W|E] ddd.ddd&quot;</source>
++        <translation>Bad position format. Must be: &quot;[N|S] ddd mm.sss [W|E] ddd mm.sss&quot; or &quot;[N|S] ddd.ddd [W|E] ddd.ddd&quot;</translation>
++    </message>
++    <message>
++        <source>Zoom out</source>
++        <translation>Zoom out</translation>
++    </message>
++    <message>
++        <source>Move Map</source>
++        <translation>Move Map</translation>
++    </message>
++    <message>
++        <source>Error open file &apos;%1&apos;: %2</source>
++        <translation>Error open file &apos;%1&apos;: %2</translation>
++    </message>
++    <message>
++        <source>Position values out of bounds. </source>
++        <translation>Position values out of bounds. </translation>
++    </message>
++    <message>
++        <source>Error ...</source>
++        <translation>Error ...</translation>
++    </message>
++    <message>
++        <source>Number of trackpoints is not equal the number of training data trackpoints.</source>
++        <translation>Number of trackpoints is not equal the number of training data trackpoints.</translation>
++    </message>
++    <message>
++        <source>Failed to read reference coordinate. Bad syntax?
++%1</source>
++        <translation>Failed to read reference coordinate. Bad syntax?
++%1</translation>
++    </message>
++    <message>
++        <source>Purge Selection</source>
++        <translation>Purge Selection</translation>
++    </message>
++    <message>
++        <source>Corrupt track ...</source>
++        <translation>Corrupt track ...</translation>
++    </message>
++    <message>
++        <source>The file is not an http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 file.</source>
++        <translation>The file is not an http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 file.</translation>
++    </message>
++    <message>
++        <source>Delete Selection</source>
++        <translation>Delete Selection</translation>
++    </message>
++    <message>
++        <source>There is a problem with your Proj4 library and localization. The key issue is that the floating point definition in your localization is different from what Proj4 uses for it&apos;s correction tables (&apos;1.2&apos; vs &apos;1,2&apos;). That might cause an offset when using raster maps. Vector maps are not affected, as they use a projection that works without a textual table. </source>
++        <translation>There is a problem with your Proj4 library and localization. The key issue is that the floating point definition in your localization is different from what Proj4 uses for it&apos;s correction tables (&apos;1.2&apos; vs &apos;1,2&apos;). That might cause an offset when using raster maps. Vector maps are not affected, as they use a projection that works without a textual table. </translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=utf-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap; }           td {padding-top: 10px;}           th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family:&apos;Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${info}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=utf-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap; }           td {padding-top: 10px;}           th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family:&apos;Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${info}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=utf-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap;}           td {padding-top: 3px;}           th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family: sans-serif; font-size: 9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${info}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=utf-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap;}           td {padding-top: 3px;}           th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family: sans-serif; font-size: 9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${info}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=utf-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap;}           td {padding-top: 3px;}           h1,th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family: sans-serif; font-size: 9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${info}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=utf-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap;}           td {padding-top: 3px;}           h1,th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family: sans-serif; font-size: 9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${info}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=UTF-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap;}           td {padding-top: 3px;}           th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family: sans-serif; font-size: 9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${copyright}&lt;/p&gt;       &lt;h1&gt;Map Levels&lt;/h1&gt;       &lt;p&gt;${maplevels}&lt;/p&gt;       &lt;h1&gt;Legend&lt;/h1&gt;       &lt;h2&gt;Lines&lt;/h2&gt;       &lt;p&gt;${legendlines}&lt;/p&gt;       &lt;h2&gt;Areas&lt;/h2&gt;       &lt;p&gt;${legendareas}&lt;/p&gt;       &lt;h2&gt;Points&lt;/h2&gt;       &lt;p&gt;${legendpoints}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</source>
++        <translation>&lt;!DOCTYPE HTML PUBLIC &apos;-//W3C//DTD HTML 4.01 Transitional//EN&apos;  &apos;http://www.w3.org/TR/html4/loose.dtd&apos;&gt;&lt;html&gt;   &lt;head&gt;       &lt;title&gt;&lt;/title&gt;       &lt;META HTTP-EQUIV=&apos;CACHE-CONTROL&apos; CONTENT=&apos;NO-CACHE&apos;&gt;       &lt;meta http-equiv=&apos;Content-Type&apos; content=&apos;text/html; charset=UTF-8&apos;&gt;       &lt;style type=&apos;text/css&apos;&gt;           p, li { white-space: pre-wrap;}           td {padding-top: 3px;}           th {background-color: darkBlue; color: white;}       &lt;/style&gt;   &lt;/head&gt;   &lt;body style=&apos; font-family: sans-serif; font-size: 9pt; font-weight:400; font-style:normal;&apos;&gt;       &lt;p&gt;${copyright}&lt;/p&gt;       &lt;h1&gt;Map Levels&lt;/h1&gt;       &lt;p&gt;${maplevels}&lt;/p&gt;       &lt;h1&gt;Legend&lt;/h1&gt;       &lt;h2&gt;Lines&lt;/h2&gt;       &lt;p&gt;${legendlines}&lt;/p&gt;       &lt;h2&gt;Areas&lt;/h2&gt;       &lt;p&gt;${legendareas}&lt;/p&gt;       &lt;h2&gt;Points&lt;/h2&gt;       &lt;p&gt;${legendpoints}&lt;/p&gt;   &lt;/body&gt;&lt;/html&gt;</translation>
++    </message>
++    <message>
++        <source>No &apos;Garmin/GarminDevice.xml&apos; found</source>
++        <translation type="unfinished">No &apos;Garmin/GarminDevice.xml&apos; found</translation>
++    </message>
++    <message>
++        <source>Failed to read...</source>
++        <translation type="unfinished">Failed to read...</translation>
++    </message>
++    <message>
++        <source>Failed to read: %1
++line %2, column %3:
++ %4</source>
++        <translation type="unfinished">Failed to read: %1
++line %2, column %3:
++ %4</translation>
++    </message>
++    <message>
++        <source>Not a GPX file: </source>
++        <translation type="unfinished">Not a GPX file: </translation>
++    </message>
++    <message>
++        <source>thin</source>
++        <translation type="unfinished">thin</translation>
++    </message>
++    <message>
++        <source>normal</source>
++        <translation type="unfinished">normal</translation>
++    </message>
++    <message>
++        <source>wide</source>
++        <translation type="unfinished">wide</translation>
++    </message>
++    <message>
++        <source>strong</source>
++        <translation type="unfinished">strong</translation>
++    </message>
++</context>
++</TS>


### PR DESCRIPTION
#### Description

The following pre-processor and compilation failures were ocurring
apparently due to changes in the compiler.

- macro expansion failure

- Unintentional assignment operator instead of comparison operator

- syntax error in copy constructor definition

Also includes patches to fix following issues:

- Provide translation file for English which fixes other installed
  languages being used in preference, even when English variant
  preferred, e.g. British English

- Set user-agent header in tile requests as required by
  OpenStreetMap.org [1] and include default configuration to fetch tiles
  from OpenStreetMap.org

[1]: https://operations.osmfoundation.org/policies/tiles/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.14 18A391
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->

Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
