### PR TITLE
update various unmaintained Python ports to their latest versions

### DIFF
--- a/python/py-aniso8601/Portfile
+++ b/python/py-aniso8601/Portfile
@@ -3,11 +3,9 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           aniso8601
-set _n              [string index ${_name} 0]
-
 name                py-aniso8601
-version             1.3.0
+version             4.1.0
+revision            0
 
 categories-append   devel textproc
 platforms           darwin
@@ -18,20 +16,33 @@ maintainers         nomaintainer
 description         A library for parsing ISO 8601 strings
 long_description    ${description}
 
-homepage            https://pypi.python.org/pypi/aniso8601
-master_sites        pypi:${_n}/${_name}
-distname            aniso8601-${version}
+homepage            https://bitbucket.org/nielsenb/aniso8601
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  6f7b46f5323c325830dc604f950def2bdaa759d9 \
-                    sha256  c3b5246f5601b6ae5671911bc4ee5b3e3fe94752e8afab5ce074d8b1232952f1
+checksums           rmd160  df1de3db675b027de98c45b6e45c56bd89e3e53b \
+                    sha256  03c0ffeeb04edeca1ed59684cc6836dc377f58e52e315dc7be3af879909889f4 \
+                    size    39902
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-dateutil
 
+    if {${python.version} eq 27} {
+        depends_test-append port:py${python.version}-mock
+    }
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
+    test.target     test
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+       xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+       xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+          ${destroot}${prefix}/share/doc/${subport}
+       }
+
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-antlr4-python3-runtime/Portfile
+++ b/python/py-antlr4-python3-runtime/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-antlr4-python3-runtime
-version             4.7.1
+version             4.7.2
+revision            0
 categories-append   lang
 platforms           darwin
 license             BSD
@@ -13,13 +14,13 @@ maintainers         nomaintainer
 description         ANTLR4 runtime for Python 3
 long_description    ${description}
 
-homepage            http://www.antlr.org
+homepage            https://www.antlr.org
 master_sites        pypi:a/antlr4-python3-runtime
 distname            antlr4-python3-runtime-${version}
 
-checksums           rmd160  29916b2cd3078aaf0f78c9a4f21c4f7e93784b14 \
-                    sha256  1b26b72c4492cef310542da10bf6b2ab4aa1775618fc6003f75b55ae9eaa3fd3 \
-                    size    111381
+checksums           rmd160  0cd4eff6938d1feea8559e2fb8a1960d669210d3 \
+                    sha256  168cdcec8fb9152e84a87ca6fd261b3d54c8f6358f42ab3b813b14a7193bb50b \
+                    size    112278
 
 python.versions     36
 
@@ -28,6 +29,4 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools
 
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-anytree/Portfile
+++ b/python/py-anytree/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-anytree
-version             2.4.3
+version             2.5.0
+revision            0
 categories-append   devel
 platforms           darwin
 license             Apache-2
@@ -23,9 +24,9 @@ master_sites        pypi:a/anytree
 
 distname            anytree-${version}
 
-checksums           rmd160  518d9d2967b68eb4ca198db10ece6d136e91dd37 \
-                    sha256  9b43699eacfd3fab153433abbc698c74e3c8f883c0505fde2c26ad38163d93fa \
-                    size    18181
+checksums           rmd160  6c8c3d458028d44fd7bc2e22cb760eaa57bd391f \
+                    sha256  409ccb966d759952648d5e5656bc311ab63a1f4a7d5ed9fc0e9715343ca2aa74 \
+                    size    18820
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-appscript/Portfile
+++ b/python/py-appscript/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-appscript
-set real_name       appscript
 version             1.0.1
-categories          python
+revision            0
 platforms           darwin
 license             public-domain
 maintainers         nomaintainer
@@ -18,28 +17,25 @@ long_description    Appscript is a high-level, user-friendly MacPython to \
                     own AppleScript language for automating your Mac.
 
 homepage            http://appscript.sourceforge.net/
-master_sites        pypi:a/${real_name}
-distname            ${real_name}-${version}
+master_sites        pypi:a/${python.rootname}
+distname            ${python.rootname}-${version}
 
 checksums           rmd160  d5bc7581a0149500b6bed18c47711ddc31024658 \
-                    sha256  24eae98bb50bd6788be9e7ce03cea1187788d63e70712eedcf186dc1b9fb6578
+                    sha256  24eae98bb50bd6788be9e7ce03cea1187788d63e70712eedcf186dc1b9fb6578 \
+                    size    411330
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+
     post-destroot {
         set subdir appscript_[string index ${python.version} 0]x
-        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}/${subdir}
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}/${subdir}
         file copy ${worksrcpath}/${subdir}/sample \
             ${destroot}${prefix}/share/doc/${subport}/${subdir}/sample
         file copy ${worksrcpath}/${subdir}/doc \
             ${destroot}${prefix}/share/doc/${subport}/${subdir}/doc
     }
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   [lindex ${master_sites} 0]
-    livecheck.regex ${real_name}-(\[0-9.\]+)${extract.suffix}
 }
-

--- a/python/py-apsw/Portfile
+++ b/python/py-apsw/Portfile
@@ -2,49 +2,40 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 
 name                py-apsw
-version             3.7.14.1-r1
+
+github.setup        rogerbinns apsw 3.26.0-r1
 platforms           darwin
 license             zlib
 maintainers         nomaintainer
 
-description         Very thin SQLite 3 wrapper for python
-long_description    APSW provides an SQLite 3 wrapper that provides \
-                    the thinnest layer over SQLite 3 possible. \
-                    Everything you can do from the C API to SQLite 3, \
-                    you can do from Python.  Although APSW looks \
-                    vaguely similar to the DBAPI, it is not compliant \
-                    with that API and instead works the way SQLite 3 does.
-homepage            https://code.google.com/p/apsw/
+description         Another Python SQLite wrapper
+long_description    APSW is a Python wrapper for the SQLite embedded relational database engine.
 
-master_sites        googlecode:apsw
-distname            apsw-${version}
-use_zip             yes
+distname            ${python.rootname}-${version}
 
-checksums           md5     ae32e46df985b5fbbdbdd17640367711 \
-                    sha1    735f1b1e236055e4f0de286e17e400d7db1f87e7 \
-                    rmd160  91df80878469dbed49c35f5d2704bdcb9cfbe549
+checksums           rmd160  fc4b75178721129b510a541c229936673087947f \
+                    sha256  2e6f2c7452728b80156c069a80dcbe7ec521c699afd48c4643b88ef02db6a0e1 \
+                    size    307840
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:sqlite3
+    depends_lib-append \
+                    port:sqlite3
 
-    post-extract {
-        copy ${filespath}/setup.cfg ${worksrcpath}/setup.cfg
-        reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/setup.cfg
-    }
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
+    test.target     test
+    test.env        PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
 
     post-destroot {
-        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath}/doc/ apsw.html \
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
                 ${destroot}${prefix}/share/doc/${subport}
     }
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://code.google.com/p/apsw/downloads/list
-    livecheck.regex {apsw-([0-9\.]+(-r1)?).zip}
 }

--- a/python/py-apsw/files/setup.cfg
+++ b/python/py-apsw/files/setup.cfg
@@ -1,4 +1,0 @@
-[build_ext]
-include_dirs=@@PREFIX@@/include
-library_dirs=@@PREFIX@@/lib
-


### PR DESCRIPTION
#### Description
- ```py-anytree```: update to 2.5.0
- ```py-antlr4-python3-runtime```: update to 4.7.2, update homepage/livecheck
- ```py-aniso8601```: update to 4.1.0, add py37, enable tests, update homepage/livecheck, install files in post-destroot
- ```py-appscript```: add py37
- ```py-apsw```: update to 3.26.0-r1, move from GoogleCode to GitHub, enable tests, update livecheck/homepage
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, where available
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
