### PR TITLE
zsh-completions: update to 0.29.0 and improve

### DIFF
--- a/sysutils/zsh-completions/Portfile
+++ b/sysutils/zsh-completions/Portfile
@@ -1,21 +1,21 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        zsh-users zsh-completions 0.28.0
+github.setup        zsh-users zsh-completions 0.29.0
 maintainers         {g5pw @g5pw} openmaintainer
 categories          sysutils shells
-license             none
+license             Permissive Apache-2
 description         Additional completion definitions for Zsh.
 long_description    Additional completion definitions for Zsh. This package \
                     includes the completion files for the MacPorts port command.
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  b4d6a1e31bb481100a1df2ec6347c01b820ac8f0 \
-                    sha256  d4e532a14403dbd38d28bb6176660d68ded221d674bf26578376d7658a1e0ef8 \
-                    size    248604
+checksums           rmd160  00392c281de6ae186a22b37fee28e304c5e41e12 \
+                    sha256  e49865c1b62e1a8ad72e8b55adddf29a6efdc04bdbb40c08fa4c9bcf78bad427 \
+                    size    251926
 
 use_configure       no
 


### PR DESCRIPTION
#### Description

* Fix the modeline
* Use the correct license, allowing binary redistribution for MacPorts

In zsh-completions, many files come with a license header. Most are
BSD- or MIT-like permissive licenses, and four files - _cf, _hledger,
_rvm, _sfdx are licensed under Apache 2. Also, files without a license
header are declared to use the same license as Zsh [1] since Oct 2017,
and the latter is also permissive.

[1] https://github.com/zsh-users/zsh-completions/commit/9e619381935dcf90794b1165c3e177bcd76dcf62

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?