### PR TITLE
py-markupsafe: update to 1.1.0

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -220,6 +220,7 @@ py-itsdangerous         0.24_1      26 33
 py-jcc                  2.13_1      26
 py-jenkins-job-builder  0.8.1_2     26
 py-jinja                1.2_2       26
+py-jinja2               2.10_1      26 33
 py-jmespath             0.9.3       34
 py-jsbeautifier         1.4.0_1     26
 py-jug                  1.6.7_1     33
@@ -241,6 +242,7 @@ py-macfsevents          0.8.1_1     33
 py-mako                 1.0.7_1     26
 py-managesieve          0.4.2_1     26
 py-matplotlib           1.5.0_1     26 33
+py-markupsafe           1.0_1       26 33
 py-mdp-toolkit          3.3_2       26 33
 py-mecab                0.996_1     26
 py-mechanize            0.2.5_1     26

--- a/python/py-jinja2/Portfile
+++ b/python/py-jinja2/Portfile
@@ -27,7 +27,7 @@ checksums           md5 61ef1117f945486472850819b8d1eb3d \
                     rmd160 552a79aaea2fa3e5b5211f89260fc8416cc28ce4 \
                     sha256 f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-setuptools \

--- a/python/py-markupsafe/Portfile
+++ b/python/py-markupsafe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-markupsafe
-version             1.0
+version             1.1.0
 categories-append   textproc
 platforms           darwin
 license             BSD
@@ -16,23 +16,28 @@ maintainers         nomaintainer
 description         Implements a XML/HTML/XHTML Markup safe string for Python
 long_description    ${description}
 
-homepage            http://www.pocoo.org/projects/markupsafe/
+homepage            https://palletsprojects.com/p/markupsafe/
 master_sites        pypi:M/MarkupSafe
-
 distname            MarkupSafe-${version}
 
-checksums           rmd160  625a540aafd068e65a7d61693862d7cdc8e9d0a1 \
-                    sha256  a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665 \
-                    size    14356
+checksums           rmd160  e6c0a61abb702197a59746c01d7747c661364996 \
+                    sha256  4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3 \
+                    size    18938
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    test.run                yes
-    test.cmd                ${python.bin} setup.py
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+    depends_test-append \
+                    port:py${python.version}-pytest
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
 
-    livecheck.type          none
-
+    livecheck.type  none
 } else {
-    livecheck.name          Markupsafe
+    livecheck.name  Markupsafe
 }

--- a/python/py-markupsafe/Portfile
+++ b/python/py-markupsafe/Portfile
@@ -9,7 +9,7 @@ categories-append   textproc
 platforms           darwin
 license             BSD
 
-python.versions     26 27 33 34 35 36 37
+python.versions     27 34 35 36 37
 
 maintainers         nomaintainer
 


### PR DESCRIPTION
#### Description
- update to version 1.1.0
- pin to version 1.0 for Python 2.6 and 3.3
- update homepage

I would be in favor of removing the py26 and py33 subports instead of pinning them to an older version, but that can only be done if @jmroot is willing to drop these version in py-jinja2 and others downstream of that as well.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
