### PR TITLE
llvm/clang - update to 7.0.1, add emulated-tls

### DIFF
--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -549,6 +549,24 @@ post-destroot {
     }
 }
 
+if {${os.major} < 11} {
+    variant emulated_tls description { enable c11/c++11 thread support on older systems using emulated-tls } {
+        # use emulated-tls to support thread_local on systems prior to 10.7
+        # requires linking against macports-libstdc++ or libc++ / libc++abi with cxa_thread_atexit
+        # the test for default emulated-tls has been moved into the backend
+
+        # this patch is needed for llvm and clang builds
+        patchfiles-append \
+            9000-patch-llvm-7.0-support-emulated-tls.diff
+
+        if {${subport} eq "clang-${llvm_version}"} {
+            patchfiles-append \
+                9000-patch-clang-7.0-support-emulated-tls.diff
+        }
+    }
+    default_variants-append +emulated_tls
+}
+
 if {${subport} eq "llvm-${llvm_version}"} {
     variant polly description {Provide the polly polyhedral optimizer} {}
 
@@ -588,6 +606,15 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/tools/scan-build/bin/set-xcode-analyzer \
                 ${worksrcpath}/tools/clang/tools/scan-view/bin/scan-view
         }
+    }
+
+    if { ${cxx_stdlib} eq "libc++" && ${os.major} < 13 } {
+        variant defaultlibcxx description {default to -stdlib=libc++ if not otherwise specified}  {
+            # on systems older than darwin 13, if macports.conf is configured to stdlib=libc++
+            # then make that the default if not otherwise specified. This matches the behaviour of newer systems.
+            patchfiles-append 9003-patch-clang-7.0-default-to-libcxx-on-all-systems.diff
+        }
+        default_variants-append +defaultlibcxx
     }
 
     variant libstdcxx description {-stdlib=macports-libstdc++ searches for MacPorts libstdc++} {
@@ -644,7 +671,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp
         }
     }
-    default_variants +libstdcxx
+    default_variants-append +libstdcxx
 
     post-patch {
         reinplace "s|@@PREFIX@@|${prefix}|" \

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -10,9 +10,9 @@ PortGroup cmake         1.0
 set llvm_version        7.0
 set llvm_version_no_dot 70
 set clang_executable_version 7
-set lldb_executable_version 7.0.0
+set lldb_executable_version 7.0.1
 name                    llvm-${llvm_version}
-revision                1
+revision                0
 subport                 clang-${llvm_version} {}
 subport                 lldb-${llvm_version} { revision 0 }
 set suffix              mp-${llvm_version}
@@ -100,7 +100,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 #default_variants-append +assertions
 #default_variants-append +debug
 
-version                 ${llvm_version}.0
+version                 ${llvm_version}.1
 epoch                   1
 master_sites            http://llvm.org/releases/${version}
 #master_sites            http://prereleases.llvm.org/${llvm_version}.0/rc2
@@ -121,34 +121,34 @@ if {${distfiles} ne ""} {
     }
 }
 
-checksums           llvm-7.0.0.src.tar.xz \
-                    rmd160  af7af75c7fb15a004f887f81d71eae58c24c11e6 \
-                    sha256  8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222 \
-                    size    28324368 \
-                    cfe-7.0.0.src.tar.xz \
-                    rmd160  10e3071762617f0623ae05500ce6176b625c680c \
-                    sha256  550212711c752697d2f82c648714a7221b1207fd9441543ff4aa9e3be45bba55 \
-                    size    12541904 \
-                    compiler-rt-7.0.0.src.tar.xz \
-                    rmd160  4ce16f26ccf228d5ac20d8cbc7b231afda899954 \
-                    sha256  bdec7fe3cf2c85f55656c07dfb0bd93ae46f2b3dd8f33ff3ad6e7586f4c670d6 \
-                    size    1815168 \
-                    libcxx-7.0.0.src.tar.xz \
-                    rmd160  7dfefd22edb305f68882a5f503f31c881fe5dc05 \
-                    sha256  9b342625ba2f4e65b52764ab2061e116c0337db2179c6bce7f9a0d70c52134f0 \
-                    size    1652496 \
-                    clang-tools-extra-7.0.0.src.tar.xz \
-                    rmd160  80f355dceb4f640599e4661775d1196619a5457f \
-                    sha256  937c5a8c8c43bc185e4805144744799e524059cac877a44d9063926cd7a19dbe \
-                    size    902780 \
-                    lldb-7.0.0.src.tar.xz \
-                    rmd160  de62a57d3a00da2b24774b258eacedf49979a1fe \
-                    sha256  7ff6d8fee49977d25b3b69be7d22937b92592c7609cf283ed0dcf9e5cd80aa32 \
-                    size    19403012 \
-                    polly-7.0.0.src.tar.xz \
-                    rmd160  a9e8992485da3cbbd11213c67f672275cbf14c55 \
-                    sha256  919810d3249f4ae79d084746b9527367df18412f30fe039addbf941861c8534b \
-                    size    8748660
+checksums           llvm-7.0.1.src.tar.xz \
+                    rmd160  dae96c6f85afb60e73564dc40d02171d01ffdb8f \
+                    sha256  a38dfc4db47102ec79dcc2aa61e93722c5f6f06f0a961073bd84b78fb949419b \
+                    size    28311056 \
+                    cfe-7.0.1.src.tar.xz \
+                    rmd160  914adafed7c97e5ebab15a437670906c404cb8bd \
+                    sha256  a45b62dde5d7d5fdcdfa876b0af92f164d434b06e9e89b5d0b1cbc65dfe3f418 \
+                    size    12488668 \
+                    compiler-rt-7.0.1.src.tar.xz \
+                    rmd160  ddc0a23cc2f05e44e0bf1b542688968a8126ee0d \
+                    sha256  782edfc119ee172f169c91dd79f2c964fb6b248bd9b73523149030ed505bbe18 \
+                    size    1864520 \
+                    libcxx-7.0.1.src.tar.xz \
+                    rmd160  ddc3aad371b5cf018bf977ddb66efbc024fd4aea \
+                    sha256  020002618b319dc2a8ba1f2cba88b8cc6a209005ed8ad29f9de0c562c6ebb9f1 \
+                    size    1638188 \
+                    clang-tools-extra-7.0.1.src.tar.xz \
+                    rmd160  d0ec60e76157a99e7d6d5f04f7b7eda56ba450da \
+                    sha256  4c93c7d2bb07923a8b272da3ef7914438080aeb693725f4fc5c19cd0e2613bed \
+                    size    901368 \
+                    lldb-7.0.1.src.tar.xz \
+                    rmd160  cc74fa4a201d6541cc918caee9abd683c18189b5 \
+                    sha256  76b46be75b412a3d22f0d26279306ae7e274fe4d7988a2184c529c38a6a76982 \
+                    size    19384628 \
+                    polly-7.0.1.src.tar.xz \
+                    rmd160  f1968870c6069bdc22b660eac4a1de4ca580cddd \
+                    sha256  1bf146842a09336b9c88d2d76c2d117484e5fad78786821718653d1a9d57fb71 \
+                    size    8755168
 
 patch.pre_args  -p1
 patchfiles \

--- a/lang/llvm-7.0/files/9000-patch-clang-7.0-support-emulated-tls.diff
+++ b/lang/llvm-7.0/files/9000-patch-clang-7.0-support-emulated-tls.diff
@@ -1,0 +1,26 @@
+diff --git a/tools/clang/lib/Basic/Targets/OSTargets.h b/tools/clang/lib/Basic/Targets/OSTargets.h
+index d0354784..102605fe 100644
+--- a/tools/clang/lib/Basic/Targets/OSTargets.h
++++ b/tools/clang/lib/Basic/Targets/OSTargets.h
+@@ -93,7 +93,7 @@ public:
+     this->TLSSupported = false;
+ 
+     if (Triple.isMacOSX())
+-      this->TLSSupported = !Triple.isMacOSXVersionLT(10, 7);
++      this->TLSSupported = !Triple.isMacOSXVersionLT(10, 4);
+     else if (Triple.isiOS()) {
+       // 64-bit iOS supported it from 8 onwards, 32-bit device from 9 onwards,
+       // 32-bit simulator from 10 onwards.
+diff --git a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+index 00fff144..052924ab 100644
+--- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
++++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+@@ -2255,7 +2255,7 @@ static void emitGlobalDtorWithCXAAtExit(CodeGenFunction &CGF,
+   const char *Name = "__cxa_atexit";
+   if (TLS) {
+     const llvm::Triple &T = CGF.getTarget().getTriple();
+-    Name = T.isOSDarwin() ?  "_tlv_atexit" : "__cxa_thread_atexit";
++    Name = (T.isOSDarwin() && !T.isMacOSXVersionLT(10, 7)) ?  "_tlv_atexit" : "__cxa_thread_atexit";
+   }
+ 
+   // We're assuming that the destructor function is something we can

--- a/lang/llvm-7.0/files/9000-patch-llvm-7.0-support-emulated-tls.diff
+++ b/lang/llvm-7.0/files/9000-patch-llvm-7.0-support-emulated-tls.diff
@@ -1,0 +1,13 @@
+diff --git a/include/llvm/ADT/Triple.h b/include/llvm/ADT/Triple.h
+index c95b16dd..ecc0f148 100644
+--- a/include/llvm/ADT/Triple.h
++++ b/include/llvm/ADT/Triple.h
+@@ -682,7 +682,7 @@ public:
+ 
+   /// Tests whether the target uses emulated TLS as default.
+   bool hasDefaultEmulatedTLS() const {
+-    return isAndroid() || isOSOpenBSD() || isWindowsCygwinEnvironment();
++    return isAndroid() || isOSOpenBSD() || isWindowsCygwinEnvironment() || isMacOSXVersionLT(10, 7);
+   }
+ 
+   /// @}

--- a/lang/llvm-7.0/files/9003-patch-clang-7.0-default-to-libcxx-on-all-systems.diff
+++ b/lang/llvm-7.0/files/9003-patch-clang-7.0-default-to-libcxx-on-all-systems.diff
@@ -1,0 +1,15 @@
+diff --git llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp
+index dc540688..64adab5c 100644
+--- llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp
++++ llvm-7.0.1.src/tools/clang/lib/Driver/ToolChains/Darwin.cpp
+@@ -700,8 +700,8 @@ types::ID MachO::LookupTypeForExtension(StringRef Ext) const {
+ bool MachO::HasNativeLLVMSupport() const { return true; }
+ 
+ ToolChain::CXXStdlibType Darwin::GetDefaultCXXStdlibType() const {
+-  // Default to use libc++ on OS X 10.9+ and iOS 7+.
+-  if ((isTargetMacOS() && !isMacosxVersionLT(10, 9)) ||
++  // Default to use libc++ on OS X 10.4+ and iOS 7+.
++  if ((isTargetMacOS() && !isMacosxVersionLT(10, 4)) ||
+        (isTargetIOSBased() && !isIPhoneOSVersionLT(7, 0)) ||
+        isTargetWatchOSBased())
+     return ToolChain::CST_Libcxx;


### PR DESCRIPTION
similar to the changes for clang 5.0 and clang 6.0
the test for defaulting to emulated-tls has been moved into the backend by upstream


[ci skip]