### PR TITLE
faust, faust-devel, faustlive-devel: update to 2.5.23 and latest git

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -4,10 +4,10 @@ PortSystem              1.0
 PortGroup               cxx11 1.1
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust f67c2e48a855f0379623ff76cb424376e8879296
+github.setup            grame-cncm faust f7772ca36e41b334075aaafe3d04bd677f29d6a2
 # When updating faust-devel to a new version, please rebuild faustlive-devel
 # simultaneously by increasing its revision or updating it to a new version.
-version                 2.5-20180211
+version                 2.5-20181030
 
 name                    faust-devel
 conflicts               faust
@@ -31,8 +31,8 @@ post-fetch {
 
 set llvm_version        3.4
 if {${os.platform} eq "darwin" && ${os.major} > 14} {
-    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
-    set llvm_version    3.9
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 7.0 instead.
+    set llvm_version    7.0
 }
 
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
@@ -52,7 +52,7 @@ post-patch {
     reinplace "s|/usr/local/|/usr/./local/|g" \
         ${worksrcpath}/tools/faust2appls/faust2faustvst
     reinplace "s|/usr/local|${prefix}|g" \
-        ${worksrcpath}/compiler/parser/enrobage.cpp \
+        ${worksrcpath}/compiler/libcode.cpp \
         ${worksrcpath}/compiler/tlib/compatibility.cpp \
         ${worksrcpath}/tools/scbuilder/scbuilder \
         {*}[glob ${worksrcpath}/tools/faust2appls/faust2*]
@@ -85,7 +85,7 @@ post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${subport}
     xinstall -d ${docdir}
     xinstall -m 644 -W ${worksrcpath} \
-        COPYING \
+        COPYING.txt \
         README.md \
         WHATSNEW \
         ${docdir}

--- a/audio/faust/Portfile
+++ b/audio/faust/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cxx11 1.1
 PortGroup               github 1.0
 
-github.setup            grame-cncm faust 2.5.21
+github.setup            grame-cncm faust 2.5.23
 github.tarball_from     releases
 
 conflicts               faust-devel
@@ -20,14 +20,14 @@ long_description        Faust is a functional programming language \
                         specifically designed for realtime audio applications \
                         and plugins.
 
-checksums               rmd160  6a356de1a359fdc93f5d93405606a69bd3d83ccb \
-                        sha256  6de2214316f9137cabf95bf075a599963cfe5305ab83d944e869bec417956f2f \
-                        size    47453689
+checksums               rmd160  f0b6ebc1542e8c91c88dbba42a57296cdc2b38ce \
+                        sha256  d87ef98a7a25367c12f51fe1ebb07fe4f2c0b37f27b63b7bcd074273b295e5fb \
+                        size    47314425
 
 set llvm_version        3.4
 if {${os.platform} eq "darwin" && ${os.major} > 14} {
-    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
-    set llvm_version    3.9
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 6.0 instead.
+    set llvm_version    6.0
 }
 
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
@@ -41,7 +41,8 @@ depends_lib             port:clang-${llvm_version} \
                         port:llvm-${llvm_version} \
                         path:lib/libssl.dylib:openssl
 
-patchfiles              patch-compiler-Makefile.unix.diff
+patchfiles              patch-compiler-Makefile.unix.diff \
+                        patch-compiler-llvm6.diff
 
 post-patch {
     reinplace "s|/usr/local/|/usr/./local/|g" \

--- a/audio/faust/files/patch-compiler-llvm6.diff
+++ b/audio/faust/files/patch-compiler-llvm6.diff
@@ -1,0 +1,11 @@
+--- compiler/Makefile.unix	2018-03-06 10:39:29.000000000 +0100
++++ compiler/Makefile.unix	2018-10-30 22:32:42.000000000 +0100
+@@ -155,7 +155,7 @@
+     CLANGLIBS=$(CLANGLIBSLIST)
+     CXXFLAGS += -std=gnu++11
+ 
+-else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 6.0.0 6.0.0svn))
++else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 6.0.0 6.0.1))
+     LLVM_VERSION = LLVM_60
+     CLANGLIBS=$(CLANGLIBSLIST)
+     CXXFLAGS += -std=gnu++11

--- a/audio/faustlive-devel/Portfile
+++ b/audio/faustlive-devel/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            grame-cncm faustlive 69d6161c2a171a2ed3d7eda544cfdc5511ce85f6
-version                 2.46-20180119
+github.setup            grame-cncm faustlive f7edb2ff41d4987fb302fbce51723616eb728f19
+version                 2.46-20181019
 
 name                    faustlive-devel
 categories              audio
@@ -35,8 +35,8 @@ post-fetch {
 
 set llvm_version        3.4
 if {${os.platform} eq "darwin" && ${os.major} > 14} {
-    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 3.9 instead.
-    set llvm_version    3.9
+    # clang 3.4 isn't supported in the latest macOS versions any more, go with LLVM 7.0 instead.
+    set llvm_version    7.0
 }
 
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
@@ -52,6 +52,9 @@ depends_lib             port:curl \
                         port:libsndfile \
                         path:lib/libssl.dylib:openssl \
                         port:qrencode
+
+patch.pre_args          -p1
+patchfiles              patch-Darwin-Makefile.diff
 
 use_configure           no
 

--- a/audio/faustlive-devel/files/patch-Darwin-Makefile.diff
+++ b/audio/faustlive-devel/files/patch-Darwin-Makefile.diff
@@ -1,0 +1,22 @@
+diff --git a/Build/Darwin/Makefile b/Build/Darwin/Makefile
+index 0915fd1..6725c4f 100644
+--- a/Build/Darwin/Makefile
++++ b/Build/Darwin/Makefile
+@@ -89,7 +89,7 @@ deploy:
+ dist: 	
+ 	rm -rf FaustLive.app
+ 	make
+-	cp $(FAUSTDIR)/bin/sound2faust FaustLive.app/Contents/MacOS
++	test -r $(FAUSTDIR)/bin/sound2faust && cp $(FAUSTDIR)/bin/sound2faust FaustLive.app/Contents/MacOS || true
+ 	macdeployqt FaustLive.app
+ 	./distribution
+ 	#./distversion
+@@ -103,7 +103,7 @@ dist:
+ APPDIR = /Applications
+ 
+ install: 
+-	cp $(FAUSTDIR)/bin/sound2faust FaustLive.app/Contents/MacOS
++	test -r $(FAUSTDIR)/bin/sound2faust && cp $(FAUSTDIR)/bin/sound2faust FaustLive.app/Contents/MacOS || true
+ 	rm -rf $(DESTDIR)$(APPDIR)/FaustLive.app
+ 	cp -R FaustLive.app $(DESTDIR)$(APPDIR)
+ 


### PR DESCRIPTION
This updates faust to 2.5.23 (latest stable release) and faust-devel / faustlive-devel to the latest from the upstream git repositories (https://github.com/grame-cncm) as of today. I also updated the LLVM dependencies to LLVM 6.0 (faust) and LLVM 7.0 (faust-devel, faustlive-devel) so that the ports will hopefully continue to work on Mojave (cf. https://trac.macports.org/ticket/57287). Tested on Sierra (ran it on a few of my own examples, works fine for me).

Test system:
macOS 10.12.6 16G1510
Xcode 9.2 9C40b