### PR TITLE
qt4-mac/kdelibs4 : convert hardwired graphics system selection to use…

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -11,7 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                qt4-mac
 version             4.8.7
-revision            7
+revision            8
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          aqua
@@ -315,7 +315,13 @@ patchfiles-append patch-qthread-stacksize.diff
 
 patchfiles-append patch-qt-custom-threadpool.diff
 
-# (34) Various from NiXos
+# (34) Allow control over the default graphics system to be used via
+# Qt's own qtconfig utility: Native vs. Raster vs. OpenGL. Qtconfig
+# is not normally built on Mac so a patch is required to activate it.
+patchfiles-append patch-tools-build_qtconfig.diff \
+                  patch-graphicssystem-via-qtconfig.diff
+
+# (35) Various from NiXos
 # see also < https://trac.macports.org/ticket/55932 >
 # and < https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/libraries/qt-4.x/4.8 >
 
@@ -1166,6 +1172,13 @@ variant cxx11 description {Add library support for C++11 (EXPERIMENTAL; does not
 post-activate {
     ui_msg "NOTE: Qt database plugins for mysql55, postgresql91, and sqlite2 are NOT installed by this port\; they are installed by qt4-mac-*-plugin instead."
 }
+
+notes-append \
+"Users experiencing graphics glitches on newer OS versions (10.13 and up) can \
+experiment with different graphics drawing systems that can be set in the \
+Interface tab of the ${qt_apps_dir}/qtconfig.app utility. Raster mode is
+the preferred mode but is incompatible with certain built-in widget styles.
+Keep an eye on the Fonts setting before saving!"
 
 livecheck.type       none
 

--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -1177,7 +1177,7 @@ notes-append \
 "Users experiencing graphics glitches on newer OS versions (10.13 and up) can \
 experiment with different graphics drawing systems that can be set in the \
 Interface tab of the ${qt_apps_dir}/qtconfig.app utility. Raster mode is
-the preferred mode but is incompatible with certain built-in widget styles.
+the preferred mode but is not compatible with all non-standard widget styles.
 Keep an eye on the Fonts setting before saving!"
 
 livecheck.type       none

--- a/aqua/qt4-mac/files/patch-graphicssystem-via-qtconfig.diff
+++ b/aqua/qt4-mac/files/patch-graphicssystem-via-qtconfig.diff
@@ -23,6 +23,24 @@ index 22da34e0154a5b37566f38c514648a9125ee5771..3efa5433eb2801bed7e2a5f1bcf8ae60
  
  #if defined(Q_WS_X11) && !defined(QT_NO_EGL)
      if (graphics_system_name.isEmpty()) {
+diff --git tools/qtconfig/main.cpp tools/qtconfig/main.cpp
+index a0f5dd6ed3cc204f61041bc65f96b1af88bdbb97..1cbb8538d5c8706b223e89fcaca70e9000db1c8b 100644
+--- tools/qtconfig/main.cpp
++++ tools/qtconfig/main.cpp
+@@ -51,6 +51,13 @@ int main(int argc, char **argv)
+ {
+     Q_INIT_RESOURCE(qtconfig);
+ 
++    const QByteArray graphicsSystem = qgetenv("QT_GRAPHICSSYSTEM");
++    if (graphicsSystem.isNull() || graphicsSystem.isEmpty()) {
++        // force native graphics mode unless the user set one via QT_GRAPHICSSYSTEM.
++        // We have to use QT_GRAPHICSSYSTEM because that will override any previous
++        // settings stored in our own settings store.
++        qputenv("QT_GRAPHICSSYSTEM", "Native");
++    }
+     QApplication app(argc, argv);
+ 
+     QTranslator translator;
 diff --git tools/qtconfig/mainwindow.cpp tools/qtconfig/mainwindow.cpp
 index 1bb6e4eae01fd43d9de41d627677abc8521908d8..e1726fb174c406311bf132d4f6c70ba3016a4c41 100644
 --- tools/qtconfig/mainwindow.cpp

--- a/aqua/qt4-mac/files/patch-graphicssystem-via-qtconfig.diff
+++ b/aqua/qt4-mac/files/patch-graphicssystem-via-qtconfig.diff
@@ -1,0 +1,104 @@
+diff --git src/gui/kernel/qapplication.cpp src/gui/kernel/qapplication.cpp
+index 22da34e0154a5b37566f38c514648a9125ee5771..3efa5433eb2801bed7e2a5f1bcf8ae609ed88d86 100644
+--- src/gui/kernel/qapplication.cpp
++++ src/gui/kernel/qapplication.cpp
+@@ -818,9 +818,19 @@ void QApplicationPrivate::construct(
+ 
+     qt_is_gui_used = (qt_appType != QApplication::Tty);
+     process_cmdline();
+-    // the environment variable has the lowest precedence of runtime graphicssystem switches
++    // the environment variable has almost the lowest precedence of runtime graphicssystem switches
+     if (graphics_system_name.isEmpty())
+         graphics_system_name = QString::fromLocal8Bit(qgetenv("QT_GRAPHICSSYSTEM"));
++    if (graphics_system_name.isEmpty()) {
++        // Fetch the default graphics system from the settings store if no other setting has been made
++        QSettings settings(QSettings::UserScope, QLatin1String("Trolltech"));
++        settings.beginGroup(QLatin1String("Qt"));
++        const QString defaultGraphicsSystem = settings.value(QLatin1String("DefaultGraphicsSystem")).toString();
++        if (! defaultGraphicsSystem.isNull() && ! defaultGraphicsSystem.isEmpty()) {
++            graphics_system_name = defaultGraphicsSystem;
++        }
++    }
++
+ 
+ #if defined(Q_WS_X11) && !defined(QT_NO_EGL)
+     if (graphics_system_name.isEmpty()) {
+diff --git tools/qtconfig/mainwindow.cpp tools/qtconfig/mainwindow.cpp
+index 1bb6e4eae01fd43d9de41d627677abc8521908d8..e1726fb174c406311bf132d4f6c70ba3016a4c41 100644
+--- tools/qtconfig/mainwindow.cpp
++++ tools/qtconfig/mainwindow.cpp
+@@ -227,6 +238,7 @@ MainWindow::MainWindow()
+     connect(ui->rtlExtensionsCheckBox, SIGNAL(toggled(bool)), SLOT(somethingModified()));
+     connect(ui->inputStyleCombo, SIGNAL(activated(int)), SLOT(somethingModified()));
+     connect(ui->inputMethodCombo, SIGNAL(activated(int)), SLOT(somethingModified()));
++    connect(ui->graphicsSystemCombo, SIGNAL(activated(int)), SLOT(somethingModified()));
+     connect(ui->guiStyleCombo, SIGNAL(activated(QString)), SLOT(styleSelected(QString)));
+     connect(ui->familySubstitutionCombo, SIGNAL(activated(QString)), SLOT(substituteSelected(QString)));
+     connect(ui->tunePaletteButton, SIGNAL(clicked()), SLOT(tunePalette()));
+@@ -416,7 +463,26 @@ MainWindow::MainWindow()
+     ui->inputMethodCombo->hide();
+     ui->inputMethodLabel->hide();
+ #endif
+-
++#ifdef Q_OS_MAC
++    ui->graphicsSystemCombo->setToolTip(tr("Select the graphicsssystem to be used by default.\n"
++        "Native: use native CoreGraphics rendering\n"
++        "Raster: use raster graphics\n"
++        "OpenGL: use OpenGL (experimental!)\n"
++        "Raster mode is the preferred default except on Mac OS 10.14 and newer where it causes flickering.\n"
++        "Use Native rendering on those newer OS versions (or if you experience other graphics glitches).\n"
++        "Note that Raster mode is not compatible with certain built-in widget styles like CDE or Plastique."));
++    QStringList graphicsSystems;
++    QString defaultGraphicsSystem = settings.value(QLatin1String("DefaultGraphicsSystem"), QLatin1String("(unset)")).toString();
++
++    graphicsSystems << "(unset)" << "Native" << "Raster" << "OpenGL";
++    ui->graphicsSystemCombo->addItems(graphicsSystems);
++    if (!defaultGraphicsSystem.isNull() && !defaultGraphicsSystem.isEmpty()) {
++        ui->graphicsSystemCombo->setCurrentIndex(graphicsSystems.indexOf(QRegExp(defaultGraphicsSystem, Qt::CaseInsensitive)));
++    }
++#else
++    ui->graphicsSystemLabel->hide();
++    ui->graphicsSystemCombo->hide();
++#endif
+     ui->fontEmbeddingCheckBox->setChecked(settings.value(QLatin1String("embedFonts"), true)
+                                           .toBool());
+     fontpaths = settings.value(QLatin1String("fontPath")).toStringList();
+@@ -573,6 +639,13 @@ void MainWindow::fileSave()
+ #if defined(Q_WS_X11) && !defined(QT_NO_XIM)
+         settings.setValue(QLatin1String("DefaultInputMethod"), ui->inputMethodCombo->currentText());
+ #endif
++#ifdef Q_OS_MAC
++        if (ui->graphicsSystemCombo->currentIndex() > 0) {
++            settings.setValue(QLatin1String("DefaultGraphicsSystem"), ui->graphicsSystemCombo->currentText());
++        } else {
++            settings.remove(QLatin1String("DefaultGraphicsSystem"));
++        }
++#endif
+ 
+         QString audioSink = settings.value(QLatin1String("audiosink"), QLatin1String("Auto")).toString();
+         QString videoMode = settings.value(QLatin1String("videomode"), QLatin1String("Auto")).toString();
+diff --git tools/qtconfig/mainwindow.ui tools/qtconfig/mainwindow.ui
+index 454021ecdf2c00b29b9f2b86a2a68893da57b572..7593f7140b8ad73b1c615439dd4b473e37b3e9a7 100644
+--- tools/qtconfig/mainwindow.ui
++++ tools/qtconfig/mainwindow.ui
+@@ -901,6 +901,20 @@
+           </property>
+          </widget>
+         </item>
++        <item>
++         <widget class="QLabel" name="graphicsSystemLabel">
++          <property name="text">
++           <string>Default Graphics System:</string>
++          </property>
++         </widget>
++        </item>
++        <item>
++         <widget class="QComboBox" name="graphicsSystemCombo">
++          <property name="currentIndex">
++           <number>-1</number>
++          </property>
++         </widget>
++        </item>
+         <item>
+          <spacer>
+           <property name="orientation">

--- a/aqua/qt4-mac/files/patch-tools-build_qtconfig.diff
+++ b/aqua/qt4-mac/files/patch-tools-build_qtconfig.diff
@@ -1,0 +1,11 @@
+--- tools/orig.tools.pro	2014-04-10 20:37:12.000000000 +0200
++++ tools/tools.pro	2015-03-21 21:58:01.000000000 +0100
+@@ -20,7 +20,7 @@
+                 SUBDIRS += designer
+             }
+         }
+-        unix:!symbian:!mac:!embedded:!qpa:SUBDIRS += qtconfig
++        unix:!symbian:!embedded:!qpa:SUBDIRS += qtconfig
+         win32:!wince*:SUBDIRS += activeqt
+     }
+     contains(QT_CONFIG, declarative) {

--- a/kde/kdelibs4/Portfile
+++ b/kde/kdelibs4/Portfile
@@ -150,9 +150,9 @@ To start it run the following command:
 
 Attention:
 
-KDE4 applications no longer default to using the Raster graphics rendering system.
-Users are invited to make this the mode with the ${qt_apps_dir}/qtconfig.app utility
-as described in the qt4-mac notes."
+Users who experience graphics glitches (like flickering) in KDE4 application on newer OS versions
+are invited to use the qtconfig application (in ${qt_apps_dir}) and experiment with
+the Native graphics system as described in the qt4-mac notes."
 
 #patch-authBackends: make possible to use OS X keychain through kwallet (see https://git.reviewboard.kde.org/r/119838/, shipped)
 variant osxkeychain description {kwallet uses the OSX KeyChain} {

--- a/kde/kdelibs4/Portfile
+++ b/kde/kdelibs4/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                kdelibs4
 version             4.14.3
-revision            11
+revision            12
 categories          kde kde4
 maintainers         {nicos @NicosPavlov}
 license             LGPL-2+ GPL-2+ BSD
@@ -144,9 +144,15 @@ post-activate {
     }
 }
 
-notes-append "An agent to provide communication between KDE programs must be started.
+notes-append "An agent must be started to maintain KDE's desktop file system configuration cache.
 To start it run the following command:
- launchctl load -w ${startup_root}/Library/LaunchAgents/org.macports.kdecache.plist"
+ launchctl load -w ${startup_root}/Library/LaunchAgents/org.macports.kdecache.plist
+
+Attention:
+
+KDE4 applications no longer default to using the Raster graphics rendering system.
+Users are invited to make this the mode with the ${qt_apps_dir}/qtconfig.app utility
+as described in the qt4-mac notes."
 
 #patch-authBackends: make possible to use OS X keychain through kwallet (see https://git.reviewboard.kde.org/r/119838/, shipped)
 variant osxkeychain description {kwallet uses the OSX KeyChain} {

--- a/kde/kdelibs4/files/patch-kapplications-raster.diff
+++ b/kde/kdelibs4/files/patch-kapplications-raster.diff
@@ -26,16 +26,15 @@ index b093034..3e1b2f2 100644
      d(new KApplicationPrivate(this))
  {
      d->read_app_startup_id();
-@@ -402,10 +432,31 @@ KApplication::KApplication(Display *display, int& argc, char** argv, const QByte
+@@ -402,10 +432,39 @@ KApplication::KApplication(Display *display, int& argc, char** argv, const QByte
  }
  #endif
  
 +#ifdef Q_OS_MAC
-+static bool useRaster = false, useRasterSet = false;
++static bool useRaster = true;
 +void KApplication::doNotUseRaster()
 +{
 +    useRaster = false;
-+    useRasterSet = true;
 +}
 +#endif
 +
@@ -48,10 +47,19 @@ index b093034..3e1b2f2 100644
 +#endif
  {
 +#ifdef Q_OS_MAC
-+    // Setting env RasterOn forces raster mode which was long the default for KDE4/Mac.
-+    if (getenv("RasterOn") != NULL) {
-+        if ((!useRasterSet || useRaster) && GUIenabled) {
-+            QApplication::setGraphicsSystem(QString("raster"));
++    // Setting env RasterOff avoids setting raster. Can be used for before/after
++    // testing and to work around an application failing when raster is set.
++
++    // Fetch the default graphics system from Qt's settings store managed via qtconfig
++    QSettings settings(QSettings::UserScope, QLatin1String("Trolltech"));
++    settings.beginGroup(QLatin1String("Qt"));
++    const QString defaultGraphicsSystem = settings.value(QLatin1String("DefaultGraphicsSystem")).toString();
++    if (defaultGraphicsSystem.isNull() || defaultGraphicsSystem.isEmpty()) {
++        // only force raster mode here when not overriden via qtconfig or one of our own mechanisms
++        if (getenv("RasterOff") == NULL) {
++            if (useRaster && GUIenabled) {
++                QApplication::setGraphicsSystem(QString("raster"));
++            }
 +        }
 +    }
 +#endif

--- a/kde/kdelibs4/files/patch-kapplications-raster.diff
+++ b/kde/kdelibs4/files/patch-kapplications-raster.diff
@@ -26,15 +26,16 @@ index b093034..3e1b2f2 100644
      d(new KApplicationPrivate(this))
  {
      d->read_app_startup_id();
-@@ -402,10 +410,31 @@ KApplication::KApplication(Display *display, int& argc, char** argv, const QByte
+@@ -402,10 +432,31 @@ KApplication::KApplication(Display *display, int& argc, char** argv, const QByte
  }
  #endif
  
 +#ifdef Q_OS_MAC
-+static bool useRaster = true;
++static bool useRaster = false, useRasterSet = false;
 +void KApplication::doNotUseRaster()
 +{
 +    useRaster = false;
++    useRasterSet = true;
 +}
 +#endif
 +
@@ -47,10 +48,9 @@ index b093034..3e1b2f2 100644
 +#endif
  {
 +#ifdef Q_OS_MAC
-+    // Setting env RasterOff avoids setting raster. Can be used for before/after
-+    // testing and to work around an application failing when raster is set.
-+    if (getenv("RasterOff") == NULL) {
-+        if (useRaster && GUIenabled) {
++    // Setting env RasterOn forces raster mode which was long the default for KDE4/Mac.
++    if (getenv("RasterOn") != NULL) {
++        if ((!useRasterSet || useRaster) && GUIenabled) {
 +            QApplication::setGraphicsSystem(QString("raster"));
 +        }
 +    }


### PR DESCRIPTION
…r option

port:kdelibs4 used to set the Raster graphics system (unless prevented from doing so).
This causes graphics issues on newer OS versions. This change puts the graphics
system under user control via Qt's own qtconfig utility. Port notes and a tooltip
in qtconfig inform and guide the user.

* modifies patch-kapplications-raster.diff (kdelibs4) so it does nothing under
  normal conditions
* patches the Qt4 buildsystem so qtconfig is built on Mac too
* adds a GUI to select the graphics system to qtconfig
* revbumps both ports

Closes: https://trac.macports.org/ticket/57577
