### PR TITLE
Update to add gradle-devel subport

### DIFF
--- a/devel/gradle/Portfile
+++ b/devel/gradle/Portfile
@@ -23,6 +23,18 @@ master_sites        https://services.gradle.org/distributions
 checksums           rmd160  91ddb4be28b859e39166526228d39bbaabf91100 \
                     sha256  b49c6da1b2cb67a0caf6c7480630b51c70a11ca2016ff2f555eaeda863143a29 \
                     size    78420037
+                    
+subport ${name}-devel {
+version             5.0-milestone-1
+homepage            https://gradle.org/
+platforms           darwin
+distname            ${name}-${version}-bin
+master_sites        https://services.gradle.org/distributions
+
+checksums           rmd160  563b96491be55eb94766d0a7addc74f74f5c5106 \
+                    sha256  0c4e5366b479934844da39c156c20d509f6b2c40b978c10598221fd591c0cf57 \
+                    size    83499032
+}
 
 worksrcdir          ${name}-${version}
 
@@ -52,7 +64,7 @@ destroot    {
     # Symlink gradle into the bin directory
     ln -s ${prefix}/share/java/${name}/bin/gradle ${destroot}${prefix}/bin
 }
-
+                    
 livecheck.type  regex
 livecheck.url   ${master_sites}
 livecheck.regex ${name}-(\\d+\\.\\d+(\\.\\d+)?)-all\\.zip


### PR DESCRIPTION
#### Description

Add gradle-devel subport

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G3020
Xcode 10.1 10O45e

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?

I looked at various -devel subports and I think the way I implemented it is the right way. I don't think there is a need to conflict with `gradle` because `gradle-devel` is just an update that compiles with the exact same config. So you can install one on top of the other (and vise versa).

I couldn't fine a way to test the subport. I looked for documentation but I couldn't figure out how to install the subport. While in the Portfile path, if you enter `sudo port install` it naturally installs `gradle` but entering `sudo port install gradle-devel` returns error because the port obviously doesn't exist in the database. I'm sure there must be a trick but I couldn't find it.