### PR TITLE
mcfly: new submission

### DIFF
--- a/sysutils/mcfly/Portfile
+++ b/sysutils/mcfly/Portfile
@@ -1,0 +1,358 @@
+PortSystem          1.0
+PortGroup           cargo 1.0
+PortGroup           github 1.0
+
+categories          sysutils
+
+github.setup        cantino mcfly 0.2.5 v
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+maintainers         nomaintainer
+description         An upgraded reverse history for Bash.
+long_description    McFly replaces your default ctrl-r Bash history search \
+                    with an intelligent search engine that takes into account \
+                    your working directory and the context of recently \
+                    executed commands. McFly's suggestions are prioritized \
+                    in real time with a small neural network.
+
+checksums           mcfly-0.2.5.tar.gz \
+                    rmd160  6f787abdf5de81e0313606af194588c571845a97 \
+                    sha256  e90b12545b49d8cf3a79cb7cb03f0516833a3d78accb2cd75e1ef28b6a1ad058 \
+                    size    242571 \
+                    aho-corasick-0.6.6.crate \
+                    sha256  c1c6d463cbe7ed28720b5b489e7c083eeb8f90d08be2a0d6bb9e1ffea9ce1afa \
+                    rmd160  cce62fd1a33e14989e1f2f62b9a52ba10b9ad170 \
+                    size    26330 \
+                    ansi_term-0.11.0.crate \
+                    sha256  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+                    rmd160  0bc10d826fc7a658ac1026dac333cc54f26f7c5b \
+                    size    17087 \
+                    argon2rs-0.2.5.crate \
+                    sha256  3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392 \
+                    rmd160  50d84e37d2513e8fa2787f642327ac88a825b10e \
+                    size    353096 \
+                    arrayvec-0.4.7.crate \
+                    sha256  a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef \
+                    rmd160  e5e6de0e55d6936afa2bfa33b772e6a55ba1f3d2 \
+                    size    22946 \
+                    atty-0.2.10.crate \
+                    sha256  2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1 \
+                    rmd160  a26723c8bf2dfea70f5f47d2f160d389a9710ae0 \
+                    size    5962 \
+                    backtrace-0.3.9.crate \
+                    sha256  89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a \
+                    rmd160  8917edb6fe6c1737bcbdea8988d5d41f09e507a8 \
+                    size    31054 \
+                    backtrace-sys-0.1.24.crate \
+                    sha256  c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0 \
+                    rmd160  723b9ecbd9a395877d2a9d62a5b27fa2f7ac730a \
+                    size    522332 \
+                    bitflags-1.0.3.crate \
+                    sha256  d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789 \
+                    rmd160  f64aa6bf708e5e7a943d40cdf59e852a3befee33 \
+                    size    13838 \
+                    blake2-rfc-0.2.18.crate \
+                    sha256  5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400 \
+                    rmd160  9c0e4ee7978a071709a9ab1e92dc585f70e582d8 \
+                    size    15676 \
+                    cc-1.0.18.crate \
+                    sha256  2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275 \
+                    rmd160  b26da25d502e71c4adbbf38d88fa1729e2a37b8c \
+                    size    42127 \
+                    cfg-if-0.1.5.crate \
+                    sha256  0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3 \
+                    rmd160  6188700603b1077e603aec815dad25b81e2aaf4d \
+                    size    7363 \
+                    clap-2.32.0.crate \
+                    sha256  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
+                    rmd160  069963d76d9d566b3ec52976b30c798d564e198d \
+                    size    196073 \
+                    cloudabi-0.0.3.crate \
+                    sha256  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+                    rmd160  4da7ab080c1d18e5881dbcb419d250d0c38387eb \
+                    size    22156 \
+                    constant_time_eq-0.1.3.crate \
+                    sha256  8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e \
+                    rmd160  42322b052eba5c2311f41bdd60f98d385b981eac \
+                    size    1279 \
+                    csv-1.0.1.crate \
+                    sha256  0bbb6d75aae072248e381715437855a69595e5a97d3abbf748fe7a95e65d77fa \
+                    rmd160  bd6a5216c54216aad6b5342bbc73d2204a03f720 \
+                    size    889533 \
+                    csv-core-0.1.4.crate \
+                    sha256  4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105 \
+                    rmd160  c768ee704b849226b490f41e9d9713e540f33d07 \
+                    size    25406 \
+                    dirs-1.0.4.crate \
+                    sha256  88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a \
+                    rmd160  46232082ab3e3600b562fb8c1add2c96aa5d5c29 \
+                    size    12844 \
+                    failure-0.1.2.crate \
+                    sha256  7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9 \
+                    rmd160  7c2bb45d83c102d025ee246a5cb9a0ab6a0bcd6f \
+                    size    31820 \
+                    failure_derive-0.1.2.crate \
+                    sha256  946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426 \
+                    rmd160  4ed8eef64aebba8be71e63cd3d40fa84d1898c05 \
+                    size    4326 \
+                    fuchsia-zircon-0.3.3.crate \
+                    sha256  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+                    rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
+                    size    22565 \
+                    fuchsia-zircon-sys-0.3.3.crate \
+                    sha256  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+                    rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
+                    size    7191 \
+                    lazy_static-1.1.0.crate \
+                    sha256  ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7 \
+                    rmd160  3cd4086bfce143b673d7589f8b05539871405aee \
+                    size    12317 \
+                    libc-0.2.42.crate \
+                    sha256  b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1 \
+                    rmd160  0063b66a8ebccc71430f7cb8edbe0fdc15cfc6ba \
+                    size    336080 \
+                    libsqlite3-sys-0.10.0.crate \
+                    sha256  742b695cbfb89e549dca6960a55e6802f67d352e33e97859ee46dee835211b0f \
+                    rmd160  09a1b2880cb6193b0d9b996844c559aa6444debd \
+                    size    2175426 \
+                    linked-hash-map-0.4.2.crate \
+                    sha256  7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939 \
+                    rmd160  9c68679bf5bf5ac5d2af189224abea47921e37ec \
+                    size    15980 \
+                    lru-cache-0.1.1.crate \
+                    sha256  4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21 \
+                    rmd160  44efe847b7019e82197195761c82dce8a2b3d163 \
+                    size    8645 \
+                    memchr-2.0.1.crate \
+                    sha256  796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d \
+                    rmd160  4894e0ad3a987cf78a6b4be9974e830865db22c5 \
+                    size    9858 \
+                    nodrop-0.1.12.crate \
+                    sha256  9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2 \
+                    rmd160  48851b37a94b2ebcd2a88e644ea09f9e85a14dde \
+                    size    3033 \
+                    pkg-config-0.3.11.crate \
+                    sha256  110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f \
+                    rmd160  1272ad31ae69e22a6882ad13745f64d393ca99a3 \
+                    size    13227 \
+                    proc-macro2-0.4.20.crate \
+                    sha256  3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee \
+                    rmd160  bcfd01b09f55b35619593bb5eda078db6299e15a \
+                    size    30516 \
+                    quote-0.6.8.crate \
+                    sha256  dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5 \
+                    rmd160  9d1a0629d5b5050db0d5c652ce8430f887616368 \
+                    size    15530 \
+                    rand-0.5.5.crate \
+                    sha256  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
+                    rmd160  09a484f5c5e3501d87ec80eb4be990fcb421b9a9 \
+                    size    137359 \
+                    rand-0.4.3.crate \
+                    sha256  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
+                    rmd160  0911fc63ee17323176b7806d7ed6db412b32ac0f \
+                    size    76094 \
+                    rand_core-0.2.1.crate \
+                    sha256  edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2 \
+                    rmd160  6d34acd1c056b5ea5fa70f5c0e5d2292bb91931f \
+                    size    19262 \
+                    redox_syscall-0.1.40.crate \
+                    sha256  c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1 \
+                    rmd160  f0d874ddc545a1c39c88648f71a5d08bb8a672df \
+                    size    14745 \
+                    redox_termios-0.1.1.crate \
+                    sha256  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+                    rmd160  4403f32fb5435279446c9b6acc54792d655d4f72 \
+                    size    3227 \
+                    redox_users-0.2.0.crate \
+                    sha256  214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26 \
+                    rmd160  4480a564575eefcc3e4bc80a09ed88a80f0a5362 \
+                    size    11104 \
+                    regex-1.0.2.crate \
+                    sha256  5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814 \
+                    rmd160  eb0bf1fb1bbc31f8c419a22e93cb0f90509e848c \
+                    size    245163 \
+                    regex-syntax-0.6.2.crate \
+                    sha256  747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d \
+                    rmd160  bc9a5abda5ce3a7fecbd581556d2f7c8372a06c2 \
+                    size    238572 \
+                    relative-path-0.4.0.crate \
+                    sha256  0e7790c7f1cc73d831d28dc5a7deb316a006e7848e6a7f467cdb10a0a9e0fb1c \
+                    rmd160  5fea4c79d81f8fd3455146842c0098211d2b579f \
+                    size    18095 \
+                    rusqlite-0.15.0.crate \
+                    sha256  39bae767eb27866f5c0be918635ae54af705bc09db11be2c43a3c6b361cf3462 \
+                    rmd160  d9bff6c39b6f15be44e2d3ca0f994008c36f4a69 \
+                    size    82548 \
+                    rustc-demangle-0.1.9.crate \
+                    sha256  bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395 \
+                    rmd160  874823ff72cbbb0dee459c1889862e864eb7aab4 \
+                    size    11463 \
+                    scoped_threadpool-0.1.9.crate \
+                    sha256  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
+                    rmd160  64a6e9903a469630a2c664fbfece56a6d4add650 \
+                    size    7800 \
+                    serde-1.0.75.crate \
+                    sha256  22d340507cea0b7e6632900a176101fea959c7065d93ba555072da90aaaafc87 \
+                    rmd160  549156f24c87513138aee3c3decf1d8e9151bb14 \
+                    size    72560 \
+                    shellexpand-1.0.0.crate \
+                    sha256  de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564 \
+                    rmd160  cd97b34ff01224270e524adb541f241ab3fefa6e \
+                    size    13055 \
+                    strsim-0.7.0.crate \
+                    sha256  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+                    rmd160  82c766cebe88a39e3058a21c730b43b3bf6e929d \
+                    size    8435 \
+                    syn-0.14.9.crate \
+                    sha256  261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741 \
+                    rmd160  85e4d1d54b77285eeb0db207474fcbbd8bd3b69b \
+                    size    135921 \
+                    synstructure-0.9.0.crate \
+                    sha256  85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7 \
+                    rmd160  e8ac76fb9e2c0b75af68ba21206876e761264709 \
+                    size    17651 \
+                    termion-1.5.1.crate \
+                    sha256  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
+                    rmd160  1dd6b33cc0518b95da88648441807c210a2a498f \
+                    size    20659 \
+                    textwrap-0.10.0.crate \
+                    sha256  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+                    rmd160  93e9595c1e99d77cfa8f5111f40b52d6292e617b \
+                    size    15986 \
+                    thread_local-0.3.5.crate \
+                    sha256  279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963 \
+                    rmd160  5d166aed0e0aa52f1ec4e0cd440aa2b5a00c878e \
+                    size    11794 \
+                    time-0.1.40.crate \
+                    sha256  d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b \
+                    rmd160  879fd9184dc31df03541a12535ef38facefae64a \
+                    size    29518 \
+                    ucd-util-0.1.1.crate \
+                    sha256  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
+                    rmd160  b36f310b6d4808dc0b20f217727a592eb48b3e05 \
+                    size    24221 \
+                    unicode-segmentation-1.2.1.crate \
+                    sha256  aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1 \
+                    rmd160  5695c194d6f49bbb4a4e7a452fcbc5b03b8d80ce \
+                    size    68223 \
+                    unicode-width-0.1.5.crate \
+                    sha256  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+                    rmd160  360df9e831a6e20931c240d13747f3711dc568d9 \
+                    size    15761 \
+                    unicode-xid-0.1.0.crate \
+                    sha256  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+                    rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
+                    size    16000 \
+                    unreachable-1.0.0.crate \
+                    sha256  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+                    rmd160  00c79ce6e523b3b09978db8766e3110a637c23ec \
+                    size    6355 \
+                    utf8-ranges-1.0.0.crate \
+                    sha256  662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122 \
+                    rmd160  1b4d6305dd44df57dc34555b7064df1da1d462fd \
+                    size    8599 \
+                    vcpkg-0.2.4.crate \
+                    sha256  cbe533e138811704c0e3cbde65a818b35d3240409b4346256c5ede403e082474 \
+                    rmd160  3de70b4237effb7d0cd32b6ca88ab6f0f2e75708 \
+                    size    9571 \
+                    vec_map-0.8.1.crate \
+                    sha256  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+                    rmd160  60ade9d4a361db970dd5a27786e5de3b491a4b62 \
+                    size    14959 \
+                    version_check-0.1.4.crate \
+                    sha256  7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051 \
+                    rmd160  b00bcd33c973bab44fd8456ac7a7dccb129e0564 \
+                    size    7946 \
+                    void-1.0.2.crate \
+                    sha256  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+                    rmd160  5d76f91beb625f5b645c156ca45ee5138e984e80 \
+                    size    2356 \
+                    winapi-0.3.5.crate \
+                    sha256  773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd \
+                    rmd160  aff8c98576b9fb68664fb891a4eca97dcd952811 \
+                    size    997942 \
+                    winapi-i686-pc-windows-gnu-0.4.0.crate \
+                    sha256  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+                    rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
+                    size    2918815 \
+                    winapi-x86_64-pc-windows-gnu-0.4.0.crate \
+                    sha256  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+                    rmd160  300417853d251d91cadb9650992a6aa98248619f \
+                    size    2947998
+
+cargo.crates \
+    aho-corasick                     0.6.6  c1c6d463cbe7ed28720b5b489e7c083eeb8f90d08be2a0d6bb9e1ffea9ce1afa \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    argon2rs                         0.2.5  3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392 \
+    arrayvec                         0.4.7  a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef \
+    atty                            0.2.10  2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1 \
+    backtrace                        0.3.9  89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a \
+    backtrace-sys                   0.1.24  c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0 \
+    bitflags                         1.0.3  d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789 \
+    blake2-rfc                      0.2.18  5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400 \
+    cc                              1.0.18  2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275 \
+    cfg-if                           0.1.5  0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3 \
+    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    constant_time_eq                 0.1.3  8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e \
+    csv                              1.0.1  0bbb6d75aae072248e381715437855a69595e5a97d3abbf748fe7a95e65d77fa \
+    csv-core                         0.1.4  4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105 \
+    dirs                             1.0.4  88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a \
+    failure                          0.1.2  7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9 \
+    failure_derive                   0.1.2  946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    lazy_static                      1.1.0  ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7 \
+    libc                            0.2.42  b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1 \
+    libsqlite3-sys                  0.10.0  742b695cbfb89e549dca6960a55e6802f67d352e33e97859ee46dee835211b0f \
+    linked-hash-map                  0.4.2  7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939 \
+    lru-cache                        0.1.1  4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21 \
+    memchr                           2.0.1  796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d \
+    nodrop                          0.1.12  9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2 \
+    pkg-config                      0.3.11  110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f \
+    proc-macro2                     0.4.20  3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee \
+    quote                            0.6.8  dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5 \
+    rand                             0.5.5  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
+    rand                             0.4.3  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
+    rand_core                        0.2.1  edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2 \
+    redox_syscall                   0.1.40  c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    redox_users                      0.2.0  214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26 \
+    regex                            1.0.2  5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814 \
+    regex-syntax                     0.6.2  747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d \
+    relative-path                    0.4.0  0e7790c7f1cc73d831d28dc5a7deb316a006e7848e6a7f467cdb10a0a9e0fb1c \
+    rusqlite                        0.15.0  39bae767eb27866f5c0be918635ae54af705bc09db11be2c43a3c6b361cf3462 \
+    rustc-demangle                   0.1.9  bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395 \
+    scoped_threadpool                0.1.9  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
+    serde                           1.0.75  22d340507cea0b7e6632900a176101fea959c7065d93ba555072da90aaaafc87 \
+    shellexpand                      1.0.0  de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564 \
+    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    syn                             0.14.9  261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741 \
+    synstructure                     0.9.0  85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7 \
+    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
+    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+    thread_local                     0.3.5  279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963 \
+    time                            0.1.40  d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b \
+    ucd-util                         0.1.1  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
+    unicode-segmentation             1.2.1  aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1 \
+    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unicode-xid                      0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+    utf8-ranges                      1.0.0  662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122 \
+    vcpkg                            0.2.4  cbe533e138811704c0e3cbde65a818b35d3240409b4346256c5ede403e082474 \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.1.4  7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051 \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    winapi                           0.3.5  773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+
+destroot {
+    # FIXME Make this work with other platforms
+    xinstall -m 0755 ${worksrcpath}/target/x86_64-apple-darwin/release/${name} ${destroot}${prefix}/bin/
+    xinstall -d ${destroot}${prefix}/share/${name}
+    xinstall -m 0644 ${worksrcpath}/${name}.bash ${destroot}${prefix}/share/${name}/
+}


### PR DESCRIPTION
#### Description

Adds [mcfly](https://github.com/cantino/mcfly). A user must source `/opt/local/share/mcfly/mcfly.bash` in their shell configuration.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?