### PR TITLE
mosquitto: make boolean variables used in cmake script effective.

### DIFF
--- a/net/mosquitto/Portfile
+++ b/net/mosquitto/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.1
 
 name                mosquitto
 version             1.5.5
+revision            1
 
 categories          net devel
 platforms           darwin
@@ -38,10 +39,9 @@ depends_test-append \
                     port:python27
 
 configure.args-append \
-                    -DUSE_LIBWRAP=yes \
-                    -DWITH_EPOLL=no \
-                    -DWITH_SRV=yes \
-                    -DWITH_WEBSOCKETS=yes
+                    -DUSE_LIBWRAP:BOOL=ON \
+                    -DWITH_SRV:BOOL=ON \
+                    -DWITH_WEBSOCKETS:BOOL=ON
 
 test.run            yes
 test.target         -C ${build.dir}/test test


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
