### PR TITLE
mpv: remove obsolete variant +enca

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -425,17 +425,6 @@ variant libarchive description {Enable transparent handling of Zip files and oth
                             --enable-libarchive
 }
 
-# Remove after 07-30-2018
-variant enca requires uchardet description {Legacy compatibility variant for enable encoding support via ENCA. Will be removed soon.} {
-    notes-append {
-                    You have enabled the legacy enca variant.
-
-                    Upstream removed support for ENCA in version 0.23.0 in favor of uchardet.
-
-                    The uchardet variant has been enabled automatically.
-    }
-}
-
 variant rubberband description {Enable support for the Rubber Band library, adding audio pitch and speed control} {
     depends_lib-append      port:rubberband
     configure.args-replace  --disable-rubberband \


### PR DESCRIPTION
#### Description

Marked obsolete in 25514ec35106cb0203d7f40684abe989dc788b71 over 1 year ago.

I would be glad if someone can proofread this in case I missed anything that should get removed.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
