### PR TITLE
py-netcdf4: revbump

### DIFF
--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 
 name                py-netcdf4
 version             1.2.9
-revision            2
+revision            3
 categories-append   science
 platforms           darwin
 maintainers         {sean @seanfarley} \

--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -27,7 +27,8 @@ master_sites        pypi:n/netCDF4
 distname            netCDF4-${version}
 
 checksums           rmd160  232de81a67802e90c21117e32c2b549d184470d2 \
-                    sha256  259edab1f03b1c1b93bdbaa804d50211a0c9d8a15eee4f23988b5685c6c0d2c0
+                    sha256  259edab1f03b1c1b93bdbaa804d50211a0c9d8a15eee4f23988b5685c6c0d2c0 \
+                    size    538450
 
 mpi.enforce_variant netcdf
 mpi.setup


### PR DESCRIPTION
#### Description

Just resolving
```
--->  Scanning binaries for linking errors
Could not open /opt/local/lib/libhdf5.101.dylib: Error opening or reading file (referenced from /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/netCDF4/_netCDF4.so)
--->  Found 2 broken files, matching files to ports      
--->  Found 2 broken ports, determining rebuild order
You can always run 'port rev-upgrade' again to fix errors.
The following ports will be rebuilt:
 py27-netcdf4 @1.2.9
 py37-netcdf4 @1.2.9
```
and wondering if perhaps these ports also need an explicit dependency on `hdf5`.

@mamoll

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
