### PR TITLE
GPXSee: update to 7.2

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.1
+github.setup        tumic0 GPXSee 7.2
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -12,13 +12,13 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 
 description         GPS log file viewer and analyzer
 long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
-                    that supports GPX, TCX, KML, FIT, IGC, NMEA, SLF, LOC and OziExplorer files.
+                    that supports all common GPS log file formats.
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  a878c59a8180294bab4663fe2608309131e96197 \
-                    sha256  6d6cc323a2809045a621ad657c5c751a7b681d3cead4910ac617f0b3d567a7fd \
-                    size    3869446
+checksums           rmd160  4682f14e57c966b1db6041cfb5827b42aad6b00c \
+                    sha256  de4cc2a3fa9c56f5be601756e198b44fe363e733a1992ffd082bc3fde4e9ce74 \
+                    size    4282092
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.2

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for DEM data (SRTM HGT files).
>   * Improved look&feel in dark styles.
>   * Added support for polar stereographic projections + Antarctica
>     map.
>   * Added support for GeoJSON files.
>   * Added Spanish localization.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
