### PR TITLE
mosquitto: Update to version 1.5.5; libwebsockets: Update to version 3.1.0.

### DIFF
--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        warmcat libwebsockets 3.0.1 v
+github.setup        warmcat libwebsockets 3.1.0 v
 categories          devel net
 platforms           darwin
 license             LGPL-2.1
@@ -18,9 +18,9 @@ long_description    \
     CPU and memory resources, and provide fast throughput in both directions \
     as client or server.
 
-checksums           rmd160  197b65f441bbcaf39cfce3c46146b26de441d769 \
-                    sha256  ed32f599092e474a2fc4f1c083de11a215d2f141ea1b30f597f6c5da578b3d17 \
-                    size    7504045
+checksums           rmd160  6932b4cd29c0f92c9a091879857b70679d2b49bf \
+                    sha256  661d4f8d3d4c28cf16c5fe7e77d49875803f7f656382a58c1693475ad16d5dde \
+                    size    8583247
 
 depends_lib-append  path:lib/libssl.dylib:openssl \
                     port:zlib
@@ -30,6 +30,10 @@ configure.args-append \
                     -DLWS_UNIX_SOCK=ON \
                     -DLWS_IPV6=ON \
                     -DLWS_WITH_HTTP2=1
+
+post-extract {
+    reinplace "s|-Werror||g" ${worksrcpath}/CMakeLists.txt
+}
 
 post-destroot {
     delete ${destroot}${prefix}/share/${name}-test-server

--- a/net/mosquitto/Portfile
+++ b/net/mosquitto/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                mosquitto
-version             1.5.3
-revision            1
+version             1.5.5
 
 categories          net devel
 platforms           darwin
@@ -23,14 +22,20 @@ long_description    \
 homepage            https://mosquitto.org
 master_sites        http://mosquitto.org/files/source/
 
-checksums           rmd160  91b6695d40742db02d6243716e494ae1044dc3ca \
-                    sha256  3081a998d303a883b1cd064009beabc88aa9159e26f5258a4ae6007160491d10 \
-                    size    425844
+checksums           rmd160  7c04ab09553a3514c0ff6411ba289ed3a971c757 \
+                    sha256  fcdb47e340864c545146681af7253399cc292e41775afd76400fda5b0d23d668 \
+                    size    431998
+
+depends_build-append \
+                    path:bin/xsltproc:libxslt
 
 depends_lib         port:c-ares \
                     port:libwebsockets \
                     port:tcp_wrappers \
                     path:lib/libssl.dylib:openssl
+
+depends_test-append \
+                    port:python27
 
 configure.args-append \
                     -DUSE_LIBWRAP=yes \
@@ -39,45 +44,48 @@ configure.args-append \
                     -DWITH_WEBSOCKETS=yes
 
 test.run            yes
-test.target         -C ${workpath}/build/test test
+test.target         -C ${build.dir}/test test
 
 pre-build {
     reinplace -E "s|\\.so\\.\[^\[:space:\]\]+|.dylib |g" ${worksrcpath}/config.mk
 }
 
 pre-test {
-    if {![file exist ${workpath}/build/test]} {
-        foreach f [list config.mk test] {
-            copy -force ${worksrcpath}/${f} ${workpath}/build
+    if {![file exist ${build.dir}/test]} {
+        foreach path [list config.mk test] {
+            copy -force ${worksrcpath}/${path} ${build.dir}
         }
-        fs-traverse dir ${workpath}/build/test {
-            if {[file tail ${dir}] eq "Makefile"} {
-                reinplace -E "s|\\.so\\.\[^\[:space:\]\]+|.dylib|g" $dir
-                reinplace -E "s|\\.so\[\[:space:\]\]+|.dylib |g" $dir
-            }
+    }
+
+    fs-traverse path ${build.dir}/test {
+        if {[file tail ${path}] eq "Makefile"} {
+            reinplace -E "s|\\.so\\.\[^\[:space:\]\]+|.dylib|g" $path
+            reinplace -E "s|\\.so\[\[:space:\]\]+|.dylib |g" $path
+        } elseif {[string match "*.py" ${path}]} {
+            reinplace "s|^#!/usr/bin/env python$|#!${prefix}/bin/python2.7|" $path
         }
+    }
+
     # `auth_plugin.c' and `auth_plugin_acl.c' have missing dependencies
     reinplace "s|^all :.*|all : auth_plugin_pwd.dylib auth_plugin_v2.dylib auth_plugin_msg_params.dylib 08|" \
-        ${workpath}/build/test/broker/c/Makefile
+        ${build.dir}/test/broker/c/Makefile
     # Test target 08 fails due to expired certificate.
     # Test target 09 fails due to I/O error when launching broker.
     reinplace "s|^test :.*|test : test-compile 01 02 03 04 05 06 07 10 11|" \
-        ${workpath}/build/test/broker/Makefile
+        ${build.dir}/test/broker/Makefile
     # `09-util-utf8-validate.c' fails to compile due to invalid encoding.
     reinplace "s|^09 :.*|09 : 09-util-topic-matching.test 09-util-topic-tokenise.test|" \
-        ${workpath}/build/test/lib/c/Makefile \
-        ${workpath}/build/test/lib/cpp/Makefile
+        ${build.dir}/test/lib/c/Makefile \
+        ${build.dir}/test/lib/cpp/Makefile
     # Test target 08 fails due to expired certificate.
     reinplace "s|^all :.*|all : 01 02 03 04 09|" \
-        ${workpath}/build/test/lib/cpp/Makefile
-
+        ${build.dir}/test/lib/cpp/Makefile
     # Test targets ./08.* fail due to expired certificate.
     reinplace "s|\\./08|#./08|" \
-        ${workpath}/build/test/lib/Makefile
+        ${build.dir}/test/lib/Makefile
     # Test target 09-util-utf8-validate fails due to invalid encoding.
     reinplace "s|\\./09-util-utf8|#./09-util-utf8|" \
-        ${workpath}/build/test/lib/Makefile
-    }
+        ${build.dir}/test/lib/Makefile
 }
 
 set mosquitto_user  mosquitto


### PR DESCRIPTION
#### Description
mosquitto: Update to version 1.5.5
libwebsockets: Update to version 3.1.0.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G4015
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
