### PR TITLE
mkcert: update to 1.2.0

### DIFF
--- a/security/mkcert/Portfile
+++ b/security/mkcert/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 
-github.setup        FiloSottile mkcert 1.1.2 v
+github.setup        FiloSottile mkcert 1.2.0 v
 
 platforms           darwin
 categories          security devel
@@ -29,9 +29,9 @@ long_description    mkcert is a simple tool for making locally-trusted \
                     the system root store, and generates locally-trusted \
                     certificates.
 
-checksums           rmd160  58f43d2362a1a19feb03dfaa15983616276b91da \
-                    sha256  4a7a4c364bd51cd1de0b173c4d5848587febaba2ff0cbde1949ca0c4d9aa8685 \
-                    size    374301
+checksums           rmd160  617155fe078c48025b57b3ab8201b6fbeb964bbe \
+                    sha256  bc70de7bc92ce0257dcae88bf1400e2b21c47a88c73c45a78efe91a881229147 \
+                    size    374808
 
 depends_build       port:go
 use_configure       no


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
