### PR TITLE
py-pyside2: update to 5.12.0, add dependency py-sphinx

### DIFF
--- a/python/py-pyside2/Portfile
+++ b/python/py-pyside2/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyside2
-version                 5.11.2
+version                 5.12.0
 categories-append       devel aqua
 platforms               darwin
 maintainers             {pmetzger @pmetzger} {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -17,9 +17,9 @@ master_sites            https://download.qt.io/official_releases/QtForPython/pys
 distname                pyside-setup-everywhere-src-${version}
 use_xz                  yes
 
-checksums               rmd160  6af60baf36f49f330b2c7d60fd171dc996d1e86b \
-                        sha256  18f572f1f832e476083d30fccabab167450f2a8cbe5cd9c6e6e4fa078ccb86c2 \
-                        size    5298804
+checksums               rmd160  528a119d3baabaca7b15be1a82f6491e1a5b044f \
+                        sha256  890149628a6c722343d6498a9f7e1906ce3c10edcaef0cc53cd682c1798bef51 \
+                        size    5368816
 
 python.versions         27 36 37
 
@@ -34,6 +34,7 @@ if {${name} ne ${subport}} {
     depends_build-append \
         path:bin/cmake:cmake \
         port:py${python.version}-setuptools \
+        port:py${python.version}-sphinx \
         port:py${python.version}-wheel
 
     build.args-append \


### PR DESCRIPTION
#### Description

The dependency on `pyXX-sphinx` was already missing; 5.11.2 would fail to build if `pyXX-sphinx` wasn't installed or trace mode was enabled.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
