### PR TITLE
py-serial: Add Python 3.7 subport.

### DIFF
--- a/python/py-serial/Portfile
+++ b/python/py-serial/Portfile
@@ -13,7 +13,7 @@ maintainers         twinleaf.com:maintainers \
                     openmaintainer
 license             BSD
 description         Python Serial Port Extension
-long_description    This module incapsulates the access for the serial port. \
+long_description    This module encapsulates the access for the serial port. \
                     It provides backends for standard Python running on Windows, \
                     Linux, BSD (possibly any POSIX compliant system) and Jython. \
                     The module named "serial" automatically selects the appropriate \
@@ -22,7 +22,7 @@ long_description    This module incapsulates the access for the serial port. \
 checksums           rmd160  6e5466e785a61d42ff9d1de2e4bfa0cf059eb02d \
                     sha256  1e4043a9b02849c3bea778c7a3c53aec17e3465643f199732f2febbf2d01b5a9
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
Also fixes a typo in the description.

TESTED:
Verified that py37-serial can be installed, and that it works with
GPSD's ubxtool.  Didn't test more extensively due to the minor
nature of the change.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
