### PR TITLE
py-pytest: update to 4.0.1

### DIFF
--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest
-version             4.0.0
+version             4.0.1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -24,9 +24,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  6a4b203d24aedec6d08e18ff3f7213e46e4b074c \
-                    sha256  488c842647bbeb350029da10325cb40af0a9c7a2fdda45aeb1dda75b60048ffb \
-                    size    901833
+checksums           rmd160  51be116c7ecd209949632490d5a492daac7c2413 \
+                    sha256  1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4 \
+                    size    903708
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
- update to latest version
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
