### PR TITLE
poppler: add legacysupport PG

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -6,6 +6,7 @@ PortGroup           conflicts_build 1.0
 PortGroup           cxx11 1.1
 PortGroup           gobject_introspection 1.0
 PortGroup           cmake 1.1
+PortGroup           legacysupport 1.0
 
 name                poppler
 conflicts           xpdf-tools


### PR DESCRIPTION
poppler now uses strndup

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

We still have to fix the thread_local issue for general use. Most systems are OK. Have to come up with a good plan for 10.6.8.