### PR TITLE
tor-devel: update to 0.4.0.1-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.3.5.6-rc
+version             0.4.0.1-alpha
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  9dcc58e39f775d075c993c6e1a4a5b651184104f \
-                    sha256  a77e2d3845fdd15ccf3294c665542acb0159e20ff0cb381301892a8fecd70981 \
-                    size    6917906
+checksums           rmd160  f680570e89c3dbe183754aea8255eccb474bd3de \
+                    sha256  7cff261f41f29ba951e422757e694b1319c9e989182bd6e580a9c6ac71a71ad0 \
+                    size    7087989
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.0.1-alpha

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.13.6 17G5014
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?