### PR TITLE
minikube: update to 0.30.0

### DIFF
--- a/sysutils/minikube/Portfile
+++ b/sysutils/minikube/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kubernetes minikube 0.28.2 v
+github.setup        kubernetes minikube 0.30.0 v
 categories          sysutils
 platforms           darwin
 supported_archs     x86_64
@@ -19,9 +19,9 @@ long_description    Minikube runs a single-node Kubernetes cluster inside a VM \
 github.tarball_from releases
 distfiles           minikube-darwin-amd64
 checksums           minikube-darwin-amd64 \
-                    rmd160  bce2c4b9536f4065bb5c44cff379e9858ca9c64c \
-                    sha256  dca43053510f5e8987ff89abf601594eaf58bc5d447d74f9a08e300f3d92133f \
-                    size    40272768
+                    rmd160  20bb06262c6e58ad308b67a568f5232070139903 \
+                    sha256  e09789c4eb751969f712947a43effd79cf73488163563e79d98bc3d15d06831e \
+                    size    42069872
 dist_subdir         ${name}/${version}
 
 depends_lib         port:kubectl
@@ -32,9 +32,9 @@ default_variants    +hyperkit
 variant hyperkit description {Install Hyperkit driver} {
     distfiles-append    docker-machine-driver-hyperkit
     checksums-append    docker-machine-driver-hyperkit \
-                        rmd160  5916c3970d9a332f6e5d88e43ac0a8703bca303a \
-                        sha256  5d057d7a3f9fa78e905f4954d54c3520cc7228418b5f4bb15662bbe8c13bc97d \
-                        size    26811748
+                        rmd160  98aea855c8df932b6d1a9f74dd76c87c2e936d33 \
+                        sha256  94b3def318938ddfeed3f8e753665b8b44db0b7044613b287e640d960312f605 \
+                        size    27219380
 }
 
 build {


### PR DESCRIPTION
#### Description

minikube: update to 0.30.0

###### Tested on
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
