### PR TITLE
multiple ports and domain names: use HTTPS

### DIFF
--- a/databases/cdb/Portfile
+++ b/databases/cdb/Portfile
@@ -12,8 +12,8 @@ maintainers         nomaintainer
 categories          databases
 license             Restrictive
 platforms           darwin
-homepage            http://cr.yp.to/cdb.html
-master_sites        http://cr.yp.to/cdb/
+homepage            https://cr.yp.to/cdb.html
+master_sites        https://cr.yp.to/cdb/
 checksums           md5 81fed54d0bde51b147dd6c20cdb92d51
 configure           {
                         reinplace "s;/usr/local;${destroot}${prefix};" ${worksrcpath}/conf-home

--- a/databases/sqlite2/Portfile
+++ b/databases/sqlite2/Portfile
@@ -15,7 +15,7 @@ long_description	SQLite is an SQL database engine in a C library. \
 					command-line access program (sqlite) that can be used \
 					to administer an SQLite database and which serves as \
 					an example of how to use the SQLite library.
-homepage		http://www.sqlite.org/
+homepage		https://www.sqlite.org/
 master_sites	${homepage}
 distname		sqlite-${version}
 checksums		sha1 75db1cf3b00ea18ae8528e676fc9fdf698e2fe58

--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -21,7 +21,7 @@ long_description    SQLite3 is an SQL database engine in a C library. \
                     to administer an SQLite3 database and which serves as \
                     an example of how to use the SQLite3 library.
 
-homepage            http://www.sqlite.org/
+homepage            https://www.sqlite.org/
 master_sites        ${homepage}2018
 
 set padded_ver      [string range [subst [regsub -all {\.([0-9]+)} "${version}.0.0" {[format %02d \1]}]] 0 6]
@@ -44,7 +44,7 @@ configure.args      --enable-threadsafe \
 build.type          gnu
 
 livecheck.type      regex
-livecheck.url       http://www.sqlite.org/news.html
+livecheck.url       https://www.sqlite.org/news.html
 livecheck.regex     (3(?:\\.\[0-9\]+)+)
 
 platform darwin 8 {

--- a/devel/libowfat/Portfile
+++ b/devel/libowfat/Portfile
@@ -7,8 +7,8 @@ platforms		darwin
 maintainers		yoobay.net:daniel
 description		reimplementation of the libdjb under GPL
 long_description	reimplementation of the libdjb under GPL
-homepage		http://www.fefe.de/libowfat/
-master_sites		http://dl.fefe.de/
+homepage		https://www.fefe.de/libowfat/
+master_sites		https://dl.fefe.de/
 checksums		md5     6bbee9a86506419657d87123b7a6f2c1 \
 			sha1    6bbe997ae1bbe94b784ab50a3d44b63a2e08d857 \
 			rmd160  3e8826e10a3f46520bdfa9602edb2741728aa370

--- a/devel/tclsqlite2/Portfile
+++ b/devel/tclsqlite2/Portfile
@@ -9,7 +9,7 @@ maintainers	nomaintainer
 description	TCL bindings for the SQLite embedded database engine
 long_description	TCL bindings for the SQLite embedded database engine. \
 			This port contains bindings for sqlite 2.x.
-homepage	http://www.sqlite.org/
+homepage	https://www.sqlite.org/
 master_sites	${homepage}
 checksums	sha1 75db1cf3b00ea18ae8528e676fc9fdf698e2fe58
 distname	sqlite-${version}

--- a/lang/lemon/Portfile
+++ b/lang/lemon/Portfile
@@ -10,8 +10,8 @@ license             public-domain
 description         An LALR(1) parser generator like yacc or bison.
 long_description    ${description}
 
-homepage            http://www.hwaci.com/sw/lemon/
-master_sites        http://people.FreeBSD.org/~seanc/ports/lemon/ \
+homepage            https://www.hwaci.com/sw/lemon/
+master_sites        https://people.FreeBSD.org/~seanc/ports/lemon/ \
                     freebsd
 checksums           sha1    0baa13c54d437b21ccf802792e4ef081e5af3348 \
                     rmd160  fe09fb8862467da6e20090bbab18d0fb1971cfbc \
@@ -34,5 +34,5 @@ destroot {
 }
 
 livecheck.type      moddate
-livecheck.url       http://www.sqlite.org/cvstrac/getfile/sqlite/tool/lemon.c
+livecheck.url       https://www.sqlite.org/cvstrac/getfile/sqlite/tool/lemon.c
 

--- a/mail/qmail-spamcontrol/Portfile
+++ b/mail/qmail-spamcontrol/Portfile
@@ -21,12 +21,11 @@ variant noverp description {Do not alow VERP addresses for recipients} {}
 variant moreipme description {Patch to account for certain NAT or load balance situations} {}
 variant bigtodo description {May make very large installations more efficient} {}
 
-homepage			http://www.fehcom.de/qmail/spamcontrol.html
+homepage			https://www.fehcom.de/qmail/spamcontrol.html
 
-master_sites		        http://www.fehcom.de/qmail/spamcontrol/:spamcontrol \
-				http://cr.yp.to/software/:qmail \
-				http://qmail.site2nd.org/:qmail \
-				http://qmail-mirror.jms1.net/:qmail \
+master_sites		        https://www.fehcom.de/qmail/spamcontrol/:spamcontrol \
+				https://cr.yp.to/software/:qmail \
+				https://qmail-mirror.jms1.net/:qmail \
 				http://www.qmail.org/:qmail
 
 distfiles			qmail-1.03.tar.gz:qmail \
@@ -192,7 +191,7 @@ To control qmail, the daemontools and ucspi-tcp ports are highly recommended.
 A good reference for setting up qmail is http://www.lifewithqmail.org/ .
 This port includes some sample files based on the Life with Qmail web site.
 They can be found in ${prefix}/var/qmail/samples .
-Also look at http://www.fehcom.de/qmail/spamcontrol.html for further info.
+Also look at https://www.fehcom.de/qmail/spamcontrol.html for further info.
 The fehcom site has docs for all the stuff added to the base qmail software.
 There are numerous configuration options to qmail. Please read all the docs!
 ******************************

--- a/math/djbfft/Portfile
+++ b/math/djbfft/Portfile
@@ -22,8 +22,8 @@ long_description	\
 		arrays. Single precision and double precision are	\
 		equally supported.
 
-homepage	http://cr.yp.to/djbfft.html
-master_sites	http://cr.yp.to/djbfft/
+homepage	https://cr.yp.to/djbfft.html
+master_sites	https://cr.yp.to/djbfft/
 
 checksums       rmd160  46de3a7ed5d6ca4b245d02a12d969702e57f7381 \
                 sha256  799d929c3631a77ef0e16a2449e4fc11af8540b62359f8733ac2899fca2b394c
@@ -44,5 +44,5 @@ build.target
 destroot.target	setup check
 
 livecheck.type	regex
-livecheck.url	http://cr.yp.to/djbfft/install.html
+livecheck.url	https://cr.yp.to/djbfft/install.html
 livecheck.regex	${name}-(\[0-9.\]+)\\.tar

--- a/math/primegen/Portfile
+++ b/math/primegen/Portfile
@@ -17,8 +17,8 @@ long_description    primegen is a small, fast library to generate prime \
                     past 32 bits. It uses the Sieve of Atkin instead of the \
                     traditional Sieve of Eratosthenes.
 
-homepage            http://cr.yp.to/primegen.html
-master_sites        http://cr.yp.to/primegen/
+homepage            https://cr.yp.to/primegen.html
+master_sites        https://cr.yp.to/primegen/
 
 checksums           rmd160  6f18fb8819e5589b0d7701f2dd69a2d8be4138b3 \
                     sha256  54285baf8eed9e421ff2220a2112d38cfb20c1ebef6014ef3f0004c22c95f40d

--- a/net/djbdns/Portfile
+++ b/net/djbdns/Portfile
@@ -26,7 +26,7 @@ long_description \
    command-line interfaces to DNS. \
    - The dnsq and dnstrace programs are DNS debugging tools.
 
-homepage            http://cr.yp.to/djbdns.html
+homepage            https://cr.yp.to/djbdns.html
 master_sites        ${homepage} \
                     http://smarden.org/pape/djb/manpages/:man
 distfiles-append    ${distname}-man-20031023.tar.gz:man
@@ -83,7 +83,7 @@ post-destroot {
 
 set ipv6_diff       ${distname}-test23.diff
 variant ipv6 conflicts dumpcache description {Patch in support for IPv6} {
-   master_sites-append   http://www.fefe.de/dns/:ipv6
+   master_sites-append   https://www.fefe.de/dns/:ipv6
    distfiles-append      ${ipv6_diff}.bz2:ipv6
    checksums-append      ${ipv6_diff}.bz2 \
                             md5     dc35e88e20ffe2670cef5bb4d8a2c183 \
@@ -121,7 +121,7 @@ variant dumpcache conflicts ipv6 description {Enable cache dumping of running dn
 
 set ignoreip_diff   ${distname}-ignoreip2.patch
 variant ignoreip description {Patch to allow ignoring a list of IP addresses} {
-   master_sites-append   http://tinydns.org/:ignoreip
+   master_sites-append   https://tinydns.org/:ignoreip
    distfiles-append      ${ignoreip_diff}:ignoreip
    checksums-append      ${ignoreip_diff} \
                             md5     c032250b209d055847a763c8d9c7e865 \
@@ -135,7 +135,7 @@ variant ignoreip description {Patch to allow ignoring a list of IP addresses} {
 
 set persistmmap_diff tinydns-persistmmap-20040418.patch
 variant persistmmap description {Add persistmmap to improve some lookup tasks} {
-   master_sites-append   http://people.FreeBSD.org/~roam/ports/patches/dns/:persistmmap
+   master_sites-append   https://people.FreeBSD.org/~roam/ports/patches/dns/:persistmmap
    distfiles-append      ${persistmmap_diff}:persistmmap
    checksums-append      ${persistmmap_diff} \
                             md5     c721977364502180f9563b85cecf133b \
@@ -148,6 +148,6 @@ variant persistmmap description {Add persistmmap to improve some lookup tasks} {
 }
 
 livecheck.type      regex
-livecheck.url       http://cr.yp.to/djbdns/install.html
+livecheck.url       https://cr.yp.to/djbdns/install.html
 livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}
 

--- a/net/ncp/Portfile
+++ b/net/ncp/Portfile
@@ -6,8 +6,8 @@ platforms		darwin
 maintainers		yoobay.net:daniel
 description		a fast file copy tool for LANs (including ncp, npush, npoll)
 long_description	a fast file copy tool for LANs (including ncp, npush, npoll)
-homepage		http://www.fefe.de/ncp/
-master_sites		http://dl.fefe.de
+homepage		https://www.fefe.de/ncp/
+master_sites		https://dl.fefe.de
 checksums		md5 421c4855bd3148b7d0a4342942b4bf13
 use_bzip2		yes
 patchfiles		patch-GNUmakefile

--- a/net/ucspi-tcp/Portfile
+++ b/net/ucspi-tcp/Portfile
@@ -16,9 +16,9 @@ long_description	tcpserver waits for incoming connections and, for each \
 			runs a program of your choice. It sets up the same environment \
 			variables as tcpserver.
 
-homepage		http://cr.yp.to/ucspi-tcp.html
-master_sites		http://cr.yp.to/ucspi-tcp/
-patch_sites		http://www.fehcom.de/qmail/rblsmtpd:greetdelay
+homepage		https://cr.yp.to/ucspi-tcp.html
+master_sites		https://cr.yp.to/ucspi-tcp/
+patch_sites		https://www.fehcom.de/qmail/rblsmtpd:greetdelay
 
 checksums		${distname}${extract.suffix} \
 				md5 39b619147db54687c4a583a7a94c9163 \

--- a/python/py-cdb/Portfile
+++ b/python/py-cdb/Portfile
@@ -12,13 +12,13 @@ maintainers         nomaintainer
 description         python module for using the constant database package
 long_description    The python-cdb extension module is an adaptation of \
                     D. J. Bernstein's constant database package (see \
-                    http://cr.yp.to/cdb.html). The cdb files are mappings \
+                    https://cr.yp.to/cdb.html). The cdb files are mappings \
                     of keys to values, designed for wickedly fast lookups \
                     and atomic updates.  This module mimics the normal cdb \
                     utilities, cdb(get|dump|make), via convenient, \
                     high-level Python objects.
 
-homepage            http://pilcrow.madison.wi.us/
+homepage            https://pilcrow.madison.wi.us/
 master_sites        ${homepage}/python-cdb/
 distname            python-cdb-${version}
 

--- a/ruby/rb-sqlite3/Portfile
+++ b/ruby/rb-sqlite3/Portfile
@@ -8,7 +8,7 @@ ruby.setup		{sqlite3 sqlite3-ruby} 1.2.5 setup.rb \
 maintainers		nomaintainer
 description		Interface to the SQLite3 DB engine from Ruby
 long_description	This module allows Ruby programs to interface with \
-					the SQLite3 database engine (http://www.sqlite.org). \
+					the SQLite3 database engine (https://www.sqlite.org). \
 					You must have the SQLite engine installed in order \
 					to build this module. \
 					Note that this module is NOT compatible with SQLite 2.x.

--- a/sysutils/daemontools/Portfile
+++ b/sysutils/daemontools/Portfile
@@ -12,8 +12,8 @@ long_description \
    services. It includes tools for starting, restarting, stopping, \
    monitoring and logging any services that you might wish to run.
 
-homepage            http://cr.yp.to/daemontools.html
-master_sites        http://cr.yp.to/daemontools/ \
+homepage            https://cr.yp.to/daemontools.html
+master_sites        https://cr.yp.to/daemontools/ \
                     http://smarden.org/pape/djb/manpages/:man
 distfiles-append    ${distname}-man.tar.gz:man
 checksums           ${distname}.tar.gz md5 1871af2453d6e464034968a0fbcb2bfc \

--- a/sysutils/vmdktool/Portfile
+++ b/sysutils/vmdktool/Portfile
@@ -17,9 +17,9 @@ long_description    ${name} ${description}. \
                     such as VMware’s ESXi and VirtualBox requires the ability to construct \
                     VMDK files as the initial filesystem images for the created guests.
 
-homepage            http://manned.org/vmdktool
+homepage            https://manned.org/vmdktool
 
-master_sites        http://people.freebsd.org/~brian/vmdktool/ \
+master_sites        https://people.freebsd.org/~brian/vmdktool/ \
                     ftp://ftp.awfulhak.org/pub/vmdktool/
 
 checksums           sha1    ed80b62cd7a97582192ad3a8f97bf73eee9ed36a \


### PR DESCRIPTION
Use HTTPS for the following domain names:
 - www.fehcom.de
 - cr.yp.to
 - people.FreeBSD.org
 - qmail-mirror.jms1.net
 - pilcrow.madison.wi.us
 - manned.org
 - www.hwaci.com
 - www.sqlite.org
 - tinydns.org
 - www.fefe.de
 - dl.fefe.de

`qmail-spamcontrol`: remove defunct mirror qmail.site2nd.org

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
