### PR TITLE
openjdk8: add openjdk8-openj9 sub-port

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -9,6 +9,15 @@ revision         0
 set build        08
 set major        8
 
+subport openjdk8-openj9 {
+    version      8u202
+    revision     0
+
+    set build    08
+    set major    8
+    set openj9_version 0.12.0
+}
+
 subport openjdk10 {
     version      10.0.2
     revision     2
@@ -69,6 +78,16 @@ if {${subport} eq "openjdk8"} {
     worksrcdir   jdk${version}-b${build}
 
     configure.cxx_stdlib libstdc++
+
+} elseif {${subport} eq "openjdk8-openj9"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
+
+    checksums    rmd160  0a88e321ed6a14c1a7723379e2c3acaf29921ddd \
+                 sha256  a416609d4bb57b91e2851de41720877f4cb01f19aae44eacd99e024711d8b353 \
+                 size    114338285
+
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
+    worksrcdir   jdk${version}-b${build}
 
 } elseif {${subport} eq "openjdk10"} {
     master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/


### PR DESCRIPTION
#### Description

New port for AdoptOpenJDK 8 with Eclipse OpenJ9 VM.

###### Tested on

macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?