### PR TITLE
spring-boot-cli: update to 2.1.2

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.1.1
+version         2.1.2
 
 categories      java
 platforms       darwin
@@ -28,9 +28,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  f436b8658475c8b096dd6eff29992f7030fcd706 \
-                sha256  03f43eaa6914a727b9cac9509190ba19f6aade7191321233f34ea219b9a25944 \
-                size    11106994
+checksums       rmd160  5548371c380145f50e562af8d387916b581570a2 \
+                sha256  ef5b91f24dc8aadab1dc1d764ddf7c845596bc9a117af73b559090d6b7bc061a \
+                size    11118378
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.1.2.

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?