### PR TITLE
py-pytimeparse: update to 1.1.8, add py37 subport

### DIFF
--- a/python/py-pytimeparse/Portfile
+++ b/python/py-pytimeparse/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 
 set base_name       pytimeparse
 name                py-$base_name
-version             1.1.6
-python.versions     27 35 36
+version             1.1.8
+python.versions     27 35 36 37
 platforms           darwin
 maintainers         openmaintainer {gmail.com:esafak @esafak}
 license             MIT
@@ -16,8 +16,9 @@ long_description    $description
 homepage            https://pypi.python.org/pypi/$base_name
 master_sites        pypi:p/$base_name
 
-checksums           rmd160  e6a4d1ecc57fd4b50f86fe7199ec8b393c4d4acd \
-                    sha256  74c52ae0db8a1d9055b9159bf09023ad5fba828b87ec47c0a9aed8129159ab46
+checksums           rmd160  e56358a299e95b6593e39f2b57013a4157a412b0 \
+                    sha256  e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a \
+                    size    9403
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
