### PR TITLE
py-matplotlib: update to 3.0.1

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        matplotlib matplotlib 3.0.0 v
+github.setup        matplotlib matplotlib 3.0.1 v
 
 name                py-matplotlib
 categories-append   graphics math
@@ -29,9 +29,9 @@ long_description    Matplotlib strives to produce publication quality 2D \
 
 homepage            https://matplotlib.org/
 
-checksums           rmd160  ab5e432648bb636bcdfde96bc01d9b24c0017d82 \
-                    sha256  5305528f1b62bd778f67b20870a5f9db70ccf9d002e08b19f4508e03b2e41c33 \
-                    size    36431763
+checksums           rmd160  8db169b26793d303bbd8f28a0ada4b74fc05a7ad \
+                    sha256  e66e0d24d1d610724a2613cf43c5b4f5e2ec924f23058bfdc3b9e81d87211b82 \
+                    size    36626350
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description


<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B67a
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

Note: I do get the following warning:
```
--->  Applying patches to py37-matplotlib
Warning: reinplace s|^cairo=False|cairo=True| didn't change anything in /opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-matplotlib/py37-matplotlib/work/matplotlib-3.0.1/setup.cfg
```

- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
