### PR TITLE
tig: update and make it redistributable

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.3.3 tig-
+github.setup        jonas tig 2.4.1 tig-
 github.tarball_from releases
-checksums           rmd160  a640bed8ad0ef8b4bb30cea35bbe3558973684a0 \
-                    sha256  d39d10c5a6db7b7663d51eff8ac2eaf075e319f5edabe09cb63a2b1b24846bea
+checksums           rmd160  1245649ee1ea022583bdcc8e326290cfb1899358 \
+                    sha256  b6b6aa183e571224d0e1fab3ec482542c1a97fa7a85b26352dc31dbafe8558b8 \
+                    size    1181900
 
 categories          devel
 maintainers         {cal @neverpanic} \
@@ -23,9 +24,11 @@ depends_build       port:automake \
                     port:asciidoc \
                     port:xmlto
 
-depends_lib         port:git \
+depends_lib         bin:git:git \
                     port:libiconv \
                     port:ncurses
+
+license_noconflict  git asciidoc
 
 # -E, -S, -save-temps and -M options are not allowed with multiple -arch flags
 universal_variant   no


### PR DESCRIPTION
#### Description

* For git, only the command line program is used. I'v also changed the
dependency spec so that users can run tig with git from Xcode.
* asciidoc is only used to generate documents

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?