### PR TITLE
mkcert: update to 1.3.0

### DIFF
--- a/security/mkcert/Portfile
+++ b/security/mkcert/Portfile
@@ -3,8 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-
-github.setup        FiloSottile mkcert 1.2.0 v
+github.setup        FiloSottile mkcert 1.3.0 v
 
 platforms           darwin
 categories          security devel
@@ -29,25 +28,16 @@ long_description    mkcert is a simple tool for making locally-trusted \
                     the system root store, and generates locally-trusted \
                     certificates.
 
-checksums           rmd160  617155fe078c48025b57b3ab8201b6fbeb964bbe \
-                    sha256  bc70de7bc92ce0257dcae88bf1400e2b21c47a88c73c45a78efe91a881229147 \
-                    size    374808
+checksums           rmd160  a121b72975a59236812fb5a6a75e5dfbe0dd62e6 \
+                    sha256  fd1e92ac17ad0839de672224afbc356b927496f41eb3e81579c7aea7fa34c7ae \
+                    size    375819
 
 depends_build       port:go
 use_configure       no
 
 build.cmd           ${prefix}/bin/go
 build.target        build
-build.env           GOPATH=${workpath}
-
-post-extract {
-    file mkdir ${workpath}/src/
-
-    ln -sf ${worksrcpath}/vendor/golang.org ${workpath}/src/golang.org
-    ln -sf ${worksrcpath}/vendor/github.com ${workpath}/src/github.com
-    ln -sf ${worksrcpath}/vendor/software.sslmate.com \
-        ${workpath}/src/software.sslmate.com
-}
+build.env           GOPATH="${workpath}"
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?