### PR TITLE
gpsd-devel: Fix build failure on <10.7.

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -64,7 +64,10 @@ if {${subport} eq ${name}} {
     master_sites        http://git.savannah.gnu.org/cgit/gpsd.git/snapshot
     distname            ${name}-${commit}
 
-    # This upstream version is completely patch-free
+    # Incorporate gpsd commit 62714ccc to fix compiler option setup.
+    # This can go away once "commit" is updated to at least that commit.
+
+    patchfiles-append   patch-compileroptions.diff
 
     livecheck.type          regex
     livecheck.version       ${commit}

--- a/net/gpsd/files/patch-compileroptions.diff
+++ b/net/gpsd/files/patch-compileroptions.diff
@@ -1,0 +1,11 @@
+--- SConstruct.orig	2018-12-04 14:59:22.000000000 -0800
++++ SConstruct	2018-12-25 18:57:29.000000000 -0800
+@@ -566,7 +566,7 @@ def CheckXsltproc(context):
+ 
+ def CheckCompilerOption(context, option):
+     context.Message('Checking if compiler accepts %s... ' % (option,))
+-    old_CFLAGS = context.env['CFLAGS']
++    old_CFLAGS = context.env['CFLAGS'][:]  # Get a *copy* of the old list
+     context.env.Append(CFLAGS=option)
+     ret = context.TryLink("""
+         int main(int argc, char **argv) {


### PR DESCRIPTION
This incorporates gpsd commit 62714ccc.  See its message for more
info.

TESTED:
Ran "port destroot gpsd-devel" on MacPro 10.9, and VMs for 10.5-10.13.
All builds now succeed.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
