### PR TITLE
armadillo: fix error with hdf5 +openmpi

### DIFF
--- a/science/armadillo/Portfile
+++ b/science/armadillo/Portfile
@@ -3,6 +3,7 @@
 PortSystem                      1.0
 PortGroup                       cmake 1.0
 PortGroup                       compiler_blacklist_versions 1.0
+PortGroup                       active_variants 1.1
 
 name                            armadillo
 version                         9.200.5
@@ -35,6 +36,10 @@ depends_build-append            port:pkgconfig
 depends_lib-append              port:hdf5
 
 cmake.out_of_source             yes
+
+if {[active_variants hdf5 openmpi]} {
+    configure.args-append       -DCMAKE_REQUIRED_INCLUDES=${prefix}/include/openmpi-mp
+}
 
 configure.args-append           -DARPACK_LIBRARY=
 


### PR DESCRIPTION
* force include path for openmpi-mp when hdf5 has openmpi variant

Closes: https://trac.macports.org/ticket/55153

#### Description
This fixes the problem with hdf5 +openmpi. I don't know about hdf5 +mpich (or other mpi variants).

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.12.6 16G1510
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
