### PR TITLE
fd: Update to 7.2.0

### DIFF
--- a/sysutils/fd/Portfile
+++ b/sysutils/fd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        sharkdp fd 7.0.0 v
+github.setup        sharkdp fd 7.2.0 v
 categories          sysutils
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -18,55 +18,57 @@ long_description    fd is a simple, fast and user-friendly alternative to find. 
                     for 80% of the use cases.
 
 checksums           fd-${version}.tar.gz \
-                    rmd160  5e44970aeef6b6b84b4f7975caef6a20a6bb8d31 \
-                    sha256  e6ba21e66a295b9fb69bfc9a361813b3c7d73b8d29dc819d37d21af750814ee9 \
-                    size    49655
+                    rmd160  34856cad2f7360e3613f8bcae1c950164c1f4f4b \
+                    sha256  1161adea1057e39f50dc17e8e09294464613a1a2c500f1667154a3f6e2ce9d2e \
+                    size    56870
 
 cargo.crates \
-    aho-corasick                     0.6.4  d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4 \
+    aho-corasick                     0.6.6  c1c6d463cbe7ed28720b5b489e7c083eeb8f90d08be2a0d6bb9e1ffea9ce1afa \
     ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
-    atty                             0.2.8  af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4 \
-    bitflags                         1.0.1  b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf \
-    bitflags                         0.9.1  4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5 \
-    cfg-if                           0.1.2  d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de \
-    clap                            2.31.1  5dc18f6f4005132120d9711636b32c46a233fad94df6217fa1d81c5e97a9f200 \
+    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
+    bitflags                         1.0.3  d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789 \
+    cc                              1.0.18  2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275 \
+    cfg-if                           0.1.5  0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3 \
+    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
     crossbeam                        0.3.2  24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19 \
-    ctrlc                            3.1.0  653abc99aa905f693d89df4797fadc08085baee379db92be9f2496cefe8a6f2c \
+    ctrlc                            3.1.1  630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e \
     diff                            0.1.11  3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a \
+    filetime                         0.2.1  da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f \
     fnv                              1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
     fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
     fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    globset                          0.3.0  1e96ab92362c06811385ae9a34d2698e8a1160745e0c78fbb434a44c8de3fabc \
-    ignore                           0.4.1  245bea0ba52531a3739cb8ba99f8689eda13d7faf8c36b6a73ce4421aab42588 \
+    globset                          0.4.1  8e49edbcc9c7fc5beb8c0a54e7319ff8bed353a2b55e85811c6281188c2a6c84 \
+    humantime                        1.1.1  0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e \
+    ignore                           0.4.3  3e9faa7c84064f07b40da27044af629f578bc7994b650d3e458d0c29183c1d91 \
     kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
-    lazy_static                      1.0.0  c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d \
-    libc                            0.2.39  f54263ad99207254cf58b5f701ecb432c717445ea2ee8af387334bdd1a03fdff \
-    log                              0.4.1  89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2 \
+    lazy_static                      1.1.0  ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7 \
+    libc                            0.2.43  76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d \
+    log                              0.4.4  cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2 \
     memchr                           2.0.1  796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d \
-    nix                              0.9.0  a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32 \
+    nix                             0.11.0  d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17 \
     num_cpus                         1.8.0  c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30 \
-    rand                             0.4.2  eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5 \
-    redox_syscall                   0.1.37  0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd \
+    quick-error                      1.2.2  9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0 \
+    rand                             0.4.3  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
+    redox_syscall                   0.1.40  c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1 \
     redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                            0.2.8  0a33e44e4f5dbeb5619910f68b874d85b01e15f86fa7bb0fbc41bbd148883a48 \
-    regex-syntax                     0.5.2  d8337992c33b62cf49462a1ce4d0eedbb021f48de017e40ec307cca445df0ca9 \
-    remove_dir_all                   0.3.0  b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5 \
+    regex                            1.0.2  5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814 \
+    regex-syntax                     0.6.2  747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d \
+    remove_dir_all                   0.5.1  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
     same-file                        1.0.2  cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637 \
     strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
-    tempdir                          0.3.6  f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e \
+    tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
     term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
     termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
-    textwrap                         0.9.0  c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693 \
-    thread_local                     0.3.5  279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963 \
+    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+    thread_local                     0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
     ucd-util                         0.1.1  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
-    unicode-width                    0.1.4  bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f \
-    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
     utf8-ranges                      1.0.0  662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122 \
-    vec_map                          0.8.0  887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c \
-    version_check                    0.1.3  6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    version_check                    0.1.4  7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051 \
     void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    walkdir                          2.1.4  63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369 \
-    winapi                           0.3.4  04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3 \
+    walkdir                          2.2.0  f1b768ba943161a9226ccd59b26bcd901e5d60e6061f4fcad3034784e0c7372b \
+    winapi                           0.3.5  773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd \
     winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
     winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D39a
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->