### PR TITLE
[WIP] various ports: fix after declaring py-pyobjc-cocoa obsolete

### DIFF
--- a/aqua/namebench/Portfile
+++ b/aqua/namebench/Portfile
@@ -5,7 +5,7 @@ PortGroup           xcode 1.0
 
 name                namebench
 version             1.3.1
-revision            2
+revision            3
 categories          aqua sysutils
 platforms           darwin
 license             Apache-2
@@ -26,8 +26,8 @@ homepage            https://code.google.com/p/namebench/
 set python.version  27
 set python.branch   2.7
 depends_lib-append      port:py${python.version}-libnamebench \
-                        port:py${python.version}-pyobjc \
-                        port:py${python.version}-pyobjc-cocoa
+                        port:py${python.version}-pyobjc
+
 
 master_sites        googlecode:${name}
 distname            ${name}-${version}-source

--- a/graphics/MyPaint/Portfile
+++ b/graphics/MyPaint/Portfile
@@ -9,7 +9,7 @@ name                        MyPaint
 if {${name} eq ${subport}} {
     conflicts               ${name}-devel
     github.setup            mypaint mypaint 1.2.1 v
-    revision                1
+    revision                2
 
     github.tarball_from     releases
     use_xz                  yes
@@ -23,7 +23,7 @@ subport ${name}-devel {
     conflicts               ${name}
     github.setup            mypaint mypaint 1fc6f4ccab6e421ef38004d481ceae95960c9f02
     version                 1.3.0-alpha.20160514+git.[string range ${git.branch} 0 7]
-    revision                1
+    revision                2
     set libmypaint_branch   65ffae19bc152749d30e78593b7f78749b294718
 
     master_sites-append     https://github.com/${github.author}/libmypaint/tarball/${libmypaint_branch}:libmypaint
@@ -74,7 +74,7 @@ depends_lib-append          path:lib/pkgconfig/glib-2.0.pc:glib2 \
                             port:py27-gobject3 \
                             port:py27-numpy \
                             port:py27-protobuf \
-                            port:py27-pyobjc-cocoa
+                            port:py27-pyobjc
 
 depends_run-append          port:hicolor-icon-theme
 

--- a/python/py-lightblue/Portfile
+++ b/python/py-lightblue/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    py-lightblue
 version                 0.4
-revision                1
+revision                2
 license                 GPL-3+
 maintainers             nomaintainer
 supported_archs         noarch
@@ -28,14 +28,14 @@ checksums               ${distname}${extract.suffix} \
 python.versions         27
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-pyobjc-cocoa
+    depends_lib-append  port:py${python.version}-pyobjc
 
     patchfiles          patch-deviceInquiryComplete_error_aborted-signature.diff
-    
+
     extract.only        lightblue-${version}.tar.gz
-    
+
     if {${os.platform} eq "darwin" && ${os.major} >= 10} {
-    
+
         distfiles-append LightAquaBlue-framework-MacOS10.6.zip LightAquaBlue-python-MacOS10.6.zip
         checksums-append LightAquaBlue-framework-MacOS10.6.zip \
                             md5     1a46f98ec2ff688bb6d23df02e91c052 \
@@ -46,7 +46,7 @@ if {${name} ne ${subport}} {
                             sha1    220cafd2ee4f4cae46dd56454d02994c27c7eb4f \
                             rmd160  08aa939afe0be496af521e3e249732ad978e1f8c
         patchfiles-append patch-setup.py.diff
-    
+
     # Extract LightAquaBlue-framework to replace existing version in tar archive
         post-extract {
             system "cd ${workpath}/${distname}/src/mac && rm -rf LightAquaBlue"
@@ -54,7 +54,7 @@ if {${name} ne ${subport}} {
                 system "cd ${workpath}/${distname}/src/mac && mv LightAquaBlue LightAquaBlue-xcode"
                 system "cd ${workpath}/${distname}/src/mac && unzip ${distpath}/LightAquaBlue-python-MacOS10.6.zip"
         }
-    
+
         post-patch {
             reinplace "s|/Library/Frameworks|${frameworks_dir}|g" \
                 ${worksrcpath}/src/mac/LightAquaBlue/__init__.py
@@ -65,7 +65,7 @@ if {${name} ne ${subport}} {
         # Fix #37361: use 10.7 SDK on 10.8 or later
         configure.sdkroot ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
     }
-    
+
     post-patch {
         reinplace "s|/Library/Frameworks|${frameworks_dir}|g" \
             ${worksrcpath}/setup.py \

--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        matplotlib matplotlib 3.0.2 v
+revision            1
 
 name                py-matplotlib
 categories-append   graphics math
@@ -46,7 +47,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-kiwisolver \
                         port:py${python.version}-numpy \
                         port:py${python.version}-parsing \
-                        port:py${python.version}-pyobjc-cocoa
+                        port:py${python.version}-pyobjc
 
     patchfiles          patch-v3-setup.cfg.diff \
                         patch-src-macosx.m.diff \

--- a/python/py-pyxg/Portfile
+++ b/python/py-pyxg/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        pyxg pyxg 0.3 v
+revision            1
 name                py-pyxg
 python.versions     27
 categories-append   devel
@@ -33,6 +34,6 @@ if {${os.platform} eq "darwin" && ${os.major} > 11} {
 }
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-pyobjc-cocoa
+    depends_lib-append  port:py${python.version}-pyobjc
     livecheck.type      none
 }

--- a/python/quodlibet/Portfile
+++ b/python/quodlibet/Portfile
@@ -7,6 +7,7 @@ PortGroup           active_variants 1.1
 
 name                quodlibet
 version             3.9.1
+revision            1
 categories-append   audio gnome
 maintainers         {elelay @elelay} openmaintainer
 license             GPL-2
@@ -36,7 +37,7 @@ depends_lib         port:dbus-python27 \
                     port:py27-mutagen \
                     port:py27-feedparser \
                     port:py27-gobject3 \
-                    port:py27-pyobjc-cocoa
+                    port:py27-pyobjc
 
 depends_run         port:adwaita-icon-theme
 
@@ -75,7 +76,7 @@ post-destroot {
       reinplace -E {s|(<string>APPL</string>)|\1 <key>LSUIElement</key><string>1</string>|} \
                 "${destroot}${applications_dir}/Quodlibet.app/Contents/Info.plist"
     }
-    
+
 }
 
 app.icon       quodlibet/images/hicolor/scalable/apps/quodlibet.svg


### PR DESCRIPTION
#### Description
In commit 9f7482c08397c12d53c25a6d365e10d729407282 changes were made to ```py-pyobjc``` and its frameworks. The few frameworks that had a separate port were declared obsolete, and now all frameworks are installed through the ```py-pyobjc``` port. This certainly makes it easier to keep all of them synchronized with the potential drawback of installing unneeded frameworks.

However, ports that depend on py-pyobjc-cocoa did not have their dependency updated / revbumped ; this PR takes care of that. All other frameworks have no dependents.

Please do ***NOT*** merge this PR yet though as there are other issues with the py-pyobjc port in the sense that an update does not work correctly.

```
>>> sudo port upgrade py37-pyobjc
--->  Computing dependencies for py37-pyobjc
--->  Fetching archive for py37-pyobjc
--->  Attempting to fetch py37-pyobjc-5.1.2_0.darwin_18.x86_64.tbz2 from https://packages.macports.org/py37-pyobjc
--->  Attempting to fetch py37-pyobjc-5.1.2_0.darwin_18.x86_64.tbz2.rmd160 from https://packages.macports.org/py37-pyobjc
--->  Installing py37-pyobjc @5.1.2_0
--->  Cleaning py37-pyobjc
--->  Computing dependencies for py37-pyobjc
--->  Deactivating py37-pyobjc @5.1.1_0
--->  Cleaning py37-pyobjc
--->  Activating py37-pyobjc @5.1.2_0
Error: Failed to activate py37-pyobjc: Image error: /opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/AppKit/_AppKit.cpython-37m-darwin.so is being used by the active py37-pyobjc-cocoa port.  Please deactivate this port first, or use 'port -f activate py37-pyobjc' to force the activation.
```

It would be good to deal with that here as well, I just don't know what the best way about it is... @ryandesign any suggestions?

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
