### PR TITLE
mcfly: don't hardcode platform-specific path in install

### DIFF
--- a/sysutils/mcfly/Portfile
+++ b/sysutils/mcfly/Portfile
@@ -1,3 +1,4 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem          1.0
 PortGroup           cargo 1.0
 PortGroup           github 1.0
@@ -351,8 +352,7 @@ cargo.crates \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
 destroot {
-    # FIXME Make this work with other platforms
-    xinstall -m 0755 ${worksrcpath}/target/x86_64-apple-darwin/release/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 {*}[glob ${worksrcpath}/target/*/release/${name}] ${destroot}${prefix}/bin/
     xinstall -d ${destroot}${prefix}/share/${name}
     xinstall -m 0644 ${worksrcpath}/${name}.bash ${destroot}${prefix}/share/${name}/
 }


### PR DESCRIPTION
#### Description

As suggested [here](https://github.com/macports/macports-ports/commit/370f7624e66615bd924ac210000d23ee3e07b981#r31756864)

On Gentoo, the [Cargo eclass](https://github.com/gentoo/gentoo/blob/master/eclass/cargo.eclass#L132) uses `cargo install --root="${D}"` to get around this issue. I think `destroot` in the Cargo PortGroup should follow this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
