### PR TITLE
py-unidecode: update to 1.0.23, add py37 subport

### DIFF
--- a/python/py-unidecode/Portfile
+++ b/python/py-unidecode/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 set realName        unidecode
 name                py-$realName
-version             0.04.20
+version             1.0.23
 categories-append   textproc
 platforms           darwin
 supported_archs     noarch
@@ -25,10 +25,11 @@ homepage            https://pypi.python.org/pypi/$realName/
 
 master_sites        pypi:u/$realName
 distname            Unidecode-${version}
-checksums           rmd160  43424072a59c6cbb88e3915cc1942bed33eeb6d5 \
-                    sha256  ed4418b4b1b190487753f1cca6299e8076079258647284414e6d607d1f8a00e0
+checksums           rmd160  60d50eae7fc8c4da28073113aaefb0951c3c6d54 \
+                    sha256  8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb \
+                    size    210727
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 if {${subport} ne ${name}} {
     livecheck.type          none


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
