### PR TITLE
greycstoration: replaced_by gmic

### DIFF
--- a/graphics/greycstoration/Portfile
+++ b/graphics/greycstoration/Portfile
@@ -1,38 +1,13 @@
 PortSystem       1.0
+PortGroup        obsolete 1.0
 
 name             greycstoration
+replaced_by      gmic
 version          2.5.2.1
+revision         1
 categories       graphics
-description      Open source algorithm for image denoising and interpolation
-long_description GREYCstoration is an image regularization algorithm which \
-                 processes an image by locally removing small variations of \
-                 pixel intensities while preserving significant global image \
-                 features, such as sharp edges and corners. The most direct \
-                 application of image regularization is denoising. \
-                 By extension, it can also be used to inpaint or resize images.
-
 maintainers      gmail.com:julien.lusson
 platforms        darwin
-homepage         http://www.greyc.ensicaen.fr/~dtschump/greycstoration/
+homepage         http://cimg.eu/greycstoration/
 
-master_sites     ${homepage}data/
-use_bzip2        yes
-
-distname         GREYCstoration-${version}
-checksums        md5 9acb29050f479b6d4e59bb1096a87451 \
-                 sha1 2bfa17573b60a1477c99f34cfb8400d9b78aa9c2 \
-                 rmd160 b3cb5d0638952c601b70158ee3e63b45feb5fb07
-
-use_configure   no
-
-depends_lib     port:gimp2
-
-build.target    olinux
-
-destroot {
-    xinstall -m 755 ${worksrcpath}/greycstoration \
-        ${destroot}${prefix}/bin/
-    xinstall -m 755 -d ${destroot}${prefix}/lib/gimp/2.0/plug-ins
-    xinstall -m 755 ${worksrcpath}/greycstoration4gimp \
-        ${destroot}${prefix}/lib/gimp/2.0/plug-ins
-}
+# Remove this after October 2019


### PR DESCRIPTION
#### Description

This PR replaces greycstoration with gmic.

The greycstoration homepage says:

> Use G'MIC instead of GREYCstoration!
>
> GREYCstoration is not maintained anymore : We have developed a new
> plug-in for GIMP, called G'MIC (GREYC's Magic for Image Computing).
> This is a complete image processing toolbox which contains all the
> GREYCstoration features (of course), but also much much more filters
> for image denoising, enhancement, applying artistic effects and so
> on... Basically, if you appreciate using GREYCstoration, you will
> love G'MIC :)

I will notify the maintainer by email.