### PR TITLE
fribidi: fix universal build

### DIFF
--- a/textproc/fribidi/Portfile
+++ b/textproc/fribidi/Portfile
@@ -28,11 +28,13 @@ depends_build   port:pkgconfig
 use_autoreconf  yes
 autoreconf.args -fvi
 
-patch {
+post-extract {
     # git.mk seems to trigger a ./config.status --recheck, which is unnecessary
     # and additionally fails due to quoting
     delete ${worksrcpath}/git.mk
 }
+
+patchfiles      patch-gen.tab-Makefile-am-dont-overwrite-cflags.diff
 
 # Parallel builds fail because gen.tab/packtab.o is built multiple times:
 # /usr/bin/clang -DHAVE_CONFIG_H -I. -I..  -I../lib -I../lib -I../charset -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/include  -pipe -Os -arch x86_64 -Wall -ansi  -MT packtab.o -MD -MP -MF .deps/packtab.Tpo -c -o packtab.o packtab.c

--- a/textproc/fribidi/files/patch-gen.tab-Makefile-am-dont-overwrite-cflags.diff
+++ b/textproc/fribidi/files/patch-gen.tab-Makefile-am-dont-overwrite-cflags.diff
@@ -1,0 +1,13 @@
+diff --git gen.tab/Makefile.am.old gen.tab/Makefile.am
+index fe3c80f..bd1a4fc 100644
+--- gen.tab/Makefile.am.old
++++ gen.tab/Makefile.am
+@@ -25,7 +25,7 @@ gen_brackets_type_tab_CPPFLAGS = $(AM_CPPFLAGS)
+ 
+ CFLAGS_FOR_BUILD += -DHAVE_CONFIG_H -I$(top_builddir) -I$(top_builddir)/lib -I$(top_srcdir)/lib
+ CC = $(CC_FOR_BUILD)
+-CFLAGS = $(CFLAGS_FOR_BUILD)
++CFLAGS += $(CFLAGS_FOR_BUILD)
+ 
+ CLEANFILES = $(EXTRA_PROGRAMS)
+ DISTCLEANFILES =


### PR DESCRIPTION
overwriting CFLAGS in gen.tab/Makefile.am breaks the universal build
closes: https://trac.macports.org/ticket/58024
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
