### PR TITLE
py-ligotimegps: added new python package

### DIFF
--- a/python/py-ligotimegps/Portfile
+++ b/python/py-ligotimegps/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        gwpy ligotimegps 2.0.0 v
+name                py-ligotimegps
+
+categories-append   science
+maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
+
+platforms           darwin
+license             GPL-3
+
+description         A pure-python version of lal.LIGOTimeGPS.
+long_description    This module provides a pure-python version of the \
+                    `LIGOTimeGPS` class, used to represent GPS times \
+                    (number of seconds elapsed since GPS epoch) with \
+                    nanoseconds precision.
+
+master_sites        pypi:l/ligotimegps \
+                    https://github.com/gwpy/ligotimegps/releases/v${version}/
+checksums           rmd160 f99edb6f50e76232ebf61a12a9f95baabf595491 \
+                    sha256 a98275b5aa4490eadc2669f9a2de108f4634ae3724e878fee562b84ccf529e83 \
+                    size   35840
+
+python.versions     27 36 37
+python.default_version  37
+
+if {${name} ne ${subport}} {
+    if {${python.version} < 30} {
+        version     1.2.3
+        checksums   rmd160 5f63a0c725bbc4b888df8c2d81707e92dcf46f18 \
+                    sha256 79ee18df7f6806d522f68d278b0ac426094626a479af58c178f32d2b319919ba \
+                    size   35648
+        depends_lib-append  port:py${python.version}-six
+    }
+
+    depends_build-append    port:py${python.version}-setuptools
+    livecheck.type          none
+}
+
+distname            ligotimegps-${version}


### PR DESCRIPTION
#### Description

This PR adds a port for [`ligotimegps`](https://github.com/gwpy/ligotimegps.git). This package has recently gone to python3-only releases, so I've added some hooks to pin the last python2.7-compatible version for the `py27-ligotimegps` subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
