### PR TITLE
py-keyring: update to 16.0.1

### DIFF
--- a/python/py-keyring/Portfile
+++ b/python/py-keyring/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keyring
-version             16.0.0
+version             16.0.1
 categories-append   security
 
 license             {MIT PSF}
@@ -21,9 +21,9 @@ homepage            https://github.com/jaraco/keyring
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  b68f547986abf18bd6332269b6404e1f030e9031 \
-                    sha256  8a9b0c2c2abc3e7326559f840e1f05e6d010ccaf397d09f450485920ba08e443 \
-                    size    43658
+checksums           rmd160  d778cb37d7820b65755c143945b989080b6471f7 \
+                    sha256  a86499736e2e6555618606c2fbc98147e803fa276f990ddba7011eb29a01b5ad \
+                    size    43862
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to version 16.0.1
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.6, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
