### PR TITLE
faust-devel: add missing cmake dependency (fixes trac #57593)

### DIFF
--- a/audio/faust-devel/Portfile
+++ b/audio/faust-devel/Portfile
@@ -38,7 +38,8 @@ if {${os.platform} eq "darwin" && ${os.major} > 14} {
 set llvm_prefix         ${prefix}/libexec/llvm-${llvm_version}
 build.env               PATH=${llvm_prefix}/bin:$env(PATH)
 
-depends_build           port:pkgconfig
+depends_build           path:bin/cmake:cmake \
+                        port:pkgconfig
 
 depends_lib             port:clang-${llvm_version} \
                         port:libmicrohttpd \
@@ -78,7 +79,8 @@ use_configure           no
 variant universal {}
 
 build.args-append       ARCHFLAGS="[get_canonical_archflags cxx]" \
-                        CXX="${configure.cxx} ${configure.cxxflags} [get_canonical_archflags cxx]"
+                        CXX="${configure.cxx} ${configure.cxxflags} [get_canonical_archflags cxx]" \
+                        VERBOSE=1
 build.target            world
 
 post-destroot {


### PR DESCRIPTION
Add the missing cmake dependency which is now required by current Faust in git.

Closes: https://trac.macports.org/ticket/57593

###### Tested on
macOS 10.12.6 16G1618
Xcode 9.2 9C40b 
