### PR TITLE
perl5 portgroup: remove use_search_cpan_org

### DIFF
--- a/_resources/port1.0/group/perl5-1.0.tcl
+++ b/_resources/port1.0/group/perl5-1.0.tcl
@@ -5,11 +5,8 @@
 #   subport will be created for each. e.g. p5.12-foo, p5.10-foo, ...
 # perl5.branches must be set in the portfile
 # perl5.default_branch: the branch used when you request p5-foo
-# perl5.use_search_cpan_org: if true use search.cpan.org instead of
-#    metacpan.org for livecheck and homepage. Default: false.
-options perl5.default_branch perl5.branches perl5.use_search_cpan_org
+options perl5.default_branch perl5.branches
 default perl5.default_branch {[perl5_get_default_branch]}
-default perl5.use_search_cpan_org {false}
 
 proc perl5_get_default_branch {} {
     global prefix perl5.branches
@@ -134,7 +131,7 @@ set perl5.cpandir ""
 # perl5 group setup procedure
 proc perl5.setup {module vers {cpandir ""}} {
     global perl5.branches perl5.default_branch perl5.bin perl5.lib \
-           perl5.module perl5.moduleversion perl5.cpandir perl5.use_search_cpan_org \
+           perl5.module perl5.moduleversion perl5.cpandir \
            prefix subport name
 
     # define perl5.module
@@ -158,12 +155,8 @@ proc perl5.setup {module vers {cpandir ""}} {
     version             [perl5_convert_version ${perl5.moduleversion}]
     categories          perl
     
-    if {${perl5.use_search_cpan_org}} {
-        homepage        http://search.cpan.org/dist/${perl5.module}/
-    } else {
-        homepage        https://metacpan.org/pod/[string map {"-" "::"} ${perl5.module}]
-    }
-
+    homepage            https://metacpan.org/pod/[string map {"-" "::"} ${perl5.module}]
+    
     master_sites        perl_cpan:${perl5.cpandir}
     distname            ${perl5.module}-${perl5.moduleversion}
     dist_subdir         perl5
@@ -233,14 +226,9 @@ proc perl5.setup {module vers {cpandir ""}} {
 
     livecheck.type      regexm
     
-    if {${perl5.use_search_cpan_org}} {
-        livecheck.url       http://search.cpan.org/dist/${perl5.module}/
-        livecheck.regex     >[quotemeta ${perl5.module}]-(\[^"\ \]+?)<
-    } else {
-        livecheck.url       https://fastapi.metacpan.org/v1/release/${perl5.module}/
-        livecheck.regex     \"name\" : \"[quotemeta ${perl5.module}]-(\[^"\]+?)\"
-    }
-
+    livecheck.url       https://fastapi.metacpan.org/v1/release/${perl5.module}/
+    livecheck.regex     \"name\" : \"[quotemeta ${perl5.module}]-(\[^"\]+?)\"
+    
     default livecheck.version {${perl5.moduleversion}}
 }
 


### PR DESCRIPTION
Originally added in e5663a931f84ab6d083ae8b7aa80f48449d454b2; 
option is unused since aecdac46c72b3a8e98c512c76034fd67d8ac0271

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
MacPorts 2.5.4

`port livecheck` and `port info --homepage` appear to work for `p5-*` ports without custom livecheck and homepage.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
