### PR TITLE
duti: add patch to build on Mojave

### DIFF
--- a/sysutils/duti/Portfile
+++ b/sysutils/duti/Portfile
@@ -27,6 +27,9 @@ checksums           rmd160 99b928d040b98f3d164ec5967f694793a3b9c03b \
                     sha256 c4ffc61b198dfbf1dbbc271ec56fdb5b3dc25ac5074f47eaecec7b62b09e4fd4 \
                     size   38097
 
+patchfiles          mojave.diff
+patch.pre_args      -p1
+
 use_autoreconf      yes
 
 configure.args-append \

--- a/sysutils/duti/files/mojave.diff
+++ b/sysutils/duti/files/mojave.diff
@@ -1,0 +1,33 @@
+From 825b5e6a92770611b000ebdd6e3d3ef8f47f1c47 Mon Sep 17 00:00:00 2001
+From: Grigory Entin <grigory.entin@gmail.com>
+Date: Thu, 4 Oct 2018 20:48:34 +0200
+Subject: [PATCH] Added support for macOS 10.14.
+
+---
+ aclocal.m4 | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/aclocal.m4 b/aclocal.m4
+index 8fd4cd1..c6836d6 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -40,7 +40,7 @@ AC_DEFUN([DUTI_CHECK_SDK],
+ 	    macosx_arches=""
+ 	    ;;
+ 
+-	darwin15*|darwin16*|darwin17*)
++	darwin15*|darwin16*|darwin17*|darwin18*)
+ 	    sdk_path="${sdk_path}/MacOSX.sdk"
+ 	    macosx_arches=""
+ 	    ;;
+@@ -106,6 +106,10 @@ AC_DEFUN([DUTI_CHECK_DEPLOYMENT_TARGET],
+ 	darwin17*)
+ 	    dep_target="10.13"
+ 	    ;;
++
++	darwin18*)
++	    dep_target="10.14"
++	    ;;
+     esac
+ 
+     if test -z "$macosx_dep_target"; then


### PR DESCRIPTION
#### Description

This adds a patch so duti will configure on Mojave. [Original PR](https://github.com/moretension/duti/pull/32)

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14
Xcode 10.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
