### PR TITLE
py-tensorflow: Add missing dependency py-absl

### DIFF
--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -70,7 +70,8 @@ if {${name} ne ${subport}} {
         port:py${python.version}-gast \
         port:py${python.version}-astor \
         port:py${python.version}-termcolor \
-        port:py${python.version}-keras
+        port:py${python.version}-keras \
+        port:py${python.version}-absl
     if {${python.version} < 34} {
         depends_lib-append \
             port:py${python.version}-enum34


### PR DESCRIPTION
#### Description

`py-absl` was missing. tensorflow worked in python3, at least, after installing it. `port test` attempts to install py27-tensorflow, and fails at

```
--->  Activating py27-backports.weakref @1.0.post1_0
Error: Failed to activate py27-backports.weakref: Image error: /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports/__init__.py is being used by the active py27-backports port.  Please deactivate this port first, or use 'port -f activate py27-backports.weakref' to force the activation.
Error: See /opt/local/var/macports/logs/_Users_esafak_code_macports_python_py-backports.weakref/py27-backports.weakref/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port py-tensorflow failed
```

When I run port activate, as instructed, it says

```
--->  Computing dependencies for py27-backports.weakref
--->  Activating py27-backports.weakref @1.0.post1_0
Warning: File /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports/__init__.py already exists.  Moving to: /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports/__init__.py.mp_1545018285.
Warning: File /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports/__init__.pyc already exists.  Moving to: /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/backports/__init__.pyc.mp_1545018285.
--->  Cleaning py27-backports.weakref
```

When I rerun `port test` it installs py27-tensorflow and its dependencies, failing at
```
Error: Failed to test py-tensorflow: py-tensorflow has no tests turned on. see 'test.run' in portfile(7)
Error: See /opt/local/var/macports/logs/_Users_esafak_code_macports_python_py-tensorflow/py-tensorflow/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port py-tensorflow failed
```

However, I can import tensorflow in both python 2.7 and 3.6 after installing py-absl.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->