### PR TITLE
OpenBLAS: update to 0.3.5

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -20,32 +20,35 @@ archive_sites
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    xianyi OpenBLAS e23366e860c9afc53608287040ee550623fefe49
-    version         20181217
-    checksums       rmd160  4c436e38f4ae41b7d329a8282df748ac9dce3a02 \
-                    sha256  90409f7337de14070469f1ce6893ac3c0dbb8bff6024210d64a0cb8e3a970baf \
-                    size    11853338
+    github.setup    xianyi OpenBLAS ed01f4932ae0d10cfcb0e896eade3cd61507a0a0
+    version         20190104 
+    checksums       rmd160  f65bf486c57ad4caaaa19780f4175a18609da0a5 \
+                    sha256  fef89c92b222139722cc811624d54df4d927dcb87f7f87781370ac7a1fdb28f2 \
+                    size    11852832
 
     name            ${github.project}-devel
     conflicts       OpenBLAS
 
+    #patch-43c2b0eb cancels commit that added -mavx2 option that does not work
     patchfiles      patch-libnoarch.devel.diff \
-                    patch-linkLib.devel.diff
+                    patch-linkLib.devel.diff \
+                    patch-43c2b0eb.diff
 
     github.livecheck.branch develop
 
 } else {
 
-    github.setup    xianyi OpenBLAS 0.3.4 v
-    checksums       rmd160 89adde42fd970f437f2133642b97c020fc5dfcf2 \
-                    sha256 b24618cdeab4671862fea011cc81b1443cfd5364530e597f33887b4fe3a3a6e8 \
-                    size   11849496
-    revision        1
+    github.setup    xianyi OpenBLAS 0.3.5 v
+    checksums       rmd160  7089b502d723602c74bac7ff42bb4de7a7157696 \
+                    sha256  f4761d863a8738b2ebe4522dabaae1402d08dcba64ddfcca3c9ffbe02d795318 \
+                    size    11853101
+    revision        0
     conflicts       OpenBLAS-devel
 
+    #patch-43c2b0eb cancels commit that added -mavx2 option that does not work
     patchfiles      patch-libnoarch.release.diff \
-                    patch-linkLib.release.diff
-
+                    patch-linkLib.release.diff \
+                    patch-43c2b0eb.diff
 }
 
 compilers.choose    fc 

--- a/math/OpenBLAS/files/patch-43c2b0eb.diff
+++ b/math/OpenBLAS/files/patch-43c2b0eb.diff
@@ -1,0 +1,20 @@
+--- Makefile.x86_64.orig	2019-01-05 18:49:47.000000000 +0900
++++ Makefile.x86_64	2019-01-05 19:19:28.000000000 +0900
+@@ -25,17 +25,6 @@
+ endif
+ endif
+ 
+-ifeq ($(CORE), HASWELL)
+-ifndef DYNAMIC_ARCH
+-ifndef NO_AVX2
+-CCOMMON_OPT += -mavx2
+-FCOMMON_OPT += -mavx2
+-endif
+-endif
+-endif
+-
+-
+-
+ ifeq ($(OSNAME), Interix)
+ ARFLAGS		= -m x64
+ endif

--- a/math/OpenBLAS/files/patch-libnoarch.devel.diff
+++ b/math/OpenBLAS/files/patch-libnoarch.devel.diff
@@ -1,6 +1,6 @@
 --- Makefile.system.orig
 +++ Makefile.system
-@@ -1194,11 +1194,11 @@
+@@ -1207,11 +1207,11 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP

--- a/math/OpenBLAS/files/patch-libnoarch.release.diff
+++ b/math/OpenBLAS/files/patch-libnoarch.release.diff
@@ -1,6 +1,6 @@
 --- Makefile.system.orig
 +++ Makefile.system
-@@ -1196,11 +1196,11 @@
+@@ -1206,11 +1206,11 @@
  
  ifneq ($(DYNAMIC_ARCH), 1)
  ifndef SMP


### PR DESCRIPTION
Also update -devel port to latest commit
Add patch to revert flag that breaks compilation

#### Description

Update of OpenBLAS to last version (0.3.5), along with new patch to revert flag that breaks compilation. The issue has been reported upstream to https://github.com/xianyi/OpenBLAS/issues/1951.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->