### PR TITLE
pHash: build fix for Mojave

### DIFF
--- a/multimedia/pHash/Portfile
+++ b/multimedia/pHash/Portfile
@@ -30,7 +30,15 @@ depends_lib         path:lib/libavcodec.dylib:ffmpeg \
 
 patchfiles          patch-ffmpeg-3.0.diff \
                     patch-audiophash.h.diff \
+                    patch-ph_fft.h.diff \
                     patch-pHash.cpp.diff
+
+# fix for Mojave where /usr/include may not exist in the traditional place
+# replace explicit reference to /usr/include with ${configure.sdkroot}/usr/include
+
+post-patch {
+    reinplace "s|@@SDK_USR_INCLUDE@@|${configure.sdkroot}/usr/include|" ${worksrcpath}/src/ph_fft.h
+}
 
 use_autoreconf      yes
 autoreconf.args     -fvi

--- a/multimedia/pHash/files/patch-ph_fft.h.diff
+++ b/multimedia/pHash/files/patch-ph_fft.h.diff
@@ -1,0 +1,11 @@
+--- src/ph_fft.h.orig	2019-01-01 17:33:40.000000000 -0800
++++ src/ph_fft.h	2019-01-01 17:34:13.000000000 -0800
+@@ -29,7 +29,7 @@
+ #define PI 3.1415926535897932
+ 
+ #include <math.h>
+-#include </usr/include/complex.h>
++#include <@@SDK_USR_INCLUDE@@/complex.h>
+ #include <stdlib.h>
+ 
+ int fft(double *x, int N, complex double *X);


### PR DESCRIPTION
 Replace explicit reference to /usr/include with ${configure.sdkroot}/usr/include.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
