### PR TITLE
eog, nautilus, tracker: Use exempi even with libstdc++

### DIFF
--- a/gnome/eog/Portfile
+++ b/gnome/eog/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 
 name                eog
 version             3.26.2
-revision            2
+revision            3
 license             GPL-2+
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         An image viewing and cataloging program.
@@ -53,14 +53,6 @@ compiler.blacklist  *gcc* {clang < 300}
 configure.args      --enable-compile-warnings=minimum \
                     --disable-schemas-compile \
                     --disable-silent-rules
-
-platform darwin {
-# exempi 2.4.0+ requires libc++
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-        depends_lib-delete      port:exempi
-        configure.args-append   --without-xmp
-    }
-}
 
 notes               "For extra functionality install eog-plugins"
 

--- a/gnome/nautilus/Portfile
+++ b/gnome/nautilus/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 
 name                nautilus
 version             3.24.2.1
-revision            3
+revision            4
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         The GNOME filemanager
 long_description    Nautilus is the official file manager for the \
@@ -51,14 +51,6 @@ configure.args      --disable-tracker \
                     --disable-silent-rules \
                     --disable-update-mimedb \
                     --disable-schemas-compile
-
-platform darwin {
-# exempi 2.4.0+ requires libc++
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-        depends_lib-delete      port:exempi
-        configure.args-append   --disable-xmp
-    }
-}
 
 variant desktop description {Enable desktop support} {
     configure.args-delete --disable-desktop

--- a/gnome/tracker/Portfile
+++ b/gnome/tracker/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 
 name                tracker
 version             1.12.4
-revision            2
+revision            3
 license             GPL-2+ LGPL-2.1+ BSD
 set branch          [join [lrange [split ${version} .] 0 1] .]
 description         Metadata database, indexer and search tool.
@@ -120,14 +120,6 @@ configure.args      --disable-schemas-compile \
                     --enable-text \
                     --enable-icon \
                     --enable-playlist
-
-platform darwin {
-# exempi 2.4.0+ requires libc++
-    if {${configure.cxx_stdlib} eq "libstdc++"} {
-        depends_lib-delete      port:exempi
-        configure.args-replace  --enable-exempi --disable-exempi
-    }
-}
 
 variant enca description {Enable libenca for Cyrillic language detection in MP3s} {
     configure.args-delete   --without-enca


### PR DESCRIPTION
#### Description

exempi was fixed to work even with libstdc++ in 0277e0362fdf59071c619836b9315c3504930363.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
OS X 10.8.5 12F2560
Xcode 5.1.1 5B1008 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
