### PR TITLE
libao: Bugfix for PR macports/macports-base#55.

### DIFF
--- a/audio/libao/Portfile
+++ b/audio/libao/Portfile
@@ -22,8 +22,12 @@ checksums           rmd160  9983f2435a45ad1fc97a2b7f2d60e8f2e6172bfa \
 
 use_bzip2           yes
 
+# This block can be removed once backward compatibility with MacPorts
+# base versions prior to PR macports/macports-base#55 is not needed.
 post-extract {
-    move [glob ${workpath}/libao-${version}-*] ${worksrcpath}
+    if {![file exists ${worksrcpath}]} {
+        move [glob ${workpath}/libao-${version}-*] ${worksrcpath}
+    }
 }
 
 # fix build on Leopard and earlier


### PR DESCRIPTION
#### Description
libao: Bugfix for PR macports/macports-base#55.
This supersedes PR #1760.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G4015
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->