### PR TITLE
netpbm: Update to 10.84.03

### DIFF
--- a/graphics/netpbm/Portfile
+++ b/graphics/netpbm/Portfile
@@ -5,12 +5,12 @@ PortGroup               github 1.0
 
 # Download distfiles from GitHub mirror because fetching from svn keeps being
 # problematic.
-github.setup            chneukirchen netpbm-mirror f79daabd7540e5cc6c6a6cd128b884ea0de54906
+github.setup            chneukirchen netpbm-mirror 79ff71515b3b4dc36ca5fd62fe0b8443a3f175f5
 name                    netpbm
-version                 10.84.02
-svn.revision            3405
-set userguide_commit    ea4ccc82bcaf4fdf8154567808ddf1c71bf983d8
-set userguide_revision  3378
+version                 10.84.03
+svn.revision            3430
+set userguide_commit    d726a17a8d41b8f44f684a5e423f68b8f9c811c4
+set userguide_revision  3420
 
 categories              graphics
 platforms               darwin freebsd linux
@@ -41,13 +41,13 @@ master_sites            ${github.master_sites}:source \
                         ${github.homepage}/tarball/${userguide_commit}:userguide
 
 checksums               ${source_distfile} \
-                        rmd160  b8d8e1a773d7e9dd5eba9c97a05fde367ed13681 \
-                        sha256  09bbc638f7e29f1d3118406cd267e17fcf7d7f27b52875fdae7e44541fe1ce16 \
-                        size    2821634 \
+                        rmd160  aed47025a9ea86f74c5881d846d7d86564ed6174 \
+                        sha256  ab182f967fcbfc378c130b2fcb27d830325f3cba8923923f56af5d5877abe1c1 \
+                        size    2822539 \
                         ${userguide_distfile} \
-                        rmd160  5ee192f111207d716e8002f2388e69f8e0e5cd57 \
-                        sha256  1f844c9eb6975a48dc8fd15fbaee67f8a5f0dc0a1293c297fc8d9a87b30a5687 \
-                        size    1206800
+                        rmd160  93f52d61ffe87f3333520c15c45974ee2329e0b3 \
+                        sha256  7db319246952517678f0f71fb54afd8ff722f5266a1d1db1b6452a5e176df1ff \
+                        size    1207031
 
 post-extract {
     move ${workpath}/${github.author}-${github.project}-[string range ${git.branch} 0 6] ${workpath}/${distname}


### PR DESCRIPTION
#### Description

netpbm: Update to 10.84.03

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
