### PR TITLE
astyle: update to 3.1

### DIFF
--- a/devel/astyle/Portfile
+++ b/devel/astyle/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem          1.0
 PortGroup           java 1.0
-PortGroup           muniversal 1.0
+PortGroup           compilers 1.0
+PortGroup           cxx11 1.1
 
 name                astyle
-version             2.05.1
+version             3.1
 categories          devel
-license             LGPL-3+
+license             MIT
 platforms           darwin
 maintainers         nomaintainer
 
@@ -18,9 +19,10 @@ long_description    Artistic Style is a source code indenter, source code format
 
 homepage            http://astyle.sourceforge.net
 master_sites        sourceforge:project/astyle/astyle/astyle%20${version}
-distname            ${name}_${version}_macosx
-checksums           rmd160  d153c0004c7a5d44dc68f235b5baa36e988afab3 \
-                    sha256  de66da286dee2b9de1dc1c05092cbf5368c0889f25d1e2ee8b51766aff8e4baf
+distname            ${name}_${version}_macos
+checksums           rmd160  5aed3c48b59aedf02e247652db6fad597ef9bd63 \
+                    sha256  c4eebbe082eb2cb98f90aafcce3da2daeb774dd092e4cf8b728102fded8d1dcf \
+                    size    187918
 
 worksrcdir          ${name}/build/mac
 
@@ -30,28 +32,15 @@ use_configure       no
 
 build.args-append   prefix=${prefix}
 
-destroot.target-append \
-                    install-lib
 destroot.args-append \
                     prefix=${prefix}
 
-foreach arch ${configure.universal_archs} {
-    lappend merger_build_args(${arch}) CXX='${configure.cxx} -arch ${arch}'
-    lappend merger_destroot_args(${arch}) CXX='${configure.cxx} -arch ${arch}'
-}
-
-if {![variant_isset universal]} {
-    if {[info exists merger_build_args(${configure.build_arch})]} {
-        build.args-append $merger_build_args(${configure.build_arch})
-    }
-    if {[info exists merger_destroot_args(${configure.build_arch})]} {
-        destroot.args-append $merger_destroot_args(${configure.build_arch})
-    }
-}
+destroot.target-append \
+                    install-lib
 
 variant java description {Build and install the JNI library} {
-    build.target-append java
-    destroot.target-append install-jnilib
+    build.target-append     java
+    destroot.target-append  install-jnilib
 }
 
 livecheck.regex     "[quotemeta $name] (\\d+(\\.\\d+)*)"

--- a/devel/astyle/files/patch-Makefile.diff
+++ b/devel/astyle/files/patch-Makefile.diff
@@ -1,58 +1,72 @@
---- Makefile.orig	2014-12-11 08:42:25.000000000 -0600
-+++ Makefile	2015-09-18 07:13:58.000000000 -0500
-@@ -33,14 +33,14 @@
+--- Makefile.orig	2018-10-21 15:13:22.000000000 -0400
++++ Makefile	2018-10-22 13:36:03.000000000 -0400
+@@ -36,23 +36,23 @@
  # define macros
  dylib = dylib
  dynamiclib = -dynamiclib
-+installname = -install_name ${prefix}/lib/
++installname = -install_name $(prefix)/lib/
  bindir = bin
  objdir = obj
  ipath=$(prefix)/bin
- CBASEFLAGS = -W -Wall -fno-rtti -fno-exceptions
--UNIVFLAGS = -arch i386 -arch x86_64
- JAVAINCS   = -I/System/Library/Frameworks/JavaVM.framework/Headers
+ CBASEFLAGS = -W -Wall -std=c++11 -stdlib=libc++ -fno-rtti -fno-exceptions  \
+ -mmacosx-version-min=10.9
+-LDBASEFLAGS = 
+-JAVAINCS  = -I/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/include \
+--I/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/include/darwin \
+--I/System/Library/Frameworks/JavaVM.framework/Headers
++LDBASEFLAGS =
++JAVAINCS  = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin
  CXX = clang++
 -INSTALL=install -o $(USER) -g wheel
 +INSTALL=install
  # INSTALL=install -o 0 -g 0
  
- # set debug directories for DEBUG=1 on the command line
-@@ -53,6 +53,7 @@
+ # for testing on linux
  ifdef linux
      dylib = so
      dynamiclib = -shared
 +    installname = -Wl,-soname,
-     JAVAINCS   = -I$(JAVA_HOME)/include
+     CXX = g++
+     JAVAINCS   = -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
  endif
- 
-@@ -125,7 +126,7 @@
- shared:  libastyle-2.05.1.$(dylib)
- libastyle-2.05.1.$(dylib):  $(OBJs)
- 	@ mkdir -p $(bindir)
--	$(CXX) $(dynamiclib) $(LDFLAGSr) $(UNIVFLAGS) -o $(bindir)/$@ $^
-+	$(CXX) $(dynamiclib) $(installname)libastyle-2.05.1.$(dylib) $(LDFLAGSr) $(UNIVFLAGS) -o $(bindir)/$@ $^
+@@ -152,10 +152,10 @@
+ 	$(CXX) $(LDFLAGSd) -o $(bindir)/AStyled $^
  	@ echo
  
- static:  libastyle.a
-@@ -137,7 +138,7 @@
- java:  libastyle-2.05.1j.$(dylib)
- libastyle-2.05.1j.$(dylib):  $(OBJsj)
+-shared:  libastyle.$(dylib)
+-libastyle.$(dylib):  $(OBJs)
++shared:  libastyle31.$(dylib)
++libastyle31.$(dylib):  $(OBJs)
  	@ mkdir -p $(bindir)
--	$(CXX) $(dynamiclib) $(LDFLAGSr) $(UNIVFLAGS) -o $(bindir)/$@ $^
-+	$(CXX) $(dynamiclib) $(installname)libastyle-2.05.1j.$(dylib) $(LDFLAGSr) $(UNIVFLAGS) -o $(bindir)/$@ $^
+-	$(CXX) $(dynamiclib) $(LDFLAGSr) -o $(bindir)/libastyle31.$(dylib) $^
++	$(CXX) $(dynamiclib) $(installname)libastyle31.$(dylib) $(LDFLAGSr) -o $(bindir)/$@ $^
  	@ echo
  
- all:  release  static  shared
-@@ -148,25 +149,35 @@
+ shareddebug:  libastyled.$(dylib)
+@@ -176,10 +176,10 @@
+ 	ar crs $(bindir)/$@ $^
+ 	@ echo
+ 
+-java:  libastylej.$(dylib)
+-libastylej.$(dylib):  $(OBJsj)
++java:  libastyle31j.$(dylib)
++libastyle31j.$(dylib):  $(OBJsj)
+ 	@ mkdir -p $(bindir)
+-	$(CXX) $(dynamiclib) $(LDFLAGSr) -o $(bindir)/libastyle31j.$(dylib) $^
++	$(CXX) $(dynamiclib) $(installname)libastyle31j.$(dylib) $(LDFLAGSr) -o $(bindir)/$@ $^
+ 	@ echo
+ 
+ javadebug:  libastylejd.$(dylib)
+@@ -198,21 +198,31 @@
  cleanobj:
  	rm -f $(objdir)/*.o
  
 -install:
 -	$(INSTALL) -m 755 -d $(ipath)
 -	@$(INSTALL) -m 755 $(bindir)/astyle  $(ipath)
-+install:  release
++install: release
 +	$(INSTALL) -m 755 -d $(DESTDIR)$(ipath)
-+	$(INSTALL) -m 755 $(bindir)/astyle  $(DESTDIR)$(ipath)
++	@$(INSTALL) -m 755 $(bindir)/astyle  $(DESTDIR)$(ipath)
  
 -	@if [ -d $(SYSCONF_PATH)/html ]; then \
 -		rm -rf  $(SYSCONF_PATH)/html; \
@@ -66,25 +80,19 @@
 +	@mkdir -p $(DESTDIR)$(SYSCONF_PATH)/html;
  	@for files in ../../doc/*.html  ../../doc/*.css; \
  	do \
--		$(INSTALL)  -m 644  $$files  $(SYSCONF_PATH)/html; \
-+		$(INSTALL)  -m 644  $$files  $(DESTDIR)$(SYSCONF_PATH)/html; \
+-		$(INSTALL)  -m 644  "$$files"  $(SYSCONF_PATH)/html; \
++		$(INSTALL)  -m 644  "$$files"  $(DESTDIR)$(SYSCONF_PATH)/html; \
  	done
- 
--	@if [ -d $(SYSCONF_PATH_OLD) ];  then \
--		rm -rf $(SYSCONF_PATH_OLD); \
-+	@if [ -d $(DESTDIR)$(SYSCONF_PATH_OLD) ];  then \
-+		rm -rf $(DESTDIR)$(SYSCONF_PATH_OLD); \
- 	fi
  
 +install-lib:  static shared
 +	$(INSTALL) -m 755 -d $(DESTDIR)$(prefix)/lib
-+	$(INSTALL) $(bindir)/libastyle.a $(bindir)/libastyle-2.05.1.$(dylib) $(DESTDIR)$(prefix)/lib
-+	ln -s libastyle-2.05.1.$(dylib) $(DESTDIR)$(prefix)/lib/libastyle.$(dylib)
++	$(INSTALL) $(bindir)/libastyle.a $(bindir)/libastyle31.$(dylib) $(DESTDIR)$(prefix)/lib
++	ln -s libastyle31$(dylib) $(DESTDIR)$(prefix)/lib/libastyle.$(dylib)
 +
 +install-jnilib:  java
 +	$(INSTALL) -m 755 -d $(DESTDIR)$(prefix)/lib
-+	$(INSTALL) $(bindir)/libastyle-2.05.1j.$(dylib) $(DESTDIR)$(prefix)/lib
-+	ln -s libastyle-2.05.1j.$(dylib) $(DESTDIR)$(prefix)/lib/libastylej.$(dylib)
++	$(INSTALL) $(bindir)/libastyle31j.$(dylib) $(DESTDIR)$(prefix)/lib
++	ln -s libastyle31j.$(dylib) $(DESTDIR)$(prefix)/lib/libastylej.$(dylib)
 +
  uninstall:
  	rm -f $(ipath)/astyle


### PR DESCRIPTION
#### Description
- update astyle to latest version
- use compilers / cxx11 portgroups ; removed universal portgroup

Closes: https://trac.macports.org/ticket/53291

It would be good if someone checked the correctness of the portgroup usage (and perhaps whether it builds correctly on older systems). @l2dy since you opened the original ticket, perhaps you want to take a peak?
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
