### PR TITLE
mod_maxminddb: new port

### DIFF
--- a/www/mod_maxminddb/Portfile
+++ b/www/mod_maxminddb/Portfile
@@ -1,0 +1,73 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        maxmind mod_maxminddb 1.1.0
+revision            0
+checksums           rmd160  bab39c27d8aba3e6a6cb8f010ebdab3ef23575da \
+                    sha256  b31e63764ddcc1379229059a4726c733ee0538018727b1336d02afaaa8940782 \
+                    size    99821
+
+categories          www
+platforms           darwin
+maintainers         nomaintainer
+license             Apache-2
+
+description         This module allows you to query MaxMind DB files from Apache 2.2+ \
+                    using the libmaxminddb library.
+
+long_description    ${description}
+
+homepage            https://maxmind.github.io/mod_maxminddb/
+github.tarball_from releases
+
+depends_lib         port:apache2 \
+                    port:libmaxminddb
+
+set apxs            ${prefix}/bin/apxs
+set ddir            ${prefix}/share/doc/${name}
+set dbdir           ${prefix}/share/GeoIP
+set mdir            ${prefix}/lib/apache2/modules
+
+patchfiles          patch-Wl.diff
+
+configure.args      --with-apxs=${apxs}
+
+test.run            yes
+test.target         check
+
+destroot {
+    xinstall -d -m 0755 ${destroot}${ddir} ${destroot}${dbdir} ${destroot}${mdir}
+    xinstall -m 0644 -W ${worksrcpath} Changes.md CONTRIBUTING.md \
+        LICENSE README.md TESTING.md ${destroot}${ddir}
+    xinstall -m 0755 ${worksrcpath}/src/.libs/${name}.so ${destroot}${mdir}
+
+    set plist [open "${destroot}${dbdir}/ReadMe_DBFiles.md" w 0644]
+    puts ${plist} "## MaxMindDB Files"
+    puts ${plist} ""
+    puts ${plist} "The database files can be downloaded from here:"
+    puts ${plist} ""
+    puts ${plist} "  - <https://dev.maxmind.com/geoip/geoip2/geolite2/#Downloads>"
+    puts ${plist} ""
+    puts ${plist} "There are 2 versions, and a MD5 checksum file of each."
+    puts ${plist} ""
+    close ${plist}
+}
+
+notes "
+If this is your first install, you might want to enable ${name} in Apache:
+
+    cd ${mdir}
+    sudo ${apxs} -a -e -n \"maxminddb\" mod_maxminddb.so
+
+And then relaunch Apache:
+
+    $ sudo apachectl restart
+
+- - -
+
+Examples/setup: https://github.com/maxmind/mod_maxminddb#examples
+                https://dev.maxmind.com/geoip/geoip2/geolite2/#Downloads
+                ---> ${dbdir}
+"

--- a/www/mod_maxminddb/files/patch-Wl.diff
+++ b/www/mod_maxminddb/files/patch-Wl.diff
@@ -1,0 +1,20 @@
+Pass LDFLAGS to apxs using "-Wl,". This patch should be sent to the developers.
+--- src/Makefile.in.orig	2016-10-19 15:07:34.000000000 -0500
++++ src/Makefile.in	2019-01-16 12:02:39.000000000 -0600
+@@ -208,6 +208,7 @@
+ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = foreign
+ WC = -Wc,"$(CFLAGS)"
++WL = -Wl,"$(LDFLAGS)"
+ CLEANFILES = *.la *.lo *.o *.so *.slo .libs/*
+ EXTRA_DIST = mod_maxminddb.c
+ all: all-am
+@@ -402,7 +402,7 @@
+
+ #   compile the DSO file
+ module: mod_maxminddb.c $(TARGET)
+-	$(APXS) -c $(LDFLAGS) $(LIBMAXMINDDB_LDFLAGS) $(LIBS) $(WC) $(APXS_LDFLAGS) mod_maxminddb.c
++	$(APXS) -c $(WL) $(LIBMAXMINDDB_LDFLAGS) $(LIBS) $(WC) $(APXS_LDFLAGS) mod_maxminddb.c
+
+ install-exec-local: module
+ 	$(APXS) -i -a -n maxminddb .libs/mod_maxminddb.so


### PR DESCRIPTION
#### Description

The Apache module for `libmaxminddb`.

> _This module allows you to query MaxMind DB files from Apache 2.2+ using the libmaxminddb library._

Closes: https://trac.macports.org/ticket/57919

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.3.3 4E3002 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?