### PR TITLE
py-spyder-kernels*: update and add new port as dependency

### DIFF
--- a/python/py-spyder-kernels-devel/Portfile
+++ b/python/py-spyder-kernels-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-spyder-kernels-devel
-version             1.1.0
+version             1.2.0
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -21,9 +21,9 @@ master_sites        pypi:s/spyder-kernels
 
 distname            spyder-kernels-${version}
 
-checksums           rmd160  6740855c82af1bdf843838b02f09dce29865d0cc \
-                    sha256  7e4d6a55e679757bdbae833f9fcdc4239f0086a8ba38439a252612cd113ac4fa \
-                    size    38846
+checksums           rmd160  a75f84c329a871a19d3b41c677dd55bf61125f09 \
+                    sha256  48db58942b6ba80489de1d8dcad973db7b5b57a5392d142922dc254d66d12057 \
+                    size    35279
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-spyder-kernels
@@ -33,20 +33,13 @@ if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-cloudpickle \
                             port:py${python.version}-ipykernel \
                             port:py${python.version}-jupyter_client \
+                            port:py${python.version}-wurlitzer \
                             port:py${python.version}-zmq
-
-    depends_test-append     port:py${python.version}-pytest \
-                            port:py${python.version}-numpy \
-                            port:py${python.version}-pandas
-
-    test.run                yes
-    test.cmd                py.test-${python.branch}
-    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt CHANGELOG.md README.md \
+        xinstall -m 0644 -W ${worksrcpath} AUTHORS.txt LICENSE.txt CHANGELOG.md README.md \
             ${destroot}${docdir}
     }
 

--- a/python/py-spyder-kernels/Portfile
+++ b/python/py-spyder-kernels/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-spyder-kernels
 version             0.3.0
+revision            1
 epoch               1
 categories-append   devel
 platforms           darwin
@@ -34,15 +35,8 @@ if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-cloudpickle \
                             port:py${python.version}-ipykernel \
                             port:py${python.version}-jupyter_client \
+                            port:py${python.version}-wurlitzer \
                             port:py${python.version}-zmq
-
-    depends_test-append     port:py${python.version}-pytest \
-                            port:py${python.version}-numpy \
-                            port:py${python.version}-pandas
-
-    test.run                no
-    test.cmd                py.test-${python.branch}
-    test.target
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-wurlitzer/Portfile
+++ b/python/py-wurlitzer/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-wurlitzer
+version             1.0.2
+categories-append   devel
+platforms           darwin
+license             MIT
+
+python.versions     27 34 35 36 37
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         Capture C-level output in context managers
+long_description    ${description}
+
+homepage            https://github.com/minrk/wurlitzer
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  2ad976f8b37c3c102059c8e34df73f9d8f2d18af \
+                    sha256  23e85af0850b98add77bef0a1eb47b243baab29160131d349234c9dfc9e57add \
+                    size    7245
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-mock
+
+    test.run                yes
+    test.cmd                py.test-${python.branch}
+    test.target             test.py
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.md ${destroot}${docdir}
+    }
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description
- add py-wurlitzer: new port, version 1.0.2

- update py-spyder-kernels-devel to 1.2.0; disable tests, removed by upstream; add dependency on py-wurlitzer

- py-spyder-kernels: add missing dependency on py-wurlitzer; remove tests



<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
