### PR TITLE
tokyocabinet: enable debug build

### DIFF
--- a/databases/tokyocabinet/Portfile
+++ b/databases/tokyocabinet/Portfile
@@ -28,7 +28,8 @@ master_sites        ${homepage}
 checksums           rmd160  8fb3c2f2e424a2135cb021d46905a783a1032a7b \
                     sha256  a003f47c39a91e22d76bc4fe68b9b3de0f38851b160bbb1ca07a4f6441de1f90
 
-patchfiles          patch-configure.diff
+patchfiles          patch-configure.diff \
+                    patch-tokyocabinet-no-static.diff
 
 depends_lib         port:zlib \
                     port:bzip2
@@ -45,11 +46,8 @@ configure.args      --mandir=${prefix}/share/man \
 test.run            yes
 test.target         check
 
-# broken on snow leopard, ticket #25513
-if {${os.major} < 10 || ${os.platform} ne "darwin"} {
 variant debug conflicts devel profile fastest description {build for debugging} {
     configure.args-append   --enable-debug
-}
 }
 
 variant devel conflicts profile fastest description {build for development} {

--- a/databases/tokyocabinet/files/patch-tokyocabinet-no-static.diff
+++ b/databases/tokyocabinet/files/patch-tokyocabinet-no-static.diff
@@ -1,0 +1,12 @@
+diff --git configure configure
+index ae1371b..3446401 100755
+--- configure
++++ configure
+@@ -2113,7 +2113,6 @@ if test "$enable_debug" = "yes"
+ then
+   MYCFLAGS="-std=c99 -Wall -fPIC -pedantic -fsigned-char -g -O0"
+   MYCPPFLAGS="$MYCPPFLAGS -UNDEBUG"
+-  MYCMDLDFLAGS="$MYCMDLDFLAGS -static"
+   enables="$enables (debug)"
+ fi
+ 


### PR DESCRIPTION
macOS does not like -static linking for anything other
than building the kernel
closes: https://trac.macports.org/ticket/25513

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
