### PR TITLE
Update p5.26-net-pcap: compatibility with libpcap 1.9.0

### DIFF
--- a/perl/p5-net-pcap/Portfile
+++ b/perl/p5-net-pcap/Portfile
@@ -21,6 +21,8 @@ platforms           darwin
 checksums           rmd160  1959ae0cc70fdd8b4cdb2d9028123fd83338c8d5 \
                     sha256  cb9bd44948c23544bb9d4e28261dbd0dbb3e7564709487a7855576e0d9b68307
 
+patchfiles          fix-build-netpcap.patch
+
 if {${perl5.major} != ""} {
     depends_lib-append \
                     port:libpcap

--- a/perl/p5-net-pcap/Portfile
+++ b/perl/p5-net-pcap/Portfile
@@ -21,7 +21,7 @@ platforms           darwin
 checksums           rmd160  1959ae0cc70fdd8b4cdb2d9028123fd83338c8d5 \
                     sha256  cb9bd44948c23544bb9d4e28261dbd0dbb3e7564709487a7855576e0d9b68307
 
-patchfiles          fix-build-netpcap.patch
+patchfiles          fix-build-netpcap.patch Net-Pcap-0.18-Adapt-a-test-to-libpcap-1.8.0.patch
 
 if {${perl5.major} != ""} {
     depends_lib-append \

--- a/perl/p5-net-pcap/files/Net-Pcap-0.18-Adapt-a-test-to-libpcap-1.8.0.patch
+++ b/perl/p5-net-pcap/files/Net-Pcap-0.18-Adapt-a-test-to-libpcap-1.8.0.patch
@@ -1,0 +1,13 @@
+diff --git a/t/09-error.t b/t/09-error.t
+--- t/09-error.t
++++ t/09-error.t
+@@ -22,7 +22,7 @@ is(   $@,   '', "compile() with an invalid filter string" );
+ is(   $res, -1, " - result must not be null: $res" );
+ eval { $err = Net::Pcap::geterr($pcap) };
+ is(   $@,   '', "geterr()" );
+-like( $err, '/^(?:parse|syntax) error$/', " - \$err must not be null: $err" );
++like( $err, '/(^|: )(?:parse|syntax) error$/', " - \$err must not be null: $err" );
+ 
+ # Testing compile() with a valid filter
+ eval { $res = Net::Pcap::compile($pcap, \$filter, "tcp", 0, $mask) };
+

--- a/perl/p5-net-pcap/files/fix-build-netpcap.patch
+++ b/perl/p5-net-pcap/files/fix-build-netpcap.patch
@@ -1,0 +1,44 @@
+diff -up ./Makefile.PL.tv ./Makefile.PL
+--- ./Makefile.PL.tv	2018-09-21 10:32:09.165570705 +0200
++++ ./Makefile.PL	2018-09-21 10:45:39.096591301 +0200
+@@ -106,7 +106,7 @@ REASON
+ # We also store the list of available functions in a file for skipping the 
+ # corresponding tests. 
+ my @funcs = have_functions(find_functions());
+-$options{DEFINE} .= cpp_defines(@funcs);
++$options{DEFINE} .= cpp_defines(@funcs). "-DHAVE_PCAP_SETSAMPLING";
+ open(FUNCS, '>funcs.txt') or warn "warning: can't write 'funcs.txt': $!\n";
+ print FUNCS join("\n", @funcs), "\n";
+ close(FUNCS);
+diff -up ./Pcap.xs.tv ./Pcap.xs
+diff -up ./stubs.inc.tv ./stubs.inc
+--- ./stubs.inc.tv	2018-09-21 10:30:08.653034412 +0200
++++ ./stubs.inc	2018-09-21 10:46:41.339897943 +0200
+@@ -354,11 +354,6 @@ int pcap_parsesrcstr(const char *source,
+ #ifdef _MSC_VER
+ #pragma message( "Warning: the function pcap_open() is not available" )
+ #endif
+-struct pcap_rmtauth {
+-    int type;
+-    char *username;
+-    char *password;
+-};
+ 
+ pcap_t * pcap_open(const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *err);
+ pcap_t * pcap_open(const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *err) {
+@@ -511,6 +511,7 @@ HANDLE pcap_getevent(pcap_t *p) {
+ #ifdef _MSC_VER
+ #pragma message( "Warning: the function pcap_setsampling() is not available" )
+ #endif
++#if 0
+ struct pcap_samp {
+     int method;
+     int value;
+@@ -522,6 +523,7 @@ struct pcap_samp *pcap_setsampling(pcap_
+     return NULL;
+ }
+ #endif
++#endif
+ 
+ 
+ /*


### PR DESCRIPTION
#### Description

* applying patch in order to be able to build Net::Pcap against libpcap-1.9.0
* applying patch in to fix tests  [https://github.com/maddingue/Net-Pcap/pull/9]

Closes: https://trac.macports.org/ticket/57757

###### Type(s)
- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->