### PR TITLE
py-cairo: update to 1.18.0

### DIFF
--- a/python/py-cairo/Portfile
+++ b/python/py-cairo/Portfile
@@ -6,7 +6,7 @@ PortGroup               active_variants 1.1
 PortGroup               github 1.0
 PortGroup               python 1.0
 
-github.setup            pygobject pycairo 1.17.1 v
+github.setup            pygobject pycairo 1.18.0 v
 github.tarball_from     releases
 
 name                    py-cairo
@@ -18,17 +18,18 @@ description             Pycairo is set of Python bindings for the cairo graphics
 
 long_description        ${description}
 
-checksums               rmd160  46c562fad05a9565df2940085ec27e335400ec52 \
-                        sha256  0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698 \
-                        size    194388
+checksums               rmd160  0e5f6d6c9be9b7a58ac74b4b2dbee802e07e8d8a \
+                        sha256  abd42a4c9c2069febb4c38fe74bfc4b4a9d3a89fea3bc2e4ba7baff7a20f783f \
+                        size    202140
 
 python.versions         27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build           port:pkgconfig
+    depends_build-append    port:pkgconfig
     depends_lib-append      path:lib/pkgconfig/cairo.pc:cairo
 
-    depends_test-append     port:py${python.version}-pytest
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-hypothesis
     test.run                yes
     test.cmd                ${python.bin} setup.py
 
@@ -50,16 +51,6 @@ if {${name} ne ${subport}} {
 
     if {[catch {set result [active_variants cairo x11]}]} {
         default_variants-append +x11
-    }
-
-    post-extract {
-        fs-traverse item ${worksrcpath} {
-            if {[file isdirectory ${item}]} {
-                file attributes ${item} -permissions a+rx
-            } elseif {[file isfile ${item}]} {
-                file attributes ${item} -permissions a+r
-            }
-        }
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description
- update to 1.18.0
- remove no longer needed post-extract

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
