### PR TITLE
py-isort: add missing dependency

### DIFF
--- a/python/py-isort/Portfile
+++ b/python/py-isort/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-isort
 version             4.3.4
-revision            1
+revision            2
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -36,7 +36,10 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:py${python.version}-setuptools
 
+    if {${python.version} eq 27} {
+        depends_lib-append \
+                    port:py${python.version}-futures
+    }
+
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- add missing py-futures dependency for Python 2.7
- use default PyPI livecheck
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
