### PR TITLE
webalizer: remove legacy variants +no_dns and +no_largefile

### DIFF
--- a/www/webalizer/Portfile
+++ b/www/webalizer/Portfile
@@ -66,31 +66,15 @@ variant debug description {Compile with debugging code} {
     configure.args-append   --enable-debug
 }
 
-variant largefile conflicts no_largefile description {Add support for large files} {
+variant largefile description {Add support for large files} {
     configure.args-delete   --disable-largefile
 }
 
-variant dns conflicts no_dns description {Enable DNS/GeoDB lookup code} {
+variant dns description {Enable DNS/GeoDB lookup code} {
     configure.args-delete   --disable-dns
     configure.args-append   --with-db=${prefix}/include/db60 \
                             --with-dblib=${prefix}/lib/db60
     depends_lib-append      port:db60
 }
 
-# Delete the below after 1/17/2019
-
-variant no_dns conflicts dns description {Legacy variant} {}
-
-if {[variant_isset no_dns]} {
-    default_variants        -dns
-} else {
-    default_variants        +dns
-}
-
-variant no_largefile conflicts largefile description {Legacy variant} {}
-
-if {[variant_isset no_largefile]} {
-    default_variants        -largefile
-} else {
-    default_variants        +largefile
-}
+default_variants        +dns +largefile


### PR DESCRIPTION
Marked as legacy in ca1a055075287abff4da1bdc3d2ef12a28313b95.


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
