### PR TITLE
mpv: fix build on SnowLeopard

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               waf 1.0
+PortGroup               legacysupport 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.29.1 v
@@ -51,7 +52,13 @@ depends_lib             path:lib/libavcodec.dylib:ffmpeg \
 
 universal_variant       no
 
-default_variants        +bundle +network +osd +rubberband +opengl +dvd +audiocd +libarchive
+default_variants        +network +osd +rubberband +opengl +dvd +audiocd +libarchive
+
+if {${os.platform} eq "darwin" && ${os.major} > 10} {
+    # current macOS bundle errors on < 10.7 due to unhandled -psn_* argument
+    default_variants-append +bundle
+}
+
 
 # Current waf doesn't support --nocache anymore. Set by PortGroup.
 configure.args-delete   --nocache
@@ -229,18 +236,7 @@ platform darwin {
     # on getting the OpenGL output to work via X11.
     # Also fix some other minor compile issues only manifesting on 10.6 and below along the way.
     if {${os.major} < 11} {
-        patchfiles-append   patch-wscript-support-older-GCC.diff \
-                            patch-misc-add-strnlen.diff \
-                            patch-waftools_detections_compiler.py-support-older-GCC.diff \
-                            patch-audio_out_ao_coreaudio_exclusive.c-compile-fix.diff \
-                            patch-video_out_opengl_video.c-fix-compile-warnings.diff \
-                            patch-audio_out_ao_coreaudio_utils.c-add-missing-header-for-getpid.diff \
-                            patch-video_out_opengl_common.h-guard-GL3-stuff.diff \
-                            patch-video_out_vo_opengl.c-guard-GL3-and-backport-old-behavior.diff \
-                            patch-video_out_opengl_common.c-hide-GL320-section.diff \
-                            patch-video_out_opengl_common.c-hide-GL3-timer-functions.diff \
-                            patch-video_out_opengl_video.c-remove-timer-functionality.diff \
-                            patch-video_out_opengl_video.c-hide-pbo-texture-upload.diff
+        patchfiles-append   patch-audio_out_ao_coreaudio_utils.c-add-missing-header-for-getpid.diff
 
         notes-append {
                         On systems older than Lion (10.7) or on architectures other than x86_64, Cocoa output support is not available.


### PR DESCRIPTION
most previous patches appear no longer needed
current app bundle version does not handle -psn_* so disable for now
this may be able to be tweaked in future to re-enable bundle

see: https://trac.macports.org/ticket/57663
will close noted ticket if buildbots indicate success

```
$ port -v installed mpv
The following ports are currently installed:
  mpv @0.29.1_2+audiocd+dvd+libarchive+network+opengl+osd+python27+rubberband+x11 (active) platform='darwin 10' archs='x86_64' date='2018-12-16T13:25:41-0500'
```