### PR TITLE
Security update to libu2f-host

### DIFF
--- a/security/libu2f-host/Portfile
+++ b/security/libu2f-host/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libu2f-host
-version             1.1.6
+version             1.1.7
 categories          security
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -21,9 +21,9 @@ master_sites        https://developers.yubico.com/${name}/Releases/
 
 use_xz              yes
 
-checksums           rmd160  f9afa18828d8224d94b88d03e22bdb37e4ea3428 \
-                    sha256  4da0bb9e32cab230e63bf65252076f9a4b5e40eb9ec2ddaf9376bcef30e7bda7 \
-                    size    469380
+checksums           rmd160  eec9e62e6a03348bf5d651bc4a29b112dd9b35be \
+                    sha256  917a259f2977538bc31e13560c830a11e49f54f27908372c774bbbb042d2dcff \
+                    size    469784
 
 depends_build       port:pkgconfig
 depends_lib         port:json-c \


### PR DESCRIPTION
Fixes CVE-2018-20340.

#### Description

Upgrade to the latest release which is security release

See https://www.yubico.com/support/security-advisories/ysa-2019-01/

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 10.14.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tested basic functionality of all binary files?
