### PR TITLE
py-docker: update to 3.5.1

### DIFF
--- a/python/py-docker/Portfile
+++ b/python/py-docker/Portfile
@@ -4,37 +4,39 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        docker docker-py 2.4.2
+github.setup        docker docker-py 3.5.1
 name                py-docker
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
 maintainers         nomaintainer
+
 description         An API client for docker written in Python
 long_description    $description
 
-checksums           rmd160  cd359dce7ab56995df8e3a1f56b3cba8a9ce2be3 \
-                    sha256  c8ee526978a80c167ddbf4f45c8f6127d51ec8c2048b4453d5675055734e72ed
+checksums           rmd160  392e3c33730011c870bc167f16b53e03ea6f36c7 \
+                    sha256  c36e4cdfffcf2620a3dd92e1aa4937e0370ae2fc052bfde33b61ad66063a15f4 \
+                    size    209425
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${subport} ne ${name}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
-    depends_lib-append  port:py${python.version}-dockerpy-creds \
-                        port:py${python.version}-pip \
-                        port:py${python.version}-requests \
-                        port:py${python.version}-six \
-                        port:py${python.version}-websocket-client
-    if {${python.version} < 35} {
-        depends_lib-append    port:py${python.version}-backports-ssl_match_hostname
-    }
-    if {${python.version} < 33} {
-        depends_lib-append    port:py${python.version}-ipaddress
-    }
-    livecheck.type  none
-} else {
-    github.livecheck.regex  {([^"r-]+)}
-}
+                    port:py${python.version}-setuptools
 
+    depends_lib-append  \
+                    port:py${python.version}-dockerpy-creds \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-six \
+                    port:py${python.version}-websocket-client
+
+    if {${python.version} < 35} {
+        depends_lib-append  port:py${python.version}-backports-ssl_match_hostname
+    }
+    if {${python.version} eq 27} {
+        depends_lib-append  port:py${python.version}-ipaddress
+    }
+
+    livecheck.type  none
+}

--- a/python/py-dockerpy-creds/Portfile
+++ b/python/py-dockerpy-creds/Portfile
@@ -4,26 +4,28 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        shin- dockerpy-creds 0.2.1
+github.setup        shin- dockerpy-creds 0.3.0
 name                py-dockerpy-creds
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-maintainers         artisancomputer.com:zdw \
-                    openmaintainer
+maintainers         artisancomputer.com:zdw openmaintainer
 description         Python bindings for the docker credentials store API
 long_description    $description
 
-checksums           rmd160  b5d71f144841751326b533474308a635191c7956 \
-                    sha256  2a24525d79ef0c4decea6161e5b15ff7228f080508456df1f9429b1cdadbaab6
+checksums           rmd160  a3075482215e137dec3aac514e6a616e41904b85 \
+                    sha256  e18c24c93d627aa4b7a8b64bc95633fa0e727a566e020529d6707ca16e6cfd1a \
+                    size    10153
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${subport} ne ${name}} {
-    depends_build-append  port:py${python.version}-setuptools
-    depends_lib-append    port:py${python.version}-six
-    livecheck.type        none
-} else {
-    github.livecheck.regex  {([^"r-]+)}
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-six
+
+    livecheck.type  none
 }

--- a/python/py-websocket-client/Portfile
+++ b/python/py-websocket-client/Portfile
@@ -4,26 +4,31 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-websocket-client
-version             0.48.0
+version             0.54.0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             LGPL-2.1
 maintainers         nomaintainer
-homepage            https://pypi.org/project/websocket-client/
+homepage            https://github.com/websocket-client/websocket-client
 description         websocket client for python
 long_description    websocket-client module is WebSocket client for python
 
 master_sites        pypi:w/${python.rootname}
 distname            websocket_client-${version}
-checksums           rmd160 599b4eeef57ad46039e780f664460ff767b30d26 \
-                    sha256 18f1170e6a1b5463986739d9fd45c4308b0d025c1b2f9b88788d8f69e8a5eb4a
+checksums           rmd160  9058c0b2d691f1bab5e0e6359e4cbc09ad1a103a \
+                    sha256  e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849 \
+                    size    36413
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${subport} ne ${name}} {
-    depends_build   port:py${python.version}-setuptools
-    depends_lib     port:py${python.version}-six
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-six
+
+    test.run        yes
+    test.env        TEST_WITH_INTERNET=1
+    test.cmd        ${python.bin} setup.py
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- py-docker: update to 3.5.1, add py37, use default livecheck
Fixes:  https://trac.macports.org/ticket/57618

Also updates its dependencies to their latest versions:
- py-dockerpy-creds: update to 0.3.0, add py37, use default livecheck
- py-websocket-client: update to 0.54.0, add py37, enable tests, update homepage
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? where available
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
