### PR TITLE
mingw-w64: update to 6.0.0

### DIFF
--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        mirror mingw-w64 5.0.4 v
+github.setup        mirror mingw-w64 6.0.0 v
 set mingw_name      w64-mingw32
 
 platforms           darwin
@@ -17,9 +17,9 @@ long_description    Mingw-w64 is an advancement of the original mingw.org projec
 
 homepage            http://mingw-w64.sourceforge.net/
 
-checksums           rmd160  c0fa570752ca30bf88741c306db0405012124587 \
-                    sha256  07410ccf5d15a5c8823f93f4d8b7a963ad5cf2a5706475a470d7d9ea2208a4f8 \
-                    size    12550903
+checksums           rmd160  4e968d216f28b7ecc440ac543448aa5cb6da504a \
+                    sha256  15ea31c5a7f3071517dd6f0075b113b45a2b30bc6083942d9a89ee4a46d8f7e6 \
+                    size    12464594
 
 # needs an out-of-source build
 configure.dir       ${workpath}/build
@@ -85,7 +85,10 @@ if {${subport} ne ${name}} {
         # *-winpthreads
         } else {
             # winpthreads needs at least stage 2 compiler (or the final one)
-            depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads
+            # as well as the latest version of crt
+            depends_build-append    path:${mingw_target}/lib/libgcc_s.a:${mingw_target}-gcc-nothreads \
+                                    port:${arch}-${mingw_name}-crt
+            depends_lib-append      port:${arch}-${mingw_name}-crt
 
             # see above
             post-destroot {
@@ -99,6 +102,9 @@ if {${subport} ne ${name}} {
         #depends_lib-append     port:${mingw_target}-binutils
         #depends_lib-append     port:${mingw_target}-headers
         configure.cppflags      "-I${prefix}/${mingw_target}/include"
+
+        # prevent MacPorts from adding -syslibroot to linker flags
+        configure.sdkroot
 
         # ----- copied from crossgcc (not sure if needed) ----
         # the generated compiler doesn't accept -arch


### PR DESCRIPTION
#### Description

This updates mingw-w64, but I need to fix two issues before merging this:
* issues with the order of upgrading (discussion on the mailing list)
* ~~https://trac.macports.org/ticket/57448~~


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->