### PR TITLE
magic-exttools: replaced_by magic

### DIFF
--- a/science/magic-exttools/Portfile
+++ b/science/magic-exttools/Portfile
@@ -1,44 +1,10 @@
 PortSystem 1.0
+PortGroup	obsolete 1.0
 
 name		magic-exttools
+replaced_by	magic
 version		7.5.134
-
+revision	1
 categories	science
-maintainers	nomaintainer
-description	extracted files conversion tools
 
-long_description	\
-	Tools to convert extracted files from Magic to IRSIM or SPICE.
-	
-platforms	darwin
-
-homepage       	http://opencircuitdesign.com/magic
-
-master_sites   	http://opencircuitdesign.com/magic/archive
-
-dist_subdir		magic
-worksrcdir		magic-${version}
-
-extract.suffix	.tgz
-
-distfiles		magic-${version}${extract.suffix}
-
-checksums	\
-			magic-7.5.134.tgz \
-				md5  6cdb6a54d26f861ebcfe0b53128ab9ab \
-				sha1  bc277b5a85a2c57eaeda0bb44c354069136b6fe1 \
-				rmd160  f0511f96c0e64ac3d5e74d1690d015636a96c4c2
-
-configure.args --with-interpreter=no --without-x
-
-post-configure {
-		system  "cd ${worksrcpath}; sed '/PROGRAMS /s/ magic//' Makefile > Makefile.new && mv Makefile.new Makefile"
-}
-
-destroot {
-    xinstall -d -m 755 ${destroot}${prefix}/bin
-    xinstall -m 755	${worksrcpath}/ext2sim/ext2sim \
-    				${worksrcpath}/ext2sim/sim2spi \
-    				${worksrcpath}/ext2spice/ext2spice \
-    				${destroot}${prefix}/bin
-}
+# Remove after October 2019


### PR DESCRIPTION
#### Description

This port was created ten years ago because apparently the ext2sim and
ext2spice programs provided by the magic port didn't work:

See: https://trac.macports.org/ticket/15173

That ticket didn't explain in what way they didn't work, but perhaps it
was as described in another ticket filed six years ago. If so, I am
unable to reproduce that problem today, so this plus the current
inability to build magic-exttools at all and it being years out of date
supports replacing it with magic.

Closes: https://trac.macports.org/ticket/36249

magic-exttools did also install sim2spi, which magic does not install,
however it can't ever have worked since it references /usr/bin/nawk
which does not exist.
