### PR TITLE
groovy: update to 2.5.6

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.5
+version         2.5.6
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,9 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  bd62a7891012cfe5b1b6d3faddb453f9e730c94e \
-                sha256  8241668701c2a756eb93117129cd82b79ab03fe7364ebb5ec6432794cd16129a \
-                size    29903517
+checksums       rmd160  442cb35d37270675bb6f9d57b7cbbc919e564842 \
+                sha256  b64d0807d85857cb9d7a2137c6d5d828890598597ad0fd149faac20198ed8e92 \
+                size    29977599
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.6.

###### Tested on

macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?