### PR TITLE
py-plumed: new submission

### DIFF
--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        plumed plumed2 2.5.0 v
+name                py-plumed
+categories          python
+
+platforms           darwin
+categories-append   science
+license             LGPL-3
+maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
+
+description         Python wrappers for plumed.
+long_description    ${description} They allow the plumed library to be directly used from python.
+
+homepage            http://www.plumed.org
+
+checksums           rmd160  3873e9d48500bd01353396c0c85723a46b7c0ca9 \
+                    sha256  196aec82920bc6759ac66e32a8673f17e72b6c942bc84aadfd347182c5d9bedf \
+                    size    66557971
+
+python.versions     27 36 37
+
+# python setup is located in python subdir of plumed repository
+worksrcdir ${distname}/python
+
+if {${name} ne ${subport}} {
+
+# setup the wrappers so that by default they load MacPorts plumed library
+    build.env-append plumed_default_kernel=${prefix}/lib/libplumedKernel.dylib \
+                     plumed_macports=yes
+
+    depends_build-append port:py${python.version}-cython
+
+    depends_lib-append   port:py${python.version}-numpy \
+                         path:${prefix}/lib/libplumedKernel.dylib:plumed
+
+    depends_test-append port:py${python.version}-nose
+    test.run            yes
+}
+
+notes "
+PLUMED is linked with runtime binding. By setting the environment variable PLUMED_KERNEL\
+to the path of libplumedKernel.dylib you can replace your own PLUMED library at runtime.\
+By default, ${prefix}/lib/libplumedKernel.dylib is linked.
+"


### PR DESCRIPTION
#### Description

This is a port that contains python wrappers to the plumed library. The library itself is installed in `$prefix/lib/libplumedKernel.dylib` through a separate port (`science/plumed`).

Notice that the source for this `py-plumed` port is located within the same github repository as `plumed`, just in a [subdirectory](https://github.com/plumed/plumed2/tree/master/python). However, the wrappers are meant to be installed separately from the library itself (the library is loaded with `dlopen` and versions of library and wrappers should not necessarily match).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

