### PR TITLE
libusb ports: use https homepage

### DIFF
--- a/devel/libusb-compat/Portfile
+++ b/devel/libusb-compat/Portfile
@@ -10,7 +10,7 @@ description     library for USB device access
 long_description \
     library for use by user level applications to \
     access USB devices regardless of OS
-homepage        http://libusb.info/
+homepage        https://libusb.info/
 
 platforms       darwin
 license         LGPL-2+

--- a/devel/libusb-legacy/Portfile
+++ b/devel/libusb-legacy/Portfile
@@ -11,7 +11,7 @@ maintainers         {snc @nerdling} {michaelld @michaelld} openmaintainer
 description         Library providing access to USB devices
 long_description    A library originally developed under Linux to give \
                     userland programs an API to access to USB hardware.
-homepage            http://libusb.org/
+homepage            https://libusb.info/
 
 platforms           darwin
 

--- a/devel/libusb/Portfile
+++ b/devel/libusb/Portfile
@@ -10,7 +10,7 @@ description     library for USB device access
 long_description \
     library for use by user level applications to \
     access USB devices regardless of OS
-homepage        http://libusb.info/
+homepage        https://libusb.info/
 
 platforms       darwin
 license         LGPL-2.1+
@@ -56,8 +56,6 @@ if {${subport} eq ${name}} {
     patchfiles-append    patch-10.7-nospeedsuper.diff
 
 }
-
-homepage         http://libusb.info/
 
 depends_build    port:libtool \
                  port:automake \


### PR DESCRIPTION
 - libusb: remove duplicate homepage in Portfile
 - libusb-legacy: libusb.org is defunct, use libusb.info instead

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
