### PR TITLE
py-numba: update to 0.42.0, new homepage

### DIFF
--- a/python/py-numba/Portfile
+++ b/python/py-numba/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-numba
-version             0.41.0
+version             0.42.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -20,14 +20,14 @@ long_description    Numba is an Open Source NumPy-aware optimizing compiler \
                     for Python. It uses the remarkable LLVM compiler \
                     infrastructure to compile Python syntax to machine code.
 
-homepage            http://numba.github.com/
+homepage            https://numba.pydata.com/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  96cceef83a00128aff88caef7ec5e3b1a223e691 \
-                    sha256  2334d46f23de4603bcd64e7d9c5a16ea5ff69ee755bf9731a438de1084913ea6 \
-                    size    1538159
+checksums           rmd160  5bec5024c9f9f00488bfaaefccaa3fdbc39d1ce0 \
+                    sha256  3de1dd3134d0b4c352b04362ab2c5e8ecb314b7ff6b2256266548402ba6b380f \
+                    size    1562387
 
 variant tbb description "Add support for TBB" {
     depends_lib-append  port:tbb


### PR DESCRIPTION
#### Description

**Please merge #3360 first**: numba 0.42.0 requires llvmlite 0.27.0

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
There are still two open tickets that should have been closed a long time ago:
- https://trac.macports.org/ticket/46189
- https://trac.macports.org/ticket/46982
I am running `import numba; numba.test()` to see if https://trac.macports.org/ticket/46983 might be closable as well.

<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
Tried some examples <!-- and ran `import numba; numba.test()` --> without errors.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
