### PR TITLE
 py-{s3fs,smart_open,gensim,jmespath-terminal}: obsolete py34 subports

### DIFF
--- a/python/py-gensim/Portfile
+++ b/python/py-gensim/Portfile
@@ -9,7 +9,7 @@ categories-append   textproc
 platforms           darwin
 license             LGPL
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -226,6 +226,7 @@ py-jenkins-job-builder  0.8.1_2     26
 py-jinja                1.2_2       26
 py-jinja2               2.10_1      26 33
 py-jmespath             0.9.3       34
+py-jmespath-terminal    0.1.1_1     34
 py-jsbeautifier         1.4.0_1     26
 py-jug                  1.6.7_1     33
 py-kapteyn              2.2_1       26

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -178,6 +178,7 @@ py-gdbm                 2.5.6_1     25 31
 py-gdl                  2.25.3_2    26
 py-generator            0.1.20120721_1 \
                                     26 33
+py-gensim               3.5.0_1     34
 py-geoip                1.3.2_1     33
 py-geopandas            0.1.1_1     33
 py-geopy                1.11.0_1    26 33
@@ -415,6 +416,7 @@ py-sh                   1.12.13_1   26 33
 py-shove                0.6.4_1     26
 py-simpy                3.0.5_1     33
 py-six                  1.11.0_1    26 33
+py-smart_open           1.7.1_1     34
 py-smisk                1.1.6_2     26
 py-smmap                2.0.3_1     26
 py-snowballstemmer      1.2.0_1     26 33
@@ -441,6 +443,7 @@ py-subvertpy            0.10.1_1    26
 py-suds-jurko           0.6_1       26 33
 py-svipc                0.14_2      26
 py-swap                 3.1.3       26 33 34 35
+py-s3fs                 0.2.0_1     34
 py-tahchee              0.9.8_1     26
 py-taskw                0.8.6_1     33
 py-tc                   0.7.2_1     26

--- a/python/py-jmespath-terminal/Portfile
+++ b/python/py-jmespath-terminal/Portfile
@@ -19,7 +19,7 @@ distname            jmespath-terminal-${version}
 checksums           rmd160  a3d5fc3c05fe2e9e71fab9c6d9f6acfeac7ce39f \
                     sha256  df26ac6fa774676b4c0eff155bdb2f9ddf0c78c013b5b4824b597f44793903f0
 
-python.versions     27 34 35 36
+python.versions     27 35 36
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-s3fs/Portfile
+++ b/python/py-s3fs/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             BSD
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-smart_open/Portfile
+++ b/python/py-smart_open/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description
For all ports the py34 subport doesn't build anymore because py34 was removed from on of their dependencies. This PR obsoletes the problematic py34 subports as well. 

Closes: https://trac.macports.org/ticket/57565
Closes: https://trac.macports.org/ticket/57586

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [ ] tried a full install with `sudo port -vst install`? N/A
- [ ] tested basic functionality of all binary files? N/A

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
