### PR TITLE
pam-google-authenticator: New port

### DIFF
--- a/security/pam-google-authenticator/Portfile
+++ b/security/pam-google-authenticator/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        google google-authenticator-libpam 1.05
+name                pam-google-authenticator
+categories          security
+platforms           darwin
+maintainers         {eborisch @eborisch} openmaintainer
+license             apache-2 
+
+description         Pluggable Authentication Module for Google Authenticator
+
+long_description    The Google Authenticator PAM module provides an easy way \
+                    use Google's 2FA (via Google Authenticator app) to your \
+                    existing user authentication infrastructure.
+
+checksums \
+    rmd160  5beabe6bcf546633dd54dbc958df8d5b19f07b7b \
+    sha256  458bbe8f376bb6f92e70a910f6088e71adf18a05c3d4fe19f91ed005d5564b28 \
+    size    57791
+
+depends_run-append      port:qrencode
+
+# While this isn't needed to compile, the application (setup) portion uses
+# dlopen to opportunistically load libqrencode. This dependency is recorded
+# above, but application needs the prefix/lib directory in the search path to
+# find it.
+configure.ldflags-append    -Wl,-rpath -Wl,${prefix}/lib
+
+patch {
+    # Match pam-u2f's location for consistency
+    reinplace "s|/security|/pam|" Makefile.am
+}
+
+use_autoreconf          yes
+autoreconf.args         --install
+
+post-destroot {
+    xinstall -m 0644 ${worksrcpath}/LICENSE \
+        ${destroot}${prefix}/share/doc/google-authenticator/
+}
+
+notes "
+Create a file for a new service in /etc/pam.d/ or edit
+an already existing one by adding a line similar to this:
+
+auth required ${prefix}/lib/pam/pam_google_authenticator.so
+
+See man google-authenticator and pam_google_authenticator or
+https://github.com/google/google-authenticator-libpam for details
+"
+


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->