### PR TITLE
py-typed-ast: update to 1.3.1

### DIFF
--- a/python/py-typed-ast/Portfile
+++ b/python/py-typed-ast/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-typed-ast
-version             1.3.0
+version             1.3.1
 revision            0
 categories-append   devel
 platforms           darwin
@@ -22,12 +22,18 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            typed-ast-${version}
 
-checksums           rmd160  b705b3aff96945f7b9f80168acaf873a215fe97b \
-                    sha256  584e9ae9b2aaa59f3535c06c595a3bf0419b0feef3a3511ff42b2b4ee4222f13 \
-                    size    204234
+checksums           rmd160  eb45862adc33ba6e6eb2333236147217a8978430 \
+                    sha256  606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424 \
+                    size    204285
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+
+    post-destroot {
+       xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+       xinstall -m 0644 -W ${worksrcpath} README.md LICENSE \
+          ${destroot}${prefix}/share/doc/${subport}
+       }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to latest version
- install files in post-destroot

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
