### PR TITLE
py-qtpy: update to 1.5.2

### DIFF
--- a/python/py-qtpy/Portfile
+++ b/python/py-qtpy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        spyder-ide qtpy 1.5.1 v
+github.setup        spyder-ide qtpy 1.5.2 v
 name                py-qtpy
 
 categories-append   devel
@@ -21,9 +21,9 @@ long_description    QtPy (pronounced 'cutie pie') is a small abstraction layer \
                     using the Qt5 layout (where the QtGui module has been split \
                     into QtGui and QtWidgets).
 
-checksums           rmd160  2ac1f3c4b7eed2f47b733247446436965d2c845e \
-                    sha256  9c6948c406c9dd483c2408a55e4b0f916d782fc23e8125605ff045c750d2a145 \
-                    size    31882
+checksums           rmd160  eeef2be5c79b37aa22b8c3b042c2e6c4b98227df \
+                    sha256  da18dac7b81e250451108efa4846cf29bbe1b13f6c6c48b4c27e92aeece148ad \
+                    size    32003
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to 1.5.2
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
