### PR TITLE
nfdump: Enable nsel variant to read and process NSEL/NEL event data

### DIFF
--- a/net/nfdump/Portfile
+++ b/net/nfdump/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        phaag nfdump 1.6.15 v
+revision            1
 categories          net
 maintainers         nomaintainer
 license             BSD
@@ -24,6 +25,7 @@ use_parallel_build  no
 configure.cflags-append -std=gnu89
 configure.args      --enable-sflow \
                     --enable-nfprofile \
+                    --enable-nsel \
                     --with-rrdpath=${prefix}
 
 post-destroot {


### PR DESCRIPTION
#### Description

This enables a variant for the nfdump package to read and process NSEL/NEL event data.

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? None found
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`? No tests in package
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?