### PR TITLE
py-bitarray: update to 0.8.3, add Python 3.7 subport

### DIFF
--- a/python/py-bitarray/Portfile
+++ b/python/py-bitarray/Portfile
@@ -7,7 +7,7 @@ set _name           bitarray
 set _n              [string index ${_name} 0]
 
 name                py-${_name}
-version             0.8.1
+version             0.8.3
 categories-append   math
 platforms           darwin
 
@@ -30,11 +30,11 @@ homepage            https://github.com/ilanschnell/${_name}
 distname            ${_name}-${version}
 master_sites        pypi:${_n}/${_name}/
 
-checksums           md5     3825184f54f4d93508a28031b4c65d3b \
-                    rmd160  58c2a2665c2759f23bf1ab096de8c34bf7fcfcbb \
-                    sha256  7da501356e48a83c61f479393681c1bc4b94e5a34ace7e08cb29e7dd9290ab18
+checksums           rmd160  f670f9981592cad78e832edc964dbe0101908c7d \
+                    sha256  050cd30b810ddb3aa941e7ddfbe0d8065e793012d0a88cb5739ec23624b9895e \
+                    size    36292
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 livecheck.type      none
 


### PR DESCRIPTION
#### Description

Note: the developer is explicitly supporting Python 3.7 in the next release, but did not make any functional changes since 0.8.3 to do so: https://github.com/ilanschnell/bitarray/commit/948db916da5453e1ee49f8af0cc343fe1c928ca3

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
I did notice this during building:
```
/usr/bin/clang -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -I/opt/local/Library/Frameworks/Python.framework/Versions/3.7/include/python3.7m -c bitarray/_bitarray.c -o build/temp.macosx-10.14-x86_64-3.7/bitarray/_bitarray.o
dyld: warning: could not load inserted library '/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib' into hardened process because no suitable image found.  Did find:
	/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib: code signature in (/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib) not valid for use in process using Library Validation: mapped file has no cdhash, completely unsigned? Code has to be at least ad-hoc signed.
	/opt/local/libexec/macports/lib/darwintrace1.0/darwintrace.dylib: stat() failed with errno=1
```
- [x] tested basic functionality of all binary files?
Successfully ran the included `test_bitarray.py` script.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
