### PR TITLE
py-httplib2: add py37 support

### DIFF
--- a/python/py-httplib2/Portfile
+++ b/python/py-httplib2/Portfile
@@ -19,7 +19,7 @@ homepage          https://pypi.python.org/pypi/${python.rootname}/
 master_sites      pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname          ${python.rootname}-${realversion}
 
-python.versions   27 34 35 36
+python.versions   27 34 35 36 37
 
 checksums         rmd160  c8c524c2fd7edca575db197da82b71c23c7f128c \
                   sha256  e71daed9a0e6373642db61166fa70beecc9bf04383477f84671348c02a04cbdf \


### PR DESCRIPTION
Allowed by `openmaintainer`.