### PR TITLE
scala2.12: Update to 2.12.8

### DIFF
--- a/lang/scala2.12/Portfile
+++ b/lang/scala2.12/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup select 1.0
 
 name            scala2.12
-version         2.12.4
+version         2.12.8
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      lang java
 license         BSD
@@ -37,10 +37,11 @@ if {$subport == $name} {
 
     distname        scala-${version}
     extract.suffix  .tgz
-    checksums       md5    57a4c9a83712193a4f892224692657d9 \
-                    sha1   b5bb5555f8106e08b5344127179a11e51b632135 \
-                    rmd160 4b2ee8c3c35ffed14b0aef52789876019adee78d \
-                    sha256 9554a0ca31aa8701863e881281b1772370a87e993ce785bb24505f2431292a21
+    checksums       md5     037b9e65274a1d35583c0d671077a008 \
+                    sha1    8072c61ced542167281681cfb5c50f28a41b8ad1 \
+                    rmd160  5ce17c06e329e458f82327abb9be770bc1a39134 \
+                    sha256  440ea00c818fd88c5261dd85889711a9d1f7e6a39caa475fcf0583ab57db80a3 \
+                    size    20467943
 
     destroot {
         set man1dir ${sharedir}/man/man1
@@ -74,10 +75,11 @@ subport ${name}-docs {
     distname        scala-docs-${version}
     use_xz          yes
     extract.suffix  .txz
-    checksums       md5    bc247d4f4823f3758c88fa770de4eede \
-                    sha1   514a5284425ec92159614376b1511e24dc895971 \
-                    rmd160 539b5d548ea30ee5a4c14c14437e363ad13529a1 \
-                    sha256 477892c8bb7df996166a767037cc16feb67ec9810273fd47bf43fa1eee0597a8
+    checksums       md5     6913ee7300e34d41ab8faca7805cc329 \
+                    sha1    cb16a05391c04d4b992cb0f98aa134b66ba62327 \
+                    rmd160  d5227e1bb7ae6d1253668c3fe5c3b87aef4c2a80 \
+                    sha256  d3f791b2e4896759b71d3845461ea8d384cd206db7c513cfe12269c12b30c653 \
+                    size    55790656
 
     worksrcdir      scala-${version}
 


### PR DESCRIPTION
#### Description

I noticed that scala2.12 seemed out of date, so I tried my hand at updating it from 2.12.4 to 2.12.8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D39a
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->