### PR TITLE
py-spyder-devel: update to 779fd0d (20181103)

### DIFF
--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -7,8 +7,8 @@ PortGroup           qt5 1.0
 PortGroup           active_variants 1.1
 PortGroup           select 1.0
 
-github.setup        spyder-ide spyder 7d928c7
-version             3.3.0-20181019
+github.setup        spyder-ide spyder 779fd0d
+version             3.3.0-20181103
 name                py-spyder-devel
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
@@ -39,9 +39,9 @@ supported_archs     noarch
 #pyNN-scipy doesn't build universal
 universal_variant   no
 
-checksums           rmd160  3a54a2788e91c61c01d081326c07b449a345dff8 \
-                    sha256  fdf6a673da22dc4b0fd953747db82574814ecac216811a07b1e73a0bb79e79e5 \
-                    size    4021883
+checksums           rmd160  c0f453e8990166f81833cbf9d60c63d64921bb7d \
+                    sha256  ea57863ac778ac4c6771a5be9705297c4807131e25268e3922b5dc2f3d4e52a3 \
+                    size    4069105
 
 if {${name} ne ${subport}} {
     require_active_variants py${python.version}-pyqt5 webengine


### PR DESCRIPTION
#### Description
- update to latest git commit, 779fd0d (20181103)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
