### PR TITLE
gnupg2: Make openldap support a variant.

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -59,7 +59,6 @@ depends_lib         port:libiconv           \
                     port:libksba            \
                     port:libgcrypt          \
                     port:libgpg-error       \
-                    port:openldap           \
                     port:readline           \
                     port:gnutls             \
                     port:libusb-compat      \
@@ -79,6 +78,14 @@ variant pinentry_mac conflicts pinentry description {Handle user input via pinen
     depends_lib-append      port:pinentry-mac
     configure.args-append   --with-pinentry-pgm=${applications_dir}/pinentry-mac.app/Contents/MacOS/pinentry-mac
 }
+
+configure.args-append --disable-openldap
+variant openldap description {Support openldap} {
+    depends_lib-append      port:openldap
+    configure.args-replace  --disable-openldap --enable-openldap
+}
+
+default_variants    +openldap
 
 test.run            yes
 test.dir            ${worksrcpath}/tests


### PR DESCRIPTION
#### Description

This is the updated patch based on the discussion in macports/macports-ports#2625.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
