### PR TITLE
tor-devel: update to 0.3.5.4-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.3.5.3-alpha
+version             0.3.5.4-alpha
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  cc2ce021d690b95b04b98f8dc3dc75a991b259e5 \
-                    sha256  b5889b17062a20c1d28b5ddf8872818584a2ff1a5ebaeb37493f7699e3c37db4 \
-                    size    6862572
+checksums           rmd160  15f176e09542759f960f434138ca4365a638e1b8 \
+                    sha256  0f026b5f5a11ce67efd5e2cad091f8538bc8c895ad4b4404737d0418c5434078 \
+                    size    6867919
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description
tor-devel: update to 0.3.5.4-alpha

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G4008
Xcode 10.1 10B61

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?