### PR TITLE
hdf4, hdf5: Fix reinplace warning

### DIFF
--- a/science/hdf4/Portfile
+++ b/science/hdf4/Portfile
@@ -40,7 +40,9 @@ post-configure {
 # remove -arch from h4cc to fix failure of h4cc -E with +universal
     reinplace -E {s|-arch [a-z0-9_]+||g} ${worksrcpath}/hdf/util/h4cc
 # remove ccache
-    reinplace {s|ccache ||} ${worksrcpath}/hdf/util/h4cc
+    if ${configure.ccache} {
+        reinplace {s|ccache ||} ${worksrcpath}/hdf/util/h4cc
+    }
 }
 
 test.run            yes

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -74,8 +74,9 @@ post-configure {
             ${dir}/c++/src/h5c++ \
             ${dir}/src/libhdf5.settings \
             ${dir}/fortran/src/h5fc
-        reinplace {s|ccache ||} ${dir}/tools/src/misc/h5cc
-        reinplace {s|ccache ||} ${dir}/c++/src/h5c++
+        if ${configure.ccache} {
+            reinplace -W ${dir} {s|ccache ||} tools/src/misc/h5cc c++/src/h5c++
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

Fix reinplace warning when `configureccache` in macports.conf is `no`.

```
Warning: reinplace s|ccache || didn't change anything in /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_science_hdf5/hdf5/work/hdf5-1.10.4/tools/src/misc/h5cc
Warning: reinplace s|ccache || didn't change anything in /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_science_hdf5/hdf5/work/hdf5-1.10.4/c++/src/h5c++
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
