### PR TITLE
libpng: Update to 1.6.36

### DIFF
--- a/graphics/libpng/Portfile
+++ b/graphics/libpng/Portfile
@@ -3,10 +3,10 @@
 PortSystem              1.0
 
 name                    libpng
-version                 1.6.35
-checksums               rmd160  98bf278474dcf200eb80596d54cd26fa900cdb2a \
-                        sha256  23912ec8c9584917ed9b09c5023465d71709dce089be503c7867fec68a93bcd7 \
-                        size    1014320
+version                 1.6.36
+checksums               rmd160  baafcb54ff4913da18c349b14d9a1e98973b17c0 \
+                        sha256  eceb924c1fa6b79172fdfd008d335f0e59172a86a66481e09d4089df872aa319 \
+                        size    1012544
 
 set branch              [join [lrange [split ${version} .] 0 1] ""]
 categories              graphics


### PR DESCRIPTION
#### Description

libpng: Update to 1.6.36

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
