### PR TITLE
Update to mkvtoolnix 30.1.0, libmatroska 1.4.9, libebml 1.3.6

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -42,7 +42,7 @@ supported_archs         x86_64
 ##
 if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     version             2.2.8
-    revision            7
+    revision            8
     license             GPL-2+
 
     platforms           darwin

--- a/multimedia/libmatroska/Portfile
+++ b/multimedia/libmatroska/Portfile
@@ -1,9 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 
 name                libmatroska
-version             1.4.8
+version             1.4.9
+revision            0
+checksums           rmd160  ca85491dca0ac8e957b55c5c0db738784bc12af0 \
+                    sha256  38a61dd5d87c070928b5deb3922b63b2b83c09e2e4a10f9393eecb6afa9795c8 \
+                    size    64556
+
 categories          multimedia
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -19,16 +25,9 @@ homepage            https://www.matroska.org
 master_sites        https://dl.matroska.org/downloads/${name}/
 use_xz              yes
 
-checksums           rmd160  90ff1b6e965ec596e8ce6ffcbc61a30e4c3f432f \
-                    sha256  d8c72b20d4c5bf888776884b0854f95e74139b5267494fae1f395f7212d7c992 \
-                    size    286284
-
-depends_build       port:pkgconfig
-
 depends_lib         port:libebml
 
-test.run            yes
-test.target         check
+configure.args      -DBUILD_SHARED_LIBS=ON
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]

--- a/multimedia/mkvtoolnix/Portfile
+++ b/multimedia/mkvtoolnix/Portfile
@@ -6,8 +6,14 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 
-github.setup        mbunkus mkvtoolnix 23.0.0 release-
+github.setup        mbunkus mkvtoolnix 30.1.0 release-
+revision            0
+checksums           rmd160  7e60883259bdc72e1d39e171d92d9d82878999f1 \
+                    sha256  4628f40d62d359edb1441c52381b1f3a61aa227279133d7e01257f91e0d92591 \
+                    size    7274296
+
 categories          multimedia
+platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             GPL-2+ LGPL-2.1+
 
@@ -16,14 +22,10 @@ long_description    mkvtoolnix will evolve to a set of tools to create, \
                     alter and inspect Matroska files under Linux and other \
                     Unices, just what the OGMtools do for the OGM format.
 homepage            https://mkvtoolnix.download
-platforms           darwin
 master_sites        ${homepage}/sources/
 use_xz              yes
-checksums           rmd160  bee9e657e58ccfb2299f0163b792c4ccd77ef016 \
-                    sha256  1da0b0cca24f6d45ef614e864bbec0043af0b53062f86a524fe799cc355c1d68 \
-                    size    4729056
 
-set version_ruby    2.4
+set version_ruby    2.6
 set version_ruby_mp [join [split $version_ruby "."] ""]
 
 depends_build       port:ruby${version_ruby_mp} \
@@ -84,6 +86,10 @@ configure.args      --mandir=${prefix}/share/man \
                     --with-po4a=${prefix}/bin/po4a \
                     --with-po4a-translate=${prefix}/bin/po4a-translate \
                     --disable-qt
+
+# https://gitlab.com/mbunkus/mkvtoolnix/issues/2485
+configure.ldflags-append \
+                    -framework CoreFoundation
 
 configure.ldflags-append ${cxx_stdlibflags}
 

--- a/textproc/libebml/Portfile
+++ b/textproc/libebml/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-
-# Don't update to 1.3.6 or later until the library version number is fixed.
-# https://github.com/Matroska-Org/libebml/issues/40
+PortGroup           cmake 1.1
 
 name                libebml
-version             1.3.5
+version             1.3.6
+revision            0
+checksums           rmd160  a5ec0996a02b59c3514586e1285072df13b71186 \
+                    sha256  1e5a7a7820c493aa62b0f35e15b4233c792cc03458c55ebdfa7a6521e4b43e9e \
+                    size    57764
+
 categories          textproc
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -22,11 +25,7 @@ homepage            https://www.matroska.org
 master_sites        https://dl.matroska.org/downloads/${name}/
 use_xz              yes
 
-checksums           rmd160  173e894c84f4d2142f679ed8dbb7c75f5e3cf617 \
-                    sha256  d818413f60742c2f036ba6f582c5e0320d12bffec1b0fc0fc17a398b6f04aa00
-
-test.run            yes
-test.target         check
+configure.args      -DBUILD_SHARED_LIBS=ON
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]


### PR DESCRIPTION
#### Description

Update mkvtoolnix to 30.1.0
Update libmatroska to 1.4.9
Update libebml to 1.3.6
Revbump vlc/libvlc to rebuild with the regressed libebml/libmatroska library versions

See https://trac.macports.org/ticket/57089

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
