### PR TITLE
org-mode: update to 9.2

### DIFF
--- a/editors/org-mode/Portfile
+++ b/editors/org-mode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           elisp 1.0
 
 name                org-mode
-version             9.1.14
+version             9.2
 categories          editors
 license             GPL-3+
 maintainers         {dports @drkp}
@@ -20,9 +20,9 @@ homepage            http://orgmode.org/
 master_sites        ${homepage}
 distname            org-${version}
 
-checksums           rmd160  c12dde95c925232e9b0229e2005b08b01b4716a0 \
-                    sha256  2acfc6658477085401d9add8b734eee4ed4f404da165cddb43a7ad97625c38d5 \
-                    size    4626747
+checksums           rmd160  c5dda078c7c49cc67b9a234fef96ad7598e4a87b \
+                    sha256  b918ba9819f1faa6182d89672bfe9080d338d32b65d257e4749430d797a08b8e \
+                    size    4611840
 
 depends_lib         path:${emacs_binary}:${emacs_binary_provider}
 depends_build       port:texinfo
@@ -38,9 +38,9 @@ destroot.target     install-lisp install-info
 
 variant contrib description "Include additional contributed packages" {
     # Install all contrib elisp files except those listed in org_skip_contrib
-    #   org-jira and ob-oz have build dependencies not available in MacPorts
+    #   these have build dependencies not available in MacPorts
     post-configure {
-        set org_skip_contrib "ob-oz org-jira"
+        set org_skip_contrib "ob-arduino ob-clojure-literate ob-sclang"
         
         set localmk [open ${worksrcpath}/local.mk "a"]
         puts $localmk "ORG_ADD_CONTRIB="


### PR DESCRIPTION
#### Description
Also update the `org_skip_contrib` list in the contrib variant to skip broken ones.

```
In toplevel form:
ob-arduino.el:36:1:Error: Cannot open load file: No such file or directory, arduino-mode
In toplevel form:
ob-clojure-literate.el:23:1:Error: Cannot open load file: No such file or directory, cider
In toplevel form:
ob-sclang.el:63:1:Error: Cannot open load file: No such file or directory, sclang
```

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
