### PR TITLE
blosc: disable tests and benchmarks

### DIFF
--- a/archivers/blosc/Portfile
+++ b/archivers/blosc/Portfile
@@ -35,4 +35,6 @@ depends_lib-append  port:lz4 \
 configure.args-append \
                     -DPREFER_EXTERNAL_LZ4=ON \
                     -DPREFER_EXTERNAL_ZLIB=ON \
-                    -DPREFER_EXTERNAL_ZSTD=ON
+                    -DPREFER_EXTERNAL_ZSTD=ON \
+                    -DBUILD_TESTS=OFF \
+                    -DBUILD_BENCHMARKS=OFF


### PR DESCRIPTION
not installed
don't easily work at present
newer benchmarks use posix_memalign() which fails on
some older systems

closes: https://trac.macports.org/ticket/57630
