### PR TITLE
py-spyder-kernels: update to 0.3.0

### DIFF
--- a/python/py-spyder-kernels/Portfile
+++ b/python/py-spyder-kernels/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-spyder-kernels
-version             0.2.6
+version             0.3.0
 epoch               1
 categories-append   devel
 platforms           darwin
@@ -22,9 +22,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            spyder-kernels-${version}
 
-checksums           rmd160  7bdfeab3c027d3aa64849bdf06b20a1f8cbb0418 \
-                    sha256  26c8e9f78f90ac107ee72ccf78b2550d65d437010990aaf30396d0f90af3282c \
-                    size    38507
+checksums           rmd160  f326654bdca192831bd53669e207f72eb59d7ea4 \
+                    sha256  dcf54b519db2a11dcbbc07d3d06caea61b102f0d498c0282a08d00d91b578005 \
+                    size    34422
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-spyder-kernels-devel
@@ -40,19 +40,18 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-numpy \
                             port:py${python.version}-pandas
 
-    test.run                yes
+    test.run                no
     test.cmd                py.test-${python.branch}
     test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt CHANGELOG.md README.md \
-            ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} AUTHORS.txt CHANGELOG.md \
+            LICENSE.txt README.md ${destroot}${docdir}
     }
 
     livecheck.type      none
 } else {
-    livecheck.type      pypi
     livecheck.regex     spyder-kernels-(0\\.\\d+\.\\d+)${extract.suffix}
 }


### PR DESCRIPTION
#### Description
- update to version 0.3.0
- disable tests for now as upstream has decided not to ship these anymore because "this package is not easey to test locally".
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? N/A
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
