### PR TITLE
groovy: update to 2.5.5

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.4
+version         2.5.5
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,9 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  700ff463b3fb2fa3e70ce672d25f864b0296be24 \
-                sha256  b2c936069831861d89cb8cf771bfa8a739b1d03c4be01b62d94e453e4b0bc6e8 \
-                size    29847597
+checksums       rmd160  bd62a7891012cfe5b1b6d3faddb453f9e730c94e \
+                sha256  8241668701c2a756eb93117129cd82b79ab03fe7364ebb5ec6432794cd16129a \
+                size    29903517
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.5.

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?