### PR TITLE
xemacs: remove legacy variant +no_sumo

### DIFF
--- a/editors/xemacs/Portfile
+++ b/editors/xemacs/Portfile
@@ -113,23 +113,15 @@ post-destroot {
     delete ${destroot}${prefix}/share/man/man1/ctags.1
 }
 
-# TODO: Remove legacy variant after 2018-07-12
-variant no_sumo \
-    description "Legacy variant" \
-    conflicts sumo { }
-
 variant sumo \
-    description "Install SUMO (all packages) and mule (multilanguage) support." \
-    conflicts no_sumo {
+    description "Install SUMO (all packages) and mule (multilanguage) support." {
     configure.args-append --with-mule
     depends_lib-append    port:gettext
     distfiles-append      ${sumo_dist}:package ${mule_dist}:package
     distfiles-delete      efs-${efs_version}-pkg.tar.gz:package xemacs-base-${base_version}-pkg.tar.gz:package
 }
 
-if {![variant_isset no_sumo]} {
-    default_variants +sumo
-}
+default_variants +sumo
 
 # https://trac.macports.org/ticket/31679
 configure.cflags-append -std=gnu89


### PR DESCRIPTION
#### Description

Negative variant was replaced by `+sumo` and scheduled for removal in 327b12b4beffe478c4f6f29cd866e8852276083c.

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
