### PR TITLE
py-pytest-cov: new port, version 2.6.0

### DIFF
--- a/python/py-pytest-cov/Portfile
+++ b/python/py-pytest-cov/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pytest-cov
+version             2.6.0
+categories-append   devel
+platforms           darwin
+license             MIT
+
+python.versions     27 36 37
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         Pytest plugin for measuring coverage.
+long_description    ${description}
+
+homepage            https://github.com/pytest-dev/pytest-cov
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  4db8f33d42d21f4d87e51bae6fe8c0dcf0760fd2 \
+                    sha256  e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762 \
+                    size    33026
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    depends_lib-append      port:py${python.version}-coverage \
+                            port:py${python.version}-pytest
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE CONTRIBUTING.rst \
+            AUTHORS.rst CHANGELOG.rst README.rst ${destroot}${docdir}
+    }
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
