### PR TITLE
tcptrace: Update upstream urls

### DIFF
--- a/net/tcptrace/Portfile
+++ b/net/tcptrace/Portfile
@@ -21,7 +21,7 @@ long_description \
     (i.e. convert thus converting to) tcpdump format files.
 
 homepage            http://tcptrace.org
-master_sites        http://tcptrace.org/download.html
+master_sites        http://tcptrace.org/download/
 
 checksums           tcptrace-${version}.tar.gz \
                         rmd160  1dd0f373f766322343ffad59d0655eba4c6682e0 \
@@ -32,7 +32,7 @@ checksums           tcptrace-${version}.tar.gz \
 
 depends_lib         lib:libpcap:libpcap
 
-patch_sites         ftp://ftp.ca.debian.org/debian-archive/debian/pool/main/t/tcptrace/
+patch_sites         https://cloudfront.debian.net/debian-archive/debian/pool/main/t/tcptrace/
 patchfiles          tcptrace_6.6.7-3.diff.gz
 patch.pre_args      -p1
 


### PR DESCRIPTION
#### Description

According to http://tcptrace.org/download.shtml the new download url is
http://tcptrace.org/download/tcptrace-6.6.7.tar.gz
The file/checksum is still the same:
$ shasum -a 256 tcptrace-6.6.7.tar.gz
63380a4051933ca08979476a9dfc6f959308bc9f60d45255202e388eb56910bd  tcptrace-6.6.7.tar.gz

Likewise the debian-mirror for the patch has moved to debian-archive,
available though https at:
https://cloudfront.debian.net/debian-archive/debian/pool/main/t/tcptrace/
$ shasum -a 256 tcptrace_6.6.7-3.diff.gz
9a5212155f5cd4bc9bfefaa73da8d3b4084a96865bcc1e96232a1e1b265bb54a  tcptrace_6.6.7-3.diff.gz

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G2208
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [s] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
