### PR TITLE
jdupes: new port

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        jbruchon jdupes 1.11 v
+platforms           darwin
+categories          sysutils
+license             MIT
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         identify and take actions upon duplicate files
+long_description    ${name} is a powerful duplicate file finder and an \
+                    enhanced fork of 'fdupes'.
+
+checksums           rmd160  8ec9967244e915e384136da2729f5b130194abaf \
+                    sha256  6366dec4caf7c50db714867ef8bb829a551970e24280e185b7c76d0434cc6980 \
+                    size    71523
+
+patchfiles          patch-Makefile.diff
+
+use_configure       no
+
+build.args          PREFIX=${prefix}
+
+destroot.args       PREFIX=${prefix}

--- a/sysutils/jdupes/files/patch-Makefile.diff
+++ b/sysutils/jdupes/files/patch-Makefile.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2018-11-03 15:02:51.000000000 -0700
++++ Makefile	2018-11-08 21:41:30.000000000 -0800
+@@ -60,7 +60,7 @@
+ #####################################################################
+ 
+ # Set built-on date for display in program version info screen
+-$(shell echo -n "#define BUILT_ON_DATE " > build_date.h)
++$(shell printf "#define BUILT_ON_DATE " > build_date.h)
+ $(shell date +"\"%Y-%m-%d %H:%M:%S %z\"" >> build_date.h)
+ COMPILER_OPTIONS += -DBUILD_DATE
+ 


### PR DESCRIPTION
#### Description

`jdupes` is a program that can identify and take actions upon duplicate files, and is an enhanced fork of `fdupes`.

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?