### PR TITLE
dtc: evice tree compiler 1.4.7 (submission)

### DIFF
--- a/cross/dtc/Portfile
+++ b/cross/dtc/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dtc
+version             1.4.7
+categories          cross devel
+platforms           darwin
+maintainers         {adfernandes @adfernandes} openmaintainer
+license             GPL-2+
+
+description         Device tree compiler
+
+long_description    Device Tree Compiler, dtc, takes as input a device-tree in a given format and outputs a \
+                    device-tree in another format for booting kernels on embedded systems.  Typically, the \
+                    input format is DTS, a human readable source format, and creates a DTB, or binary \
+                    format as output.
+
+homepage            https://git.kernel.org/pub/scm/utils/dtc/dtc.git
+master_sites        "${homepage}/snapshot/"
+
+checksums           rmd160  24fe392d763f07f0d414ae945fdc5469796b6ca0 \
+                    sha256  603d6f4f5f34921b368e6febe6690c89022d098edda77187a758b8eeeeff53ea \
+                    size    191568
+
+depends_build       port:gmake
+
+configure.cmd       echo
+
+build.cmd           gmake NO_PYTHON=1 "PREFIX=${destroot}${prefix}" install
+
+post-destroot       {
+                        file delete -force "${destroot}${prefix}/var"
+                        file mkdir "${destroot}${prefix}/share/doc/${name}"
+                        xinstall -m 0644 {*}[glob "${worksrcpath}/Documentation/*.*"] "${destroot}${prefix}/share/doc/${name}"
+                    }
+
+livecheck.type     regex
+livecheck.url      "${homepage}"
+livecheck.regex    "${name}-(\\d+(?:\\.\\d+)*)"


### PR DESCRIPTION
#### Description

Device Tree Compiler, dtc, takes as input a device-tree in a given format and outputs a device-tree in another format for booting kernels on embedded systems.  Typically, the input format is DTS, a human readable source format, and creates a DTB, or binary format as output.

###### Type(s)

submission (new Portfile) 

###### Tested on

macOS 10.12

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?