### PR TITLE
tor-devel: update to 0.3.5.5-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.3.5.4-alpha
+version             0.3.5.5-alpha
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  15f176e09542759f960f434138ca4365a638e1b8 \
-                    sha256  0f026b5f5a11ce67efd5e2cad091f8538bc8c895ad4b4404737d0418c5434078 \
-                    size    6867919
+checksums           rmd160  597310466b0d2c6ec08c17c5e36505658416175e \
+                    sha256  84d746abc960e8212fc8bffbf91020ab55d426d2a00751cfd038c41c1bee1332 \
+                    size    6893528
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description
tor-devel: update to 0.3.5.5-alpha

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G4012
Xcode 10.1 10B61 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?