### PR TITLE
mesos: add new port with minimal configuration

### DIFF
--- a/devel/mesos/Portfile
+++ b/devel/mesos/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cxx11 1.1
+
+name                mesos
+version             1.7.0
+
+categories          devel
+platforms           darwin
+maintainers         {@dgilman gilslotd.com:dgilman} openmaintainer
+license             Apache-2
+homepage            https://mesos.apache.org/
+master_sites        apache:mesos/${version}
+
+description         Apache Mesos abstracts CPU, memory, storage, and other compute resources \
+                    away from machines (physical or virtual), enabling fault-tolerant \
+                    and elastic distributed systems to easily be built and run effectively.
+long_description    ${description}
+
+checksums           rmd160  28a10cb2975657034fadd0b5da6ff2b9498564d5 \
+                    sha256  0d02700eafef0af07f2257537eb164a3fd31b6cae291e0d025335f5333acd8bf \
+                    size    69737576
+
+configure.args-append --with-svn=${prefix} \
+                      --with-apr=${prefix} \
+                      --disable-werror \
+                      --disable-python \
+                      --disable-java \
+                      --disable-maintainer-mode
+
+depends_lib         port:apr-util \
+                    port:subversion
+
+build.env           MAVEN_OPTS=-Duser.home=${workpath}/.home
+


### PR DESCRIPTION
This will bring up a client and server but won't have java or python
bindings.

#### Description

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
