### PR TITLE
texinfo: fix compatibility with perl5.28

### DIFF
--- a/textproc/texinfo/Portfile
+++ b/textproc/texinfo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                texinfo
 version             6.5
-revision            3
+revision            4
 categories          textproc
 platforms           darwin
 license             GPL-3+
@@ -38,6 +38,8 @@ use_xz              yes
 checksums           rmd160  a490883f71a7bd0723045357fe6617b0982f1cf9 \
                     sha256  77774b3f4a06c20705cc2ef1c804864422e3cf95235e965b1f00a46df7da5f62 \
                     size    4503048
+
+patchfiles          patch-p5.28-compatibility.diff
 
 configure.perl      ${prefix}/bin/perl${pbranch}
 pre-configure {

--- a/textproc/texinfo/files/patch-p5.28-compatibility.diff
+++ b/textproc/texinfo/files/patch-p5.28-compatibility.diff
@@ -1,0 +1,34 @@
+https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898994
+
+From 1f27900352e04ff4f19bec1c1e9635adad2be31c Mon Sep 17 00:00:00 2001
+From: Niko Tyni <ntyni@debian.org>
+Date: Fri, 18 May 2018 10:40:00 +0100
+Subject: [PATCH] Fix unescaped left braces in regexps, deprecated since Perl
+ 5.27.8
+
+This fixes test failures on recent Perl versions.
+---
+ tp/Texinfo/Parser.pm | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tp/Texinfo/Parser.pm b/tp/Texinfo/Parser.pm
+index dc32ca2..c577aa9 100644
+--- tp/Texinfo/Parser.pm
++++ tp/Texinfo/Parser.pm
+@@ -5478,11 +5478,11 @@ sub _parse_special_misc_command($$$$)
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1;
+       $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
+       $has_comment = 1 if (defined($4));
+     } else {
+       $self->line_error (sprintf($self->__(
+-- 
+2.17.0
+


### PR DESCRIPTION
Upstream patch for compatibility with perl5.28.

Closes: https://trac.macports.org/ticket/57885

@deldotvee: please test

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix


###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (tested that the bug is gone)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->