### PR TITLE
py-rstcheck: new port, version 3.3.1

### DIFF
--- a/python/py-rstcheck/Portfile
+++ b/python/py-rstcheck/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rstcheck
+version             3.3.1
+revision            0
+categories-append   devel
+license             MIT
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+description         Checks syntax of reStructuredText and code blocks nested within it
+long_description    ${description}
+platforms           darwin
+homepage            https://github.com/myint/rstcheck
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  95397717b850a92f622293cba2cefed64ec9fed6 \
+                    sha256  92c4f79256a54270e0402ba16a2f92d0b3c15c8f4410cb9c57127067c215741f \
+                    size    13825
+
+python.versions     27 37
+
+if {${subport} ne ${name}} {
+    depends_lib-append \
+                    port:py${python.version}-docutils \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-sphinx
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
