### PR TITLE
wireguard-go: update to 0.0.20181018

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20181001
+version             0.0.20181018
 categories          net
 platforms           darwin
 license             GPL-2
@@ -23,12 +23,11 @@ homepage            https://www.wireguard.com/
 master_sites        https://git.zx2c4.com/wireguard-go/snapshot/
 use_xz              yes
 
-checksums           rmd160  ce17aa151d2fe12128d2609823fec2227bc3e249 \
-                    sha256  46242e6ddc5f8e2cffbb5cf9634399e1d0f7b9d9634d09c35b65ac8f4bbe222a \
-                    size    54388
+checksums           rmd160  438342fc56f50ec296ca03b1818b945b67af8115 \
+                    sha256  6bedec38d12596d55cfba4b3f7dfa99d5c2555c2f0bf3b3c9a26feb7c6b073ff \
+                    size    54268
 
-depends_build       port:dep \
-                    port:git \
+depends_build       port:git \
                     port:go
 
 use_configure       no


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
