### PR TITLE
New Portfile py-gpstime

### DIFF
--- a/python/py-gpstime/Portfile
+++ b/python/py-gpstime/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-gpstime
+version             0.3.2
+
+platforms           darwin
+supported_archs     noarch
+license             GPL-3
+maintainers         {gmail.com:stefan.countryman @stefco} openmaintainer
+
+description         GPS-aware datetime module with leap-second fetching
+long_description    This package provides a gpstime package, including a \
+                    gpstime subclass of the built-in datetime class with the \
+                    addition of GPS access and conversion methods.  Leap \
+                    second data is provided by the ietf_leap_seconds module \
+                    that helps automatically maintain a local copy of the \
+                    IETF leap second list: \
+                    https://www.ietf.org/timezones/data/leap-seconds.list \
+                    A command-line GPS data conversion utility that uses the \
+                    gpstime module is also included.  It is a rough \
+                    work-alike to tconvert.
+
+homepage            https://git.ligo.org/cds/${python.rootname}
+
+master_sites        https://git.ligo.org/cds/${python.rootname}/-/archive/${version}/
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  d62957cd15570ce24e5e17d5fe6d587777698809 \
+                    sha256  b303807ba1e6a93f1ee1d47f36c014f2580348dd5045dd0cb28c1a59a0d700aa \
+                    size    23900
+
+python.versions     35 36 37
+
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-dateutil \
+                        port:py${python.version}-requests
+    livecheck.type  none
+} else {
+    livecheck.type      regex
+    livecheck.url       https://git.ligo.org/api/v4/projects/cds%2Fgpstime/repository/tags?sort=asc
+    livecheck.regex     {"([0-9]\.[0-9]+\.[0-9]+)"}
+}


### PR DESCRIPTION

#### Description

Added `py-gpstime`, a [GPS-aware Python datetime module](https://git.ligo.org/cds/gpstime/) maintained by the Laser Interferometer Gravitational Wave Observatory (LIGO) that is useful for translating between GPS times and other time formats recognized by the python `datetime` module.

This package provides a gpstime package, including a gpstime subclass
of the built-in datetime class with the addition of GPS access and
conversion methods.

Leap second data is provided by the ietf_leap_seconds module that
helps automatically maintain a local copy of the IETF leap second
list:

https://www.ietf.org/timezones/data/leap-seconds.list

A command-line GPS data conversion utility that uses the gpstime
module is also included.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.0 10A255

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
~- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~ **NA**
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->