### PR TITLE
fluidsynth: use configure.cc for all components

### DIFF
--- a/multimedia/fluidsynth/Portfile
+++ b/multimedia/fluidsynth/Portfile
@@ -42,6 +42,10 @@ platform darwin 8 {
                     patch-tiger.diff
 }
 
+# respect MacPorts compiler for builing make_tables.exe
+# see https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append   patch-external_project_cc.diff
+
 configure.args-append \
                     -Denable-jack=OFF \
                     -Denable-dbus=OFF \

--- a/multimedia/fluidsynth/files/patch-external_project_cc.diff
+++ b/multimedia/fluidsynth/files/patch-external_project_cc.diff
@@ -1,0 +1,10 @@
+--- src/CMakeLists.txt.orig	2018-12-30 04:42:00.000000000 -0700
++++ src/CMakeLists.txt	2019-02-05 05:02:59.000000000 -0700
+@@ -366,6 +366,7 @@
+ ExternalProject_Add(gentables
+     DOWNLOAD_COMMAND ""
+     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gentables
++    CMAKE_ARGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/gentables
+     INSTALL_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/gentables/make_tables.exe "${CMAKE_BINARY_DIR}/"
+ )


### PR DESCRIPTION
See https://trac.macports.org/wiki/UsingTheRightCompiler

Use configure.cc to build make_tables.exe.
Since make_tables.exe is used but not installed, no revbump.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->