### PR TITLE
valgrind-devel: add test for incompatible systems

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -110,6 +110,11 @@ subport valgrind-devel {
             ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up."
             return -code error "incompatible macOS version"
         }
+
+        if {${os.platform} eq "darwin" && ${os.major} > 17 } {
+            ui_error "${subport} @${version} is not presently compatible with macOS Mojave or newer"
+            return -code error "incompatible macOS version"
+        }
     }
 
     use_autoreconf      yes


### PR DESCRIPTION
valgrind is always updated some time after new OS
releases.
closes: https://trac.macports.org/ticket/57649
