### PR TITLE
libuv: peg at 1.24.1 for < 10.7

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -60,26 +60,37 @@ depends_build       port:automake \
                     port:libtool \
                     port:pkgconfig
 
-platform darwin 8 {
+platform darwin {
+    # peg version 1.24.1 for 10.5 and 10.6
+    # see https://trac.macports.org/ticket/57926
+    if { ${os.major} == 9 || ${os.major} == 10 } {
+        github.setup    libuv libuv 1.24.1 v
+        checksums       rmd160 9f059f60d7350aa203f7864e3ccc685ef7da6f5e \
+                        sha256 838e167bef01136adda06cff9243c1c991607fe0d4220d6a7d042933d23d64a6 \
+                        size   1204246
+        revision        0
+    }
 
-    # pegged version with patches for Tiger, updated occasionally
+    if { ${os.major} == 8 } {
+        # pegged version with patches for Tiger, updated occasionally
+        github.setup    libuv libuv 1.24.0 v
+        checksums       rmd160 4dae1e3af9188c0bb49380f304a75db7bf360f08 \
+                        sha256 b3a627b5a4f98edcac8e11adc92f5d21a04a82b363e625f3a7675615d57a34a7 \
+                        size   1201804
+        revision        0
 
-    github.setup    libuv libuv 1.24.0 v
-    checksums       rmd160 4dae1e3af9188c0bb49380f304a75db7bf360f08 \
-                    sha256 b3a627b5a4f98edcac8e11adc92f5d21a04a82b363e625f3a7675615d57a34a7 \
-                    size   1201804
+        maintainers-prepend {kencu @kencu}
+        long_description  ${long_description} This version is pegged for Tiger and is updated occasionally. \
+                          Improvements are welcome if you can improve the test suite success (a few tests fail).
+        configure.cppflags-append -D__DARWIN_UNIX03
+        # prevent conflicting opentransport header from being pulled in
+        configure.cppflags-append -D__OPENTRANSPORTPROVIDERS__
 
-    maintainers-prepend {kencu @kencu}
-    long_description  ${long_description} This version is pegged for Tiger and is updated occasionally. \
-                      Improvements are welcome if you can improve the test suite success (a few tests fail).
-    configure.cppflags-append -D__DARWIN_UNIX03
-    # prevent conflicting opentransport header from being pulled in
-    configure.cppflags-append -D__OPENTRANSPORTPROVIDERS__
-
-    # delete any patchfiles that may be added above later
-    # Tiger unified patch
-    patchfiles          patch-libuv-1-23-2-tiger.diff
-    # Tiger has no libutil
-    patchfiles-append   patch-makefile-am-no-libutil-on-Tiger.diff
+        # delete any patchfiles that may be added above later
+        # Tiger unified patch
+        patchfiles          patch-libuv-1-23-2-tiger.diff
+        # Tiger has no libutil
+        patchfiles-append   patch-makefile-am-no-libutil-on-Tiger.diff
+    }
 
 }


### PR DESCRIPTION
1.25.x changes to 10.7+ only API
closes: https://trac.macports.org/ticket/57926

[ci skip]