### PR TITLE
openjdk11: update to 11.0.2

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -18,10 +18,10 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.1
-    revision     3
+    version      11.0.2
+    revision     0
 
-    set build    13
+    set build    7
     set major    11
 }
 
@@ -85,9 +85,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  e579e79d76ba1692a1ac5ea59ea0ffa9a3a1daa3 \
-                 sha256  e219e7e2d586ed09ae65f4ec390fca5d5f0c37a61b47677648610194daf1aaa7 \
-                 size    189911499
+    checksums    rmd160  d660157fc7e9aec42eeb786eab24a1a961522c34 \
+                 sha256  c52dd6e34b5a0521e41715d4fe4fd7ba071a5fed7035e7348844e88b37480448 \
+                 size    189828178
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.2.

###### Tested on

macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?