### PR TITLE
gWakeOnLAN: New port, version 0.6.2

### DIFF
--- a/net/gWakeOnLAN/Portfile
+++ b/net/gWakeOnLAN/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               active_variants 1.1
+PortGroup               app 1.0
+PortGroup               github 1.0
+PortGroup               python 1.0
+
+github.setup            muflone gwakeonlan 0.6.2
+checksums               rmd160  767335959f8acfe4cc5c165d4bbe7f1764aef39a \
+                        sha256  fa6a88351f5a437ca2171c012352f01a3cab147a09ac6c6b3278980f14eeb862 \
+                        size    87426
+
+name                    gWakeOnLAN
+categories              net
+platforms               darwin
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 GPL-2+
+supported_archs         noarch
+
+description             wake machines on your network using Wake-on-LAN
+
+long_description        ${name} is a GTK+ GUI for waking machines on your \
+                        network using Wake-on-LAN.
+
+homepage                http://www.muflone.com/gwakeonlan
+github.tarball_from     releases
+
+python.default_version  27
+
+depends_lib-append      port:gtk3 \
+                        port:py${python.version}-gobject3 \
+                        port:py${python.version}-xdg
+
+post-destroot {
+    system "gzip -9 ${destroot}${python.prefix}/share/man/man1/gwakeonlan.1"
+    ln -s ${python.prefix}/share/man/man1/gwakeonlan.1.gz ${destroot}${prefix}/share/man/man1
+}
+
+variant x11 conflicts quartz {
+    require_active_variants gtk3 x11
+}
+
+variant quartz conflicts x11 {
+    require_active_variants gtk3 quartz
+}
+
+if {![variant_isset quartz]} {
+    default_variants +x11
+}
+
+if {![variant_isset x11] && ![variant_isset quartz]} {
+    ui_error "Either the x11 variant or the quartz variant must be selected"
+    return -code error "select x11 or quartz variant"
+}
+
+app.executable          ${python.prefix}/bin/gwakeonlan
+app.icon                icons/128x128/gwakeonlan.png
+app.use_launch_script   yes


### PR DESCRIPTION
#### Description

gWakeOnLAN: New port, version 0.6.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
