### PR TITLE
kdelibs4: force RasterOff=true

### DIFF
--- a/kde/kdelibs4/Portfile
+++ b/kde/kdelibs4/Portfile
@@ -53,7 +53,11 @@ depends_skip_archcheck aspell-dict-en
 #workaround-kdeinit4-crash: Mac-specific patch developed by Macports to circumvent some crashes.
 #default-kde4-xdg-menu-prefix: solves a conflict with a file from gnome-menus (see ticket #18914)
 #add-bundles-to-path: improve support for KIO slaves by adding a search path
-#kapplications-raster: ensures that kde applications start in raster (faster) mode, but also provides a switch for non-working applications
+#kapplications-raster: ensures that kde applications start in raster (faster)
+#mode, but also provides a switch for non-working applications -- the patch is
+#now hacked to force RasterOff=true for everything. This solves a flickering
+#problem on Mojave in all GUI's, as well as in dialog boxes on earlier MacOS's;
+#JJS 11/9/18
 #removeFindFlex: remove FindFlex.cmake which may hide the working one of cmake (ticket #44119)
 #cmake-modules-FindKDE4-Internal.cmake: Fixes zlib detection (see ticket #24128)
 #nativeDialogs: Use native mac dialogs (see https://reviewboard.kde.org/r/119243/)

--- a/kde/kdelibs4/files/patch-kapplications-raster.diff
+++ b/kde/kdelibs4/files/patch-kapplications-raster.diff
@@ -31,7 +31,7 @@ index b093034..3e1b2f2 100644
  #endif
  
 +#ifdef Q_OS_MAC
-+static bool useRaster = true;
++static bool useRaster = false;
 +void KApplication::doNotUseRaster()
 +{
 +    useRaster = false;


### PR DESCRIPTION
#### Description
Or, rather, `useRaster=false` (the `rasterOff` environmental variable is the counterpart that does the same thing). This solves a "blinking" problem in all KDE4 GUI's on Mojave. Further, it solves a blinking problem in dialog boxes on previous MacOS's.

Note that I just hacked the existing patch `patch-kapplications-raster.diff`. Much of that patch is consequently superfluous, and there may be a more elegant way to handle this. But it works and solves a major usability problem.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
