### PR TITLE
gstreamer1-gst-plugins-bad: Fix build with gstreamer1-gst-plugins-base -x11+universal

### DIFF
--- a/gnome/gstreamer1-gst-plugins-bad/Portfile
+++ b/gnome/gstreamer1-gst-plugins-bad/Portfile
@@ -12,7 +12,7 @@ name                gstreamer1-gst-plugins-bad
 set my_name         gst-plugins-bad
 # please only commit stable updates (even numbered releases)
 version             1.14.4
-revision            2
+revision            3
 description         A set of plug-ins for GStreamer that need more quality.
 long_description    GStreamer Bad Plug-ins is a set of plug-ins that aren't up to par compared \
                     to the rest. They might be close to being good quality, but they're missing \
@@ -109,8 +109,6 @@ configure.args      --disable-silent-rules \
 
 #
 # port:soundtouch (fails on autoreconf on darwin 8 & 9, see #27533) disable soundtouch on these platforms
-# plugin applemedia (Apple video) now only builds on darwin 14 and later due to use of
-# constant AVQueuedSampleBufferRenderingStatusFailed introduced in OSX 10.10
 # chromaprint 1.4+ requires libc++ (see #53072)
 
 platform darwin {
@@ -142,19 +140,39 @@ variant fdkaac description {Enable fdkaac AAC plugin} {
 }
 
 # Window system is provided by gstreamer1-gst-plugins-base, so sync up.
-variant x11 {
+variant x11 conflicts applemedia {
     require_active_variants port:gstreamer1-gst-plugins-base x11
 }
 
-default_variants +x11
-
-platform macosx {
-    if {![variant_isset x11] && ![variant_isset universal] && ${os.major} >= 13} {
-        # Apple_Media requires CGL, which can only be provided on newer platforms and without X11 enabled.
-        require_active_variants port:gstreamer1-gst-plugins-base {} x11
-        configure.args-replace  --disable-apple_media \
-                                --enable-apple_media
+# plugin applemedia (Apple video) requires CGL, which can only be provided
+# on newer macosx platforms and without X11 enabled, and does not work with
+# +universal due to use of -fobjc-arc
+variant applemedia conflicts x11 conflicts universal description {Enable apple media plugin} {
+    pre-fetch {
+        if {${os.subplatform} ne "macosx" || ${os.major} < 13} {
+            ui_error "${name} +applemedia requires OS X 10.9 or later"
+            return -code error "incompatible variant selection"
+        }
     }
+    require_active_variants port:gstreamer1-gst-plugins-base {} {x11 universal}
+    configure.args-replace  --disable-apple_media \
+                            --enable-apple_media
+}
+
+if {[catch {set result [active_variants port:gstreamer1-gst-plugins-base x11]}] || $result} {
+    default_variants +x11
+}
+
+if {![variant_isset x11] && ![variant_isset universal]} {
+    if {[catch {set result [active_variants port:gstreamer1-gst-plugins-base {} {x11 universal}]}] || $result} {
+        if {${os.subplatform} eq "macosx" && ${os.major} >= 13} {
+            default_variants +applemedia
+        }
+    }
+}
+
+if {![variant_isset x11]} {
+    require_active_variants port:gstreamer1-gst-plugins-base {} x11
 }
 
 if {[variant_isset universal]} {

--- a/gnome/gstreamer1-gst-plugins-base/Portfile
+++ b/gnome/gstreamer1-gst-plugins-base/Portfile
@@ -113,12 +113,6 @@ platform macosx {
     }
 }
 
-if {[variant_isset universal]} {
-    if {![variant_isset x11]} {
-        ui_error "${name} ${version} requires +x11 if +universal is set."
-        return -code error "incompatible variant selection."
-    }
-}
 variant ogg description {Build with support for libogg, libvorbis, libtheora} {
     depends_lib-append    port:libogg port:libvorbis port:libtheora
     configure.args-replace  --disable-ogg \


### PR DESCRIPTION
#### Description

Add applemedia variant so that it can be enabled or not based on the active variants of gstreamer1-gst-plugins-base.

Fixes https://trac.macports.org/ticket/57020

Although this port has no maintainer, I am tagging @Ionic in case he wants to review this since he made a previous attempt to fix this issue.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1510
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
