### PR TITLE
apr: update to 1.6.5

### DIFF
--- a/devel/apr/Portfile
+++ b/devel/apr/Portfile
@@ -1,26 +1,26 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-PortSystem	1.0
+PortSystem         1.0
 
-name		apr
-version		1.6.5
-categories	devel
-maintainers	{geeklair.net:dluke @danielluke}
-platforms	darwin
-description	The apache group's portability library
-license		Apache-2
+name               apr
+version            1.6.5
+categories         devel
+maintainers        {geeklair.net:dluke @danielluke}
+platforms          darwin
+description        The apache group's portability library
+license            Apache-2
 
-long_description	The Apache Portable Runtime is a library of C data \
-			structures and routines, forming a system portability \
-			layer that covers as many operating systems as \
-			possible, including Unices, Win32, BeOS, and OS/2.
+long_description   The Apache Portable Runtime is a library of C data \
+                   structures and routines, forming a system portability \
+                   layer that covers as many operating systems as \
+                   possible, including Unices, Win32, BeOS, and OS/2.
 
-homepage	http://apr.apache.org/
-master_sites	apache:apr
+homepage           http://apr.apache.org/
+master_sites       apache:apr
 
-use_bzip2	yes
-checksums  rmd160  ce1f38641feceb09df8d6fea33fbf76b7c1e9ee0 \
-           sha256  a67ca9fcf9c4ff59bce7f428a323c8b5e18667fdea7b0ebad47d194371b0a105 \
-           size    855393
+use_bzip2          yes
+checksums          rmd160  ce1f38641feceb09df8d6fea33fbf76b7c1e9ee0 \
+                   sha256  a67ca9fcf9c4ff59bce7f428a323c8b5e18667fdea7b0ebad47d194371b0a105 \
+                   size    855393
 
 # Xcode 3.x's gcc-4.0 generates bad code in apr's translation which can be caught by enabling
 # debugging in apr, apr-util, and subversion with LANG="en_US.UTF-8"
@@ -29,31 +29,31 @@ if {[vercmp ${xcodeversion} 3.0] >= 0} {
     compiler.blacklist-append gcc-4.0
 }
 
-use_parallel_build	yes
-configure.ccache	no
+use_parallel_build yes
+configure.ccache   no
 #configure's tests don't work right for sed/gsed if we just set SED here
-configure.env   ac_cv_prog_AWK=awk ac_cv_path_SED=sed lt_ECHO=/bin/echo lt_cv_path_SED=sed
-configure.args	--with-installbuilddir=${prefix}/share/apr-1/build \
-		--enable-nonportable-atomics \
-		ac_cv_func_setpgrp_void=no
+configure.env      ac_cv_prog_AWK=awk ac_cv_path_SED=sed lt_ECHO=/bin/echo lt_cv_path_SED=sed
+configure.args     --with-installbuilddir=${prefix}/share/apr-1/build \
+                   --enable-nonportable-atomics \
+                   ac_cv_func_setpgrp_void=no
 
-patchfiles	apr_h_patch.diff
+patchfiles         apr_h_patch.diff
 
-test.run	yes
-test.target	check
-test.env	DYLD_LIBRARY_PATH=${worksrcpath}/.libs
-pre-test	{
-	use_parallel_build	no
+test.run           yes
+test.target        check
+test.env           DYLD_LIBRARY_PATH=${worksrcpath}/.libs
+pre-test {
+    use_parallel_build no
 }
 
 if {[variant_isset universal]} {
-	post-destroot {
-		reinplace -E {s|-arch [a-z0-9_]+||g} \
-			${destroot}${prefix}/share/apr-1/build/apr_rules.mk \
-			${destroot}${prefix}/share/apr-1/build/libtool
-	}
+    post-destroot {
+        reinplace -E {s|-arch [a-z0-9_]+||g} \
+            ${destroot}${prefix}/share/apr-1/build/apr_rules.mk \
+            ${destroot}${prefix}/share/apr-1/build/libtool
+        }
 }
 
-livecheck.type  regex
-livecheck.url   http://apr.apache.org
-livecheck.regex {APR (\d+(?:\.\d+)*), released}
+livecheck.type     regex
+livecheck.url      http://apr.apache.org
+livecheck.regex    {APR (\d+(?:\.\d+)*), released}

--- a/devel/apr/Portfile
+++ b/devel/apr/Portfile
@@ -1,7 +1,8 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem	1.0
 
 name		apr
-version		1.6.3
+version		1.6.5
 categories	devel
 maintainers	{geeklair.net:dluke @danielluke}
 platforms	darwin
@@ -17,11 +18,10 @@ homepage	http://apr.apache.org/
 master_sites	apache:apr
 
 use_bzip2	yes
-checksums	md5	12f2a349483ad6f12db49ba01fbfdbfa \
-		sha1	4f3aa8d8204a2674868b9d485c11349e1848987d \
-		rmd160	6238854544a4f8a515f64849038be6fd5aa90cf6 \
-		sha256	131f06d16d7aabd097fa992a33eec2b6af3962f93e6d570a9bd4d85e95993172
-                    
+checksums  rmd160  ce1f38641feceb09df8d6fea33fbf76b7c1e9ee0 \
+           sha256  a67ca9fcf9c4ff59bce7f428a323c8b5e18667fdea7b0ebad47d194371b0a105 \
+           size    855393
+
 # Xcode 3.x's gcc-4.0 generates bad code in apr's translation which can be caught by enabling
 # debugging in apr, apr-util, and subversion with LANG="en_US.UTF-8"
 # Assertion failed: (node->next == NULL), function put_xlate_handle_node, file subversion/libsvn_subr/utf.c, line 378.


### PR DESCRIPTION
#### Description
I tested this with `port -d test apr`, and it worked, although I am not sure if I was able to do integration tests with users of apr. At any rate, I can tell you that looking at the changelog there were hardly any changes and nothing API breaking so things look safe.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
