### PR TITLE
netpbm: fix userguide_commit

### DIFF
--- a/graphics/netpbm/Portfile
+++ b/graphics/netpbm/Portfile
@@ -9,7 +9,7 @@ github.setup            chneukirchen netpbm-mirror ebf403d4015d30f19a37895efdce2
 name                    netpbm
 version                 10.84.05
 svn.revision            3458
-set userguide_commit    18fa5dc553c7645f08e1f0e826f6886f7cc775XX
+set userguide_commit    18fa5dc553c7645f08e1f0e826f6886f7cc775fe
 set userguide_revision  3456
 # need 3463+
 


### PR DESCRIPTION
The update to 10.84.05 (b57abd7621c1e3b5a6cf3cd7eff6d861ba93e137) contained an invalid `userguide_commit` (last two hex digits should be `fe`, not `XX`)

Fixes https://trac.macports.org/ticket/57817

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
$ port lint netpbm
--->  Verifying Portfile for netpbm
Warning: Variant x11 overrides global description
--->  0 errors and 1 warnings found.
$ port lint libnetpbm
--->  Verifying Portfile for libnetpbm
--->  0 errors and 0 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
Just for `libnetpbm`
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
