### PR TITLE
Pipenv

### DIFF
--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pipenv
-version             2018.7.1
+version             2018.10.13
 revision            0
 categories-append   devel
 platforms           darwin
@@ -34,9 +34,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  3f461574954d859b264d21a49d28842bd4ac68e7 \
-                    sha256  bb6bd074f853d9bab675942226a785a64d4fc42b5847538755e9573f5b77f63a \
-                    size    4625795
+checksums           rmd160  24df5d001bf64c919af63120a998f1777bbd0fff \
+                    sha256  a785235bf2ddf65ea8a91531b3372471d9ad86036335dba8bd63f20c00a68e63 \
+                    size    6524582
 
 python.default_version 37
 

--- a/python/pipenv/Portfile
+++ b/python/pipenv/Portfile
@@ -65,3 +65,8 @@ if {${python.version} < 30} {
         port:py${python.version}-requests \
         port:py${python.version}-ordereddict
 }
+
+test.run            yes
+test.cmd            pipenv
+test.target         install
+test.args           pip


### PR DESCRIPTION
#### Description

This adds a smoke test, and updates pipenv to fix https://github.com/pypa/pipenv/issues/2924.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
