### PR TITLE
obc: bump to 3.1.0

### DIFF
--- a/lang/obc/Portfile
+++ b/lang/obc/Portfile
@@ -3,12 +3,13 @@
 PortSystem          1.0
 
 name                obc
-version             2.9.1
-revision            2
+version             3.1.0
 categories          lang
 platforms           darwin
 maintainers         nomaintainer
-supported_archs     i386 ppc
+use_bzip2           yes
+distname            rel-${version}
+worksrcdir          Spivey-obc-3-74f5d876f4d9
 
 description         Oxford Oberon 2 Compiler
 
@@ -17,17 +18,21 @@ long_description    The Oxford Oberon 2 Compiler is a powerful and easy to \
                     designed by Niklaus Wirth.
 
 homepage            http://spivey.oriel.ox.ac.uk/corner/Oxford_Oberon-2_compiler
-master_sites        http://spivey.oriel.ox.ac.uk/wiki/resources/sw/
+master_sites        https://bitbucket.org/Spivey/obc-3/get/
 
-checksums           sha1    4cc81fa256bd1ed9166b8746f1a52a003e3ed347 \
-                    rmd160  5d2a24f29240b2f59c44d6327795e38e9cc75437
+checksums           rmd160  a2688028121947c62e9c6594d14852a40332dc35 \
+                    sha256  bfb27edf34bab6740e28cc4dad61ddf8297a6097d0c147a0bb64d59abcd03b39 \
+                    size    735087
 
 depends_skip_archcheck ocaml
 depends_build          port:ocaml port:pkgconfig
 
 patchfiles          patch-destdir.diff
 
-use_parallel_build  no
+use_autoreconf      yes
+
 universal_variant   no
+
+test.run            yes
 
 configure.args      --disable-debugger

--- a/lang/obc/files/patch-destdir.diff
+++ b/lang/obc/files/patch-destdir.diff
@@ -1,6 +1,6 @@
---- Makefile.in.old	2011-01-15 23:52:08.000000000 -0600
-+++ Makefile.in	2011-01-15 23:52:42.000000000 -0600
-@@ -230,17 +230,17 @@
+--- Makefile.in.old	2018-12-20 19:20:34.000000000 -0800
++++ Makefile.in	2018-12-20 19:21:43.000000000 -0800
+@@ -275,18 +275,18 @@
  
  # Install after building
  install:: force
@@ -9,13 +9,15 @@
 -	for f in $(LIBSRC); do $(INSTALL_DATA) $$f $(libdir)/obc; done
 -	for f in $(LIB); do $(INSTALL_DATA) $$f $(libdir)/obc; done
 -	for f in $(LIBX); do $(INSTALL_PROG) $$f $(libdir)/obc; done
--	for f in $(MAN); do $(INSTALL_DATA) $$f $(mandir)/man1; done
+-	for f in $(RES); do $(INSTALL_DATA) $$f $(libdir)/obc/resources; done
+-	for f in $(MAN); do $(INSTALL_DATA) man/$$f $(mandir)/man1; done
 +	for d in $(DIRS); do $(INSTALL) -d $(DESTDIR)$$d; done
 +	for f in $(BIN); do $(INSTALL_PROG) $$f $(DESTDIR)$(bindir); done
 +	for f in $(LIBSRC); do $(INSTALL_DATA) $$f $(DESTDIR)$(libdir)/obc; done
 +	for f in $(LIB); do $(INSTALL_DATA) $$f $(DESTDIR)$(libdir)/obc; done
 +	for f in $(LIBX); do $(INSTALL_PROG) $$f $(DESTDIR)$(libdir)/obc; done
-+	for f in $(MAN); do $(INSTALL_DATA) $$f $(DESTDIR)$(mandir)/man1; done
++	for f in $(RES); do $(INSTALL_DATA) $$f $(DESTDIR)$(libdir)/obc/resources; done
++	for f in $(MAN); do $(INSTALL_DATA) man/$$f $(DESTDIR)$(mandir)/man1; done
  
  ifdef ENABLE_DEBUGGER
    ifdef MACOS


### PR DESCRIPTION
new master site
needs to autoreconf now
passes all tests
destdir patch freshened
closes: https://trac.macports.org/ticket/57224

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
