### PR TITLE
libuv: update to 1.24.1

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -18,10 +18,10 @@ long_description \
 
 if {${subport} eq ${name}} {
 
-    github.setup    libuv libuv 1.24.0 v
-    checksums       rmd160 4dae1e3af9188c0bb49380f304a75db7bf360f08 \
-                    sha256 b3a627b5a4f98edcac8e11adc92f5d21a04a82b363e625f3a7675615d57a34a7 \
-                    size   1201804
+    github.setup    libuv libuv 1.24.1 v
+    checksums       rmd160 9f059f60d7350aa203f7864e3ccc685ef7da6f5e \
+                    sha256 838e167bef01136adda06cff9243c1c991607fe0d4220d6a7d042933d23d64a6 \
+                    size   1204246
 
     conflicts       libuv-devel
 


### PR DESCRIPTION
#### Description
Testing: I ran `port -d test libuv` and that worked. I thought I could test this with nodejs/npm because node uses libuv, right? But it turns out that nodejs ships a vendored version of libuv and doesn't use the free-standing macports one. So I was unable to do a more functional test of libuv as the only package I had that depended on it was cmake and idk how to test cmake.

Maybe a takeaway here is that the macports nodejs ports should use the shared libuv?

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
