### PR TITLE
openjdk8: workaround for @rpath/libfreetype.6.dylib UnsatisfiedLinkError

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -4,7 +4,7 @@ PortSystem       1.0
 
 name             openjdk8
 version          8u192
-revision         0
+revision         1
 
 set build        12
 set major        8
@@ -120,6 +120,13 @@ set destroot_target ${destroot}${target}
 destroot {
     xinstall -m 755 -d ${destroot_target}
     copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+# Workaround for https://github.com/AdoptOpenJDK/openjdk-build/issues/489
+if {${subport} eq "openjdk8"} {
+    post-destroot {
+        ln -s libfreetype.dylib.6 ${destroot_target}/Contents/Home/jre/lib/libfreetype.6.dylib
+    }
 }
 
 notes "


### PR DESCRIPTION
#### Description

Workaround for https://github.com/AdoptOpenJDK/openjdk-build/issues/489

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?