### PR TITLE
npm6: update to 6.7.0

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm6
-version             6.6.0
+version             6.7.0
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -25,10 +25,10 @@ distname            npm-${version}
 extract.suffix      .tgz
 
 # Please keep the sha1 - users can use it to validate sha values published on npmjs.org for the package
-checksums           sha1    2ab953bc38c005897f3ec4431120385c668ea572 \
-                    rmd160  a6724ee4111aea9f4df516df704e54ce13ef84ae \
-                    sha256  01e6ec454d1564bbcc313245fc42ced7e6b52be1e2e4ab44fdcfb087364be747 \
-                    size    5145189
+checksums           sha1    a563d6e6806913b2afa4c713ba63047cb7c63ea4 \
+                    rmd160  599787b048701f45368e385fb32a5403c3dfde30 \
+                    sha256  6ce036f070fe8fe602577fd80c103c3d7684077b0f567fdc8792c9ec65d35685 \
+                    size    5138996
 
 worksrcdir          "package"
 


### PR DESCRIPTION
#### Description
Tested with a `npm ls` in a decently sized angular project.

Just kicking ideas around: would it be a good idea to have the post-patch section validate all the files in the destroot to make sure nothing has `/usr/bin/env node` hashbangs? How do you accomplish that in a portfile?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
