### PR TITLE
py-pytest-runner: update to 4.2

### DIFF
--- a/python/py-pytest-runner/Portfile
+++ b/python/py-pytest-runner/Portfile
@@ -3,11 +3,8 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           pytest-runner
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             3.0
+name                py-pytest-runner
+version             4.2
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -19,13 +16,13 @@ long_description    \
     ${description}. Setup scripts can use pytest-runner to invoke py.test as distutils \
     command and provices dependency resolution.
 
-homepage            https://pypi.python.org/pypi/${_name}/${version}
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+homepage            https://github.com/pytest-dev/pytest-runner
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5     8f8363a52bbabc4cedd5e239beb2ba11 \
-                    rmd160  7ee6d4c839cb4cedb6aa341c0b247685cbd4c7fd \
-                    sha256  0f7c3a3cf5aead13f54baaa01ceb49e5ae92aba5d3ff1928e81e189c40bc6703
+checksums           rmd160  594dd82bf0ee027ebbdebde75f8056e985577499 \
+                    sha256  d23f117be39919f00dd91bffeb4f15e031ec797501b717a245e377aee0f577be \
+                    size    11947
 
 python.versions     27 34 35 36 37
 
@@ -34,8 +31,4 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-setuptools_scm
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\.tar\\.gz\""
 }


### PR DESCRIPTION
#### Description
- update to 4.2
- modernize checksums
- use default PyPI livecheck
- update homepage
- make use of python.rootname

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 10.0 10A255
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
