### PR TITLE
amber: update to v0.9.0

### DIFF
--- a/www/amber/Portfile
+++ b/www/amber/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        amberframework amber 0.8.0 v
+github.setup        amberframework amber 0.9.0 v
 
 categories          www devel
 platforms           darwin
@@ -22,9 +22,9 @@ depends_lib         port:crystal \
                     port:redis \
                     port:shards
 
-checksums           rmd160  ac486ad4b362a777a8cee86a9903a17098ed8654 \
-                    sha256  d2706633fccfbce4102077b7455595d0935f5a542d85c68b744eb129edd64c6b \
-                    size    177801
+checksums           rmd160  a40f3bfda8b651defeab79436ac507ca237342fb \
+                    sha256  b4e2620fa4ccdc03ab427d6eb7f8a61395c505f596a92d04bf431ac2d9577062 \
+                    size    178051
 
 pre-fetch {
   if {${os.major} < 16} {


### PR DESCRIPTION
#### Description

The purpose of this PR is to update amber to v0.9.0.  Furthermore, this PR also fixes the issue that people started having recently with checksum mismatch:

https://trac.macports.org/ticket/56796

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.1 18B50c
Xcode 10.0 10A255 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->