### PR TITLE
openjdk8: add OpenJ9 subports with large heap support

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -18,6 +18,15 @@ subport openjdk8-openj9 {
     set openj9_version 0.12.0
 }
 
+subport openjdk8-openj9-large-heap {
+    version      8u202
+    revision     0
+
+    set build    08
+    set major    8
+    set openj9_version 0.12.1
+}
+
 subport openjdk10 {
     version      10.0.2
     revision     2
@@ -37,6 +46,15 @@ subport openjdk11 {
 subport openjdk11-openj9 {
     version      11.0.2
     revision     1
+
+    set build    9
+    set major    11
+    set openj9_version 0.12.1
+}
+
+subport openjdk11-openj9-large-heap {
+    version      11.0.2
+    revision     0
 
     set build    9
     set major    11
@@ -96,6 +114,25 @@ if {${subport} eq "openjdk8"} {
                  OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
+} elseif {${subport} eq "openjdk8-openj9-large-heap"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
+
+    checksums    rmd160  106ae8c2da187bebc357a4a4674f192acb3af87a \
+                 sha256  3d890c5de3b76928e65f634777fff14b0f141f176ade73ccd8bd52e113347596 \
+                 size    114333605
+
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}-openj9-${openj9_version}
+    worksrcdir   jdk${version}-b${build}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads. \
+                 \
+                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
 } elseif {${subport} eq "openjdk10"} {
     master_sites https://download.java.net/java/GA/jdk${major}/${version}/19aef61b38124481863b1413dce1855f/${build}/
 
@@ -141,6 +178,25 @@ if {${subport} eq "openjdk8"} {
                  OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
+} elseif {${subport} eq "openjdk11-openj9-large-heap"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+
+    checksums    rmd160  eb03ec6d873a35ef673621c6a05b1b800ed030aa \
+                 sha256  1e663b03258a3d30c0b77d745a4e8d30148f159ac15fc791d67bb35b22437d2a \
+                 size    194704380
+
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}-openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}_openj9-${openj9_version}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads. \
+                 \
+                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
 }
 
 use_configure    no


### PR DESCRIPTION
#### Description

Add Eclipse OpenJ9 supports with large heap support.

###### Tested on

macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?