### PR TITLE
creduce: bump to 2.8.0

### DIFF
--- a/devel/creduce/Portfile
+++ b/devel/creduce/Portfile
@@ -47,6 +47,23 @@ checksums               rmd160  fd9ed41cbb8464ee95bc94ec9ccc50b22303bd9a \
                         sha256  77f622453a7fc52aa061a89aed457f23ab538b12270df0a2a79b6957fd381def \
                         size    774668
 
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} <= 9} {
+        ui_error "${name} is only supported on 10.6 or newer."
+        return -code error "unsupported macOS version"
+    }
+}
+
+if {${os.platform} eq "darwin" && ${os.major} <= 12} {
+    # forcing libc++ works on these platforms
+    depends_lib-append      port:libcxx
+    configure.cxx_stdlib    libc++
+    # clang < macOS 10.9 don't work. clang-5.0 tested and works.
+    # cannot use cxx11 1.1 PG due to other issues
+    # just whitelist working compilers rather than a long list of blacklisting and fallback additions
+    compiler.whitelist      macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+}
+
 configure.perl          ${prefix}/bin/perl${perl5.major}
 configure.args          --libexecdir=${prefix}/libexec/${name} \
                         --with-llvm=${prefix}/libexec/llvm-${llvm_version}

--- a/devel/creduce/Portfile
+++ b/devel/creduce/Portfile
@@ -3,8 +3,7 @@
 PortSystem              1.0
 
 name                    creduce
-version                 2.7.0
-revision                1
+version                 2.8.0
 categories              devel
 platforms               darwin
 license                 NCSA
@@ -22,8 +21,8 @@ long_description        C-Reduce is a tool that takes a large C, C++, \
 homepage                http://embed.cs.utah.edu/creduce
 
 # INSTALL notes the specific version of LLVM that is required.
-set llvm_version 4.0
-set perl5.major 5.26
+set llvm_version        6.0
+set perl5.major         5.26
 
 # INSTALL mentions flex, but the tarball ships with pregenerated parsers.
 depends_build           port:llvm-${llvm_version}
@@ -33,24 +32,20 @@ depends_lib             port:ncurses port:zlib
 
 # Not required at compile time, but the configure script checks for them.
 depends_lib-append      port:clang-${llvm_version} \
-                        port:astyle \
-                        port:gindent \
                         port:perl${perl5.major} \
                         port:p${perl5.major}-exporter-lite \
                         port:p${perl5.major}-file-which \
                         port:p${perl5.major}-getopt-tabular \
                         port:p${perl5.major}-regexp-common \
-                        port:p${perl5.major}-sys-cpu \
                         port:p${perl5.major}-term-readkey
 depends_skip_archcheck  clang-${llvm_version} \
-                        astyle \
                         perl${perl5.major} \
-                        p${perl5.major}-sys-cpu \
                         p${perl5.major}-term-readkey
 
 master_sites            ${homepage}/
-checksums               rmd160  8c4cf6231983bf22790bab0a0cf5443924673ca3 \
-                        sha256  36dca859c97a988e71b1a08e0cbd5849e4da051d248c5e483494194c4a231a41
+checksums               rmd160  fd9ed41cbb8464ee95bc94ec9ccc50b22303bd9a \
+                        sha256  77f622453a7fc52aa061a89aed457f23ab538b12270df0a2a79b6957fd381def \
+                        size    774668
 
 configure.perl          ${prefix}/bin/perl${perl5.major}
 configure.args          --libexecdir=${prefix}/libexec/${name} \
@@ -64,6 +59,11 @@ post-destroot {
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS COPYING NEWS README ${destroot}${docdir}
 }
+
+test.run                yes
+test.dir                ${worksrcpath}/tests
+test.cmd                ./run_tests
+test.target
 
 livecheck.type          regex
 livecheck.url           ${homepage}


### PR DESCRIPTION
change llvm dependency to 6.0
remove unrequired dependencies on
  astyle, gindent, p5-sys-cpu
add size param
add tests

closes:  https://trac.macports.org/ticket/57591
closes:  https://trac.macports.org/ticket/57592

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
