### PR TITLE
syncthing-0.14: use golang-1.0 portgroup

### DIFF
--- a/net/syncthing-0.14/Portfile
+++ b/net/syncthing-0.14/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        syncthing syncthing 0.14.51 v
+go.setup            github.com/syncthing/syncthing 0.14.51 v
+revision            1
 name                syncthing-0.14
 categories          net
 platforms           darwin
@@ -18,27 +19,18 @@ long_description    Syncthing replaces proprietary sync and cloud services \
                     and how it's transmitted over the Internet.
 homepage            https://syncthing.net
 
-github.tarball_from releases
-distname            syncthing-source-v${version}
+checksums           rmd160  75f49c2a6a54225f41531bd95f369d4bc5e078d1 \
+                    sha256  9102200ebddd785b22b5bff094a257ea7b8c4e8c79833c7156f575c67a8a254f \
+                    size    10972006
 
-checksums           rmd160  999a4788d168325920daaa1e871001cf87a7ff46 \
-                    sha256  10bf5de6f5f01dc605667185ac0b485548ae9088abaa8401fc0f3a2528b2f09e \
-                    size    10971917
-
-worksrcdir          src/github.com/syncthing/syncthing
-extract.mkdir       yes
-extract.post_args-append --strip-components=1
-
-depends_build       port:go
-use_configure       no
-use_parallel_build  no
-build.cmd           ${prefix}/bin/go run build.go
+build.cmd           ${go.bin} run build.go
 build.target        install syncthing
 build.pre_args      -version v${version} -no-upgrade
 build.post_args     ${build.target}
-build.env           GOPATH=${workpath}
 
 test.run            yes
+test.cmd            ${build.cmd}
+test.target         test
 
 destroot {
     xinstall -W ${worksrcpath}/bin syncthing ${destroot}${prefix}/bin
@@ -57,4 +49,4 @@ notes-append        \
     "2. Edit syncthing.plist by replacing USERNAME with your actual username" \
     "3. Log out and in again, or run: launchctl load ~/Library/LaunchAgents/syncthing.plist"
 
-livecheck.url       ${github.homepage}/releases/latest
+github.livecheck.regex  {([0-9.-]+)}


### PR DESCRIPTION
#### Description

Change the syncthing-0.14 port to use the golang-1.0 portgroup.

The portgroup currently doesn't work with `github.tarball_from releases`, so I changed it to the default (`tags`); this is why the checksums changed. If it is really desired to keep using `releases` then that will be possible pending some additional changes I'm working on to the portgroup.

Aside: why is `-0.14` in the port name?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
