### PR TITLE
py-coverage: update to 4.5.2

### DIFF
--- a/python/py-coverage/Portfile
+++ b/python/py-coverage/Portfile
@@ -3,11 +3,8 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           coverage
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             4.5.1
+name                py-coverage
+version             4.5.2
 categories-append   devel
 maintainers         {petr @petrrr} openmaintainer
 license             Apache-2
@@ -21,22 +18,21 @@ long_description    Coverage measures code coverage, typically during test \
 
 platforms           darwin
 
-homepage            http://nedbatchelder.com/code/${_name}/
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+homepage            https://github.com/nedbat/coveragepy
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  23be4f1a1e21e4b409a684017fc3b5c68e009166 \
-                    sha256  56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1 \
-                    size    379675
+checksums           rmd160  c3172e234848232518e6bf023e02db77ca268b0a \
+                    sha256  ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4 \
+                    size    384845
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-setuptools
 
     patchfiles      patch-setup.py.diff
 
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-coverage/files/patch-setup.py.diff
+++ b/python/py-coverage/files/patch-setup.py.diff
@@ -1,6 +1,6 @@
---- setup.orig.py
-+++ setup.py
-@@ -80,13 +80,8 @@
+--- setup.py.orig	2018-11-12 08:58:25.000000000 -0500
++++ setup.py	2018-11-17 11:13:23.000000000 -0500
+@@ -87,13 +87,7 @@
      },
  
      entry_points={
@@ -11,7 +11,6 @@
 -            'coverage%d = coverage.cmdline:main' % sys.version_info[:1],
 -            'coverage-%d.%d = coverage.cmdline:main' % sys.version_info[:2],
 -        ],
-+        # 2017-04-17, petr -- replaces former patch from 2015-12-15
 +        'console_scripts': ['coverage = coverage.cmdline:main'],
      },
  


### PR DESCRIPTION
#### Description
- update to 4.5.2
- fix setuptools dependency type
- update homepage
- make use of python.rootname
- use default PyPI livecheck

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
