### PR TITLE
pulseaudio: fix licenses

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                pulseaudio
 version             12.2
 revision            0
-license             LGPL-2.1+ AGPL-3+ MIT BSD
+license             LGPL-2.1+ MIT BSD
 categories          audio
 maintainers         {ionic @Ionic} openmaintainer
 platforms           darwin


### PR DESCRIPTION
Since PulseAudio 12.0, the only AGPL-licensed file qpaeq is relicensed
as LGPL [1]. Also, results of `grep -ir agpl` or `grep -ir affero`
contain nothing more than the relicensing note.

This change makes pulseaudio binary-redistributable.

[1] https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/12.0/

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
(untested)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?