### PR TITLE
qemu: remove compatibility variant +target_or32

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -103,9 +103,6 @@ foreach t {i386 x86_64 alpha {arm aarch64} cris lm32 m68k {microblaze microblaze
 }
 default_variants-append +target_i386 +target_x86_64
 
-# Compatiblity variant, remove after 2018-12-31
-variant target_or32 description "Compatibility variant, renamed to +target_or1k" requires target_or1k {}
-
 if {![variant_isset curses]} {
     default_variants-append +cocoa
 }


### PR DESCRIPTION
#### Description

Variant was renamed to `+target_or1k` and scheduled for removal in 698e7e18f7d878fbf837085870798c45e33b2081.

<!-- Note: it is best make pull requests from a branch rather than from master -->
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
