### PR TITLE
OpenBLAS: Use compilers portgroup

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -71,12 +71,7 @@ pre-build {
             } else {
                 puts $makeINC "BINARY = 32"
             }
-            if {![variant_isset clang]} {
-                 puts $makeINC "COMMON_OPT = -O3"
-            } else {
-                #Ensure to use the AVX-capable assembler
-                puts $makeINC "COMMON_OPT = -O3"
-            }
+            puts $makeINC "COMMON_OPT = -O3"
             puts $makeINC "COMMON_PROF = -pg"
 
             if {![variant_isset lapack]} {
@@ -100,12 +95,7 @@ pre-build {
         } else {
             puts $makeINC "BINARY = 32"
         }
-        if {![variant_isset clang]} {
-            puts $makeINC "COMMON_OPT = -O3"
-        } else {
-            #Ensure to use the AVX-capable assembler
-            puts $makeINC "COMMON_OPT = -O3"
-        }
+        puts $makeINC "COMMON_OPT = -O3"
         puts $makeINC "COMMON_PROF = -pg"
 
         if {![variant_isset lapack]} {

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -20,11 +20,11 @@ archive_sites
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    xianyi OpenBLAS b6363f45398812b3d725b54174efab793915df4c
+    github.setup    xianyi OpenBLAS e23366e860c9afc53608287040ee550623fefe49
     version         20181125
-    checksums       rmd160 dfd38438cedfd93791e6e72746769a84bc21dd2c\
-                    sha256 cfc0e939c7d94c33282ae88f5bbfba987209d481611211c3a147bb16cdd98e6e\
-                    size   11846759
+    checksums       rmd160  4c436e38f4ae41b7d329a8282df748ac9dce3a02 \
+                    sha256  90409f7337de14070469f1ce6893ac3c0dbb8bff6024210d64a0cb8e3a970baf \
+                    size    11853338
 
     name            ${github.project}-devel
     conflicts       OpenBLAS
@@ -40,7 +40,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160 89adde42fd970f437f2133642b97c020fc5dfcf2 \
                     sha256 b24618cdeab4671862fea011cc81b1443cfd5364530e597f33887b4fe3a3a6e8 \
                     size   11849496
-
+    revision        1
     conflicts       OpenBLAS-devel
 
     patchfiles      patch-libnoarch.release.diff \

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
+PortGroup           compilers 1.0
 
 name                OpenBLAS
 categories          math science
@@ -47,101 +48,8 @@ if {[string first "-devel" $subport] > 0} {
 
 }
 
-# declare +clang variant
-
-variant clang description "Use Clang as C/C++ compiler (required for AVX)" {}
-
-# default to +clang if the processor has avx instructions
-if {![catch {sysctl hw.optional.avx1_0} has_avx] && $has_avx == 1 &&
-    ![variant_isset clang]} {
-    default_variants +clang
-}
-
-# it is OK to use -clang, so don't check for that condition here
-
-# declare +gcc* variants
-
-set GCC_VERSIONS_NO_DOT {45 46 47 48 49 5 6 7 8}
-
-foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
-    set ndx [lsearch -exact ${this_gcc_version_no_dot} ${this_gcc_version_no_dot}]
-    set this_conflicts [lreplace ${this_gcc_version_no_dot} ${ndx} ${ndx}]
-    if {[variant_isset clang]} {
-        set this_description "Use gcc${this_gcc_version_no_dot} as Fortran compiler"
-    } else {
-        set this_description "Use gcc${this_gcc_version_no_dot} for the compiler suite"
-    }
-    variant gcc${this_gcc_version_no_dot} \
-        conflicts {*}${this_conflicts} \
-        description ${this_description} {}
-}
-
-# set default +gcc* variant: default to +gcc8 if not other +gcc*
-# variant is selected. this variant is used for Fortran, no matter
-# whether +clang is selected or not. if +clang is not selected or
-# -clang is selected, then use the selected +gcc* variant for the
-# compiler suite.
-
-set GCC_VER_NO_DOT 0
-foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
-    if {[variant_isset gcc${this_gcc_version_no_dot}]} {
-        set GCC_VER_NO_DOT ${this_gcc_version_no_dot}
-        break
-    }
-}
-
-if {${GCC_VER_NO_DOT} == 0} {
-    default_variants +gcc8
-}
-
-# make sure -gcc8 was not selected alone
-
-set GCC_VER_NO_DOT 0
-foreach this_gcc_version_no_dot ${GCC_VERSIONS_NO_DOT} {
-    if {[variant_isset gcc${this_gcc_version_no_dot}]} {
-        set GCC_VER_NO_DOT ${this_gcc_version_no_dot}
-        break
-    }
-}
-
-if {${GCC_VER_NO_DOT} == 0} {
-    ui_error "\n\nYou must select a Fortran compiler variant; you cannot select -gcc8 alone.\n"
-    return -code error "Invalid variant selection."
-}
-
-set GCC_VER_DOT [join [split ${GCC_VER_NO_DOT} ""] "."]
-
-# set compilers to use
-
-if {[variant_isset clang]} {
-
-    # use selected +gcc* for Fortran only
-    depends_build-append    port:gcc${GCC_VER_NO_DOT}
-    # add correct libgcc as a runtime dependency
-    depends_lib-append      path:lib/libgcc/libgcc_s.1.dylib:libgcc
-    if { ${GCC_VER_NO_DOT} <= 7 } { depends_lib-append port:libgcc7 }
-    if { ${GCC_VER_NO_DOT} <= 6 } { depends_lib-append port:libgcc6 }
-    
-    configure.fc            ${prefix}/bin/gfortran-mp-${GCC_VER_DOT}
-
-    if {[vercmp $xcodeversion 5.0] >= 0} {
-        configure.compiler      clang
-    } else {
-        # Xcode's clang < 5.0 does not support avx
-
-        #Use a compiler depending on system
-        if {${configure.cxx_stdlib} eq "libc++"} {
-            configure.compiler      macports-clang-3.7
-        } else {
-            configure.compiler      macports-clang-3.4
-        }
-    }
-} else {
-
-    # use selected +gcc* for the whole compiler suite
-    configure.compiler  macports-gcc-${GCC_VER_DOT}
-
-}
+compilers.choose    fc 
+compilers.setup     default_fortran
 
 variant lapack description "Add Lapack/CLapack support to the library" { }
 default_variants-append +lapack
@@ -174,7 +82,7 @@ pre-build {
             if {![variant_isset lapack]} {
                 puts $makeINC "NO_LAPACK = 1"
             }
-            if {![variant_isset clang]} {
+            if {![avx_compiler_isset]} {
                 puts $makeINC "NO_AVX = 1"
             }
             close $makeINC
@@ -203,11 +111,9 @@ pre-build {
         if {![variant_isset lapack]} {
             puts $makeINC "NO_LAPACK = 1"
         }
-        if {![variant_isset clang]} {
-            if { ![catch {sysctl hw.optional.avx1_0} has_avx] && $has_avx == 1 } {
-                ui_msg "Warning: the chosen compiler cannot handle advanced optimisation instructions."
-                ui_msg "         AVX instructions are disabled."
-            }
+        if {![avx_compiler_isset]} {
+            ui_msg "Warning: the chosen compiler cannot handle advanced optimisation instructions."
+            ui_msg "         AVX instructions are disabled."
             puts $makeINC "NO_AVX = 1"
         }
         close $makeINC

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -21,7 +21,7 @@ subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
     github.setup    xianyi OpenBLAS e23366e860c9afc53608287040ee550623fefe49
-    version         20181125
+    version         20181217
     checksums       rmd160  4c436e38f4ae41b7d329a8282df748ac9dce3a02 \
                     sha256  90409f7337de14070469f1ce6893ac3c0dbb8bff6024210d64a0cb8e3a970baf \
                     size    11853338


### PR DESCRIPTION
#### Description

The compilers portgroup is the recommended way to enable the choice of compilers. This PR changes OpenBLAS to use it. The current behavior of the Portfile cannot be reproduced completely identically, so that there are slight differences.

Behavior of original OpenBLAS port:
	- with +clang, use it and gcc variants are to select fortran compiler only
	- without +clang, gcc variants are defined for the whole compiler suite

Behavior with compilers portgroup, used to select only Fortran compiler
	- there is no clang variant. It is used by default if no other variant
	- variants define only fortran compiler
	  C compiler can be chosen as usually through configure.compiler

It would be possible to set the compilers portgroup to also set the cc compilers through variants, but then choosing a variant would set both c and fortran compilers, and choosing a Fortran compiler alone would not be possible.

Tested with different variants to validate build. "Standard" choices build fine, but exotic ones break somewhere in the Fortran code. 
- default (+gcc8). works
- +gcc6 works
- default (+gcc8) and configure.compiler=macports-gcc-8 works.
- +gcc6 and configure.compiler=macports-gcc-8 breaks.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->