### PR TITLE
Travis: Only use the MacPorts CDN, not the mirrors

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -16,6 +16,8 @@ unset CC && source /opt/local/share/macports/setupenv.bash
 sudo sed -i "" "s|rsync://rsync.macports.org/macports/release/tarballs/ports.tar|file://${PWD}|; /^file:/s/default/nosync,default/" /opt/local/etc/macports/sources.conf
 # CI is not interactive
 echo "ui_interactive no" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
+# Only download from the CDN, not the mirrors
+echo "host_blacklist *.distfiles.macports.org *.packages.macports.org" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
 # Update PortIndex
 rsync --no-motd -zvl "rsync://rsync.macports.org/macports/release/ports/PortIndex_darwin_${OS_MAJOR}_i386/PortIndex*" .
 git remote add macports https://github.com/macports/macports-ports.git


### PR DESCRIPTION
#### Description

When Travis tries to build a port and an archive can't be found, it tries three mirrors before building from source:

```
--->  Fetching archive for fluidsynth
DEBUG: Executing org.macports.archivefetch (fluidsynth)
DEBUG: euid/egid changed to: 0/0
DEBUG: chowned /opt/local/var/macports/incoming to macports
DEBUG: euid/egid changed to: 502/501
--->  fluidsynth-2.0.2_0.darwin_17.x86_64.tbz2 doesn't seem to exist in /opt/local/var/macports/incoming/verified
--->  Attempting to fetch fluidsynth-2.0.2_0.darwin_17.x86_64.tbz2 from https://packages.macports.org/fluidsynth
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
DEBUG: Fetching archive failed: The requested URL returned error: 404 Not Found
--->  Attempting to fetch fluidsynth-2.0.2_0.darwin_17.x86_64.tbz2 from http://ywg.ca.packages.macports.org/mirror/macports/packages/fluidsynth
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
DEBUG: Fetching archive failed: The requested URL returned error: 404 Not Found
--->  Attempting to fetch fluidsynth-2.0.2_0.darwin_17.x86_64.tbz2 from http://sea.us.packages.macports.org/macports/packages/fluidsynth
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
DEBUG: Fetching archive failed: The requested URL returned error: 404 Not Found
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: Skipping completed org.macports.fetch (fluidsynth)
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: checksum phase started at Wed Nov 28 15:48:26 GMT 2018
--->  Verifying checksums for fluidsynth
DEBUG: Executing org.macports.checksum (fluidsynth)
```

This is how MacPorts works, because the mirror closest to the user might not have synced recently enough to have a particular archive yet, so we try a couple others before giving up and building from source.

But in the case of our CI systems, where we frequently build new ports or new versions of ports for which archives aren't available, we should just check a single server. We should just check the main CDN location, since if the file isn't there, it won't be on the mirrors either. The CDN has multiple points of presence, and it's the URL Travis was checking first anyway, so one of the CDN's POPs was already the closest server to Travis, so this change won't slow Travis downloads down, and will speed things up slightly by not checking an unnecessary 2nd and 3rd URL.

The buildbot already does this, based on how mpbb-checkout sets up macports.conf, but since for Travis CI we don't use mpbb-checkout, this PR makes the equivalent change to the bootstrap.sh script.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix
