### PR TITLE
octave-image: respect MacPorts CXXFLAGS

### DIFF
--- a/math/octave-image/Portfile
+++ b/math/octave-image/Portfile
@@ -5,7 +5,7 @@ PortGroup           cxx11 1.1
 PortGroup           octave 1.0
 
 octave.setup        image 2.8.0
-revision            1
+revision            2
 platforms           darwin
 license             GPL-3+ MIT FreeBSD
 maintainers         {mps @Schamschula} openmaintainer
@@ -23,7 +23,6 @@ checksums           rmd160  49ad88f333bdb037715d47a786cfc764d4a6d968 \
 
 depends_lib-append  port:octave-signal
 
-patchfiles-append   patch-src-Makefile.in.diff \
-                    patch-src_connectivity.cc.diff
+patchfiles-append   patch-src_connectivity.cc.diff
 
 configure.env-append "PREFIX_BIN=${prefix}/bin"

--- a/math/octave-image/files/patch-src-Makefile.in.diff
+++ b/math/octave-image/files/patch-src-Makefile.in.diff
@@ -1,8 +1,0 @@
---- src/Makefile.in.orig	2016-10-21 09:19:56.000000000 -0500
-+++ src/Makefile.in	2016-11-01 07:38:21.000000000 -0500
-@@ -1,4 +1,4 @@
--FLAGGED_MKOCTFILE = @MKOCTFILE@ @XTRA_CXXFLAGS@ @CXXFLAGS@
-+FLAGGED_MKOCTFILE = @MKOCTFILE@ @XTRA_CXXFLAGS@ -pipe -Os -stdlib=libc++
- 
- ## We can't link oct files, and Octave's package system does not handle
- ## shared libraries. Because of this, we need to create object files for


### PR DESCRIPTION
The patch was introduced in
https://github.com/macports/macports-ports/commit/c8c542f28c5f71ae0d8814a08507395f77da2606

The underlying problem was fixed in
https://github.com/macports/macports-ports/commit/5c63c9706d260f6a6557b110bb7608f0d92287bf

Now, the patch causes failures on systems that use
-stdlib=macports-libstdc++ instead of -stdlib=libc++.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.0 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
