### PR TITLE
llvm-3.3: drop old Python variants

### DIFF
--- a/lang/llvm-3.3/Portfile
+++ b/lang/llvm-3.3/Portfile
@@ -311,25 +311,11 @@ if {${subport} == "llvm-${llvm_version}"} {
     set pythonver ""
     set pythonverdot ""
 
-    if {![variant_isset python25] && ![variant_isset python26]} {
+    if {![variant_isset python27]} {
         default_variants-append +python27
     }
 
-    variant python25 conflicts python26 python27 description {Use python 2.5} {
-        set pythonver 25
-        set pythonverdot 2.5
-        depends_build-append port:python25
-        configure.args-append --with-python=${prefix}/bin/python2.5
-    }
-
-    variant python26 conflicts python25 python27 description {Use python 2.6} {
-        set pythonver 26
-        set pythonverdot 2.6
-        depends_build-append port:python26
-        configure.args-append --with-python=${prefix}/bin/python2.6
-    }
-
-    variant python27 conflicts python25 python26 description {Use python 2.7} {
+    variant python27 description {Use python 2.7} {
         set pythonver 27
         set pythonverdot 2.7
         depends_build-append port:python27


### PR DESCRIPTION
#### Description

Closes https://trac.macports.org/ticket/47691

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?