### PR TITLE
GPXSee: update to 7.1

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.0
+github.setup        tumic0 GPXSee 7.1
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,14 +16,16 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  bf041990796d2bba240f481519f0b3adaca0f5cd \
-                    sha256  6cceb86c58090b8779e295c313fa6e4362e630b6e906e2a7166d5cf815fea498 \
-                    size    3869441
+checksums           rmd160  a878c59a8180294bab4663fe2608309131e96197 \
+                    sha256  6d6cc323a2809045a621ad657c5c751a7b681d3cead4910ac617f0b3d567a7fd \
+                    size    3869446
 
 patchfiles          patch-src_GUI_app_cpp.diff
 
 qt5.depends_build_component     qttools
 qt5.depends_runtime_component   qtimageformats qttranslations
+
+depends_run-append  port:QtPBFImagePlugin
 
 post-configure {
     system -W ${worksrcpath} "${qt_lrelease_cmd} gpxsee.pro"


### PR DESCRIPTION
#### Description

GPXSee - Update to 7.1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.0

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
