### PR TITLE
gdb: update to 8.2.1

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -52,6 +52,8 @@ depends_lib     port:boehmgc \
 
 # clang 600.0.57 is known to segfault when building this
 compiler.blacklist {clang >= 600 < 601}
+# clang 703.0.31 fails
+compiler.blacklist-append {clang >= 703 < 704}
 
 configure.args \
     --with-docdir=${prefix}/share/doc \

--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -6,8 +6,8 @@ PortGroup       muniversal 1.0
 PortGroup       cxx11 1.1
 
 name            gdb
-version         8.0.1
-revision        1
+version         8.2.1
+revision        0
 categories      devel
 license         GPL-3+
 maintainers     nomaintainer
@@ -34,9 +34,9 @@ supported_archs x86_64 i386
 
 master_sites    gnu
 
-checksums       rmd160  5ad7e7417dea2f4c7cc4795b74a58b948d8d93b2 \
-                sha256  52017d33cab5b6a92455a1a904046d075357abf24153470178c0aadca2d479c5 \
-                size    36359351
+checksums       rmd160  a92cabfd5da3e358e16aa424a4a3d8de63366614 \
+                sha256  0107985f1edb8dddef6cdd68a4f4e419f5fec0f488cc204f0b7d482c0c6c9282 \
+                size    37601384
 
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.


### PR DESCRIPTION
builds cleanly on 10.6.8 with clang-5.0 and libc++
will let the ci system confirm builds