### PR TITLE
Add ports for Flutter iOS development

### DIFF
--- a/devel/ideviceinstaller/Portfile
+++ b/devel/ideviceinstaller/Portfile
@@ -38,3 +38,21 @@ depends_lib         port:libplist \
                     port:libimobiledevice
 
 configure.cmd       ./autogen.sh
+
+subport ideviceinstaller-devel {
+    github.setup    libimobiledevice ideviceinstaller f14def7cd9303a0fe622732fae9830ae702fdd7c
+    version         20181001
+
+    checksums       rmd160  a79a163dc2dffe032c6c6128f982a734cecbd85d \
+                    sha256  d40b4094821c37cfdf7bfbce48554527ce44b5012832a08863591a5efffcc6eb \
+                    size    19969
+
+    depends_lib-delete port:libimobiledevice
+    depends_lib-append port:libimobiledevice-devel
+
+    conflicts       ideviceinstaller
+}
+
+if {${subport} eq ${name}} {
+    conflicts       ideviceinstaller-devel
+}

--- a/devel/ios-deploy/Portfile
+++ b/devel/ios-deploy/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcode 1.0
+
+github.setup        ios-control ios-deploy 1.9.4
+categories          devel
+license             GPL-3+
+maintainers         {amake @amake} openmaintainer
+
+description         Install and debug iPhone apps from the command line, without using Xcode
+long_description    ${description}
+platforms           darwin
+
+checksums           rmd160  dec10dc3053fd6b568ba38afd74c85d715c94d99 \
+                    sha256  f6257f92005896fbb07adb139e62988c53776c0b830180109cb1a139833efe69 \
+                    size    43882
+
+xcode.configuration Release
+xcode.target        ${name}
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath}/build/${xcode.configuration} \
+        ${name} ${destroot}${prefix}/bin
+    xinstall -m 0644 -W ${worksrcpath}/build/${xcode.configuration} \
+        libios-deploy.a ${destroot}${prefix}/lib
+    xinstall -m 0644 -W ${worksrcpath}/build/${xcode.configuration} \
+        libios_deploy.h ${destroot}${prefix}/include
+}

--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -46,3 +46,22 @@ configure.cmd       ./autogen.sh
 
 configure.args      --disable-silent-rules \
                     --without-cython
+
+subport libimobiledevice-devel {
+    github.setup    libimobiledevice libimobiledevice 92c5462adef87b1e577b8557b6b9c64d5a089544
+    version         20181030
+    revision        0
+
+    checksums       rmd160  8ea7c0da17f775b35d1356763533d57e4e82ef64 \
+                    sha256  3b2e20a5689032a44dde60ac05a7d9e50ecff69b5a79414ad540bb9aa8436105 \
+                    size    236074
+
+    depends_lib-delete port:libusbmuxd
+    depends_lib-append port:libusbmuxd-devel
+
+    conflicts       libimobiledevice
+}
+
+if {${subport} eq ${name}} {
+    conflicts       libimobiledevice-devel
+}

--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -31,3 +31,18 @@ depends_lib         port:libplist
 configure.cmd       ./autogen.sh
 
 configure.args      --disable-silent-rules
+
+subport libusbmuxd-devel {
+    github.setup    libimobiledevice libusbmuxd 9db5747cd823b1f59794f81560a4af22a031f5c9
+    version         20181021
+
+    checksums       rmd160  69c7fd4d9bb2cee5436b32f5358cadd997fce239 \
+                    sha256  a5b13ecaad58896b1d111c24b8cb0d2490d328d201d89f405e9a4f02722b9846 \
+                    size    38676
+
+    conflicts       libusbmuxd
+}
+
+if {${subport} eq ${name}} {
+    conflicts       libusbmuxd-devel
+}


### PR DESCRIPTION
#### Description

[Flutter](https://flutter.io/), Google's Dart-based cross-platform mobile app framework, uses a handful of external tools for deploying apps to iOS devices. The blessed path is to install these through Homebrew, but even then [it's convoluted](https://flutter.io/docs/get-started/install/macos#deploy-to-ios-devices) because a bunch of the tools haven't had official releases for years.

This PR adds `-devel` subports (and one unrelated required port) that allow MacPorts users to install everything they need with just

```
port install ideviceinstaller-devel ios-deploy
```

(And get cocoapods from `gem`.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
