### PR TITLE
plumed-devel: update to 2.5-20181005

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -107,14 +107,14 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 831f17cee3c266a92ccd55133d80fd5ee1944a02
-    version             2.5-20181005
+    github.setup        plumed plumed2 60c3d2b6b9f4c4ba5af4131f3c7e2644b40de1db
+    version             2.5-20181008
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  7ad58c8e684f9d64fa51bb9412c62107f81d587d \
-                        sha256  ae1c839a00f633bd723db674ecdb928f3c8b1f12f6f91f812ef662c75a75527b \
-                        size    66992403
+    checksums           rmd160  254b79514cc93cb50530704cf635b84032a06877 \
+                        sha256  8a60e9816171286db23c0f658ece889d8438ece7877be18ba8d8aca6aac32757 \
+                        size    66988569
     configure.ldflags-delete -lmatheval
     depends_lib-delete       port:libmatheval
 # plumed 2.5 supports python. However, I disable it here since it is


### PR DESCRIPTION
#### Description

I think I managed to fix an error upstream in how flags are passed that could make plumed-devel compile on older OSX (<10.9). I currently have no way to test it. It would be great if this pull request, that just downloads a slightly newer source code, would be merged so as to test compilation on the build bots. Thanks!

###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

