### PR TITLE
py-kerfi-vangasvipur: fix installation

### DIFF
--- a/python/py-kerfi-vangasvipur/Portfile
+++ b/python/py-kerfi-vangasvipur/Portfile
@@ -7,32 +7,37 @@ PortGroup           github 1.0
 
 github.setup        steenzout python-kerfi-vangasvipur 1.0.0
 
-set real_name       kerfi-vangasvipur
 name                py-kerfi-vangasvipur
 version             1.0.0
 maintainers         {gmail.com:pedro.salgado @steenzout}
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-description         python tool to manipulate OS X system_profiler output.
-long_description    Python tool to manipulate OS X system_profiler output.
-homepage            https://www.github.com/steenzout/python-${real_name}/
+description         Python tool to manipulate OS X system_profiler output.
+long_description    ${description}
 
 checksums           sha256 0513135f4b13c9bb3d1297e0de02ccf77db258bc7d493b44dbe07e868f1ed42a \
-                    rmd160 168a81a270feb979da9df562e78283fc581b2642
+                    rmd160 168a81a270feb979da9df562e78283fc581b2642 \
+                    size   11652
 
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_lib-append port:${real_name}_select \
-                       port:py${python.version}-pip
-    livecheck.type     none
-    select.group       ${real_name}
-    select.file        ${filespath}/kv-print${python.version}
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    patchfiles          patch-setup.py.diff
+
+    depends_run-append  port:${python.rootname}_select
+    select.group        ${python.rootname}
+    select.file         ${filespath}/kv-print${python.version}
+
     notes "
-To make the Python ${python.branch} version of ${real_name} the one that is run\
+To make the Python ${python.branch} version of ${python.rootname} the one that is run\
 when you execute the commands without a version suffix, e.g. 'kv-print', run:
 
 port select --set ${select.group} [file tail ${select.file}]
 "
+
+    livecheck.type      none
 }

--- a/python/py-kerfi-vangasvipur/files/patch-setup.py.diff
+++ b/python/py-kerfi-vangasvipur/files/patch-setup.py.diff
@@ -1,0 +1,29 @@
+--- setup.py.orig	2018-12-02 22:48:29.000000000 -0500
++++ setup.py	2018-12-02 22:49:56.000000000 -0500
+@@ -3,10 +3,14 @@
+ 
+ import kerfi
+ 
++from setuptools import find_packages, setup
+ 
+-from pip.req import parse_requirements
++with open('requirements.txt', 'r') as f:
++    install_reqs = f.read().splitlines()
++
++with open('test-requirements.txt', 'r') as f:
++    test_reqs = f.read().splitlines()
+ 
+-from setuptools import find_packages, setup
+ 
+ setup(name='kerfi-vangasvipur',
+       version=kerfi.version(),
+@@ -17,7 +21,7 @@
+       maintainer_email='steenzout@ymail.com',
+       url='https://github.com/steenzout/python-kerfi-vangasvipur',
+       packages=find_packages(exclude=('*.tests', '*.tests.*', 'tests.*', 'tests')),
+-      install_requires=[str(pkg.req) for pkg in parse_requirements('requirements.txt')],
+-      tests_requires=[str(pkg.req) for pkg in parse_requirements('test-requirements.txt')],
++      install_requires=install_reqs,
++      tests_requires=test_reqs,
+       scripts=(
+           'scripts/kv-print',),)


### PR DESCRIPTION
#### Description
- patch setup.py so that pip.req is no longer needed
- update dependencies
- make use of python.rootname
- use default GitHub homepage
- modernize checksums

Closes: https://trac.macports.org/ticket/56578
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
