### PR TITLE
openjdk*: fix for target directory

### DIFF
--- a/java/openjdk10/Portfile
+++ b/java/openjdk10/Portfile
@@ -4,7 +4,7 @@ PortSystem       1.0
 
 name             openjdk10
 version          10.0.2
-revision         1
+revision         2
 set              openjdk_version 10
 
 subport openjdk11 {
@@ -56,9 +56,9 @@ build {}
 destroot.violate_mtree yes
 
 destroot {
-    set target ${destroot}/Library/Java/JavaVirtualMachines
+    set target ${destroot}/Library/Java/JavaVirtualMachines/openjdk${openjdk_version}
     xinstall -m 755 -d ${target}
-    copy ${worksrcpath} ${target}/openjdk${openjdk_version}
+    copy ${worksrcpath}/Contents ${target}
 }
 
 if {${subport} eq ${name}} {


### PR DESCRIPTION
#### Description

Previously `/Library/Java/JavaVirtualMachines` was created by each `openjdk*` port, which also caused `/Library/Java/JavaVirtualMachines` to be removed after uninstalling all `openjdk*` ports. This change makes sure each `openjdk*` only installs its own `/Library/Java/JavaVirtualMachines/openjdk<major-version>`, which will also be the only directory that gets removed when uninstall the port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?