### PR TITLE
libxml2: Include iconv and icu by absolute path

### DIFF
--- a/textproc/libxml2/Portfile
+++ b/textproc/libxml2/Portfile
@@ -6,6 +6,7 @@ PortSystem          1.0
 
 name                libxml2
 version             2.9.9
+revision            1
 categories          textproc
 platforms           darwin
 license             MIT
@@ -32,7 +33,10 @@ checksums           rmd160  a7d5f9ca4a24db329108f4bfb6bd4eed0f61ab21 \
                     sha256  94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871 \
                     size    5476717
 
-post-extract {
+patchfiles-append   include.patch
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/include/libxml/encoding.h
     reinplace -locale C "s|/etc|${prefix}/etc|g" \
         ${worksrcpath}/catalog.c \
         ${worksrcpath}/runtest.c \
@@ -52,7 +56,7 @@ configure.args      --disable-silent-rules \
 
 destroot.keepdirs   ${destroot}${prefix}/etc/xml
 post-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/etc/xml
+    xinstall -m 0755 -d ${destroot}${prefix}/etc/xml
 }
 
 test.run            yes

--- a/textproc/libxml2/files/include.patch
+++ b/textproc/libxml2/files/include.patch
@@ -1,0 +1,17 @@
+Ensure MacPorts libiconv and icu are found even if -I/opt/local/include
+is not in CPPFLAGS.
+--- include/libxml/encoding.h.orig	2016-06-07 05:04:14.000000000 -0500
++++ include/libxml/encoding.h	2019-02-01 14:37:30.000000000 -0600
+@@ -25,10 +25,10 @@
+ #include <libxml/xmlversion.h>
+ 
+ #ifdef LIBXML_ICONV_ENABLED
+-#include <iconv.h>
++#include <@PREFIX@/include/iconv.h>
+ #endif
+ #ifdef LIBXML_ICU_ENABLED
+-#include <unicode/ucnv.h>
++#include <@PREFIX@/include/unicode/ucnv.h>
+ #endif
+ #ifdef __cplusplus
+ extern "C" {


### PR DESCRIPTION
#### Description

libxml2: Include iconv and icu by absolute path

Closes: https://trac.macports.org/ticket/57990

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
