### PR TITLE
py-pysvn: Don't use rpath

### DIFF
--- a/python/py-pysvn/Portfile
+++ b/python/py-pysvn/Portfile
@@ -5,6 +5,7 @@ PortGroup python    1.0
 
 name                py-pysvn
 version             1.9.6
+revision            1
 categories-append   devel
 maintainers         {blair @blair} openmaintainer
 platforms           darwin
@@ -57,6 +58,7 @@ if {${name} ne ${subport}} {
                     --svn-bin-dir=${prefix}/bin \
                     --svn-inc-dir=${prefix}/include/subversion-1 \
                     --svn-lib-dir=${prefix}/lib \
+                    --link-python-framework-via-dynamic-lookup \
                     --pycxx-dir=${worksrcpath}/../Import/pycxx-7.0.3
     configure.universal_args-delete --disable-dependency-tracking
 


### PR DESCRIPTION
#### Description

py-pysvn: Don't use rpath

Fixes [build failure with gcc 4.2](https://build.macports.org/builders/ports-10.6_x86_64_legacy-builder/builds/85265/steps/install-port/logs/stdio).

I'm not really certain of the implications of doing this, beyond the fact that it fixes the build failure on older systems and still builds on newer ones. There is also a comment in Source/setup_configure.py that says Homebrew uses this option as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518 

macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
