### PR TITLE
spring-boot-cli: update to 2.1.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.0.6
+version         2.1.0
 
 categories      java
 platforms       darwin
@@ -28,9 +28,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  854a5ac6d42fe730931bb174971703ddd3334c7c \
-                sha256  45ab9ade0527d6adbc554f4cb7c79cb5f9216adcbfbd0d46ebfe412c4738b296 \
-                size    9121608
+checksums       rmd160  c3ded1d42ac9db71416974fbabc37ac8d44ffcd8 \
+                sha256  21831c34a7cd7737a18681945b7e11693ac056062a7dab94fbcee84e94939e87 \
+                size    11120150
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.1.0.RELEASE.

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?