### PR TITLE
py-exif: update to 2.1.2, major portfile rewrite

### DIFF
--- a/python/py-exif/Portfile
+++ b/python/py-exif/Portfile
@@ -1,31 +1,25 @@
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
 
-name			py-exif
-version			1.0.2
-license			BSD
-platforms		darwin freebsd
-supported_archs	noarch
-maintainers		nomaintainer
-description		Python interface to the EXIF meta-data
-long_description	Exchangeable Image File Format for Digital Still \
-				Cameras is a meta-information tag that can be embedded \
-				in tiff or jpeg image files. py-exif is a Python \
-				interface to this data.
+github.setup        ianare exif-py 2.1.2
+name                py-exif
+license             BSD
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+description         Python interface to the EXIF meta-data
+long_description    Exchangeable Image File Format for Digital Still \
+                    Cameras is a meta-information tag that can be embedded \
+                    in tiff or jpeg image files. py-exif is a Python \
+                    interface to this data.
 
-homepage		https://sourceforge.net/projects/exif-py/
-master_sites	sourceforge:exif-py
-distname		EXIFpy_${version}
-checksums		md5 7df9f94e98b6ff5da872105a11069356 \
-			sha1 859411ec882fc297a4aa4f1368aa5c2a14688573 \
-			rmd160 26bbc5fbdd01b7c8cf472895f66a9f633b0510fd
+checksums           rmd160  c24bf810a72a7a176833b7e1d564349d316fe868 \
+                    sha256  53b0fa8e33071320ab1d8ae4713a7bea859ec166bc3774df9003b25ffea94b90 \
+                    size    32200
 
-python.versions	27
+python.versions     27 37
 
 if {${name} ne ${subport}} {
-    extract.mkdir   yes
-    post-extract	{
-        file copy ${filespath}/setup.py ${worksrcpath}
-        reinplace "s|VERSION|${version}|g" ${worksrcpath}/setup.py
-    }
+    depends_build-append    port:py${python.version}-setuptools
 }

--- a/python/py-exif/files/setup.py
+++ b/python/py-exif/files/setup.py
@@ -1,7 +1,0 @@
-from distutils.core import setup
-
-setup(
-    name = 'exif',
-    version = "VERSION",
-    packages = [''],
-    )


### PR DESCRIPTION
 - Whitespace changes
 - Use github portgroup; distfile no longer hosted on SourceForge
 - Remove freebsd from platforms
 - Add build dependency pyXX-setuptools; remove unneeded setup.py script
 - Add subport for Python 3.7

#### Description

The decision to keep the port was made along with suggested improvements: https://github.com/macports/macports-ports/pull/3374#issuecomment-452427717

The portfile is updated to use the 2.1.2 release from GitHub. I think it would take me a few more days to find a more recent commit or create patches for beneficial changes since the 2.1.2 release. So far I have tested the 2.1.2 release and the latest commit (https://github.com/ianare/exif-py/commit/ea5af101ff0a4c478cc05b1a193372d4b33218d8), and each had different minor bugs present. The project has a repository of test images that are useful for finding if any bugs are fixed or introduced: https://github.com/ianare/exif-samples/

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
