### PR TITLE
py-spyder-devel: update to 8be3fd8 (20181217)

### DIFF
--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -7,8 +7,8 @@ PortGroup           qt5 1.0
 PortGroup           active_variants 1.1
 PortGroup           select 1.0
 
-github.setup        spyder-ide spyder 9d8cd53
-version             3.3.0-20181122
+github.setup        spyder-ide spyder 8be3fd8
+version             3.3.0-20181217
 name                py-spyder-devel
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
@@ -39,9 +39,9 @@ supported_archs     noarch
 #pyNN-scipy doesn't build universal
 universal_variant   no
 
-checksums           rmd160  3cd910182b51532e456c14c651055938af265716 \
-                    sha256  ab73d294f4044ccb599db33d47d07de0a50709ee606f622f715c40ebed4c2cbc \
-                    size    4083537
+checksums           rmd160  5330b282406bd02246dee8eb7a0e120579aa76cb \
+                    sha256  1028fe7c3b753b7549c6e88d8f978316189ef71f9f9f86c998118a5c89f9b9b1 \
+                    size    4097065
 
 if {${name} ne ${subport}} {
     require_active_variants py${python.version}-pyqt5 webengine

--- a/python/py-spyder-devel/files/patch-spyder_app_mainwindow.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_app_mainwindow.py.diff
@@ -1,6 +1,6 @@
---- spyder/app/mainwindow.py.orig	2018-10-19 15:04:42.000000000 -0400
-+++ spyder/app/mainwindow.py	2018-10-20 11:20:38.000000000 -0400
-@@ -219,7 +219,7 @@
+--- spyder/app/mainwindow.py.orig	2018-12-15 10:39:50.000000000 -0500
++++ spyder/app/mainwindow.py	2018-12-18 10:17:21.000000000 -0500
+@@ -220,7 +220,7 @@
              return file_uri(osp.join(doc_path, python_chm[0]))
      else:
          vinf = sys.version_info

--- a/python/py-spyder-devel/files/patch-spyder_config_main.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_config_main.py.diff
@@ -1,11 +1,11 @@
---- spyder/config/main.py.orig	2018-09-08 13:07:26.000000000 -0400
-+++ spyder/config/main.py	2018-09-08 13:08:43.000000000 -0400
-@@ -664,7 +664,7 @@
+--- spyder/config/main.py.orig	2018-12-17 09:30:34.000000000 -0500
++++ spyder/config/main.py	2018-12-17 09:30:50.000000000 -0500
+@@ -666,7 +666,7 @@
              ('lsp-server', {
                  'python': {
                      'index': 0,
 -                    'cmd': 'pyls',
 +                    'cmd': '@@PYLS_BIN_NAME@@',
-                     'args': '--host %(host)s --port %(port)s --tcp',
+                     'args': '--host {host} --port {port} --tcp',
                      'host': '127.0.0.1',
                      'port': 2087,

--- a/python/py-spyder-devel/files/patch-spyder_plugins_editor_lsp_client.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_plugins_editor_lsp_client.py.diff
@@ -1,6 +1,6 @@
---- spyder/plugins/editor/lsp/client.py.orig	2018-10-19 15:04:42.000000000 -0400
-+++ spyder/plugins/editor/lsp/client.py	2018-10-20 11:20:38.000000000 -0400
-@@ -302,7 +302,7 @@
+--- spyder/plugins/editor/lsp/client.py.orig	2018-12-15 10:39:50.000000000 -0500
++++ spyder/plugins/editor/lsp/client.py	2018-12-18 10:10:55.000000000 -0500
+@@ -310,7 +310,7 @@
      from spyder.utils.qthelpers import qapplication
      app = qapplication(test_time=8)
      server_args_fmt = '--host %(host)s --port %(port)s --tcp'

--- a/python/py-spyder-devel/files/patch-spyder_plugins_editor_lsp_transport_main.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_plugins_editor_lsp_transport_main.py.diff
@@ -1,6 +1,6 @@
---- spyder/plugins/editor/lsp/transport/main.py.orig	2018-10-19 15:04:42.000000000 -0400
-+++ spyder/plugins/editor/lsp/transport/main.py	2018-10-20 11:20:38.000000000 -0400
-@@ -46,7 +46,7 @@
+--- spyder/plugins/editor/lsp/transport/main.py.orig	2018-12-15 10:39:50.000000000 -0500
++++ spyder/plugins/editor/lsp/transport/main.py	2018-12-18 10:17:21.000000000 -0500
+@@ -44,7 +44,7 @@
                      help="Initial current working directory used to "
                           "initialize ls-server")
  parser.add_argument('--server',

--- a/python/py-spyder-devel/files/patch-spyder_plugins_editor_lsp_transport_producer.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_plugins_editor_lsp_transport_producer.py.diff
@@ -1,6 +1,6 @@
---- spyder/plugins/editor/lsp/transport/producer.py.orig	2018-10-19 15:04:42.000000000 -0400
-+++ spyder/plugins/editor/lsp/transport/producer.py	2018-10-20 11:20:38.000000000 -0400
-@@ -41,7 +41,7 @@
+--- spyder/plugins/editor/lsp/transport/producer.py.orig	2018-12-15 10:39:50.000000000 -0500
++++ spyder/plugins/editor/lsp/transport/producer.py	2018-12-18 10:10:55.000000000 -0500
+@@ -42,7 +42,7 @@
  
      def __init__(self, host='127.0.0.1', port=2087, workspace=getcwd(),
                   use_external_server=False, zmq_in_port=7000,

--- a/python/py-spyder-devel/files/patch-spyder_utils_programs.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_utils_programs.py.diff
@@ -1,5 +1,5 @@
---- spyder/utils/programs.py.orig	2018-10-19 15:04:42.000000000 -0400
-+++ spyder/utils/programs.py	2018-10-20 11:20:38.000000000 -0400
+--- spyder/utils/programs.py.orig	2018-12-17 08:52:19.000000000 -0500
++++ spyder/utils/programs.py	2018-12-17 08:51:44.000000000 -0500
 @@ -63,6 +63,11 @@
          abspath = osp.join(path, basename)
          if osp.isfile(abspath):


### PR DESCRIPTION
#### Description
- update to 8be3fd8 (20181217)
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
