### PR TITLE
boehmgc: update to 8.0.0

### DIFF
--- a/devel/boehmgc/Portfile
+++ b/devel/boehmgc/Portfile
@@ -4,10 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
-github.setup        ivmai bdwgc 7.6.8 v
-checksums           rmd160  1e3952a2920e97393080fd4cc6a366c2c4ce2416 \
-                    sha256  0e78c46ca44b398943c4c915288ca2215f025d524334d4ab756e73a474081fd6 \
-                    size    781759
+github.setup        ivmai bdwgc 8.0.2 v
+revision            0
+checksums           rmd160  1d9142e8c01e0ef6278d7574b05cc892560c2153 \
+                    sha256  ea3069e218a6d2cf387fc6bb3cd40fb97942e0f8da5dcca0fb47f2c812b585ae \
+                    size    802285
 
 name                boehmgc
 conflicts           boehmgc-devel
@@ -36,7 +37,8 @@ depends_build-append \
                 port:pkgconfig \
                 port:libatomic_ops
 
-configure.args  --enable-cplusplus
+configure.args  --enable-cplusplus \
+                --enable-static
 configure.cppflags-append \
                 -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
 

--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -7,6 +7,7 @@ PortGroup       cxx11 1.1
 
 name            gdb
 version         8.0.1
+revision        1
 categories      devel
 license         GPL-3+
 maintainers     nomaintainer

--- a/devel/scriptix/Portfile
+++ b/devel/scriptix/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name             scriptix
 version          0.31
-revision         1
+revision         2
 categories       devel
 license          BSD
 maintainers      nomaintainer

--- a/editors/zile/Portfile
+++ b/editors/zile/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name                zile
 version             2.4.14
+revision            1
 categories          editors
 license             GPL-3+
 platforms           darwin

--- a/games/awemud/Portfile
+++ b/games/awemud/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name             awemud
 version          0.22
-revision         1
+revision         2
 categories       games
 license          BSD
 maintainers      nomaintainer

--- a/graphics/asymptote/Portfile
+++ b/graphics/asymptote/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           texlive 1.0
 
 github.setup        vectorgraphics asymptote 2.44
+revision            1
 categories          graphics
 maintainers         {mojca @mojca} openmaintainer
 description         A vector graphics language

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -7,7 +7,7 @@ PortGroup           cxx11 1.1
 name                inkscape
 conflicts           inkscape-devel
 version             0.92.3
-revision            7
+revision            8
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}
 categories          graphics gnome

--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        crystal-lang crystal 0.26.1
+revision            1
 categories          lang
 platforms           darwin
 supported_archs     x86_64

--- a/lang/gwydion-dylan/Portfile
+++ b/lang/gwydion-dylan/Portfile
@@ -1,7 +1,7 @@
 PortSystem                     1.0
 name                           gwydion-dylan
 version                        2.3.11
-revision                       1
+revision                       2
 categories                     lang
 maintainers                    nomaintainer
 description                    The Gwydion Dylan Compiler

--- a/lang/neko/Portfile
+++ b/lang/neko/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                neko
 version             1.8.2
-revision            2
+revision            3
 categories          lang
 platforms           darwin
 maintainers         ryandesign openmaintainer

--- a/lang/pypy/Portfile
+++ b/lang/pypy/Portfile
@@ -8,6 +8,7 @@ PortGroup           select 1.0
 
 name                pypy
 bitbucket.setup     pypy pypy 6.0.0 {release-pypy${python.branch}-v}
+revision            1
 categories          lang python devel
 license             MIT PSF
 maintainers         {danchr @danchr} openmaintainer

--- a/lang/see/Portfile
+++ b/lang/see/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                see
 version             3.1.1424
-revision            2
+revision            3
 categories          lang
 maintainers         nomaintainer
 platforms           darwin

--- a/lang/stklos/Portfile
+++ b/lang/stklos/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name			stklos
 version			1.10
-revision		2
+revision		3
 categories		lang
 platforms		darwin
 maintainers		nomaintainer

--- a/www/w3m/Portfile
+++ b/www/w3m/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                w3m
 version             0.5.3
-revision            10
+revision            11
 categories          www
 license             MIT
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description
For testing this, I ran w3m without recompiling w3m against the latest boehmgc. The process started up fine and browsed the web without crashing. I am not sure if I need to revbump on this major version change - there are a bunch of scary-sounding API changes in the ChangeLog like `Do not install gc_allocator.h, gc_disclaim.h unless the features enabled` but w3m seems to have worked anyway. I did a `port rev-upgrade --id-loadcmd-check` and there were no errors.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
