### PR TITLE
php-igbinary: Update to 2.0.8, add php73 subport

### DIFF
--- a/php/php-igbinary/Portfile
+++ b/php/php-igbinary/Portfile
@@ -4,14 +4,21 @@ PortSystem          1.0
 PortGroup           php 1.1
 
 name                php-igbinary
-version             2.0.5
 categories-append   net devel
 license             BSD PHP-3.01
 platforms           darwin freebsd openbsd
 maintainers         {pixilla @pixilla} openmaintainer
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 php.pecl            yes
+
+if {[vercmp ${php.branch} 5.2] >= 0} {
+    version         2.0.8
+    revision        0
+    checksums       rmd160  ea29b28150104df01f26557c0465af4bf2819ece \
+                    sha256  bacbab1172e073b1857dc07a486bfdaca6d60fbed678ce0f4b37cd018ef5b680 \
+                    size    76708
+}
 
 description         PHP serializer.
 
@@ -21,9 +28,5 @@ long_description    Igbinary is a drop in replacement for the standard PHP \
                     a compact binary form. Savings are significant when \
                     using memcached or similar memory based storages for \
                     serialized data.
-
-checksums           rmd160  e0a783c3ae2d9e9697fe7cf18570e5a244e7ae8c \
-                    sha256  526b21f10b08eb9f6e17a6e92b6675348a5049e6d0f5a4ea0a38f24ec3513d34 \
-                    size    72129
 
 test.run            yes

--- a/php/php-memcached/Portfile
+++ b/php/php-memcached/Portfile
@@ -9,7 +9,7 @@ platforms               darwin freebsd openbsd
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP-3
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 php.pecl                yes
 
 if {[vercmp ${php.branch} 7] >= 0} {
@@ -18,6 +18,7 @@ if {[vercmp ${php.branch} 7] >= 0} {
     checksums           rmd160  c5c7ffcf482094690cf805319d842911a075c7ad \
                         sha256  561db4c8abdb7c344703a6b7b0ff4f29c2fe0fbacf7b2a2a704d0ed9b1a17d11 \
                         size    78776
+    patchfiles          php73-memcached.patch
 } else {
     version             2.2.0
     revision            0

--- a/php/php-memcached/files/php73-memcached.patch
+++ b/php/php-memcached/files/php73-memcached.patch
@@ -1,0 +1,50 @@
+Fix build with php 7.3+.
+https://github.com/php-memcached-dev/php-memcached/issues/385
+https://github.com/php-memcached-dev/php-memcached/pull/390
+--- php_memcached.c.orig
++++ php_memcached.c
+@@ -1298,7 +1298,7 @@ static PHP_METHOD(Memcached, __construct)
+ 		le.type = php_memc_list_entry();
+ 		le.ptr  = intern->memc;
+ 
+-		GC_REFCOUNT(&le) = 1;
++		GC_SET_REFCOUNT(&le, 1);
+ 
+ 		/* plist_key is not a persistent allocated key, thus we use str_update here */
+ 		if (zend_hash_str_update_mem(&EG(persistent_list), ZSTR_VAL(plist_key), ZSTR_LEN(plist_key), &le, sizeof(le)) == NULL) {
+@@ -3831,7 +3831,7 @@ PHP_METHOD(MemcachedServer, on)
+ 
+ 		Z_TRY_ADDREF(fci.function_name);
+ 		if (fci.object) {
+-			GC_REFCOUNT(fci.object)++;
++			GC_ADDREF(fci.object);
+ 		}
+ 	}
+ 	RETURN_BOOL(rc);
+--- php_memcached_private.h.orig
++++ php_memcached_private.h
+@@ -72,6 +72,13 @@ typedef unsigned long int uint32_t;
+ #  endif
+ #endif
+ 
++/* Backwards compatibility for GC API change in PHP 7.3 */
++#if PHP_VERSION_ID < 70300
++#  define GC_ADDREF(p)            ++GC_REFCOUNT(p)
++#  define GC_DELREF(p)            --GC_REFCOUNT(p)
++#  define GC_SET_REFCOUNT(p, rc)  GC_REFCOUNT(p) = rc
++#endif
++
+ /****************************************
+   Structures and definitions
+ ****************************************/
+--- php_memcached_session.c.orig
++++ php_memcached_session.c
+@@ -376,7 +376,7 @@ PS_OPEN_FUNC(memcached)
+ 		le.type = s_memc_sess_list_entry();
+ 		le.ptr  = memc;
+ 
+-		GC_REFCOUNT(&le) = 1;
++		GC_SET_REFCOUNT(&le, 1);
+ 
+ 		/* plist_key is not a persistent allocated key, thus we use str_update here */
+ 		if (zend_hash_str_update_mem(&EG(persistent_list), plist_key, plist_key_len, &le, sizeof(le)) == NULL) {


### PR DESCRIPTION
#### Description

php-igbinary: Update to 2.0.8, add php73 subport

See: https://trac.macports.org/ticket/57748

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
