### PR TITLE
curl: update to 7.63.0

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -3,7 +3,7 @@
 PortSystem                      1.0
 
 name                            curl
-version                         7.62.0
+version                         7.63.0
 categories                      net www
 platforms                       darwin freebsd
 maintainers                     {ryandesign @ryandesign}
@@ -26,9 +26,9 @@ set curl_distfile               ${distfiles}
 distfiles                       ${curl_distfile}:curl
 
 checksums                       ${curl_distfile} \
-                                rmd160  a8139e2e1e5af4bedeea329cac100490a8895ac9 \
-                                sha256  dab5643a5fe775ae92570b9f3df6b0ef4bc2a827a959361fb130c73b721275c1 \
-                                size    2395476
+                                rmd160  6985390ee929d95cd0a3e7d929f6084996669031 \
+                                sha256  9600234c794bfb8a0d3f138e9294d60a20e7a5f10e35ece8cf518e2112d968c4 \
+                                size    2390408
 
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
@@ -220,8 +220,8 @@ subport curl-ca-bundle {
     set certdata_file           certdata.txt
     # The output of the Tcl command "clock seconds" (you can run it in tclsh) when
     # the certdata.txt file in the port was last updated.
-    set certdata_updated        1540974500
-    set certdata_version        dc2f7806fbc1
+    set certdata_updated        1545056376
+    set certdata_version        3a4a3b9133e9
     set certdata_extract_cmd    bzip2
     set certdata_extract_suffix .tar.bz2
     set certdata_distfile       certdata-${certdata_version}${certdata_extract_suffix}
@@ -237,9 +237,9 @@ subport curl-ca-bundle {
     distfiles-append            ${certdata_distfile}:certdata
 
     checksums-append            ${certdata_distfile} \
-                                rmd160  14db32f6ecd8a8eb3ee22703057426c5d1d14992 \
-                                sha256  b5b644548d33cb849121818deba39211ba4ac263d7e82e904d8e630806073a6d \
-                                size    190775
+                                rmd160  39cd56f6d1e13ca53eee747629aad349206d5ddb \
+                                sha256  c191063da22a44d5694c765aa2210373e4c48c4a5f1d700321a3c03e80eae16b \
+                                size    191985
 
     extract.only                ${curl_distfile}
     set curl_mk_ca_bundle_files "${worksrcdir}/Makefile ${worksrcdir}/lib/mk-ca-bundle.pl"


### PR DESCRIPTION
#### Description
Tested with a `curl -v https://www.google.com`.

How necessary is the timestamp stuff around curl-ca-bundle? You're keying off of the exact commit ID from the repository, the comments around stealth updates ring a bit hollow for me, Mozilla can't stealth update a commit id.


###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?