### PR TITLE
openjdk8: update to 8u202

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,10 +3,10 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u192
-revision         1
+version          8u202
+revision         0
 
-set build        12
+set build        08
 set major        8
 
 subport openjdk10 {
@@ -52,9 +52,9 @@ homepage         https://adoptopenjdk.net/
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  625de009ff2a8a31d72774a863ae6dc6a17fbc96 \
-                 sha256  cde59e884c473c3be52400bfad14b3ea1d8c42c994649f064ef335a727a36594 \
-                 size    75821422
+    checksums    rmd160  5b31b2248693d5ad51d4930fb646e384aa84f84d \
+                 sha256  35e8f9b18f6c7b627dba13a4c6f45e6266552ccd7156043d92391443db0d60d6 \
+                 size    101955034
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -120,13 +120,6 @@ set destroot_target ${destroot}${target}
 destroot {
     xinstall -m 755 -d ${destroot_target}
     copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-# Workaround for https://github.com/AdoptOpenJDK/openjdk-build/issues/489
-if {${subport} eq "openjdk8"} {
-    post-destroot {
-        ln -s libfreetype.dylib.6 ${destroot_target}/Contents/Home/jre/lib/libfreetype.6.dylib
-    }
 }
 
 notes "


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u202.

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?