### PR TITLE
py-qdarkstyle: update to 2.5.4

### DIFF
--- a/python/py-qdarkstyle/Portfile
+++ b/python/py-qdarkstyle/Portfile
@@ -7,7 +7,7 @@ set _name           QDarkStyle
 set _n              [string index ${_name} 0]
 
 name                py-qdarkstyle
-version             2.1
+version             2.5.4
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -15,7 +15,7 @@ license             MIT
 
 maintainers         {petr @petrrr} openmaintainer
 
-description         A dark stylesheet for PyQt/PySide applications
+description         A dark stylesheet for Python and Qt applications
 
 long_description    This package provides a dark style sheet for \
                     PySide/PyQt4/PyQt5 applications.
@@ -25,25 +25,23 @@ homepage            https://github.com/ColinDuquesnoy/QDarkStyleSheet
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-checksums           md5     0f50dd5f1c7ed07e3547115a5e614ea6 \
-                    rmd160  f845a22dd31936b51ecfb7a184ff411d458ff0cf \
-                    sha256  137eb8f707ddc954224ec28bfa03d1e2d5db8fbde0ad2f622294dfed36f9d6ea
+checksums           rmd160  2a17115d6ca7a856c656a715c4edce097c4c1974 \
+                    sha256  3eb60922b8c4d9cedecb6897ca4c9f8a259d81bdefe5791976ccdf12432de1f0 \
+                    size    140396
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
-    # add COPYING
     post-destroot {
         set dest_doc ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${dest_doc}
-        xinstall -m 644 ${worksrcpath}/COPYING ${dest_doc}
+        xinstall -m 644 -W ${worksrcpath} AUTHORS.md CHANGES.md \
+            LICENSE.md PRODUCTION.md README.md ${dest_doc}
     }
 
     livecheck.type  none
 } else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
+    livecheck.name  ${_name}
 }


### PR DESCRIPTION
#### Description
This port is a new dependency for py-spyder-devel, a few updates/changes:
- update to 2.5.4
- add py37 subport
- modernize checksums
- update livecheck and post-destroot

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
