### PR TITLE
openjdk8, openjdk11: fixed typo in description

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -34,7 +34,7 @@ supported_archs  x86_64
 description      Open Java Development Kit ${major}
 
 long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infratructure.
+                 open-source set of build scripts and infrastructure.
 
 homepage         https://adoptopenjdk.net/
 


### PR DESCRIPTION
#### Description

Replaced 'infratructure' with 'infrastructure' in description of `openjdk8` and `openjdk11` ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.1 18B75
Xcode 10.1 10B6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?