### PR TITLE
py-typed-ast: update to 1.1.1

### DIFF
--- a/python/py-typed-ast/Portfile
+++ b/python/py-typed-ast/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typed-ast
-version             1.1.0
+version             1.1.1
 categories-append   devel
 platforms           darwin
 license             Apache-2
@@ -21,14 +21,12 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            typed-ast-${version}
 
-checksums           rmd160  0b5c87b0360d7268ff407bfc18171c6e256343d1 \
-                    sha256  57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa \
-                    size    200587
+checksums           rmd160  1c1e35d77add567e8ac470f032578db71a84e707 \
+                    sha256  6cb25dc95078931ecbd6cbcc4178d1b8ae8f2b513ae9c3bd0b7f81c2191db4c6 \
+                    size    202693
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- update to latest version 1.1.1.
- use default PyPI livecheck
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 3.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
