### PR TITLE
wireshark2: fix build with +lua when lua5.3 is installed

### DIFF
--- a/net/wireshark2/Portfile
+++ b/net/wireshark2/Portfile
@@ -62,6 +62,12 @@ configure.args-append \
                     -DENABLE_ZLIB=OFF \
                     -DBUILD_wireshark=OFF
 
+# fix include directory for lua -- stop putting zlib.h include directory first
+# and then do put lua-52/lua.h directory first in list of include directories
+# fixes the accidental finding of the lua-5.3 lua.h in ${prefix}/include, which fails
+patchfiles-append   patch-wireshark2-luafix-001.diff
+patchfiles-append   patch-wireshark2-luafix-002.diff
+
 variant qt5 conflicts no_gui description {Build wireshark with a qt5 GUI} {
     PortGroup               qt5 1.0
     configure.args-replace  -DENABLE_APPLICATION_BUNDLE=OFF -DENABLE_APPLICATION_BUNDLE=ON

--- a/net/wireshark2/files/patch-wireshark2-luafix-001.diff
+++ b/net/wireshark2/files/patch-wireshark2-luafix-001.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2018-11-08 16:10:15.000000000 -0800
++++ CMakeLists.txt	2018-11-08 16:10:20.000000000 -0800
+@@ -1223,7 +1223,7 @@
+ 	set(HAVE_ZLIB 1)
+ 	# Always include the "true" zlib includes first. This works around a
+ 	# bug in the Windows setup of GTK[23] which has a faulty zconf.h.
+-	include_directories(BEFORE ${ZLIB_INCLUDE_DIRS})
++	# include_directories(BEFORE ${ZLIB_INCLUDE_DIRS})
+ endif()
+ if(HAVE_LIBLZ4)
+ 	set(HAVE_LZ4 1)

--- a/net/wireshark2/files/patch-wireshark2-luafix-002.diff
+++ b/net/wireshark2/files/patch-wireshark2-luafix-002.diff
@@ -1,0 +1,11 @@
+--- cmake/modules/FindLUA.cmake.orig	2018-11-08 15:53:04.000000000 -0800
++++ cmake/modules/FindLUA.cmake	2018-11-08 15:53:49.000000000 -0800
+@@ -89,6 +89,8 @@
+ IF(LUA_LIBRARY)
+   SET( LUA_LIBRARIES "${LUA_LIBRARY}")
+   SET( LUA_INCLUDE_DIRS ${LUA_INCLUDE_DIR} )
++# put lua_include_dir ahead of other include directories to pick up the right lua.h
++  include_directories(BEFORE ${LUA_INCLUDE_DIR})
+   if (WIN32)
+     set ( LUA_DLL_DIR "${LUA_HINTS}"
+       CACHE PATH "Path to Lua DLL"


### PR DESCRIPTION
brings lua 5.2 include directory ahead of system directories
so the lua 5.2 lua.h is found as required
closes: https://trac.macports.org/ticket/57489

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
