### PR TITLE
cppcheck: update to 1.86

### DIFF
--- a/devel/cppcheck/Portfile
+++ b/devel/cppcheck/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 PortGroup                   cxx11 1.1
 PortGroup                   github 1.0
 
-github.setup                danmar cppcheck 1.85
+github.setup                danmar cppcheck 1.86
 name                        cppcheck
 categories                  devel
 license                     GPL-3
@@ -19,9 +19,9 @@ long_description            Cppcheck is an analysis tool for C and C++ code. Unl
                             the compilers normally fail to detect. The goal is no false \
                             positives.
 
-checksums                   rmd160  b950f8f06139549682eaafa81b4316ef24a61a93 \
-                            sha256  684b931da2f9b2b4ce8676c8e54208957d8d31a5d514b08b0d941db3d2c27a4c \
-                            size    2151221
+checksums                   rmd160  5ec70b52a7b6421c1228f2e256bfd2a04d624487 \
+                            sha256  a0e2292e747102509904ea713d925db1197deb0f98213111325f4e05452deeec \
+                            size    2185193
 
 depends_build               port:libxslt \
                             port:docbook-xsl-nons \


### PR DESCRIPTION
#### Description
- update to 1.86

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
