### PR TITLE
Add xdebug 2.7 for PHP 7.3

### DIFF
--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -16,11 +16,11 @@ php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 php.extensions.zend     xdebug
 
 if {[vercmp ${php.branch} 7.3] >= 0} {
-    version             2.7.0beta1
+    version             2.7.0
     revision            0
-    checksums           rmd160  c0b72e06b0f769bb8b006145a375f30bd67218b8 \
-                        sha256  90a0ceaf95c7d936113ed0d7474f16978ec2277453be69239d92d0523e0910be \
-                        size    226296
+    checksums           rmd160  0664ae992dee55aa7ab51f59a783049fa69f864a \
+                        sha256  e896da91ce0373f5fd8f4ca392c68da8593932ad51b2ec5eb3ee032b50d4b2d6 \
+                        size    230326
 } elseif {[vercmp ${php.branch} 7.0] >= 0} {
     version             2.6.1
     revision            0

--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -12,10 +12,16 @@ license                 Xdebug-1.01
 homepage                https://xdebug.org
 master_sites            ${homepage}/files/
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 php.extensions.zend     xdebug
 
-if {[vercmp ${php.branch} 7.0] >= 0} {
+if {[vercmp ${php.branch} 7.3] >= 0} {
+    version             2.7.0beta1
+    revision            0
+    checksums           rmd160  c0b72e06b0f769bb8b006145a375f30bd67218b8 \
+                        sha256  90a0ceaf95c7d936113ed0d7474f16978ec2277453be69239d92d0523e0910be \
+                        size    226296
+} elseif {[vercmp ${php.branch} 7.0] >= 0} {
     version             2.6.1
     revision            0
     checksums           rmd160  961b2d6abdd8d235f9d30e93cdcd25ddcdacd083 \


### PR DESCRIPTION
This version is only installed for PHP 7.3, previous versions should
keep using the 2.6 branch for now.

#### Description

This adds xdebug v. 2.7.0beta1, installed only for PHP 7.3. Since PHP 7.3 doesn't have an existing xdebug package and this version is only installed for 7.3, this should be a reasonably low-impact change.

This particular xdebug version has been in beta for ~3 months now and since xdebug is an essential tool in many debugging environments (for php), making it installable in MacPorts should be generally useful.

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.1 18B75
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
