### PR TITLE
py-clang: update 7.0.0 to 7.0.1

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 # meta-version; bump whenever underlying clangs are updated. Needed to support
 # portindex (variants can't have different versions.)
-version                 1
+version                 2
 # Needed for change to meta-versioning
 epoch                   1
 name                    py-clang
@@ -46,14 +46,14 @@ if {${name} ne ${subport}} {
      cfe-6.0.1.src.tar.xz \
       rmd160  c280cd2037b19f9bd733944b765f9ca23b35e0a4 \
       sha256  7c243f1485bddfdfedada3cd402ff4792ea82362ff91fbdac2dae67c6026b667 \
-     cfe-7.0.0.src.tar.xz \
-      rmd160  10e3071762617f0623ae05500ce6176b625c680c \
-      sha256  550212711c752697d2f82c648714a7221b1207fd9441543ff4aa9e3be45bba55 \
+     cfe-7.0.1.src.tar.xz \
+      rmd160  914adafed7c97e5ebab15a437670906c404cb8bd \
+      sha256  a45b62dde5d7d5fdcdfa876b0af92f164d434b06e9e89b5d0b1cbc65dfe3f418 \
 
     depends_build-append    port:py${python.version}-setuptools
 
     set clanglist       {37    38    39    40    50    60    70}
-    set clangvlist      {3.7.1 3.8.1 3.9.1 4.0.1 5.0.2 6.0.1 7.0.0}
+    set clangvlist      {3.7.1 3.8.1 3.9.1 4.0.1 5.0.2 6.0.1 7.0.1}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

~~Not yet tested. Waiting for llvm/clang to build.~~
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
Can do `import clang`, `import clang.cindex`, `import clang.enumerations` without issues. 
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
