### PR TITLE
libidn2: update to 2.1.0

### DIFF
--- a/devel/getdns/Portfile
+++ b/devel/getdns/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                getdns
 version             1.4.2
+revision            1
 categories          devel
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer

--- a/devel/gnutls/Portfile
+++ b/devel/gnutls/Portfile
@@ -8,7 +8,7 @@ PortGroup       legacysupport 1.0
 
 name            gnutls
 version         3.6.5
-revision        0
+revision        1
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      devel security
 # yes, some of the libs are GPL only

--- a/mail/libidn2/Portfile
+++ b/mail/libidn2/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libidn2
-version             2.0.5
+version             2.1.0
 categories          mail
 license             {LGPL-2.1+ GPL-3+}
 description         GNU International Domain Name Library (current version 2)
@@ -17,9 +17,9 @@ platforms           darwin
 maintainers         nomaintainer
 master_sites        gnu:libidn
 
-checksums           rmd160  e85a3910edfb870be573dd3fb1174ec1d0db9d5e \
-                    sha256  53f69170886f1fa6fa5b332439c7a77a7d22626a82ef17e2c1224858bb4ca2b8 \
-                    size    2091929
+checksums           rmd160  db22408f829bb98f377a822dc08b308694d87bd7 \
+                    sha256  032398dbaa9537af43f51a8d94e967e3718848547b1b2a4eb3138b20cad11d32 \
+                    size    2102683
 
 depends_build       port:pkgconfig
 
@@ -31,5 +31,8 @@ use_autoreconf      yes
 autoreconf.args     -fvi
 
 configure.args      --disable-silent-rules
+
+test.run            yes
+test.target         check
 
 livecheck.distname  ${name}

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -4,6 +4,7 @@ PortSystem                      1.0
 
 name                            curl
 version                         7.63.0
+revision                        1
 categories                      net www
 platforms                       darwin freebsd
 maintainers                     {ryandesign @ryandesign}

--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        rockdaboot libpsl 0.20.2 libpsl-
+revision            1
 license             MIT
 description         A C library and utility to handle the Public Suffix List
 long_description    ${description}

--- a/net/wget/Portfile
+++ b/net/wget/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    wget
 version                 1.20.1
-revision                1
+revision                2
 checksums               rmd160  82f71ce2a47a052ed7fb7b0d18f0a62e62142b75 \
                         sha256  0f63e84dd23dc53ab3ab6f483c3afff8301e54c165783f772101cdd9b1c64928 \
                         size    2120611

--- a/net/whois/Portfile
+++ b/net/whois/Portfile
@@ -15,6 +15,7 @@ PortGroup                   perl5 1.0
 name                        whois
 conflicts                   bahamut expect ripe-whois
 version                     5.3.2
+revision                    1
 categories                  net
 maintainers                 {ryandesign @ryandesign}
 license                     GPL-2+

--- a/perl/p5-net-libidn2/Portfile
+++ b/perl/p5-net-libidn2/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
 perl5.setup         Net-LibIDN2 1.00
+revision            1
 license             {Artistic-1 GPL}
 maintainers         {devans @dbevans} openmaintainer
 description         Net::LibIDN2 - Perl bindings for GNU Libidn2


### PR DESCRIPTION
#### Description
Note this will NOT build: gnutls is naughty and used a function that is no longer exported by this library. gnutls needs to release a new version before libidn2 can be upgraded.

This is a minor release with a few changes, however some internal functions are no longer exposed and as a result the maintainers have bumped the SONAME of the library. All libraries linking against libidn2 must be revbumped.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
