### PR TITLE
db46: remove +java variant

### DIFF
--- a/databases/db46/Portfile
+++ b/databases/db46/Portfile
@@ -138,11 +138,6 @@ if {$subport == $name} {
         delete ${destroot}${prefix}/share/doc/${name}/java
     }
 
-    # Delete this variant on or after 2013-10-08.
-    variant java description "Java API - moved to ${name}-java port" {
-        notes "${name}'s +java variant has been replaced with the ${name}-java port."
-    }
-
     variant tcl description {build Tcl API} {
         depends_lib-append      port:tcl
         configure.args-append   --enable-tcl --with-tcl=${prefix}/lib


### PR DESCRIPTION
#### Description

Variant was replaced by `db46-java` subport in 357800d6066f7d30d8785f2f931d4e6f189319c5 over 6 years ago.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
