### PR TITLE
extractpdfmark: Fix build with newer clang++ compiler versions.

### DIFF
--- a/textproc/extractpdfmark/Portfile
+++ b/textproc/extractpdfmark/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
 github.setup        trueroad extractpdfmark 1.0.2 v
-revision            1
+revision            2
 categories          textproc
 platforms           darwin
 license             GPL-3+
@@ -31,5 +31,7 @@ depends_build       port:pkgconfig
 
 depends_lib         port:libiconv \
                     port:poppler
+
+configure.args      --disable-codecvt
 
 github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
