### PR TITLE
Update py-scipy to 1.2.0

### DIFF
--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -6,11 +6,11 @@ PortGroup               active_variants 1.1
 PortGroup               github 1.0
 PortGroup               compilers 1.0
 
-github.setup            scipy scipy 1.1.0 v
-revision                1
-checksums               rmd160 af116f12c34c57cccbf16cd846fe3b6e3f08391d \
-                        sha256 a731c05d8bffb56edc7f6d09a2e39b79fb094a7d61dc012b3f8b025bb5f5c1e4 \
-                        size   17978853
+github.setup            scipy scipy 1.2.0 v
+revision                0
+checksums               rmd160  e847b6ba0ce8795824c48e6b9231b311a2f73596 \
+                        sha256  7671582e729e36cbf12274fa85a110aa90dbf508fb2cfb8a87f9a83488924d73 \
+                        size    18554429
 
 name                    py-scipy
 platforms               darwin


### PR DESCRIPTION
#### Description

This PR bumps the `py-scipy` version to 1.2.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
