### PR TITLE
tor-devel: update to 0.3.5.6-rc

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.3.5.5-alpha
+version             0.3.5.6-rc
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  597310466b0d2c6ec08c17c5e36505658416175e \
-                    sha256  84d746abc960e8212fc8bffbf91020ab55d426d2a00751cfd038c41c1bee1332 \
-                    size    6893528
+checksums           rmd160  9dcc58e39f775d075c993c6e1a4a5b651184104f \
+                    sha256  a77e2d3845fdd15ccf3294c665542acb0159e20ff0cb381301892a8fecd70981 \
+                    size    6917906
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.3.5.6-rc

###### Type(s)

- [X] enhancement

###### Tested on

macOS 10.13.6 17G5006
Xcode 10.1 10B61 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?