### PR TITLE
new port: lerna

### DIFF
--- a/devel/lerna/Portfile
+++ b/devel/lerna/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        lerna lerna 3.4.3 v
+homepage            https://lernajs.io/
+
+platforms           darwin
+categories          devel
+license             MIT
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         A tool for managing JavaScript projects with multiple \
+                    packages.
+
+long_description    Splitting up large codebases into separate independently \
+                    versioned packages is extremely useful for code sharing. \
+                    However, making changes across many repositories is messy \
+                    and difficult to track, and testing across repositories \
+                    gets complicated really fast.  \
+                    Lerna is a tool that optimizes the workflow around \
+                    managing multi-package repositories with git and npm. 
+
+depends_run         port:npm6 port:nodejs10
+depends_build       port:npm6
+
+checksums           rmd160  e124c044e6cabbc9c372d16630ff52a17297f05d \
+                    sha256  0be29ed6f713ab331492348a46c8d63221d85d1ef2873d5af9e110ef105aa3ad \
+                    size    377699
+
+use_configure       no
+
+set npm_bin         ${prefix}/bin/npm
+
+build.cmd           ${npm_bin}
+build.target        install
+build.args          --production --no-save
+
+
+destroot {
+    set node_modules_path [ exec ${npm_bin} root -g ]
+    set lerna_root "${node_modules_path}/${name}-${version}"
+
+    xinstall -d [file dirname "${destroot}${lerna_root}"]
+
+    move ${worksrcpath} ${destroot}${lerna_root}
+
+    exec ${npm_bin} install -g \
+                            --prefix=${destroot}${prefix} \
+                            --production \
+                            --no-save \
+                            ${destroot}${lerna_root}
+}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
