### PR TITLE
Fixes #55850: Resolve correct CXX11 dependency

### DIFF
--- a/science/seqan-apps/Portfile
+++ b/science/seqan-apps/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
+PortGroup           cxx11 1.1
 
 name                seqan-apps
 version             2.2.0
@@ -29,12 +30,16 @@ distname            seqan-seqan-v${version}
 checksums           rmd160  c8f7ba426d96339bfa96ae735f0a2cae219e0020 \
                     sha256  6add074932c2723ef1fb658c88f906bdd6ced1fc34cb16a7410251ffc4cb8cc8
 
-# llvm-gcc42 is broken and won't be fixed anymore, see: https://trac.macports.org/ticket/40713
-# For OpenMP only the apple clang version really needs to be blacklisted.
-# Macports clang-3.8 and higher fully support OpenMP 3.1, so we make them the default fallback option and remove gcc from this list.
+# Update the compiler blacklist from cxx11 1.1 PortGroup.
+# Minimum requirement is gcc>=4.9 and clang>=3.5
+# Apple clang (provided by Xcode) does not support OpenMP
+# Macports clang-3.8 and higher fully support OpenMP 3.1, so we make them the default fallback option in case gcc
+# is blacklisted by cxx11 1.1 PortGroup
 
-compiler.blacklist  *gcc* *clang-3.7 *clang-3.6 *clang-3.5 *clang-3.4 *clang-3.3 *dragonegg*
-compiler.fallback   macports-clang-3.9 macports-clang-3.8
+compiler.blacklist-append  macports-gcc-4.6 macports-gcc-4.7 macports-gcc-4.8  \
+                           clang *clang-3.7 *clang-3.6 *clang-3.5 *clang-3.4 *clang-3.3 \
+                           *dragonegg*
+compiler.fallback-append   macports-clang-6.0 macports-clang-5.0 macports-clang-4.0 macports-clang-3.9 macports-clang-3.8
 
 configure.args-append   -DSEQAN_BUILD_SYSTEM=SEQAN_RELEASE_APPS
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Fixes correct CXX11 dependency for seqan-apps 2.2.0 port. See https://trac.macports.org/ticket/55850 for more information.

 - Uses cxx11 portgroup
 - updates compiler blacklist for unsupported compilers
 - updates compiler fallbacks to more recent macports-clang versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1815
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? - There aren't any tests turned on for the port
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
