### PR TITLE
valgrind: update to 3.14.0, use https master_sites

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -18,7 +18,7 @@ long_description \
     all memory operations are checked for invalid read or write.
 
 homepage            http://valgrind.org
-master_sites        http://sourceware.org/pub/valgrind/
+master_sites        https://sourceware.org/pub/valgrind/
 
 compilers.choose    cc cxx
 mpi.setup           -gcc44 -gcc45 -gcc46
@@ -60,7 +60,6 @@ pre-patch {
     }
 }
 
-
 pre-configure {
     if {[mpi_variant_isset]} {
         configure.args-delete --without-mpicc
@@ -69,13 +68,13 @@ pre-configure {
 }
 
 if {$subport eq $name} {
-    version             3.13.0
-    revision            1
+    version             3.14.0
+    revision            0
     conflicts           valgrind-devel
 
-    checksums           md5     817dd08f1e8a66336b9ff206400a5369 \
-                        sha256  d76680ef03f00cd5e970bbdcd4e57fb1f6df7d2e2c071635ef2be74790190c3b \
-                        rmd160  809dcd3c656633cb9e1153eec491dce7d3e532c0
+    checksums           rmd160  562359c6222acd8546eedf6f0b6db964e91bd434 \
+                        sha256  037c11bfefd477cc6e9ebe8f193bb237fe397f7ce791b4a4ce3fa1c6a520baa5 \
+                        size    16602858
 
     use_bzip2           yes
 
@@ -83,9 +82,8 @@ if {$subport eq $name} {
     extract.post_args-append --exclude=${distname}/docs/html/FAQ.html
 
     pre-fetch {
-        if {${os.platform} eq "darwin" && (${os.major} < 9 || [vercmp $xcodeversion 9.0] > 0)} {
-            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up and Xcode8 or less."
-            ui_error "Please install valgrind-devel to work with Xcode9 until version 3.14 is released."
+        if {${os.platform} eq "darwin" && (${os.major} < 9 || ${os.major} > 17)} {
+            ui_error "${subport} @${version} is only compatible with macOS versions from 10.5 up to 10.13."
             return -code error "incompatible macOS version"
         }
     }


### PR DESCRIPTION
#### Description
Please test this before merging, I don't have a compatible macOS to test on.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
