### PR TITLE
polyml: build requires pkgconfig to find libffi

### DIFF
--- a/lang/polyml/Portfile
+++ b/lang/polyml/Portfile
@@ -18,6 +18,8 @@ checksums           rmd160  17644f9f9c3073486788e1bf6a368247788cfd35 \
                     sha256  31d01e21af6203af75f8b377eeb90aa3eb8b7b1a6e2d942323da53ae390c57e5 \
                     size    7218581
 
+depends_build       port:pkgconfig
+
 depends_lib         port:gmp port:libffi
 
 configure.args      --mandir=${prefix}/share/man --build=${build_arch}-apple-darwin${os.major} \


### PR DESCRIPTION
#### Description
configure must have pkgconfig available to find the header files for libffi because the libffi port doesn't install headers to /opt/local/include.  My machine didn't pick this up as pkgconfig was already installed.  Presumably the CI machines didn't pick this up for the same reason.

This was picked up by the i386 legacy build bot:
https://build.macports.org/builders/ports-10.6_i386_legacy-watcher/builds/19184
It seems the other build bots didn't complain because they decided there was nothing to do on the last commit to the Poly/ML port (that switched to using the libffi port rather than libffi bundled with Poly/ML), e.g.
https://build.macports.org/builders/ports-10.13_x86_64-watcher/builds/10013

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.10.5 14F2511
Xcode 6.2 6C131e 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->