### PR TITLE
libdynd: Fix build on 10.8 and earlier

### DIFF
--- a/devel/libdynd/Portfile
+++ b/devel/libdynd/Portfile
@@ -1,13 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           cxx11 1.1
 PortGroup           github 1.0
-PortGroup           cmake 1.0
 
 set git_sha1        341d6d91931fdb04ad657d27ed740cf533fc925b
 
 github.setup        libdynd libdynd 0.7.2 v
-
+revision            1
 categories          devel math
 platforms           darwin
 license             BSD
@@ -18,7 +20,8 @@ description         LibDyND is a C++ library for dynamic, multidimensional array
 long_description    ${description}
 
 checksums           rmd160  58a444d46d348fddc6f4cf04669d301dbb47981e \
-                    sha256  7bc14b26537a0b5c0e8ad9d8b0143b94eab38917ca42082be44cfa0fbb605e01
+                    sha256  7bc14b26537a0b5c0e8ad9d8b0143b94eab38917ca42082be44cfa0fbb605e01 \
+                    size    1342463
 
 patchfiles-append   patch-CMakeLists.txt.diff
 
@@ -27,7 +30,9 @@ post-patch {
     reinplace "s|@@DYND_VERSION_STRING@@|v${version}|g" ${worksrcpath}/CMakeLists.txt
 }
 
-cmake.out_of_source yes
+# Requires C++14
+compiler.blacklist-append \
+                    {clang < 602}
 
 configure.args-append \
                     -DDYND_SHARED_LIB:BOOL=ON \

--- a/devel/libdynd/files/patch-CMakeLists.txt.diff
+++ b/devel/libdynd/files/patch-CMakeLists.txt.diff
@@ -1,5 +1,14 @@
---- CMakeLists.txt.orig	2016-03-20 16:56:09.000000000 +0300
-+++ CMakeLists.txt	2016-03-20 16:58:36.000000000 +0300
+--- CMakeLists.txt.orig	2016-03-16 14:34:36.000000000 -0500
++++ CMakeLists.txt	2018-11-12 11:56:38.000000000 -0600
+@@ -89,7 +89,7 @@
+             message(FATAL_ERROR "Only GCC 4.9 and later are supported by LibDyND. Found version ${CMAKE_CXX_COMPILER_VERSION}.")
+         endif()
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fmax-errors=20 -Wno-type-limits")
+-    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
++    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -ferror-limit=20 -Wno-missing-braces")
+     endif()
+ endif()
 @@ -100,10 +100,8 @@
  #llvm_map_components_to_libnames(LLVM_LINK_LIBS core option target bitreader support profiledata codegen irreader linker instrumentation objcarcopts lto)
  


### PR DESCRIPTION
#### Description

Fixes libdynd build on OS X 10.8 and earlier, by declaring that it requires C++14 so that MacPorts can pick a compatible compiler.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
