### PR TITLE
llvm-6,7,devel : fix typo on  pthread_setname_np patch test

### DIFF
--- a/lang/llvm-6.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-6.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -24,7 +24,7 @@ index 267af388ecd..1c8c1b026e3 100644
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-7.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-7.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -24,7 +24,7 @@ index 267af388ecd..1c8c1b026e3 100644
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif

--- a/lang/llvm-devel/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-devel/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -24,7 +24,7 @@ index 267af388ecd..1c8c1b026e3 100644
    ::pthread_setname_np(::pthread_self(), "%s",
      const_cast<char *>(NameStr.data()));
  #elif defined(__APPLE__)
-+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
    ::pthread_setname_np(NameStr.data());
  #endif
 +#endif


### PR DESCRIPTION
__MAC_OS_X_VERSION_MAX_ALLOWED should be
MAC_OS_X_VERSION_MAX_ALLOWED

fixes llvm 6, 7, devel build error on Leopard and earlier