### PR TITLE
seqan, seqan-apps: update to 2.4.0

### DIFF
--- a/science/seqan-apps/Portfile
+++ b/science/seqan-apps/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake 1.0
 PortGroup           cxx11 1.1
 
 name                seqan-apps
-version             2.2.0
-revision            2
+version             2.4.0
+revision            0
 categories          science
 platforms           darwin
 universal_variant   no
@@ -27,16 +27,17 @@ master_sites        http://packages.seqan.de/seqan-src
 distfiles           seqan-src-${version}${extract.suffix}
 distname            seqan-seqan-v${version}
 
-checksums           rmd160  c8f7ba426d96339bfa96ae735f0a2cae219e0020 \
-                    sha256  6add074932c2723ef1fb658c88f906bdd6ced1fc34cb16a7410251ffc4cb8cc8
+checksums           rmd160  c843f8c749e6f2d8ff5233f160d9683743dce7c2 \
+                    sha256  d7084d17729214003e84818e0280a16f223c8f1c6a30eeef040c27e0c0047bd7 \
+                    size    109626901
 
 # Update the compiler blacklist from cxx11 1.1 PortGroup.
-# Minimum requirement is gcc>=4.9 and clang>=3.5
+# Minimum requirement is gcc>=5 and clang>=3.6
 # Apple clang (provided by Xcode) does not support OpenMP
 # Macports clang-3.8 and higher fully support OpenMP 3.1, so we make them the default fallback option in case gcc
 # is blacklisted by cxx11 1.1 PortGroup
 
-compiler.blacklist-append  macports-gcc-4.6 macports-gcc-4.7 macports-gcc-4.8  \
+compiler.blacklist-append  macports-gcc-4.6 macports-gcc-4.7 macports-gcc-4.8 macports-gcc-4.9 \
                            clang *clang-3.7 *clang-3.6 *clang-3.5 *clang-3.4 *clang-3.3 \
                            *dragonegg*
 compiler.fallback-append   macports-clang-6.0 macports-clang-5.0 macports-clang-4.0 macports-clang-3.9 macports-clang-3.8

--- a/science/seqan-apps/Portfile
+++ b/science/seqan-apps/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           cxx11 1.1
+PortGroup           xcodeversion 1.0
 
 name                seqan-apps
 version             2.4.0
@@ -36,6 +37,8 @@ checksums           rmd160  c843f8c749e6f2d8ff5233f160d9683743dce7c2 \
 # Apple clang (provided by Xcode) does not support OpenMP
 # Macports clang-3.8 and higher fully support OpenMP 3.1, so we make them the default fallback option in case gcc
 # is blacklisted by cxx11 1.1 PortGroup
+
+minimum_xcodeversions {16 8.1}
 
 compiler.blacklist-append  macports-gcc-4.6 macports-gcc-4.7 macports-gcc-4.8 macports-gcc-4.9 \
                            clang *clang-3.7 *clang-3.6 *clang-3.5 *clang-3.4 *clang-3.3 \

--- a/science/seqan/Portfile
+++ b/science/seqan/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                seqan
-version             2.2.0
+version             2.4.0
 categories          science
 platforms           darwin
 supported_archs     noarch
@@ -23,8 +23,9 @@ master_sites        http://packages.seqan.de/${name}-library
 use_xz              yes
 distname            ${name}-library-${version}
 
-checksums           rmd160  f7b2ebdc8635c9568abc9826b2a23f8c607c6d35 \
-                    sha256  b5c036a3d2fc2fe5f2d57dcd4d7c523a6df146ab7b44bc789f42004b058d72fd
+checksums           rmd160  b7426de5fb7f7bb7c8ade4055f7afe238a39dd84 \
+                    sha256  dd97b1514ab83acb7d7be911b157979e188e8ca72cc61c430c1e0fd03bcd41a5 \
+                    size    4868868
 
 use_configure       no
 
@@ -37,7 +38,7 @@ destroot {
     file copy ${worksrcpath}/share/doc/seqan ${destroot}${prefix}/share/doc
     file copy ${worksrcpath}/share/pkgconfig/${name}-${major}.pc ${destroot}${prefix}/lib/pkgconfig/
     file mkdir ${destroot}${prefix}/lib/cmake/${name}
-    file copy ${worksrcpath}/share/cmake/Modules/FindSeqAn.cmake ${destroot}${prefix}/lib/cmake/${name}/${name}-config.cmake
+    file copy ${worksrcpath}/share/cmake/seqan/seqan-config.cmake ${destroot}${prefix}/lib/cmake/${name}/
 }
 
 livecheck.type      regex


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/55851

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Updates seqan ports to the latest release 2.4.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G1815
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
