### PR TITLE
iTerm2: Update to 3.2.5

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
-github.setup        gnachman iTerm2 3.2.0 v
+github.setup        gnachman iTerm2 3.2.5 v
 categories          aqua shells
 platforms           darwin
 maintainers         {emer.net:emer @markemer} openmaintainer
@@ -19,9 +19,9 @@ long_description    \
 
 homepage            https://iterm2.com/
 
-checksums           rmd160  07915ff5db0545c0c059f47e7f71761e023a26e1 \
-                    sha256  017aff348352369abcc994caaca0f6112e1f17c4d65041acdb9f19830b2b96bd \
-                    size    11969144
+checksums           rmd160  90844a6638bf2b5dd6168af515faa7a1853a080c \
+                    sha256  64185b6334f38b5ee62764e52b8300765e10f1180aa5d6abc15b13a999ba0118 \
+                    size    11637927
 
 github.livecheck.regex {(\d+(?:\.\d+)*)}
 

--- a/aqua/iTerm2/files/patch-Makefile.diff
+++ b/aqua/iTerm2/files/patch-Makefile.diff
@@ -1,13 +1,26 @@
 Declare dependencies so we don't unnecessarily rebuild when running "make install"
---- Makefile.orig	2016-07-11 17:10:54.000000000 -0500
-+++ Makefile	2016-08-01 23:05:10.000000000 -0500
-@@ -31,7 +31,8 @@
- Dep:
- 	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment
- 
+--- Makefile.orig	2018-10-29 12:31:47.000000000 -0400
++++ Makefile	2018-11-04 14:07:03.000000000 -0500
+@@ -21,7 +21,7 @@
+ 	find . -name "*.[mhMH]" -exec etags -o ./TAGS -a '{}' +
+
+ install: | Deployment backup-old-iterm
+-	cp -R build/Deployment/iTerm2.app $(APPS)
++	cp -R DerivedData/Build/Products/Deployment/iTerm2.app $(APPS)
+
+ Development:
+ 	echo "Using PATH for build: $(PATH)"
+@@ -36,9 +36,10 @@
+ 	xcodebuild -parallelizeTargets -target iTerm2 -configuration Beta && \
+ 	chmod -R go+rX build/Beta
+
 -Deployment:
+-	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment && \
+-	chmod -R go+rX build/Deployment
 +Deployment: build/Deployment/iTerm2.app/Contents/MacOS/iTerm2
 +build/Deployment/iTerm2.app/Contents/MacOS/iTerm2:
- 	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment && \
- 	chmod -R go+rX build/Deployment
- 
++	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment -scheme iTerm2 -derivedDataPath ./DerivedData && \
++	chmod -R go+rX DerivedData/Build/Products/Deployment
+
+ Nightly: force
+ 	cp plists/nightly-iTerm2.plist plists/iTerm2.plist


### PR DESCRIPTION
#### Description

* Update to 3.2.5
* Fix makefile so it builds with Xcode 10 on macOS 10.14

Closes: https://trac.macports.org/ticket/57197
Closes: https://trac.macports.org/ticket/57190

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
