### PR TITLE
megatools: update to 1.10.2

### DIFF
--- a/net/megatools/Portfile
+++ b/net/megatools/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                megatools
-version             1.9.91
+version             1.10.2
 
 categories          net
 license             GPL-2+
@@ -18,15 +18,12 @@ long_description    Megatools is a collection of programs for accessing Mega \
 homepage            https://megatools.megous.com/
 master_sites        https://megatools.megous.com/builds/
 
-checksums           rmd160  e447e2b966227f17088468d1e9829105b7d5d3e4 \
-                    sha256  31d0e55a25ba8420889a0ab6f43b04bdc4a919a2301c342b7baf1aab311f6841
+checksums           rmd160  01a2437f40da4112e496de15682268cb0da70bd9 \
+                    sha256  179e84c68e24696c171238a72bcfe5e28198e4c4e9f9043704f36e5c0b17c38a
 
-depends_build       port:pkgconfig
-depends_lib         port:curl \
-                    port:osxfuse
+depends_build       port:asciidoc \
+                    port:pkgconfig
+depends_lib         port:curl
 depends_run         port:glib-networking
-
-# osxfuse is not universal
-universal_variant   no
 
 configure.args      --disable-silent-rules

--- a/net/megatools/Portfile
+++ b/net/megatools/Portfile
@@ -19,7 +19,8 @@ homepage            https://megatools.megous.com/
 master_sites        https://megatools.megous.com/builds/
 
 checksums           rmd160  01a2437f40da4112e496de15682268cb0da70bd9 \
-                    sha256  179e84c68e24696c171238a72bcfe5e28198e4c4e9f9043704f36e5c0b17c38a
+                    sha256  179e84c68e24696c171238a72bcfe5e28198e4c4e9f9043704f36e5c0b17c38a \
+                    size    300486
 
 depends_build       port:asciidoc \
                     port:pkgconfig


### PR DESCRIPTION
Dependency changes:
 - asciidoc is needed to build man pages.
 - osxfuse is no longer a dependency. It was used by the experimental
   megafs, removed in 1.9.98.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
