### PR TITLE
cvs-fast-export: update to 1.44

### DIFF
--- a/devel/cvs-fast-export/Portfile
+++ b/devel/cvs-fast-export/Portfile
@@ -1,11 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.0
 
 name                cvs-fast-export
-version             1.43
-revision            1
+version             1.44
 categories          devel
 license             GPL-2
 platforms           darwin
@@ -26,8 +24,9 @@ long_description    This program analyzes a collection of RCS files in a CVS \
 homepage            http://www.catb.org/~esr/cvs-fast-export/
 master_sites        ${homepage}
 
-checksums           rmd160  638f893b01cd72eaa391d51c6c4429f484e51830 \
-                    sha256  a31613a1faf2aac69533f9c3b371f8352dd98224b9b91023f8a6d5ce082eb79f
+checksums           rmd160  d4e66e102b852c11ced1eb35d7b1f439fe3225db \
+                    sha256  a03620c5eadecfb71f6e0bd55511d9adecf7777931ca3623999ff04db4a7f0d0 \
+                    size    512435
 
 depends_build       port:flex \
                     port:bison \

--- a/devel/cvs-fast-export/files/patch-Makefile.diff
+++ b/devel/cvs-fast-export/files/patch-Makefile.diff
@@ -1,7 +1,7 @@
 --- Makefile.orig
 +++ Makefile
 @@ -17,12 +17,16 @@
- VERSION=1.40
+ VERSION=1.44
  
  .PATH: $(.PARSEDIR)
 -prefix?=/usr/local
@@ -48,15 +48,15 @@
 @@ -113,9 +117,9 @@ lex.o: lex.c gram.h
  
  # Requires asciidoc and xsltproc/docbook stylesheets.
- .asc.1:
+ .adoc.1:
 -	a2x --doctype manpage --format manpage $<
 +	$(A2X) --doctype manpage --format manpage $<
- .asc.html:
+ .adoc.html:
 -	a2x --doctype manpage --format xhtml -D . $<
 +	$(A2X) --doctype manpage --format xhtml -D . $<
  	rm -f docbook-xsl.css
  
- reporting-bugs.html: reporting-bugs.asc
+ reporting-bugs.html: reporting-bugs.adoc
 @@ -167,7 +171,7 @@ CSUPPRESSIONS = -U__UNUSED__ -UYYPARSE_PARAM -UYYTYPE_INT16 -UYYTYPE_INT8 \
  	-U_SC_NPROCESSORS_ONLN -Ushort -Usize_t -Uyytext_ptr \
  	-Uyyoverflow -U__cplusplus


### PR DESCRIPTION
@ewenmcneill: please check if this solves the problem
@cjones051073 or @kencu: can you please verify that I'm not doing this the wrong way by reverting your commit?

My understanding is that the software doesn't really need support for CLOCK_REALTIME, so I removed the `legacysupport` PortGroup. Actually the patch was doing the reverse: preventing 10.14 from defining some fallback definitions from inside the software.

The previous patch was incorporated upstream.

Hopefully closes: https://trac.macports.org/ticket/57822

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->