### PR TITLE
inkscape-devel: update to 1.0alpha

### DIFF
--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -3,21 +3,22 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
+PortGroup           cmake 1.1
+cmake.generator     Ninja
 
 name                inkscape-devel
 conflicts           inkscape
 epoch               1
-set git_commit      31483c312000d1fe2778d38a502233b948b0cbb1
-set git_date        20181223
-version             0.92.3-${git_date}
-revision            1
+set git_commit      d4cc460846
+set git_date        20190115
+version             1.0alpha-${git_date}
+revision            0
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}
 categories          graphics gnome
 platforms           darwin
 
-description         This a recent maintenance snapshot of Inkscape 0.92 taken from \
-                    the upstream git 0.92.x release branch.
+description         This a recent snapshot of the upstream master branch.
 
 long_description    Inkscape is an multi-platform, Open-Source Vector Graphics Editor \
                     that uses SVG as its native file format. \
@@ -26,24 +27,33 @@ long_description    Inkscape is an multi-platform, Open-Source Vector Graphics E
 homepage            http://www.inkscape.org/
 
 fetch.type          git
-git.url             -b 0.92.x --depth 100 git://git.launchpad.net/inkscape
+git.url             -b master --depth 100 https://gitlab.com/inkscape/inkscape.git
 git.branch          ${git_commit}
 
-set perl_version    5.28
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
 
-depends_build       port:pkgconfig \
-                    port:autoconf \
-                    port:automake \
+set python_major    3
+set python_minor    7
+set python_version  ${python_major}${python_minor}
+
+depends_build-append \
+                    port:pkgconfig \
                     port:libtool \
                     port:intltool \
-                    port:perl${perl_version}
+                    port:python${python_version}
 
-depends_lib         port:desktop-file-utils \
-                    port:popt \
+depends_lib-append \
+                    port:desktop-file-utils \
+                    port:libxslt \
+                    port:adwaita-icon-theme \
+                    port:gdl3 \
+                    port:libsoup \
+                    port:cairo \
                     path:lib/libgc.dylib:boehmgc \
-                    port:gdk-pixbuf2 \
                     port:gsl \
-                    port:gtkmm \
+                    port:gtkmm3 \
                     port:dbus-glib \
                     port:lcms2 \
                     port:poppler \
@@ -54,56 +64,28 @@ depends_lib         port:desktop-file-utils \
                     port:libvisio-0.1 \
                     port:libwpg-0.3 \
                     port:aspell \
-                    port:gtkspell2 \
                     port:potrace \
-                    port:py27-lxml \
-                    port:py27-numpy
-
-patchfiles          patch-use-configured-perl.diff
-
-# see https://trac.macports.org/ticket/57744
-patchfiles-append   patch-openmp_test.diff
+                    port:py${python_version}-lxml \
+                    port:py${python_version}-numpy
 
 post-patch {
-    reinplace "s|@@MP_PERL@@|${prefix}/bin/perl${perl_version}|" ${worksrcpath}/Makefile.am
-    reinplace "s|\"python-interpreter\", \"python\"|\"python-interpreter\", \"python2.7\"|g" ${worksrcpath}/src/extension/implementation/script.cpp
+    reinplace "s|\"python-interpreter\", \"python\"|\"python-interpreter\", \"python${python_major}.${python_minor}\"|g" ${worksrcpath}/src/extension/implementation/script.cpp
     reinplace "s|^#include \"Object.h\"|#include \"${prefix}/include/poppler/Object.h\"|" ${worksrcpath}/src/extension/internal/pdfinput/pdf-parser.h
     reinplace "s|^#include \"Object.h\"|#include \"${prefix}/include/poppler/Object.h\"|" ${worksrcpath}/src/extension/internal/pdfinput/pdf-parser.cpp
+    reinplace "s|lib/inkscape|lib|" ${worksrcpath}/src/CMakeLists.txt
 }
 
 # py27-numpy is currently not universal (#48263).
 
 universal_variant no
 
-platform darwin {
-# on Sierra, building with clang optimization enabled causes crash at startup
-# issue affects both +x11 and +quartz builds
-    if {${os.major} > 15} {
-        configure.optflags  -O0
-    }
-}
-
 # clang-425.0.28 cannot handle glibmm's headers
 compiler.blacklist-append {clang < 500} gcc-4.0 *gcc-4.2
 
-configure.cmd       ./autogen.sh && ./configure
-
-configure.python    ${prefix}/bin/python2.7
-
-configure.args      --without-gnome-vfs \
-                    --enable-lcms \
-                    --enable-poppler-cairo \
-                    --enable-dbusapi \
-                    --disable-openmp \
-                    --disable-silent-rules \
-                    --disable-strict-build
-
-configure.cppflags-append \
-                    -I${worksrcpath}/src/extension/script
-
-variant strict description {Enable strict build} {
-    configure.args-replace  --disable-strict-build --enable-strict-build
-}
+configure.args-append \
+    -DWITH_DBUS:BOOL=ON \
+    -DWITH_OPENMP=OFF \
+    -DWITH_JEMALLOC=OFF
 
 #
 # the following dummy variants are used
@@ -119,7 +101,7 @@ if {![variant_isset quartz]} {
 }
 
 post-activate {
-        system "${prefix}/bin/gtk-update-icon-cache -f -t ${prefix}/share/icons/hicolor"
+        system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
         system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
 }
 


### PR DESCRIPTION
#### Description

Update `inkscape-devel` to 1.0alpha

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
