### PR TITLE
soprano: fix JDK location for mojave

### DIFF
--- a/devel/soprano/Portfile
+++ b/devel/soprano/Portfile
@@ -42,7 +42,7 @@ configure.args-append \
                     -DSOPRANO_DISABLE_CLUCENE_INDEX=1
 
 pre-configure {
-    if {![file isfile "/System/Library/Frameworks/JavaVM.framework/Headers/jni.h"]} {
+    if {![file isfile "/System/Library/Frameworks/JavaVM.framework/Headers/jni.h"] && ![file isfile "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers/jni.h"]} {
         ui_error "${name} requires the Java for Mac OS X development headers."
         if {${os.major} == 11} {
             ui_error "Download the Java Developer Package from: <http://support.apple.com/kb/DL1421>"


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/57255

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
