### PR TITLE
py-ligo-gracedb: renamed 'ligo-gracedb' port

### DIFF
--- a/python/py-ligo-gracedb/Portfile
+++ b/python/py-ligo-gracedb/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-ligo-gracedb
+version             1.28
+categories-append   science
+platforms           darwin
+supported_archs     noarch
+maintainers         {ram @skymoo}
+license             GPL-3+
+
+# The GPL and OpenSSL licenses conflict with each other, and our build
+# dependency on Python results in an indirect dependency on OpenSSL.
+# However, there is no real conflict in the case of LALSuite because Python
+# is used as a separately installed interpreter.
+license_noconflict  openssl
+
+description         Gravitational-wave Candidate Event Database
+long_description \
+    A prototype system to organize candidate events from \
+    gravitational-wave searches and to provide an environment to record \
+    information about follow-ups. This package provides a simple client \
+    tool to submit candidate events to the database.
+
+homepage        https://www.lsc-group.phys.uwm.edu/daswg/projects/gracedb.html
+master_sites    http://software.ligo.org/lscsoft/source/
+distname        ligo-gracedb-${version}
+
+checksums       rmd160  3d0d34fb23a47fccb219521615c4bb6a0cb4a5ed \
+                sha256  57cac6843dd67fa45924eb899046407f6129db6439caaf673bc01058a1feabdd \
+                size    2189424
+
+python.versions     27 36 37
+python.default_version  27
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_lib-append      port:py${python.version}-ligo-common \
+                            port:py${python.version}-six
+}
+
+if {${name} eq ${subport}} {
+    livecheck.type      regex
+    livecheck.url       ${master_sites}
+    livecheck.regex     {ligo-gracedb-(\d+(?:\.\d+)*).tar.gz}
+}

--- a/science/lalinference/Portfile
+++ b/science/lalinference/Portfile
@@ -27,18 +27,26 @@ depends_lib   port:gsl \
               port:lalburst \
               port:lalinspiral \
               port:lalpulsar \
-              port:healpix-c \
-              port:ligo-gracedb
+              port:healpix-c
 
 # add Python dependencies for python subports
 if {[string match "py*" ${subport}]} {
     set numbers [regexp -all -inline -- {[0-9]+} ${subport}]
     set v [lindex ${numbers} 0]
     # python, C-library port, and numpy are automatically added below
-    depends_lib     port:py${v}-lal port:py${v}-lalmetaio port:py${v}-lalsimulation \
-                    port:py${v}-lalburst port:py${v}-lalinspiral port:py${v}-lalpulsar \
-                    port:py${v}-scipy port:py${v}-lscsoft-glue port:py${v}-healpy \
-                    port:py${v}-astropy port:py${v}-matplotlib port:py${v}-h5py \
+    depends_lib     port:py${v}-lal \
+                    port:py${v}-lalmetaio \
+                    port:py${v}-lalsimulation \
+                    port:py${v}-lalburst \
+                    port:py${v}-lalinspiral \
+                    port:py${v}-lalpulsar \
+                    port:py${v}-scipy \
+                    port:py${v}-lscsoft-glue \
+                    port:py${v}-ligo-gracedb \
+                    port:py${v}-healpy \
+                    port:py${v}-astropy \
+                    port:py${v}-matplotlib \
+                    port:py${v}-h5py \
                     port:py${v}-shapely
     revision        1
 }

--- a/science/ligo-gracedb/Portfile
+++ b/science/ligo-gracedb/Portfile
@@ -1,43 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem    1.0
-PortGroup     python 1.0
-
-name          ligo-gracedb
-version       1.28
-categories    science
-platforms     darwin
-supported_archs noarch
-maintainers   {ram @skymoo}
-license       GPL-3+
-
-# The GPL and OpenSSL licenses conflict with each other, and our build
-# dependency on Python results in an indirect dependency on OpenSSL.
-# However, there is no real conflict in the case of LALSuite because Python
-# is used as a separately installed interpreter.
-license_noconflict openssl
-
-description   Gravitational-wave Candidate Event Database
-long_description \
-  A prototype system to organize candidate events from \
-  gravitational-wave searches and to provide an environment to record \
-  information about follow-ups. This package provides a simple client \
-  tool to submit candidate events to the database.
-
-homepage      https://www.lsc-group.phys.uwm.edu/daswg/projects/gracedb.html
-master_sites  http://software.ligo.org/lscsoft/source/
-
-checksums     rmd160  3d0d34fb23a47fccb219521615c4bb6a0cb4a5ed \
-              sha256  57cac6843dd67fa45924eb899046407f6129db6439caaf673bc01058a1feabdd \
-              size    2189424
-
-python.default_version  27
-
-depends_lib-append port:py${python.version}-ligo-common \
-                   port:py${python.version}-m2crypto \
-                   port:py${python.version}-cjson \
-                   port:py${python.version}-setuptools
-
-livecheck.type   regex
-livecheck.url    ${master_sites}
-livecheck.regex  {ligo-gracedb-(\d+(?:\.\d+)*).tar.gz}
+PortSystem        1.0
+PortGroup         obsolete 1.0
+name              ligo-gracedb
+replaced_by       py27-ligo-gracedb
+version           1.28
+revision          3
+categories        science
+platforms         darwin
+supported_archs   noarch
+maintainers       {ram @skymoo}
+license           GPL-3+


### PR DESCRIPTION
#### Description

This PR renames `/science/ligo-gracedb` -> `/python/py-ligo-gracedb` and adds subports for the supported python versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
