### PR TITLE
zabbix4: Update to latest.

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -1,14 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
+PortGroup           active_variants 1.1
 
 name                zabbix4
-version             4.0.1
-revision            0
+version             4.0.2
+revision            1
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
 platforms           darwin
 
-license             GPL-2
+license             GPL-2+
+license_noconflict  openssl
 
 description         An open source application and network monitor
 
@@ -29,18 +31,17 @@ master_sites \
     sourceforge:project/zabbix/ZABBIX%20Release%20Candidates/${version}
 dist_subdir         zabbix4
 
-conflicts           zabbix zabbix2 zabbix3
-
 checksums \
-    rmd160  18a5b97472baeb99c8729a89d039244ba7f25fd5 \
-    sha256  c73d54074885ae68c23dddc060e9e7f24c96f808eb502c5ee648c2820790e2fd \
-    size    18005197
+    rmd160  44d1b192303a6c9a9ea1601aa2d8bfb98d993b29 \
+    sha256  1cef52e89dc8d20343d8b9c3881490bf86e98102de2229a3b852009f1659780c \
+    size    18018925
 
 patchfiles          log_and_pid_locations.patch
 
 universal_variant   no
 
 subport             zabbix4-agent {}
+subport             zabbix4-frontend {}
 
 configure.args      --bindir=${prefix}/bin/zabbix \
                     --sbindir=${prefix}/sbin/zabbix \
@@ -55,13 +56,16 @@ configure.args      --bindir=${prefix}/bin/zabbix \
 
 configure.ldflags-append    -lresolv
 
-startupitem.create      yes
-depends_lib-append      port:libiconv \
-                        port:gnutls \
-                        port:pcre \
-                        port:libevent
+if { ${subport} ne "zabbix4-frontend" } {
+    startupitem.create      yes
+    depends_lib-append      port:libiconv \
+                            port:gnutls \
+                            port:pcre \
+                            port:libevent
+}
 
-if { ${name} ne ${subport} } {
+if { ${subport} eq "zabbix4-agent" } {
+    long_description-append "This port provides the local monitoring agent."
     conflicts               zabbix2-agent zabbix3-agent
     startupitem.name        zabbix4-agentd
     startupitem.executable  \
@@ -74,17 +78,43 @@ if { ${name} ne ${subport} } {
 
     destroot.keepdirs \
         ${destroot}${prefix}/etc/zabbix4/zabbix_agentd.conf.d \
-        ${destroot}${prefix}/var/run/zabbix4 \
+        ${destroot}${prefix}/var/run/zabbix \
         ${destroot}${prefix}/var/log/zabbix
+} elseif { ${subport} eq "zabbix4-frontend" } {
+    long_description-append "This port provides the web (PHP) frontend."
+    supported_archs         noarch
+    depends_run-append      port:apache2
+
+    foreach php {php56 php70 php71} {
+        variant ${php} description "Use ${php}" "
+            depends_run-append      port:${php} \
+                                    port:${php}-apache2handler \
+                                    port:${php}-gd \
+                                    port:${php}-gettext \
+                                    port:${php}-mbstring \
+                                    port:${php}-sockets
+        "
+    }
+
+    if {![variant_isset php56] && ![variant_isset php70]
+                               && ![variant_isset php71]} {
+        default_variants        +php71
+    }
+    use_configure           no
+    build {}
+    # Kept in post-destroot sections below for consistency
+    destroot {}
 } else {
+    long_description-append "This port provides the central server component."
+    conflicts               zabbix zabbix2 zabbix3
+
     depends_lib-append      port:curl \
                             port:libssh2 \
                             port:net-snmp \
                             port:OpenIPMI \
                             port:libxml2
 
-    depends_run-append      port:fping \
-                            port:apache2
+    depends_run-append      port:fping
 
     configure.args-append   --enable-server \
                             --with-libcurl=${prefix}/bin/curl-config \
@@ -108,27 +138,19 @@ if { ${name} ne ${subport} } {
         ${destroot}${prefix}/var/run/zabbix4 \
         ${destroot}${prefix}/var/log/zabbix
 
-    foreach php {php56 php70 php71} {
-        variant ${php} description "Use ${php}" "
-            depends_run-append      port:${php} \
-                                    port:${php}-apache2handler \
-                                    port:${php}-gd \
-                                    port:${php}-gettext \
-                                    port:${php}-mbstring \
-                                    port:${php}-sockets
-        "
-    }
-
-    if {![variant_isset php56] && ![variant_isset php70]
-                               && ![variant_isset php71]} {
-        default_variants        +php71
-    }
-
     variant full_server description {
-        Adds dependencies a complete server are installed.
-    } {
+        Dependencies for a complete server (w/DB) are installed.
+    } {}
+    
+    variant frontend description {Include frontend PHP files / deps} {
+        depends_run-append  port:zabbix4-frontend
     }
 
+    default_variants-append +frontend
+}
+
+if { ${subport} ne "zabbix4-agent" } {
+    # Logic for database backends. Needed for -frontend and -server
     # Items are "display name" "port name" "config arg" "php interface"
     array set DBLIST {
         mysql5  {"MySQL 5.x"            mysql5 \
@@ -169,22 +191,26 @@ if { ${name} ne ${subport} } {
             set ::ZDB               [lindex ${prms} 1]
             set ::DBFILES           [lindex ${prms} 3]
             set ::MYSQL_MODE        [string equal [lindex ${prms} 3] mysql]
-            depends_lib-append      port:[lindex ${prms} 1]
             configure.args-append   --with-[lindex ${prms} 2]
 
-            if {[variant_isset php56]} {
-                depends_run-append \
-                    port:php56-[lindex ${prms} 3]
-            }
+            if { \"${subport}\" eq {zabbix4-frontend} } {
+                if {[variant_isset php56]} {
+                    depends_run-append \
+                        port:php56-[lindex ${prms} 3]
+                }
 
-            if {[variant_isset php70]} {
-                depends_run-append \
-                    port:php70-[lindex ${prms} 3]
-            }
+                if {[variant_isset php70]} {
+                    depends_run-append \
+                        port:php70-[lindex ${prms} 3]
+                }
 
-            if {[variant_isset php71]} {
-                depends_run-append \
-                    port:php71-[lindex ${prms} 3]
+                if {[variant_isset php71]} {
+                    depends_run-append \
+                        port:php71-[lindex ${prms} 3]
+                }
+            } else {
+                depends_lib-append      port:[lindex ${prms} 1]
+                require_active_variants port:zabbix4-agent ${dbitem}
             }
 
             if {[string compare ${dbitem} sqlite3] && \
@@ -206,7 +232,7 @@ if { ${name} ne ${subport} } {
         ![variant_isset pgsql95] &&
         ![variant_isset pgsql96] &&
         ![variant_isset sqlite3]} {
-        default_variants            +mysql5
+        default_variants            +mysql57
     }
 }
 
@@ -214,7 +240,7 @@ post-extract {
     if { ${name} == ${subport} } {
         if { ${MYSQL_MODE} == 1 &&
              [variant_isset full_server] } {
-                set repstr "s|# DBSocket=/tmp/mysql.sock|"
+                set repstr "s|# DBSocket=|"
                 append repstr "DBSocket=${prefix}/var/run/${ZDB}/mysqld.sock|"
             reinplace ${repstr} ${worksrcpath}/conf/zabbix_server.conf
         }
@@ -234,7 +260,7 @@ post-patch {
 add_users zabbix group=zabbix
 
 post-destroot {
-    if { ${name} ne ${subport} } {
+    if { ${subport} eq "zabbix4-agent" } {
      ####### AGENT #######
 # Copy sample agent .conf files
         xinstall -m 755 -d \
@@ -244,6 +270,14 @@ post-destroot {
 
 # Don't overwrite user settings on each install
         delete ${destroot}${prefix}/etc/zabbix4/zabbix_agentd.conf
+    } elseif { ${subport} eq "zabbix4-frontend" } {
+# Copy the front end files
+        file mkdir ${destroot}${prefix}/share/zabbix/frontends/
+        file copy ${worksrcpath}/frontends/php/ \
+            ${destroot}${prefix}/share/zabbix/frontends/
+
+# Set permissions for etc (protect passwords) and the frontend
+        system "chown -R www:www ${destroot}${prefix}/share/zabbix/frontends/*"
     } else {
      ####### SERVER #######
 # Copy sample server and agent .conf files
@@ -264,19 +298,13 @@ post-destroot {
         #file copy ${worksrcpath}/upgrades \
         #    ${destroot}${prefix}/share/zabbix/
 
-# Copy the front end files
-        file mkdir ${destroot}${prefix}/share/zabbix/frontends/
-        file copy ${worksrcpath}/frontends/php/ \
-            ${destroot}${prefix}/share/zabbix/frontends/
-
-# Set permissions for etc (protect passwords) and the frontend
-        system "chmod 660 ${destroot}${prefix}/etc/zabbix4/*"
-        system "chown -R www:www ${destroot}${prefix}/share/zabbix/frontends/*"
-
         xinstall -d -m 755 -d \
             ${destroot}${prefix}/share/zabbix/zabbix_agent_win32
         xinstall -m 755 ${worksrcpath}/bin/win32/zabbix_agentd.exe \
             ${destroot}${prefix}/share/zabbix/zabbix_agent_win32
+        # Set permissions for etc (protect passwords) 
+        system "chmod ug+rwX,o-rwx ${destroot}${prefix}/etc/zabbix4/*"
+        system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix4"
     }
 
     foreach dname {run log} {
@@ -284,10 +312,9 @@ post-destroot {
         system "chown -R zabbix:zabbix ${destroot}${prefix}/var/${dname}/zabbix"
     }
 
-    system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix4"
 }
 
-if { ${name} ne ${subport} } {
+if { ${subport} eq "zabbix4-agent" } {
     notes "
 ####                                        ####
 #### ZABBIX4 agent installation section     ####
@@ -307,6 +334,38 @@ if { ${name} ne ${subport} } {
 
 #### End ZABBIX4 agent installation section ####
 ####                                        ####
+"
+} elseif { ${subport} eq "zabbix4-agent" } {
+    notes "
+####                                              ####
+#### Begin ZABBIX4 frontend installastion section ####
+
+1) Set a symbolic link in your Apache document root pointing to the PHP
+   frontend files
+
+    sudo ln -s ${prefix}/share/zabbix/frontends/php <Apache-docroot>/zabbix
+
+
+2) Enable your desired php version in httpd.conf and make sure the following
+   are set in the associated php.ini:
+   
+    max_execution_time = 300
+    max_input_time = 300
+    post_max_size = 16M
+    date.timezone = < Your TZ; see http://php.net/manual/en/timezones.php >
+
+   And for php56:
+    always_populate_raw_post_data = -1
+
+
+3) Open http://localhost/zabbix/ in your browser and walk through the setup,
+   then login with default user 'Admin' and password 'zabbix'.
+
+
+4) Read the fine manual at http://www.zabbix.com/documentation/
+
+#### End ZABBIX4 frontend installation section   ####
+####                                             ####
 "
 } else {
     notes "
@@ -343,38 +402,16 @@ if { ${name} ne ${subport} } {
       Typically ${prefix}/var/run/mysql\[51|55\]/mysqld.sock
 
 
-4) Set a symbolic link in your Apache document root pointing to the PHP
-   frontend files
-
-    sudo ln -s ${prefix}/share/zabbix/frontends/php <Apache-docroot>/zabbix
-
-
-5) Set zabbix_server to run at system boot (also starts it immediately):
+4) Set zabbix_server to run at system boot (also starts it immediately):
 
     sudo port load zabbix4
 
 
-6) A Win32 agent is in ${prefix}/share/zabbix/zabbix_agent_win32 for\
+5) A Win32 agent is in ${prefix}/share/zabbix/zabbix_agent_win32 for\
    installation on Windows.
 
 
-7) Enable your desired php version in httpd.conf and make sure the following
-   are set in the associated php.ini:
-   
-    max_execution_time = 300
-    max_input_time = 300
-    post_max_size = 16M
-    date.timezone = < Your TZ; see http://php.net/manual/en/timezones.php >
-
-   And for php56:
-    always_populate_raw_post_data = -1
-
-
-8) Open http://localhost/zabbix/ in your browser and walk through the setup,
-   then login with default user 'Admin' and password 'zabbix'.
-
-
-9) Read the fine manual at http://www.zabbix.com/documentation/
+6) Read the fine manual at http://www.zabbix.com/documentation/
 
 
 #### End ZABBIX4 local server installation section   ####


### PR DESCRIPTION
Also split zabbix4 into zabbix4 / zabbix4-frontend. Depend on frontend
by default, but this allows a much thinner frontend to be installed
(or skipped for fewer deps to server-only install) as desired.

New license includes openssl linking exception.

Maintainer update, but I'll leave it here for a day or two to see if anyone has comments / concerns.