### PR TITLE
atom: update to 1.33.1 and rewrite env setup

### DIFF
--- a/editors/atom/Portfile
+++ b/editors/atom/Portfile
@@ -24,25 +24,22 @@ depends_lib-append  path:bin/npm:npm5 \
                     port:git \
                     port:python27
 
-use_configure       no
-build.cmd           script/build
-build.env-append    CC="${configure.cc} [get_canonical_archflags cc]" \
-                    CXX="${configure.cxx} [get_canonical_archflags cxx]" \
-                    PYTHON="${prefix}/bin/python2.7"
-
-if {${os.major} > 17} {
-    # Make sure the compiler builds against libc++ for macOS 10.14 and newer (#57243)
-    build.env-append    CFLAGS="${configure.cflags} -mmacosx-version-min=10.9" \
-                        CXXFLAGS="${configure.cxxflags} -mmacosx-version-min=10.9" \
-                        LDFLAGS="${configure.ldflags} -mmacosx-version-min=10.9"
-} else {
-    build.env-append    CFLAGS="${configure.cflags}" \
-                        CXXFLAGS="${configure.cxxflags}" \
-                        LDFLAGS="${configure.ldflags}"
-}
-
-build.target-delete all
-build.args-append   --ci
+# atom does not use configure but a custom build script. Additionally, node (or
+# some of the packages) seem to override MACOSX_DEPLOYMENT_TARGET. This has
+# caused issues at least once (#57243) so explicitly set it here.
+use_configure              no
+build.cmd                  script/build
+configure.cflags-append    "-mmacosx-version-min=${macosx_deployment_target}"
+configure.cxxflags-append  "-mmacosx-version-min=${macosx_deployment_target}"
+configure.ldflags-append   "-mmacosx-version-min=${macosx_deployment_target}"
+build.env-append           CC="${configure.cc} [get_canonical_archflags cc]" \
+                           CXX="${configure.cxx} [get_canonical_archflags cxx]" \
+                           PYTHON="${prefix}/bin/python2.7" \
+                           CFLAGS="${configure.cflags}" \
+                           CXXFLAGS="${configure.cxxflags}" \
+                           LDFLAGS="${configure.ldflags}"
+build.target-delete        all
+build.args-append          --ci
 
 universal_variant   no
 

--- a/editors/atom/Portfile
+++ b/editors/atom/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        atom atom 1.31.2 v
+github.setup        atom atom 1.33.1 v
 categories          editors
 platforms           darwin
 license             MIT
@@ -14,9 +14,9 @@ long_description    ${description}
 
 homepage            https://atom.io
 
-checksums           rmd160  e2ff226be405b3c9f5324da14b363b04a3bc9e06 \
-                    sha256  842089888a98712ace0f03eb840dda89fbfc24baa8dbea903345de078c480110 \
-                    size    11632654
+checksums           rmd160  d6d789ef780376deb904ebb773e761c52c76d52f \
+                    sha256  f2abd9528a546b07cfc13ccb78f4f946e163fabd478e0fd12c6b876e606b4359 \
+                    size    11754207
 
 patchfiles          patch-install-prefix.diff
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

- Update atom to the most recent version 1.33.1
- Unify the build among different macOS versions by always setting MACOSX_DEPLOYMENT_TARGET to the value provided by macports. This is basically an implementation of the suggestion made at https://github.com/macports/macports-ports/commit/08c7fb67ad9696b68669b7dd137fe3c670d93407#r30826316

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
  (The two commits are logically independent of each other but I can of course squash the two commits if preferred.)
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
