### PR TITLE
exempi: use legacysupport PG

### DIFF
--- a/graphics/exempi/Portfile
+++ b/graphics/exempi/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cxx11 1.1
+PortGroup           legacysupport 1.0
 
 # requires libc++ as of 2.4.0
 


### PR DESCRIPTION
needs strnlen
```
$ port -v installed exempi
The following ports are currently installed:
  exempi @2.5.0_0 (active) platform='darwin 10' archs='x86_64' date='2019-01-10T18:00:36-0800'
```