### PR TITLE
py-backports.weakref: fix destroot issue

### DIFF
--- a/python/py-backports.weakref/Portfile
+++ b/python/py-backports.weakref/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-backports.weakref
 version             1.0.post1
+revision            1
 platforms           darwin
 supported_archs     noarch
 license             PSF
@@ -21,12 +22,24 @@ checksums           rmd160 348aceddeb8e58622ffffe3983fae82101bc39c6 \
                     sha256 bc4170a29915f8b22c9e7c4939701859650f2eb84184aee80da329ac0b9825c2 \
                     size   10574
 
-python.versions     27 35 36
+python.versions     27
 
 if {${name} ne ${subport}} {
 
     depends_build-append \
-        port:py${python.version}-setuptools \
-        port:py${python.version}-setuptools_scm
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-setuptools_scm
+
+    depends_lib-append  port:py${python.version}-backports
+
+    post-destroot {
+        foreach f {__init__.py __init__.pyc __init__.pyo __pycache__} {
+            set fp "${destroot}${python.pkgd}/backports/$f"
+            if {[file exists ${fp}]} {
+                file delete -force ${fp}
+            }
+        }
+    }
+
     livecheck.type      none
 }

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -66,7 +66,7 @@ py-backports            1.0_1       33
 py-backports-ssl_match_hostname \
                         3.5.0.1_1   33
 py-backports_abc        0.5_1       33
-py-backports.weakref    1.0.post1   34
+py-backports.weakref    1.0.post1_1 34 35 36
 py-barnaba              0.1.6       34 35
 py-bcolz                1.2.1_1     34
 py-beaker               1.10.0_1    26

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -11,7 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                py-tensorflow
 version             1.12.0
-revision            0
+revision            1
 github.setup        tensorflow tensorflow ${version} v
 platforms           darwin
 supported_archs     x86_64
@@ -74,11 +74,8 @@ if {${name} ne ${subport}} {
         port:py${python.version}-absl
     if {${python.version} < 34} {
         depends_lib-append \
+            port:py${python.version}-backports.weakref \
             port:py${python.version}-enum34
-    }
-    if {${python.version} < 37} {
-        depends_lib-append \
-            port:py${python.version}-backports.weakref
     }
 
     use_configure yes


### PR DESCRIPTION
#### Description
- fix destroot issue with py-backports.weakref (https://trac.macports.org/ticket/58004)
- removed subports for PY35/PY36 as this functionality was introduced in PY34
- fixed py-tensorflow dependency on py-backports.weakref that was incorrect

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`? Yes, for py27-backports.weakref and py36-tensorflow.
```py-tensorflow``` fails on my computer, likely because it doesn't use the RightCompiler. I have followed the instructions [here](https://trac.macports.org/wiki/UsingTheRightCompiler) and the logfile says: 
```
Warning: The following files inside the MacPorts prefix not installed by a port were accessed:
  /opt/local/bin/no_default_gcc/cc
  /opt/local/bin/no_default_gcc/gcc
```
Anyhow, if this is an issue - it's certainly not introduced by this PR. Perhaps @cjones051073 and @emcrisostomo can take a look?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
