### PR TITLE
py-keyring: update to 17.0.0

### DIFF
--- a/python/py-keyring/Portfile
+++ b/python/py-keyring/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keyring
-version             16.1.1
+version             17.0.0
 categories-append   security
 
 license             {MIT PSF}
@@ -21,9 +21,9 @@ homepage            https://github.com/jaraco/keyring
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  0204a924e482bee7d17032a5184da1f81cd4346d \
-                    sha256  e663a36c46ecd5070d6a019d0046ed331e2830363d8b7ef0f510a6497f65abe0 \
-                    size    43922
+checksums           rmd160  33e1cf607ba17a6408b2ac00c5be404cb50aa409 \
+                    sha256  d3744d22e398c19405d819d3c2d3bb82dc05a96513f577411c8847bb207dc289 \
+                    size    44171
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to 17.0.0
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
