### PR TITLE
screen: limit termcap, fix blanker, fix error messages

### DIFF
--- a/sysutils/screen/Portfile
+++ b/sysutils/screen/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                screen
 version             4.6.2
-revision            1
+revision            2
 homepage            https://www.gnu.org/software/screen/
 description         Screen manager with VT100/ANSI terminal emulation
 long_description    \
@@ -41,7 +41,10 @@ checksums           ${distname}${extract.suffix} \
                     sha256  dcd2786d82865fb10542c20e97d7052110f7ca9a551f2ab5628c607f20e2bb2f
 
 patchfiles          patch-apple.diff \
-                    patch-config.h.in.diff
+                    patch-config.h.in.diff \
+                    patch-limit-termcap-size.diff \
+                    patch-blanker-fix.diff \
+                    patch-panic-fix.diff
 depends_lib         port:ncurses
 
 extract.only        ${distname}${extract.suffix}

--- a/sysutils/screen/files/patch-blanker-fix.diff
+++ b/sysutils/screen/files/patch-blanker-fix.diff
@@ -1,0 +1,168 @@
+Fix blanker to work when screen is suid root
+
+* Change RunBlanker to call OpenDevice so permissions on slave
+  PTY are correctly set.
+* Update handling of file descriptors after fork to be similar to
+  ForkWindow on at pty (fixes debug and leaked descriptors)
+* DEBUG now creates screen.blanker to debug blanker fork
+* Allow display of error message when display blocked by blanker
+  (because message is probably from blanker failing to start)
+
+Fixes screen bug: https://savannah.gnu.org/bugs/?55512
+
+Signed-off-by: Scott Shambarger <devel@shambarger.net>
+
+--- display.c
++++ display.c
+@@ -3958,6 +3958,7 @@ char **cmdv;
+   char *m;
+   int pid;
+   int slave = -1;
++  int ptype = 0;
+   char termname[MAXTERMLEN + 6];
+ #ifndef TIOCSWINSZ
+   char libuf[20], cobuf[20];
+@@ -3969,9 +3970,9 @@ char **cmdv;
+   termname[sizeof(termname) - 1] = 0;
+   KillBlanker();
+   D_blankerpid = -1;
+-  if ((D_blankerev.fd = OpenPTY(&m)) == -1)
++  if ((D_blankerev.fd = OpenDevice(cmdv, 0, &ptype, &m)) == -1)
+     {
+-      Msg(0, "OpenPty failed");
++      Msg(0, "OpenDevice failed");
+       return;
+     }
+ #ifdef O_NOCTTY
+@@ -3996,25 +3997,48 @@ char **cmdv;
+       return;
+     case 0:
+       displays = 0;
+-#ifdef DEBUG
+-      if (dfp && dfp != stderr)
+-	{
+-	  fclose(dfp);
+-	  dfp = 0;
+-	}
++#ifdef SIGPIPE
++      signal(SIGPIPE, SIG_DFL);
+ #endif
+       if (setgid(real_gid) || setuid(real_uid))
+         Panic(errno, "setuid/setgid");
+       brktty(D_userfd);
+       freetty();
++#ifdef DEBUG
++      if (dfp && dfp != stderr)
++	  fclose(dfp);
++#endif
++      if (slave != -1)
++	{
++	  close(0);
++	  dup(slave);
++	  close(slave);
++	  closeallfiles(D_blankerev.fd);
++	  slave = dup(0);
++	}
++      else
++        closeallfiles(D_blankerev.fd);
++#ifdef DEBUG
++      if (dfp)
++        {
++          char buf[256];
++
++	  sprintf(buf, "%s/screen.blanker", DEBUGDIR);
++	  if ((dfp = fopen(buf, "a")) == 0)
++	    dfp = stderr;
++	  else
++	    (void) chmod(buf, 0666);
++	}
++      debug1("=== RunBlanker: pid %d\n", (int)getpid());
++#endif
+       close(0);
+       close(1);
+       close(2);
+-      closeallfiles(slave);
+       if (open(m, O_RDWR))
+ 	Panic(errno, "Cannot open %s", m);
+       dup(0);
+       dup(0);
++      close(D_blankerev.fd);
+       if (slave != -1)
+ 	close(slave);
+       InitPTY(0);
+@@ -4028,17 +4052,17 @@ char **cmdv;
+       glwz.ws_row = D_height;
+       (void)ioctl(0, TIOCSWINSZ, (char *)&glwz);
+ #else
++      /* Always turn off nonblocking mode */
++      (void)fcntl(0, F_SETFL, 0);
+       sprintf(libuf, "LINES=%d", D_height);
+       sprintf(cobuf, "COLUMNS=%d", D_width);
+       *np++ = libuf;
+       *np++ = cobuf;
+ #endif
+-#ifdef SIGPIPE
+-      signal(SIGPIPE, SIG_DFL);
+-#endif
+-      display = 0;
++      debug1("calling execvpe %s\n", *cmdv);
+       execvpe(*cmdv, cmdv, NewEnv + 3);
+-      Panic(errno, "%s", *cmdv);
++      debug1("exec error: %d\n", errno);
++      Panic(errno, "Cannot exec '%s'", *cmdv);
+     default:
+       break;
+     }
+--- socket.c
++++ socket.c
+@@ -742,6 +742,7 @@ char *tty, *buf;
+   struct msg m;
+   bool is_socket;
+ 
++  debug2("SendErrorMsg: %s %s\n", tty, buf);
+   strncpy(m.m.message, buf, sizeof(m.m.message) - 1);
+   m.m.message[sizeof(m.m.message) - 1] = 0;
+   is_socket = IsSocket(SockPath);
+@@ -1237,7 +1238,13 @@ ReceiveMsg()
+           FinishAttach(&m);
+         break;
+       case MSG_ERROR:
++      {
++        int blocked=D_blocked;
++        if(D_blocked == 4) /* allow error messages while in blanker mode */
++          D_blocked=0; /* likely they're from failed blanker */
+         Msg(0, "%s", m.m.message);
++        D_blocked=blocked;
++      }
+         break;
+       case MSG_HANGUP:
+         if (!wi) /* ignore hangups from inside */
+--- window.c
++++ window.c
+@@ -102,7 +102,6 @@ static void pseu_writeev_fn __P((struct event *, char *));
+ static void win_silenceev_fn __P((struct event *, char *));
+ static void win_destroyev_fn __P((struct event *, char *));
+ 
+-static int  OpenDevice __P((char **, int, int *, char **));
+ static int  ForkWindow __P((struct win *, char **, char *));
+ #ifdef ZMODEM
+ static void zmodem_found __P((struct win *, int, char *, int));
+@@ -1091,7 +1090,7 @@ struct win *wp;
+   free((char *)wp);
+ }
+ 
+-static int
++int
+ OpenDevice(args, lflag, typep, namep)
+ char **args;
+ int lflag;
+--- window.h
++++ window.h
+@@ -351,6 +351,7 @@ struct win
+ #define Layer2Window(l) ((struct win *)(l)->l_bottom->l_data)
+ 
+ int WindowChangeNumber __P((int, int));
++int OpenDevice __P((char **, int, int *, char **));
+ 
+ #endif /* SCREEN_WINDOW_H */
+ 

--- a/sysutils/screen/files/patch-limit-termcap-size.diff
+++ b/sysutils/screen/files/patch-limit-termcap-size.diff
@@ -1,0 +1,154 @@
+Create TERMCAP entries limited to 1023 bytes by default.
+
+TERMCAP_BUF defaults to 1023 to create TERMCAP entries that work on
+most systems.  To save space, TERMCAP is unwrapped, and vt220 extra
+keys are skipped (unless TERMCAP_BUF > 1023); navigation keys are
+still included.  Entries larger than TERMCAP_BUF are now truncated,
+and no longer Panic screen.
+
+Termcap entries are still wrapped when saved to a file.
+
+Fixes screen bug: https://savannah.gnu.org/bugs/?55482
+
+Signed-off-by: Scott Shambarger <devel@shambarger.net>
+
+--- extern.h
++++ extern.h
+@@ -235,6 +235,7 @@ extern int   StuffKey __P((int));
+ /* termcap.c */
+ extern int   InitTermcap __P((int, int));
+ extern char *MakeTermcap __P((int));
++extern void  DumpTermcap __P((int, FILE *));
+ extern char *gettermcapstring __P((char *));
+ #ifdef MAPKEYS
+ extern int   remap __P((int, int));
+--- fileio.c
++++ fileio.c
+@@ -479,10 +479,7 @@ void WriteFile(struct acluser *user, char *fn, int dump) {
+                 break;
+ 
+             case DUMP_TERMCAP:
+-              if ((p = index(MakeTermcap(fore->w_aflag), '=')) != NULL) {
+-                fputs(++p, f);
+-                putc('\n', f);
+-              }
++              DumpTermcap(fore->w_aflag, f);
+ 	      break;
+ 
+ #ifdef COPY_PASTE
+--- os.h
++++ os.h
+@@ -507,7 +507,7 @@ typedef struct fd_set { int fds_bits[1]; } fd_set;
+  */
+ 
+ #ifndef TERMCAP_BUFSIZE
+-# define TERMCAP_BUFSIZE 2048
++# define TERMCAP_BUFSIZE 1023
+ #endif
+ 
+ #ifndef MAXPATHLEN
+--- term.c
++++ term.c
+@@ -197,6 +197,7 @@ struct term term[T_N] =
+   { "F1", T_STR  }, KMAPDEF("\033[23~")
+   { "F2", T_STR  }, KMAPDEF("\033[24~")
+   /* extra keys for vt220 (David.Leonard@it.uq.edu.au) */
++/* define T_FEXTRA */
+   { "F3", T_STR  },
+   { "F4", T_STR  },
+   { "F5", T_STR  },
+--- termcap.c
++++ termcap.c
+@@ -75,11 +75,10 @@ char screenterm[MAXTERMLEN + 1];	/* new $TERM, usually "screen" */
+ 
+ char *extra_incap, *extra_outcap;
+ 
+-static const char TermcapConst[] = "\\\n\
+-\t:DO=\\E[%dB:LE=\\E[%dD:RI=\\E[%dC:UP=\\E[%dA:bs:bt=\\E[Z:\\\n\
+-\t:cd=\\E[J:ce=\\E[K:cl=\\E[H\\E[J:cm=\\E[%i%d;%dH:ct=\\E[3g:\\\n\
+-\t:do=^J:nd=\\E[C:pt:rc=\\E8:rs=\\Ec:sc=\\E7:st=\\EH:up=\\EM:\\\n\
+-\t:le=^H:bl=^G:cr=^M:it#8:ho=\\E[H:nw=\\EE:ta=^I:is=\\E)0:";
++static const char TermcapConst[] = "DO=\\E[%dB:LE=\\E[%dD:RI=\\E[%dC:\
++UP=\\E[%dA:bs:bt=\\E[Z:cd=\\E[J:ce=\\E[K:cl=\\E[H\\E[J:cm=\\E[%i%d;%dH:\
++ct=\\E[3g:do=^J:nd=\\E[C:pt:rc=\\E8:rs=\\Ec:sc=\\E7:st=\\EH:up=\\EM:\
++le=^H:bl=^G:cr=^M:it#8:ho=\\E[H:nw=\\EE:ta=^I:is=\\E)0:";
+ 
+ char *
+ gettermcapstring(s)
+@@ -824,21 +823,13 @@ AddCap(s)
+ char *s;
+ {
+   register int n;
+-
+-  if (tcLineLen + (n = strlen(s)) > 55 && Termcaplen < TERMCAP_BUFSIZE - 4 - 1)
+-    {
+-      strcpy(Termcap + Termcaplen, "\\\n\t:");
+-      Termcaplen += 4;
+-      tcLineLen = 0;
+-    }
++  n=strlen(s);
+   if (Termcaplen + n < TERMCAP_BUFSIZE - 1)
+     {
+       strcpy(Termcap + Termcaplen, s);
+       Termcaplen += n;
+       tcLineLen += n;
+     }
+-  else
+-    Panic(0, "TERMCAP overflow - sorry.");
+ }
+ 
+ /*
+@@ -1074,6 +1065,12 @@ int aflag;
+ 	{
+ 	  if (i >= T_KEYPAD)	/* don't put keypad codes in TERMCAP */
+ 	    continue;		/* - makes it too big */
++#if (TERMCAP_BUF < 1024)
++          if (i >= T_FEXTRA && i < T_BACKTAB) /* also skip extra vt220 keys */
++            continue;
++          if (i > T_BACKTAB && i < T_NAVIGATE) /* more vt220 keys */
++            continue;
++#endif
+ 	  if (i >= T_CURSOR && i < T_OCAPS)
+ 	    {
+ 	      act = &umtab[i - (T_CURSOR - T_OCAPS + T_CAPS)];
+@@ -1128,6 +1125,37 @@ int aflag;
+   return Termcap;
+ }
+ 
++#define TERMCAP_MAX_WIDTH 63
++void
++DumpTermcap(aflag, f)
++int aflag;
++FILE *f;
++{
++  register const char *p, *pe;
++  int n, col=0;
++
++  if ((p = index(MakeTermcap(aflag), '=')) == NULL)
++    return;
++  p++;
++  debug1("DumpTermcap: '%s'\n", p);
++  /* write termcap entry with wrapping */
++  while((pe = index(p, ':')))
++    {
++      n = pe - p + 1;
++      if((col > 8) && ((col + n) > TERMCAP_MAX_WIDTH))
++        {
++          fwrite("\\\n\t:", 1, 4, f);
++          col = 8;
++        }
++      fwrite(p, 1, n, f);
++      col += n;
++      p = ++pe;
++    }
++  if(*p)
++    fwrite(p, 1, strlen(p), f);
++  fputc('\n', f);
++}
++
+ static void
+ MakeString(cap, buf, buflen, s)
+ char *cap, *buf;
+-- 
+2.17.2 (Apple Git-113)
+

--- a/sysutils/screen/files/patch-panic-fix.diff
+++ b/sysutils/screen/files/patch-panic-fix.diff
@@ -1,0 +1,140 @@
+Prevent Panic causing Panic, and children removing sockets
+
+* Set eff_uid/eff_gid after setuid/setgid to prevent nested Panic in
+  MakeClientSocket which calls xseteuid(eff_uid=0) - results in nested
+  Panic and SendErrorMsg not getting sent.
+* Set ServerSocket to -1 after fork so that child Panic doesn't
+  remove socket in eexit.
+* Fix descriptor leak if fork fails
+
+Fixes screen bug: https://savannah.gnu.org/bugs/?55511
+
+Signed-off-by: Scott Shambarger <devel@shambarger.net>
+
+--- attacher.c
++++ attacher.c
+@@ -55,6 +55,8 @@ static sigret_t AttacherChld __P(SIGPROTOARG);
+ static sigret_t AttachSigCont __P(SIGPROTOARG);
+ 
+ extern int real_uid, real_gid, eff_uid, eff_gid;
++extern int ServerSocket;
++extern struct display *displays;
+ extern char *SockName, *SockMatch, SockPath[];
+ extern char HostName[];
+ extern struct passwd *ppp;
+@@ -307,9 +309,9 @@ int how;
+       xseteuid(real_uid); /* multi_uid, allow backend to send signals */
+     }
+ #endif
++  eff_uid = real_uid;
+   if (setgid(real_gid))
+     Panic(errno, "setgid");
+-  eff_uid = real_uid;
+   eff_gid = real_gid;
+ 
+   debug2("Attach: uid %d euid %d\n", (int)getuid(), (int)geteuid());
+@@ -737,6 +739,8 @@ LockTerminal()
+       if ((pid = fork()) == 0)
+         {
+           /* Child */
++          displays = 0;		/* beware of Panic() */
++          ServerSocket = -1;
+           if (setgid(real_gid))
+             Panic(errno, "setgid");
+ #ifdef MULTIUSER
+--- display.c
++++ display.c
+@@ -102,6 +102,7 @@ extern struct winsize glwz;
+ #endif
+ extern char **NewEnv;
+ extern int real_uid, real_gid;
++extern int ServerSocket, eff_uid, eff_gid;
+ #endif
+ 
+ /*
+@@ -3997,11 +3998,14 @@ char **cmdv;
+       return;
+     case 0:
+       displays = 0;
++      ServerSocket = -1;
+ #ifdef SIGPIPE
+       signal(SIGPIPE, SIG_DFL);
+ #endif
+       if (setgid(real_gid) || setuid(real_uid))
+         Panic(errno, "setuid/setgid");
++      eff_uid = real_uid;
++      eff_gid = real_gid;
+       brktty(D_userfd);
+       freetty();
+ #ifdef DEBUG
+--- fileio.c
++++ fileio.c
+@@ -42,6 +42,7 @@
+ extern struct display *display, *displays;
+ extern struct win *fore;
+ extern struct layer *flayer;
++extern int ServerSocket;
+ extern int real_uid, eff_uid;
+ extern int real_gid, eff_gid;
+ extern char *extra_incap, *extra_outcap;
+@@ -704,7 +705,7 @@ int printpipe(struct win *p, char *cmd) {
+     case 0:
+       display = p->w_pdisplay;
+       displays = 0;
+-
++      ServerSocket = -1;
+ #ifdef DEBUG
+       if (dfp && dfp != stderr)
+         fclose(dfp);
+@@ -714,6 +715,8 @@ int printpipe(struct win *p, char *cmd) {
+       closeallfiles(0);
+       if (setgid(real_gid) || setuid(real_uid))
+         Panic(errno, "printpipe setuid");
++      eff_uid = real_uid;
++      eff_gid = real_gid;
+ 
+ #ifdef SIGPIPE
+       signal(SIGPIPE, SIG_DFL);
+@@ -741,6 +744,7 @@ int readpipe(char **cmdv) {
+     return -1;
+   case 0:
+     displays = 0;
++    ServerSocket = -1;
+ #ifdef DEBUG
+     if (dfp && dfp != stderr)
+       fclose(dfp);
+@@ -756,6 +760,8 @@ int readpipe(char **cmdv) {
+       close(1);
+       Panic(errno, "setuid/setgid");
+     }
++    eff_uid = real_uid;
++    eff_gid = real_gid;
+ #ifdef SIGPIPE
+     signal(SIGPIPE, SIG_DFL);
+ #endif
+--- window.c
++++ window.c
+@@ -55,6 +55,7 @@ extern char *screenlogfile;
+ extern char HostName[];
+ extern int TtyMode;
+ extern int SilenceWait;
++extern int ServerSocket;
+ extern int real_uid, real_gid, eff_uid, eff_gid;
+ extern char Termcap[];
+ extern char **NewEnv;
+@@ -1253,6 +1254,7 @@ char **args, *ttyn;
+     {
+     case -1:
+       Msg(errno, "fork");
++      close(slave);
+       break;
+     case 0:
+       signal(SIGHUP, SIG_DFL);
+@@ -1271,6 +1273,7 @@ char **args, *ttyn;
+ #endif
+ 
+       displays = 0;		/* beware of Panic() */
++      ServerSocket = -1;
+       if (setgid(real_gid) || setuid(real_uid))
+ 	Panic(errno, "Setuid/gid");
+       eff_uid = real_uid;


### PR DESCRIPTION
Screen creates invalid TERMCAP entries for full featured terminals
like xterm-256color.  Adds patch to limit the size of TERMCAP
to 1023 characters by skipping some function keys but keeping
important navigation keys.

Screen currently fails to run blanker when suid root.  Adds patch
to correctly prepare the PTY before running the blanker.  Also
allows errors to be displayed when blanker is blocking the display.

When screen fails in a child process and is suid root, the Panic
message isn't sent as the Panic process also Panics.  Adds patch
to correctly set the internal effective uid so that error messages
are sent to the parent.  Also fixes children to not remove the
screen socket when they Panic.

I've submitted all patches upstream, but it appears the maintainers
don't often push new screen releases.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Adds patches to limit the TERMCAP size to fix errors like:
"TERMCAP", line 20, col 1, terminal 'SC': Missing separator 
displayed when an ncurses5 program (eg /usr/bin/man, /bin/ls) is run and no screen.<TERM> is available in /usr/share/terminfo or ~/.terminfo

Adds patch to fix the blanker program (correct pty permissions), and adds another patch so that when it fails, the error is correctly displayed and the screen socket isn't removed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
