### PR TITLE
mspdebug: add missing dependency on readline

### DIFF
--- a/devel/mspdebug/Portfile
+++ b/devel/mspdebug/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dlbeer mspdebug 0.25 v
+revision            1
 maintainers         {g5pw @g5pw} openmaintainer
 categories          devel cross
 description         MSPDebug is a free debugger for use with MSP430 MCUs.
@@ -24,7 +25,8 @@ checksums           rmd160  18cfcf737205ab78119a12ebad27ec051487ac5f \
 
 depends_build       port:pkgconfig
 depends_lib         port:hidapi-devel \
-                    port:libusb-compat
+                    port:libusb-compat \
+                    port:readline
 
 patchfiles          patch-Makefile.diff
 


### PR DESCRIPTION
Untested, noticed a broken binary after readline update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G3025
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
