### PR TITLE
harfbuzz: update to 2.3.0

### DIFF
--- a/graphics/harfbuzz/Portfile
+++ b/graphics/harfbuzz/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                harfbuzz
-version             1.9.0
-checksums           rmd160  903f848d7456c366f0646de4a9daacfd76034901 \
-                    sha256  11eca62bf0ac549b8d6be55f4e130946399939cdfe7a562fdaee711190248b00 \
-                    size    3870586
+version             2.3.0
+checksums           rmd160  c2a6c2a16cac38e150bd05c881de933fa33e1782 \
+                    sha256  3b314db655a41d19481e18312465fa25fca6f63382217f08062f126059f96764 \
+                    size    17909479
 
 categories          graphics
 platforms           darwin


### PR DESCRIPTION
#### Description
I know the version number is scary, but I don't think everything needs to be revbumped. Note that when Debian went from 1.9.0 in https://tracker.debian.org/news/989152/accepted-harfbuzz-190-1-source-into-unstable/ to 2.1.1 in https://tracker.debian.org/news/1002774/accepted-harfbuzz-211-1-source-into-unstable/ the SONAME did not change. Digging into the source, the upstream harfbuzz author has merely wrapped depreciated functions in a compile-time depreciation warning and not actually removed anything yet, so it is safe to upgrade without revbumps. And for what it's worth, macports didn't see any need to recompile pango on my machine.

Testing: I did `port -d test harfbuzz` and that works.

I also exercised harfbuzz and pango/cairo using graphviz.  Here's my example dotfile, with arabic generated from a lorem ipsum arabic text generator I found on the internet:

```
digraph example {
   A [label="yolo"];
   B [label="swag"];
   C [label="غريمه الأول العالمي عن تلك, تحرّكت والروسية لم الى. دار لم والمانيا المتساقطة،. يكن ثم هُزم وترك لإعادة, جُل رئيس ماليزيا، عل. حادثة بتخصيص ليرتفع يكن قد, في التكاليف العمليات الى. كل على الثانية والروسية, انتهت الجنود نفس مع, تلك سقوط وبريطانيا كل. فقد في أوزار مكثّفة البشريةً."];

   A -> B
   B -> C
   C -> A
}
```

And here's how I invoked graphviz, forcing PDF output as this appears to require pango/cairo/harfbuzz:

`DYLD_PRINT_LIBRARIES=yes dot -Tpdf -O ./arabic.dot`

I verified that harfbuzz was being loaded by the linker and the PDF's text looked nice to me.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
