### PR TITLE
yarn: use NodeJS v10

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -5,6 +5,8 @@ PortGroup           github 1.0
 
 github.setup        yarnpkg yarn 1.12.1 v
 
+revision            1
+
 categories          devel
 
 platforms           darwin
@@ -12,8 +14,8 @@ supported_archs     noarch
 
 license             BSD
 
-maintainers         andrewsforge.com:code \
-                    gmail.com:isomarcte \
+maintainers         {andrewsforge.com:code @jambonrose} \
+                    {gmail.com:isomarcte @isomarcte} \
                     openmaintainer
 
 description         JavaScript dependency manager
@@ -30,13 +32,15 @@ checksums           rmd160  4ea718e17eaf01e5ff33ca5f843e970a5d64ff5c \
                     sha256  09bea8f4ec41e9079fa03093d3b2db7ac5c5331852236d63815f8df42b3ba88d \
                     size    1150378
 
-depends_run         path:bin/node:nodejs6
+depends_run         path:bin/node:nodejs10
 
 platform darwin {
     # Fix for https://trac.macports.org/ticket/53166
     # Mac OS X 10.6 Snow Leopard and earlier cannot install Node JS v6
     if {${os.major} < 11} {
-        depends_run-replace path:bin/node:nodejs6 path:bin/node:nodejs4
+        depends_run-replace path:bin/node:nodejs10 path:bin/node:nodejs4
+    } elseif {${os.major} < 13} {
+        depends_run-replace path:bin/node:nodejs10 path:bin/node:nodejs6
     }
 }
 


### PR DESCRIPTION
#### Description

NodeJS 8 has been the active LTS version of Node since the end of October, 2017.
https://github.com/nodejs/Release

This PR updates Yarn to use NodeJS v8 by default, only falling back to v6 and v4 as per older macOS versions.

If a user has node6 already installed, trying to install yarn might cause a conflict as node8 and node6 can't be installed side-by-side.  How should that be handled?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
