### PR TITLE
py-algopy/py-numdifftools: new ports

### DIFF
--- a/python/py-algopy/Portfile
+++ b/python/py-algopy/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-algopy
+version             0.5.7
+categories-append   math
+platforms           darwin
+license             BSD
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         AlgoPy is a Research Prototype for Algorithmic Differentation in Python
+long_description    ${description}
+
+homepage            https://github.com/b45ch1/algopy
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+use_zip             yes
+
+checksums           rmd160  afde10c39cdb717c11586c6f19710581f646b05c \
+                    sha256  6955f676fce3858fa3585cb7f3f7e1796cb93377d24016419b6699291584b7df \
+                    size    189516
+
+python.versions     27 36 37
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-numpy \
+                        port:py${python.version}-scipy
+
+    livecheck.type  none
+}

--- a/python/py-numdifftools/Portfile
+++ b/python/py-numdifftools/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-numdifftools
+version             0.9.20
+categories-append   math
+platforms           darwin
+license             MIT
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         Solve automatic numerical differentiation problems in one or more variables.
+long_description    ${description}
+
+homepage            https://github.com/pbrod/numdifftools
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  b501dc1d3b3d70a2416ddd1d03543b401ac8784c \
+                    sha256  a6af9a28851cc9a207720d949b34b6ac70f0bccb365d9df3c6ef3ffd91176257 \
+                    size    3049850
+
+python.versions     27 36 37
+
+if {${name} ne ${subport}} {
+    patchfiles-append   patch-remove-pyscaffold.diff
+
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append  port:py${python.version}-algopy \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-scipy \
+                        port:py${python.version}-six
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} AUTHORS.rst LICENSE.txt CHANGES.rst \
+            README.rst ${destroot}${docdir}
+    }
+
+    livecheck.type      none
+}

--- a/python/py-numdifftools/files/patch-remove-pyscaffold.diff
+++ b/python/py-numdifftools/files/patch-remove-pyscaffold.diff
@@ -1,0 +1,16 @@
+--- setup.py.orig	2018-11-08 10:01:32.000000000 -0500
++++ setup.py	2018-11-08 10:02:51.000000000 -0500
+@@ -59,10 +59,10 @@
+ def setup_package():
+     needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
+     sphinx = ['sphinx', 'numpydoc', 'sphinx_rtd_theme>=0.1.7'] if needs_sphinx else []
+-    setup(setup_requires=['six', 'pyscaffold>=2.4rc1,<2.5a0'] + sphinx,
++    setup(setup_requires=['six'],
+           tests_require=['pytest_cov', 'pytest', 'hypothesis', 'matplotlib'],
+-          use_pyscaffold=True)
+-    print_version()
++          packages=['numdifftools', 'numdifftools.tests'])
++
+ 
+ 
+ if __name__ == "__main__":


### PR DESCRIPTION
#### Description
- py-algopy: new port, version 0.5.7
- py-numdifftools: new port, version 0.9.20
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
