### PR TITLE
tomcat-native: update to version 1.2.18

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                tomcat-native
-version             1.2.17
+version             1.2.18
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
 license             Apache-2
@@ -16,9 +16,9 @@ long_description    This port provides access to native apr and other \
 homepage            http://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  947417c6c0580570e86081931dcad57db2bec4f9 \
-                    sha256  e16858e6ad91c26c17491a26f3ed4a53ab441c44fb3490caf09075ef4dda857e \
-                    size    408967
+checksums           rmd160  26b6ab2d089eb34e9c8ec795131d70790ffed602 \
+                    sha256  846c579ff81655f72382597272c1bcf850491d39ba5ba079b541c79887d827d2 \
+                    size    411789
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native


### PR DESCRIPTION
#### Description

Update tomcat-native to version 1.2.18

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
