### PR TITLE
kross-interpreters: remove old python variants

### DIFF
--- a/kde/kross-interpreters/Portfile
+++ b/kde/kross-interpreters/Portfile
@@ -27,12 +27,7 @@ patchfiles          patch-CMakeLists.txt.diff
 configure.args-append   -DFALCON_INCLUDE_DIR=${prefix}/include/falcon0.9.6/falcon \
                         -DFALCON_LIBRARIES=${prefix}/lib/libfalcon_engine.dylib
 
-#python25 and python26 variants made obsolete on 2014/12/20
-variant python25 description "Legacy compatibility variant" requires python27 {}
-
-variant python26 description "Legacy compatibility variant" requires python27 {}
-
-variant python27 conflicts description {Use python 2.7} {
+variant python27 description {Use python 2.7} {
     configure.pre_args-append   -DCMAKE_PREFIX_PATH=${prefix}/Library/Frameworks/Python.framework/Versions/2.7/
     depends_lib-append      port:python27
 }


### PR DESCRIPTION
`+python25` and `+python26` were made obsolete in 0f8531532d8dd5b71f454859fe909fd9852e60e1 over 4 years ago.

Remove unused `conflicts` option in `+python27` variant

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
