### PR TITLE
linphone-devel: remove obsolete port

### DIFF
--- a/net/linphone-devel/Portfile
+++ b/net/linphone-devel/Portfile
@@ -1,9 +1,0 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-
-PortSystem            1.0
-replaced_by           linphone
-PortGroup             obsolete 1.0
-name                  linphone-devel
-version               3.1.99.2
-revision              1
-categories            net


### PR DESCRIPTION
#### Description

Port was marked obsolete 2 years ago: 03f19706097de24dea5fe49a560969451633fded

(The "stable" port also seems abandoned, see https://trac.macports.org/ticket/57860)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
