### PR TITLE
Added py37 subports for py-gitdb and py-gitpython

### DIFF
--- a/python/py-gitdb/Portfile
+++ b/python/py-gitdb/Portfile
@@ -13,7 +13,7 @@ license             BSD
 description         GitDB is a pure-Python git object database
 long_description    ${description}
 
-python.versions     27 36
+python.versions     27 36 37
 
 checksums           rmd160  b7e127468f5d3859c7e466a36ee739ed75b75d6b \
                     sha256  8078d816da0b952a46ba761bbb7b29c3c535aa89b039671a58f4641efa384d29 \

--- a/python/py-gitpython/Portfile
+++ b/python/py-gitpython/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  26d60c211c58174b885370663af858e2f51a7d33 \
                     sha256  8e2f57750df91fe72ba5cd1608e4c1954f94bea35c5d735081b2a9b082341bc5 \
                     size    519437
 
-python.versions     27 36
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

This PR adds `py37` sub-ports for `py-gitdb` and `py-gitpython`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
