### PR TITLE
perl5.28: new port

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -12,7 +12,6 @@ maintainers         {mojca @mojca} openmaintainer
 
 homepage            https://www.perl.org/
 master_sites        http://www.cpan.org/src/5.0/
-#                   https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/
 
 # current Perl versions
 #
@@ -29,7 +28,8 @@ set perl5.versions_info {
     5.20 3 4 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b  13743405
     5.22 4 2 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
     5.24 4 1 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
-    5.26 3 0 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
+    5.26 3 1 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
+    5.28 1 0 e2f0618fc01bcd253ef6e003c1d9b957b6f6aa53  fea7162d4cca940a387f0587b93f6737d884bf74d8a9d7cfd978bc12cd0b202d  12372080
 }
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5.size} ${perl5.versions_info} {
@@ -51,7 +51,11 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
 
         distname            perl-${perl5.major}.${perl5.subversion}
         dist_subdir         perl${perl5.major}
-        use_bzip2           yes
+        if {${perl5.major} >= 5.28} {
+           use_xz           yes
+        } else {
+           use_bzip2        yes
+        }
 
         # TODO: revise patch naming scheme
         patchfiles          ${perl5.major}/clean-up-paths.patch \
@@ -95,11 +99,15 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             patchfiles-append \
                             ${perl5.major}/remove-10.3-target-PR126360.patch
         }
-        if {${perl5.major} == 5.26} {
+        if {${perl5.major} >= 5.26} {
             # enable syscall() on Sierra for compatibility with earlier OS versions and perl5.24
             # Apple has deprecated syscall() on Sierra but it is still available
             patchfiles-append \
                             ${perl5.major}/enable-syscall-on-sierra.patch
+            # Fix library path (backported)
+            # https://rt.perl.org/Public/Bug/Display.html?id=126706
+            patchfiles-append \
+                            ${perl5.major}/adjust-dependency-paths-PR126706.patch
         }
 
         post-patch {

--- a/lang/perl5/files/5.26/adjust-dependency-paths-PR126706.patch
+++ b/lang/perl5/files/5.26/adjust-dependency-paths-PR126706.patch
@@ -1,0 +1,136 @@
+https://github.com/Perl/perl5/commit/191f8909fa4eca1db16a91ada42dd4a065c04890.patch
+
+From 191f8909fa4eca1db16a91ada42dd4a065c04890 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Thu, 4 Oct 2018 14:41:03 +1000
+Subject: [PATCH] (perl #127606) adjust dependency paths on installation on
+ darwin
+
+SIP (System Integrity Protection) on OS X prevents the
+DYLD_LIBRARY_PATH environment variable from being propagated through
+/bin/sh, causes many tests to fail (and some more recent build issues)
+for -Duseshrplib builds.
+
+To avoid that, we change the way libperl.dylib is linked to perl, so
+for the initial build the library's id is at the build location rather
+than the install location, and the generated executable also expects
+to find libperl in that location.
+
+This obviously won't work once we copy both to the installation
+directory, so we adjust both the id of the library and the dependency
+path in the executable to point to the new location of the library.
+
+A previous attempt set -rpath and used @rpath in the id, but this made
+the embedding test fail.
+---
+ Makefile.SH | 34 ++++++++++++++++++++++++++++++++--
+ installperl | 25 +++++++++++++++++++++++++
+ 2 files changed, 57 insertions(+), 2 deletions(-)
+
+diff --git Makefile.SH Makefile.SH
+index 6e4d5ee684f..bebe50dc131 100755
+--- Makefile.SH
++++ Makefile.SH
+@@ -67,8 +67,16 @@ true)
+                             -compatibility_version \
+ 				${api_revision}.${api_version}.${api_subversion} \
+ 			     -current_version \
+-				${revision}.${patchlevel}.${subversion} \
+-			     -install_name \$(shrpdir)/\$@"
++				${revision}.${patchlevel}.${subversion}"
++		case "$osvers" in
++	        1[5-9]*|[2-9]*)
++			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			exeldflags="-Xlinker -headerpad_max_install_names"
++			;;
++		*)
++			shrpldflags="$shrpldflags -install_name \$(shrpdir)/\$@"
++			;;
++		esac
+ 		;;
+ 	cygwin*)
+ 		shrpldflags="$shrpldflags -Wl,--out-implib=libperl.dll.a -Wl,--image-base,0x52000000"
+@@ -334,6 +342,14 @@ MANIFEST_SRT = MANIFEST.srt
+ 
+ !GROK!THIS!
+ 
++case "$useshrplib$osname" in
++truedarwin)
++	$spitshell >>$Makefile <<!GROK!THIS!
++PERL_EXE_LDFLAGS=$exeldflags
++!GROK!THIS!
++	;;
++esac
++
+ case "$usecrosscompile$perl" in
+ define?*)
+ 	$spitshell >>$Makefile <<!GROK!THIS!
+@@ -1045,6 +1061,20 @@ $(PERL_EXE): $& $(perlmain_dep) $(LIBPERL) $(static_ext) ext.libs $(PERLEXPORT)
+ 	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(LLIBPERL) $(static_ext) `cat ext.libs` $(libs)
+ !NO!SUBS!
+         ;;
++
++	darwin)
++	    case "$useshrplib$osvers" in
++	    true1[5-9]*|true[2-9]*) $spitshell >>$Makefile <<'!NO!SUBS!'
++	$(SHRPENV) $(CC) -o perl $(PERL_EXE_LDFLAGS) $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(static_ext) $(LLIBPERL) `cat ext.libs` $(libs)
++!NO!SUBS!
++	       ;;
++	    *) $spitshell >>$Makefile <<'!NO!SUBS!'
++	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(static_ext) $(LLIBPERL) `cat ext.libs` $(libs)
++!NO!SUBS!
++	       ;;
++	    esac
++        ;;
++
+         *) $spitshell >>$Makefile <<'!NO!SUBS!'
+ 	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(static_ext) $(LLIBPERL) `cat ext.libs` $(libs)
+ !NO!SUBS!
+diff --git installperl installperl
+index 3bf79d2d6fc..6cd65a09238 100755
+--- installperl
++++ installperl
+@@ -304,6 +304,7 @@ elsif ($^O ne 'dos') {
+ 	safe_unlink("$installbin/$perl_verbase$ver$exe_ext");
+ 	copy("perl$exe_ext", "$installbin/$perl_verbase$ver$exe_ext");
+ 	strip("$installbin/$perl_verbase$ver$exe_ext");
++	fix_dep_names("$installbin/$perl_verbase$ver$exe_ext");
+ 	chmod(0755, "$installbin/$perl_verbase$ver$exe_ext");
+     }
+     else {
+@@ -388,6 +389,7 @@ foreach my $file (@corefiles) {
+     if (copy_if_diff($file,"$installarchlib/CORE/$file")) {
+ 	if ($file =~ /\.(\Q$so\E|\Q$dlext\E)$/) {
+ 	    strip("-S", "$installarchlib/CORE/$file") if $^O eq 'darwin';
++	    fix_dep_names("$installarchlib/CORE/$file");
+ 	    chmod($SO_MODE, "$installarchlib/CORE/$file");
+ 	} else {
+ 	    chmod($NON_SO_MODE, "$installarchlib/CORE/$file");
+@@ -791,4 +793,27 @@ sub strip
+     }
+ }
+
++sub fix_dep_names {
++    my $file = shift;
++
++    $^O eq "darwin" && $Config{osvers} =~ /^(1[5-9]|[2-9])/
++      && $Config{useshrplib}
++      or return;
++
++    my @opts;
++    my $so = $Config{so};
++    my $libperl = "$Config{archlibexp}/CORE/libperl.$Config{so}";
++    if ($file =~ /\blibperl.\Q$Config{so}\E$/a) {
++        push @opts, -id => $libperl;
++    }
++    else {
++        push @opts, -change => getcwd . "/libperl.$so", $libperl;
++    }
++    push @opts, $file;
++
++    $opts{verbose} and print "  install_name_tool @opts\n";
++    system "install_name_tool", @opts
++      and die "Cannot update $file dependency paths\n";
++}
++
+ # ex: set ts=8 sts=4 sw=4 et:

--- a/lang/perl5/files/5.28/adjust-dependency-paths-PR126706.patch
+++ b/lang/perl5/files/5.28/adjust-dependency-paths-PR126706.patch
@@ -1,0 +1,136 @@
+https://github.com/Perl/perl5/commit/191f8909fa4eca1db16a91ada42dd4a065c04890.patch
+
+From 191f8909fa4eca1db16a91ada42dd4a065c04890 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Thu, 4 Oct 2018 14:41:03 +1000
+Subject: [PATCH] (perl #127606) adjust dependency paths on installation on
+ darwin
+
+SIP (System Integrity Protection) on OS X prevents the
+DYLD_LIBRARY_PATH environment variable from being propagated through
+/bin/sh, causes many tests to fail (and some more recent build issues)
+for -Duseshrplib builds.
+
+To avoid that, we change the way libperl.dylib is linked to perl, so
+for the initial build the library's id is at the build location rather
+than the install location, and the generated executable also expects
+to find libperl in that location.
+
+This obviously won't work once we copy both to the installation
+directory, so we adjust both the id of the library and the dependency
+path in the executable to point to the new location of the library.
+
+A previous attempt set -rpath and used @rpath in the id, but this made
+the embedding test fail.
+---
+ Makefile.SH | 34 ++++++++++++++++++++++++++++++++--
+ installperl | 25 +++++++++++++++++++++++++
+ 2 files changed, 57 insertions(+), 2 deletions(-)
+
+diff --git Makefile.SH Makefile.SH
+index 6e4d5ee684f..bebe50dc131 100755
+--- Makefile.SH
++++ Makefile.SH
+@@ -67,8 +67,16 @@ true)
+                             -compatibility_version \
+ 				${api_revision}.${api_version}.${api_subversion} \
+ 			     -current_version \
+-				${revision}.${patchlevel}.${subversion} \
+-			     -install_name \$(shrpdir)/\$@"
++				${revision}.${patchlevel}.${subversion}"
++		case "$osvers" in
++	        1[5-9]*|[2-9]*)
++			shrpldflags="$shrpldflags -install_name `pwd`/\$@ -Xlinker -headerpad_max_install_names"
++			exeldflags="-Xlinker -headerpad_max_install_names"
++			;;
++		*)
++			shrpldflags="$shrpldflags -install_name \$(shrpdir)/\$@"
++			;;
++		esac
+ 		;;
+ 	cygwin*)
+ 		shrpldflags="$shrpldflags -Wl,--out-implib=libperl.dll.a -Wl,--image-base,0x52000000"
+@@ -339,6 +347,14 @@ MANIFEST_SRT = MANIFEST.srt
+ 
+ !GROK!THIS!
+ 
++case "$useshrplib$osname" in
++truedarwin)
++	$spitshell >>$Makefile <<!GROK!THIS!
++PERL_EXE_LDFLAGS=$exeldflags
++!GROK!THIS!
++	;;
++esac
++
+ case "$usecrosscompile$perl" in
+ define?*)
+ 	$spitshell >>$Makefile <<!GROK!THIS!
+@@ -1050,6 +1066,20 @@ $(PERL_EXE): $& $(perlmain_dep) $(LIBPERL) $(static_ext) ext.libs $(PERLEXPORT)
+ 	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(LLIBPERL) $(static_ext) `cat ext.libs` $(libs)
+ !NO!SUBS!
+         ;;
++
++	darwin)
++	    case "$useshrplib$osvers" in
++	    true1[5-9]*|true[2-9]*) $spitshell >>$Makefile <<'!NO!SUBS!'
++	$(SHRPENV) $(CC) -o perl $(PERL_EXE_LDFLAGS) $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(static_ext) $(LLIBPERL) `cat ext.libs` $(libs)
++!NO!SUBS!
++	       ;;
++	    *) $spitshell >>$Makefile <<'!NO!SUBS!'
++	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(static_ext) $(LLIBPERL) `cat ext.libs` $(libs)
++!NO!SUBS!
++	       ;;
++	    esac
++        ;;
++
+         *) $spitshell >>$Makefile <<'!NO!SUBS!'
+ 	$(SHRPENV) $(CC) -o perl $(CLDFLAGS) $(CCDLFLAGS) $(perlmain_objs) $(static_ext) $(LLIBPERL) `cat ext.libs` $(libs)
+ !NO!SUBS!
+diff --git installperl installperl
+index 3bf79d2d6fc..6cd65a09238 100755
+--- installperl
++++ installperl
+@@ -304,6 +304,7 @@ elsif ($^O ne 'dos') {
+ 	safe_unlink("$installbin/$perl_verbase$ver$exe_ext");
+ 	copy("perl$exe_ext", "$installbin/$perl_verbase$ver$exe_ext");
+ 	strip("$installbin/$perl_verbase$ver$exe_ext");
++	fix_dep_names("$installbin/$perl_verbase$ver$exe_ext");
+ 	chmod(0755, "$installbin/$perl_verbase$ver$exe_ext");
+     }
+     else {
+@@ -388,6 +389,7 @@ foreach my $file (@corefiles) {
+     if (copy_if_diff($file,"$installarchlib/CORE/$file")) {
+ 	if ($file =~ /\.(\Q$so\E|\Q$dlext\E)$/) {
+ 	    strip("-S", "$installarchlib/CORE/$file") if $^O eq 'darwin';
++	    fix_dep_names("$installarchlib/CORE/$file");
+ 	    chmod($SO_MODE, "$installarchlib/CORE/$file");
+ 	} else {
+ 	    chmod($NON_SO_MODE, "$installarchlib/CORE/$file");
+@@ -791,4 +793,27 @@ sub strip
+     }
+ }
+
++sub fix_dep_names {
++    my $file = shift;
++
++    $^O eq "darwin" && $Config{osvers} =~ /^(1[5-9]|[2-9])/
++      && $Config{useshrplib}
++      or return;
++
++    my @opts;
++    my $so = $Config{so};
++    my $libperl = "$Config{archlibexp}/CORE/libperl.$Config{so}";
++    if ($file =~ /\blibperl.\Q$Config{so}\E$/a) {
++        push @opts, -id => $libperl;
++    }
++    else {
++        push @opts, -change => getcwd . "/libperl.$so", $libperl;
++    }
++    push @opts, $file;
++
++    $opts{verbose} and print "  install_name_tool @opts\n";
++    system "install_name_tool", @opts
++      and die "Cannot update $file dependency paths\n";
++}
++
+ # ex: set ts=8 sts=4 sw=4 et:

--- a/lang/perl5/files/5.28/avoid-no-cpp-precomp-PR38913.patch
+++ b/lang/perl5/files/5.28/avoid-no-cpp-precomp-PR38913.patch
@@ -1,0 +1,11 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -130,7 +130,7 @@ esac
+ 
+ # Avoid Apple's cpp precompiler, better for extensions
+ if [ "X`echo | ${cc} -no-cpp-precomp -E - 2>&1 >/dev/null`" = "X" ]; then
+-    cppflags="${cppflags} -no-cpp-precomp"
++
+ 
+     # This is necessary because perl's build system doesn't
+     # apply cppflags to cc compile lines as it should.

--- a/lang/perl5/files/5.28/clean-up-paths.patch
+++ b/lang/perl5/files/5.28/clean-up-paths.patch
@@ -1,0 +1,37 @@
+--- Configure.orig
++++ Configure
+@@ -108,8 +108,8 @@ if test -d c:/. || ( uname -a | grep -i 
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
++paths='/bin /usr/bin /usr/ucb /usr/lbin'
++paths="$paths /opt/bin __PREFIX__/bin __PREFIX__ /opt/lbin"
+ paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+ paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+ paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+@@ -1427,7 +1427,7 @@ archobjs=''
+ i_whoami=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
++locincpth="__PREFIX__/include /usr/gnu/include"
+ locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
+ :
+ : no include file wanted by default
+@@ -1444,12 +1444,12 @@ libnames=''
+ : change the next line if compiling for Xenix/286 on Xenix/386
+ xlibpth='/usr/lib/386 /lib/386'
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
++loclibpth="__PREFIX__/lib /usr/gnu/lib"
+ loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
+ 
+ : general looking path for locating libraries
+ glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
++glibpth="$glibpth /usr/ccs/lib /usr/ucblib"
+ test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+ test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+ test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"

--- a/lang/perl5/files/5.28/config.h.ed
+++ b/lang/perl5/files/5.28/config.h.ed
@@ -1,0 +1,157 @@
+/define[ 	]PRINTF_FORMAT_NULL_OK/c
+#ifdef __LP64__
+/*#define PRINTF_FORMAT_NULL_OK	/ **/
+#else /* !__LP64__ */
+#define PRINTF_FORMAT_NULL_OK	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]LONGSIZE/c
+#ifdef __LP64__
+#define LONGSIZE 8		/**/
+#else /* !__LP64__ */
+#define LONGSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]CASTI32/c
+#ifdef __ppc__
+#define CASTI32		/**/
+#else /* !__ppc__ */
+/*#define CASTI32		/ **/
+#endif /* __ppc__ */
+.
+/define[ 	]CASTNEGFLOAT/a
+.
+.,.+1c
+#ifdef __i386__
+/*#define CASTNEGFLOAT		/ **/
+#define CASTFLAGS 1		/**/
+#else
+#define CASTNEGFLOAT		/**/
+#define CASTFLAGS 0		/**/
+#endif
+.
+/define[ 	]Quad_t/a
+.
+.,.+2c
+#ifdef __LP64__
+#   define Quad_t long	/**/
+#   define Uquad_t unsigned long	/**/
+#   define QUADKIND 2	/**/
+#else /* !__LP64__ */
+#   define Quad_t long long	/**/
+#   define Uquad_t unsigned long long	/**/
+#   define QUADKIND 3	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]PTRSIZE/c
+#ifdef __LP64__
+#define PTRSIZE 8		/**/
+#else /* !__LP64__ */
+#define PTRSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_BSD_SETPGRP/c
+#if __DARWIN_UNIX03
+/*#define USE_BSD_SETPGRP	/ **/
+#else /* !__DARWIN_UNIX03 */
+#define USE_BSD_SETPGRP	/**/
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]I32TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I32TYPE		int	/**/
+#define	U32TYPE		unsigned int	/**/
+#else /* !__LP64__ */
+#define	I32TYPE		long	/**/
+#define	U32TYPE		unsigned long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]I64TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I64TYPE		long	/**/
+#define	U64TYPE		unsigned long	/**/
+#else /* !__LP64__ */
+#define	I64TYPE		long long	/**/
+#define	U64TYPE		unsigned long long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]IVSIZE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	IVSIZE		8		/**/
+#define	UVSIZE		8		/**/
+#else /* !__LP64__ */
+#define	IVSIZE		4		/**/
+#define	UVSIZE		4		/**/
+#endif /* __LP64__ */
+.
+/NV_PRESERVES_UV$/a
+.
+.,.+1c
+#ifdef __LP64__
+#undef	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	53
+#else /* !__LP64__ */
+#define	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	32
+#endif /* __LP64__ */
+.
+/define[ 	]HAS_STDIO_STREAM_ARRAY/a
+.
+.,.+3c
+#if __DARWIN_UNIX03
+/*#define	HAS_STDIO_STREAM_ARRAY	/ **/
+#define STDIO_STREAM_ARRAY	
+#else /* !__DARWIN_UNIX03 */
+#define	HAS_STDIO_STREAM_ARRAY	/**/
+#define STDIO_STREAM_ARRAY	__sF
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]USE_64_BIT_INT/c
+#ifdef __LP64__
+#define	USE_64_BIT_INT		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_INT		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_64_BIT_ALL/c
+#ifdef __LP64__
+#define	USE_64_BIT_ALL		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_ALL		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]Gid_t_f/c
+#ifdef __LP64__
+#define	Gid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Gid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]Size_t_size/c
+#ifdef __LP64__
+#define Size_t_size 8		/* */
+#else /* !__LP64__ */
+#define Size_t_size 4		/* */
+#endif /* __LP64__ */
+.
+/define[ 	]Uid_t_f/c
+#ifdef __LP64__
+#define	Uid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Uid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]NEED_VA_COPY/c
+#ifdef __LP64__
+#define	NEED_VA_COPY		/**/
+#else /* !__LP64__ */
+/*#define	NEED_VA_COPY		/ **/
+#endif /* __LP64__ */
+.
+w

--- a/lang/perl5/files/5.28/enable-syscall-on-sierra.patch
+++ b/lang/perl5/files/5.28/enable-syscall-on-sierra.patch
@@ -1,0 +1,18 @@
+--- hints/darwin.sh.orig	2017-09-28 10:47:53.000000000 -0700
++++ hints/darwin.sh	2017-09-28 10:56:53.000000000 -0700
+@@ -346,9 +346,12 @@
+     prodvers_minor=$(echo $prodvers|awk -F. '{print $2}')
+ 
+     # macOS (10.12) deprecated syscall().
+-    if [ "$prodvers_minor" -ge 12 ]; then
+-        d_syscall='undef'
+-    fi
++    # but it's still available on both macOS 10.12 and 10.13
++    # for compatibility with perl5.24 allow syscall() configuration on Sierra and later
++    # will auto-configure without syscall() if and when it's actually removed
++    # if [ "$prodvers_minor" -ge 12 ]; then
++    #     d_syscall='undef'
++    # fi
+ 
+    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+    ;;

--- a/lang/perl5/files/5.28/fix-miniperl-linking-PR36438.patch
+++ b/lang/perl5/files/5.28/fix-miniperl-linking-PR36438.patch
@@ -1,0 +1,11 @@
+--- Makefile.SH.orig
++++ Makefile.SH
+@@ -1004,7 +1004,7 @@ NAMESPACEFLAGS = -force_flat_namespace
+ 		$spitshell >>$Makefile <<'!NO!SUBS!'
+ lib/buildcustomize.pl: $& $(miniperl_objs) write_buildcustomize.pl
+ 	-@rm -f miniperl.xok
+-	$(CC) $(CLDFLAGS) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
++	unset LIBRARY_PATH && $(CC) $(subst -L__PREFIX__/lib,,$(CLDFLAGS)) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
+ 	    $(miniperl_objs) $(libs)
+ 	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
+ 	$(MINIPERL) -f write_buildcustomize.pl

--- a/lang/perl5/files/5.28/install-under-short-version-PR43480.patch
+++ b/lang/perl5/files/5.28/install-under-short-version-PR43480.patch
@@ -1,0 +1,39 @@
+https://trac.macports.org/ticket/43480
+--- Configure.orig
++++ Configure
+@@ -4363,6 +4363,8 @@ dos|vms)
+ *)
+ 	version=`echo $revision $patchlevel $subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
++	version_short=`echo $revision $patchlevel | \
++		 $awk '{ printf "%d.%d\n", $1, $2 }'`
+ 	api_versionstring=`echo $api_revision $api_version $api_subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
+ 	;;
+@@ -7336,7 +7338,7 @@ esac
+ : /opt/perl/lib/perl5... would be redundant.
+ : The default "style" setting is made in installstyle.U
+ case "$installstyle" in
+-*lib/perl5*) set dflt privlib lib/$package/$version ;;
++*lib/perl5*) set dflt privlib lib/$package/$version_short ;;
+ *)	 set dflt privlib lib/$version ;;
+ esac
+ eval $prefixit
+@@ -7584,7 +7586,7 @@ siteprefixexp="$ansexp"
+ prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ case "$sitelib" in
+ '') case "$installstyle" in
+-	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version ;;
++	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version_short ;;
+ 	*)	 dflt=$siteprefix/lib/site_$prog/$version ;;
+ 	esac
+ 	;;
+@@ -8001,7 +8003,7 @@ case "$vendorprefix" in
+ 	'')
+ 		prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ 		case "$installstyle" in
+-		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version ;;
++		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version_short ;;
+ 		*)	     dflt=$vendorprefix/lib/vendor_$prog/$version ;;
+ 		esac
+ 		;;

--- a/lang/perl5/files/5.28/patch-Configure-remove-libs.diff
+++ b/lang/perl5/files/5.28/patch-Configure-remove-libs.diff
@@ -1,0 +1,14 @@
+* Prevent build from picking up the bind9 port's static libbind
+* Don't link against cryptlib
+  https://trac.macports.org/ticket/53446
+--- Configure.orig
++++ Configure
+@@ -1483,7 +1483,7 @@ archname=''
+ usereentrant='undef'
+ : List of libraries we want.
+ : If anyone needs extra -lxxx, put those in a hint file.
+-libswanted="cl pthread socket bind inet nsl ndbm gdbm dbm db malloc dl ld"
++libswanted="pthread socket inet nsl ndbm gdbm dbm db malloc dl ld"
+ libswanted="$libswanted sun m crypt sec util c cposix posix ucb bsd BSD"
+ : We probably want to search /usr/shlib before most other libraries.
+ : This is only used by the lib/ExtUtils/MakeMaker.pm routine extliblist.


### PR DESCRIPTION
#### Description
The following tests fail in an invocation of `port -d test perl5.28`:
```
	../cpan/DB_File/t/db-hash.t
	../dist/Time-HiRes/t/stat.t
	../lib/ExtUtils/t/Embed.t
```
These don't appear to be a regression from 5.26, and I have left some comments on the db-hash one in the ticket about that issue.

I imagine that the one 5.28 patch will be merged in the release of 5.28.2.

I tested this with `port test` as listed above and did a "hello world" from the command line.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
