### PR TITLE
Renamed glue -> py-lscsoft-glue

### DIFF
--- a/python/py-lscsoft-glue/Portfile
+++ b/python/py-lscsoft-glue/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem           1.0
+PortGroup            python 1.0
+
+name                 py-lscsoft-glue
+version              1.60.0
+
+categories-append    science
+platforms            darwin
+maintainers          {ram @skymoo} \
+                     {ligo.org:duncan.macleod @duncanmmacleod} \
+                     {ligo.org:ryan.fisher @rpfisher}
+license              GPL-3+
+
+description          Grid LSC User Environment
+long_description \
+  Glue is a suite of python modules and programs to allow users to run \
+  LSC codes on the grid.
+
+homepage             https://git.ligo.org/lscsoft/glue/
+master_sites         http://software.ligo.org/lscsoft/source/
+distname             lscsoft-glue-${version}
+
+checksums            rmd160  08ad85a70e86960a6baa4bf1c283c7b0fda80498 \
+                     sha256  89d8e55c7e9d9abacec0abac9f91090f0bb0789279309b530c5e4d9fe1a8e687 \
+                     size    2490073
+
+python.versions      27 36 37
+python.default_version 27
+
+if {${name} ne ${subport}} {
+    depends_lib-append port:py${python.version}-six \
+                       port:py${python.version}-numpy \
+                       port:py${python.version}-pyrxp \
+                       port:py${python.version}-openssl \
+                       port:py${python.version}-ligo-segments
+    if {${python.version} == 27} {
+        depends_lib-append port:py${python.version}-cjson
+    }
+    depends_build-append port:py${python.version}-setuptools
+}
+
+# py-pyrxp is not universal
+universal_variant no
+
+if {${name} eq ${subport}} {
+    livecheck.type   regex
+    livecheck.url    ${master_sites}
+    livecheck.regex  {lscsoft-glue-(\d+(?:\.\d+)*).tar.gz}
+} else {
+    livecheck.type   none
+}
+

--- a/python/py-pyrxp/Portfile
+++ b/python/py-pyrxp/Portfile
@@ -17,7 +17,7 @@ homepage          https://pypi.python.org/pypi/pyRXP
 master_sites      pypi:p/pyRXP/
 distname          pyRXP-${version}
 
-python.versions   27 34 35 36
+python.versions   27 34 35 36 37
 
 checksums         md5     945b6586a0bc16e1735bca1244e824c6 \
                   rmd160  62140c9da21066772582d5e0908c28e5971255ac \

--- a/science/dqsegdb/Portfile
+++ b/science/dqsegdb/Portfile
@@ -24,7 +24,7 @@ checksums     rmd160 8c4a8067dd1f9e2fbf98857e2e855b96447fa1d2 \
 
 python.default_version 27
 
-depends_lib-append port:glue \
+depends_lib-append port:py${python.version}-lscsoft-glue \
                    port:py${python.version}-six \
                    port:py${python.version}-pyrxp \
                    port:py${python.version}-m2crypto

--- a/science/glue/Portfile
+++ b/science/glue/Portfile
@@ -1,44 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem    1.0
-PortGroup     python 1.0
+PortGroup     obsolete 1.0
 
 name          glue
+replaced_by   py27-lscsoft-glue
 version       1.58.2
+revision      2
 categories    science
 platforms     darwin
+supported_archs noarch
 maintainers   {ram @skymoo} {ligo.org:duncan.macleod @duncanmmacleod}
 license       GPL-3+
-
-# The GPL and OpenSSL licenses conflict with each other, and our build
-# dependency on Python results in an indirect dependency on OpenSSL.
-# However, there is no real conflict in the case of LALSuite because Python
-# is used as a separately installed interpreter.
-license_noconflict openssl
-
-description   Grid LSC User Environment
-long_description \
-  Glue is a suite of python modules and programs to allow users to run \
-  LSC codes on the grid.
-
-homepage      https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html
-master_sites  http://software.ligo.org/lscsoft/source/
-distname      lscsoft-${name}-${version}
-
-checksums     rmd160 1df76f5f46646a09d649d94c77b4b46af5cbec28 \
-              sha256 3d48ce049ff9369cd890428312a2fc68d6ac8324448b8b8a8ef8baf497e68339 \
-              size 2535460
-
-python.default_version 27
-
-depends_lib-append port:py${python.version}-numpy \
-                   port:py${python.version}-pyrxp \
-                   port:py${python.version}-openssl \
-                   port:py${python.version}-cjson
-
-# py-pyrxp is not universal
-universal_variant no
-
-livecheck.type   regex
-livecheck.url    ${master_sites}
-livecheck.regex  {lscsoft-glue-(\d+(?:\.\d+)*).tar.gz}

--- a/science/lalapps/Portfile
+++ b/science/lalapps/Portfile
@@ -64,7 +64,7 @@ depends_lib   port:openmpi-${clangver} \
               port:lalpulsar port:py27-lalpulsar \
               port:lalinference port:py27-lalinference \
               port:lalstochastic port:py27-lalstochastic \
-              port:glue \
+              port:py27-lscsoft-glue \
               port:python27 \
               port:py27-numpy \
               port:py27-h5py

--- a/science/ligo-lars/Portfile
+++ b/science/ligo-lars/Portfile
@@ -24,7 +24,7 @@ checksums     rmd160 2b6533731c613595d576ace9461912eb0c8a4b37 \
 python.default_version  27
 
 depends_lib-append port:py${python.version}-ligo-common \
-                   port:glue \
+                   port:py${python.version}-glue \
                    port:py${python.version}-m2crypto
 
 livecheck.type   regex

--- a/science/pylal/Portfile
+++ b/science/pylal/Portfile
@@ -40,7 +40,7 @@ depends_build      port:pkgconfig
 depends_lib-append port:py${python.version}-numpy \
                    port:py${python.version}-scipy \
                    port:py${python.version}-matplotlib \
-                   port:glue \
+                   port:py${python.version}-glue \
                    port:py${python.version}-lal \
                    port:py${python.version}-lalframe \
                    port:py${python.version}-lalmetaio \


### PR DESCRIPTION
#### Description

This PR renames the `science/glue` port to `python/py-lscsoft-glue` and introduces multiple pyXY subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
