### PR TITLE
py-future: update to 0.17.1

### DIFF
--- a/python/py-future/Portfile
+++ b/python/py-future/Portfile
@@ -3,12 +3,8 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           future
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             0.16.0
-revision            1
+name                py-future
+version             0.17.1
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -24,13 +20,13 @@ long_description    \
     minimal overhead. The futurize script aids in converting code from \
     either Python 2 or Python 3 to code compatible with both platforms.
 
-homepage            http://python-future.org/
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+homepage            https://python-future.org/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  69456fbc593b4ae123fafca1afb8d58062f44b97 \
-                    sha256  e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb \
-                    size    824484
+checksums           rmd160  b61bd5644d24d2045feed1d3aaa983d74a0315bd \
+                    sha256  67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8 \
+                    size    829119
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to 0.17.1 
- make use of python.rootname
- use https for homepage
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
