### PR TITLE
zabbix3: Fix paths in launchd plist

### DIFF
--- a/net/zabbix3/Portfile
+++ b/net/zabbix3/Portfile
@@ -68,8 +68,8 @@ if { ${name} ne ${subport} } {
     startupitem.executable  \
         ${prefix}/sbin/zabbix/zabbix_agentd \
         -c ${prefix}/etc/zabbix3/zabbix_agentd.conf
-    startupitem.pidfile     auto ${prefix}/var/run/zabbix/zabbix_agentd.pid
-    startupitem.logfile     ${prefix}/var/log/zabbix/zabbix_agentd.launch
+    startupitem.pidfile     auto ${prefix}/var/run/zabbix3/zabbix_agentd.pid
+    startupitem.logfile     ${prefix}/var/log/zabbix3/zabbix_agentd.launch
 
     configure.args-append   --enable-agent
 
@@ -96,12 +96,12 @@ if { ${name} ne ${subport} } {
 
     startupitem.name        zabbix3-server
     startupitem.start       ${prefix}/sbin/zabbix/zabbix_server
-    set pidfile             ${prefix}/var/run/zabbix/zabbix_server.pid
+    set pidfile             ${prefix}/var/run/zabbix3/zabbix_server.pid
     # Gracefully wait up to two minutes for zabbix to shut down / clean up
     startupitem.stop \
         "let x=120; while /usr/bin/pkill -u zabbix -F ${pidfile}; \
          do sleep 1; let x--; \[ \$x -le 0 \] && break; done"
-    startupitem.logfile     ${prefix}/var/log/zabbix/zabbix_server.launch
+    startupitem.logfile     ${prefix}/var/log/zabbix3/zabbix_server.launch
     startupitem.netchange   yes
 
     destroot.keepdirs \
@@ -281,8 +281,8 @@ post-destroot {
     }
 
     foreach dname {run log} {
-        xinstall -d -m 755 ${destroot}${prefix}/var/${dname}/zabbix
-        system "chown -R zabbix:zabbix ${destroot}${prefix}/var/${dname}/zabbix"
+        xinstall -d -m 755 ${destroot}${prefix}/var/${dname}/zabbix3
+        system "chown -R zabbix:zabbix ${destroot}${prefix}/var/${dname}/zabbix3"
     }
 
     system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix3"

--- a/net/zabbix3/files/log_and_pid_locations.patch
+++ b/net/zabbix3/files/log_and_pid_locations.patch
@@ -5,7 +5,7 @@
  # PidFile=/tmp/zabbix_agentd.pid
  
 +# MACPORTS CONFIG. PLEASE ONLY EDIT IF YOU KNOW WHAT YOU ARE DOING
-+PidFile=%%PREFIX%%/var/run/zabbix/zabbix_agentd.pid
++PidFile=%%PREFIX%%/var/run/zabbix3/zabbix_agentd.pid
 +# END MACPORTS CONFIG
 +
  ### Option: LogType
@@ -16,7 +16,7 @@
  # LogFile=
  
 -LogFile=/tmp/zabbix_agentd.log
-+LogFile=%%PREFIX%%/var/log/zabbix/zabbix_agentd.log
++LogFile=%%PREFIX%%/var/log/zabbix3/zabbix_agentd.log
  
  ### Option: LogFileSize
  #	Maximum size of log file in MB.
@@ -27,7 +27,7 @@
  # LogFile=
  
 -LogFile=/tmp/zabbix_server.log
-+LogFile=%%PREFIX%%/var/log/zabbix/zabbix_server.log
++LogFile=%%PREFIX%%/var/log/zabbix3/zabbix_server.log
  
  ### Option: LogFileSize
  #	Maximum size of log file in MB.
@@ -36,7 +36,7 @@
  # PidFile=/tmp/zabbix_server.pid
  
 +# MACPORTS CONFIG. PLEASE ONLY EDIT IF YOU KNOW WHAT YOU ARE DOING
-+PidFile=%%PREFIX%%/var/run/zabbix/zabbix_server.pid
++PidFile=%%PREFIX%%/var/run/zabbix3/zabbix_server.pid
 +# END MACPORTS CONFIG
 + 
  ### Option: SocketDir


### PR DESCRIPTION
#### Description

The paths in the launchd plist for zabbix3-agent and zabbix3-server
were incorrect since 6713e30, when the destroot.keepdirs were
changed to PREFIX/var/run/zabbix3 and PREFIX/var/log/zabbix3.
The plist and sample config files still pointed to .../zabbix.

This mismatch caused launchd via daemondo to continuously relaunch
zabbix_agentd and zabbix_serverd because it could not find the
pidfile. Users copying the sample config files would also have gotten
permissions errors because the specified log and pidfile directories
were not created and chowned to zabbix:zabbix at install time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
