### PR TITLE
py-pyqt5: avoid unnecessary conflict with qscintilla

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -5,6 +5,7 @@ PortGroup               python 1.0
 
 name                    py-pyqt5
 version                 5.11.3
+revision                1
 categories-append       devel
 platforms               darwin
 maintainers             {mmoll @mamoll} openmaintainer
@@ -54,11 +55,6 @@ if {${subport} eq "${name}-common"} {
         depends_lib-append port:py27-enum34
     }
 
-    # declare a runtime, arch-independent dependency on ${name}-common
-    depends_run-append  port:${name}-common
-    depends_skip_archcheck-append \
-                        ${name}-common
-
     use_configure       yes
     configure.pre_args
     configure.cmd       "${python.bin} configure.py"
@@ -72,7 +68,6 @@ if {${subport} eq "${name}-common"} {
                         --designer-plugindir=${qt_plugins_dir}/designer/Py${python.version}Qt5 \
                         --qml-plugindir=${qt_plugins_dir}/Py${python.version}Qt5 \
                         --no-qsci-api \
-                        --no-sip-files \
                         --disable=QtWebKit \
                         --disable=QtWebKitWidgets \
                         --disable=QtWebEngine \
@@ -93,16 +88,6 @@ if {${subport} eq "${name}-common"} {
     build.target        all
     destroot.cmd        ${build.cmd}
     destroot.destdir    DESTDIR=${destroot}
-
-    post-destroot {
-        # make the .sip files accessible via the "normal" path too
-        file delete -force ${destroot}${python.prefix}/share/sip/PyQt5
-        xinstall -m 755 -d ${destroot}${python.prefix}/share/sip
-        ln -s ${prefix}/share/sip/PyQt5 ${destroot}${python.prefix}/share/sip
-        # as well as via the actual sip repository of the version we're using
-        xinstall -m 755 -d ${destroot}${prefix}/share/py${python.version}-sip
-        ln -s ../sip/PyQt5 ${destroot}${prefix}/share/py${python.version}-sip
-    }
 
     variant debug description "Build debug libraries" {
         configure.cmd-append --debug


### PR DESCRIPTION
Both py-pyqt5 and qscintilla install files into the directory
${python.prefix}/share/sip/PyQt5.
Therefore, py-pyqt5 should not try to make it a link to another
directory.
This causes an unnecessary conflict between the two ports.

Revert part of
https://github.com/macports/macports-ports/commit/363ab1ad713cd0e7c50669f084d045407ffcf5b5

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
