### PR TITLE
audacity: fix build on < 10.7 with libcxx

### DIFF
--- a/audio/audacity/Portfile
+++ b/audio/audacity/Portfile
@@ -151,6 +151,14 @@ if {[variant_exists wx32] && [variant_isset wx32]} {
                     ${PPREFIX}patch-wxw-31x.diff
 }
 
+# this software does some funky SL fixes that don't work with
+# newer compilers building against libc++ -- disable those if
+# building with libc++
+if {${configure.cxx_stdlib} eq "libc++"} {
+    patchfiles-append patch-src-memoryx-disable-snowleopard-fix.diff
+}
+
+
 # quelch a huge number of warnings
 configure.cxxflags-append \
                     -Wno-inconsistent-missing-override \

--- a/audio/audacity/files/patch-src-memoryx-disable-snowleopard-fix.diff
+++ b/audio/audacity/files/patch-src-memoryx-disable-snowleopard-fix.diff
@@ -1,0 +1,11 @@
+--- a/src/MemoryX.h.old	2017-11-18 15:43:36.000000000 -0800
++++ b/src/MemoryX.h	2017-11-18 15:43:51.000000000 -0800
+@@ -12,7 +12,7 @@
+ // std:: containers knowing about rvalue references
+ #undef __AUDACITY_OLD_STD__
+ 
+-#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED <= __MAC_10_6
++#if 0
+ 
+ #define __AUDACITY_OLD_STD__
+ 


### PR DESCRIPTION
the software author(s) have done quite a bit of work to enable
a built on SnowLeopard which I greatly appreciate, however when
MacPorts is set up to use libc++ and when building with a current
clang system, these specific fixes now cause the build to fail.

This patch disables those fixes if MacPorts is setup to use libc++.

As the fixes were only enabled for SnowLeopard, disabling them universally
if MacPorts is setup for libc++ is desirable to allow detection of meaningful changes
in the source file, and will have no effect on any systems other than < 10.7

```
$ port -v installed audacity
The following ports are currently installed:
  audacity @2.2.2_1 (active) platform='darwin 10' archs='x86_64' date='2019-01-10T20:51:01-0800'
```