### PR TITLE
openjdk11-openj9: Update to AdoptOpenJDK 11.0.2+9

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -26,11 +26,12 @@ subport openjdk11 {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.1
+    version      11.0.2
     revision     0
 
-    set build    13
+    set build    9
     set major    11
+    set openj9_version 0.12.0
 }
 
 categories       java devel
@@ -100,11 +101,11 @@ if {${subport} eq "openjdk8"} {
 } else {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  dbb5724e61f924d55cec365c90e2fcd021716b2d \
-                 sha256  c5e9b588b4ac5b0bd5b4edd69d59265d1199bb98af7ca3270e119b264ffb6e3f \
-                 size    180993478
+    checksums    rmd160  cbf6475cb9715303bbae726ab5353c27b8bf75d9 \
+                 sha256  0589fea4f9012299267dd3c533417a37540a3db61ae86f411bda67195b3636f4 \
+                 size    194718798
 
-    distname     OpenJDK${major}-jdk_x64_mac_openj9_${version}_${build}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
 
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.2+9.

###### Tested on

macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?