### PR TITLE
dcm2niix: New port

### DIFF
--- a/science/dcm2niix/Portfile
+++ b/science/dcm2niix/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        rordenlab dcm2niix 1.0.20181125 v
+version             ${github.version}
+
+categories          science
+maintainers         {eborisch @eborisch} openmaintainer
+
+description         DICOM to NifTI converter
+
+long_description    dcm2niix is a designed to convert neuroimaging data from \
+                    the DICOM format to the NIfTI format
+
+license             BSD MIT
+platforms           darwin
+
+checksums \
+    rmd160  518b52a35c422511f0f5f73154b14dcaddb5f033 \
+    sha256  d766c345a41954b21d4dc1d90c2c5ddc6425e36228e6d9d8abccd03fc5427c06 \
+    size    312848
+
+depends_build-append    port:git \
+                        port:py37-sphinx
+
+depends_lib-append      port:openjpeg \
+                        port:yaml-cpp \
+                        port:zlib
+
+configure.args-append   -DUSE_OPENJPEG=ON \
+                        -DBUILD_DOCS=ON \
+                        -DBATCH_VERSION=ON \
+                        -DZLIB_IMPLEMENTATION=custom \
+                        -DZLIB_ROOT=${prefix}
+
+patch {
+    reinplace "/NAMES/s/$/ sphinx-build-3.7/" docs/CMakeLists.txt
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        README.md \
+        VERSIONS.md \
+        license.txt \
+        ${destroot}${docdir}
+}
+


### PR DESCRIPTION
#### Description
New port. DICOM to NifTI converter.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->