### PR TITLE
smartmontools: build without c++11 on old systems

### DIFF
--- a/sysutils/smartmontools/Portfile
+++ b/sysutils/smartmontools/Portfile
@@ -31,6 +31,13 @@ configure.args      --without-savestates \
                     --enable-sample \
                     --with-libcap-ng=no
 
+platform darwin {
+    if {${configure.cxx_stdlib} eq "libstdc++"} {
+        configure.args-append \
+                    --with-cxx11-option=no
+    }
+}
+
 destroot.keepdirs   ${destroot}${prefix}/var/run \
                     ${destroot}${prefix}/var/lib/smartmontools
 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/55730

