### PR TITLE
Apache2: Adding a new variant: “mpms_shared_all”

### DIFF
--- a/www/apache2/Portfile
+++ b/www/apache2/Portfile
@@ -190,6 +190,10 @@ variant openldap description {Enable LDAP support through OpenLDAP} {
     }
 }
 
+variant mpms_shared_all description {Build all MPM's as DSO for dynamic loading} {
+    configure.args-append --enable-mpms-shared=all
+}
+
 variant preforkmpm conflicts workermpm eventmpm description {Use prefork MPM} {
     configure.args-append --with-mpm=prefork
 }


### PR DESCRIPTION
#### Description

I'd like to add a new variant to apache2: mpms_shared_all

It will build all MPM's as DSO for dynamic loading. They're all static today.
When using this variant, the other variants (for MPM) will act as an enabler instead ([..»]).

[..»]: https://httpd.apache.org/docs/current/programs/configure.html#mpms

- - -

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5 11G63
Xcode 4.3.3 4E3002

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with my changes?
