### PR TITLE
prosody: update to 0.11.2

### DIFF
--- a/net/prosody/Portfile
+++ b/net/prosody/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                prosody
-version             0.9.14
+version             0.11.2
 maintainers         {g5pw @g5pw} openmaintainer
 
 categories          net chat
@@ -16,7 +16,7 @@ long_description    ${description} It aims to be easy to set up and configure, \
 
 platforms           darwin
 
-homepage            http://prosody.im
+homepage            https://prosody.im
 license             MIT
 
 master_sites        ${homepage}/downloads/source/
@@ -24,11 +24,21 @@ master_sites        ${homepage}/downloads/source/
 depends_lib         port:lua-luasocket \
                     port:lua-luasec \
                     port:lua-luaexpat \
+                    port:lua-luafilesystem \
                     port:libidn
 
-checksums           rmd160  d0c671dda5f9b36e8da4d11c9603f886510e4a40 \
-                    sha256  27d1388acd79eaa453f2b194bd23c25121fe0a704d0dd940457caf1874ea1123 \
-                    size    268253
+checksums           rmd160  a27ba1b4ddd4511842cba45aeef7193b42c7ff17 \
+                    sha256  8911f6dc29b9e0c4edf9e61dc23fa22d77bc42c4caf28b809ab843b2f08e4831 \
+                    size    420689
+
+set logdir          ${prefix}/var/log/${name}
+set rundir          ${prefix}/var/run/${name}
+
+patchfiles          patch-config.diff
+
+post-patch {
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/prosody.cfg.lua.dist
+}
 
 configure.cflags-append  -fPIC
 configure.ldflags-append -bundle -undefined dynamic_lookup
@@ -42,6 +52,20 @@ configure.args-append \
                     --linker=${configure.cc} \
                     --cflags=\"${configure.cflags}\" \
                     --ldflags=\"${configure.ldflags}\"
+
+startupitem.create  yes
+startupitem.start   "${prefix}/bin/${name}ctl start"
+startupitem.stop    "${prefix}/bin/${name}ctl stop"
+startupitem.restart "${prefix}/bin/${name}ctl restart"
+startupitem.pidfile auto ${rundir}/prosody.pid
+
+add_users           ${name} group=${name} realname=Prosody\ Server
+
+destroot.keepdirs   ${destroot}${logdir} ${destroot}${rundir}
+
+post-destroot {
+    xinstall -o ${name} -g ${name} -d ${destroot}${logdir} ${destroot}${rundir}
+}
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/net/prosody/files/patch-config.diff
+++ b/net/prosody/files/patch-config.diff
@@ -1,0 +1,21 @@
+--- prosody.cfg.lua.dist.orig	2019-01-07 19:34:23.000000000 +0400
++++ prosody.cfg.lua.dist	2019-01-28 01:48:22.000000000 +0400
+@@ -16,6 +16,7 @@
+ ---------- Server-wide settings ----------
+ -- Settings in this section apply to the whole server and are the default settings
+ -- for any virtual hosts
++pidfile = "@@PREFIX@@/var/run/prosody/prosody.pid"
+ 
+ -- This is a (by default, empty) list of accounts that are admins
+ -- for the server. Note that you must create the accounts separately
+@@ -153,8 +154,8 @@
+ -- Logging configuration
+ -- For advanced logging see https://prosody.im/doc/logging
+ log = {
+-	info = "prosody.log"; -- Change 'info' to 'debug' for verbose logging
+-	error = "prosody.err";
++	info = "@@PREFIX@@/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
++	error = "@@PREFIX@@/var/log/prosody/prosody.err";
+ 	-- "*syslog"; -- Uncomment this for logging to syslog
+ 	-- "*console"; -- Log to the console, useful for debugging with daemonize=false
+ }


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/50684

I've added a `startupitem` which delegates to `prosodyctl` essentially, but it doesn't seem to actually start for me. `sudo prosodyctl start` works, but `sudo port load prosody` launches `daemondo` then chills. What it's supposed to do is launch `prosody` as the `prosody` user.

###### Tested on
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?