### PR TITLE
esniper: update to 2.35.0

### DIFF
--- a/net/esniper/Portfile
+++ b/net/esniper/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 
 name                esniper
-version             2.33.0
-revision            1
+version             2.35.0
 categories          net
 license             BSD
 platforms           darwin
@@ -14,11 +13,13 @@ long_description    ${description}
 
 homepage            http://esniper.sourceforge.net/
 master_sites        sourceforge:project/${name}/${name}/${version}
-distname            esniper-[strsed ${version} {g/[.]/-/}]
+distname            ${name}-[string map {. -} ${version}]
 extract.suffix      .tgz
 
-checksums           rmd160  5489e2d8a6fffe1ebc52e289218d25b3cc8565af \
-                    sha256  c9b8b10aefe5c397d7dee4c569f87f227c6710de528b1dc402379e5b4f1793dd
+checksums           md5 83c2b45efbb0b47ac01951cab4d11820 \
+                    sha1 a36a6b23d23af86dbce1d0a5a2cfba13705d8e27 \
+                    rmd160 481683cd3955636cd91323056bdfef30b538952a \
+                    sha256 a93d4533e31640554f2e430ac76b43e73a50ed6d721511066020712ac8923c12
 
 depends_lib         port:curl \
                     port:zlib \


### PR DESCRIPTION
#### Description

Released 2018-06-17

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->