### PR TITLE
libedit: fix tab completion and history in Python

### DIFF
--- a/devel/libedit/Portfile
+++ b/devel/libedit/Portfile
@@ -6,6 +6,7 @@ PortGroup           muniversal 1.0
 name                libedit
 epoch               20090923
 version             20180525-3.1
+revision            1
 categories          devel
 platforms           darwin
 license             BSD
@@ -42,6 +43,14 @@ patchfiles-append   src__Makefile.in.patch \
 # this patch is taken from
 #    https://opensource.apple.com/source/libedit/libedit-48/src/el.c.auto.html
 patchfiles-append   patch-non_ascii.diff
+
+# revert part of http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libedit/readline.c?sortby=date#rev1.142
+# see https://trac.macports.org/ticket/57584
+patchfiles-append   patch-history.diff
+
+# render moot http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libedit/filecomplete.c?sortby=date#rev1.47
+# see https://trac.macports.org/ticket/57584
+patchfiles-append   patch-no_escaping.diff
 
 post-patch {
     copy ${filespath}/getline.c ${worksrcpath}/src

--- a/devel/libedit/files/patch-history.diff
+++ b/devel/libedit/files/patch-history.diff
@@ -1,0 +1,13 @@
+--- src/readline.c.orig	2018-05-25 11:09:38.000000000 -0700
++++ src/readline.c	2018-11-17 08:13:35.000000000 -0700
+@@ -2096,9 +2096,8 @@
+ void
+ rl_callback_handler_remove(void)
+ {
++	el_set(e, EL_UNBUFFERED, 0);
+ 	rl_linefunc = NULL;
+-	el_end(e);
+-	e = NULL;
+ }
+ 
+ void

--- a/devel/libedit/files/patch-no_escaping.diff
+++ b/devel/libedit/files/patch-no_escaping.diff
@@ -1,0 +1,37 @@
+--- src/filecomplete.c.orig	2018-05-25 11:09:38.000000000 -0700
++++ src/filecomplete.c	2018-11-17 08:17:12.000000000 -0700
+@@ -130,34 +130,7 @@
+ static int
+ needs_escaping(char c)
+ {
+-	switch (c) {
+-	case '\'':
+-	case '"':
+-	case '(':
+-	case ')':
+-	case '\\':
+-	case '<':
+-	case '>':
+-	case '$':
+-	case '#':
+-	case ' ':
+-	case '\n':
+-	case '\t':
+-	case '?':
+-	case ';':
+-	case '`':
+-	case '@':
+-	case '=':
+-	case '|':
+-	case '{':
+-	case '}':
+-	case '&':
+-	case '*':
+-	case '[':
+-		return 1;
+-	default:
+ 		return 0;
+-	}
+ }
+ 
+ static char *


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/57584

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->