### PR TITLE
libressl-devel: update to 2.8.2

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libressl-devel
-version             2.8.1
+version             2.8.2
 distname            libressl-${version}
 
 categories          security devel
@@ -23,9 +23,9 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160 fcc1241815c094f0e16dd5cd2e4de90e18eb0689 \
-                    sha256 334bf7050f1db4087feebb30571ec13d9fa975bf05d6003ce3ab6d7d2452cf42 \
-                    size   3375642
+checksums           rmd160  e5804bd4a4db10cf7f622d130cd572bef41f5a72 \
+                    sha256  b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5 \
+                    size    3373599
 
 patchfiles \
     openssldir-cert.pem.patch


### PR DESCRIPTION
Please refer to https://trac.macports.org/ticket/55264#comment:20

One may have a look at ​https://www.libressl.org/releases.html
  - LibreSSL 2.8.2 (October 18th, 2018)
  - LibreSSL 2.6.5, 2.7.4 (June 13th, 2018) 

Unfortunately, MacPorts current ports are somewhat outdated:
  - libressl @2.5.5
  - libressl-devel @2.8.1 

However, I would like to thank the maintainers for the good work and for providing the libressl-devel port certainly.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] update

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13 (darwin/17.7.0) arch i386
Xcode 10.1

'Error: Failed to test libressl-devel: libressl-devel has no tests turned on. see 'test.run' in portfile(7)'

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?   (minor adjustments to Portfile only)
- [ ] tried existing tests with `sudo port test`?   (see above as there seem to be no existings tests)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
