### PR TITLE
py-mayavi:  fix patch location

### DIFF
--- a/python/py-mayavi/Portfile
+++ b/python/py-mayavi/Portfile
@@ -22,11 +22,7 @@ checksums           rmd160  e1228d368978b5abde4ee4946306b82e3431e087 \
     size    9051159
 
 python.versions     27 35 36 37
-
-# https://github.com/enthought/mayavi/issues/652
-post-patch {
-    reinplace "/vtk/d" ${worksrcpath}/mayavi/__init__.py
-}
+python.default_version      36
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \
@@ -40,6 +36,9 @@ if {${name} ne ${subport}} {
     require_active_variants vtk python${python.version}
     
     post-patch {
+        # https://github.com/enthought/mayavi/issues/652
+        reinplace "/vtk/d" ${worksrcpath}/mayavi/__init__.py
+        
         reinplace "s|sphinx-build|sphinx-build-${python.branch}|g" \
             ${worksrcpath}/docs/Makefile \
             ${worksrcpath}/docs/MakefileMayavi \


### PR DESCRIPTION
* move a post-patch block to be within subport block
* add default subport version

Closes:  https://trac.macports.org/ticket/57932

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1710
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
