### PR TITLE
squid4: add "-lresolv" to kerberos variant

### DIFF
--- a/net/squid4/Portfile
+++ b/net/squid4/Portfile
@@ -5,6 +5,7 @@ PortGroup cxx11 1.1
 
 name            squid4
 version         4.4
+revision        1
 categories      net
 platforms       darwin
 license         GPL-2+
@@ -142,6 +143,7 @@ variant ipfw_transparent description "Enable transparent proxy support using IPF
 
 variant kerberos description "Enable MIT kerberos support" {
     depends_lib-append port:kerberos5
+    configure.ldflags-append "-lresolv"
     configure.args-delete --enable-auth-negotiate="wrapper" \
                           --without-mit-krb5
     configure.args-append --enable-auth-negotiate


### PR DESCRIPTION
 Refering to ​
  - https://trac.macports.org/ticket/57652#comment:4

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
