### PR TITLE
llvm-7.0: blacklist clang-3.4

### DIFF
--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -309,12 +309,13 @@ if {${subport} eq "llvm-${llvm_version}"} {
 # Xcode 5.1's clang (clang-503.0.40) has codegen issues (resulting compiler crashes)
 # Xcode 6.2's clang (600.0.57) fails due to https://llvm.org/bugs/show_bug.cgi?id=25753
 compiler.blacklist *gcc* {clang < 602}
+
+# clang older than 3.5 fail due to https://llvm.org/bugs/show_bug.cgi?id=25753
+# llvm-7.0 builds with clang-3.4 but has codegen issues (resulting compiler crashes) (kencu)
+compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
+
 compiler.fallback-append macports-clang-3.7 macports-clang-3.9
 
-if {${subport} eq "clang-${llvm_version}"} {
-    # clang older than 3.5 fail due to https://llvm.org/bugs/show_bug.cgi?id=25753
-    compiler.blacklist-append macports-clang-3.3 macports-clang-3.4
-}
 
 if {${subport} eq "lldb-${llvm_version}"} {
     # Xcode 6.4's clang (602.0.53) fails to build lldb with 'thread-local storage is not supported for the current target'


### PR DESCRIPTION
has codegen issues; resulting compiler crashes,
at least on 10.5 Intel. llvm-7.0 built with clang-3.7
functions normally without faults
