### PR TITLE
Extremely urgent fix for crucial macports package

### DIFF
--- a/games/sl/Portfile
+++ b/games/sl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        mtoyoda sl 5.02
-revision            1
+revision            2
 categories          games
 maintainers         {grimreaper @grimreaper}
 license             Permissive
@@ -30,6 +30,10 @@ build {
 
 destroot {
     xinstall -m 755 ${worksrcpath}/sl ${destroot}${prefix}/bin/sl
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -d ${destroot}${prefix}/share/man/ja/man1
+    xinstall -m 644 ${worksrcpath}/sl.1 ${destroot}${prefix}/share/man/man1
+    xinstall -m 644 ${worksrcpath}/sl.1.ja ${destroot}${prefix}/share/man/ja/man1/sl.1
 }
 
 variant universal {}


### PR DESCRIPTION
#### Description
Include english and japanese manpages for `sl', the standard UNIX steam locomotive simulator

Note that the macports manpage gzipper magic doesn't know about manpages for other languages - I can see that the japanese manpage here and the other language manpages for (example) vim are also not compressed. This is probably a bug in macports?

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
