### PR TITLE
mpv: add +python37 variant, mark +python36 variant as obsolete, remove obsolete variant +python35

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -278,9 +278,13 @@ platform darwin {
 
 
 # Shameless copy from ipe-tools.
-set python.versions         {27 36}
-# Remove after 07-30-2018.
-dict set python.legacy_versions 35 36
+set python.versions         {27 37}
+dict set python.legacy_versions 36 37
+# After Python 3.8 is released, and mpv can be built with it,
+# replace with the above lines with the following:
+#set python.versions         {27 38}
+#dict set python.legacy_versions 37 38
+
 set python.default_version  27
 set python.version          ""
 


### PR DESCRIPTION
#### Description

Follow-up from https://github.com/macports/macports-ports/pull/3359#discussion_r247405350 by attempting to remove the already-obsolete `+python35` port and reuse the existing `python.legacy_versions` logic in the portfile to make `+python37` the new default variant and `+python36` the new obsolete variant (based on changes proposed in https://trac.macports.org/ticket/57344).

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 3.7.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
