### PR TITLE
py-biopython: update to 1.73, whitespace changes, use HTTPS URLs

### DIFF
--- a/python/py-biopython/Portfile
+++ b/python/py-biopython/Portfile
@@ -1,28 +1,28 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name            py-biopython
-version         1.72
-categories-append     science
-maintainers     {mmoll @mamoll} openmaintainer
-platforms       darwin
-description     python tools for computational molecular biology
+name                py-biopython
+version             1.72
+categories-append   science
+maintainers         {mmoll @mamoll} openmaintainer
+platforms           darwin
+description         python tools for computational molecular biology
 long_description    python tools for computational molecular biology: \
-                parsers for various file formats, interfaces for programs, \
-                tools for performing common operations on sequences, etc.
+                    parsers for various file formats, interfaces for programs, \
+                    tools for performing common operations on sequences, etc.
 
-homepage        http://www.biopython.org/
-license         MIT
-master_sites    ${homepage}/DIST
-distname        biopython-${version}
-checksums       rmd160  8d3659c93a8d6c916ea242a2ae689609879454ce \
-                sha256  ab6b492443adb90c66267b3d24d602ae69a93c68f4b9f135ba01cb06d36ce5a2 \
-                size    16391360
+homepage            https://biopython.org/
+license             MIT
+master_sites        ${homepage}/DIST
+distname            biopython-${version}
+checksums           rmd160  8d3659c93a8d6c916ea242a2ae689609879454ce \
+                    sha256  ab6b492443adb90c66267b3d24d602ae69a93c68f4b9f135ba01cb06d36ce5a2 \
+                    size    16391360
 
 
-python.versions 27 34 35 36 37
+python.versions     27 34 35 36 37
 
 if { ${name} ne ${subport} } {
     depends_lib-append  port:py${python.version}-numpy
@@ -34,15 +34,15 @@ if { ${name} ne ${subport} } {
             ${destroot}${prefix}/share/doc/${subport}
     }
 
-    build.env   CFLAGS=-I${python.include}
+    build.env           CFLAGS=-I${python.include}
 
-    test.run        no
-    test.cmd        ${build.cmd}
-    test.target     test
+    test.run            no
+    test.cmd            ${build.cmd}
+    test.target         test
 
-    livecheck.type  none
+    livecheck.type      none
 } else {
-    livecheck.type  regex
-    livecheck.url   http://biopython.org/wiki/Download
-    livecheck.regex biopython-(\[0-9\.\]+).tar.gz
+    livecheck.type      regex
+    livecheck.url       https://biopython.org/wiki/Download
+    livecheck.regex     biopython-(\[0-9\.\]+).tar.gz
 }

--- a/python/py-biopython/Portfile
+++ b/python/py-biopython/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-biopython
-version             1.72
+version             1.73
 categories-append   science
 maintainers         {mmoll @mamoll} openmaintainer
 platforms           darwin
@@ -17,9 +17,9 @@ homepage            https://biopython.org/
 license             MIT
 master_sites        ${homepage}/DIST
 distname            biopython-${version}
-checksums           rmd160  8d3659c93a8d6c916ea242a2ae689609879454ce \
-                    sha256  ab6b492443adb90c66267b3d24d602ae69a93c68f4b9f135ba01cb06d36ce5a2 \
-                    size    16391360
+checksums           rmd160  cb96af9bcf6c0826420ae76f4145931550d578a5 \
+                    sha256  70c5cc27dc61c23d18bb33b6d38d70edc4b926033aea3b7434737c731c94a5e0 \
+                    size    15715102
 
 
 python.versions     27 34 35 36 37
@@ -30,7 +30,8 @@ if { ${name} ne ${subport} } {
     post-destroot {
         file delete -force ${destroot}${prefix}/share/doc/${subport}
         file copy ${worksrcpath}/Doc ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath} CONTRIB DEPRECATED LICENSE NEWS README \
+        xinstall -m 644 -W ${worksrcpath} CONTRIB.rst CONTRIBUTING.rst \
+            DEPRECATED.rst LICENSE.rst NEWS.rst README.rst \
             ${destroot}${prefix}/share/doc/${subport}
     }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
Left as two commits due to unrelated changes; can squash into single commit if desired.

- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
Seems to import and run basic examples fine.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
