### PR TITLE
py-XlsxWriter: add py37 subport

### DIFF
--- a/python/py-XlsxWriter/Portfile
+++ b/python/py-XlsxWriter/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        jmcnamara XlsxWriter 1.1.1 RELEASE_
 name                py-XlsxWriter
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 python.default_version 27
 platforms           darwin
 license             BSD


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->