### PR TITLE
py-dateutil: update to 2.7.5

### DIFF
--- a/python/py-dateutil/Portfile
+++ b/python/py-dateutil/Portfile
@@ -4,38 +4,44 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-dateutil
-version             2.7.3
+python.rootname     python-dateutil
+version             2.7.5
+revision            0
 platforms           darwin
 supported_archs     noarch
 license             BSD
 maintainers         nomaintainer
 
-python.rootname     python-dateutil
-set _n              [string index ${python.rootname} 0]
-
 description         Extensions to the standard Python datetime module
 long_description    The dateutil module provides powerful extensions \
                     to the datetime module available in the Python \
                     standard library.
-homepage            https://pypi.python.org/pypi/${python.rootname}
+homepage            https://github.com/dateutil/dateutil/
 
-master_sites        pypi:${_n}/${python.rootname}/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
 distname            ${python.rootname}-${version}
-checksums           rmd160  1e5686291037033d17519cabf138cfcfdf507d5f \
-                    sha256  e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8 \
-                    size    302871
+checksums           rmd160  50fbd5d6bfc873b2b1d020b3bc78b3307da0938b \
+                    sha256  88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02 \
+                    size    316043
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build       port:py${python.version}-setuptools \
-                        port:py${python.version}-setuptools_scm
-    depends_run         path:${python.pkgd}/pytz:py${python.version}-tz
-    depends_lib-append  port:py${python.version}-six
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
+    depends_run-append \
+                    path:${python.pkgd}/pytz:py${python.version}-tz
+    depends_lib-append \
+                    port:py${python.version}-six
 
+    depends_test-append \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-freezegun \
+                    port:py${python.version}-mock
     test.run        yes
-    test.cmd        ${python.bin} setup.py
-    test.target     test
+    test.cmd        py.test-${python.branch}
+    test.target
     test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
@@ -47,6 +53,4 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type  none
-} else {
-    livecheck.name  ${python.rootname}
 }


### PR DESCRIPTION
#### Description
- update to latest version
- update tests that now use pytest
- update homepage
- make use of python.rootname

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61
Python 2.7, 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
