### PR TITLE
py-qtawesome: update to 0.5.6 ; py-pytest-qt: new port

### DIFF
--- a/python/py-pytest-qt/Portfile
+++ b/python/py-pytest-qt/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pytest-qt
+version             3.2.2
+categories-append   devel
+platforms           darwin
+license             MIT
+
+python.versions     27 34 35 36 37
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         pytest support for PyQt and PySide applications
+long_description    ${description}
+
+homepage            https://github.com/pytest-dev/pytest-qt
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  2076a4d3d069a626d8370d86dae6f0c5f5383bb0 \
+                    sha256  f6ecf4b38088ae1092cbd5beeaf714516d1f81f8938626a2eac546206cdfe7fa \
+                    size    114618
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-setuptools_scm
+
+    depends_lib-append      port:py${python.version}-pytest
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE CHANGELOG.rst \
+            README.rst ${destroot}${docdir}
+    }
+
+    livecheck.type      none
+}

--- a/python/py-qtawesome/Portfile
+++ b/python/py-qtawesome/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        spyder-ide qtawesome 0.5.5 v
+github.setup        spyder-ide qtawesome 0.5.6 v
 name                py-qtawesome
 
 license             MIT
@@ -16,9 +16,9 @@ description         Iconic Fonts in PyQt and PySide applications.
 long_description    QtAwesome enables iconic fonts such as Font Awesome and \
                     Elusive Icons in PyQt and PySide applications.
 
-checksums           rmd160  ee04a5cf5cb4b66b1258a6106e108a3b924bbe8d \
-                    sha256  d65843bb101c48811d37fee00505e6fb115dcf7e8bcaf5a939e3bec1f0257e4c \
-                    size    682421
+checksums           rmd160  6d938369e8ca3ba8705466b249b01400ef4a8f69 \
+                    sha256  a1196d40b9633298e01c9e4231f29041c996ebe94a6ff4e69ebaa5510f87cdf4 \
+                    size    683685
 
 python.versions     27 34 35 36 37
 
@@ -32,10 +32,12 @@ if {${name} ne ${subport}} {
     pre-test {
         reinplace "s|python|${python.bin}|g" ${worksrcpath}/qtawesome/tests/test_qtawesome.py
     }
-    depends_test-append     port:py${python.version}-pytest
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-pytest-qt
     test.run                yes
     test.cmd                py.test-${python.branch}
     test.target
+    test.env                PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description
- update py-qtawesome to its latest version
- add new port, which is a test dependency
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, for py-qtawesome.
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
