### PR TITLE
p5-term-readline-gnu: update to 1.36

### DIFF
--- a/perl/p5-term-readline-gnu/Portfile
+++ b/perl/p5-term-readline-gnu/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Term-ReadLine-Gnu 1.35
-revision            1
+perl5.setup         Term-ReadLine-Gnu 1.36
+revision            0
 
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
@@ -14,8 +14,9 @@ long_description    This is an implementation of Term::ReadLine using the \
                     GNU Readline/History Library.
 platforms           darwin
 
-checksums           rmd160  14ab8dc5dd211c5ceb3d793b92940253e6416478 \
-                    sha256  575d32d4ab67cd656f314e8d0ee3d45d2491078f3b2421e520c4273e92eb9125
+checksums           rmd160  4f7b090100a108e22f763931f334ff6911640c98 \
+                    sha256  9a08f7a4013c9b865541c10dbba1210779eb9128b961250b746d26702bab6925 \
+                    size    128336
 
 if {${perl5.major} != ""} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Perl 5.28.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?

<details><summary>Full test results:</summary>

```
--->  Testing p5.28-term-readline-gnu
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-term-readline-gnu/p5.28-term-readline-gnu/work/Term-ReadLine-Gnu-1.36" && /usr/bin/make test
"/opt/local/bin/perl5.28" -MExtUtils::Command::MM -e 'cp_nonempty' -- Gnu.bs blib/arch/auto/Term/ReadLine/Gnu/Gnu.bs 644
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.28" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
Use of uninitialized value $Term::ReadLine::Gnu::VERSION in concatenation (.) or string at t/00checkver.t line 29.

#   Failed test 'An object of class 'Term::ReadLine::Stub' isa 'Term::ReadLine''
#   at t/00checkver.t line 32.
#     The object of class 'Term::ReadLine::Stub' isn't a 'Term::ReadLine'

#   Failed test ''Attribs' isa 'Term::ReadLine''
#   at t/00checkver.t line 34.
#     'Attribs' isn't a 'Term::ReadLine'
Use of uninitialized value in concatenation (.) or string at t/00checkver.t line 38.
Use of uninitialized value in printf at t/00checkver.t line 38.
Use of uninitialized value $ENV{"TERM"} in concatenation (.) or string at t/00checkver.t line 39.
# Looks like you failed 2 tests of 4.
t/00checkver.t ...
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/4 subtests
t/01test_use.t ... ok
t/02test_use.t ... ok

#   Failed test 'An object of class 'Term::ReadLine::Stub' isa 'Term::ReadLine''
#   at t/callback.t line 38.
#     The object of class 'Term::ReadLine::Stub' isn't a 'Term::ReadLine'

#   Failed test ''Attribs' isa 'Term::ReadLine''
#   at t/callback.t line 40.
#     'Attribs' isn't a 'Term::ReadLine'
Use of uninitialized value in pattern match (m//) at t/callback.t line 42.
# skipped since Tk is not available.
# Looks like you failed 2 tests of 8.
t/callback.t .....
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/8 subtests
Use of uninitialized value $Term::ReadLine::Gnu::VERSION in concatenation (.) or string at t/history.t line 36.

#   Failed test 'An object of class 'Term::ReadLine::Stub' isa 'Term::ReadLine''
#   at t/history.t line 42.
#     The object of class 'Term::ReadLine::Stub' isn't a 'Term::ReadLine'

#   Failed test '$t->ReadLine'
#   at t/history.t line 48.

#   Failed test ''Attribs' isa 'Term::ReadLine''
#   at t/history.t line 55.
#     'Attribs' isn't a 'Term::ReadLine'
Use of uninitialized value in pattern match (m//) at t/history.t line 57.
Can't locate object method "using_history" via package "Term::ReadLine::Stub" at t/history.t line 64.
# Looks like your test exited with 255 just after 4.
t/history.t ......
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 87/88 subtests
Bareword "ISKMAP" not allowed while "strict subs" in use at t/readline.t line 302.
Bareword "ISFUNC" not allowed while "strict subs" in use at t/readline.t line 305.
Bareword "ISMACR" not allowed while "strict subs" in use at t/readline.t line 309.
Bareword "RL_STATE_INITIALIZED" not allowed while "strict subs" in use at t/readline.t line 152.
Bareword "ISFUNC" not allowed while "strict subs" in use at t/readline.t line 222.
Bareword "ISFUNC" not allowed while "strict subs" in use at t/readline.t line 234.
Bareword "ISKMAP" not allowed while "strict subs" in use at t/readline.t line 318.
Bareword "ISMACR" not allowed while "strict subs" in use at t/readline.t line 322.
Bareword "prompt" not allowed while "strict subs" in use at t/readline.t line 659.
Bareword "prompt" not allowed while "strict subs" in use at t/readline.t line 663.
Bareword "prompt" not allowed while "strict subs" in use at t/readline.t line 665.
Bareword "prompt" not allowed while "strict subs" in use at t/readline.t line 669.
Bareword "prompt" not allowed while "strict subs" in use at t/readline.t line 671.
Bareword "ISFUNC" not allowed while "strict subs" in use at t/readline.t line 988.
Bareword "ISKMAP" not allowed while "strict subs" in use at t/readline.t line 988.
Bareword "ISMACR" not allowed while "strict subs" in use at t/readline.t line 988.
Bareword "prompt" not allowed while "strict subs" in use at t/readline.t line 997.
Execution of t/readline.t aborted due to compilation errors.
# Looks like your test exited with 255 before it could output anything.
t/readline.t .....
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 147/147 subtests
Use of uninitialized value $Term::ReadLine::Gnu::VERSION in concatenation (.) or string at t/utf8_binary.t line 43.

#   Failed test 'An object of class 'Term::ReadLine::Stub' isa 'Term::ReadLine''
#   at t/utf8_binary.t line 90.
#     The object of class 'Term::ReadLine::Stub' isn't a 'Term::ReadLine'

#   Failed test 'input layers after 'new''
#   at t/utf8_binary.t line 95.
#     Structures begin differing at:
#          $got->[2] = Does not exist
#     $expected->[2] = 'stdio'

#   Failed test 'output layers after 'new''
#   at t/utf8_binary.t line 98.
#     Structures begin differing at:
#          $got->[2] = Does not exist
#     $expected->[2] = 'stdio'
# Looks like you failed 3 tests of 13.
t/utf8_binary.t ..
Dubious, test returned 3 (wstat 768, 0x300)
Failed 3/13 subtests
Use of uninitialized value $Term::ReadLine::Gnu::VERSION in concatenation (.) or string at t/utf8_text.t line 48.

#   Failed test 'An object of class 'Term::ReadLine::Stub' isa 'Term::ReadLine''
#   at t/utf8_text.t line 116.
#     The object of class 'Term::ReadLine::Stub' isn't a 'Term::ReadLine'
# Looks like you failed 1 test of 14.
t/utf8_text.t ....
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/14 subtests

Test Summary Report
-------------------
t/00checkver.t (Wstat: 512 Tests: 4 Failed: 2)
  Failed tests:  2-3
  Non-zero exit status: 2
t/callback.t   (Wstat: 512 Tests: 8 Failed: 2)
  Failed tests:  2-3
  Non-zero exit status: 2
t/history.t    (Wstat: 65280 Tests: 4 Failed: 3)
  Failed tests:  2-4
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 88 tests but ran 4.
t/readline.t   (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 147 tests but ran 0.
t/utf8_binary.t (Wstat: 768 Tests: 13 Failed: 3)
  Failed tests:  6-8
  Non-zero exit status: 3
t/utf8_text.t  (Wstat: 256 Tests: 14 Failed: 1)
  Failed test:  7
  Non-zero exit status: 1
Files=8, Tests=47,  2 wallclock secs ( 0.08 usr  0.06 sys +  1.22 cusr  0.40 csys =  1.76 CPU)
Result: FAIL
Failed 6/8 test programs. 11/47 subtests failed.
make: *** [test_dynamic] Error 1
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-term-readline-gnu/p5.28-term-readline-gnu/work/Term-ReadLine-Gnu-1.36" && /usr/bin/make test
Exit code: 2
Warning: The following existing files were hidden from the build system by trace mode:
  /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/Cwd.pm
  /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/File/Spec.pm
  /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/File/Spec/Unix.pm
  /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/List/Util.pm
  /opt/local/lib/perl5/vendor_perl/5.28/darwin-thread-multi-2level/Scalar/Util.pm
The following file would have been hidden from the build system by trace mode if it existed:
  /usr/gnu/include
Error: Failed to test p5.28-term-readline-gnu: command execution failed
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_github.com_macports_macports-ports_perl_p5-term-readline-gnu/p5.28-term-readline-gnu/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port p5.28-term-readline-gnu failed
```

</details>


- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
