### PR TITLE
carthage: Change maintainer to me

### DIFF
--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -10,7 +10,7 @@ platforms           darwin
 
 universal_variant   no
 license             MIT
-maintainers         {sean @seanfarley} openmaintainer
+maintainers         {saagarjha.com:saagarjha @saagarjha} openmaintainer
 
 description         A simple, decentralized dependency manager for Cocoa
 long_description    ${description}


### PR DESCRIPTION
#### Description

@seanfarley seemed like he didn't want to maintain this anymore (https://github.com/macports/macports-ports/pull/3468#issuecomment-455994680), so I thought I'd take over maintaining the port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->