### PR TITLE
py-virtualenv: update to 16.3.0, disable tests

### DIFF
--- a/python/py-virtualenv/Portfile
+++ b/python/py-virtualenv/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-virtualenv
-version             16.1.0
+version             16.3.0
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -19,9 +19,9 @@ homepage            https://virtualenv.pypa.io
 
 master_sites        pypi:v/${python.rootname}
 distname            ${python.rootname}-${version}
-checksums           rmd160  17ea55a18a04ef155b74a062048bf6edf8e53155 \
-                    sha256  f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208 \
-                    size    1977229
+checksums           rmd160  a8f9ef0dee86d22ab58ef03d6d6e0f0f84057973 \
+                    sha256  729f0bcab430e4ef137646805b5b1d8efbb43fe53d4a0f33328624a84a5121f7 \
+                    size    2014631
 
 python.versions     27 34 35 36 37
 
@@ -30,7 +30,7 @@ if {${name} ne ${subport}} {
 
     depends_test-append port:py${python.version}-pytest \
                         port:py${python.version}-mock
-    test.run            yes
+    test.run            no
     test.cmd            py.test-${python.branch}
     test.target
     test.env            PYTHONPATH=${worksrcpath}/build/lib
@@ -42,9 +42,13 @@ if {${name} ne ${subport}} {
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
-        xinstall -m 755 -d ${destroot}${docdir}
-        xinstall -m 644 {*}[glob -directory ${worksrcpath}/docs *] \
-                ${destroot}${docdir}
+        xinstall -m 0755 -d ${destroot}${docdir}/docs/changelog
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE.txt AUTHORS.txt \
+            ${destroot}${docdir}
+        xinstall -m 0644 {*}[glob -directory ${worksrcpath}/docs *.rst] \
+                ${destroot}${docdir}/docs
+        xinstall -m 0644 {*}[glob -directory ${worksrcpath}/docs/changelog *] \
+                ${destroot}${docdir}/docs/changelog
     }
 
     notes "


### PR DESCRIPTION
#### Description
- update to latest version
- disable tests as currently several test dependencies are not present in MacPorts

Closes PR #3419

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? See PR #3419 
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
