### PR TITLE
gitlab-runner: update to 11.7.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.6.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 11.7.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  f33298dad6418d64f3e124a4452af4b773135f5f \
-                    sha256  4a30f114e44dc79804d76c2036cc89d9808a9d8de1c8fda60008879c86e09826 \
-                    size    25747817
+checksums           rmd160  28db5e5ec84dff00bb27c7d93b82e3ebd7009186 \
+                    sha256  ba5726feef52b302b3bf6f38a1a9eeb9d957cf54ec7b45a9774518ecc5995523 \
+                    size    25771756
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 11.7.0.

###### Tested on

macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?