### PR TITLE
wireguard-tools: update to 0.0.20181018

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -9,7 +9,7 @@ name                wireguard-tools
 # the WireGuard repository and its updates primarily deals with the
 # Linux kernel module, which isn't useful or relevant for macOS (we're
 # just interested in its tools for manipulating WireGuard interfaces).
-version             0.0.20181007
+version             0.0.20181018
 categories          net
 platforms           darwin
 license             GPL-2
@@ -27,9 +27,9 @@ master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
 
-checksums           rmd160  0e7d122bb7328db488c3422ca8874e5ad0e47c6b \
-                    sha256  d26e0d1216594871b5947e76d64c2fa50e9b34b68cdcfa3fdad588cbb314af89 \
-                    size    299128
+checksums           rmd160  22585e7bf14e49cd1a02b8f483aecffac53d64dc \
+                    sha256  af05824211b27cbeeea2b8d6b76be29552c0d80bfe716471215e4e43d259e327 \
+                    size    299432
 
 depends_run         port:bash \
                     port:wireguard-go


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?