### PR TITLE
iTerm2: update to 3.2.7 and fix version strings

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -12,11 +12,11 @@ if {[vercmp ${os.version} 17.0.0] < 0} {
         size    11969144
     patchfiles          patch-Makefile.diff
 } else {
-    version             3.2.6
+    version             3.2.7
     checksums \
-        rmd160  e591606dd31528da470522dbdb1ee728472dfef8 \
-        sha256  c79e6faaa0a852571d7112ca2eb85276b789a29bb06dc42c2788988cc18928f5 \
-        size    11834219
+        rmd160  82b3f206a23189319281c2512b456bb00a498b4d \
+        sha256  e798eb994638c30d8500b0f085c3edaf4bc51066b47df8f85153a9ec1275972f \
+        size    11849614
     patchfiles          patch-Makefile-XC10.diff
 }
 
@@ -41,11 +41,6 @@ github.livecheck.regex {(\d+(?:\.\d+)*)}
 
 post-patch {
     reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
-
-    # Fix version number
-    set versionfd [open ${worksrcpath}/version.txt "w"]
-    puts $versionfd "${version}"
-    close $versionfd
 }
 
 compiler.cpath
@@ -56,6 +51,13 @@ use_configure       no
 build.target        prod
 
 destroot.destdir    APPS=${destroot}${applications_dir}
+
+post-destroot {
+    # Fix version number; see iTerm2/tools/updateVersion.py for version keys
+    foreach {key} {CFBundleGetInfoString CFBundleShortVersionString CFBundleVersion} {
+        system "/usr/libexec/PlistBuddy -c \"Set :${key} ${version}\" ${destroot}${applications_dir}/iTerm2.app/Contents/Info.plist"
+    }
+}
 
 minimum_xcodeversions {16 9.0 17 10.0}
 


### PR DESCRIPTION
Upstream iTerm2 ships a script tools/updateVersion.py to write version
strings to Info.plist. However, with at least Xcode 10, the correct
version strings are later overwritten by the step
"builtin-infoPlistUtility". Writing the version strings out at the
post-destroot stage can make sure they are not overwritten.

Closes: https://trac.macports.org/ticket/57625

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? (N/A)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
