### PR TITLE
py-virtualenv: update to 16.1.0

### DIFF
--- a/python/py-virtualenv/Portfile
+++ b/python/py-virtualenv/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-virtualenv
-version             16.0.0
+version             16.1.0
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -19,9 +19,9 @@ homepage            https://virtualenv.pypa.io
 
 master_sites        pypi:v/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           rmd160  ed709651e82f28dd131900010d566dda3fd2c577 \
-                    sha256  ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752 \
-                    size    1970558
+checksums           rmd160  17ea55a18a04ef155b74a062048bf6edf8e53155 \
+                    sha256  f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208 \
+                    size    1977229
 
 python.versions     27 34 35 36 37
 
@@ -33,6 +33,7 @@ if {${name} ne ${subport}} {
     test.run            yes
     test.cmd            py.test-${python.branch}
     test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     depends_run-append  port:virtualenv_select
 


### PR DESCRIPTION
#### Description
- update to 16.1.0
- set PYTHONPATH for tests to avoid failures
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
