### PR TITLE
bfs: new port

### DIFF
--- a/sysutils/bfs/Portfile
+++ b/sysutils/bfs/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        tavianator bfs 1.3.2
+
+categories          sysutils
+platforms           darwin freebsd linux
+license             BSD
+maintainers         {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
+description         A breadth-first version of the UNIX find command.
+
+long_description    bfs is a variant of the UNIX find command that operates breadth-first rather \
+    than depth-first. It is otherwise intended to be compatible with many \
+    versions of find, including: POSIX find, GNU find, \{Free,Open,Net\}BSD find \
+    and macOS find. If you're not familiar with find, the GNU find manual \
+    provides a good introduction.
+
+checksums           rmd160   a1112bdffa3662f6f96b349e995c76b774e8ac9f \
+                    sha256   e28944bd08efcb1c0644864906f6d020d52f9fbad8a3ac61c74c8eabfa640540 \
+                    size     88188
+
+use_configure       no
+build.target        release
+destroot.args       PREFIX=${prefix}
+test.run            yes
+test.target         check
+
+variant universal {
+    build.args-append CFLAGS="${configure.universal_cflags}"
+    build.args-append CC="${configure.cc}"
+}


### PR DESCRIPTION
#### Description

This adds a new port for the [`bfs`](https://github.com/tavianator/bfs) program, a breadth-first version of the Unix `find` command.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
