### PR TITLE
libressl-devel: update to 2.9.0

### DIFF
--- a/security/libressl-devel/Portfile
+++ b/security/libressl-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libressl-devel
-version             2.8.2
+version             2.9.0
 distname            libressl-${version}
 
 categories          security devel
@@ -23,9 +23,9 @@ homepage            https://www.libressl.org
 conflicts           openssl libressl
 
 master_sites        openbsd:LibreSSL
-checksums           rmd160  e5804bd4a4db10cf7f622d130cd572bef41f5a72 \
-                    sha256  b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5 \
-                    size    3373599
+checksums           rmd160  02173dfeae0b02485547a6a3f7e58319c99a1d47 \
+                    sha256  eb5f298408b723f11a0ca0192c122ecb79b4855bfdf7eea183a6264296a13cf4 \
+                    size    3400383
 
 patchfiles \
     openssldir-cert.pem.patch


### PR DESCRIPTION
This updates the libressl-devel port to LibreSSL 2.9.0

- [x] bugfix
- [x] enhancement
- [x] security fix

Tested on macOS 10.13.6 17G3025 Xcode 10.1 10B61
Tested against openssh, curl and lynx.

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
