### PR TITLE
giza: requires std=c99

### DIFF
--- a/science/giza/Portfile
+++ b/science/giza/Portfile
@@ -33,6 +33,8 @@ depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
 
 compilers.setup     require_fortran -g95
 
+configure.cflags-append -std=c99
+
 configure.args      --disable-silent-rules
 
 build.args-append   X11DIR=${prefix} PREFIX=${prefix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

fixes build on compilers that don't default to at least c99, like gcc-4.2 (tiger, leopard, snowleopard).