### PR TITLE
py-BitVector: update to 3.4.8, add py37 subport

### DIFF
--- a/python/py-BitVector/Portfile
+++ b/python/py-BitVector/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 set _name           BitVector
 
 name                py-${_name}
-version             3.4.7
+version             3.4.8
 categories-append   math
 platforms           darwin
 supported_archs     noarch
@@ -26,10 +26,11 @@ homepage            https://engineering.purdue.edu/kak/dist/${_name}-${version}.
 distname            ${_name}-${version}
 master_sites        https://engineering.purdue.edu/kak/dist
 
-checksums           rmd160  c4dd203a2e09ebb9e69ddd94814ad3c82279c674 \
-                    sha256  daedd1081ed7040684ca97f5749947ef7b86eaabae27e7a9b69bfd613d22751a
+checksums           rmd160  4830e41317c6bf5753983bcea05477b4bb44f97e \
+                    sha256  c636d81495a15c3ccd8c3c1497d90deaf7fdcf60aa8cfc91e60a771796ba7f72 \
+                    size    126947
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Note: The module's author has not indicated compatibility with Python 3.6 or 3.7; most recent version mentioned on [homepage](https://engineering.purdue.edu/kak/dist/BitVector-3.4.8.html) is 3.5.3.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing py37-BitVector
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_python_py-BitVector/py37-BitVector/work/BitVector-3.4.8" && /opt/local/Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 TestBitVector/Test.py
......
----------------------------------------------------------------------
Ran 6 tests in 0.002s

OK

Testing constructors

Testing Boolean operators

Testing comparison operators

Testing permutations

Testing CircularShifts
```
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
