### PR TITLE
audio/mpd: Adding portgroup legacysupport to use wcpcpy

### DIFF
--- a/audio/mpd/Portfile
+++ b/audio/mpd/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
+PortGroup           legacysupport 1.0
 
 name                mpd
 version             0.20.21


### PR DESCRIPTION
#### Description

Building port `mpd` on `darwin9-powerpc` aborts due to lack of the wide-character string copy function `wcpcpy`. Those are contained in the recent `legacy-support` port upgrade (as well as in its `-devel` subport). Adding `PortGroup legacysupport` therefore fixes the issue.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8 9L31a
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? *(none found)*
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? *(there are none)*
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
