### PR TITLE
py-ctypeslib2: Update to 2.2.2, retire py34/35

### DIFF
--- a/python/py-ctypeslib2/Portfile
+++ b/python/py-ctypeslib2/Portfile
@@ -3,9 +3,9 @@
 PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
-github.setup            trolldbois ctypeslib 2.2.1
+github.setup            trolldbois ctypeslib 2.2.2
 name                    py-ctypeslib2
-python.versions         27 34 35 36
+python.versions         27 36 37
 python.default_version  27
 platforms               darwin
 license                 MIT
@@ -20,8 +20,8 @@ long_description        This fork of ctypeslib is mainly about using the \
                         code from C source code, instead of gccxml.
 
 checksums \
-    rmd160  461e97b795246ab2d1ef0c6f99ec5737f6fd5a17 \
-    sha256  1beb48fa7dcf290217d541db521b9c7b5b75ab052a300e1eca9eed6f8583510a
+    rmd160  f99e20769f606d44ddb34aff6e20183fd186aaa2 \
+    sha256  e968d0c60101fdebbd51f392bd6402e5bad415fa62dff23de79cc467d24c1eee
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -98,6 +98,7 @@ py-couchdbkit           0.6.5_1     26
 py-country              0.10_1      26
 py-cssutils             1.0.2_1     26
 py-ctags                1.0.5_1     26
+py-ctypeslib2           2.2.2       34 35
 py-curl                 7.19.0_2    26
 py-cvxopt               1.1.9_1     33
 py-cycler               0.10.0_1    26 33


### PR DESCRIPTION
Maintainer update.