### PR TITLE
yarn: update to 1.12.3

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -3,9 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        yarnpkg yarn 1.12.1 v
-
-revision            1
+github.setup        yarnpkg yarn 1.12.3 v
 
 categories          devel
 
@@ -28,9 +26,9 @@ homepage            https://yarnpkg.com/
 
 github.tarball_from releases
 distname            ${name}-${git.branch}
-checksums           rmd160  4ea718e17eaf01e5ff33ca5f843e970a5d64ff5c \
-                    sha256  09bea8f4ec41e9079fa03093d3b2db7ac5c5331852236d63815f8df42b3ba88d \
-                    size    1150378
+checksums           rmd160  a4cfbdafba2ac4c38fbf0bec757ddc451b81616d \
+                    sha256  02cd4b589ec22c4bdbd2bc5ebbfd99c5e99b07242ad68a539cb37896b93a24f2 \
+                    size    1166553
 
 depends_run         path:bin/node:nodejs10
 


### PR DESCRIPTION
Locally tested on 10.14 with Macports 2.5.4.

macOS 10.14.1 18B75
Xcode 10.1 10B61 

I have:

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL
- [X] checked your Portfile with `port lint`
- [X] tried existing tests with `sudo port test`
- [X] tried a full install with `sudo port -vst install`
- [X] tested basic functionality of all binary files

Be advised that running `port test` returns:

```shell
$ sudo port test
Password:
--->  Computing dependencies for yarn
--->  Fetching distfiles for yarn
--->  Verifying checksums for yarn
--->  Extracting yarn
--->  Configuring yarn
--->  Building yarn
--->  Testing yarn
Error: Failed to test yarn: yarn has no tests turned on. see 'test.run' in portfile(7)
Error: See /opt/local/var/macports/logs/_Users_magus_Development_macports-ports_devel_yarn/yarn/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port yarn failed
```
