### PR TITLE
ffmpeg / ffmpeg-devel: enable features on snowleopard and lion

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -170,9 +170,13 @@ platform darwin {
     }
 
     # AudioToolbox support requires CoreMedia Framework available on 10.7+
-    # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
     if {${os.major} > 10} {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
+    }
+
+    # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
+    # but builds on Snow Leopard
+    if {${os.major} > 9} {
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
     }
@@ -193,8 +197,8 @@ platform darwin {
         patchfiles-append patch-configure-no-error-on-missing-prototypes.diff
     }
 
-    # kCVPixelFormatType_OneComponent8 used in avfoundation indev is only available on 10.8+
-    if {${os.major} < 12} {
+    # avfoundation is only available on 10.7+
+    if {${os.major} < 11} {
         configure.args-append --disable-indev=avfoundation
     }
 }

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -11,6 +11,7 @@ github.setup        FFmpeg FFmpeg 07bc603757caa5d2054c56629bb93d7a177e8e88
 name                ffmpeg-devel
 conflicts           ffmpeg
 version             20181108
+revision            1
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -11,7 +11,7 @@ conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
 version             4.1
-revision            1
+revision            2
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -197,8 +197,8 @@ platform darwin {
         patchfiles-append patch-configure-no-error-on-missing-prototypes.diff
     }
 
-    # kCVPixelFormatType_OneComponent8 used in avfoundation indev is only available on 10.8+
-    if {${os.major} < 12} {
+    # avfoundation is only available on 10.7+
+    if {${os.major} < 11} {
         configure.args-append --disable-indev=avfoundation
     }
 }

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -174,9 +174,13 @@ platform darwin {
     }
 
     # AudioToolbox support requires CoreMedia Framework available on 10.7+
-    # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
     if {${os.major} > 10} {
         configure.args-replace --disable-audiotoolbox --enable-audiotoolbox
+    }
+
+    # libsdl2 requires minimum Xcode 10.7 SDK to build successfully
+    # but builds on Snow Leopard
+    if {${os.major} > 9} {
         configure.args-replace --disable-sdl2 --enable-sdl2
         depends_lib-append     port:libsdl2
     }


### PR DESCRIPTION
avfoundation can be used on Lion - upstream has guarded the previous troublesome definition.

SDL2 is available on Snow Leopard, so we can enable it in ffmpeg.