### PR TITLE
py-autopep8: update to 1.4.3

### DIFF
--- a/python/py-autopep8/Portfile
+++ b/python/py-autopep8/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-autopep8
-version             1.4.2
+version             1.4.3
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -26,9 +26,9 @@ homepage            https://github.com/hhatto/autopep8
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  50415c5e70e2f8430822495c79ab229ed4165747 \
-                    sha256  1b8d42ebba751a91090d3adb5c06840b1151d71ed43e1c7a9ed6911bfe8ebe6c \
-                    size    113510
+checksums           rmd160  a0e2afcd494dd0f149d31bb9ed59be0b96483686 \
+                    sha256  33d2b5325b7e1afb4240814fe982eea3a92ebea712869bfd08b3c0393404248c \
+                    size    113940
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to 1.4.3
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
