### PR TITLE
py-plyvel: Fix build on 10.6 and earlier

### DIFF
--- a/python/py-plyvel/Portfile
+++ b/python/py-plyvel/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-plyvel
 version             1.0.5
+revision            1
 categories-append   devel
 platforms           darwin
 license             BSD
@@ -37,6 +38,8 @@ if {${name} ne ${subport}} {
         # https://github.com/pypa/setuptools/issues/617
         system "chmod -R a+r ${worksrcpath}"
     }
+
+    patchfiles              setup.py.patch
 
     livecheck.type          none
 } else {

--- a/python/py-plyvel/files/setup.py.patch
+++ b/python/py-plyvel/files/setup.py.patch
@@ -1,0 +1,17 @@
+Enable C++ mode in the C compiler the standard way.
+Do not override the MacPorts deployment target and stdlib choices.
+Fixes build with non-clang compilers, which don't understand -stdlib.
+https://github.com/wbolster/plyvel/pull/91
+--- setup.py.orig	2018-01-16 12:49:11.000000000 -0600
++++ setup.py	2018-11-08 12:53:25.000000000 -0600
+@@ -14,9 +14,7 @@
+         return fp.read()
+ 
+ 
+-extra_compile_args = ['-Wall', '-g']
+-if platform.system() == 'Darwin':
+-    extra_compile_args += ['-mmacosx-version-min=10.7', '-stdlib=libc++']
++extra_compile_args = ['-Wall', '-g', '-x', 'c++']
+ 
+ ext_modules = [
+     Extension(


### PR DESCRIPTION
#### Description

py-plyvel: Fix build on 10.6 and earlier

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13, Mac OS X 10.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
