### PR TITLE
nsf: update to nsf 2.2.0

### DIFF
--- a/lang/nsf/Portfile
+++ b/lang/nsf/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            nsf
-version         2.1.0
+version         2.2.0
 categories      lang
 license         MIT
 maintainers     {wu.ac.at:neumann @gustafn} openmaintainer
@@ -14,14 +14,14 @@ long_description    The Next Scripting Framework (NSF) was developed based on th
             the development on a rich set of predefined but extensible set of functions \
             (typically implemented in C) which can be registered on object / class skeletons. \
             NSF provides a basis for defining object-oriented, domain-specific languages. \
-            The framework is packaged with XOTcl 2.1 and NX (Next Scripting Language, \
+            The framework is packaged with XOTcl 2.2 and NX (Next Scripting Language, \
             successor of XOTcl)
 platforms       darwin
 homepage        https://next-scripting.org/
 
 # Set tclv and checksums to the current MacPorts Tcl port version, though port doesn't
 # break if they aren't in sync.
-set tclv        8.6.6
+set tclv        8.6.9
 
 master_sites    sourceforge:project/next-scripting/${version}:nsf \
                 sourceforge:project/tcl/Tcl/${tclv}:tcl
@@ -32,11 +32,11 @@ distfiles       ${distname}.tar.gz:nsf \
                 tcl${tclv}-src.tar.gz:tcl
 
 checksums       ${distname}.tar.gz \
-                    sha1    00ed655eac33a85128094f9049166eea37569b68 \
-                    rmd160  7e2c738765c61cb73f1f80d070e2581cc27e1a62 \
+                    sha1    ee50e594837ad241dc8012e88af7b878f5437607 \
+                    rmd160  dcd623ef9e977ff3a31035ff8391087066cbada8 \
                 tcl${tclv}-src.tar.gz \
-                    sha1    169dd1589cad62c9fac4257c113db245da502cd0 \
-                    rmd160  2386a69eb841f8af51c1b124f68e0b812a225cca
+                    sha1    cf8c0cdfe953179991d052346642b5c42aa9c6c3 \
+                    rmd160  2c8bca97b2f8782fb27d4a297b84ba190a797185
 
 depends_lib     port:tcl
 

--- a/lang/nsf/Portfile
+++ b/lang/nsf/Portfile
@@ -34,9 +34,13 @@ distfiles       ${distname}.tar.gz:nsf \
 checksums       ${distname}.tar.gz \
                     sha1    ee50e594837ad241dc8012e88af7b878f5437607 \
                     rmd160  dcd623ef9e977ff3a31035ff8391087066cbada8 \
+                    sha256  fa83d7561694a0cc4d1d0613e776f012e56d14a112d781a17e0383a7e121796c \
+                    size    3068054 \
                 tcl${tclv}-src.tar.gz \
                     sha1    cf8c0cdfe953179991d052346642b5c42aa9c6c3 \
-                    rmd160  2c8bca97b2f8782fb27d4a297b84ba190a797185
+                    rmd160  2c8bca97b2f8782fb27d4a297b84ba190a797185 \
+                    sha256  04abaa207f4bf4f453bea5bbdbcf6cf4bcdba3ed1c5160bfd732c6b8c70c6269 \
+                    size    10000391
 
 depends_lib     port:tcl
 


### PR DESCRIPTION

#### Description

nsf 2.2.0 was released September 28, 2018.
This update  fixes a problem with nsf 2.1.0 with the new release of Tcl 8.6.9

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
