### PR TITLE
claws-mail: disable fancy plugin, drop webkit2-gtk

### DIFF
--- a/mail/claws-mail/Portfile
+++ b/mail/claws-mail/Portfile
@@ -5,7 +5,7 @@ PortGroup       active_variants 1.1
 
 name            claws-mail
 version         3.17.3
-revision        0
+revision        1
 categories      mail news
 platforms       darwin
 license         GPL-3+
@@ -48,8 +48,7 @@ depends_lib     port:gtk2 \
                 port:enchant \
                 port:poppler \
                 port:ghostscript \
-                port:bogofilter \
-                port:webkit2-gtk
+                port:bogofilter
 
 # claws uses gdk/gdkx.h, which is not installed by gtk2 +quartz.
 require_active_variants \
@@ -65,6 +64,7 @@ configure.args  --disable-jpilot \
                 --disable-acpi_notifier-plugin \
                 --disable-bsfilter-plugin \
                 --disable-clamd-plugin \
+                --disable-fancy-plugin \
                 --disable-notification-plugin \
                 --disable-perl-plugin \
                 --disable-python-plugin \


### PR DESCRIPTION
#### Description
    
claws-mail depends on webkitgtk-1.0 (ports webkit-gtk, webkit-gtk-2.0)
to build the fancy plugin. Current dependency webkit2-gtk provides
webkitgtk-4.0 and is neither supported nor used.
    
Currently claws-mail will opportunistically build the fancy plugin
if either webkit-gtk or webkit-gtk-2.0 is active. Unfortunately,
these ports have been long deprecated due to security issues and
have been proposed for removal.
    
See https://trac.macports.org/ticket/52398.
    
To avoid such opportunistic building or introducing a dependency
on the outdated ports,  disable the fancy plugin and remove the
dependency on webkit2-gtk.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
