### PR TITLE
smartmontools: version bump to 7.0

### DIFF
--- a/sysutils/smartmontools/Portfile
+++ b/sysutils/smartmontools/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                smartmontools
-version             6.6
+version             7.0
 categories          sysutils
 license             GPL-2+
 platforms           darwin
@@ -22,11 +22,11 @@ long_description \
 homepage            http://smartmontools.sourceforge.net/
 master_sites        sourceforge:project/smartmontools/smartmontools/${version}/
 
-checksums           rmd160  8504a7a04e99d26acb3662ae5e0e8e6d38a52b5d \
-                    sha256  51f43d0fb064fccaf823bbe68cf0d317d0895ff895aa353b3339a3b316a53054
+checksums           rmd160  db20533115aa05a52836dbef0006c664083fbe90 \
+                    sha256  e5e1ac2786bc87fdbd6f92d0ee751b799fbb3e1a09c0a6a379f9eb64b3e8f61c \
+                    size    944925
 
-configure.args      --with-drivedb \
-                    --without-savestates \
+configure.args      --without-savestates \
                     --without-attributelog \
                     --enable-sample \
                     --with-libcap-ng=no


### PR DESCRIPTION
#### Description

Update smartmontools


###### Tested on
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
