### PR TITLE
smartmontools: use cxx11 PG

### DIFF
--- a/sysutils/smartmontools/Portfile
+++ b/sysutils/smartmontools/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11 1.1
 
 name                smartmontools
 version             7.0


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/55730

as the port is already testing for c++11 features, and as
gsmartcontrol already requires c++11 to build, it just makes
sense to build this with c++11 turned on. Every system can
build with a c++11 so there is no downside
