### PR TITLE
clang-3.9+ : make cctools a lib dependency

### DIFF
--- a/lang/llvm-3.9/Portfile
+++ b/lang/llvm-3.9/Portfile
@@ -11,7 +11,7 @@ set llvm_version        3.9
 set llvm_version_no_dot 39
 name                    llvm-${llvm_version}
 revision                5
-subport                 clang-${llvm_version} { revision 8 }
+subport                 clang-${llvm_version} { revision 9 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -56,9 +56,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     # Older Xcode's lipo doesn't support x86_64h slices
-    # https://trac.macports.org/ticket/53159#ticket
+    # https://trac.macports.org/ticket/53159
+    # Older Xcode's ranlib doesn't understand objects produced by newer clang (malformed object (unknown load command 2))
+    # https://trac.macports.org/ticket/57412
     if {[vercmp $xcodeversion "6.0.0"] < 0} {
-        depends_build-append port:cctools
+        depends_lib-append port:cctools
         depends_skip_archcheck-append cctools
     }
 

--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -13,7 +13,7 @@ set clang_executable_version 4.0
 set lldb_executable_version 4.0.1
 name                    llvm-${llvm_version}
 revision                2
-subport                 clang-${llvm_version} { revision 5 }
+subport                 clang-${llvm_version} { revision 6 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -59,9 +59,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     # Older Xcode's lipo doesn't support x86_64h slices
-    # https://trac.macports.org/ticket/53159#ticket
+    # https://trac.macports.org/ticket/53159
+    # Older Xcode's ranlib doesn't understand objects produced by newer clang (malformed object (unknown load command 2))
+    # https://trac.macports.org/ticket/57412
     if {[vercmp $xcodeversion "6.0.0"] < 0} {
-        depends_build-append port:cctools
+        depends_lib-append port:cctools
         depends_skip_archcheck-append cctools
     }
 

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -12,7 +12,7 @@ set llvm_version_no_dot 50
 set clang_executable_version 5.0
 set lldb_executable_version 5.0.2
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} { revision 1 }
+subport                 clang-${llvm_version} { revision 2 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -58,9 +58,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     # Older Xcode's lipo doesn't support x86_64h slices
-    # https://trac.macports.org/ticket/53159#ticket
+    # https://trac.macports.org/ticket/53159
+    # Older Xcode's ranlib doesn't understand objects produced by newer clang (malformed object (unknown load command 2))
+    # https://trac.macports.org/ticket/57412
     if {[vercmp $xcodeversion "6.0.0"] < 0} {
-        depends_build-append port:cctools
+        depends_lib-append port:cctools
         depends_skip_archcheck-append cctools
     }
 

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -12,7 +12,7 @@ set llvm_version_no_dot 60
 set clang_executable_version 6.0
 set lldb_executable_version 6.0.1
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} {}
+subport                 clang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -58,9 +58,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     # Older Xcode's lipo doesn't support x86_64h slices
-    # https://trac.macports.org/ticket/53159#ticket
+    # https://trac.macports.org/ticket/53159
+    # Older Xcode's ranlib doesn't understand objects produced by newer clang (malformed object (unknown load command 2))
+    # https://trac.macports.org/ticket/57412
     if {[vercmp $xcodeversion "6.0.0"] < 0} {
-        depends_build-append port:cctools
+        depends_lib-append port:cctools
         depends_skip_archcheck-append cctools
     }
 

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -12,7 +12,7 @@ set llvm_version_no_dot 70
 set clang_executable_version 7
 set lldb_executable_version 7.0.0
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} {}
+subport                 clang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -58,9 +58,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     # Older Xcode's lipo doesn't support x86_64h slices
-    # https://trac.macports.org/ticket/53159#ticket
+    # https://trac.macports.org/ticket/53159
+    # Older Xcode's ranlib doesn't understand objects produced by newer clang (malformed object (unknown load command 2))
+    # https://trac.macports.org/ticket/57412
     if {[vercmp $xcodeversion "6.0.0"] < 0} {
-        depends_build-append port:cctools
+        depends_lib-append port:cctools
         depends_skip_archcheck-append cctools
     }
 

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -12,7 +12,7 @@ set llvm_version_no_dot devel
 set clang_executable_version 8
 set lldb_executable_version 8.0.0
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} {}
+subport                 clang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -58,9 +58,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib-append  port:libedit port:libffi port:ncurses port:zlib
 
     # Older Xcode's lipo doesn't support x86_64h slices
-    # https://trac.macports.org/ticket/53159#ticket
+    # https://trac.macports.org/ticket/53159
+    # Older Xcode's ranlib doesn't understand objects produced by newer clang (malformed object (unknown load command 2))
+    # https://trac.macports.org/ticket/57412
     if {[vercmp $xcodeversion "6.0.0"] < 0} {
-        depends_build-append port:cctools
+        depends_lib-append port:cctools
         depends_skip_archcheck-append cctools
     }
 


### PR DESCRIPTION
so cctools is available both at build and at runtime
on all systems less than Xcode 6.0.0
closes: https://trac.macports.org/ticket/57412
