### PR TITLE
dcmtk: Add jpeg dependency and small patch

### DIFF
--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -7,7 +7,7 @@ PortGroup               github 1.0
 
 github.setup            DCMTK dcmtk 3.6.4 DCMTK-
 
-revision                0
+revision                1
 set unpatched_version   [lindex [split ${version} _] 0]
 set stripped_version    [string map {. ""} ${unpatched_version}]
 categories              graphics
@@ -30,8 +30,6 @@ long_description        DCMTK is a collection of libraries and applications    \
 
 homepage                http://dicom.offis.de/dcmtk
 
-distname                DCMTK-${version}
-
 checksums \
     rmd160  3cec9851ec086d4bbb7087310e0ee087bf013fbb \
     sha256  6ae2dbae581ad5ea799d4c4546c6bad8a1782e7acd06a6497c7fb4f2f4bfee42 \
@@ -46,7 +44,8 @@ conflicts_build         ${name}
 
 depends_lib             port:zlib \
                         port:libiconv \
-                        port:tcp_wrappers
+                        port:tcp_wrappers \
+                        port:jpeg
 
 configure.args-append   -DDCMTK_WITH_TIFF=OFF \
                         -DDCMTK_WITH_PNG=OFF \
@@ -59,6 +58,18 @@ configure.args-append   -DDCMTK_WITH_TIFF=OFF \
                         -DDCMTK_WITH_SNDFILE=OFF \
                         -DDCMTK_WITH_WRAP=ON \
                         -DDCMTK_ENABLE_CXX11=OFF
+
+patch {
+    # DCMTK by default installs headers with PACKAGE_VERSION and friends
+    # defined, rather than some more unique name. We'll just change that for
+    # them...
+    set replstring \
+      {s/[[:<:]](PACKAGE_(VERSION(_SUFFIX|_NUMBER)?|DATE|NAME|STRING))[[:>:]]/\1_DCMTK/g} 
+    # Yes, yes, reinplace etc. There are some files that sed chokes on if I
+    # just iterate over all of them. Plus this is much faster.
+    system -W ${worksrcpath} \
+      "grep --null -lr PACKAGE_ . | xargs -0 sed -i '' -E '${replstring}'"
+}
 
 post-configure {
     # 7921b2e in base creates symlinks, bypassing the github portgroup's move


### PR DESCRIPTION
DCMTK defines generic PACKAGE_VERSION (and friends) macros in its installed headers; rename this
to PACKAGE_(...)_DCMTK to be unique.

Maintainer update; just making the PR to see if anyone had concerns with this approach to cleaning up a package using the PACKAGE_(VERSION(|_SUFFIX|_NUMBER)|DATE|NAME|STRING) #defines in its installed headers. This does not change the CMAKE package configuration outputs, which use some of these names, but in an unrelated (not part of *.h files) fashion.

This appends _DCMTK to the above strings; it builds and tests (and I use it daily in my own applications) fine.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G5019
Xcode 10.1 10B61
