### PR TITLE
py-autopep8: update to 1.4.2

### DIFF
--- a/python/py-autopep8/Portfile
+++ b/python/py-autopep8/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-autopep8
-version             1.4.1
+version             1.4.2
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -26,9 +26,9 @@ homepage            https://github.com/hhatto/autopep8
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  8d06d10fa0c3d4fe939ba6e96d95a6694237caf0 \
-                    sha256  096426ef4b489784c08395d7fc7f8cbf38a107b806984513e4c2d9070b0dc1d8 \
-                    size    113238
+checksums           rmd160  50415c5e70e2f8430822495c79ab229ed4165747 \
+                    sha256  1b8d42ebba751a91090d3adb5c06840b1151d71ed43e1c7a9ed6911bfe8ebe6c \
+                    size    113510
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to 1.4.2
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
