### PR TITLE
google-cloud-sdk: update to 228.0.0, added maintainer

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             220.0.0
+version             228.0.0
 categories          devel python
 license             Apache-2
-maintainers         nomaintainer
+maintainers         {breun.nl:nils @breun} openmaintainer
 description         Command-line interface for Google Cloud Platform products and services
 long_description    ${description}
 
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  43f50035b51eb2654a0d5bf50448dba32b8a2de4 \
-                    sha256  c645244380d0ce2c552d8320836ae69026442acd96a73afbc48f7f3ad5c67897 \
-                    size    17427658
+checksums           rmd160  2abf954540d9dad65b55a60c83b5960cd16925a7 \
+                    sha256  68b0b1248a808700c4d2a94ca0cd26093969ac4ed51a9866b26845555ddeba27 \
+                    size    17974757
 
 python.default_version 27
 
@@ -38,7 +38,7 @@ destroot {
     set libexecdir ${destroot}${prefix}/libexec/${name}
     xinstall -d ${libexecdir}
     copy ${worksrcpath}/bin ${worksrcpath}/lib ${worksrcpath}/platform ${libexecdir}
-    foreach f {gcloud bq gsutil} {
+    foreach f { bq docker-credential-gcloud gcloud gsutil } {
         ln -s ../libexec/${name}/bin/${f} ${destroot}${prefix}/bin/${f}
     }
     ln -s ../libexec/${name}/bin/git-credential-gcloud.sh ${destroot}${prefix}/bin/git-credential-gcloud
@@ -55,4 +55,4 @@ variant bash_completion {
     depends_run-append path:etc/bash_completion:bash-completion
 }
 
-livecheck.url       https://cloud.google.com/sdk/docs/quickstart-mac-os-x
+livecheck.url       https://cloud.google.com/sdk/docs/quickstart-macos


### PR DESCRIPTION
#### Description

Update to version 228.0.0 and added myself as maintainer (openmaintainer).

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?