### PR TITLE
py-lmfit: update to 0.9.12

### DIFF
--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-lmfit
-version                 0.9.11
+version                 0.9.12
 categories-append       math
 license                 BSD
 maintainers             {gmail.com:jjstickel @jjstickel} {gmail.com:ottenr.work @reneeotten} openmaintainer
@@ -18,9 +18,9 @@ homepage                https://lmfit.github.io/lmfit-py/
 master_sites            pypi:l/lmfit/
 distname                lmfit-${version}
 
-checksums               rmd160  fe1c29354627524f769cde7f03517dad45d7cacb \
-                        sha256  f635c69fa67cd4d3daa1148f449abc2ff1e19adf5761b3eac7d314224d7506e2 \
-                        size    1600601
+checksums               rmd160  dc4bb6835e34fadd8786c1dd760f09df694dba6b \
+                        sha256  a8fb058f8ab792fbd01a5d7a659f630822a279c780210df6e32640e1aba58d31 \
+                        size    1569497
 
 python.versions         27 34 35 36 37
 

--- a/python/py-lmfit/Portfile
+++ b/python/py-lmfit/Portfile
@@ -24,22 +24,21 @@ checksums               rmd160  fe1c29354627524f769cde7f03517dad45d7cacb \
 
 python.versions         27 34 35 36 37
 
-if {$subport ne $name} {
-    depends_build-append       port:py${python.version}-setuptools
+if {${subport} ne ${name}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
 
-    depends_lib-append         port:py${python.version}-scipy \
-                               port:py${python.version}-numpy \
-                               port:py${python.version}-six \
-                               port:py${python.version}-asteval \
-                               port:py${python.version}-uncertainties
+    depends_lib-append  port:py${python.version}-scipy \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-six \
+                        port:py${python.version}-asteval \
+                        port:py${python.version}-uncertainties
 
-    depends_test-append        port:py${python.version}-pytest
-    test.run                   yes
-    test.cmd                   py.test-${python.branch}
+    depends_test-append port:py${python.version}-pytest
+    test.run            yes
+    test.cmd            py.test-${python.branch}
     test.target
-    test.env                   PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type      none
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}
@@ -48,6 +47,6 @@ if {$subport ne $name} {
        xinstall -m 644 {*}[glob ${worksrcpath}/examples/*] \
           ${destroot}${prefix}/share/doc/${subport}/examples
        }
-} else {
-    livecheck.type      pypi
+
+    livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to 0.9.12
- whitespace changes
- use default livecheck

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
