### PR TITLE
tmux: update to 2.8

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -3,13 +3,13 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tmux tmux 2.7
+github.setup    tmux tmux 2.8
 if {${subport} eq ${name}} {
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux 5a7cf897f266345635c6adeca20c9bb90dbe1e2f
-    version         20181001-[string range ${github.version} 0 6]
+    github.setup    tmux tmux f54f171d5c43a22414caeecbe8a71db44f345b4e
+    version         20181017-[string range ${github.version} 0 6]
     conflicts       tmux
 }
 categories      sysutils
@@ -28,14 +28,14 @@ depends_lib     port:libevent port:ncurses
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
-    checksums               rmd160  0f36f35969fb61b8d2771845deba2596b047b7b7 \
-                            sha256  9ded7d100313f6bc5a87404a4048b3745d61f2332f99ec1400a7c4ed9485d452 \
-                            size    487585
+    checksums               rmd160  13f097f02b2d3f489fb00af5b3f702cb2eae523f \
+                            sha256  7f6bf335634fafecff878d78de389562ea7f73a7367f268b66d37ea13617a2ba \
+                            size    491195
 }
 subport tmux-devel {
-    checksums               rmd160  0935046f1966bae3946e5839333d4c243d932316 \
-                            sha256  d278566a6fadf66a231d9e1d33459c2d00d263ba5c1a1869b600b5793fce64d9 \
-                            size    643875
+    checksums               rmd160  3cbdc1f154068630455c9a571bfab060c940a1df \
+                            sha256  e78065879bffdda52f066c04683002e75538ebfca8472b9506eb62a261a6d5a8 \
+                            size    645365
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh
@@ -44,6 +44,9 @@ subport tmux-devel {
                             port:automake \
                             port:libtool \
                             port:pkgconfig
+    post-extract {
+        reinplace "s|AC_INIT(tmux, master)|AC_INIT(tmux, ${version})|g" ${worksrcpath}/configure.ac
+    }
 }
 
 platform darwin 8 {
@@ -60,12 +63,6 @@ post-destroot {
     xinstall -m 0644 ${filespath}/tmux.vim ${destroot}${prefix}/share/vim/vimfiles/syntax
     xinstall -m 0755 -d ${destroot}${prefix}/share/vim/vimfiles/ftdetect
     xinstall -m 0644 ${filespath}/ftdetect-tmux.vim ${destroot}${prefix}/share/vim/vimfiles/ftdetect/tmux.vim
-}
-
-variant screen description "behave more like screen" {
-    post-destroot {
-        xinstall -m 0644 ${worksrcpath}/examples/screen-keys.conf ${destroot}${prefix}/etc/tmux.conf
-    }
 }
 
 notes "If you want integration with system pasteboard consider installing port tmux-pasteboard as well"


### PR DESCRIPTION
- update tmux-devel to latest commit (f54f171d5c43a22414caeecbe8a71db44f345b4e)
- remove variant 'screen': tmux no longer bundles an examples directory
- use a nice version (instead of 'master') for tmux-devel



- [x] update


macOS 10.13.6 17G65
Xcode 10.0 10A255

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?