### PR TITLE
pd-pure, pd-faust: update to latest releases (0.26, 0.18)

### DIFF
--- a/pure/pd-faust/Portfile
+++ b/pure/pd-faust/Portfile
@@ -3,7 +3,7 @@
 PortSystem                      1.0
 PortGroup                       pure 1.0
 
-pure.setup                      pd-faust 0.16
+pure.setup                      pd-faust 0.18
 categories-append               audio devel
 platforms                       darwin
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
@@ -15,8 +15,9 @@ description                     a Pd plugin loader which lets you run Faust \
 
 long_description                ${name} provides ${description}.
 
-checksums                       rmd160  effbebb56b3aae70955df7317cac6b3893ef8eb9 \
-                                sha256  6297a4951ce8e933b56735dfe5b0b3c339205d87ecf8fa0f3e0e47dddd692a37
+checksums                       rmd160  03ec95981c27d10b710b427c76f6f747125583f6 \
+                                sha256  e9798eb69abaaf1e3b4617e8183ca9fda3c2b83bc00359612f419c9bd09ff7bf \
+                                size    223575
 
 depends_build-append            path:bin/faust:faust \
                                 port:pkgconfig

--- a/pure/pd-pure/Portfile
+++ b/pure/pd-pure/Portfile
@@ -3,7 +3,7 @@
 PortSystem                      1.0
 PortGroup                       pure 1.0
 
-pure.setup                      pd-pure 0.25
+pure.setup                      pd-pure 0.26
 categories-append               audio devel
 platforms                       darwin
 maintainers                     {ryandesign @ryandesign} {gmail.com:aggraef @agraef}
@@ -13,8 +13,9 @@ description                     a Pd plugin loader which lets you run Pure scrip
 
 long_description                ${name} provides ${description}.
 
-checksums                       rmd160  de36d284f62cedeecfa15634b1030e1bdad2a7ae \
-                                sha256  958092eb5bc7d3a7230541840f80feb6bf93e4c8d0822b5848f83bf0a3078d0a
+checksums                       rmd160  6a0e73b3ab4c68da436bb52cee99e1da940454cd \
+                                sha256  6ea9487c8854d7d87ac7d2d593a87d5554a2cce0c6368911fcad6eafe0db2b54 \
+                                size    87122
 
 depends_build-append            port:pkgconfig
 


### PR DESCRIPTION
This updates pd-pure to 0.26 and pd-faust to 0.18 (latest releases from the Pure project, https://github.com/agraef/pure-lang/releases).

Tested on Sierra:
macOS 10.12.6 16G1510
Xcode 9.2 9C40b
