### PR TITLE
polyml: use system libffi

### DIFF
--- a/lang/polyml/Portfile
+++ b/lang/polyml/Portfile
@@ -17,10 +17,10 @@ checksums           rmd160  17644f9f9c3073486788e1bf6a368247788cfd35 \
                     sha256  31d01e21af6203af75f8b377eeb90aa3eb8b7b1a6e2d942323da53ae390c57e5 \
                     size    7218581
 
-depends_lib         port:gmp
+depends_lib         port:gmp port:libffi
 
 configure.args      --mandir=${prefix}/share/man --build=${build_arch}-apple-darwin${os.major} \
-                    --enable-shared
+                    --enable-shared --with-system-libffi
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description
The libffi port should be used rather than the version bundled with Poly/ML.

Also, the i386 build bot fails to build libffi bundled with Poly/ML so using the port version should avoid this:
https://build.macports.org/builders/ports-10.6_i386_legacy-watcher/builds/18971

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10.5 14F2511
Xcode 6.2 6C131e 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->