### PR TITLE
gcin: set to nomaintainer

### DIFF
--- a/x11/gcin/Portfile
+++ b/x11/gcin/Portfile
@@ -3,7 +3,7 @@ name		gcin
 version		1.2.1
 revision        3
 categories	x11
-maintainers	mac.com:candyz0416
+maintainers	nomaintainer
 description	a Chinese input method server.
 long_description \
 		gcin is a Chinese input method server for traditional \


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/57916

https://trac.macports.org/ticket/19065 should also be unassigned when this is merged

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
See https://github.com/macports/macports-ports/pull/3568#issuecomment-460025057
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
