### PR TITLE
exact-image: Use the right -arch flags and other flags

### DIFF
--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -64,9 +64,6 @@ configure.args      --with-freetype \
 
 configure.universal_args-delete --disable-dependency-tracking
 
-# for unknown reason, variable isn't saved in config.make
-configure.env-append EXPATLIBS="-lexpat"
-
 # see https://lists.macports.org/pipermail/macports-dev/2018-November/thread.html#39694
 configure.post_args-append " && printenv >> config.make"
 

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -5,6 +5,7 @@ PortGroup           legacysupport 1.0
 
 name                exact-image
 version             1.0.1
+revision            1
 categories          graphics
 license             GPL-2
 maintainers         nomaintainer
@@ -26,6 +27,7 @@ checksums           rmd160  fbcc51db9881f7c3b3f9b668a7751278396333f7 \
 
 patchfiles-append   patch-compiler.diff
 patchfiles-append   patch-no_fast.diff
+patchfiles-append   patch-cflags-cxxflags.diff
 patchfiles-append   patch-static-library-ar.diff
 patchfiles-append   patch-save-config.log.diff
 

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -69,6 +69,9 @@ configure.env-append EXPATLIBS="-lexpat"
 # see https://lists.macports.org/pipermail/macports-dev/2018-November/thread.html#39694
 configure.post_args-append " && printenv >> config.make"
 
+# Disable silent rules.
+build.args          Q=
+
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -32,6 +32,7 @@ post-patch {
 }
 
 patchfiles-append   patch-no_fast.diff
+patchfiles-append   patch-static-library-ar.diff
 patchfiles-append   patch-save-config.log.diff
 
 depends_build       port:pkgconfig

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -33,6 +33,7 @@ post-patch {
 
 # avoid compiler flags that just generate warnings
 patchfiles-append   patch-no_fast.diff
+patchfiles-append   patch-save-config.log.diff
 
 depends_build       port:pkgconfig
 depends_lib         port:antigraingeometry \

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -24,13 +24,7 @@ checksums           rmd160  fbcc51db9881f7c3b3f9b668a7751278396333f7 \
                     sha256  3bf45d21e653f6a4664147eb4ba29178295d530400d5e16a2ab19ac79f62b76c \
                     size    314168
 
-# see https://trac.macports.org/wiki/UsingTheRightCompiler
 patchfiles-append   patch-compiler.diff
-post-patch {
-    reinplace "s|__MACPORTS_CXX__|${configure.cxx} [get_canonical_archflags cxx]|g" ${worksrcpath}/config/functions
-    reinplace "s|__MACPORTS_CC__|${configure.cc} [get_canonical_archflags cc]|g"   ${worksrcpath}/config/functions
-}
-
 patchfiles-append   patch-no_fast.diff
 patchfiles-append   patch-static-library-ar.diff
 patchfiles-append   patch-save-config.log.diff

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -69,6 +69,11 @@ configure.env-append EXPATLIBS="-lexpat"
 # see https://lists.macports.org/pipermail/macports-dev/2018-November/thread.html#39694
 configure.post_args-append " && printenv >> config.make"
 
+# Search MacPorts includes after project includes, not before. The build system
+# appends to CPPFLAGS rather than prepending; this is easier than fixing the
+# build system.
+configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
+
 # Disable silent rules.
 build.args          Q=
 

--- a/graphics/exact-image/Portfile
+++ b/graphics/exact-image/Portfile
@@ -31,7 +31,6 @@ post-patch {
     reinplace "s|__MACPORTS_CC__|${configure.cc} [get_canonical_archflags cc]|g"   ${worksrcpath}/config/functions
 }
 
-# avoid compiler flags that just generate warnings
 patchfiles-append   patch-no_fast.diff
 patchfiles-append   patch-save-config.log.diff
 

--- a/graphics/exact-image/files/patch-cflags-cxxflags.diff
+++ b/graphics/exact-image/files/patch-cflags-cxxflags.diff
@@ -1,0 +1,29 @@
+Append to MacPorts CFLAGS and CXXFLAGS rather than overwriting them.
+--- Makefile.orig	2019-01-08 17:13:16.000000000 -0600
++++ Makefile	2019-01-08 17:32:37.000000000 -0600
+@@ -7,7 +7,7 @@
+ X_BUILD_IMPLICIT=1
+ 
+ # -s silcently corrupts binaries on OS X, sigh -ReneR
+-CFLAGS := -Wall -O2 # -O1 -ggdb # -fsanitize=address -fsanitize=undefined
++COMPILER_FLAGS := -Wall
+ 
+ # for config.h
+ CPPFLAGS += -I .
+@@ -19,12 +19,13 @@
+ cc-option = $(shell if $(CC) $(1) -S -o /dev/null -xc /dev/null \
+             > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi ;)
+ 
+-CFLAGS += -funroll-loops -fomit-frame-pointer
++COMPILER_FLAGS += -funroll-loops -fomit-frame-pointer
+ 
+ # we have some unimplemented colorspaces in the Image::iterator :-(
+-CFLAGS += $(call cc-option,-Wno-switch -Wno-switch-enum,)
++COMPILER_FLAGS += $(call cc-option,-Wno-switch -Wno-switch-enum,)
+ 
+-CXXFLAGS := $(CFLAGS) -Wno-sign-compare
++CFLAGS += $(COMPILER_FLAGS)
++CXXFLAGS += $(COMPILER_FLAGS) -Wno-sign-compare
+ 
+ ifeq "$(STATIC)" "1"
+ X_EXEFLAGS += -static

--- a/graphics/exact-image/files/patch-compiler.diff
+++ b/graphics/exact-image/files/patch-compiler.diff
@@ -1,23 +1,61 @@
---- config/functions.orig	2018-11-11 14:10:06.000000000 -0700
-+++ config/functions	2018-11-11 14:11:57.000000000 -0700
-@@ -357,7 +357,15 @@
+Use the right compiler and flags for configure tests, but don't use
+CFLAGS/CXXFLAGS when checking headers because if building universal
+the multiple -arch flags would cause this error:
+clang: error: cannot use 'c++-cpp-output' output with multiple -arch options
+
+This patch replaces "cc" or "c++" at the beginning of $1 with the right
+compiler and flags from the environment variables. This is done (instead
+of just checking if $1 is exactly equal to "cc" or "c++") to accommodate
+the use case where $1 also contains some flags, which currently occurs
+when configure invokes headercheck to find evas.
+--- config/functions.bak	2015-02-23 08:26:30.000000000 -0600
++++ config/functions	2019-01-10 14:25:50.000000000 -0600
+@@ -1,3 +1,8 @@
++: "${CC:=cc}"
++: "${CFLAGS:=}"
++: "${CPPFLAGS:=}"
++: "${CXX:=c++}"
++: "${CXXFLAGS:=}"
+ 
+ # Initalization
  #
+@@ -41,6 +46,25 @@
+   eval $1'="${'$1'#$b$a}"'
+ }
+ 
++# Remove at the beginning of a variable.
++#	var_remove_prefix var separator prefix
++#
++var_remove_prefix() {
++  local a=${2//\/\\/}
++  local b=${3//\/\\/}
++  eval '[ "$'$1'" = "$3" ] && '$1'="" || true'
++  eval $1'="${'$1'#$b$a}"'
++}
++
++# Replace at the beginning of a variable.
++#	var_replace_prefix var separator prefix content
++#
++var_replace_prefix() {
++  eval 'case "$'$1'$2" in "$3$2"*) true;; *) false;; esac;' || return 0
++  var_remove_prefix "$1" "$2" "$3"
++  var_insert "$1" "$2" "$4"
++}
++
+ # Test for a key in a give "array".
+ #	in_list key values
+ #
+@@ -358,6 +381,9 @@
  compile () {
    local errors=0
--  local PROG="$1" ; shift
-+  local PROG="$1"
-+  case "$1" in
-+	c++)
-+	  local COMPILER="__MACPORTS_CXX__"
-+	  ;;
-+	cc)
-+	  local COMPILER="__MACPORTS_CC__"
-+  esac
-+  shift
+   local PROG="$1" ; shift
++  local COMPILER="$PROG"
++  var_replace_prefix COMPILER " " cc "$CC $CPPFLAGS $CFLAGS"
++  var_replace_prefix COMPILER " " c++ "$CXX $CPPFLAGS $CXXFLAGS"
  
    while [ "$1" ] ; do
  	local file="config/$PROG-$1"
-@@ -369,7 +377,7 @@
+@@ -369,7 +395,7 @@
  	  cflags="`grep -a CFLAGS= $file | sed 's/.* CFLAGS="\(.*\)".*/\1/'`"
  	  libs="`grep -a LIBS= $file | sed 's/.* LIBS="\(.*\)".*/\1/'`"
  	  status "$desc ... "
@@ -26,20 +64,13 @@
  	     >/dev/null 2>> config.log ; then
  		status_result "yes"
  	  else
-@@ -387,11 +395,19 @@
- #
+@@ -388,10 +414,13 @@
  headercheck () {
    local errors=0
--  local PROG="$1" ; shift
-+  local PROG="$1"
-+  case "$1" in
-+	c++)
-+	  local COMPILER="__MACPORTS_CXX__"
-+	  ;;
-+	cc)
-+	  local COMPILER="__MACPORTS_CC__"
-+  esac
-+  shift
+   local PROG="$1" ; shift
++  local COMPILER="$PROG"
++  var_replace_prefix COMPILER " " cc "$CC $CPPFLAGS"
++  var_replace_prefix COMPILER " " c++ "$CXX $CPPFLAGS"
    while [ "$1" ] ; do
  	echo "#include <$1>" > conftest.c
  	status "checking for header "$1" ... "
@@ -48,19 +79,12 @@
  	  status_result "found"
  	else
  	  status_result "not found"
-@@ -412,7 +428,14 @@
-   local FLAGSVAR="$1" ; shift
+@@ -413,6 +442,8 @@
  
    if [ $mode = lib -o $mode = header ]; then
--	local prg="$1"; shift
-+	case "$1" in
-+	  c++)
-+	  local prg="__MACPORTS_CXX__"
-+	  ;;
-+	cc)
-+	  local prg="__MACPORTS_CC__"
-+	esac
-+	shift
+ 	local prg="$1"; shift
++	var_replace_prefix prg " " cc "$CC $CPPFLAGS $CFLAGS"
++	var_replace_prefix prg " " c++ "$CXX $CPPFLAGS $CXXFLAGS"
  	local args="$*"; shift $#
    elif [ $mode = shell ]; then
  	local script="$1"; shift

--- a/graphics/exact-image/files/patch-no_fast.diff
+++ b/graphics/exact-image/files/patch-no_fast.diff
@@ -1,3 +1,4 @@
+Avoid compiler flags that just generate warnings.
 --- Makefile.orig	2016-06-18 12:35:35.000000000 -0700
 +++ Makefile	2018-11-11 14:22:16.000000000 -0700
 @@ -19,31 +19,7 @@

--- a/graphics/exact-image/files/patch-save-config.log.diff
+++ b/graphics/exact-image/files/patch-save-config.log.diff
@@ -1,0 +1,11 @@
+Don't truncate config.log when configuration is successful.
+--- config/functions.orig	2019-01-08 19:10:46.000000000 -0600
++++ config/functions	2019-01-08 19:12:28.000000000 -0600
+@@ -219,7 +219,6 @@
+ #
+ save () {
+   # initilize the config files
+-  echo -n "" > config.log 
+   echo -n "" > config.make
+   echo -n "" > config.h
+ 

--- a/graphics/exact-image/files/patch-static-library-ar.diff
+++ b/graphics/exact-image/files/patch-static-library-ar.diff
@@ -1,0 +1,16 @@
+Use ar to link static libraries to support universal builds.
+I don't understand why upstream stopped using ar back in version 0.0.3.
+--- build/bottom.make.orig	2016-02-25 12:41:01.000000000 -0600
++++ build/bottom.make	2019-01-08 18:50:57.000000000 -0600
+@@ -66,10 +66,7 @@
+ 
+ $($(X_MODULE)_OUTPUT)/$(BINARY)$(X_LIBEXT): $($(X_MODULE)_OBJS)
+ 	@echo '  LINK LIB  $@'
+-	$(Q)$(LD) -r -o '$@' $^
+-#	# no AR anymore due to static initilizers
+-#	$(Q)$(AR) r '$@' $^ 2> /dev/null
+-#	$(Q)$(RANLIB) '$@'
++	$(Q)$(AR) -rcs '$@' $^
+ 
+ $($(X_MODULE)_OUTPUT)/$(BINARY)$(X_DYNEXT): $($(X_MODULE)_OBJS)
+ 	@echo '  LINK DYN  $@'


### PR DESCRIPTION
#### Description

This PR began in an effort to fix the universal build failure I reported [here](https://trac.macports.org/ticket/57607). But there are so many things wrong in this build system that it took a larger effort to fix. I'm submitting it as a PR so that I can separate each logical change into its own commit, and to get a second opinion on whether I've done anything wrong. But it builds universal now for me, where it did not before. @MarcusCalhoun-Lopez, maybe you can take a look, since I'm changing a lot of stuff you added in the update to 1.0.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
