### PR TITLE
DesktopManager: restrict to Mac OS X 10.4

### DIFF
--- a/aqua/DesktopManager/Portfile
+++ b/aqua/DesktopManager/Portfile
@@ -24,6 +24,13 @@ worksrcdir		${name}
 
 universal_variant no
 
+pre-fetch {
+    if {${os.major} != 8} {
+        ui_error "${name} ${version} requires Mac OS X 10.4."
+        return -code error "incompatible macOS version"
+    }
+}
+
 # Don't set INSTALL_PATH. This build system uses INSTALL_PATH internally to
 # link the application and frameworks together with relative paths.
 xcode.destroot.type


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/57628
Closes: https://trac.macports.org/ticket/13900

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2

I can only confirm it no longer allows installing on recent macOS versions. I **do not** have access to a 10.4 machine, so I have not confirmed that it can still install on machines using that version.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] ~~tried existing tests with `sudo port test`?~~
- [ ] ~~tried a full install with `sudo port -vst install`?~~
- [ ] ~~tested basic functionality of all binary files?~~

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
