### PR TITLE
Update wcslib and py-astropy

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
 version             3.0.4
+revision            1
 maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
 
 dist_subdir         ${name}/${version}
@@ -35,6 +36,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} < 35} {
         version             2.0.8
+        revision            1
         dist_subdir         ${name}/${version}
         distname            astropy-${version}
 

--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -3,8 +3,12 @@
 PortSystem          1.0
 PortGroup           python 1.0
 name                py-astropy
-version             3.0.4
-revision            1
+version             3.0.5
+revision            0
+checksums           rmd160  fde9b379d0992f0587d2624f7a1e7bd9be3c759d \
+                    sha256  82d1ff422c8a62930821b5e58c4a9fc2bfe42b924cad12129ef69e04abb18d76 \
+                    size    8061570
+
 maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
 
 dist_subdir         ${name}/${version}
@@ -20,10 +24,6 @@ license             BSD
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
 distname            astropy-${version}
-checksums           md5     05ffa1d9f8288a562661c85a4f9e1a23 \
-                    rmd160  75b415a1865f1be8c606c50ec4ab0cd6a73d311c \
-                    sha256  f5d37d20632ba74bd0b12a85179c12f64a9ea037ffc916d8a2de3be4f4656c76 \
-                    size    8040822
 
 python.versions     27 34 35 36 37
 

--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -10,9 +10,6 @@ checksums           rmd160  fde9b379d0992f0587d2624f7a1e7bd9be3c759d \
                     size    8061570
 
 maintainers         {robitaille @astrofrog} {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
-
-dist_subdir         ${name}/${version}
-
 categories-append   science
 description         A Community Python Library for Astronomy
 long_description    The Astropy project is a common effort to develop \
@@ -23,7 +20,6 @@ license             BSD
 
 homepage            http://www.astropy.org
 master_sites        pypi:a/astropy/
-distname            astropy-${version}
 
 python.versions     27 34 35 36 37
 
@@ -37,9 +33,6 @@ if {${name} ne ${subport}} {
     if {${python.version} < 35} {
         version             2.0.8
         revision            1
-        dist_subdir         ${name}/${version}
-        distname            astropy-${version}
-
         checksums           md5     9a236c7f02abcaa8dc33c8a725c35007 \
                             rmd160  22a2b3ad351420977fb1524e22b45046154ec260 \
                             sha256  a8015f84c42051342a2a8ee710868e682b9775a3b7948fdc1e87124bcd6e69dc \
@@ -62,3 +55,6 @@ if {${name} ne ${subport}} {
     destroot.cmd  ${python.bin} setup.py --no-user-cfg --offline --no-git
 
 }
+
+dist_subdir         ${name}/${version}
+distname            astropy-${version}

--- a/science/wcslib/Portfile
+++ b/science/wcslib/Portfile
@@ -4,7 +4,11 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 
 name                wcslib
-version             5.17
+version             6.2
+checksums           rmd160  9a1f4b3660f21fe86affd2e5562e39d00341fd57 \
+                    sha256  bb4dfe242959bc4e5540890e0475754ad4a027dba971903dc4d82df8d564d805 \
+                    size    2377603
+
 categories          science
 license             LGPL-3+
 platforms           darwin
@@ -19,16 +23,27 @@ master_sites        ftp://ftp.atnf.csiro.au/pub/software/wcslib/ \
                     ftp://ftp.eso.org/pub/dfs/pipelines/libraries/wcslib/
 use_bzip2           yes
 
-checksums           rmd160  425e227f0293b73e2cbfd3ec6e1c68d7d7400f1f \
-                    sha256  5c9cb5c86be01703f6488774ef3ea44fd6918a4dcdfddc70855905c05de8436c
-
 depends_lib         port:cfitsio
-configure.args      --disable-fortran
 
 universal_variant   no
 use_parallel_build  no
 
 patchfiles          patch-configure.diff
+
+configure.args      --disable-fortran \
+                    --with-cfitsio \
+                    --with-cfitsioinc=${prefix}/include \
+                    --with-cfitsiolib=${prefix}/lib \
+                    --without-pgplot
+
+# The -I flag from CPPFLAGS ends up in the wrong place on the build line
+# (before the -I flags for source directories). The build system will add
+# its own -I and -L flags from the --with-cfitsioinc and --with-cfitsiolib
+# configure args.
+configure.cppflags-delete \
+                    -I${prefix}/include
+configure.ldflags-delete \
+                    -L${prefix}/lib
 
 livecheck.type      regex
 livecheck.url       http://www.atnf.csiro.au/people/mcalabre/WCS/CHANGES
@@ -39,5 +54,9 @@ compilers.setup
 
 if {[fortran_variant_isset]} {
     depends_lib-append      port:pgplot
-    configure.args-delete   --disable-fortran
+
+    configure.args-replace  --disable-fortran   --enable-fortran
+    configure.args-replace  --without-pgplot    --with-pgplot
+    configure.args-append   --with-pgplotinc=${prefix}/include \
+                            --with-pgplotlib=${prefix}/lib
 }

--- a/science/wcslib/files/patch-configure.diff
+++ b/science/wcslib/files/patch-configure.diff
@@ -1,11 +1,69 @@
---- configure.orig	2014-05-21 01:06:01.000000000 +0200
-+++ configure	2014-05-21 01:05:37.000000000 +0200
-@@ -9837,7 +9837,7 @@
+Set the install_name.
+Don't search in directories we didn't specify.
+--- configure.orig	2018-10-20 05:03:18.000000000 -0500
++++ configure	2018-11-15 21:56:02.000000000 -0600
+@@ -6896,7 +6896,7 @@
    darwin*)
      SHRLIB="libwcs.$LIBVER.dylib"
      SONAME="libwcs.$SHVER.dylib"
 -    SHRLD="$SHRLD -dynamiclib -single_module"
 +    SHRLD="$SHRLD -dynamiclib -install_name $prefix/lib/$SONAME -single_module"
      SHRLD="$SHRLD -compatibility_version $SHVER -current_version $LIBVER"
-     SHRLN=
+     SHRLN="libwcs.dylib"
  
+@@ -7427,14 +7427,6 @@
+   if test "x$with_cfitsioinc" != x ; then
+     CFITSIO_INCDIRS="$with_cfitsioinc"
+   fi
+-
+-  CFITSIO_INCDIRS="$CFITSIO_INCDIRS   \
+-           /usr/local/cfitsio/include \
+-           /local/cfitsio/include"
+-
+-  LIBDIRS="$LIBDIRS           \
+-           /usr/local/cfitsio/lib \
+-           /local/cfitsio/lib"
+ fi
+ 
+ 
+@@ -7466,26 +7458,11 @@
+   if test "x$with_pgplotinc" != x ; then
+     PGPLOT_INCDIRS="$with_pgplotinc"
+   fi
+-
+-  PGPLOT_INCDIRS="$PGPLOT_INCDIRS    \
+-           /usr/local/pgplot/include \
+-           /local/pgplot/include"
+-
+-  LIBDIRS="$LIBDIRS           \
+-           /usr/local/pgplot/lib  \
+-           /local/pgplot/lib"
+ fi
+ 
+ 
+ if test "x$with_cfitsio" != xno -o \
+         "x$with_pgplot"  != xno ; then
+-  LIBDIRS="$LIBDIRS           \
+-           /usr/local/lib     \
+-           /local/lib         \
+-           /opt/local/lib     \
+-           /opt/SUNWspro/lib  \
+-           /sw/lib"
+-
+   for LIBDIR in $LIBDIRS ; do
+     as_ac_File=`$as_echo "ac_cv_file_$LIBDIR" | $as_tr_sh`
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $LIBDIR" >&5
+@@ -7513,12 +7490,7 @@
+   done
+ 
+   # Generic include directories.
+-  INCDIRS="/usr/local/include \
+-           /local/include     \
+-           /opt/local/include \
+-           /sw/include        \
+-           /local             \
+-           /usr/include"
++  INCDIRS=
+ 
+ 
+   # CFITSIO.


### PR DESCRIPTION
#### Description

Update wcslib to 6.2

Revbump py-astropy to rebuild with the new libwcs library version.

Update py-astropy to 3.0.5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
