### PR TITLE
wxWidgets-3.2: update to 3.1.2

### DIFF
--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -9,7 +9,7 @@ PortGroup           wxWidgets       1.0
 # simply fetch a newer version from git (master) until 3.1.1 comes out.
 # This is a development port anyway and generally not used as dependency.
 
-github.setup        wxWidgets wxWidgets 3.1.1 v
+github.setup        wxWidgets wxWidgets 3.1.2 v
 name                wxWidgets-3.2
 wxWidgets.use       wxWidgets-3.2
 
@@ -28,9 +28,9 @@ long_description    wxWidgets ${branch} is an open-source cross-platform C++ \
 
 homepage            http://www.wxwidgets.org/
 
-checksums           rmd160  2fa5164dad43063274e72cc13626fdb90107a8a7 \
-                    sha256  8268f9ee24f37556b5ee6642801b121a85e053390eeab07ffc250a49dbc346cc \
-                    size    20042631
+checksums           rmd160  f359c3c076d872b70d49055b5b86eaec7f1750c1 \
+                    sha256  79bdda90d672b098d37f2dcb494d2a62e9c95d94a8f7aaed60e245716a5eba8c \
+                    size    20111698
 
 dist_subdir         wxWidgets/${version}
 worksrcdir          ${distname}/build

--- a/multimedia/mediainfo/Portfile
+++ b/multimedia/mediainfo/Portfile
@@ -36,7 +36,7 @@ subport MediaInfo-gui {
     PortGroup           app 1.0
     PortGroup           wxWidgets 1.0
     wxWidgets.use       wxWidgets-3.2
-    revision            0
+    revision            1
 
     description         Identifies audio and video codecs in a media file. GUI
     long_description    MediaInfo supplies technical and tag information about a \


### PR DESCRIPTION
#### Description

`wxMaxima`, `audacity` (@RJVB) and `mediainfo` (@ctreleaven) [optionally] depend on wxWidgets-3.2. If maintainers are willing to test those ports before merging ...

###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->