### PR TITLE
[WIP] arm-none-eabi-gcc: fix after isl update to 0.20

### DIFF
--- a/cross/arm-none-eabi-gcc/Portfile
+++ b/cross/arm-none-eabi-gcc/Portfile
@@ -10,7 +10,8 @@ crossgcc.setup_libc newlib 3.0.0
 revision            4
 maintainers         nomaintainer
 
-patchfiles          patch-enable-with-multilib-list-for-arm.diff
+patchfiles          patch-enable-with-multilib-list-for-arm.diff \
+                    patch-upstream-gcc-graphite.h.diff
 
 # specific to ARM
 configure.args-append \

--- a/cross/arm-none-eabi-gcc/files/patch-upstream-gcc-graphite.h.diff
+++ b/cross/arm-none-eabi-gcc/files/patch-upstream-gcc-graphite.h.diff
@@ -1,0 +1,13 @@
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724
+
+--- gcc/graphite.h
++++ gcc/graphite.h
+@@ -37,6 +37,8 @@ along with GCC; see the file COPYING3.  If not see
+ #include <isl/schedule.h>
+ #include <isl/ast_build.h>
+ #include <isl/schedule_node.h>
++#include <isl/id.h>
++#include <isl/space.h>
+ 
+ typedef struct poly_dr *poly_dr_p;
+ 


### PR DESCRIPTION
This fixed the build of `arm-none-eabi-gcc` after `isl` was updated to version 0.20 in f00fc27e36243f30cf0c3ee4fc31e39d6084c6c6 (about a month ago).

* I strongly suspect that this is not the only port being affected.
* I suspect that we might need to add a dependency on `isl` to the `crossgcc` portgroup.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724
Closes: https://trac.macports.org/ticket/57573

(There are also a number of other tickets for this port. The most annoying one is https://trac.macports.org/ticket/55213 - build failure on AFPS - due to which I had to restart the build about ten times. The number of repeated attempts needed is usually one, not sure why it was so annoying for this port, maybe due to `newlib` or due to a larger number of supported "architectures".)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
  * I did not yet test the trace mode.
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->