### PR TITLE
libuv: peg at 1.23.2 for Tiger

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -56,3 +56,28 @@ depends_build       port:automake \
                     port:autoconf \
                     port:libtool \
                     port:pkgconfig
+
+platform darwin 8 {
+
+    # pegged version with patches for Tiger, updated occasionally
+
+    github.setup    libuv libuv 1.23.2 v
+    revision        1
+    checksums       rmd160 7fda655697a845693008daa9e0a483d15d6214d8 \
+                    sha256 f5c360b53c5d5c22c4429af9e8cb61c9504d176a4bdd533813aaead78447730c \
+                    size   1192667
+
+    maintainers-prepend {kencu @kencu}
+    long_description  ${long_description} This version is pegged for Tiger and is updated occasionally. \
+                      Improvements are welcome if you can improve the test suite success (a few tests fail).
+    configure.cppflags-append -D__DARWIN_UNIX03
+    # prevent conflicting opentransport header from being pulled in
+    configure.cppflags-append -D__OPENTRANSPORTPROVIDERS__
+
+    # delete any patchfiles that may be added above later
+    # Tiger unified patch
+    patchfiles          patch-libuv-1-23-2-tiger.diff
+    # Tiger has no libutil
+    patchfiles-append   patch-makefile-am-no-libutil-on-Tiger.diff
+
+}

--- a/devel/libuv/files/patch-libuv-1-23-2-tiger.diff
+++ b/devel/libuv/files/patch-libuv-1-23-2-tiger.diff
@@ -1,0 +1,79 @@
+diff --git src/unix/fs.c src/unix/fs.c
+index 3db5f89..3f0d719 100644
+--- src/unix/fs.c
++++ src/unix/fs.c
+@@ -59,7 +59,7 @@
+ # include <sys/sendfile.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++#if ( defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+ # include <copyfile.h>
+ #elif defined(__linux__) && !defined(FICLONE)
+ # include <sys/ioctl.h>
+@@ -589,7 +589,7 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
+ 
+     return -1;
+   }
+-#elif defined(__APPLE__)           || \
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050  || \
+       defined(__DragonFly__)       || \
+       defined(__FreeBSD__)         || \
+       defined(__FreeBSD_kernel__)
+@@ -760,7 +760,7 @@ done:
+ }
+ 
+ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
+-#if defined(__APPLE__) && !TARGET_OS_IPHONE
++#if ( defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050) && !TARGET_OS_IPHONE
+   /* On macOS, use the native copyfile(3). */
+   copyfile_flags_t flags;
+ 
+@@ -925,7 +925,7 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
+   dst->st_blksize = src->st_blksize;
+   dst->st_blocks = src->st_blocks;
+ 
+-#if defined(__APPLE__)
++#if ( defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+   dst->st_atim.tv_sec = src->st_atimespec.tv_sec;
+   dst->st_atim.tv_nsec = src->st_atimespec.tv_nsec;
+   dst->st_mtim.tv_sec = src->st_mtimespec.tv_sec;
+diff --git src/unix/fsevents.c src/unix/fsevents.c
+index ee45299..4c821ca 100644
+--- src/unix/fsevents.c
++++ src/unix/fsevents.c
+@@ -21,7 +21,7 @@
+ #include "uv.h"
+ #include "internal.h"
+ 
+-#if TARGET_OS_IPHONE
++#if TARGET_OS_IPHONE || ( defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED < 1050)
+ 
+ /* iOS (currently) doesn't provide the FSEvents-API (nor CoreServices) */
+ 
+diff --git src/unix/tty.c src/unix/tty.c
+index 74d3d75..ee8e186 100644
+--- src/unix/tty.c
++++ src/unix/tty.c
+@@ -44,7 +44,7 @@ static int uv__tty_is_slave(const int fd) {
+   int dummy;
+ 
+   result = ioctl(fd, TIOCGPTN, &dummy) != 0;
+-#elif defined(__APPLE__)
++#elif ( defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+   char dummy[256];
+ 
+   result = ioctl(fd, TIOCPTYGNAME, &dummy) != 0;
+diff --git test/test-fs.c test/test-fs.c
+index 01f5a7b..d1eaf13 100644
+--- test/test-fs.c
++++ test/test-fs.c
+@@ -1190,7 +1190,7 @@ TEST_IMPL(fs_fstat) {
+   ASSERT(s->st_size == (uint64_t) t.st_size);
+   ASSERT(s->st_blksize == (uint64_t) t.st_blksize);
+   ASSERT(s->st_blocks == (uint64_t) t.st_blocks);
+-#if defined(__APPLE__)
++#if ( defined(__APPLE__) && defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050)
+   ASSERT(s->st_atim.tv_sec == t.st_atimespec.tv_sec);
+   ASSERT(s->st_atim.tv_nsec == t.st_atimespec.tv_nsec);
+   ASSERT(s->st_mtim.tv_sec == t.st_mtimespec.tv_sec);

--- a/devel/libuv/files/patch-makefile-am-no-libutil-on-Tiger.diff
+++ b/devel/libuv/files/patch-makefile-am-no-libutil-on-Tiger.diff
@@ -1,0 +1,11 @@
+--- Makefile.am.orig	2018-11-10 13:20:23.000000000 -0800
++++ Makefile.am	2018-11-10 13:20:54.000000000 -0800
+@@ -363,7 +363,7 @@
+                     src/unix/fsevents.c \
+                     src/unix/kqueue.c \
+                     src/unix/proctitle.c
+-test_run_tests_LDFLAGS += -lutil
++# not on Tiger test_run_tests_LDFLAGS += -lutil
+ endif
+ 
+ if DRAGONFLY


### PR DESCRIPTION
with specific patches for Tiger that uses existing
fallback routines written into libuv
passes 98% of test suite
fulfils needs of many ports (eg cmake)
set up to not interfere with existing libuv port which can essentially
ignore the tiger section when doing updates or fixes

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4.11 8S165
Xcode DevToolsSupport-794.0 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
