### PR TITLE
php-xdebug: fix xdebug_docs url

### DIFF
--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -56,7 +56,7 @@ extract.suffix          .tgz
 if {${name} ne ${subport}} {
     configure.args      --enable-xdebug
     
-    set xdebug_docs     ${homepage}docs/
+    set xdebug_docs     ${homepage}/docs/
     notes "
 You can get a list of the available configuration settings for xdebug\
 with the following command:


### PR DESCRIPTION

#### Description

fix xdebug_docs url currently it's shown as:

> https://xdebug.orgdocs/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->