### PR TITLE
gnupg2: bison is not used at all

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -55,7 +55,6 @@ depends_lib         port:libiconv           \
                     port:gettext            \
                     port:zlib               \
                     port:bzip2              \
-                    port:bison              \
                     port:libassuan          \
                     port:libksba            \
                     port:libgcrypt          \


### PR DESCRIPTION
#### Description

gnupg2 builds and runs without bison. In the source code tarball, there are some bison or yacc words but none indicates either is used.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? (N/A)
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?