### PR TITLE
py-spyder: update to 3.3.2, add py37 subport

### DIFF
--- a/python/py-spyder/Portfile
+++ b/python/py-spyder/Portfile
@@ -7,13 +7,13 @@ PortGroup           qt5 1.0
 PortGroup           active_variants 1.1
 PortGroup           select 1.0
 
-github.setup        spyder-ide spyder 3.3.1 v
+github.setup        spyder-ide spyder 3.3.2 v
 name                py-spyder
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
 epoch               20111202
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 categories-append   devel
 platforms           darwin
@@ -38,9 +38,9 @@ supported_archs     noarch
 #pyNN-scipy doesn't build universal
 universal_variant   no
 
-checksums           rmd160  5379a2289668d4baf45b8883b083b76975375989 \
-                    sha256  7068e0c392257e9d72a9c7746dc48dd504d4d718e66ff5ac967ea830daa1e0e9 \
-                    size    3866157
+checksums           rmd160  94973e2faadc6e720ec3efec6dc8080e588da337 \
+                    sha256  963f07d92748c0a5513ceac99a6203bdb15b8d032663841e01426a16ca0ee23a \
+                    size    3946683
 
 if {${name} ne ${subport}} {
     require_active_variants    py${python.version}-pyqt5 webengine
@@ -128,7 +128,7 @@ if {${name} ne ${subport}} {
 
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} AUTHORS Announcements.md LICENSE \
+        xinstall -m 0644 -W ${worksrcpath} AUTHORS.txt Announcements.md LICENSE.txt \
             CHANGELOG.md CONTRIBUTING.md README.md RELEASE.md TROUBLESHOOTING.md \
             ${destroot}${docdir}
     }

--- a/python/py-spyder/files/spyder-37
+++ b/python/py-spyder/files/spyder-37
@@ -1,0 +1,1 @@
+bin/spyder-3.7


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
Successful for `py37-spyder` (I have not tried other versions)
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
