### PR TITLE
MacVim: update to released snapshot 152

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -3,7 +3,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 set vim_version     8.1
-set snapshot        151
+set snapshot        152
 github.setup        macvim-dev macvim ${snapshot} snapshot-
 name                MacVim
 version             ${vim_version}.snapshot${snapshot}
@@ -19,10 +19,10 @@ long_description \
     integrate seamlessly with the native user interface.
 
 homepage            https://macvim-dev.github.io/macvim/
- 
-checksums           rmd160  0298a22f02d406d35deb73964ac8d5e8a0914cc7 \
-                    sha256  58cc94b31d4a4c6a5e925f55def146d553547c03589148e6a041309209104bde \
-                    size    20133403
+
+checksums           rmd160  8e49ac97f182d395c597f745deef783039bc08ad \
+                    sha256  7fc68174feb63a8bebcc27011b09b6532f65387943038a2083fa07c2334de7b5 \
+                    size    20243167 
 
 depends_lib         port:ncurses \
                     port:gettext \

--- a/editors/MacVim/files/patch-remove-Homebrew-python.diff
+++ b/editors/MacVim/files/patch-remove-Homebrew-python.diff
@@ -1,30 +1,44 @@
-Upstream: https://github.com/macvim-dev/macvim/pull/423 (reverting partly)
-
---- src/MacVim/vimrc
-+++ src/MacVim/vimrc
-@@ -13,25 +13,3 @@
+--- src/MacVim/vimrc.orig	2018-12-07 14:53:59.000000000 -0600
++++ src/MacVim/vimrc	2018-12-07 14:54:07.000000000 -0600
+@@ -13,41 +13,3 @@
  " the entire MacVim menu is set up in a nib file which currently only is
  " translated to English).
  set langmenu=none
 -
 -" Python2
--" MacVim uses Homebrew python2 if installed, otherwise configured one
+-" MacVim is configured by default to use the pre-installed System python2
+-" version. However, following code tries to find a Homebrew, MacPorts or
+-" an installation from python.org:
 -if exists("&pythondll") && exists("&pythonhome")
--  if filereadable("/usr/local/Frameworks/Python.framework/Versions/2.7/Python")
+-  if filereadable("/usr/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
 -    " Homebrew python 2.7
 -    set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python
 -    set pythonhome=/usr/local/Frameworks/Python.framework/Versions/2.7
+-  elseif filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
+-    " MacPorts python 2.7
+-    set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+-    set pythonhome=/opt/local/Library/Frameworks/Python.framework/Versions/2.7
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/2.7/Python")
+-    " https://www.python.org/downloads/mac-osx/
+-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/2.7/Python
+-    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/2.7
 -  endif
 -endif
 -
 -" Python3
--" MacVim uses Homebrew python3 if installed, next try to use python.org binary
+-" MacVim is configured by default to use Homebrew python3 version
+-" If this cannot be found, following code tries to find a MacPorts
+-" or an installation from python.org:
 -if exists("&pythonthreedll") && exists("&pythonthreehome") &&
 -      \ !filereadable(&pythonthreedll)
--  if filereadable("/Library/Frameworks/Python.framework/Versions/3.6/Python")
+-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python")
+-    " MacPorts python 3.7
+-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python
+-    set pythonthreehome=/opt/local/Library/Frameworks/Python.framework/Versions/3.7
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
 -    " https://www.python.org/downloads/mac-osx/
--    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.6/Python
--    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/3.6
+-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.7/Python
+-    set pythonthreehome=/Library/Frameworks/Python.framework/Versions/3.7
 -  endif
 -endif
 -


### PR DESCRIPTION
#### Description

snapshot 152 contains various rendering fixes that makes MacVim usable
on OS X 10.14.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->