### PR TITLE
py-typed-ast: update to 1.2.0, add py37

### DIFF
--- a/python/py-typed-ast/Portfile
+++ b/python/py-typed-ast/Portfile
@@ -4,12 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typed-ast
-version             1.1.1
+version             1.2.0
+revision            0
 categories-append   devel
 platforms           darwin
 license             Apache-2
 
-python.versions     34 35 36
+python.versions     34 35 36 37
 
 maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
 
@@ -21,9 +22,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            typed-ast-${version}
 
-checksums           rmd160  1c1e35d77add567e8ac470f032578db71a84e707 \
-                    sha256  6cb25dc95078931ecbd6cbcc4178d1b8ae8f2b513ae9c3bd0b7f81c2191db4c6 \
-                    size    202693
+checksums           rmd160  adbe18acdb8650d001772d5d84769a0292118e2c \
+                    sha256  b4726339a4c180a8b6ad9d8b50d2b6dc247e1b79b38fe2290549c98e82e4fd15 \
+                    size    202702
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
- update to 1.2.0, add py37 subport 

It runs with Python 3.7, but... typed_ast has not yet been updated to be based on the Python 3.7 parser. The main consequence of this that await and async are not treated as keywords.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
