### PR TITLE
py-pbr: update to 5.1.2, adopt port

### DIFF
--- a/python/py-pbr/Portfile
+++ b/python/py-pbr/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pbr
-version             5.1.1
+version             5.1.2
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-maintainers         nomaintainer
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
 
 description         Python Build Reasonableness
 long_description    A library for managing setuptools packaging needs \
@@ -25,9 +25,9 @@ homepage            https://docs.openstack.org/pbr/latest/
 master_sites        pypi:p/pbr
 distname            pbr-${version}
 
-checksums           rmd160  8fa5deed40f49d5146be94b522e72ad8aa4d23b6 \
-                    sha256  f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68 \
-                    size    113476
+checksums           rmd160  cbe394431bc60cee5571129804c540324398105a \
+                    sha256  d717573351cfe09f49df61906cd272abaa759b3e91744396b804965ff7bff38b \
+                    size    115789
 
 python.versions     27 34 35 36 37
 


### PR DESCRIPTION
#### Description
- update to latest version
- add myself as maintainer
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
