### PR TITLE
gmpc: add dependency on libxspf, rebuild

### DIFF
--- a/audio/gmpc/Portfile
+++ b/audio/gmpc/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            gmpc
 version         11.8.16
-revision        2
+revision        3
 categories      audio
 platforms       darwin
 license         GPL-2+
@@ -39,7 +39,8 @@ depends_lib     port:libmpd \
                 port:zlib \
                 path:lib/libssl.dylib:openssl \
                 port:curl \
-                port:libsoup
+                port:libsoup \
+                port:libxspf
 
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 


### PR DESCRIPTION
Prevents opportunistic linking.

An alternative would be to add --disable-libxspf to configure.args

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
