### PR TITLE
ncdu: Update to 1.14

### DIFF
--- a/sysutils/ncdu/Portfile
+++ b/sysutils/ncdu/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                ncdu
-version             1.13
+version             1.14
 categories          sysutils
 maintainers         {snc @nerdling} openmaintainer
 license             MIT
@@ -19,9 +19,10 @@ master_sites        https://dev.yorhel.nl/download/
 
 depends_lib         port:ncurses
 
-checksums           md5     67239592ac41f42290f52ab89ff198be \
-                    rmd160  948a45d5a5c3607dd3a7ae9236cd369ae24e1205 \
-                    sha1    3233c4185208d9989ac528a94817ed92dd59c773 \
-                    sha256  f4d9285c38292c2de05e444d0ba271cbfe1a705eee37c2b23ea7c448ab37255a
+checksums           md5     d26c0aa57728c19969c3c5036fa272a0 \
+                    rmd160  746fc2e92c647b1092a3396260de8f5c95817625 \
+                    sha1    28c7003ad23d2e3a2d22d2c349bb0c7170752396 \
+                    sha256  c694783aab21e27e64baad314b7c1ff34541bfa219fe9645ef6780f1c5558c44 \
+                    size    145911
 
 livecheck.regex     ${name}-(\\d\\.\\d+)${extract.suffix}


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E174f
Xcode 10.2 10P91b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
