### PR TITLE
osxfuse: update to version 3.8.3

### DIFF
--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                osxfuse
 epoch               1
-version             3.8.2
+version             3.8.3
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          fuse devel
 platforms           macosx
@@ -47,11 +47,11 @@ if {${kernel_arch} ne "x86_64"} {
 distfiles
 dist_subdir ${name}/${version}
 set mp.dist {
-    osxfuse     120c6ce
-    kext        60c55dd
+    osxfuse     48bc246
+    kext        416c143
     framework   8b79906
     prefpane    095ba9c
-    fuse        5de6743
+    fuse        1a1977a
     support     2cdc560
 }
 
@@ -73,14 +73,14 @@ if { $use_signed_kext } {
     distfiles-append ${name}-${version}.dmg
 }
 
-checksums           osxfuse-120c6ce.tar.gz \
-                    rmd160  50c93857d53649e6fb1bfad918f153e3de35f98f \
-                    sha256  0e83540afed7c5efa6878538e0645cc453ed2bf4ef93ce49ffa02e558e7db679 \
-                    size    32355 \
-                    kext-60c55dd.tar.gz \
-                    rmd160  7b33e3d0069f448097272b4f1fb08f21e90729ed \
-                    sha256  e0fb92ee033da07c9e60d902c0d722ea8971683a00bbdf97c390a2783481c147 \
-                    size    119156 \
+checksums           osxfuse-48bc246.tar.gz \
+                    rmd160  e36ee956945058e54573eb7bd705664beac87ccf \
+                    sha256  cc810302c14e1e06808a95647fffd2e0655b201ba3e14b390059d5d150c164d7 \
+                    size    32351 \
+                    kext-416c143.tar.gz \
+                    rmd160  05417d7d42aec901e1f93f764514460b477e4492 \
+                    sha256  011b03b8819cdc467ef923a2dc97feae7915a2db77da7d6195c2fc98e6045f42 \
+                    size    119375 \
                     framework-8b79906.tar.gz \
                     rmd160  d3ad907fc8ed42fb7ca5cdf08ceb8aa09ba1ec74 \
                     sha256  f08a2e063aa6b3299e4edc4cd898a557c20b6d6c85eb26cd489eb6a642d682e6 \
@@ -89,18 +89,18 @@ checksums           osxfuse-120c6ce.tar.gz \
                     rmd160  c7794cd3d644cf1f036b248d21a83901d93187ca \
                     sha256  2426c4669aeb1c1179e5e89af46f2d9a30743f6929419c6414c7eeb8b3212fae \
                     size    5346030 \
-                    fuse-5de6743.tar.gz \
-                    rmd160  fdc52f04c0b345ae3ffde57a355fbb96f907f5c3 \
-                    sha256  e487fac223060caea4bbbaeca861ea35c1d99b98aac75ab393cdfbb97c72b031 \
-                    size    231697 \
+                    fuse-1a1977a.tar.gz \
+                    rmd160  26735fb56773d142f1e9a9a0fed3e64ec1fe6cdd \
+                    sha256  562f92a9a2b1acad725d8ea86494e53ed4f8bf48cf2664f964d069552b236e97 \
+                    size    231739 \
                     support-2cdc560.tar.gz \
                     rmd160  096fc6f329f626ca63d9ec5901004173357327bd \
                     sha256  1c65b389628d5a675d700330143c55c60854faafd791a0743a05cf310721fcf8 \
                     size    3391234 \
-                    osxfuse-3.8.2.dmg \
-                    rmd160  2aa7fea8104f62f4f2bb7c21027a9fba3f4831d7 \
-                    sha256  03a3e561803cdf9fa797c146dc33f0ec0d665cc2bf41cf2b68b3c5b34b03b758 \
-                    size    6945638
+                    osxfuse-3.8.3.dmg \
+                    rmd160  4c26f209dd60329ebe97a0f4c65b374181142584 \
+                    sha256  87e507c44c19689beefa3d47dd00ba953254d9e616cb633c1b4343407fe99700 \
+                    size    6967386
 
 # extract phase will just extract the dmg; post-extract will expand
 # the tarballs
@@ -165,7 +165,7 @@ build.args      -v 5 \
                 -a [join [get_canonical_archs] " -a "] \
                 --framework-prefix="${prefix}" \
                 --fsbundle-prefix="${prefix}" \
-                --library-prefix="${prefix}" 
+                --library-prefix="${prefix}"
 
 # Clear CPATH and LIBRARY_PATH because a ncurses include file
 # conflicts with the one in MacPorts. It doesn't matter much anyway


### PR DESCRIPTION
#### Description

* update to version 3.8.3
* IDECustomDerivedData patch is needed
* libclang.dylib link needed
* removed space

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->