### PR TITLE
clustalx: Fix build failures

### DIFF
--- a/science/clustalx/Portfile
+++ b/science/clustalx/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           qmake 1.0
 
 name                clustalx
 version             2.1
+revision            1
 categories          science
 maintainers         {snc @nerdling} openmaintainer
 license             LGPL-3 GPL-3
@@ -20,17 +22,19 @@ long_description    ${name} provides an integrated environment for performing\
 homepage            http://www.clustal.org/clustal2/
 
 platforms           darwin
-depends_build       port:qt4-mac
 
 master_sites        http://www.clustal.org/download/current/ \
                     ftp://ftp.ebi.ac.uk/pub/software/clustalw2/${version}/
 
 dist_subdir         ${name}/${version}_1
 checksums           rmd160  a50b74d2b698a6ab618c5ce8bcb0139976814ffd \
-                    sha256  e10adb728c320598a165ca529f1aa3d2560061de0236e0a0926eaca9554afa05
+                    sha256  e10adb728c320598a165ca529f1aa3d2560061de0236e0a0926eaca9554afa05 \
+                    size    341649
 
-configure.cmd       ${prefix}/libexec/qt4/bin/qmake
-configure.pre_args  PREFIX=${prefix}
+patchfiles          string.patch
+
+configure.ldflags-append \
+                    -F${qt_frameworks_dir}
 
 destroot {
     xinstall -d ${destroot}${applications_dir}/${name}.app/Contents/MacOS
@@ -43,8 +47,6 @@ destroot {
         colprot.xml coldna.xml colprint.xml clustalx.hlp \
         ${destroot}${applications_dir}/${name}.app/Contents/MacOS/
 }
-
-universal_variant   no
 
 livecheck.type      regex
 livecheck.url       ${homepage}

--- a/science/clustalx/files/string.patch
+++ b/science/clustalx/files/string.patch
@@ -1,0 +1,11 @@
+error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
+--- clustalW/general/VectorOutOfRange.h.orig	2010-11-17 04:12:30.000000000 -0600
++++ clustalW/general/VectorOutOfRange.h	2018-10-23 02:30:15.000000000 -0500
+@@ -5,6 +5,7 @@
+  */
+ #include <stdexcept>
+ #include <exception>
++#include <string>
+ namespace clustalw
+ {
+ 


### PR DESCRIPTION
#### Description

Fix build failures due to lack of `<string>` include and lack of path to Qt frameworks.

Closes: https://trac.macports.org/ticket/43306

Include qmake portgroup to simplify the portfile and to use the right `-arch` flags, which also enables the universal variant. This also fixes qt4-mac to be a library dependency, which requires increasing the revision.

See: https://trac.macports.org/ticket/39424

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
