### PR TITLE
zabbix3-agent: Fix #57631 Failed to configure

### DIFF
--- a/net/zabbix3/Portfile
+++ b/net/zabbix3/Portfile
@@ -51,6 +51,7 @@ configure.args      --bindir=${prefix}/bin/zabbix \
                     --with-gnutls=${prefix} \
                     --enable-ipv6 \
                     --with-libevent=${prefix} \
+                    --with-iconv=${prefix} \
                     --with-libpcre=${prefix}
 
 configure.ldflags-append    -lresolv


### PR DESCRIPTION
#### Description

Fixes [Trac #57631](https://trac.macports.org/ticket/57631), in which Zabbix's `configure` can't find iconv because MacPorts isn't telling it to look in `${prefix}`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
