### PR TITLE
wireguard-go: update to 0.0.20181222

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20181018
+version             0.0.20181222
 categories          net
 platforms           darwin
 license             GPL-2
@@ -23,9 +23,9 @@ homepage            https://www.wireguard.com/
 master_sites        https://git.zx2c4.com/wireguard-go/snapshot/
 use_xz              yes
 
-checksums           rmd160  438342fc56f50ec296ca03b1818b945b67af8115 \
-                    sha256  6bedec38d12596d55cfba4b3f7dfa99d5c2555c2f0bf3b3c9a26feb7c6b073ff \
-                    size    54268
+checksums           rmd160  8304150849896761b2febca58ef8fd5ba4c8b54e \
+                    sha256  53dc611524c40cddd242c972a9559f9793e128a0ce772483f12a2704c9f48c54 \
+                    size    53032
 
 depends_build       port:git \
                     port:go


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?