### PR TITLE
py-pyqt5: fix spelling in comment

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -85,7 +85,7 @@ if {${subport} eq "${name}-common"} {
     # do not clear include directories just because --dbus is given
     patchfiles-append   patch-dbus_includes.diff
     # PyQt5 insists on using a private copy of sip, but the default sip seems to work just fine
-    # (actually, the insistance appears to be on sip using a private module directory;
+    # (actually, the insistence appears to be on sip using a private module directory;
     # see the online pyqt5 build-from-source instructions).
     patchfiles-append   patch-use-default-sip.diff
 


### PR DESCRIPTION
It would be the correct spelling in French, though :^)