### PR TITLE
jmol: update to 14.29.28

### DIFF
--- a/science/jmol/Portfile
+++ b/science/jmol/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                jmol
-version             14.29.22
+version             14.29.28
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science
 platforms           darwin
@@ -23,9 +23,9 @@ master_sites        sourceforge:project/jmol/Jmol/Version%20${branch}/Jmol%20${v
 
 distname            Jmol-${version}-binary
 
-checksums           rmd160  1799d0d28adaaae58063d387b4d6f36d4aedadcf \
-                    sha256  fb3a1109cbe888fb0920bf13e910265d8be17048e17555ee323fa9cf85cdd9f2 \
-                    size    66351584
+checksums           rmd160  806568a8aec982cef70501e9ee8ebaa4b4f86a66 \
+                    sha256  e005e003744275a07431f37e24b16cf99fef4944477929cf3d8069ab71e1e254 \
+                    size    86896639
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
Updates jmol to current upstream stable version, providing bug fixes and new features, see  https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.29/Jmol%2014.29.28/README-14.29.28.properties/download for details.

#### Description

Upstream update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 
Java 1.8.0_152-b16

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
