### PR TITLE
p5-tkx: demo improvements

### DIFF
--- a/perl/p5-tkx/Portfile
+++ b/perl/p5-tkx/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
 perl5.setup         Tkx 1.09
-revision            1
+revision            2
 
 platforms           darwin
 maintainers         {@chrstphrchvz gmx.us:chrischavez} {@mojca mojca} openmaintainer
@@ -20,9 +20,19 @@ checksums           rmd160  d9901b5c3c033a49003331ff04c9d152746edc2b \
                     size    28390
 
 if {${perl5.major} != ""} {
+
+    patchfiles 0001-tkx-ed-remove-tclCarbonProcesses-usage.patch
+
+    # Remove unusable demo script
+    # See https://trac.macports.org/ticket/57581
+    post-patch {
+        reinplace "s|tkx-prove||g" ${worksrcpath}/Makefile.PL
+    }
+
     depends_lib-append \
-                    port:tk \
-                    port:p${perl5.major}-tcl
+                    port:BWidget \
+                    port:p${perl5.major}-tcl \
+                    port:tk
 
     livecheck.type  none
 }

--- a/perl/p5-tkx/files/0001-tkx-ed-remove-tclCarbonProcesses-usage.patch
+++ b/perl/p5-tkx/files/0001-tkx-ed-remove-tclCarbonProcesses-usage.patch
@@ -1,0 +1,35 @@
+From 0d4440b8085149b34319783039d95673334cd63a Mon Sep 17 00:00:00 2001
+From: Christopher Chavez <chrischavez@gmx.us>
+Date: Fri, 18 Jan 2019 18:17:58 -0600
+Subject: [PATCH] tkx-ed: remove tclCarbonProcesses usage
+
+Recent Tk releases use Cocoa rather than Carbon,
+so CarbonCritLib no longer works.
+---
+ tkx-ed | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git tkx-ed tkx-ed
+index fc3cc74..3ee7097 100644
+--- tkx-ed
++++ tkx-ed
+@@ -20,16 +20,6 @@ if ($IS_AQUA) {
+     # The console can pop up unexpectedly from the tkkit
+     Tkx::catch("console hide");
+ 
+-    # Set the process name that is displayed in the Activity Monitor
+-    # and the Force Quit dialog
+-    eval {
+-        Tkx::package_require('tclCarbonProcesses');
+-        my $psn = Tkx::carbon__getCurrentProcess();
+-        Tkx::carbon__setFrontProcess($psn);
+-        Tkx::carbon__setProcessName($psn, $PROGNAME);
+-    };
+-    warn $@ if $@;
+-
+     Tkx::interp_alias("", "::tk::mac::OpenDocument", "", [\&load]);
+ }
+ 
+-- 
+2.17.2 (Apple Git-113)
+


### PR DESCRIPTION
Remove unusable `tkx-prove` demo

For `tkx-ed` demo:
 - Add `BWidget` dependency
 - Remove `tclCarbonProcesses` usage (patch has been submitted upstream: https://github.com/gisle/tkx/pull/6)

Fixes https://trac.macports.org/ticket/57581

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
