### PR TITLE
bzflag: update to 2.4.18

### DIFF
--- a/games/bzflag/Portfile
+++ b/games/bzflag/Portfile
@@ -5,8 +5,7 @@ PortGroup           app 1.0
 PortGroup           cxx11 1.1
 
 name                bzflag
-version             2.4.14
-revision            1
+version             2.4.18
 categories          games
 platforms           darwin
 maintainers         {allejo.io:me @allejo} openmaintainer
@@ -20,13 +19,14 @@ homepage            https://www.bzflag.org/
 master_sites        https://download.bzflag.org/bzflag/source/${version}/
 use_bzip2           yes
 
-checksums           rmd160  4831f3915256fcb8c762acbd47bcc19afdaeb02c \
-                    sha256  09a46ec14cf956cb69fd069cee978de4dec321cb563036b16367ea8aae529bdc \
-                    size    14066129
+checksums           rmd160  b9116b75d749aaeec191d8c43613bd0e139b17ab \
+                    sha256  9d0d512f3a09a207ab399a8dc4807224564cdc7a9346b702fec80d5b7918bfbe \
+                    size    14011236
 
 depends_build       port:pkgconfig
 depends_lib         port:c-ares \
                     port:curl \
+                    port:glew \
                     port:libsdl2 \
                     port:ncurses \
                     port:zlib


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
