### PR TITLE
tix: fix livecheck

### DIFF
--- a/x11/tix/Portfile
+++ b/x11/tix/Portfile
@@ -54,3 +54,5 @@ if {![variant_isset quartz]} {
 
 test.run            yes
 test.target         test
+
+livecheck.regex     {/tix/(\d+\.\d+\.\d+)}


### PR DESCRIPTION
Existing regex erroneously detects "840" as newer version.
(Latest version is 8.4.3, released in 2008.)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
