### PR TITLE
libarchive: Add zstd support and program symlinks

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -16,6 +16,7 @@ long_description \
 platforms        darwin
 
 version          3.3.3
+revision         1
 checksums        rmd160  c59dd17f764e33c2984058091ea00b5768e35ce4 \
                  sha256  ba7eb1781c9fbbae178c4c6bad1c6eb08edab9a1496c64833d1715d022b30e2e \
                  size    6535598
@@ -25,7 +26,7 @@ master_sites     ${homepage}downloads/
 
 depends_lib      port:bzip2 port:zlib port:libxml2 port:xz \
                  port:lzo2 port:libiconv \
-                 port:lz4 port:expat
+                 port:lz4 port:expat port:zstd
 
 patchfiles       patch-libarchive__archive_read_support_format_lha.c.diff
 
@@ -38,7 +39,14 @@ depends_build    port:autoconf port:automake port:libtool \
 
 configure.args   --enable-bsdtar=shared --enable-bsdcpio=shared \
                  --disable-silent-rules --without-nettle \
-                 --without-openssl --with-lzo2
+                 --without-openssl --with-lzo2 --with-zstd
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/libexec/${subport}
+    foreach program [glob -tails -directory ${destroot}${prefix}/bin *] {
+        ln -s ${prefix}/bin/${program} ${destroot}${prefix}/libexec/${subport}
+    }
+}
 
 livecheck.type  regex
 livecheck.regex libarchive-(\[0-9.\]+)\\.tar.gz


### PR DESCRIPTION
#### Description

libarchive already used zstd opportunistically if it happened to be installed at build time. This adds the dependency and makes explicit that we want it.

The symlinks make it easier to use bsdtar from a libarchive installed by one copy of MacPorts in another copy of MacPorts, such as how we want to use it on the buildbot workers.

See: https://trac.macports.org/ticket/57396

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
