### PR TITLE
postgresql11: Add LLVM_CONFIG to env

### DIFF
--- a/databases/postgresql11/Portfile
+++ b/databases/postgresql11/Portfile
@@ -146,4 +146,5 @@ variant tcl description {add Tcl support} {
 variant llvm description {add support for JIT compilation} {
     depends_lib-append      port:llvm-6.0
     configure.args-append   --with-llvm
+    configure.env-append    LLVM_CONFIG=${prefix}/libexec/llvm-6.0/bin/llvm-config
 }


### PR DESCRIPTION
Fixes trac issue 57527: postgresql11 build fails when +llvm is specified but no default llvm is selected. The portfile itself is locked to llvm-6.0, so I just set the env to point to that directly.

Closes: https://trac.macports.org/ticket/57527

###### Tested on

macOS 10.14 18A391
Xcode 10.0 10A255
