### PR TITLE
QtPBFImagePlugin: new port

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+github.setup        tumic0 QtPBFImagePlugin 1.1
+categories          graphics
+platforms           darwin
+license             LGPL-3
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         PBF image plugin for Qt5
+long_description    Qt image plugin for displaying Mapbox vector tiles.
+
+checksums           rmd160  814697cf675470d17989a0c47c58e10d5879cdf1 \
+                    sha256  7b78877e12a0ca1d8d934333251196b507d2e942a71beb86bd13ac0a2a31c9d7 \
+                    size    193414
+
+configure.args-append  PROTOBUF=${prefix} ZLIB=${prefix}
+
+depends_lib-append  port:protobuf3-cpp \
+                    port:zlib


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
QtPBFImagePlugin - new port. Optional dependency for [gis/GPXSee-7.0](https://github.com/macports/macports-ports/tree/master/gis/GPXSee).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
