### PR TITLE
llvm-related ports: use https urls for llvm.org

### DIFF
--- a/lang/dragonegg-3.3/Portfile
+++ b/lang/dragonegg-3.3/Portfile
@@ -16,6 +16,6 @@ subport                 ${name}-gcc-4.8 {}
 categories              lang
 platforms               darwin
 license                 GPL-2
-homepage                http://dragonegg.llvm.org/
+homepage                https://dragonegg.llvm.org/
 
 livecheck.type          none

--- a/lang/dragonegg-3.4/Portfile
+++ b/lang/dragonegg-3.4/Portfile
@@ -42,7 +42,7 @@ long_description        DragonEgg replaces GCC optimizers and code generators \
                         by the LLVM optimizing infrastructure. It supersedes \
                         llvm-gcc.
 
-homepage                http://dragonegg.llvm.org/
+homepage                https://dragonegg.llvm.org/
 
 if {${subport} eq ${name}} {
 version                 ${llvm_version}
@@ -83,7 +83,7 @@ depends_skip_archcheck-append gcc${gcc_version_no_dot}
 
 version                 ${llvm_version}
 epoch                   1
-master_sites            http://llvm.org/releases/${version}/
+master_sites            https://releases.llvm.org/${version}/
 extract.suffix          .tar.gz
 distname                dragonegg-${version}.src
 worksrcdir              dragonegg-${version}

--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -19,9 +19,9 @@ long_description        ${description} \
                         users must build the port with +replacemnt_libcxx and install the root manually if they wish \
                         to replace the existing host implementation.
 
-homepage                http://libcxx.llvm.org/
+homepage                https://libcxx.llvm.org/
 
-master_sites            http://www.llvm.org/releases/${version}/
+master_sites            https://releases.llvm.org/${version}/
 dist_subdir             llvm
 
 use_xz                  yes

--- a/lang/libcxxabi/Portfile
+++ b/lang/libcxxabi/Portfile
@@ -18,5 +18,5 @@ long_description        ${description} \
                         users must build the port with +replacemnt_libcxx and install the root manually if they wish \
                         to replace the existing host implementation.
 
-homepage                http://libcxxabi.llvm.org/
+homepage                https://libcxxabi.llvm.org/
 livecheck.type          none

--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -42,7 +42,7 @@ if { ${subport} eq "libomp-devel" } {
             size    1471884
 
         livecheck.url \
-            http://llvm.org/viewvc/llvm-project/openmp/trunk/?view=log
+            https://llvm.org/viewvc/llvm-project/openmp/trunk/?view=log
         livecheck.version       ${version}
         livecheck.regex         revision=(\[0-9\]+)
         set rtpath              "runtime/"

--- a/lang/llvm-3.3/Portfile
+++ b/lang/llvm-3.3/Portfile
@@ -20,7 +20,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} == "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -32,7 +32,7 @@ if {${subport} == "llvm-${llvm_version}"} {
     depends_lib         port:libffi
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} == "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -67,7 +67,7 @@ if {${subport} == "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}
 epoch                   1
-master_sites            http://llvm.org/releases/${version}
+master_sites            https://releases.llvm.org/${version}
 extract.suffix          .tar.gz
 distfiles               llvm-${version}.src${extract.suffix}
 worksrcdir              llvm-${version}.src

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -20,7 +20,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -32,7 +32,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libffi port:ncurses port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -73,7 +73,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.2
 epoch                   1
-master_sites            http://llvm.org/releases/${version} http://llvm.org/releases/${llvm_version}
+master_sites            https://releases.llvm.org/${version} https://releases.llvm.org/${llvm_version}
 extract.suffix          .tar.gz
 distfiles               llvm-${version}.src${extract.suffix}
 worksrcdir              llvm-${version}.src

--- a/lang/llvm-3.5/Portfile
+++ b/lang/llvm-3.5/Portfile
@@ -27,7 +27,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -48,7 +48,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.2
 epoch                   1
-master_sites            http://llvm.org/releases/${version}
+master_sites            https://releases.llvm.org/${version}
 use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -27,7 +27,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -46,7 +46,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
         depends_skip_archcheck-append cctools
     }
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -87,7 +87,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.1
 epoch                   1
-master_sites            http://llvm.org/releases/${version}
+master_sites            https://releases.llvm.org/${version}
 use_xz                  yes
 distfiles               llvm-${version}.src${extract.suffix}
 worksrcdir              llvm-${version}.src

--- a/lang/llvm-3.9/Portfile
+++ b/lang/llvm-3.9/Portfile
@@ -21,7 +21,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -33,7 +33,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -84,7 +84,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.1
 epoch                   1
-master_sites            http://llvm.org/releases/${version}
+master_sites            https://releases.llvm.org/${version}
 use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}

--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -24,7 +24,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -36,7 +36,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -70,7 +70,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     default_variants    +analyzer
 } elseif {${subport} eq "lldb-${llvm_version}"} {
-    homepage            http://lldb.llvm.org/
+    homepage            https://lldb.llvm.org/
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
@@ -102,7 +102,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.1
 epoch                   2
-master_sites            http://llvm.org/releases/${version}
+master_sites            https://releases.llvm.org/${version}
 use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -23,7 +23,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -35,7 +35,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -69,7 +69,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     default_variants    +analyzer
 } elseif {${subport} eq "lldb-${llvm_version}"} {
-    homepage            http://lldb.llvm.org/
+    homepage            https://lldb.llvm.org/
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
@@ -101,8 +101,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.2
 epoch                   2
-master_sites            http://llvm.org/releases/${version}
-#master_sites             http://prereleases.llvm.org/${llvm_version}.0/rc4
+master_sites            https://releases.llvm.org/${version}
+#master_sites             https://prereleases.llvm.org/${llvm_version}.0/rc4
 use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -23,7 +23,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -35,7 +35,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -69,7 +69,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     default_variants    +analyzer
 } elseif {${subport} eq "lldb-${llvm_version}"} {
-    homepage            http://lldb.llvm.org/
+    homepage            https://lldb.llvm.org/
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
@@ -101,7 +101,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.1
 epoch                   1
-master_sites            http://llvm.org/releases/${version}
+master_sites            https://releases.llvm.org/${version}
 use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -24,7 +24,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -36,7 +36,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -70,7 +70,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     default_variants    +analyzer
 } elseif {${subport} eq "lldb-${llvm_version}"} {
-    homepage            http://lldb.llvm.org/
+    homepage            https://lldb.llvm.org/
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
@@ -102,8 +102,8 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
 version                 ${llvm_version}.1
 epoch                   1
-master_sites            http://llvm.org/releases/${version}
-#master_sites            http://prereleases.llvm.org/${llvm_version}.0/rc2
+master_sites            https://releases.llvm.org/${version}
+#master_sites            https://prereleases.llvm.org/${llvm_version}.0/rc2
 use_xz                  yes
 extract.suffix          .tar.xz
 distfiles               llvm-${version}.src${extract.suffix}

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -23,7 +23,7 @@ license                 NCSA
 maintainers             {jeremyhu @jeremyhu} {larryv @larryv}
 
 if {${subport} eq "llvm-${llvm_version}"} {
-    homepage            http://llvm.org/
+    homepage            https://llvm.org/
     description         llvm is a next generation compiler infrastructure
     long_description    The LLVM Core libraries provide a modern source- and \
                         target-independent optimizer, along with code \
@@ -35,7 +35,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
     depends_lib         port:libedit port:libffi port:ncurses path:lib/libxar.dylib:xar port:zlib
     depends_run         bin:perl:perl5 port:llvm_select
 } elseif {${subport} eq "clang-${llvm_version}"} {
-    homepage            http://clang.llvm.org/
+    homepage            https://clang.llvm.org/
     description         C, C++, Objective C and Objective C++ compiler
     long_description    Clang is an "LLVM native" C/C++/Objective-C compiler, \
                         which aims to deliver amazingly fast compiles (e.g. \
@@ -69,7 +69,7 @@ if {${subport} eq "llvm-${llvm_version}"} {
 
     default_variants    +analyzer
 } elseif {${subport} eq "lldb-${llvm_version}"} {
-    homepage            http://lldb.llvm.org/
+    homepage            https://lldb.llvm.org/
     description         the LLVM debugger
     long_description    Lldb is the "LLVM native" debugger.
 
@@ -101,7 +101,7 @@ default_variants-append +assertions
 
 #version                 ${llvm_version}.0
 #epoch                   1
-#master_sites            http://llvm.org/releases/${version}
+#master_sites            https://releases.llvm.org/${version}
 #use_xz                  yes
 #extract.suffix          .tar.xz
 #distfiles               llvm-${version}.src${extract.suffix}

--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -24,7 +24,7 @@ supported_archs         noarch
 if {${name} ne ${subport}} {
     # Share llvm's downloads
     dist_subdir             llvm
-    livecheck.url           http://llvm.org/
+    livecheck.url           https://llvm.org/
     use_xz                  yes
 
     checksums \
@@ -67,7 +67,7 @@ if {${name} ne ${subport}} {
         variant clang${cvnum} description {
                Use clang${cvnum}'s libclang
         } conflicts {*}${cflist} "
-            master_sites        http://llvm.org/releases/${clang_version}
+            master_sites        https://releases.llvm.org/${clang_version}
             depends_lib-append  port:clang-${cvstr}
             distfiles           cfe-${clang_version}.src.tar.xz
             worksrcdir          cfe-${clang_version}.src/bindings/python


### PR DESCRIPTION
Applied to `livecheck.url`, `homepage`, and `master_sites`

Use `releases.llvm.org` instead of `llvm.org/releases/` to prevent redirects

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

I have not updated the URLs used by the `svn` command in `llvm-3.9` or earlier (I think these were first set to https in `llvm-devel` by f6f07fa541003e55102f4e9da3713867389ed153). Is it better to leave those as-is or change those to use https as well?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
