### PR TITLE
cuneiform: fix build on modern compilers

### DIFF
--- a/textproc/cuneiform/Portfile
+++ b/textproc/cuneiform/Portfile
@@ -37,6 +37,7 @@ platform darwin powerpc {
 
 patchfiles-append       patch-cuneiform_src-Kern-ced-sources-main-ced_func_rtf.cpp.diff
 patchfiles-append       patch-cuneiform_src-Kern-leo-src-leo_dll.c.diff
+patchfiles-append       patch-cuneiform_src-Kern-rimage-sources-main-cricontrol-abs.diff
 
 cmake.out_of_source     yes
 

--- a/textproc/cuneiform/Portfile
+++ b/textproc/cuneiform/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               cmake 1.0
+PortGroup               cmake 1.1
 
 name                    cuneiform
 version                 1.1.0
-revision                4
+revision                5
 set branch              [join [lrange [split ${version} .] 0 1] .]
 platforms               darwin
 maintainers             nomaintainer
@@ -38,8 +38,6 @@ platform darwin powerpc {
 patchfiles-append       patch-cuneiform_src-Kern-ced-sources-main-ced_func_rtf.cpp.diff
 patchfiles-append       patch-cuneiform_src-Kern-leo-src-leo_dll.c.diff
 patchfiles-append       patch-cuneiform_src-Kern-rimage-sources-main-cricontrol-abs.diff
-
-cmake.out_of_source     yes
 
 configure.args-append   -DImageMagick_Magick++_INCLUDE_DIR:PATH=${prefix}/include/ImageMagick-6 \
                         -DImageMagick_Magick++_LIBRARY:FILEPATH=${prefix}/lib/libMagick++-6.Q16.dylib

--- a/textproc/cuneiform/files/patch-cuneiform_src-Kern-rimage-sources-main-cricontrol-abs.diff
+++ b/textproc/cuneiform/files/patch-cuneiform_src-Kern-rimage-sources-main-cricontrol-abs.diff
@@ -1,0 +1,15 @@
+diff --git cuneiform_src/Kern/rimage/sources/main/cricontrol.cpp cuneiform_src/Kern/rimage/sources/main/cricontrol.cpp
+index d03aced..a242c79 100644
+--- cuneiform_src/Kern/rimage/sources/main/cricontrol.cpp
++++ cuneiform_src/Kern/rimage/sources/main/cricontrol.cpp
+@@ -594,8 +594,8 @@ Bool32 CRIControl::CreateDestinatonDIB(uint32_t BitCount)
+ 		return FALSE;
+ 	}
+ 
+-	wNewHeight = (mbMarginsFlag ? abs(mrMargins.rmBottomMarg - mrMargins.rmTopMarg) : mpSourceDIB->GetLinesNumber());
+-	wNewWidth = (mbMarginsFlag ? abs(mrMargins.rmLeftMarg - mrMargins.rmRightMarg) : mpSourceDIB->GetLineWidth());
++	wNewHeight = (mbMarginsFlag ? abs(static_cast<int>(mrMargins.rmBottomMarg - mrMargins.rmTopMarg)) : mpSourceDIB->GetLinesNumber());
++	wNewWidth = (mbMarginsFlag ? abs(static_cast<int>(mrMargins.rmLeftMarg - mrMargins.rmRightMarg)) : mpSourceDIB->GetLineWidth());
+ 	mpSourceDIB->GetResolutionDPM( &wXResolution, &wYResolution);
+ 
+ 	if ( !mpDestinationDIB->CreateDIBBegin( wNewWidth, wNewHeight, BitCount) )


### PR DESCRIPTION
I saw also <https://trac.macports.org/ticket/33708> with an error when running this application, but I had no such issues; all the test files seemed to successfully OCR for me on this 10.6.8 machine (clang-5.0, libc ++).

Sending up to the CI system for a set of test builds to verify.