### PR TITLE
clang-5.0 enhancements for older systems

### DIFF
--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -602,6 +602,18 @@ if {${subport} eq "llvm-${llvm_version}"} {
         default_variants-append +emulated_tls
     }
 
+
+    variant defaultlibcxx description {default to -stdlib=libc++ on all systems}  {
+        #patch clang to always default to -stdlib=libc++ if not otherwise specified
+        patchfiles-append 9003-patch-clang-5.0-Toolchains-default-to-libcxx-on-all-systems.diff
+    }
+
+    # if macports.conf is configured to stdlib=libc++ then make that the default if not otherwise specified
+    # exactly matches the behaviour of newer systems
+    if { ${cxx_stdlib} eq "libc++" } {
+        default_variants-append +defaultlibcxx
+    }
+
     variant libstdcxx description {-stdlib=macports-libstdc++ searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -12,7 +12,7 @@ set llvm_version_no_dot 50
 set clang_executable_version 5.0
 set lldb_executable_version 5.0.2
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} { revision 2 }
+subport                 clang-${llvm_version} { revision 3 }
 subport                 lldb-${llvm_version} {}
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -394,6 +394,10 @@ platform darwin {
         # https://llvm.org/bugs/show_bug.cgi?id=13671
         patchfiles-append leopard-no-asan.patch
         configure.args-append -DCOMPILER_RT_BUILD_SANITIZERS=OFF
+    }
+
+    if {${subport} eq "clang-${llvm_version}" && ${os.major} <= 9} {
+        patchfiles-append leopard-no-blocks.patch
     }
 
     if {${os.major} < 11} {

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -591,6 +591,17 @@ if {${subport} eq "llvm-${llvm_version}"} {
         }
     }
 
+    variant emulated_tls description { enable c11/c++11 thread support on older systems using emulated-tls } {
+        # allow clang to use emulated-tls to support thread_local on systems prior to 10.7
+        # emulated TLS works when linking against macports-libstdc++ or against
+        # libc++ / libc++abi with cxa_thread_atexit and emutls.c objects included
+        patchfiles-append \
+            9000-patch-clang-support-emulated-tls.diff
+    }
+    if {${os.major} < 11} {
+        default_variants-append +emulated_tls
+    }
+
     variant libstdcxx description {-stdlib=macports-libstdc++ searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
@@ -645,7 +656,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp
         }
     }
-    default_variants +libstdcxx
+    default_variants-append +libstdcxx
 
     post-patch {
         reinplace "s|@@PREFIX@@|${prefix}|" \

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -155,7 +155,8 @@ patchfiles \
     0002-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.patch \
     0003-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch \
     0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch \
-    0005-Dont-build-LibFuzzer-pre-Lion-due-to-missing-__threa.patch
+    0005-Dont-build-LibFuzzer-pre-Lion-due-to-missing-__threa.patch \
+    0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
 
 if {${subport} eq "clang-${llvm_version}"} {
     patchfiles-append \
@@ -172,6 +173,7 @@ if {${subport} eq "clang-${llvm_version}"} {
         3001-Fix-local-and-iterator-when-building-with-Lion-and-n.patch \
         3002-Fix-missing-long-long-math-prototypes-when-using-the.patch \
         3003-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch \
+        3004-compiler-rt-leopard-no-libdispatch.patch \
         openmp-locations.patch
 
     # https://llvm.org/bugs/show_bug.cgi?id=25681
@@ -277,6 +279,18 @@ if {${subport} eq "llvm-${llvm_version}"} {
         configure.args-append \
             -DCOMPILER_RT_BUILD_SANITIZERS=OFF
     }
+
+    if {${os.major} <= 11} {
+        # libfuzzer uses TLS, so disable it on Snow Leopard and earlier
+	configure.args-append \
+	    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
+    }
+    if {${os.major} <= 9} {
+        # xray calls in sanitizer_common, which presently
+        # does not build on < SnowLeopard
+	configure.args-append \
+	    -DCOMPILER_RT_BUILD_XRAY=OFF
+    }
 } elseif {${subport} eq "lldb-${llvm_version}"} {
     #select.group        lldb
     #select.file         ${filespath}/mp-${subport}
@@ -301,6 +315,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 # Xcode 5.1's clang (clang-503.0.40) has codegen issues (resulting compiler crashes)
 # Xcode 6.2's clang (600.0.57) fails due to https://llvm.org/bugs/show_bug.cgi?id=25753
 compiler.blacklist *gcc* {clang < 602}
+compiler.fallback-append macports-clang-3.7
 
 if {${subport} eq "clang-${llvm_version}"} {
     # clang older than 3.5 fail due to https://llvm.org/bugs/show_bug.cgi?id=25753
@@ -379,10 +394,6 @@ platform darwin {
         # https://llvm.org/bugs/show_bug.cgi?id=13671
         patchfiles-append leopard-no-asan.patch
         configure.args-append -DCOMPILER_RT_BUILD_SANITIZERS=OFF
-    }
-
-    if {${subport} eq "clang-${llvm_version}" && ${os.major} <= 9} {
-        patchfiles-append leopard-no-blocks.patch
     }
 
     if {${os.major} < 11} {

--- a/lang/llvm-5.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
+++ b/lang/llvm-5.0/files/0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch
@@ -1,0 +1,36 @@
+From 1bbe86f7fae2f5222ee6d88d7e3c8d2dae3145c6 Mon Sep 17 00:00:00 2001
+From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+Date: Wed, 27 Dec 2017 23:05:43 -0800
+Subject: [PATCH 5/5] Threading: Only call pthread_setname_np() on SnowLeopard+
+
+Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
+---
+ lib/Support/Unix/Threading.inc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git llvm_master/lib/Support/Unix/Threading.inc macports_master/lib/Support/Unix/Threading.inc
+index 267af388ecd..1c8c1b026e3 100644
+--- llvm_master/lib/Support/Unix/Threading.inc
++++ macports_master/lib/Support/Unix/Threading.inc
+@@ -15,6 +15,7 @@
+ #include "llvm/ADT/Twine.h"
+ 
+ #if defined(__APPLE__)
++#include <Availability.h>
+ #include <mach/mach_init.h>
+ #include <mach/mach_port.h>
+ #endif
+@@ -153,8 +154,10 @@ void llvm::set_thread_name(const Twine &Name) {
+   ::pthread_setname_np(::pthread_self(), "%s",
+     const_cast<char *>(NameStr.data()));
+ #elif defined(__APPLE__)
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+   ::pthread_setname_np(NameStr.data());
+ #endif
++#endif
+ }
+ 
+ void llvm::get_thread_name(SmallVectorImpl<char> &Name) {
+-- 
+2.15.1
+

--- a/lang/llvm-5.0/files/3004-compiler-rt-leopard-no-libdispatch.patch
+++ b/lang/llvm-5.0/files/3004-compiler-rt-leopard-no-libdispatch.patch
@@ -1,0 +1,49 @@
+diff --git a/projects/compiler-rt/lib/builtins/os_version_check.c b/projects/compiler-rt/lib/builtins/os_version_check.c
+index 74ade2f5..709ea687 100644
+--- a/projects/compiler-rt/lib/builtins/os_version_check.c
++++ b/projects/compiler-rt/lib/builtins/os_version_check.c
+@@ -15,8 +15,11 @@
+ 
+ #ifdef __APPLE__
+ 
++#include <AvailabilityMacros.h>
+ #include <CoreFoundation/CoreFoundation.h>
+-#include <dispatch/dispatch.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++ #include <dispatch/dispatch.h>
++#endif
+ #include <TargetConditionals.h>
+ #include <dlfcn.h>
+ #include <stdint.h>
+@@ -26,7 +29,15 @@
+ 
+ /* These three variables hold the host's OS version. */
+ static int32_t GlobalMajor, GlobalMinor, GlobalSubminor;
+-static dispatch_once_t DispatchOnceCounter;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++ static dispatch_once_t DispatchOnceCounter;
++#endif
++
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++/* declare a missing reference not found in SDK < 10.6 for function called below */
++typedef struct __CFError * CFErrorRef;
++extern CFPropertyListRef CFPropertyListCreateWithData(CFAllocatorRef, CFDataRef, CFOptionFlags, CFPropertyListFormat *, CFErrorRef *);
++#endif
+ 
+ /* Find and parse the SystemVersion.plist file. */
+ static void parseSystemVersionPList(void *Unused) {
+@@ -161,8 +171,13 @@ Fail:
+ 
+ int32_t __isOSVersionAtLeast(int32_t Major, int32_t Minor, int32_t Subminor) {
+   /* Populate the global version variables, if they haven't already. */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+   dispatch_once_f(&DispatchOnceCounter, NULL, parseSystemVersionPList);
+-
++#else
++  /* expensive procedure, only do once. GlobalMajor will not be 0 once run. */
++  if (GlobalMajor == 0) 
++    parseSystemVersionPList(NULL);
++#endif
+   if (Major < GlobalMajor) return 1;
+   if (Major > GlobalMajor) return 0;
+   if (Minor < GlobalMinor) return 1;

--- a/lang/llvm-5.0/files/9000-patch-clang-support-emulated-tls.diff
+++ b/lang/llvm-5.0/files/9000-patch-clang-support-emulated-tls.diff
@@ -1,0 +1,57 @@
+<kencu@macports.org> Ken Cunningham
+
+Patches to enable emulated-tls for older darwin systems in clang.
+1) tell clang that TLS is supported on all systems
+2) tell clang to pass -femulated-tls by default on systems older than 10.7
+3) tell llvm to use cxa_thread_atexit instead of tlv_atexit on systems older than 10.7
+
+requires linking against a std c++ lib that supports TLS and contains cxa_thread_atexit
+(libgcc newer than 4.8, or libc++abi with cxa_thread_atexit added).
+
+requires emutls.c objects available at link time to supply supporting routines for emulated-tls.
+emutls is available in libgcc, and should be available in libc++abi for supporting emulated-tls
+
+ideally : llvm should call cxa_thread_atexit rather than tlv_atexit based on 
+          the -femulated-tls flag rather than based on the system version
+
+these patches were originally formatted against clang-5.0
+they can be applied to all clang builds, and will only affect systems 10.4 to 10.6 at present
+
+
+--- a/tools/clang/lib/Basic/Targets.cpp.orig
++++ b/tools/clang/lib/Basic/Targets.cpp
+@@ -264,7 +264,7 @@
+     this->TLSSupported = false;
+ 
+     if (Triple.isMacOSX())
+-      this->TLSSupported = !Triple.isMacOSXVersionLT(10, 7);
++      this->TLSSupported = !Triple.isMacOSXVersionLT(10, 4);
+     else if (Triple.isiOS()) {
+       // 64-bit iOS supported it from 8 onwards, 32-bit from 9 onwards.
+       if (Triple.getArch() == llvm::Triple::x86_64 ||
+--- a/tools/clang/lib/Driver/ToolChains/Clang.cpp.orig
++++ b/tools/clang/lib/Driver/ToolChains/Clang.cpp
+@@ -3209,9 +3209,9 @@
+   Args.AddLastArg(CmdArgs, options::OPT_fheinous_gnu_extensions);
+   Args.AddLastArg(CmdArgs, options::OPT_fno_operator_names);
+   // Emulated TLS is enabled by default on Android and OpenBSD, and can be enabled
+-  // manually with -femulated-tls.
++  // manually with -femulated-tls. Also default on Darwin < 10.7
+   bool EmulatedTLSDefault = Triple.isAndroid() || Triple.isOSOpenBSD() ||
+-                            Triple.isWindowsCygwinEnvironment();
++     Triple.isMacOSXVersionLT(10, 7) || Triple.isWindowsCygwinEnvironment();
+   if (Args.hasFlag(options::OPT_femulated_tls, options::OPT_fno_emulated_tls,
+                    EmulatedTLSDefault))
+     CmdArgs.push_back("-femulated-tls");
+--- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp.orig
++++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+@@ -2163,7 +2163,8 @@
+   const char *Name = "__cxa_atexit";
+   if (TLS) {
+     const llvm::Triple &T = CGF.getTarget().getTriple();
+-    Name = T.isOSDarwin() ?  "_tlv_atexit" : "__cxa_thread_atexit";
++    // Darwin 10.7+ has _tlv_atexit
++    Name = (T.isOSDarwin() && !T.isMacOSXVersionLT(10, 7)) ?  "_tlv_atexit" : "__cxa_thread_atexit";
+   }
+ 
+   // We're assuming that the destructor function is something we can

--- a/lang/llvm-5.0/files/9003-patch-clang-5.0-Toolchains-default-to-libcxx-on-all-systems.diff
+++ b/lang/llvm-5.0/files/9003-patch-clang-5.0-Toolchains-default-to-libcxx-on-all-systems.diff
@@ -1,0 +1,13 @@
+--- a/tools/clang/lib/Driver/ToolChains/Darwin.cpp.orig	2018-01-22 19:03:16.000000000 -0800
++++ b/tools/clang/lib/Driver/ToolChains/Darwin.cpp	2018-01-22 19:05:24.000000000 -0800
+@@ -680,8 +680,8 @@
+ bool MachO::HasNativeLLVMSupport() const { return true; }
+ 
+ ToolChain::CXXStdlibType Darwin::GetDefaultCXXStdlibType() const {
+-  // Default to use libc++ on OS X 10.9+ and iOS 7+.
+-  if ((isTargetMacOS() && !isMacosxVersionLT(10, 9)) ||
++  // Default to use libc++ on OS X 10.4+ and iOS 7+.
++  if ((isTargetMacOS() && !isMacosxVersionLT(10, 4)) ||
+        (isTargetIOSBased() && !isIPhoneOSVersionLT(7, 0)) ||
+        isTargetWatchOSBased())
+     return ToolChain::CST_Libcxx;

--- a/lang/llvm-5.0/files/leopard-no-blocks.patch
+++ b/lang/llvm-5.0/files/leopard-no-blocks.patch
@@ -3,16 +3,9 @@ From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Wed, 7 Jan 2015 03:42:15 -0800
 Subject: [PATCH] Leopard: Default to -fno-blocks
 
-Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
----
- lib/Driver/ToolChains.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/lib/Driver/ToolChains.h b/lib/Driver/ToolChains.h
-index 876bb01..27aa2ee 100644
---- a/tools/clang/lib/Driver/ToolChains.h
-+++ b/tools/clang/lib/Driver/ToolChains.h
-@@ -257,7 +257,7 @@ public:
+--- a/tools/clang/lib/Driver/ToolChains/Darwin.h.orig
++++ b/tools/clang/lib/Driver/ToolChains/Darwin.h
+@@ -198,7 +198,7 @@
    bool IsBlocksDefault() const override {
      // Always allow blocks on Apple; users interested in versioning are
      // expected to use /usr/include/Block.h.


### PR DESCRIPTION
1. fix build on Leopard
2. enable __thread and thread_local support
3. default to -stdlib=libc++ if users macports.conf is so configured
4. revbump and freshen leopard no-blocks patch

all of this is designed to make clang-5.0 on older systems work as similarly to clang on newer systems as possible, to minimize support and maximize functionality.

We could consider using the port:libblocksruntime and enable blocks on leopard and tiger as well...