### PR TITLE
ffmpeg: update to 4.0.3

### DIFF
--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -9,8 +9,7 @@ PortGroup           active_variants 1.1
 name                ffmpeg
 conflicts           ffmpeg-devel
 epoch               1
-version             4.0.2
-revision            1
+version             4.0.3
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -52,9 +51,9 @@ master_sites        ${homepage}releases/
 
 use_xz              yes
 
-checksums           rmd160  61a3049dee1e5ea958a21d4cc743fee200813d83 \
-                    sha256  a95c0cc9eb990e94031d2183f2e6e444cc61c99f6f182d1575c433d62afb2f97 \
-                    size    8662984
+checksums           rmd160  7eebedb9e0bb3c961f07c85bec66a624e2f79477 \
+                    sha256  253c37e3f1d3626a2566e496554de9a4c29050753660835909a466d66b12e2ed \
+                    size    8668388
 
 depends_build       port:pkgconfig \
                     port:gmake \


### PR DESCRIPTION
#### Description
Fixes CVE-2018-15822.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
