### PR TITLE
mod_perl2: update to use perl5.28

### DIFF
--- a/www/mod_perl2/Portfile
+++ b/www/mod_perl2/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                mod_perl2
 version             2.0.10
-revision            2
+revision            3
 maintainers         nomaintainer
 categories          www
 license             Apache-2
@@ -29,11 +29,12 @@ master_sites        apache:perl/
 distname            mod_perl-${version}
 
 checksums           rmd160  65fd0774bc495aa02af7dee249427f24d8a58b0e \
-                    sha256  d1cf83ed4ea3a9dfceaa6d9662ff645177090749881093051020bf42f9872b64
+                    sha256  d1cf83ed4ea3a9dfceaa6d9662ff645177090749881093051020bf42f9872b64 \
+                    size    3846211
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
-perl5.branches          5.26
+perl5.branches          5.26 5.28
 perl5.create_variants   ${perl5.branches}
 
 depends_lib         port:apache2 \
@@ -57,7 +58,7 @@ if {[variant_isset apache22]} {
     set mdir        ${prefix}/lib/apache2/modules/
 }
 
-variant apache22 description "use apache22 instead of apache2" {
+variant apache22 description "Use apache22 instead of apache2" {
     depends_lib-replace port:apache2 port:apache22
     destroot.violate_mtree  yes
 }
@@ -88,12 +89,12 @@ post-destroot {
 }
 
 notes "
-If this your first install, you might want to enable mod_perl in apache:
+If this is your first install, you might want to enable mod_perl in Apache:
 
     cd ${mdir}
     sudo ${apxs} -a -e -n \"perl\" mod_perl.so
 
-And then relaunch apache:
+And then relaunch Apache:
 
     ${apachectl} restart
 "


### PR DESCRIPTION
#### Description

I was going to fix a grammar in the notes (that @mf2k found in another port). Updated the port to perl5.28 while I was doing it. Also, added the missing “size” in checksums.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.7.5 11G63
Xcode 4.3.3 4E3002 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?