### PR TITLE
restic: Add restic  (backup software)

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/restic/restic 0.9.4 v
+categories          sysutils
+
+license             BSD
+maintainers         nomaintainer
+
+description         Fast, secure, efficient backup program.
+long_description    Restic is a program that does backups right. Its design goals are: Easy, Fast, Verifiable, Secure, Efficient and Free.
+
+homepage            https://restic.net/
+
+checksums           rmd160  05dde2739f3c2ed9109f1ece2e96008cec36ac2a \
+                    sha256  9198c43abd08b3a09ea59226282447316e13da579713dda2d81a28c37902d2c8 \
+                    size    26211387
+
+build.cmd           go run build.go
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -m 755 -d ${destroot}${docdir}
+    xinstall -m 644 -W ${worksrcpath} LICENSE README.rst ${destroot}${docdir}
+}


### PR DESCRIPTION
#### Description

Restic is a program that does backups right.

https://restic.net/

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix
- [x] submission

###### Tested on

macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

