### PR TITLE
cppcheck: update to 1.85

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem                  1.0
 PortGroup                   cxx11 1.1
+PortGroup                   github 1.0
 
+github.setup                danmar cppcheck 1.85
 name                        cppcheck
-version                     1.84
 categories                  devel
 license                     GPL-3
 platforms                   darwin
@@ -18,14 +19,9 @@ long_description            Cppcheck is an analysis tool for C and C++ code. Unl
                             the compilers normally fail to detect. The goal is no false \
                             positives.
 
-homepage                    http://cppcheck.sourceforge.net/
-master_sites                sourceforge:project/cppcheck/${version}
-
-use_bzip2                   yes
-
-checksums                   rmd160  3b56239fecc0d3995ac3ea0311571c68c77ff85f \
-                            sha256  850beb591bb760b9a236ee481e9f6db4e0fed187ec176545de97fd3e1590e8e6 \
-                            size    1640207
+checksums                   rmd160  b950f8f06139549682eaafa81b4316ef24a61a93 \
+                            sha256  684b931da2f9b2b4ce8676c8e54208957d8d31a5d514b08b0d941db3d2c27a4c \
+                            size    2151221
 
 depends_build               port:libxslt \
                             port:docbook-xsl-nons \


### PR DESCRIPTION
#### Description
- update to latest version (1.85)
- switch to GitHub and use portgroup
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
