### PR TITLE
[WIP] msp430-elf crosscompiler

### DIFF
--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -60,7 +60,7 @@ proc crossbinutils.setup {target version} {
     if {[info exists crossbinutils.versions_info($version)]} {
         use_[lindex [set crossbinutils.versions_info($version)] 0] yes
 
-        checksums   {*}[lindex [set crossbinutils.versions_info($version)] 1]
+        checksums   binutils-${version}${extract.suffix} {*}[lindex [set crossbinutils.versions_info($version)] 1]
     } else {
         # the old default
         use_bzip2   yes

--- a/_resources/port1.0/group/crossbinutils-1.0.tcl
+++ b/_resources/port1.0/group/crossbinutils-1.0.tcl
@@ -11,6 +11,11 @@
 options crossbinutils.target
 
 array set crossbinutils.versions_info {
+    2.26 {bzip2 {
+        rmd160  ce0400ffcc1200280854fefb29f97b63507bad14 \
+        sha256  c2ace41809542f5237afc7e3b8f32bb92bc7bc53c6232a84463c423b0714ecd9 \
+        size    25543552
+    }}
     2.30 {xz {
         rmd160  7f439bd642e514e89075a47758414ea65c50c3b3 \
         sha256  6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6 \

--- a/_resources/port1.0/group/crossgcc-1.0.tcl
+++ b/_resources/port1.0/group/crossgcc-1.0.tcl
@@ -58,6 +58,11 @@ array set crossgcc.versions_info {
 }
 
 array set newlib.versions_info {
+    2.4.0 {gz {
+        rmd160  e7a98a00aca89aad0ee2e2b98993fd8e643d98ce \
+        sha256  545b3d235e350d2c61491df8b9f775b1b972f191380db8f52ec0b1c829c52706 \
+        size    17574364
+    }}
     3.0.0 {gz {
         rmd160  505d486c9c658d10ed3b1af13459b2f289680b1f \
         sha256  c8566335ee74e5fcaeb8595b4ebd0400c4b043d6acb3263ecb1314f8f5501332 \

--- a/cross/msp430-elf-binutils/Portfile
+++ b/cross/msp430-elf-binutils/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossbinutils 1.0
+
+crossbinutils.setup msp430-elf 2.26
+set vers_patch      7.3.2.154
+set name_patch      msp430-gcc-${vers_patch}-source-patches
+set file_patch      ${name_patch}.tar.bz2
+
+maintainers         {g5pw @g5pw}
+
+homepage            http://www.ti.com/tool/msp430-gcc-opensource
+master_sites-append http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/:patch
+
+distfiles-append    ${file_patch}:patch
+
+checksums-append    ${file_patch} \
+                    rmd160  d6b1825ef792a4ca61e34a4bee35aca66d8c8d9e \
+                    sha256  a9ae65464771549c7ffd0909a04fe0f783be7d04e5abe23ef191f536b2a3b8b4 \
+                    size    427757
+
+depends_extract-append bin:bzip2:bzip2
+
+post-extract {
+    system -W ${workpath} "${prefix}/bin/bzip2 -dc ${distpath}/${file_patch} | /usr/bin/tar xf -"
+}
+pre-patch {
+    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/binutils-2_26.patch"
+}
+
+configure.args-append \
+                    --disable-werror
+
+# --with-mpfr-include=${prefix}/include \
+# --with-mpfr-lib=${prefix}/lib \
+# --with-gmp-include=${prefix}/include \
+# --with-gmp-lib=${prefix}/lib \
+# --with-mpc-include=${prefix}/include \
+# --with-mpc-lib=${prefix}/lib

--- a/cross/msp430-elf-gcc/Portfile
+++ b/cross/msp430-elf-gcc/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossgcc 1.0
+
+crossgcc.setup      msp430-elf 7.3.0
+crossgcc.setup_libc newlib 2.4.0
+
+set vers_patch      7.3.2.154
+set name_patch      msp430-gcc-${vers_patch}-source-patches
+set file_patch      ${name_patch}.tar.bz2
+
+maintainers         {g5pw @g5pw}
+
+homepage            http://www.ti.com/tool/msp430-gcc-opensource
+master_sites-append http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/:patch
+
+distfiles-append    ${file_patch}:patch
+checksums-append    ${file_patch} \
+                    rmd160  d6b1825ef792a4ca61e34a4bee35aca66d8c8d9e \
+                    sha256  a9ae65464771549c7ffd0909a04fe0f783be7d04e5abe23ef191f536b2a3b8b4 \
+                    size    427757
+
+depends_run         port:msp430-gcc-support-files
+
+depends_extract-append \
+                    port:bzip2
+
+post-extract {
+    system -W ${workpath} "${prefix}/bin/bzip2 -dc ${distpath}/${file_patch} | /usr/bin/tar xf -"
+}
+pre-patch {
+    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/gcc-7_3_0-release.patch"
+    system -W ${workpath}/newlib-2.4.0 "/usr/bin/patch -p0 < ${workpath}/${name_patch}/newlib-2_4_0.patch"
+}
+
+configure.args-append \
+                    --enable-target-optspace \
+                    --enable-newlib-nano-formatted-io

--- a/cross/msp430-gcc-support-files/Portfile
+++ b/cross/msp430-gcc-support-files/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                msp430-gcc-support-files
+version             1.206
+
+description         MSP430 header and linker files
+long_description    ${description}
+categories          cross devel
+maintainers         {@g5pw g5pw} {@mojca mojca} openmaintainer
+platforms           darwin
+supported_archs     noarch
+license             BSD
+
+homepage            http://www.ti.com/tool/msp430-gcc-opensource
+master_sites        http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/
+use_zip             yes
+
+checksums           rmd160  fed93e0d8ad9ba3c7c0e1456f3b064cf898fe7bc \
+                    sha256  b67ef790367d8ca7a12b90deeb8878b36ba6969d7703b8e35562e0c0e1e5cbe0 \
+                    size    21872264
+
+worksrcdir          ${name}
+use_configure       no
+build               {}
+
+destroot {
+    set installdir ${destroot}${prefix}/msp430-elf
+    xinstall -d -m 755 ${installdir}/include
+    xinstall -d -m 755 ${installdir}/lib
+    xinstall -m 644 {*}[glob ${worksrcpath}/include/*.h]  ${installdir}/include
+    xinstall -m 644 {*}[glob ${worksrcpath}/include/*.ld] ${installdir}/lib
+}
+
+destroot.violate_mtree  yes


### PR DESCRIPTION
#### Description

This is an attempt to bring the old cross-compilers (`msp430-gcc[-devel]` and `msp430-binutils[-devel]`) up to date, but I didn't actually test the functionality (I'm not actually sure how to test), and some stuff might be missing.

I could potentially push the changes in `crossbinutils` and `crossgcc` earlier than those for the msp cross-compiler.

What annoys me most and I would be grateful for some feedback/suggestions/brainstorming: I hate the way patching is done. The patches for `binutils`, `gcc`, `newlib`, `gdb` all come together in a single `.tar.bz2` file which basically contains four relatively big patch files.
* I would be slightly tempted to extract those files and put them to `files/`, but at least for `gcc` they are too massive to warrant this simplification.
* I tried to manually extract the patches and then using full path to them, like:
    ```tcl
    patchfiles ${workpath}/${name_patch}/binutils-2_26.patch
    ```
    but this failed to work as MacPorts tried to search for that patch inside `files/`, or maybe tried to fetch it from the website etc.
* I could extract all the patches and temporarily attach them to a trac ticket or somewhere else, so that the port could fetch them from some random URL.
* MacPorts in theory supports `bzcat` directly (out-of-the-box), the only problem is that the tarball contains patches for four different pieces of software and patching everything together fails.
Yet another ugly aspect is that the same file with patches (in the way it's currently done) ends up in several different directories inside distfiles (`binutils`, `gcc`, `gdb`).

What else is missing:
* If @g5pw and others agree, I would make the old `msp430*` ports obsolete (I would do some commit history edit magic).
* It would probably make sense to make the ports `openmaintainer` (see also #3339).
* I decided to use the name `msp430-elf` because the build instructions mention using `--target=msp430-elf`. I don't actually know to what extent this distinction makes any difference, if any at all.
* I need feedback about the naming of support files (currently `msp430-gcc-support-files`).
* The `gdb` port is still missing (I suspect that all the old ports are broken on newer OSes, so that's not so critical yet, but it should be done). I started playing with a `crossgdb` PortGroup, but there's still quite some stuff missing and I cannot get the includes for `gettext` done right.
* The `*.specs` files from newlib are not installed:
    ```
    > msp430-elf-gcc -mmcu=msp430g2211 -specs=nosys.specs -o test.elf test.c
    msp430-elf-gcc: error: nosys.specs: No such file or directory
    ```
* Someone would need to double-check the required configure flags.
* It would be great to actually test the crosscompiler.
* It could be nice (but nobody else does that yet) to enable gcc's own test.

@g5pw @MarcusCalhoun-Lopez @raimue

###### Tickets

Closes: https://trac.macports.org/ticket/44009
Closes: https://trac.macports.org/ticket/44010
Closes: https://trac.macports.org/ticket/49323
Closes: https://trac.macports.org/ticket/50571
Closes: https://trac.macports.org/ticket/56109
Closes: https://trac.macports.org/ticket/57238
See: https://trac.macports.org/ticket/56887

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->