### PR TITLE
clang-7.0: work around no libdispatch on < 10.6

### DIFF
--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -171,6 +171,7 @@ if {${subport} eq "clang-${llvm_version}"} {
         3001-Fix-local-and-iterator-when-building-with-Lion-and-n.patch \
         3002-Fix-missing-long-long-math-prototypes-when-using-the.patch \
         3003-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch \
+        3004-compiler-rt-leopard-no-libdispatch.patch \
         openmp-locations.patch
 
     # https://llvm.org/bugs/show_bug.cgi?id=25681
@@ -308,6 +309,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 # Xcode 5.1's clang (clang-503.0.40) has codegen issues (resulting compiler crashes)
 # Xcode 6.2's clang (600.0.57) fails due to https://llvm.org/bugs/show_bug.cgi?id=25753
 compiler.blacklist *gcc* {clang < 602}
+compiler.fallback-append macports-clang-3.7 macports-clang-3.9
 
 if {${subport} eq "clang-${llvm_version}"} {
     # clang older than 3.5 fail due to https://llvm.org/bugs/show_bug.cgi?id=25753

--- a/lang/llvm-7.0/files/3004-compiler-rt-leopard-no-libdispatch.patch
+++ b/lang/llvm-7.0/files/3004-compiler-rt-leopard-no-libdispatch.patch
@@ -1,0 +1,46 @@
+--- a/projects/compiler-rt/lib/builtins/os_version_check.c.orig	2018-06-18 19:56:24.000000000 -0700
++++ b/projects/compiler-rt/lib/builtins/os_version_check.c	2018-11-27 23:41:04.000000000 -0800
+@@ -15,9 +15,12 @@
+ 
+ #ifdef __APPLE__
+ 
++#include <AvailabilityMacros.h>
+ #include <CoreFoundation/CoreFoundation.h>
+ #include <TargetConditionals.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ #include <dispatch/dispatch.h>
++#endif
+ #include <dlfcn.h>
+ #include <stdint.h>
+ #include <stdio.h>
+@@ -26,7 +29,15 @@
+ 
+ /* These three variables hold the host's OS version. */
+ static int32_t GlobalMajor, GlobalMinor, GlobalSubminor;
+-static dispatch_once_t DispatchOnceCounter;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++ static dispatch_once_t DispatchOnceCounter;
++#endif
++
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++/* declare a missing reference not found in SDK < 10.6 for function called below */
++typedef struct __CFError * CFErrorRef;
++extern CFPropertyListRef CFPropertyListCreateWithData(CFAllocatorRef, CFDataRef, CFOptionFlags, CFPropertyListFormat *, CFErrorRef *);
++#endif
+ 
+ typedef CFDataRef (*CFDataCreateWithBytesNoCopyFuncTy)(CFAllocatorRef,
+                                                        const UInt8 *, CFIndex,
+@@ -180,7 +190,13 @@
+ 
+ int32_t __isOSVersionAtLeast(int32_t Major, int32_t Minor, int32_t Subminor) {
+   /* Populate the global version variables, if they haven't already. */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+   dispatch_once_f(&DispatchOnceCounter, NULL, parseSystemVersionPList);
++#else
++  /* expensive procedure, only do once. GlobalMajor will not be 0 once run. */
++  if (GlobalMajor == 0) 
++    parseSystemVersionPList(NULL);
++#endif
+ 
+   if (Major < GlobalMajor)
+     return 1;


### PR DESCRIPTION
similar but not identical to the fix in clang-6.0

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
