### PR TITLE
mplayer: add note about fonts to +osd variant

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -130,6 +130,14 @@ variant osd \
     configure.args-delete   --disable-fontconfig
     configure.args-delete   --disable-freetype
     configure.args-append   --enable-menu
+    notes-append "
+       To use the osd variant, you may need to specify a font:
+         1. open mplayer at least once, to create ~/.mplayer/config
+         2. edit ~/.mplayer/config to add a reference to your desired font
+         3. to do this, add a line like the following to  ~/.mplayer/config
+         4. font = /Library/Fonts/Arial.ttf
+         5. your font should now be used on the next launch
+    "
 }
 
 variant fribidi requires osd \


### PR DESCRIPTION
it is sometimes required to specify a font for
this variant to work properly

- [x] enhancement
