### PR TITLE
lilypond-devel: Remove obsolete code.

### DIFF
--- a/textproc/lilypond-devel/Portfile
+++ b/textproc/lilypond-devel/Portfile
@@ -122,8 +122,6 @@ variant mactex description {Allow lilypond-devel to use MacTeX or another\
 patchfiles          patch-scripts-build-mf2pt1.pl.diff \
                     patch-no-Wstrict-prototypes-warning.diff
 post-patch {
-    reinplace s|__vector|lily_vector|g ${worksrcpath}/flower/include/std-vector.hh
-
     # Use guile18 header files
     reinplace s|libguile\.h|libguile18.h|g \
         ${worksrcpath}/aclocal.m4 \


### PR DESCRIPTION
This has been fixed in lilypond's git about 9 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
