### PR TITLE
p5-graveyard: remove deleted port p5-sys-cpu

### DIFF
--- a/perl/p5-graveyard/Portfile
+++ b/perl/p5-graveyard/Portfile
@@ -1397,7 +1397,6 @@ p5-switch					2.170.0_1
 p5-syntax					0.4.0_1
 p5-syntax-highlight-perl			1.0.0_2
 p5-syntax-keyword-junction			0.3.8_1
-p5-sys-cpu					0.610.0_2
 p5-sys-cpuload					0.30.0_3
 p5-sys-filesystem				1.406.0_5
 p5-sys-hostname-long				1.500.0_4


### PR DESCRIPTION
Deleted in c98242f026a4264ac34600bef495d6165e51c913

As suggested in #3433

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
