### PR TITLE
osxfuse: don't build BridgeSupport metadata by default

### DIFF
--- a/_ci/bootstrap.sh
+++ b/_ci/bootstrap.sh
@@ -45,9 +45,3 @@ sudo tar -xpf "getopt-v1.1.6.tar.bz2" -C /
 # Download and run CI runner
 curl -fsSLO "https://github.com/macports/mpbot-github/releases/download/v0.0.1/runner"
 chmod 0755 runner
-
-# Work around broken gen_bridge_metadata / bridgesupportparser.bundle on High Sierra and Mojave
-# See https://trac.macports.org/ticket/54939
-if ! /usr/bin/gen_bridge_metadata --version >/dev/null 2>&1; then
-    sudo ln -s XcodeDefault.xctoolchain "$(xcode-select -p)"/Toolchains/OSX"$(sw_vers -productVersion | cut -d. -f1-2)".xctoolchain
-fi

--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -109,6 +109,8 @@ if { $use_signed_kext } {
     extract.only ${name}-${version}.dmg
 }
 
+variant bridge_support description {Build BridgeSupport metadata} {}
+
 post-extract {
     # Extract the pkg and the appropriate payload from the binary dmg
     if { $use_signed_kext } {
@@ -127,10 +129,15 @@ post-extract {
             move ${workpath}/osxfuse-${mp.comp}-${mp.rev} ${workpath}/${worksrcdir}/${mp.comp}
         }
     }
+
+    if {![variant_isset bridge_support]} {
+        reinplace "s|/usr/bin/gen_bridge_metadata|/usr/bin/gen_bridge_metadata-disabled|" \
+            ${worksrcpath}/framework/OSXFUSE.xcodeproj/project.pbxproj
+    }
 }
 
 pre-build {
-    if {${os.major} >= 17 && [catch {system "/usr/bin/gen_bridge_metadata --version > /dev/null 2>&1"}]} {
+    if {[variant_isset bridge_support] && ${os.major} >= 17 && [catch {system "/usr/bin/gen_bridge_metadata --version > /dev/null 2>&1"}]} {
         ui_error "This port will fail to build because of a bug in macOS,"
         ui_error "unless you apply one of the following two workarounds:"
         ui_error ""


### PR DESCRIPTION
#### Description

Building BridgeSupport metadata is broken on High Sierra or newer due to
an macOS and/or Xcode bug [1]. As the workaround breaks building iTerm2
[2], I'd like to skip the fragile step instead playing more with Xcode
and macOS.

Apparently BridgeSupport metadata is used when programs using scripting languages want to utilize frameworks written in Objective-C. Examples are MacRuby [3], PyObjC [4] and NodObjC (for node.js) [5]. Looking into ports depending on osxfuse, apparently none uses these technologies. py-fuse and py-llfuse uses the C binding of osxfuse, and other are usual C/C++ programs/libraries. If there's really a port requiring BridgeSupport metadata, I'd like to tell port maintainers for it to use `require_active_variants`.

[1] https://trac.macports.org/ticket/54939
[2] https://github.com/macports/macports-ports/pull/3525#issuecomment-458799559
[3] https://github.com/amirrajan/rubymotion-bridgesupport
[4] https://pythonhosted.org/pyobjc/metadata/bridgesupport.html

###### Type(s)

- [x] bugfix (for other ports, anyway)
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
I've built osxfuse without BridgeSuppport metadata and rebuilt VeraCrypt against that modified version. I can still mount my secret volume and read files from it.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
