### PR TITLE
librttopo: new port

### DIFF
--- a/gis/librttopo/Portfile
+++ b/gis/librttopo/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                librttopo
+categories          gis
+license             GPL-2
+version             1.1.0-RC1
+revision            0
+platforms           darwin
+maintainers         nomaintainer
+
+description         RT Topology Library
+
+long_description    The RT Topology Library exposes an API to create and\
+                    manage standard (ISO 13249 aka SQL/MM) topologies using\
+                    user-provided data stores.
+
+homepage            https://strk.kbt.io/projects/rttopo/
+
+master_sites        https://git.osgeo.org/gogs/rttopo/librttopo/archive/
+distname            ${name}-${version}
+
+checksums           rmd160  aa9212e9de49015ca88d35e156c4c30be17915d1 \
+                    sha256  ca7123e607c8bc10a30c2b2f4d36769b40f3d951920649ff9b5f5b11ec967597 \
+                    size    301074
+
+extract.mkdir       yes
+extract.post_args   | tar -x -C ${worksrcpath} --strip-components 1
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+autoreconf.args
+
+depends_build       port:autoconf \
+                    port:automake \
+                    port:libtool
+depends_lib         port:geos


### PR DESCRIPTION
* builds [librttopo](https://strk.kbt.io/projects/rttopo/)
* replaces liblwgeom in SpatiaLite version 5.0
* adds advanced functions to SpatiaLite
* add as variant to SpatiaLite when version 5.0 releases
* start with version 1.1.0-RC1 as [recommended](https://groups.google.com/forum/#!msg/spatialite-users/MlXsPU0ZMYw/t-ynEJ2TBQAJ) by maintainer

#### Description

[SpatiaLite](https://www.gaia-gis.it/fossil/libspatialite/index) has some useful [advanced functions](http://www.gaia-gis.it/gaia-sins/spatialite-sql-5.0.0.html#p14d) which require an additional library. Prior to SpatiaLite version 5.0, this library was known as *lwgeom*. It was only distributed as part of PostGIS, without its own versioning, and building it was a bit tricky.  It was not available in MacPorts.

Recently, the functionality of *lwgeom* was extracted to its own independent project, [*rttopo*](https://strk.kbt.io/projects/rttopo/index.html). From version 5.0 of SpatiaLite (currently in beta), the *lwgeom* library is replaced by the *rttopo* library.

This port provides *librttopo* in anticipation of SpatiaLite version 5.0. In the SpatiaLite portfile, the following variant will add the *rttopo* functions:

    variant rttopo description {add RTTOPO functions} {
        depends_lib-append          port:librttopo
        configure.args-append       --enable-rttopo
    }

I am using *rttopo* version 1.1.0-RC1 as [recommended](https://groups.google.com/forum/#!msg/spatialite-users/MlXsPU0ZMYw/t-ynEJ2TBQAJ) by the maintainer. I am currently using this port with the SpatiaLite 5.0 beta, with good results.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?
