### PR TITLE
scribus-devel: patch to properly detect Mojave

### DIFF
--- a/print/scribus-devel/Portfile
+++ b/print/scribus-devel/Portfile
@@ -87,7 +87,7 @@ variant bitmap description {Input filters for most GraphicsMagick bitmap formats
 
 build.env           HOME=${worksrcpath}
 
-patchfiles          poppler.patch
+patchfiles          poppler.patch CMakeLists.txt.patch
 
 # These can be uncommented to livecheck for the devel version
 livecheck.url       https://www.scribus.net/downloads/unstable-branch/

--- a/print/scribus-devel/files/CMakeLists.txt.patch
+++ b/print/scribus-devel/files/CMakeLists.txt.patch
@@ -1,0 +1,39 @@
+--- CMakeLists.txt.orig	2018-04-25 14:42:32.000000000 -0400
++++ CMakeLists.txt	2018-11-16 07:58:11.000000000 -0500
+@@ -164,6 +164,10 @@
+ ## Do our Apple OSX version setup
+ if (APPLE AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND (ARCH_X86 EQUAL 1 OR ARCH_X86_64 EQUAL 1))
+ 	string(REGEX REPLACE ".*-darwin([0-9]+).*" "\\1" _apple_ver "${MACHINE}")
++	if (_apple_ver EQUAL "18")
++        message(STATUS "Found macOS Mojave Target: Apple, 64 bit, X86")
++		set(APPLE_10_14_X 1 CACHE TYPE BOOL)
++	endif()
+ 	if (_apple_ver EQUAL "17")
+ 		message(STATUS "Found macOS High Sierra Target: Apple, 64 bit, X86")
+ 		set(APPLE_10_13_X 1 CACHE TYPE BOOL)
+@@ -452,6 +456,16 @@
+ 
+ #Based on our build type, setup our build options
+ if(APPLE)
++	if(APPLE_10_14_X)
++		set(OSXMINVER "10.14" CACHE TYPE STRING)
++		if (WANT_OSX_SDK)
++			if(EXISTS("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"))
++				set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk")
++			elseif(EXISTS("/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk"))
++				set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk")
++			endif()
++		endif()
++	endif()
+ 	if(APPLE_10_13_X)
+ 		set(OSXMINVER "10.13" CACHE TYPE STRING)
+ 		if (WANT_OSX_SDK)
+@@ -542,7 +556,7 @@
+ 			if (WANT_OSX_SDK)
+ 				set(CMAKE_OSX_DEPLOYMENT_TARGET "${OSXMINVER}")
+ 			endif()
+-			if(APPLE_10_6_X OR APPLE_10_7_X OR APPLE_10_8_X OR APPLE_10_9_X OR APPLE_10_10_X OR APPLE_10_11_X OR APPLE_10_12_X OR APPLE_10_13_X)
++            if(APPLE_10_6_X OR APPLE_10_7_X OR APPLE_10_8_X OR APPLE_10_9_X OR APPLE_10_10_X OR APPLE_10_11_X OR APPLE_10_12_X OR APPLE_10_13_X OR APPLE_10_14_X)
+ 				message("Setting x86_64 Architecture for OSX Build/Bundle")
+ 				set(CMAKE_OSX_ARCHITECTURES "x86_64" )
+ 				set(CMAKE_TRY_COMPILE_OSX_ARCHITECTURES "x86_64" )


### PR DESCRIPTION
This patches CMakeLists.txt in order to make it detect
Mojave. This fix should no longer be necessary once
scribus 1.5.5 development candidate is released.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
