### PR TITLE
libtorrent: update to 0.13.7

### DIFF
--- a/net/libtorrent/Portfile
+++ b/net/libtorrent/Portfile
@@ -1,11 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
+PortGroup           github 1.0
 
-name                libtorrent
+github.setup        rakshasa libtorrent 0.13.7 v
+
 conflicts           libtorrent-devel
-version             0.13.2
-revision            1
 categories          net
 platforms           darwin
 maintainers         nomaintainer
@@ -17,22 +18,21 @@ long_description    libTorrent is a BitTorrent library written in C++ for \
                     *nix. It is designed to avoid redundant copying and \
                     storing of data that other clients and libraries suffer from.
 
-homepage            http://libtorrent.rakshasa.no/
-master_sites        ${homepage}downloads/
-
-checksums           rmd160  090e6af9b4318a6176064159f6a8f70ab708c7fe \
-                    sha256  ed2f2dea16c29cac63fa2724f6658786d955f975861fa6811bcf1597ff8a5e4f
+checksums           rmd160  e0a6f01eac616cec788cb81995318e7b9fc7baac \
+                    sha256  7de1c2e2ebb23ff0f13891f1f865a2ac6899141d8e662b269156c3cb11518a4d \
+                    size    356972
 
 depends_build       port:pkgconfig
 
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:libsigcxx2
 
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
 configure.args      --disable-debug \
                     --enable-ipv6 \
                     --with-kqueue
-
-compiler.blacklist  gcc-4.0
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
requires cxx11 1.1 PG
move to github

see also: https://trac.macports.org/ticket/52476

Let's see how Travis likes this

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 

