### PR TITLE
gtk3 3.22.30: Fix large fonts on Retina displays (HiDPI) for quartz

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -10,6 +10,7 @@ name                gtk3
 set real_name       gtk+
 epoch               1
 version             3.22.30
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome x11
 license             LGPL-2.1+
@@ -59,6 +60,7 @@ patchfiles          O_CLOEXEC-10.6-and-earlier.patch
 
 if {[variant_isset quartz]} {
     compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 425}
+    patchfiles-append patch-quartz-hardcode-screen-resolution.patch
 } else {
     compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 300}
 }

--- a/gnome/gtk3/files/patch-quartz-hardcode-screen-resolution.patch
+++ b/gnome/gtk3/files/patch-quartz-hardcode-screen-resolution.patch
@@ -1,0 +1,61 @@
+This patch comprises two upstream patches
+
+https://github.com/GNOME/gtk/commit/828f634 and
+https://github.com/GNOME/gtk/commit/bb376222c104aef0ec7e31b40959bc35eecf2253
+
+for the gtk3 3.22.30 release to solve the font rendering
+problem for the quartz backend of gtk on HiDPI screens
+like the MacBookPro Retina. The 828f634 patch is already
+in 3.24.1 and the bb3762 patch will be in 3.24.2. See
+
+https://bugzilla.gnome.org/show_bug.cgi?id=787867
+
+for a detailed discussion.
+---
+ gdk/quartz/gdkscreen-quartz.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/gdk/quartz/gdkscreen-quartz.c b/gdk/quartz/gdkscreen-quartz.c
+index 586f7af02a6..219338832ee 100644
+--- gdk/quartz/gdkscreen-quartz.c
++++ gdk/quartz/gdkscreen-quartz.c
+@@ -67,7 +67,7 @@ static void  gdk_quartz_screen_calculate_layout (GdkQuartzScreen *screen);
+ static void display_reconfiguration_callback (CGDirectDisplayID            display,
+                                               CGDisplayChangeSummaryFlags  flags,
+                                               void                        *userInfo);
+-
++static const double dpi = 72.0;
+ static gint get_mm_from_pixels (NSScreen *screen, int pixels);
+ 
+ G_DEFINE_TYPE (GdkQuartzScreen, gdk_quartz_screen, GDK_TYPE_SCREEN);
+@@ -76,10 +76,17 @@ static void
+ gdk_quartz_screen_init (GdkQuartzScreen *quartz_screen)
+ {
+   GdkScreen *screen = GDK_SCREEN (quartz_screen);
+-  NSDictionary *dd = [[[NSScreen screens] objectAtIndex:0] deviceDescription];
+-  NSSize size = [[dd valueForKey:NSDeviceResolution] sizeValue];
++  /* Screen resolution is used exclusively to pass to Pango for font
++   * scaling. There's a long discussion in
++   * https://bugzilla.gnome.org/show_bug.cgi?id=787867 exploring how
++   * screen resolution and pangocairo-coretext interact. The summary
++   * is that MacOS takes care of scaling fonts for Retina screens and
++   * that while the Apple Documentation goes on about "points" they're
++   * CSS points (96/in), not typeography points (72/in) and
++   * pangocairo-coretext needs to default to that scaling factor.
++   */
+ 
+-  _gdk_screen_set_resolution (screen, size.width);
++  _gdk_screen_set_resolution (screen, dpi);
+ 
+   gdk_quartz_screen_calculate_layout (quartz_screen);
+ 
+@@ -335,9 +342,6 @@ static gint
+ get_mm_from_pixels (NSScreen *screen, int pixels)
+ {
+   const float mm_per_inch = 25.4;
+-  NSDictionary *dd = [[[NSScreen screens] objectAtIndex:0] deviceDescription];
+-  NSSize size = [[dd valueForKey:NSDeviceResolution] sizeValue];
+-  float dpi = size.width;
+   return (pixels / dpi) * mm_per_inch;
+ }
+ 


### PR DESCRIPTION
#### Description
The font rendering with pango 1.42.4 and gtk 3.22.30 shows too large fonts for all gtk widgets on MacOS HiDPI devices like the MacBookPro Retina models. The problem is discussed in
https://bugzilla.gnome.org/show_bug.cgi?id=787867
This is a problem between gtk and pango. The ugly result with pango 1.42.4 (unpatched) and gtk 3.22.30 shows much too large fonts in the widgets and looks like this:

![font-pango1 42 4-gtk3 22 30](https://user-images.githubusercontent.com/1280457/48315495-341f5c80-e5d7-11e8-85f2-cf37ba26006e.JPG)

A fix is already in the gtk 3.22 and 3.24 branch. However there seem to be no
more releases for 3.22. I tried pango 1.42.4 unpatched with gtk 3.24.1. The results
look still a little bit too large for me, but the 3.24.1 gtk
felt unstable. For example the tool hint hovering was blinking. However the fonts look like this:

![font-pango1 42 4-gtk-3 24 1](https://user-images.githubusercontent.com/1280457/48315509-7779cb00-e5d7-11e8-8604-6e7a047375f0.JPG)

The patch here is also applied in the homebrew project. The patch might be removed with gtk3 3.24.1. With the patch, the application looks o.k. So this works with pango 1.42.4 (patched) and gtk3 3.22.30. 

![font-pango1 42 4-patch-gtk-3 22 30](https://user-images.githubusercontent.com/1280457/48315515-90827c00-e5d7-11e8-80c3-d1844535481c.JPG)

All pictures are taken with a MacBook Pro Retina (2015) model.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->