### PR TITLE
Io: fix of outdated python dependency

### DIFF
--- a/lang/Io/Portfile
+++ b/lang/Io/Portfile
@@ -51,14 +51,14 @@ depends_lib             path:lib/pkgconfig/cairo.pc:cairo \
                         port:ossp-uuid \
                         path:lib/pkgconfig/pango.pc:pango \
                         port:pcre \
-                        port:python27 \
+                        port:python37 \
                         port:readline \
                         port:sqlite3 \
                         port:tiff \
                         port:yajl \
                         port:zlib
 
-configure.python        ${prefix}/bin/python2.7
+configure.python        ${prefix}/bin/python3.7
 
 # ../../_build/binaries/io_static: No such file or directory
 use_parallel_build      no


### PR DESCRIPTION
#### Description
* upgrade python requirement from 2.7 to 3.7

Closes: https://trac.macports.org/ticket/57511

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C38b
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
