### PR TITLE
emacs-mac-app: update to 7.4

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           bitbucket 1.0
 
 set emacs_version   26.1
-set emacs_mac_ver   7.3
+set emacs_mac_ver   7.4
 
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
@@ -21,9 +21,9 @@ long_description    ${name} is "Mac port" addition to GNU Emacs ${emacs_version}
 platforms           darwin
 license             GPL-3+
 
-checksums           rmd160  f65c3428ef5895f4a1ec6d4c4ac7f1c150bccf67 \
-                    sha256  352e566b6082cdc7eaea600f22850c8448f2cbee7a5521e3ba1a1a6dfb87bd44 \
-                    size    41603656
+checksums           rmd160  ea6d01b586896aaa3ecf7fbd15c54e38f34ceee9 \
+                    sha256  8f8037dfef837cba41954f60d9f11979b810c02c2c55fddb257b99abd8995ab9 \
+                    size    41596057
 
 depends_lib         port:ncurses \
                     port:libxml2 \


### PR DESCRIPTION
#### Description

Update emacs-mac-app to 7.4.

I am making a pull request rather than just pushing because I am actually not able to build this right now. In fact I can't build the current port version, 7.3, despite doing so with no problem 3 weeks ago when it was released.

The only relevant thing I can think of that changed in the meantime is that Xcode went from 10 to 10.1. The errors also seem to point in that direction:

```
In file included from macappkit.m:41:
./macappkit.h:828:36: error: no type or protocol named 'NSMenuItemValidation'
@interface EmacsWindow : NSWindow <NSMenuItemValidation>
                                   ^
./macappkit.h:1203:63: error: cannot find protocol declaration for 'NSToolbarItemValidation'
@interface EmacsFrameController (Toolbar) <NSToolbarDelegate, NSToolbarItemValidation>
                                                              ^
./macappkit.h:1228:46: error: cannot find protocol declaration for 'NSFontChanging'
@interface EmacsFrameController (FontPanel) <NSFontChanging>
                                             ^
./macappkit.h:1251:68: error: cannot find protocol declaration for 'NSFontChanging'
@interface EmacsFontDialogController : NSObject <NSWindowDelegate, NSFontChanging>
                                                                   ^
macappkit.m:1215:16: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
      [manager dispatchRawAppleEvent:&appleEvent withRawReply:&reply
               ^
macappkit.m:2565:51: error: use of undeclared identifier 'NSAppKitVersionNumber10_13'
      else if (!(floor (NSAppKitVersionNumber) <= NSAppKitVersionNumber10_13))
                                                  ^
macappkit.m:2665:44: error: use of undeclared identifier 'NSAppKitVersionNumber10_13'
      if (floor (NSAppKitVersionNumber) <= NSAppKitVersionNumber10_13)
                                           ^
macappkit.m:13400:38: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
      NSData *compiledData = [script compiledDataForType:nil
                                     ^                   ~~~
2 warnings and 6 errors generated.
```

[main.log](https://github.com/macports/macports-ports/files/2591826/main.log)

I want to try building with Xcode 10 but it will take me a long time to get it downloaded.

I get identical errors when building 7.3 right now on my system, and the [upstream changes in this version](https://bitbucket.org/mituharu/emacs-mac/commits/fd1cf1f3e7576ac3e5ffe6e2041fb881427d6acc?at=master) don't seem related.

Any ideas?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
