### PR TITLE
py-django-*: obsolete py34 subport

### DIFF
--- a/python/py-django-htmlmin/Portfile
+++ b/python/py-django-htmlmin/Portfile
@@ -22,7 +22,7 @@ long_description \
 checksums           rmd160  6b0a90fdb8d3591f0273d56211c2d04d1337c145 \
                     sha256  7f00773ecadb73161f74e12a1ab57d029fbb3ef631a9c62c9655949c84a549b3
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-django-htmlmin/files/django-htmlmin34
+++ b/python/py-django-htmlmin/files/django-htmlmin34
@@ -1,1 +1,0 @@
-bin/pyminify-3.4

--- a/python/py-django-nose/Portfile
+++ b/python/py-django-nose/Portfile
@@ -23,7 +23,7 @@ checksums           md5     199d5358317a804b39fe05d806cab427 \
                     rmd160  bdd535ec8bbd042eab00c47b605848ad67b14fdd \
                     sha256  9aae16b562866a4ddaa5e8978729abadbbed544728d88e0b9c9af7b31dd072ed
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_lib     port:py${python.version}-django \

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -128,8 +128,8 @@ py-distutils-extra      2.39_1      33
 py-django               1.11.11_1   26 33 34
 py-django-debug-toolbar 0.9.4_1     26
 py-django-extensions    1.1.1_1     26
-py-django-htmlmin       1.2_1       26
-py-django-nose          0.7.0_1     26
+py-django-htmlmin       0.10.0_1    26 34
+py-django-nose          1.2_1       26 34
 py-djvubind             1.2.1_2     33
 py-dnspython            1.15.0_1    26 33
 py-docx                 0.0.2_2     26


### PR DESCRIPTION
#### Description
This PR removes the py34 subports of py-django-htmlmin and py-django-nose that both depend on py-django for which the py34 subport was already removed. Both have no dependencies.

Closes: https://trac.macports.org/ticket/57620

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A only removed subports
- [ ] tried a full install with `sudo port -vst install`? N/A only removed subports
- [ ] tested basic functionality of all binary files? N/A only removed subports

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
