### PR TITLE
p5-tcl: update options provided to Makefile.PL, add myself as co-maintainer

### DIFF
--- a/perl/p5-tcl/Portfile
+++ b/perl/p5-tcl/Portfile
@@ -5,9 +5,10 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26
 perl5.setup         Tcl 1.27
+revision            1
 
 platforms           darwin
-maintainers         {@mojca mojca} openmaintainer
+maintainers         {@chrstphrchvz gmx.us:chrischavez} {@mojca mojca} openmaintainer
 license             {Artistic-1 GPL}
 
 description         Tcl extension module for Perl
@@ -23,7 +24,9 @@ if {${perl5.major} != ""} {
     depends_lib-append \
                     port:tcl
     configure.args-append \
-                    --nousestub
+                    --tclsh ${prefix}/bin/tclsh \
+                    --tclconfig ${prefix}/lib/tclConfig.sh \
+                    --nousestubs
 
     livecheck.type  none
 }


### PR DESCRIPTION
A few months ago, `p5-tcl` was using (at runtime) macOS' included Tcl 8.5 on my machine, even though Tcl was installed by MacPorts, and `p5-tcl` depended on the `tcl` port. However, after a couple weeks, this no longer happened, likely after `tcl` or `p5-tcl` ports being reinstalled. I have not been able to reproduce this issue since, and never found the exact cause; though specifying these options in theory should help ensure MacPorts' Tcl is used.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
https://trac.macports.org/ticket/56638 (mainly also about `p5-tkx` not depending on the `tk` port)
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
```
--->  Testing p5.26-tcl
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-tcl/p5.26-tcl/work/Tcl-1.27" && /usr/bin/make test
"/opt/local/bin/perl5.26" -MExtUtils::Command::MM -e 'cp_nonempty' -- Tcl.bs blib/arch/auto/Tcl/Tcl.bs 644
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.26" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/call.t ............. ok
t/constants.t ........ ok
t/createcmd.t ........ ok
t/disposal-subs-a.t .. ok
t/disposal-subs-b.t .. ok
t/disposal-subs-c.t .. ok
t/disposal-subs-d.t .. ok
t/disposal-subs-e.t .. ok
t/disposal-subs-f.t .. ok
[[::perl::Eval ::perl::CODE(0x7fc4970e7c40); ]]
t/disposal-subs.t .... ok
t/eval.t ............. ok
t/export_to_tcl.t .... ok
t/info.t ............. ok
t/memleak-a.t ........ ok
t/result.t ........... ok
t/set-callback.t ..... ok
t/subclass.t ......... ok
t/trace.t ............ ok
t/unicode.t .......... ok
t/var.t .............. ok
All tests successful.

Test Summary Report
-------------------
t/info.t           (Wstat: 0 Tests: 6 Failed: 0)
  TODO passed:   2
Files=20, Tests=107, 35 wallclock secs ( 0.13 usr  0.08 sys +  1.69 cusr  0.50 csys =  2.40 CPU)
Result: PASS
```
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
