### PR TITLE
aria2: Fix SSL deps, and add ssl lib variants

### DIFF
--- a/net/aria2/Portfile
+++ b/net/aria2/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  08740b76b24f42894c85cc81231715b9c212e359 \
                     size    1525908
 
 depends_build-append    port:pkgconfig
-depends_lib-append      port:gettext port:libiconv port:gnutls port:libxml2
+depends_lib-append      port:gettext port:libiconv port:libxml2
 
 # use_* must be defined after depends_*, otherwise the automatic dependencies
 # will be overwritten.
@@ -30,13 +30,24 @@ depends_lib-append      port:gettext port:libiconv port:gnutls port:libxml2
 
 configure.cxxflags-append -I${prefix}/include/libxml2
 configure.ldflags-append  -lintl
-configure.args      --with-gnutls --with-libgnutls-prefix=${prefix} \
-                    --with-libiconv-prefix=${prefix} \
+configure.args      --with-libiconv-prefix=${prefix} \
                     --with-libintl-prefix=${prefix} \
                     --with-xml-prefix=${prefix} \
                     --without-sqlite3
 
+variant gnutls description {Use GNU TLS instead of Apple built-in TLS library} {
+    configure.args-append   --without-appletls
+    configure.args-append   --with-gnutls --with-libgnutls-prefix=${prefix}
+    depends_lib-append      port:gnutls
+}
+
+variant openssl description {Use OpenSSL instead of Apple built-in TLS library} {
+    configure.args-append   --without-appletls --without-gnutls
+    configure.args-append   --with-openssl --with-openssl-prefix=${prefix}
+    depends_lib-append      port:openssl
+}
+
 # appletls not available on 10.6 or earlier
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
-        configure.args-append "--without-appletls"
+        default_variants-append +gnutls
 }


### PR DESCRIPTION
#### Description

Currently, aria2 claims a dependency on gnutls that it doesn't actually have. Even with the "with-gnutls" configure arg, it will usually auto-discover Apple's built in TLS library and use that instead.

So, this MR fixes that, and also adds +gnutls and +openssl variants that properly disable the apple-tls stuff.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->