### PR TITLE
micronaut: update to 1.0.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.0.1 v
+github.setup    micronaut-projects micronaut-core 1.0.2 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        http://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  807c0558ff858466f0ab0f3bf3d2ec6de3f48a67 \
-                sha256  960c744565bbf6b7dc34b2fbaaa8273b13c5f2f7c1b31d922de1ccd25c9295dc \
-                size    12687600
+checksums       rmd160  2b389ff16adde6e944b2e4ace4e5af18df9cddd6 \
+                sha256  164eca3ffde6d4e3019dee28528e916a0ca13ffb3d49e00dbdefe003a10c78db \
+                size    12758794
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.0.2.

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?