### PR TITLE
tix: patch tixPort.h for +quartz

### DIFF
--- a/x11/tix/Portfile
+++ b/x11/tix/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tix
 version             8.4.3
-revision            1
+revision            2
 platforms           darwin
 categories          x11
 license             BSD

--- a/x11/tix/files/patch-tk_x11.diff
+++ b/x11/tix/files/patch-tk_x11.diff
@@ -12,3 +12,14 @@
  
  #if !defined(WIN32) && !defined(MAC_OSX_TK)
  #define TkPutImage(colors, ncolors, display, pixels, gc, image, destx, desty, srcx, srcy, width, height) \
+--- generic/tixPort.h.orig	2005-03-25 14:15:53.000000000 -0600
++++ generic/tixPort.h	2018-11-16 02:49:09.000000000 -0600
+@@ -50,7 +50,7 @@
+ #	include "tixMacPort.h"
+ #   else
+ #   if defined(MAC_OSX_TK)
+-#	include <X11/X.h>
++#	include <X11_tk/X.h>
+ #	define Cursor XCursor
+ #	define Region XRegion
+ #	include "../unix/tixUnixPort.h"


### PR DESCRIPTION
#### Description

Currently there is an error building with trace mode enabled and with `tk +quartz` rather than `tk +x11` installed:

```
--->  Building tix
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tix/tix/work/Tix8.4.3" && /usr/bin/make -j4 -w all 
make: Entering directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tix/tix/work/Tix8.4.3'
ccache /usr/bin/clang -DPACKAGE_NAME=\"Tix\" -DPACKAGE_TARNAME=\"tix\" -DPACKAGE_VERSION=\"8.4.3\" -DPACKAGE_STRING=\"Tix\ 8.4.3\" -DPACKAGE_BUGREPORT=\"\" -DMAC_OSX_TK=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DNO_VALUES_H=1 -DHAVE_LIMITS_H=1 -DHAVE_SYS_PARAM_H=1 -DUSE_THREAD_ALLOC=1 -D_REENTRANT=1 -D_THREAD_SAFE=1 -DTCL_THREADS=1 -DTCL_WIDE_INT_IS_LONG=1 -DUSE_TCL_STUBS=1 -DUSE_TK_STUBS=1   -I. -I"./generic" -I. -I"./unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9"/macosx -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/generic" -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/generic" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/xlib" -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/macosx     -pipe -Os -arch x86_64 -pipe  -Os -Wall -Wno-implicit-int -fno-common -I/opt/local/include -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk  -c `echo ./generic/tixClass.c`
ccache /usr/bin/clang -DPACKAGE_NAME=\"Tix\" -DPACKAGE_TARNAME=\"tix\" -DPACKAGE_VERSION=\"8.4.3\" -DPACKAGE_STRING=\"Tix\ 8.4.3\" -DPACKAGE_BUGREPORT=\"\" -DMAC_OSX_TK=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DNO_VALUES_H=1 -DHAVE_LIMITS_H=1 -DHAVE_SYS_PARAM_H=1 -DUSE_THREAD_ALLOC=1 -D_REENTRANT=1 -D_THREAD_SAFE=1 -DTCL_THREADS=1 -DTCL_WIDE_INT_IS_LONG=1 -DUSE_TCL_STUBS=1 -DUSE_TK_STUBS=1   -I. -I"./generic" -I. -I"./unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9"/macosx -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/generic" -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/generic" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/xlib" -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/macosx     -pipe -Os -arch x86_64 -pipe  -Os -Wall -Wno-implicit-int -fno-common -I/opt/local/include -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk  -c `echo ./generic/tixCmds.c`
ccache /usr/bin/clang -DPACKAGE_NAME=\"Tix\" -DPACKAGE_TARNAME=\"tix\" -DPACKAGE_VERSION=\"8.4.3\" -DPACKAGE_STRING=\"Tix\ 8.4.3\" -DPACKAGE_BUGREPORT=\"\" -DMAC_OSX_TK=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DNO_VALUES_H=1 -DHAVE_LIMITS_H=1 -DHAVE_SYS_PARAM_H=1 -DUSE_THREAD_ALLOC=1 -D_REENTRANT=1 -D_THREAD_SAFE=1 -DTCL_THREADS=1 -DTCL_WIDE_INT_IS_LONG=1 -DUSE_TCL_STUBS=1 -DUSE_TK_STUBS=1   -I. -I"./generic" -I. -I"./unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9"/macosx -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/generic" -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/generic" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/xlib" -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/macosx     -pipe -Os -arch x86_64 -pipe  -Os -Wall -Wno-implicit-int -fno-common -I/opt/local/include -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk  -c `echo ./generic/tixCompat.c`
ccache /usr/bin/clang -DPACKAGE_NAME=\"Tix\" -DPACKAGE_TARNAME=\"tix\" -DPACKAGE_VERSION=\"8.4.3\" -DPACKAGE_STRING=\"Tix\ 8.4.3\" -DPACKAGE_BUGREPORT=\"\" -DMAC_OSX_TK=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DNO_VALUES_H=1 -DHAVE_LIMITS_H=1 -DHAVE_SYS_PARAM_H=1 -DUSE_THREAD_ALLOC=1 -D_REENTRANT=1 -D_THREAD_SAFE=1 -DTCL_THREADS=1 -DTCL_WIDE_INT_IS_LONG=1 -DUSE_TCL_STUBS=1 -DUSE_TK_STUBS=1   -I. -I"./generic" -I. -I"./unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9"/macosx -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/generic" -I"/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_lang_tcl/tcl/work/tcl8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/generic" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/unix" -I"/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/xlib" -I/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tk/tk/work/tk8.6.9/macosx     -pipe -Os -arch x86_64 -pipe  -Os -Wall -Wno-implicit-int -fno-common -I/opt/local/include -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -isysroot/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk  -c `echo ./generic/tixError.c`
In file included from ./generic/tixCmds.c:17:
./generic/tixPort.h:53:11: fatal error: 'X11/X.h' file not found
#       include <X11/X.h>
                ^~~~~~~~~
In file included from ./generic/tixCompat.c:16:
./generic/tixPort.h:53:11: fatal error: 'X11/X.h' file not found
#       include <X11/X.h>
                ^~~~~~~~~
1 error generated.
In file included from ./generic/tixError.c:16:
make: *** [tixCompat.o] Error 1
make: *** Waiting for unfinished jobs....
./generic/tixPort.h:53:11: fatal error: 'X11/X.h' file not found
#       include <X11/X.h>
                ^~~~~~~~~
1 error generated.
make: *** [tixError.o] Error 1
In file included from ./generic/tixClass.c:29:
./generic/tixPort.h:53:11: fatal error: 'X11/X.h' file not found
#       include <X11/X.h>
                ^~~~~~~~~
1 error generated.
make: *** [tixCmds.o] Error 1
1 error generated.
make: *** [tixClass.o] Error 1
make: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tix/tix/work/Tix8.4.3'
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tix/tix/work/Tix8.4.3" && /usr/bin/make -j4 -w all 
Exit code: 2
Warning: The following existing files were hidden from the build system by trace mode:
  /opt/local/include/X11/X.h
  /var/db/timezone/zoneinfo/America/Chicago
The following files would have been hidden from the build system by trace mode if they existed:
  /usr/gnu/include
  /usr/local/cuda
  /usr/local/cuda-7.0
  /usr/local/cuda-7.5
  /usr/local/cuda-8.0
Error: Failed to build tix: command execution failed
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_github.com_macports_macports-ports_x11_tix/tix/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port tix failed
```

I resolved this by changing use of `<X11/X.h>` in generic/tixPort.h to `<X11_tk/X.h>`, similar to what was done for unix/tixUnixXpm.c (changing `<X11/Xutil.h>` to `<X11_tk/Xutil.h>`; see [#57534](https://trac.macports.org/ticket/57534)).

@MarcusCalhoun-Lopez would you be able to review this?

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of ~~all~~ binary files?
Was able to run a Tix demo from `p5-tcl-ptk`.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
