### PR TITLE
dnsmasq: remove obsolete no_* variants

### DIFF
--- a/net/dnsmasq/Portfile
+++ b/net/dnsmasq/Portfile
@@ -59,31 +59,11 @@ livecheck.type      regex
 livecheck.url       ${master_sites}
 livecheck.regex     LATEST_IS_(\\d\\.\\d+)
 
-# TODO: remove no_* variants after 2015-01-09
-if { ! [variant_isset no_dhcp] } {
-    default_variants-append +dhcp
-}
-if { ! [variant_isset no_tftp] } {
-    default_variants-append +tftp
-}
-if { ! [variant_isset no_ipv6] } {
-    default_variants-append +ipv6
-}
+default_variants    +dhcp +tftp +ipv6
 
-variant no_dhcp conflicts dhcp description { obsolete } {}
-variant dhcp conflicts no_dhcp description { Provide built-in DHCP server } {
-    build.args-delete   -DNO_DHCP
-}
-
-variant no_tftp conflicts tftp description { obsolete } {}
-variant tftp conflicts no_tftp description { Provide built-in TFTP server } {
-    build.args-delete   -DNO_TFTP
-}
-
-variant no_ipv6 conflicts ipv6 description { obsolete } {}
-variant ipv6 conflicts no_ipv6 description { Provide IPV6 support } {
-    build.args-delete   -DNO_IPV6
-}
+variant dhcp description { Provide built-in DHCP server } {}
+variant tftp description { Provide built-in TFTP server } {}
+variant ipv6 description { Provide IPV6 support } {}
 
 set COPTS {}
 if {![variant_isset dhcp]} {


### PR DESCRIPTION
Variants `+no_tftp`, `+no_dhcp`, and `+no_ipv6` were marked obsolete in 97686bf20d1dd15967b8a2ce15ce85cf9369cd90 5 years ago.

Remove unneeded `build.args-delete -DNO_…` from remaining variants. (From what I understand, these are grouped into a single build argument `COPTS=…` passed to `make`, rather than individually passed to the compiler.)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
