### PR TITLE
libvirt, py-libvirt: Update to 4.10.0

### DIFF
--- a/python/py-libvirt/Portfile
+++ b/python/py-libvirt/Portfile
@@ -5,10 +5,10 @@ PortGroup           python 1.0
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                py-libvirt
-version             4.9.0
-checksums           rmd160  b81157a8c3a91ee2cae6bacfef59f7c7c5323ce4 \
-                    sha256  01c4becf50b521a9e3d1b48a3a79d83cb389d86d760b895d911d78f5b6ae7b60 \
-                    size    191922
+version             4.10.0
+checksums           rmd160  28ab00336a6f72ca92ed90c3ca57770603920867 \
+                    sha256  6949fa09d5e3a2a03438c1334c2ed441f502222c7f21e654620f466593bcd185 \
+                    size    192707
 
 platforms           darwin
 license             MIT

--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
-version             4.9.0
-checksums           rmd160  9866b57bbfe31b5b0d86d55b893cd69efdfcf53d \
-                    sha256  4fd4bfe7312b7996a817c7919cf0062de0d5b3c400c93bd30855a46c40dd455a \
-                    size    14744184
+version             4.10.0
+checksums           rmd160  a47ada095ae6f0e980dd6740dadf7a35188a5b86 \
+                    sha256  7f9d830173f146ed3b8a8fdf6b6e03a99ce72b21a26c1468b2b688e5fdff276c \
+                    size    14841188
 
 categories          sysutils
 license             LGPL-2.1+


### PR DESCRIPTION
#### Description

libvirt, py-libvirt: Update to 4.10.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
