### PR TITLE
_ci: install port from source only

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -41,6 +41,7 @@ portindex -e
 sudo /opt/local/postflight && sudo rm -f /opt/local/postflight
 # Install mpbb and its dependency getopt
 git clone --depth 1 https://github.com/macports/mpbb.git ../mpbb
+sed -i "" "s/ -dkn install / -dkns install /" ../mpbb/mpbb-install-port
 curl -fsSLO "https://dl.bintray.com/macports-ci-bot/getopt/getopt-v1.1.6.tar.bz2"
 sudo tar -xpf "getopt-v1.1.6.tar.bz2" -C /
 # Download and run CI runner


### PR DESCRIPTION
#### Description
Add `-s` to port install command to always build from source on Travis CI.

Should we add an option in mpbb instead?