### PR TITLE
texlive-bin: setup ABI for macports-libstdc++

### DIFF
--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -225,11 +225,15 @@ build.env                   OBJC=${configure.objc} \
                             OBJCFLAGS="${configure.objcflags} [get_canonical_archflags objc]" \
                             OBJCXX=${configure.objcxx}
 
+# this is not optimal, but we have to duplicate this cxx11 PG logic here
+# because of https://trac.macports.org/ticket/56280
 if {[string match *clang* ${configure.cxx}]} {
-    build.env-append        OBJCXXFLAGS="${configure.objcxxflags} [get_canonical_archflags objcxx] -stdlib=${configure.cxx_stdlib}"
-} else {
-    build.env-append        OBJCXXFLAGS="${configure.objcxxflags} [get_canonical_archflags objcxx]"
+    lappend configure.objcxxflags -stdlib=${configure.cxx_stdlib}
 }
+if {[string match macports-libstdc++ ${configure.cxx_stdlib}]} {
+        lappend configure.objcxxflags -D_GLIBCXX_USE_CXX11_ABI=0
+}
+build.env-append        OBJCXXFLAGS="${configure.objcxxflags} [get_canonical_archflags objcxx]"
 
 # work around differences between libc++ and libstdc++ headers building with clang
 # https://trac.macports.org/ticket/54358#comment:26


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/57774
 
@drkp -- what do you think of this approach?

Verified to fix build on 10.14 (libc++) and 10.8 (macports-libstdc++). Unfortunate that we have to do this at all, but ...