### PR TITLE
openjdk11-openj9: new submission for OpenJDK 11 with OpenJ9 VM

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -25,21 +25,31 @@ subport openjdk11 {
     set major    11
 }
 
+subport openjdk11-openj9 {
+    version      11.0.1
+    revision     0
+
+    set build    13
+    set major    11
+}
+
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
 license          GPL-2
 supported_archs  x86_64
 
-description      Open Java Development Kit ${major}
+description      Open Java Development Kit ${major} (AdoptOpenJDK) with HotSpot VM
 
-long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
-                 open-source set of build scripts and infrastructure.
+long_description OpenJDK build provided by AdoptOpenJDK, built from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 HotSpot is the VM from the OpenJDK community and  the most widely used VM. \
+                 It is suitable for all workloads.
 
 homepage         https://adoptopenjdk.net/
 
-if {${subport} eq ${name}} {
-    # openjdk8 (AdoptOpenJDK)
+if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
     checksums    rmd160  625de009ff2a8a31d72774a863ae6dc6a17fbc96 \
@@ -51,7 +61,6 @@ if {${subport} eq ${name}} {
 
     configure.cxx_stdlib libstdc++
 } elseif {${subport} eq "openjdk10"} {
-    # openjdk10 (Oracle)
     master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
 
     checksums    rmd160  d29498411adc487bf8191adbc4276c72602022cf \
@@ -61,6 +70,7 @@ if {${subport} eq ${name}} {
     distname     openjdk-${version}_osx-x64_bin
     worksrcdir   jdk-${version}.jdk
 
+    description  Oracle OpenJDK ${major} with HotSpot VM
     long_description Production-ready, free and open-source build of the Java \
                  Development Kit, an implementation of the Java Standard \
                  Edition (SE) ${major} Platform. OpenJDK is the official reference \
@@ -69,8 +79,7 @@ if {${subport} eq ${name}} {
                  compiler.
 
     homepage     https://jdk.java.net/${major}/
-} else {
-    # openjdk11 (AdoptOpenJDK)
+} elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
     checksums    rmd160  e579e79d76ba1692a1ac5ea59ea0ffa9a3a1daa3 \
@@ -79,6 +88,23 @@ if {${subport} eq ${name}} {
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
+} else {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
+
+    checksums    rmd160  dbb5724e61f924d55cec365c90e2fcd021716b2d \
+                 sha256  c5e9b588b4ac5b0bd5b4edd69d59265d1199bb98af7ca3270e119b264ffb6e3f \
+                 size    180993478
+
+    distname     OpenJDK${major}-jdk_x64_mac_openj9_${version}_${build}
+    worksrcdir   jdk-${version}+${build}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads.
 }
 
 use_configure    no
@@ -88,7 +114,7 @@ build {}
 # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
 destroot.violate_mtree yes
 
-set target /Library/Java/JavaVirtualMachines/openjdk${major}
+set target /Library/Java/JavaVirtualMachines/${subport}
 set destroot_target ${destroot}${target}
 
 destroot {


### PR DESCRIPTION
#### Description

New port for OpenJDK 11 with OpenJ9 VM from AdoptOpenJDK.

###### Tested on

macOS 10.14.1 18B75
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?