### PR TITLE
nginx: remove +spdy variant

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -185,9 +185,6 @@ variant gzip_static description {Avoids compressing the same file each time it i
     configure.args-append   --with-http_gzip_static_module
 }
 
-variant spdy requires http2 description {Legacy compatibility variant: SPDY has been replaced by HTTP/2} {
-    # added 2015-11-05
-}
 variant http2 requires ssl description {Add HTTP/2 support to the server} {
     configure.args-append   --with-http_v2_module
 }


### PR DESCRIPTION
Replaced by `+http2` variant in ebfe3ac050 over 3 years ago.


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
