### PR TITLE
gstreamer1: Remove gtk3 dependency

### DIFF
--- a/gnome/gstreamer010-gnonlin/Portfile
+++ b/gnome/gstreamer010-gnonlin/Portfile
@@ -29,6 +29,9 @@ depends_lib         port:gstreamer010-gst-plugins-base \
 
 configure.cflags-append -funroll-loops -fstrict-aliasing
 
+configure.args-append \
+                    --disable-silent-rules
+
 post-patch {
     reinplace "s|-flat_namespace -undefined suppress|-undefined define_a_way|g" \
         ${worksrcpath}/configure

--- a/gnome/gstreamer010-gst-ffmpeg/Portfile
+++ b/gnome/gstreamer010-gst-ffmpeg/Portfile
@@ -41,6 +41,9 @@ autoreconf.args     -fvi
 # This will cause the installed ffmpeg headers to be used, remove it.
 configure.cppflags-delete -I${prefix}/include
 
+# Disable silent rules
+build.args-append   V=1
+
 if {[lsearch [get_canonical_archs] i386] != -1} {
     # clang-3.1 hits https://trac.macports.org/ticket/30137 (<rdar://problem/11542429>)
     # clang-139 hits https://trac.macports.org/ticket/38141

--- a/gnome/gstreamer010-gst-plugins-base/Portfile
+++ b/gnome/gstreamer010-gst-plugins-base/Portfile
@@ -40,6 +40,7 @@ gobject_introspection no
 
 configure.args-append \
     --enable-experimental \
+    --disable-silent-rules \
     --disable-examples \
     --disable-libvisual \
     --disable-gst_v4l \

--- a/gnome/gstreamer010-gst-plugins-gl/Portfile
+++ b/gnome/gstreamer010-gst-plugins-gl/Portfile
@@ -42,7 +42,8 @@ autoreconf.args -fvi
 
 # gst-plugins-gl sees libsdl if it is present and uses it to build examples which 
 # fail to build as of 0.10.3
-configure.args-append   --disable-examples
+configure.args-append   --disable-silent-rules \
+                        --disable-examples
 
 post-extract {
     reinplace "s|-flat_namespace -undefined suppress|-undefined define_a_way|g" \

--- a/gnome/gstreamer010-gst-plugins-good/Portfile
+++ b/gnome/gstreamer010-gst-plugins-good/Portfile
@@ -59,7 +59,12 @@ post-patch {
 use_autoreconf          yes
 autoreconf.args         -fvi
 
-configure.args-append   --disable-gtk-doc --disable-schemas-install --with-default-videosink=ximagesink --disable-jack --disable-pulse
+configure.args-append   --disable-silent-rules \
+                        --disable-gtk-doc \
+                        --disable-schemas-install \
+                        --with-default-videosink=ximagesink \
+                        --disable-jack \
+                        --disable-pulse
 configure.env-append    "HAVE_CXX=yes"
 
 platform darwin {

--- a/gnome/gstreamer010-gst-plugins-ugly/Portfile
+++ b/gnome/gstreamer010-gst-plugins-ugly/Portfile
@@ -44,7 +44,9 @@ depends_lib         port:gstreamer010-gst-plugins-base \
 patchfiles          libcdio.patch
 patch.pre_args      -p1
 
-configure.args              mandir=${prefix}/share/man --enable-static
+configure.args              mandir=${prefix}/share/man \
+                            --disable-silent-rules \
+                            --enable-static
 configure.cppflags-append   "-L${prefix}/lib"
 configure.cflags-append     -funroll-loops -fstrict-aliasing
 

--- a/gnome/gstreamer010-gst-rtsp/Portfile
+++ b/gnome/gstreamer010-gst-rtsp/Portfile
@@ -33,6 +33,8 @@ depends_lib \
     port:gstreamer010 \
     port:gstreamer010-gst-plugins-base
 
+configure.args      --disable-silent-rules
+
 gobject_introspection no
 
 livecheck.type      none

--- a/gnome/gstreamer010/Portfile
+++ b/gnome/gstreamer010/Portfile
@@ -50,6 +50,9 @@ conflicts_build     check
 configure.env-append    PERL_PATH=${prefix}/bin/perl
 configure.cflags-append -funroll-loops -fstrict-aliasing -fno-common
 
+configure.args-append \
+                    --disable-silent-rules
+
 if {[variant_isset universal]} {
     set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}
     set merger_host(i386) i686-apple-${os.platform}${os.major}

--- a/gnome/gstreamer010/Portfile
+++ b/gnome/gstreamer010/Portfile
@@ -51,6 +51,7 @@ configure.env-append    PERL_PATH=${prefix}/bin/perl
 configure.cflags-append -funroll-loops -fstrict-aliasing -fno-common
 
 configure.args-append \
+                    --disable-examples \
                     --disable-silent-rules
 
 if {[variant_isset universal]} {

--- a/gnome/gstreamer1/Portfile
+++ b/gnome/gstreamer1/Portfile
@@ -11,6 +11,7 @@ name                gstreamer1
 set my_name         gstreamer
 # please only commit stable updates (even numbered releases)
 version             1.14.4
+revision            1
 description         GStreamer is a library for constructing graphs of media-handling components.
 long_description    The applications it supports range from simple Ogg/Vorbis playback, audio/video \
                     streaming to complex audio (mixing) and video (non-linear editing) processing.
@@ -38,7 +39,6 @@ depends_lib         port:bison \
                     port:flex \
                     port:gettext \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:gtk3 \
                     port:libxml2
 
 gobject_introspection yes
@@ -59,6 +59,7 @@ if {[string match "*gcc-4.2" ${configure.compiler}]} {
 }
 
 configure.args-append \
+                    --disable-examples \
                     --disable-fatal-warnings \
                     --disable-silent-rules \
                     --without-dw \

--- a/gnome/gstreamer1/Portfile
+++ b/gnome/gstreamer1/Portfile
@@ -60,7 +60,9 @@ if {[string match "*gcc-4.2" ${configure.compiler}]} {
 
 configure.args-append \
                     --disable-fatal-warnings \
-                    --disable-silent-rules
+                    --disable-silent-rules \
+                    --without-dw \
+                    --without-unwind
 
 if {[variant_isset universal]} {
     set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}


### PR DESCRIPTION
#### Description

The purpose of this PR is to remove the gtk3 dependency from gstreamer1.

gtk3 was only used by the examples, which were built but not installed. So this PR disables building the examples in gstreamer1 and gstreamer010.

While I was there, I also fixed gstreamer010* ports to disable silent rules, which the gstreamer1* ports already do.

I also explicitly disabled the use of dw and unwind in gstreamer1. We don't have a port for dw and the port of libunwind that we have is unsuitable for gstreamer because it doesn't contain a pkg-config file, so these wouldn't have been used anyway, but it's good to be explicit about what we want and don't want.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
