### PR TITLE
dcmtk: Update to 3.6.4, use github mirror.

### DIFF
--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -2,11 +2,11 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               muniversal 1.0
 PortGroup               conflicts_build 1.0
-
-name                    dcmtk
 PortGroup               cmake 1.0
+PortGroup               github 1.0
 
-version                 3.6.3
+github.setup            DCMTK dcmtk 3.6.4 DCMTK-
+
 revision                0
 set unpatched_version   [lindex [split ${version} _] 0]
 set stripped_version    [string map {. ""} ${unpatched_version}]
@@ -30,18 +30,12 @@ long_description        DCMTK is a collection of libraries and applications    \
 
 homepage                http://dicom.offis.de/dcmtk
 
-#Go back to non-snapshots once a new release finally comes...
-master_sites \
- ftp://dicom.offis.de/pub/dicom/offis/software/dcmtk/dcmtk${stripped_version}/ \
- http://dicom.offis.de/download/dcmtk/dcmtk${stripped_version}/
-#master_sites            http://dicom.offis.de/download/dcmtk/snapshot/ \
-                        http://dicom.offis.de/download/dcmtk/snapshot/old/
-
-distname                ${name}-${version}
+distname                DCMTK-${version}
 
 checksums \
-    rmd160  236beec5b0ac04f238cd82ca8f06e9e8855fb1bc \
-    sha256  63c373929f610653f10cbb8218ec643804eec6f842d3889d2b46a227da1ed530
+    rmd160  3cec9851ec086d4bbb7087310e0ee087bf013fbb \
+    sha256  6ae2dbae581ad5ea799d4c4546c6bad8a1782e7acd06a6497c7fb4f2f4bfee42 \
+    size    6199593
 
 cmake.out_of_source     yes
 
@@ -65,6 +59,15 @@ configure.args-append   -DDCMTK_WITH_TIFF=OFF \
                         -DDCMTK_WITH_SNDFILE=OFF \
                         -DDCMTK_WITH_WRAP=ON \
                         -DDCMTK_ENABLE_CXX11=OFF
+
+post-configure {
+    # 7921b2e in base creates symlinks, bypassing the github portgroup's move
+    # which would be OK, except Doxygen doesn't seem to like being pointed to a
+    # symlink as the base of the directories to search for sources. However,
+    # adding a '/.' to the end of the INPUT line makes it happy again, so...
+    # https://github.com/doxygen/doxygen/issues/3518
+    reinplace -E "s|^(INPUT .*)|\\1/.|" doxygen/htmldocs.cfg
+}
 
 variant doc description "Install documentation" {
     depends_build-append    port:doxygen


### PR DESCRIPTION
Maintainer update to 3.6.4.
Work-around changes incoming with https://github.com/macports/macports-base/pull/55 which broke +doc generation.