### PR TITLE
iTerm2: Split pre/post XC10 versions.

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -4,7 +4,23 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
-github.setup        gnachman iTerm2 3.2.0 v
+if {[vercmp $xcodeversion 10.0] < 0} {
+    version             3.2.0
+    checksums \
+        rmd160  07915ff5db0545c0c059f47e7f71761e023a26e1 \
+        sha256  017aff348352369abcc994caaca0f6112e1f17c4d65041acdb9f19830b2b96bd \
+        size    11969144
+    patchfiles          patch-Makefile.diff
+} else {
+    version             3.2.5
+    checksums \
+        rmd160  90844a6638bf2b5dd6168af515faa7a1853a080c \
+        sha256  64185b6334f38b5ee62764e52b8300765e10f1180aa5d6abc15b13a999ba0118 \
+        size    11637927
+    patchfiles          patch-Makefile-XC10.diff
+}
+
+github.setup        gnachman iTerm2 ${version} v
 categories          aqua shells
 platforms           darwin
 maintainers         {emer.net:emer @markemer} openmaintainer
@@ -19,13 +35,9 @@ long_description    \
 
 homepage            https://iterm2.com/
 
-checksums           rmd160  07915ff5db0545c0c059f47e7f71761e023a26e1 \
-                    sha256  017aff348352369abcc994caaca0f6112e1f17c4d65041acdb9f19830b2b96bd \
-                    size    11969144
 
 github.livecheck.regex {(\d+(?:\.\d+)*)}
 
-patchfiles          patch-Makefile.diff
 
 post-patch {
     reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj

--- a/aqua/iTerm2/files/patch-Makefile-XC10.diff
+++ b/aqua/iTerm2/files/patch-Makefile-XC10.diff
@@ -1,0 +1,26 @@
+Declare dependencies so we don't unnecessarily rebuild when running "make install"
+--- Makefile.orig	2018-10-29 12:31:47.000000000 -0400
++++ Makefile	2018-11-04 14:07:03.000000000 -0500
+@@ -21,7 +21,7 @@
+ 	find . -name "*.[mhMH]" -exec etags -o ./TAGS -a '{}' +
+
+ install: | Deployment backup-old-iterm
+-	cp -R build/Deployment/iTerm2.app $(APPS)
++	cp -R DerivedData/Build/Products/Deployment/iTerm2.app $(APPS)
+
+ Development:
+ 	echo "Using PATH for build: $(PATH)"
+@@ -36,9 +36,10 @@
+ 	xcodebuild -parallelizeTargets -target iTerm2 -configuration Beta && \
+ 	chmod -R go+rX build/Beta
+
+-Deployment:
+-	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment && \
+-	chmod -R go+rX build/Deployment
++Deployment: build/Deployment/iTerm2.app/Contents/MacOS/iTerm2
++build/Deployment/iTerm2.app/Contents/MacOS/iTerm2:
++	xcodebuild -parallelizeTargets -target iTerm2 -configuration Deployment -scheme iTerm2 -derivedDataPath ./DerivedData && \
++	chmod -R go+rX DerivedData/Build/Products/Deployment
+
+ Nightly: force
+ 	cp plists/nightly-iTerm2.plist plists/iTerm2.plist


### PR DESCRIPTION
Rework of https://github.com/macports/macports-ports/pull/2939 to split processing based on XCode version.