### PR TITLE
npm6: use NodeJS v10

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                npm6
 version             6.4.1
+revision            1
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -31,11 +32,11 @@ checksums           sha1    4f39f9337b557a28faed4a771d5c8802d6b4288b \
 
 worksrcdir          "package"
 
-depends_lib         path:bin/node:nodejs8
+depends_lib         path:bin/node:nodejs10
 
 platform darwin {
     if {${os.major} < 13} {
-        depends_lib-replace path:bin/node:nodejs8 path:bin/node:nodejs6
+        depends_lib-replace path:bin/node:nodejs10 path:bin/node:nodejs6
     }
 }
 


### PR DESCRIPTION
#### Description

Just as in #2877, this PR makes NPM v6 default to NodeJS v10, since that is the current active LTS version of NodeJS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
