### PR TITLE
wine-devel: update to 3.21

### DIFF
--- a/x11/wine-devel/Portfile
+++ b/x11/wine-devel/Portfile
@@ -14,7 +14,7 @@ PortGroup                   compiler_blacklist_versions 1.0
 name                        wine-devel
 conflicts                   wine wine-crossover
 set my_name                 wine
-version                     3.20
+version                     3.21
 set branch                  [lindex [split ${version} .] 0].x
 license                     LGPL-2.1+
 categories                  x11
@@ -59,9 +59,9 @@ distfiles                   ${wine_distfile}:winesource \
                             ${wine_mono_distfile}:winemono
 
 checksums                   ${wine_distfile} \
-                            rmd160  fd5b517ca27acae5ed429ea700fb15ab547839e1 \
-                            sha256  33d61122085056e091042df7d2cbe908ffb9c06e602278611dca2eea6a566f18 \
-                            size    21541928 \
+                            rmd160  e4984745ebaaa4ac55702926def7632778d713b5 \
+                            sha256  a84cc06015df06e12c524213a98d879caa0d63f474b911cdd87f693fcfe2e0c0 \
+                            size    21573872 \
                             ${wine_gecko_distfile} \
                             rmd160  abf7cc78b49dd0623bc8fe87ae0e32bb8694e13d \
                             sha256  3b8a361f5d63952d21caafd74e849a774994822fb96c5922b01d554f1677643a \


### PR DESCRIPTION
#### Description

Update to wine 3.21, released 2018-11-23

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
macOS 10.13.6 17G65
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x ] checked your Portfile with `port lint`?
- [x ] tried existing tests with `sudo port test`?
- [x ] tried a full install with `sudo port -vst install`?
- [x ] tested basic functionality of all binary files?
