### PR TITLE
py-dqsegdb2: new port

### DIFF
--- a/python/py-dqsegdb2/Portfile
+++ b/python/py-dqsegdb2/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-dqsegdb2
+version             1.0.0
+
+categories-append   science
+maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+
+platforms           darwin
+license             GPL-3
+
+description         Simplified python interface to DQSEGDB
+long_description    dqsegdb2 is a simplified Python implementation of the \
+                    DQSEGDB API as defined in LIGO-T1300625. \
+                    This package only provides a query interface for GET \
+                    bequests, any users wishing to make POST requests \
+                    should refer to the official 'dqsegdb' port.
+homepage            https://dqsegdb2.readthedocs.io
+
+master_sites        pypi:d/dqsegdb2
+distname            dqsegdb2-${version}
+checksums           rmd160 dc1275e619fb7bc9713903bde44a9a3f557fe936 \
+                    sha256 828a1afd0af31b4fda2bba3427836aa5cf7fb751b636140ba6e8c48d1e6aac34 \
+                    size   17980
+
+python.versions     27 36 37
+python.default_version \
+                    36
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-gwdatafind \
+                    port:py${python.version}-ligo-segments
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

This PR adds a python port set for [`dqsegdb2`](https://dqsegdb2.readthedocs.io).
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
