### PR TITLE
py-stevedore: update to 1.30.0

### DIFF
--- a/python/py-stevedore/Portfile
+++ b/python/py-stevedore/Portfile
@@ -3,11 +3,8 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           stevedore
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             1.28.0
+name                py-stevedore
+version             1.30.0
 categories-append   devel
 platforms           darwin
 maintainers         nomaintainer
@@ -17,14 +14,14 @@ license             Apache-2
 description         Manage dynamic plugins for Python applications
 long_description    ${description}
 
-homepage            https://pypi.python.org/pypi/${_name}/${version}
+homepage            https://docs.openstack.org/stevedore
 
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  a17cd13695020b58b7259262a1c0e5eab442a015 \
-                    sha256  f1c7518e7b160336040fee272174f1f7b29a46febb3632502a8f2055f973d60b \
-                    size    504872
+checksums           rmd160  e4870809846505f36c75f507196b947b0e3485b5 \
+                    sha256  b92bc7add1a53fb76c634a178978d113330aaf2006f9498d9e2414b31fbfc104 \
+                    size    507632
 
 python.versions     27 34 35 36 37
 
@@ -45,6 +42,4 @@ if {${name} ne ${subport}} {
                 ${dest_doc}
     }
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- update to latest version
- make use of python.rootname
- use default PyPI livecheck
- update homepage

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
