### PR TITLE
kotlin: update to 1.3.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.3.20 v
+github.setup        JetBrains kotlin 1.3.21 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,9 +21,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  34c1380a9cf0858997c922abe6f6fd4b41f58475 \
-                    sha256  2d505fb505c53db7fc6a2a570d97ba3b7a6d3526d4f64aee28de6fda7502f3f0 \
-                    size    38640675
+checksums           rmd160  cc2e2070880f4e0fa30a062138048c7509622599 \
+                    sha256  dbc7fbed67e0fa9a2f2ef6efd89fc1ef8d92daa38bb23c1f23914869084deb56 \
+                    size    38644484
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.3.21.

###### Tested on

macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?