### PR TITLE
claws-mail: disable unrecognized ld flag on older systems

### DIFF
--- a/mail/claws-mail/Portfile
+++ b/mail/claws-mail/Portfile
@@ -55,6 +55,12 @@ depends_lib     port:gtk2 \
 require_active_variants \
                 gtk2 x11
 
+if {${os.platform} eq "darwin" && ${os.version} < 12} {
+    # the ld on older systems doesn't understand the -export_dynamic flag
+    # see https://trac.macports.org/ticket/57673
+    patchfiles  patch-claws-mail-no-export-dynamic-on-older-ld-versions.diff
+}
+
 configure.args  --disable-jpilot \
                 --disable-acpi_notifier-plugin \
                 --disable-bsfilter-plugin \

--- a/mail/claws-mail/files/patch-claws-mail-no-export-dynamic-on-older-ld-versions.diff
+++ b/mail/claws-mail/files/patch-claws-mail-no-export-dynamic-on-older-ld-versions.diff
@@ -1,0 +1,10 @@
+--- configure.ac.old	2018-11-25 13:41:01.000000000 -0800
++++ configure.ac	2018-11-25 13:41:24.000000000 -0800
+@@ -118,7 +118,6 @@
+     ;;
+ 	*-apple-*)
+ 		platform_osx=yes
+-		LDFLAGS="$LDFLAGS -Wl,-export_dynamic"
+ 		;;
+   *)
+     platform_win32=no


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/57673

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 3.2.6

