### PR TITLE
py-spyder-devel: update to 9d8cd53 (20181122)

### DIFF
--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -7,8 +7,8 @@ PortGroup           qt5 1.0
 PortGroup           active_variants 1.1
 PortGroup           select 1.0
 
-github.setup        spyder-ide spyder 779fd0d
-version             3.3.0-20181103
+github.setup        spyder-ide spyder 9d8cd53
+version             3.3.0-20181122
 name                py-spyder-devel
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
@@ -39,9 +39,9 @@ supported_archs     noarch
 #pyNN-scipy doesn't build universal
 universal_variant   no
 
-checksums           rmd160  c0f453e8990166f81833cbf9d60c63d64921bb7d \
-                    sha256  ea57863ac778ac4c6771a5be9705297c4807131e25268e3922b5dc2f3d4e52a3 \
-                    size    4069105
+checksums           rmd160  3cd910182b51532e456c14c651055938af265716 \
+                    sha256  ab73d294f4044ccb599db33d47d07de0a50709ee606f622f715c40ebed4c2cbc \
+                    size    4083537
 
 if {${name} ne ${subport}} {
     require_active_variants py${python.version}-pyqt5 webengine


### PR DESCRIPTION
#### Description
- update to 9d8cd53 (20181122)
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
