### PR TITLE
kotlin: update to 1.3.11

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.3.10 v
+github.setup        JetBrains kotlin 1.3.11 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,9 +21,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  98bb9000d0d488f83fc2d25a2dceeb89ad77381e \
-                    sha256  ca79c93151e14e34ff49cfb56ec4c0fe83e1383143b1469af8cdc4f62fb8c67d \
-                    size    37248115
+checksums           rmd160  2ff1f5f97e6799ceb46344c295d015f5cacfa03f \
+                    sha256  03de0f1a4b49d36433e60ae495982f046782eb3725e6e22a04e24ef38be9a409 \
+                    size    37248747
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.3.11.

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?