### PR TITLE
cpprestsdk: Add tests variant.

### DIFF
--- a/www/cpprestsdk/Portfile
+++ b/www/cpprestsdk/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
 github.setup        Microsoft cpprestsdk 2.10.6 v
+revision            1
 categories          www devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -22,8 +23,14 @@ checksums           rmd160  c1b27cd17c3d1c6f89f9592db3ae0d5c16051a7d \
                     sha256  884098022b09bf490dfdac6218824b5de8bcbef77da843445d9c98d4105bb5ab \
                     size    2069638
 
-depends_lib         port:boost \
-                    path:lib/libssl.dylib:openssl \
-                    port:zlib
+depends_lib-append  port:boost \
+                    port:libiconv \
+                    path:lib/libssl.dylib:openssl
 
 configure.args-append -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF
+
+variant tests description {build tests.} {
+    configure.args-replace      -DBUILD_TESTS=OFF -DBUILD_TESTS=ON
+    configure.post_args-append  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+    test.run                    yes
+}


### PR DESCRIPTION
#### Description

I was preparing a cpprestsdk port but it seems @mohd-akram beat me to the punch...

Anyway, here's a PR with a variant to build and run tests. Currently, not all tests pass but this is fixed upstream and should be ok in the next release.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
