### PR TITLE
openmpi: Fix GCC check and reenable parallel build

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -37,18 +37,19 @@ livecheck.regex     Open MPI v(\[0-9\.\]+) released
 
 if {[string first "-devel" $subport] > 0} {
     name                openmpi-devel
-    version             3.0.99
+    version             4.0.99
     revision            0
 
-    set base            201803180305
-    set tag             ecbdf17
+    set base            201902010241
+    set tag             4dfb938
     distname            openmpi-v${branch}.x-${base}-${tag}
 
     master_sites        http://www.open-mpi.org/nightly/v${branch}.x \
                         http://www.open-mpi.de/nightly/v${branch}.x
 
-    checksums           rmd160  73a09f4df8017a63c53ca7996c1575c9f0e461eb \
-                        sha256  ea03b0078611046d10cb7b6154d3bed0c86c5e5a6c9eb582f2dd1fd34f19b3dd
+    checksums           rmd160  484afcc1668ef16f8b135c50743b7d9eb60ed5c4 \
+                        sha256  0545dbc889a4c909c65d50c06e14e169e32a6f2d513cf63a9eec3f97161dba41 \
+                        size    9921641
 
     livecheck.version   ${base}
     livecheck.url       [lindex ${master_sites} 0]
@@ -142,9 +143,6 @@ if {${subport} != ${name}} {
     select.file                 ${filespath}/${name}-${cname}
     livecheck.type              none
 
-    # avoid "Can't open profile/psizeof_f08.f90 for writing"
-    use_parallel_build no
-
     if {[string first "-default" $subport] < 0} {
         configure.compiler      [lindex $clist($cname) 0]
         append long_description "\\n\\nTHIS SUBPORT WRAPS ${cname}'s C/C++"
@@ -209,10 +207,10 @@ if {${subport} != ${name}} {
     } else {
         append long_description " (AND THE FORTRAN COMPILER SELECTED BY THE VARIANT, IF ANY)"
 
-        compilers.choose   fc
-        compilers.setup    default_fortran
-
         if {[fortran_variant_isset]} {
+            compilers.choose   fc
+            compilers.setup    default_fortran
+
             configure.args-delete   --disable-mpi-fortran
             configure.args-append   --enable-mpi-fortran
             select.file             ${filespath}/${name}-${cname}-fortran


### PR DESCRIPTION
#### Description

There are a couple of things to note here:
* I've reenabled parallel builds. In the process of updating Open MPI, I must have run a dozen or so builds and didn't see any issues, so I figured it might be OK to remove the restriction in hopes that it had been fixed upstream.
* I've moved around some lines relating to Fortran in an effort to fix what I felt were bugs in the current install, which would always depend on GCC and hence enable Fortran unconditionally. I'm not super confident on how this variant is supposed to work, since it looks to me that you cannot use Fortran with clang anyways, but I think the new behavior is better than what we had before.

Finally, one odd quirk that I didn't see fit to include in this pull request but I thought I'd mention: I run MacPorts so that it pulls port information off of Git, so in the Fortran variant builds I'd get an error where some autogenerated files would have lines like these:

```fortran
include '/opt/local/var/macports/build/_Users_saagarjha_Git_macports-ports_science_openmpi/openmpi-default/work/openmpi-4.0.0/ompi/mpiext/pcollreq/mpif-h/mpiext_pcollreq_mpifh.h'
```

which would kill the build unless I set `FCFLAGS='-ffree-line-length-none'` because apparently it's a syntax error in Fortran to have a line longer than 132 characters.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E184e
Xcode 10.2 10P91b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->