### PR TITLE
py-ipython-sql: fix install for py27 subport

### DIFF
--- a/python/py-ipython-sql/Portfile
+++ b/python/py-ipython-sql/Portfile
@@ -3,10 +3,7 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           ipython-sql
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
+name                py-ipython-sql
 version             0.3.9
 categories-append   databases
 platforms           darwin
@@ -24,8 +21,8 @@ long_description    \
 
 homepage            https://github.com/catherinedevlin/ipython-sql
 
-distname            ${_name}-${version}
-master_sites        pypi:${_n}/${_name}/
+distname            ${python.rootname}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
 
 checksums           rmd160  350da7130942b86415eebf899552edd57379ca07 \
                     sha256  7187f6371f38b89d8fb63c2c7c4233d9000fb53b460dae79e4a359df366cc3ed \
@@ -34,6 +31,10 @@ checksums           rmd160  350da7130942b86415eebf899552edd57379ca07 \
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
+    # upstream fix for Python 2 compatibility  issue reported in
+    # https://trac.macports.org/ticket/57559
+    patchfiles-append       patch-setup.py.diff
+
     depends_build-append    port:py${python.version}-setuptools
 
     depends_lib-append      port:py${python.version}-ipython \
@@ -44,8 +45,4 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-six
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
 }

--- a/python/py-ipython-sql/files/patch-setup.py.diff
+++ b/python/py-ipython-sql/files/patch-setup.py.diff
@@ -1,0 +1,7 @@
+--- setup.py.orig	2018-12-07 00:02:11.000000000 -0500
++++ setup.py	2018-12-07 00:02:28.000000000 -0500
+@@ -1,3 +1,4 @@
++from io import open
+ from setuptools import setup, find_packages
+ import os
+


### PR DESCRIPTION
#### Description
- add upstream patch to setup.py for PY2 compatibility
- make use of python.rootname
- use default PyPI livecheck

No need to increase the revision because the py27 subport doesn't install and the patch does not affect PY3 subports.

Closes: https://trac.macports.org/ticket/57559
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
