### PR TITLE
chromedriver: update to version 2.44

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             2.41
+version             2.44
 categories          www
 platforms           darwin
 maintainers         nomaintainer
@@ -24,9 +24,9 @@ dist_subdir         ${name}/${version}
 distname            ${name}_mac64
 use_zip             yes
 
-checksums           rmd160  9138b7cc77a74009e6fcc997348261359709ff8d \
-                    sha256  fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae \
-                    size    5760121
+checksums           rmd160  c8359d13c080003c59e555c98de478174f316f70 \
+                    sha256  3fd49c2782a5f93cb48ff2dee021004d9a7fb393798e4c4807b391cedcd30ed9 \
+                    size    6909780
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description

chromedriver: update from version 2.4.1 to version 2.44

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 10.1 10B61 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
