### PR TITLE
zabbix4: bump to build against new libidn2

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -4,7 +4,7 @@ PortGroup           active_variants 1.1
 
 name                zabbix4
 version             4.0.3
-revision            0
+revision            1
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
 platforms           darwin


### PR DESCRIPTION
Maintainer update.