### PR TITLE
Multiple ruby ports: set to nomaintainer

### DIFF
--- a/ruby/rb-activeldap/Portfile
+++ b/ruby/rb-activeldap/Portfile
@@ -3,7 +3,7 @@ PortGroup           ruby 1.0
 
 ruby.setup          {activeldap ruby-activeldap} 0.8.3.1 gem \
                     {} rubygems
-maintainers         basen.net:kajtzu
+maintainers         nomaintainer
 description         an ActiveRecord inspired way of accessing LDAP
 long_description    Ruby/ActiveLDAP provides an object oriented interface to LDAP. \
                     This library was inspired by ActiveRecord (both the concept and the \

--- a/ruby/rb-mechanize/Portfile
+++ b/ruby/rb-mechanize/Portfile
@@ -5,7 +5,7 @@ PortGroup			ruby 1.0
 
 ruby.setup			mechanize 1.0.0 gem {} rubygems
 platforms           darwin
-maintainers			basen.net:kajtzu
+maintainers			nomaintainer
 
 description			WWW::Mechanize, a handy web browsing ruby object.
 long_description	${description}

--- a/ruby/rb-piston/Portfile
+++ b/ruby/rb-piston/Portfile
@@ -6,7 +6,7 @@ PortGroup			ruby 1.0
 ruby.setup			piston 1.3.3 gem {} rubygems
 revision			1
 platforms           darwin
-maintainers			basen.net:kajtzu
+maintainers			nomaintainer
 
 description			A Ruby utility to manage local copies of remote repository locations.
 long_description	${description}

--- a/ruby/rb-snmp/Portfile
+++ b/ruby/rb-snmp/Portfile
@@ -5,7 +5,7 @@ PortGroup           ruby 1.0
 
 ruby.setup          snmp 1.0.1 gem {} rubygems
 platforms           darwin
-maintainers         basen.net:kajtzu
+maintainers         nomaintainer
 description         SNMP library implemented in ruby
 
 long_description    This library implements SNMP (the Simple Network \


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/57918

https://trac.macports.org/ticket/19197 should also be unassigned when this is merged.



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
