### PR TITLE
py-protobuf: conflict with py-protobuf3 (and vice versa)

### DIFF
--- a/python/py-protobuf/Portfile
+++ b/python/py-protobuf/Portfile
@@ -43,6 +43,8 @@ platforms       darwin
 python.versions 27
 
 if {${name} ne ${subport}} {
+    conflicts       py${python.version}-protobuf3
+
     depends_build   port:py${python.version}-google-apputils
     depends_lib     port:protobuf-cpp \
                     port:py${python.version}-setuptools

--- a/python/py-protobuf3/Portfile
+++ b/python/py-protobuf3/Portfile
@@ -45,6 +45,8 @@ platforms       darwin
 python.versions 27 35 36 37
 
 if {${name} ne ${subport}} {
+    conflicts       py${python.version}-protobuf
+
     depends_build   port:py${python.version}-setuptools \
                     port:py${python.version}-absl
 


### PR DESCRIPTION
Triggered by a recent email on the mailing list.

I suspect this also needs a revbump of both ports?

###### Type(s)

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
