### PR TITLE
wireguard-tools: update to 0.0.20190123

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,13 +3,8 @@
 PortSystem          1.0
 
 name                wireguard-tools
-# please only update the version when the tools (in "src/tools") have
-# been modified/updated (git commit messages starting with "tools:").
-#
-# the WireGuard repository and its updates primarily deals with the
-# Linux kernel module, which isn't useful or relevant for macOS (we're
-# just interested in its tools for manipulating WireGuard interfaces).
-version             0.0.20181218
+version             0.0.20190123
+revision            0
 categories          net
 platforms           darwin
 license             GPL-2
@@ -27,9 +22,9 @@ master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
 
-checksums           rmd160  e116fa54019d92364986c1e321c226d352f885a2 \
-                    sha256  2e9f86acefa49dbfb7fa6f5e10d543f1885a2d5460cd5e102696901107675735 \
-                    size    318496
+checksums           rmd160  cfcfe52aec93a042129c0dabfdbaff2a0e10e95a \
+                    sha256  edd13c7631af169e3838621b1a1bff3ef73cf7bc778eec2bd55f7c1089ffdf9b \
+                    size    323052
 
 depends_run         port:bash \
                     port:wireguard-go


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G4015
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?