### PR TITLE
wireguard-tools: update to 0.0.20181218

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -9,7 +9,7 @@ name                wireguard-tools
 # the WireGuard repository and its updates primarily deals with the
 # Linux kernel module, which isn't useful or relevant for macOS (we're
 # just interested in its tools for manipulating WireGuard interfaces).
-version             0.0.20181119
+version             0.0.20181218
 categories          net
 platforms           darwin
 license             GPL-2
@@ -27,9 +27,9 @@ master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
 
-checksums           rmd160  5738fb599845c79098fdd5d2da6c129f7a35b1d2 \
-                    sha256  7d47f7996dd291069de4efb3097c42f769f60dc3ac6f850a4d5705f321e4406b \
-                    size    319816
+checksums           rmd160  e116fa54019d92364986c1e321c226d352f885a2 \
+                    sha256  2e9f86acefa49dbfb7fa6f5e10d543f1885a2d5460cd5e102696901107675735 \
+                    size    318496
 
 depends_run         port:bash \
                     port:wireguard-go


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?