### PR TITLE
mariadb-10.2: update to 10.2.19

### DIFF
--- a/databases/mariadb-10.2/Portfile
+++ b/databases/mariadb-10.2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mariadb-10.2
 set name_mysql      ${name}
-version             10.2.17
+version             10.2.19
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump version.
 set revision_client 0
@@ -45,9 +45,9 @@ if {$subport eq $name} {
     patchfiles          patch-cmake-install_layout.cmake.diff \
                         patch-CMakeLists.txt.diff
 
-    checksums           rmd160  125e507a88542d61ff44381d10086e3a81c5f54a \
-                        sha256  e7b3078f8de874a4d451242a8a3eed49bf6f916dcd52fc3efa55886f5f35be27 \
-                        size    73409162
+    checksums           rmd160  ededbc6769bbf4a7fbba606f9f2d0e4a3ef61d4c \
+                        sha256  c0e103cfd73ee96d58402073e9513f0f7b5c0bd216641faecc8d763fb6529727 \
+                        size    71856357
 
     depends_lib-append  port:zlib port:tcp_wrappers port:ncurses port:judy
     depends_run-append  port:mysql_select


### PR DESCRIPTION
#### Description
https://mariadb.com/kb/en/library/mariadb-10219-release-notes/

Notable Changes...

Fixes for the following security vulnerabilities:

    CVE-2018-3282
    CVE-2016-9843
    CVE-2018-3174
    CVE-2018-3143
    CVE-2018-3156
    CVE-2018-3251
    CVE-2018-3185
    CVE-2018-3277
    CVE-2018-3162
    CVE-2018-3173
    CVE-2018-3200
    CVE-2018-3284

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
