### PR TITLE
 libfdk-aac: update to 2.0.0

### DIFF
--- a/audio/libfdk-aac/Portfile
+++ b/audio/libfdk-aac/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libfdk-aac
-version             0.1.6
+version             2.0.0
 categories          audio
 license             Restrictive
 platforms           darwin
@@ -19,9 +19,9 @@ compiler.blacklist  gcc-4.2
 homepage            https://sourceforge.net/projects/opencore-amr/
 master_sites        sourceforge:project/opencore-amr/fdk-aac
 distname            fdk-aac-${version}
-checksums           rmd160  cd792eac8339d65b6997c8769c8eda4565fb9201 \
-                    sha256  aab61b42ac6b5953e94924c73c194f08a86172d63d39c5717f526ca016bed3ad \
-                    size    2091618
+checksums           rmd160  8999925e5b8a17c93df359467a7e198bfd38d012 \
+                    sha256  f7d6e60f978ff1db952f7d5c3e96751816f5aef238ecf1d876972697b85fd96c \
+                    size    2864593
 
 livecheck.type      regex
 livecheck.url       https://sourceforge.net/projects/opencore-amr/files/fdk-aac/

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -11,7 +11,7 @@ github.setup        FFmpeg FFmpeg 07bc603757caa5d2054c56629bb93d7a177e8e88
 name                ffmpeg-devel
 conflicts           ffmpeg
 version             20181108
-revision            1
+revision            2
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -11,7 +11,7 @@ conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
 version             4.1
-revision            2
+revision            3
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer


### PR DESCRIPTION
#### Description

Update libfdk-aac to 2.0.0; revbump ffmpeg/ffmpeg-devel.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1618
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
