### PR TITLE
xorg-server-devel: avoid redefinition error on older compilers

### DIFF
--- a/x11/xorg-server-devel/Portfile
+++ b/x11/xorg-server-devel/Portfile
@@ -47,8 +47,7 @@ depends_lib \
 # https://trac.macports.org/ticket/36055
 # https://llvm.org/bugs/show_bug.cgi?id=30346
 # https://trac.macports.org/ticket/53910
-# https://trac.macports.org/ticket/57333
-compiler.blacklist gcc-4.* llvm-gcc-4.2 macports-clang-3.9 macports-clang-devel \
+compiler.blacklist gcc-4.0 macports-clang-3.9 macports-clang-devel \
                    {clang >= 802 < 900} {clang < 100}
 
 platform darwin {
@@ -93,6 +92,14 @@ patchfiles \
         5004-fb-Revert-fb-changes-that-broke-XQuartz.patch \
         5005-fb-Revert-fb-changes-that-broke-XQuartz.patch
 
+# the following two patches avoid redefinition errors on pre-C11 compilers
+# https://trac.macports.org/ticket/57333
+# another approach would be to update the port to build with gcc6+
+# patches to do that are in the above noted ticket/57333.
+patchfiles-append \
+        5006-patch-xorg-server-dont-redefine-GLXscreen.diff \
+        5007-patch-randr-randrstr-h-dont-redefine-CARD32.diff
+
 # Fixes what appears to be a mis-match in the way
 # hw/xquartz/GL/visualConfigs.c allocates __GLXconfig
 # objects with a single calloc call to the way
@@ -103,6 +110,10 @@ patchfiles \
 patchfiles-append fix-calloc-free-mis-match-bug.patch
 
 patch.pre_args -p1
+
+platform darwin 8 {
+    configure.args-append --disable-dependency-tracking
+}
 
 use_autoreconf yes
 autoreconf.args -fvi

--- a/x11/xorg-server-devel/files/5006-patch-xorg-server-dont-redefine-GLXscreen.diff
+++ b/x11/xorg-server-devel/files/5006-patch-xorg-server-dont-redefine-GLXscreen.diff
@@ -1,0 +1,18 @@
+diff --git xorg-server-devel-1.20.3/include/glx_extinit.h.old xorg-server-devel-1.20.3/include/glx_extinit.h
+index 07f3cc8..56a66e7 100644
+--- xorg-server-devel-1.20.3/include/glx_extinit.h.old
++++ xorg-server-devel-1.20.3/include/glx_extinit.h
+@@ -30,7 +30,13 @@
+ /* XXX this comment no longer makes sense i think */
+ #ifdef GLXEXT
+ typedef struct __GLXprovider __GLXprovider;
++
++#ifndef _GLX_screens_h_
++/* this identical struct is also defined in glx/glxscreens.h and this causes */
++/* redefinition errors on compilers that don't support C11 */
+ typedef struct __GLXscreen __GLXscreen;
++#endif
++
+ struct __GLXprovider {
+     __GLXscreen *(*screenProbe) (ScreenPtr pScreen);
+     const char *name;

--- a/x11/xorg-server-devel/files/5007-patch-randr-randrstr-h-dont-redefine-CARD32.diff
+++ b/x11/xorg-server-devel/files/5007-patch-randr-randrstr-h-dont-redefine-CARD32.diff
@@ -1,0 +1,16 @@
+--- xorg-server-devel-1.20.3/randr/randrstr.h.orig	2019-01-31 11:25:32.000000000 -0800
++++ xorg-server-devel-1.20.3/randr/randrstr.h	2019-01-31 11:31:44.000000000 -0800
+@@ -63,7 +63,13 @@
+ typedef XID RROutput;
+ typedef XID RRCrtc;
+ typedef XID RRProvider;
++
++/* don't define this here. Causes redefinition errors with pre-C11 compilers
++due to a conflict in X11/Xmd.h (xorg-xorgproto)
++and there is no indication it is used anywhere in the xorg-server source
++
+ typedef XID RRLease;
++*/
+ 
+ extern int RREventBase, RRErrorBase;
+ 


### PR DESCRIPTION
fixes build on pre-C11 compilers used by default
Tested on 10.4 PPC, 10.5 PPC/Intel, 10.6, 10.14

If we don't want to do this, we'll have to use the patches previously outined in ticket 57333 to force the build with gcc6 instead, and I guess that is a lot more work in the end..
