### PR TITLE
p5-encode: add missing static function definition

### DIFF
--- a/perl/p5-encode/Portfile
+++ b/perl/p5-encode/Portfile
@@ -18,3 +18,12 @@ checksums           rmd160  c92b178274de861a5f48146718bd17a505a7c6fb \
                     size    2053762
 
 perl5.link_binaries no
+
+
+# on < 10.6:
+#/Encode/encode.h:488:1: error: static declaration of 'S_is_utf8_overlong_given_start_byte_ok' follows non-static declaration
+#S_is_utf8_overlong_given_start_byte_ok(const U8 * const s, const STRLEN len)
+
+if {${perl5.major} != ""} {
+    patchfiles p5-Encode-add-static-defn.diff
+}

--- a/perl/p5-encode/files/p5-Encode-add-static-defn.diff
+++ b/perl/p5-encode/files/p5-Encode-add-static-defn.diff
@@ -1,0 +1,14 @@
+diff --git Encode/encode.h Encode/encode.h
+index 8de56eb..3510b50 100644
+--- Encode/encode.h
++++ Encode/encode.h
+@@ -371,6 +371,9 @@ S_unexpected_non_continuation_text(const U8 * const s,
+                            (int) non_cont_byte_pos);
+ }
+ 
++static int
++S_is_utf8_overlong_given_start_byte_ok(const U8 * const s, const STRLEN len);
++
+ static int
+ S_does_utf8_overflow(const U8 * const s,
+                        const U8 * e,


### PR DESCRIPTION
this error shows up on < 10.6, even building with clang
adding  the missing function definition before it's first use
fixes the build

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4 PPC, 10.5 PPC, 10.5 Intel
Xcode 2.5 - 3.2
