### PR TITLE
libatomic_ops: upgrade to 7.6.8

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                pulseaudio
 version             12.2
-revision            1
+revision            2
 license             LGPL-2.1+ MIT BSD
 categories          audio
 maintainers         {ionic @Ionic} openmaintainer

--- a/devel/boehmgc/Portfile
+++ b/devel/boehmgc/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.0
 
 github.setup        ivmai bdwgc 8.0.2 v
-revision            0
+revision            1
 checksums           rmd160  1d9142e8c01e0ef6278d7574b05cc892560c2153 \
                     sha256  ea3069e218a6d2cf387fc6bb3cd40fb97942e0f8da5dcca0fb47f2c812b585ae \
                     size    802285

--- a/devel/libatomic_ops/Portfile
+++ b/devel/libatomic_ops/Portfile
@@ -8,11 +8,11 @@ name                libatomic_ops
 subport             libatomic_ops-devel {}
 
 if {${subport} eq ${name}} {
-    github.setup    ivmai libatomic_ops 7.6.6 v
+    github.setup    ivmai libatomic_ops 7.6.8 v
 
-    checksums       rmd160  e14870bd44058ff16a464483285e05eec6aefccd \
-                    sha256  f7bdea1b787a31421cd76b3db56abf63cd85b8e7111649948358a1e98f2e23c2 \
-                    size    137298
+    checksums       rmd160  4e047938e39f4b41b4a755ea48f3d8a551c9cccc \
+                    sha256  ea823fb141b4ea1d25abf1de1658ad5e6564dc885c99dd95daff6e330db114c4 \
+                    size    137692
 } else {
     # remove after Feb. 16, 2019
     replaced_by     libatomic_ops

--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -6,6 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                MoarVM
 version             2018.12
+revision            1
 categories          lang devel
 platforms           darwin
 license             Artistic-2 MIT BSD ISC public-domain


### PR DESCRIPTION
Bump revision of dependencies as the entire library is statically
linked. How cool is that?

Testing: I did `port -d test libatomic_ops`, revbumped boehmgc and did `port -d test boehmgc` as well. I finally ran `w3m google.com` and browsed around a bit and it didn't crash.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
