### PR TITLE
py-[gitdb/smmap]: update to 2.0.5

### DIFF
--- a/python/py-gitdb/Portfile
+++ b/python/py-gitdb/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        gitpython-developers gitdb 2.0.4
+github.setup        gitpython-developers gitdb 2.0.5
 name                py-gitdb
 maintainers         nomaintainer
 platforms           darwin
@@ -15,9 +15,9 @@ long_description    ${description}
 
 python.versions     27 36
 
-checksums           rmd160  06c9af12ddf02bf660466467938d0ece8a4ed25b \
-                    sha256  d5d377870fe5beb89b86f078d5c615f024d95956f109e69605ea8cfe5ed7c43c \
-                    size    407327
+checksums           rmd160  b7e127468f5d3859c7e466a36ee739ed75b75d6b \
+                    sha256  8078d816da0b952a46ba761bbb7b29c3c535aa89b039671a58f4641efa384d29 \
+                    size    407348
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-smmap/Portfile
+++ b/python/py-smmap/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        gitpython-developers smmap 2.0.4 v
+github.setup        gitpython-developers smmap 2.0.5 v
 name                py-smmap
 maintainers         nomaintainer
 platforms           darwin
@@ -14,9 +14,9 @@ license             BSD
 description         Pure python sliding memory map manager
 long_description    ${description}
 
-checksums           rmd160  631fbe75b503de3f4e25f213dbd10f2005e1fea3 \
-                    sha256  c0b0947e036b3c457dc7c15c7bf502803b0b1f7453146181340683366a60f9a2 \
-                    size    29108
+checksums           rmd160  a5613971d57514243c9e1c4e1560290e709a851e \
+                    sha256  bc94d885e63934dbeb80cc5131c63ab3a920749d22386234757818d516e50db4 \
+                    size    28555
 
 python.versions     27 35 36 37
 python.default_version 36


### PR DESCRIPTION
#### Description
- update to latest version (2.0.5)
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7 (py-smmap only)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (yes, but tests are only available for py-smmap)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
