### PR TITLE
tcl: remove outdated comment

### DIFF
--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -53,8 +53,6 @@ post-destroot {
     ln -s libtcl8.6.dylib ${destroot}${prefix}/lib/libtcl.dylib
 }
 
-# dont enable threads by default as Tcl uses thread-local storage which makes
-# passing Tcl_Obj* around between threads fatal
 variant threads description {add multithreading support} {
     configure.args-replace --disable-threads \
                            --enable-threads


### PR DESCRIPTION
Comment was added at the same time as `+threads` variant in 79cbcbea17; `+threads` then became a default variant in 469e9dcb2b.

I'm not sure if this comment still has any relevance, i.e. whether it needs to be rephrased rather than removed.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
