### PR TITLE
xcircuit, xcircuit-devel: require +x11 variants of tk and cairo

### DIFF
--- a/x11/xcircuit-devel/Portfile
+++ b/x11/xcircuit-devel/Portfile
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 
 name                xcircuit-devel
 version             3.10.12
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          x11 cad
 platforms           darwin
@@ -42,6 +44,11 @@ depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     port:ghostscript \
                     port:tk \
                     port:xpm
+
+# Currently, xcircuit crashes upon start if tk is built without +x11
+require_active_variants tk x11 quartz
+
+require_active_variants cairo x11
 
 use_autoreconf      yes
 autoreconf.args     -fvi

--- a/x11/xcircuit/Portfile
+++ b/x11/xcircuit/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                xcircuit
 version             3.9.73
-revision            3
+revision            4
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          x11 cad
 platforms           darwin
@@ -45,6 +45,8 @@ depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
 
 # Currently, xcircuit crashes upon start if tk is built without +x11
 require_active_variants tk x11 quartz
+
+require_active_variants cairo x11
 
 use_autoreconf      yes
 autoreconf.args     -fvi


### PR DESCRIPTION
 - `tk +x11`: See https://trac.macports.org/ticket/37203
Copied from portfile for `xcircuit`: https://github.com/macports/macports-ports/blob/68b710554745dcffe34fb9b47d9ba7cd9efd442b/x11/xcircuit/Portfile#L46-L47
 - `cairo +x11`: See https://trac.macports.org/ticket/57666#comment:5

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
