### PR TITLE
coreutils: Fix symlink for gnucut

### DIFF
--- a/sysutils/coreutils/Portfile
+++ b/sysutils/coreutils/Portfile
@@ -5,6 +5,7 @@ PortSystem      1.0
 name            coreutils
 conflicts       gexpr
 version         8.30
+revision        1
 categories      sysutils
 platforms       darwin
 license         GPL-3+
@@ -70,8 +71,8 @@ post-destroot {
         ln -s ${prefix}/bin/${binary} ${destroot}${prefix}/libexec/gnubin/[string range $binary 1 end]
     }
 
-    # Fix symlink to gnucut
-    move ${destroot}${prefix}/libexec/gnubin/nucut ${destroot}${prefix}/libexec/gnubin/gnucut
+    # Fix symlink to gnu cut
+    move ${destroot}${prefix}/libexec/gnubin/nucut ${destroot}${prefix}/libexec/gnubin/cut
 
     xinstall -m 755 -d ${destroot}${prefix}/libexec/gnubin/man/man1
     foreach manpage [glob -tails -directory ${destroot}${prefix}/share/man/man1 g*] {


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/55327

#### Description

Fixes a small error in the original fix for #55327 (see 7ec5110be2cd0c5f659c36d7721243558458b1e4). 

Instead of just renaming the binary to `gnucut`, the symlink under `/opt/local/libexec/gnubin` was renamed as well.

This means that users with `/opt/local/libexec/gnubin` at the head of their path are actually running the BSD version when they execute cut (`/usr/bin/cut`) rather than the GNU version as intended.

This PR changes the name of the symlink back to `cut` which should fix the issue.

Please let me know if I need to do anything further.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
