### PR TITLE
gstreamer1-gst-plugins-base: Fix -x11+universal

### DIFF
--- a/gnome/gstreamer1-gst-plugins-base/Portfile
+++ b/gnome/gstreamer1-gst-plugins-base/Portfile
@@ -101,11 +101,19 @@ variant x11 {
 # Prefer X11 implementation.
 default_variants +x11
 
-# Cocoa-GL implementation, not a variant because base reacts weirdly to such a setup.
-# Only enable on supported platforms and if neither the x11 or universal variants
-# have been passed.
+# Cocoa-GL
+# Only enable on OS X 10.9 or later, if the x11 variant is not enabled.
+# Requires ARC (automatic reference counting, a clang feature enabled by
+# -fobjc-arc), which was not supported when targeting the legacy fragile
+# Objective-C runtime used on 32-bit x86 until Xcode 7.3 / clang 3.9
+# (https://llvm.org/viewvc/llvm-project?view=revision&revision=250955).
+# If building universal or for i386 then ensure that a sufficiently recent
+# version of clang is used, since the Xcode clang may be too old.
 platform macosx {
-    if {![variant_isset x11] && ${build_arch} eq "x86_64" && ${os.major} >= 13 && ![variant_isset universal]} {
+    if {![variant_isset x11] && ${os.major} >= 13} {
+        if {[variant_isset universal] || ${build_arch} eq "i386"} {
+            compiler.blacklist-append *gcc* {macports-clang-3.[0-8]} {clang < 703}
+        }
         configure.args-replace  --disable-cocoa \
                                 --enable-cocoa \
                                 --disable-opengl \
@@ -113,12 +121,6 @@ platform macosx {
     }
 }
 
-if {[variant_isset universal]} {
-    if {![variant_isset x11]} {
-        ui_error "${name} ${version} requires +x11 if +universal is set."
-        return -code error "incompatible variant selection."
-    }
-}
 variant ogg description {Build with support for libogg, libvorbis, libtheora} {
     depends_lib-append    port:libogg port:libvorbis port:libtheora
     configure.args-replace  --disable-ogg \


### PR DESCRIPTION
#### Description

Allow -x11+universal with a sufficiently recent version of clang.
On some older OS versions, the clang from Xcode may be too old.

Fixes https://trac.macports.org/ticket/57020

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1618
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
