### PR TITLE
py-language-server/py-python-jsonrpc-server: update to 0.21.5 and 0.1.2

### DIFF
--- a/python/py-language-server/Portfile
+++ b/python/py-language-server/Portfile
@@ -5,7 +5,8 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-github.setup        palantir python-language-server 0.21.4
+github.setup        palantir python-language-server 0.21.5
+revision            0
 name                py-language-server
 categories-append   devel
 license             MIT
@@ -16,9 +17,9 @@ long_description    ${description}
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  d479f4a1b8ac269c6c57d8a01690c9bee6f3f9ba \
-                    sha256  ac2b4cdee490b915f473554b7f01d3625bdf54279d51567af058f9d00dade93b \
-                    size    439386
+checksums           rmd160  c73bdce0be0ee98344d260b8ce73d90bddd86d66 \
+                    sha256  1b7e064d56214c548f1d403c840f47ccad042d1526107a08447677e453e4560c \
+                    size    439400
 
 python.versions     27 35 36 37
 

--- a/python/py-python-jsonrpc-server/Portfile
+++ b/python/py-python-jsonrpc-server/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-python-jsonrpc-server
-version             0.0.2
+version             0.1.2
+revision            0
 platforms           darwin
 license             MIT
 maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
@@ -16,9 +17,9 @@ homepage            https://github.com/palantir/python-jsonrpc-server
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  9a5af71c7b4dee186bae7c34616942b5e2b2837f \
-                    sha256  533434fa982eb42c36ddb0b6758cef8e6eaf46d014f76b70a401b8790a3e6d57 \
-                    size    24845
+checksums           rmd160  3c29535bc63fa7c71c70c391ef523175d177b7aa \
+                    sha256  09b418e3b1ba9032aecc7aefdd185511dd230fb8dacf18ec195d14dfd89d9e54 \
+                    size    25541
 
 python.versions     27 35 36 37
 


### PR DESCRIPTION
#### Description
- both ports need to be updated simultaneously due to name change in library
<!-- Note: it is best make pull requests from a branch rather than from master -->
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
