### PR TITLE
py-keyring: update to 16.1.0

### DIFF
--- a/python/py-keyring/Portfile
+++ b/python/py-keyring/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keyring
-version             16.0.2
+version             16.1.0
 categories-append   security
 
 license             {MIT PSF}
@@ -21,9 +21,9 @@ homepage            https://github.com/jaraco/keyring
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  b6fa71e07cf1f24debe1139388d8c10fb3c17e05 \
-                    sha256  95e4f1d0342d0bf5d137d1d2352d59f7abbebb1507bec1ac26831c411ac23150 \
-                    size    43566
+checksums           rmd160  08fe827c558c7e6e8fe7dba175d6b433c70a0b1a \
+                    sha256  e9d58fcb4e559f13ae7d10df301cef45ef2786ef8162a648373f8566b1761eb0 \
+                    size    43863
 
 python.versions     27 34 35 36 37
 
@@ -37,7 +37,7 @@ if {${name} ne ${subport}} {
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 644 -W ${worksrcpath} CHANGES.rst LICENSE README.rst \
+        xinstall -m 0644 -W ${worksrcpath} CHANGES.rst LICENSE README.rst \
             ${destroot}${docdir}
     }
 


### PR DESCRIPTION
#### Description
- update to 16.1.0
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
