### PR TITLE
util-linux: peg at v2.32.1 for < darwin 14

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -25,6 +25,17 @@ checksums           rmd160  e07164962fb506f0ceb1e2c5057c918e2972bb91 \
                     sha256  f261b9d73c35bfeeea04d26941ac47ee1df937bd3b0583e748217c1ea423658a \
                     size    4663072
 
+if { ${os.platform} eq "darwin" && ${os.major} < 14 } {
+    # versions after this use faccessat and are compatible with darwin 14 and newer
+    # https://github.com/karelzak/util-linux/issues/716
+    github.setup        karelzak util-linux 2.32.1 v
+    revision            1
+
+    checksums           rmd160  bf61cb460eabcfdb90909dbcfd8e64bb9097ce65 \
+                        sha256  86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2 \
+                        size    4561088
+}
+
 depends_lib-append  port:gettext \
                     port:ncurses
 


### PR DESCRIPTION
newer versions use faccessat which is not
available on older systems