### PR TITLE
[WIP] GraphicsMagick: Enable OpenMP support.

### DIFF
--- a/graphics/GraphicsMagick/Portfile
+++ b/graphics/GraphicsMagick/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 
 name                    GraphicsMagick
 version                 1.3.31
+revision                1
 checksums               rmd160  55f4448820f8b24f2d50f989775cc263490451fd \
                         sha256  096bbb59d6f3abd32b562fc3b34ea90d88741dc5dd888731d61d17e100394278 \
                         size    5547684
@@ -38,12 +39,15 @@ depends_lib             port:libxml2 \
                         port:lcms2 \
                         port:jasper \
                         port:jpeg \
-                        port:webp
+                        port:webp \
+                        path:lib/libomp/libomp.dylib:libomp
 
 use_xz                  yes
 
 # llvm-gcc-4.2 gives "Undefined symbols for architecture x86_64: ___builtin_object_size"
-compiler.blacklist      *llvm-gcc-4.2
+# OpenMP is very beneficial for GM: http://www.graphicsmagick.org/OpenMP.html
+# (mp-clang.3.[8..] support openmp)
+configure.compiler      macports-clang-7.0
 
 configure.args          --with-jbig=no \
                         --with-jpeg=yes \
@@ -65,7 +69,8 @@ configure.args          --with-jbig=no \
                         --with-ttf=yes \
                         --with-webp=yes \
                         --without-umem \
-                        --enable-shared=yes
+                        --enable-shared=yes \
+                        --enable-openmp
 
 use_parallel_build      yes
 


### PR DESCRIPTION
#### Description

Just seeing if anyone is interested in having this setup. I've been running it for years (with various clang versions, obviously) ... if we want to support OpenMP, I would suggest having it be the default (a variant could be added to disable it if needed) such that it can be built on the bots and most users wouldn't need to install MP's toolchain.

Similar changes could be applied to imagemagick to enable its OpenMP, which there are a few tickets for...

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?  (It fails 6 tests, but the standard build does, too; haven't tracked down.)
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->