### PR TITLE
libomp: Add clang-7.0 to the blacklist when not available.

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -95,7 +95,7 @@ compiler.blacklist-append {clang < 500} *gcc*
 
 # Avoid dependency cycle
 # https://trac.macports.org/ticket/53110
-foreach ver {3.8 3.9 4.0 5.0 6.0 devel} {
+foreach ver {3.8 3.9 4.0 5.0 6.0 7.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }


### PR DESCRIPTION
Maintainer update. Add latest LLVM to list of compiler to blacklist when not installed. (Avoid circular dep.)