### PR TITLE
perl5.{16,18,20,22,24,26,28}: fix DB_File

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -23,13 +23,13 @@ master_sites        http://www.cpan.org/src/5.0/
 # - sha256
 # - size
 set perl5.versions_info {
-    5.16 3 6 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8  13724906
-    5.18 4 5 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5  14059430
-    5.20 3 4 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b  13743405
-    5.22 4 2 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
-    5.24 4 1 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
-    5.26 3 1 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
-    5.28 1 0 e2f0618fc01bcd253ef6e003c1d9b957b6f6aa53  fea7162d4cca940a387f0587b93f6737d884bf74d8a9d7cfd978bc12cd0b202d  12372080
+    5.16 3 7 f25fdd72449156a7cbe989e8bd339fdba1afabc0  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8  13724906
+    5.18 4 6 d97181a98f7acc80125b0d2a182a6a2cd7542ceb  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5  14059430
+    5.20 3 5 499846a1c92e00dd357cb782bc14787b8cd47051  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b  13743405
+    5.22 4 3 54fdbcbf249134dc7d82b693417900286201b5e7  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71  13745983
+    5.24 4 2 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
+    5.26 3 2 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
+    5.28 1 1 e2f0618fc01bcd253ef6e003c1d9b957b6f6aa53  fea7162d4cca940a387f0587b93f6737d884bf74d8a9d7cfd978bc12cd0b202d  12372080
 }
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5.size} ${perl5.versions_info} {
@@ -47,7 +47,8 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
                             administration, web development, network \
                             programming, GUI development, and more.
 
-        depends_lib-append  port:gdbm
+        depends_lib-append  port:db48 \
+                            port:gdbm
 
         distname            perl-${perl5.major}.${perl5.subversion}
         dist_subdir         perl${perl5.major}
@@ -60,6 +61,10 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
         # TODO: revise patch naming scheme
         patchfiles          ${perl5.major}/clean-up-paths.patch \
                             ${perl5.major}/avoid-no-cpp-precomp-PR38913.patch
+
+        # Use correct location of db48 (Berkeley Data Base library)
+        # https://trac.macports.org/ticket/55207
+        patchfiles-append   ${perl5.major}/fix-db_file-paths.patch
 
         # - Prevent build from picking up the bind9 port's static libbind, which
         #   duplicates symbols from /usr/lib/libdl (r10638).
@@ -114,7 +119,7 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
 
         post-patch {
             reinplace -W ${worksrcpath} "s|__PREFIX__|${prefix}|g" \
-                    Configure Makefile.SH
+                    Configure Makefile.SH cpan/DB_File/config.in
         }
 
         configure.ccache    no

--- a/lang/perl5/files/5.16/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.16/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.18/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.18/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.20/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.20/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.22/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.22/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.24/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.24/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.26/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.26/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.28/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.28/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib


### PR DESCRIPTION
Mirror what the p5-db_file package does and manually fix up the version
of DB_File that gets distributed with the perl interpreter.

This adds a dependency on db48 to perl.

#### Description
I have run `port -d test` on perl5.28 but not the others - I can do so if you can confirm that this is the approach that will be done to fix the DB_File issue.

Note that I am still getting test failures with Time::HiRes, but digging into it (it's some sort of subsecond timestamp difference on stat calls for a file) I imagine it's because I'm using the new apfs and upstream hasn't yet patched in support for its quirks.

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
