### PR TITLE
stlink: update to version 1.5.1

### DIFF
--- a/cross/stlink/Portfile
+++ b/cross/stlink/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        texane stlink 1.3.0
+github.setup        texane stlink 1.5.1 v
+
 categories          cross devel
 license             BSD
 maintainers         nomaintainer
@@ -14,8 +15,9 @@ description         Stlink Tools Texane
 long_description    Open source version of the STMicroelectronics Stlink Tools. \
                     Provides the following tools: st-flash, st-info, st-term, st-util.
 
-checksums           rmd160  1fffecc282c328e1a3b493f0ff49830f83af5afa \
-                    sha256  2c392d3005f6b3059c4e4e11a1eaf2451d41130de2c7dac9192d3a8dd61c4eb5
+checksums           rmd160  6f4011b750810d25facfb5444542ea530e14dccf \
+                    sha256  470168e427325df6d0903b37cbdee6c28186c578115f843bae945396b4b38b90 \
+                    size    190237
 
 depends_lib-append  path:lib/libusb-1.0.dylib:libusb
 

--- a/cross/stlink/files/patch-cmake-modules-FindLibUSB.cmake.diff
+++ b/cross/stlink/files/patch-cmake-modules-FindLibUSB.cmake.diff
@@ -1,6 +1,6 @@
---- cmake/modules/FindLibUSB.cmake.orig	2017-01-28 04:55:48.000000000 -0600
-+++ cmake/modules/FindLibUSB.cmake	2017-02-05 20:44:46.000000000 -0600
-@@ -45,7 +45,7 @@
+--- cmake/modules/FindLibUSB.cmake.orig	2019-01-26 11:30:24.000000000 -0600
++++ cmake/modules/FindLibUSB.cmake	2019-01-26 11:30:34.000000000 -0600
+@@ -23,7 +23,7 @@
  endif()
  
  if (APPLE)
@@ -8,4 +8,4 @@
 +	set(LIBUSB_NAME libusb-1.0.dylib)
  elseif(MSYS OR MINGW)
  	set(LIBUSB_NAME usb-1.0)
- elseif(WIN32 OR CMAKE_VS_PLATFORM_NAME)
+ elseif(MSVC)

--- a/cross/stlink/files/patch-src-logging.c.diff
+++ b/cross/stlink/files/patch-src-logging.c.diff
@@ -1,6 +1,17 @@
---- src/logging.c.orig	2017-01-28 11:55:48.000000000 +0100
-+++ src/logging.c	2017-02-03 00:12:16.000000000 +0100
-@@ -30,25 +30,25 @@
+--- src/logging.c.orig	2019-01-26 11:28:32.000000000 -0600
++++ src/logging.c	2019-01-26 11:42:55.000000000 -0600
+@@ -18,7 +18,10 @@
+     return 0;
+ }
+ 
++#define UNUSED(x) (void)(x)
++
+ int ugly_log(int level, const char *tag, const char *format, ...) {
++    UNUSED(tag);
+     if (level > max_level) {
+         return 0;
+     }
+@@ -30,19 +33,19 @@
      fprintf(stderr, "%d-%02d-%02dT%02d:%02d:%02d ", tt->tm_year + 1900, tt->tm_mon + 1, tt->tm_mday, tt->tm_hour, tt->tm_min, tt->tm_sec);
      switch (level) {
      case UDEBUG:
@@ -18,13 +29,6 @@
      case UERROR:
 -        fprintf(stderr, "ERROR %s: ", tag);
 +        fprintf(stderr, "ERROR: ");
-         break;
-     case UFATAL:
--        fprintf(stderr, "FATAL %s: ", tag);
-+        fprintf(stderr, "FATAL: ");
-         vfprintf(stderr, format, args);
-         exit(EXIT_FAILURE);
-         // NEVER GETS HERE!!!
          break;
      default:
 -        fprintf(stderr, "%d %s: ", level, tag);


### PR DESCRIPTION

#### Description

* update to version 1.5.1
* change github parameters to fetch correct source tarball
* redo patches

I redid the two patches since the patched code has moved. One of the patches removes paths from source code logging, as mentioned in https://trac.macports.org/ticket/53474. Simply reapplying this patch resulted in a unused parameter warning/error, so I add a macro to artificially use the unused parameter. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
