### PR TITLE
py-scikit-learn: use https homepage

### DIFF
--- a/python/py-scikit-learn/Portfile
+++ b/python/py-scikit-learn/Portfile
@@ -22,7 +22,7 @@ long_description    Scikit-learn integrates machine learning algorithms \
                     it provides versatile tools for data mining and analysis \
                     in any field of science and engineering.
 
-homepage            http://scikit-learn.org/
+homepage            https://scikit-learn.org/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}


### PR DESCRIPTION
#### Description

~~Please tag as WIP because I failed to build this for Python 3.7. I have not found nor filed an upstream bug report. Looking online briefly, the errors look similar to ones when older Cython is used, however I have checked that I have the latest version active (0.29).~~

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
~~Successful for Python 2.7 and 3.6, but not 3.7 (full log: https://gist.github.com/chrstphrchvz/939ce70ecd1f862606752401b473442e)~~ Maintainer's update works with Python 3.7.
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
