### PR TITLE
extractpdfmark: requires cctools on <= 10.6

### DIFF
--- a/textproc/extractpdfmark/Portfile
+++ b/textproc/extractpdfmark/Portfile
@@ -29,6 +29,11 @@ checksums           rmd160  1f1bac62afac8b52e54a796084d5b6c87453122e \
 
 depends_build       port:pkgconfig
 
+# malformed object (unknown load command 2)
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    depends_build-append  port:cctools
+}
+
 depends_lib         port:libiconv \
                     port:poppler
 


### PR DESCRIPTION
Without this patch you get

  malformed object (unknown load command 2)

Eventually this dependency will be part of the cxx11 1.1 port group.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
