### PR TITLE
hub: update to 2.6.0

### DIFF
--- a/devel/hub/Portfile
+++ b/devel/hub/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        github hub 2.5.1 v
+github.setup        github hub 2.6.0 v
 categories          devel
 platforms           darwin
 license             MIT
@@ -16,9 +16,9 @@ long_description    \
 
 homepage            https://hub.github.com/
 
-checksums           rmd160  ee3a8d3c6efe7d9917dc1fda35d01b2c7acffd1b \
-                    sha256  c0b21d40f077ab6b67233fc331c0be970b616d08814e4baae6c433edb335e434 \
-                    size    991233
+checksums           rmd160 9df972b98328ac7457b2f4e23abcda50e5b67578 \
+                    sha256 49000a62569b62f1a7630087bf1a4dd3cec8775d6034fcaad53987b24f75eb6d \
+                    size   994357
 
 worksrcdir          src/github.com/${github.author}/${name}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->