### PR TITLE
gdal: add sqlite3 prefix to configuration arguments

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -10,6 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 mpi.setup
 
 github.setup        OSGeo gdal 2.3.2 v
+revision            1
 categories          gis
 license             MIT BSD
 platforms           darwin
@@ -90,7 +91,7 @@ configure.args-append \
                     --with-proj=${prefix}/lib/proj5 \
                     --with-qhull=yes \
                     --with-pam \
-                    --with-sqlite3=yes \
+                    --with-sqlite3=${prefix} \
                     --with-spatialite=${prefix} \
                     --with-curl=${prefix}/bin/curl-config \
                     --with-geos=${prefix}/bin/geos-config \


### PR DESCRIPTION
#### Description

I updated to gdal @2.3.2_0 and listed the available OGR vector formats with `ogrinfo --formats`. I found that the `SQLite` format was missing (as was `GPKG`, another sqlite3-based format). I was also unable to use `-dialect sqlite` in OGR commands.

I fixed this by changing a configuration argument from `--with-sqlite3=yes` to `--with-sqlite3=${prefix}` in the Portfile. After this change, the `SQLite` and `GPKG` formats became available, and I was able to use `-dialect sqlite` in OGR commands.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tested basic functionality of all binary files?
