### PR TITLE
OpenBLAS : Use gcc8 by default

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -76,7 +76,7 @@ foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
         description ${this_description} {}
 }
 
-# set default +gcc* variant: default to +gcc6 if not other +gcc*
+# set default +gcc* variant: default to +gcc8 if not other +gcc*
 # variant is selected. this variant is used for Fortran, no matter
 # whether +clang is selected or not. if +clang is not selected or
 # -clang is selected, then use the selected +gcc* variant for the
@@ -91,10 +91,10 @@ foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
 }
 
 if {${GCC_VER_NO_DOT} == 0} {
-    default_variants +gcc6
+    default_variants +gcc8
 }
 
-# make sure -gcc6 was not selected alone
+# make sure -gcc8 was not selected alone
 
 set GCC_VER_NO_DOT 0
 foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
@@ -105,7 +105,7 @@ foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
 }
 
 if {${GCC_VER_NO_DOT} == 0} {
-    ui_error "\n\nYou must select a Fortran compiler variant; you cannot select -gcc6 alone.\n"
+    ui_error "\n\nYou must select a Fortran compiler variant; you cannot select -gcc8 alone.\n"
     return -code error "Invalid variant selection."
 }
 


### PR DESCRIPTION
#### Description

Update default gcc variant from 6 to 8, to match defaults now used in most other places. Avoids unnecessary multiple gcc dependencies from dependants.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G65
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
