### PR TITLE
curl: Stop overlinking due to curl-config

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -33,13 +33,17 @@ checksums                       ${curl_distfile} \
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    2
+    revision                    3
 
     depends_build               port:pkgconfig
 
     depends_lib                 port:libidn2 \
                                 port:libpsl \
                                 port:zlib
+
+    # Prevent curl-config from telling curl's dependents that they have to
+    # link with all of curl's dependencies as well.
+    patchfiles                  configure.patch
 
     configure.args              --disable-silent-rules \
                                 --enable-ipv6 \

--- a/net/curl/files/configure.patch
+++ b/net/curl/files/configure.patch
@@ -1,0 +1,11 @@
+--- configure.orig	2018-12-12 17:59:16.000000000 +1100
++++ configure	2019-01-11 07:12:57.000000000 +1100
+@@ -13218,7 +13218,7 @@
+   else
+     whole_archive_flag_spec=''
+   fi
+-  link_all_deplibs=yes
++  link_all_deplibs=no
+   allow_undefined_flag=$_lt_dar_allow_undefined
+   case $cc_basename in
+      ifort*|nagfor*) _lt_dar_can_shared=yes ;;


### PR DESCRIPTION
Before this change, anything that used `curl-config --libs` to figure
out how to link against libcurl would end up linked with all of curl's
dependencies as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
