### PR TITLE
net-snmp: add optional dependency libpcap

### DIFF
--- a/net/net-snmp/Portfile
+++ b/net/net-snmp/Portfile
@@ -5,7 +5,7 @@ PortGroup               perl5 1.0
 
 name                    net-snmp
 version                 5.8
-revision                1
+revision                2
 checksums               rmd160  66770d78f2583cda36e90cc35032d7dae2d354c3 \
                         sha256  b2fc3500840ebe532734c4786b0da4ef0a5f67e51ef4c86b3345d697e4976adf \
                         size    6591680
@@ -30,6 +30,7 @@ long_description        This is net-snmp, a derivative of CMU's SNMP \
 perl5.branches          5.28
 
 depends_lib             port:bzip2 \
+                        port:libpcap \
                         port:pcre \
                         port:perl${perl5.major} \
                         port:zlib


### PR DESCRIPTION
#### Description

During configuration, net-snmp checks for and uses libpcap
if available.  Adding this dependency ensures that libpcap
is always used, avoiding opportunistic linking.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
