### PR TITLE
submission flashrom: universal flash programming utility

### DIFF
--- a/sysutils/flashrom/Portfile
+++ b/sysutils/flashrom/Portfile
@@ -30,6 +30,9 @@ depends_lib         port:libftdi0 \
                     port:libusb-compat
 
 use_configure       no
+build.args-append   CC=${configure.cc} \
+                    CXX=${configure.cxx} \
+                    CPP=${configure.cpp}
 
 build.env           CONFIG_GFXNVIDIA=0 \
                     CONFIG_NIC3COM=0 \

--- a/sysutils/flashrom/Portfile
+++ b/sysutils/flashrom/Portfile
@@ -7,7 +7,7 @@ version             1.0
 categories          sysutils
 platforms           darwin
 license             GPL-2
-maintainers         ra1nb0w openmaintainer
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
 description         universal flash programming utility
 long_description    utility for identifying, reading, writing, verifying and erasing flash chips.\
                     It is designed to flash BIOS/EFI/coreboot/firmware/optionROM images on \
@@ -27,8 +27,7 @@ patchfiles          patch-libusb_set_debug-deprecated.diff
 depends_build       port:pkgconfig
 
 depends_lib         port:libftdi0 \
-                    port:libusb-compat \
-                    port:libusb
+                    port:libusb-compat
 
 use_configure       no
 

--- a/sysutils/flashrom/Portfile
+++ b/sysutils/flashrom/Portfile
@@ -52,7 +52,7 @@ destroot.env        [option build.env]
 
 pre-build {
     reinplace "s|sbin|bin|g" ${worksrcpath}/Makefile
-    reinplace "s|/usr/local|/opt/local|g" ${worksrcpath}/Makefile
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile
 }
 
 test.run            yes

--- a/sysutils/flashrom/Portfile
+++ b/sysutils/flashrom/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                flashrom
+version             1.0
+categories          sysutils
+platforms           darwin
+license             GPL-2
+maintainers         ra1nb0w openmaintainer
+description         universal flash programming utility
+long_description    utility for identifying, reading, writing, verifying and erasing flash chips.\
+                    It is designed to flash BIOS/EFI/coreboot/firmware/optionROM images on \
+                    mainboards, network/graphics/storage controller cards, and various other \
+                    programmer devices.
+homepage            https://www.flashrom.org/Flashrom
+master_sites        https://download.flashrom.org/releases/
+use_bzip2           yes
+
+checksums           rmd160  b2e0c62d8a0ae592a6d84b69c5f5ea3283dcfefe \
+                    sha256  3702fa215ba5fb5af8e54c852d239899cfa1389194c1e51cb2a170c4dc9dee64 \
+                    size    321693
+
+# needed until next version
+patchfiles          patch-libusb_set_debug-deprecated.diff
+
+depends_build       port:pkgconfig
+
+depends_lib         port:libftdi0 \
+                    port:libusb-compat \
+                    port:libusb
+
+use_configure       no
+
+build.env           CONFIG_GFXNVIDIA=0 \
+                    CONFIG_NIC3COM=0 \
+                    CONFIG_NICREALTEK=0 \
+                    CONFIG_NICNATSEMI=0 \
+                    CONFIG_NICINTEL=0 \
+                    CONFIG_NICINTEL_SPI=0 \
+                    CONFIG_NICINTEL_EEPROM=0 \
+                    CONFIG_OGP_SPI=0 \
+                    CONFIG_SATAMV=0 \
+                    CONFIG_SATASII=0 \
+                    CONFIG_DRKAISER=0 \
+                    CONFIG_RAYER_SPI=0 \
+                    CONFIG_INTERNAL=0 \
+                    CONFIG_IT8212=0 \
+                    CONFIG_ATAHPT=0 \
+                    CONFIG_ATAVIA=0
+destroot.env        [option build.env]
+
+pre-build {
+    reinplace "s|sbin|bin|g" ${worksrcpath}/Makefile
+    reinplace "s|/usr/local|/opt/local|g" ${worksrcpath}/Makefile
+}
+
+test.run            yes
+test.cmd            ./flashrom --version

--- a/sysutils/flashrom/files/patch-libusb_set_debug-deprecated.diff
+++ b/sysutils/flashrom/files/patch-libusb_set_debug-deprecated.diff
@@ -1,0 +1,35 @@
+From 291764a70e6d8b212680e311bfb0825abf2b9a2f Mon Sep 17 00:00:00 2001
+From: Alex James <theracermaster@gmail.com>
+Date: Sat, 14 Apr 2018 22:59:57 -0500
+Subject: [PATCH] ch341a_spi: Avoid deprecated libusb functions
+
+libusb 1.0.22 marked libusb_set_debug as deprecated. For such versions
+of libusb, use libusb_set_option instead.
+
+Change-Id: Ib71ebe812316eaf49136979a942a946ef9e4d487
+Signed-off-by: Alex James <theracermaster@gmail.com>
+Reviewed-on: https://review.coreboot.org/25681
+Tested-by: Nico Huber <nico.h@gmx.de>
+Reviewed-by: David Hendricks <david.hendricks@gmail.com>
+---
+ ch341a_spi.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/ch341a_spi.c b/ch341a_spi.c
+index 95e9c9577..ee18624ea 100644
+--- ch341a_spi.c
++++ ch341a_spi.c
+@@ -441,7 +441,12 @@ int ch341a_spi_init(void)
+ 		return -1;
+ 	}
+ 
+-	libusb_set_debug(NULL, 3); // Enable information, warning and error messages (only).
++	/* Enable information, warning, and error messages (only). */
++#if LIBUSB_API_VERSION < 0x01000106
++	libusb_set_debug(NULL, 3);
++#else
++	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
++#endif
+ 
+ 	uint16_t vid = devs_ch341a_spi[0].vendor_id;
+ 	uint16_t pid = devs_ch341a_spi[0].device_id;


### PR DESCRIPTION
flashrom is a utility for identifying, reading, writing, verifying and
erasing flash chips.

The patch is needed because libusb 1.0.22 marked libusb_set_debug
as deprecated. With the next release could be deleted.

Tested with buspirate on
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Type(s)

- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
