### PR TITLE
jdupes: use right compiler and universal build flags

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -20,6 +20,7 @@ patchfiles          patch-Makefile.diff
 
 use_configure       no
 
-build.args          PREFIX=${prefix}
+build.args          PREFIX=${prefix} \
+                    CC="${configure.cc} [get_canonical_archflags cc]"
 
 destroot.args       PREFIX=${prefix}


### PR DESCRIPTION
#### Description
Pass the [right compiler](https://trac.macports.org/wiki/UsingTheRightCompiler) and [universal build flags](https://trac.macports.org/wiki/UniversalDevelopment) to `make`.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?