### PR TITLE
p5-term-readkey: update to 2.38

### DIFF
--- a/perl/p5-term-readkey/Portfile
+++ b/perl/p5-term-readkey/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Term-ReadKey 2.37 ../../authors/id/J/JS/JSTOWE
+perl5.setup         Term-ReadKey 2.38 ../../authors/id/J/JS/JSTOWE
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 platforms           darwin
@@ -15,8 +15,9 @@ long_description    ${description}
 distname            TermReadKey-${perl5.moduleversion}
 homepage            https://metacpan.org/release/TermReadKey
 
-checksums           rmd160  c09b5024af5af4b39d73c690002280fe81ebd24c \
-                    sha256  4a9383cf2e0e0194668fe2bd546e894ffad41d556b41d2f2f577c8db682db241
+checksums           rmd160  0e46e07e70bf8e52799d9dee263eb04b9f11ee57 \
+                    sha256  5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290 \
+                    size    85164
 
 use_parallel_build  no
 


### PR DESCRIPTION
#### Description
Tested with `port -d test p5.26-term-readkey`

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
