### PR TITLE
renameutils: update to 0.12.0

### DIFF
--- a/sysutils/renameutils/Portfile
+++ b/sysutils/renameutils/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                renameutils
-version             0.10.0
-revision            2
+version             0.12.0
+revision            0
 categories          sysutils
 license             GPL-3+
 platforms           darwin
@@ -19,16 +19,18 @@ long_description    The file renaming utilities consists of five programs - \
                     removes URL encoded characters from filenames.
 
 homepage            https://www.nongnu.org/renameutils/
-master_sites        http://ftp.twaren.net/Unix/NonGNU/renameutils/
+master_sites        http://ftp.twaren.net/Unix/NonGNU/renameutils/ \
+                    https://download.savannah.gnu.org/releases/renameutils/
 
-checksums           md5     77f2bb9a18bb25c7cc3c23b64f2d394b \
-                    sha1    e90cbc7cff75e639037c48c5d33cbfc21b9d618b \
-                    rmd160  c67506035400917844fa2be7b095e6b5f65a3a91
+checksums           rmd160  996cf00d764ed3f4443fcf7af4ed3649bda365f3 \
+                    sha256  cbd2f002027ccf5a923135c3f529c6d17fabbca7d85506a394ca37694a9eb4a3 \
+                    size    954114
 
 depends_lib         port:readline \
                     port:gettext \
                     port:coreutils
 
-patchfiles          patch-use_coreutils.diff
+patchfiles          patch-use_coreutils.diff \
+                    patch-fix_install.diff
 
 configure.ldflags-append    -liconv -lintl

--- a/sysutils/renameutils/files/patch-fix_install.diff
+++ b/sysutils/renameutils/files/patch-fix_install.diff
@@ -1,0 +1,11 @@
+--- src/Makefile.in.orig
++++ src/Makefile.in
+@@ -1577,7 +1577,7 @@ all-local:
+ 	@[ -f icp ] || (echo $(LN_S) icmd icp ; $(LN_S) icmd icp)
+ 
+ install-exec-local:
+-	$(mkdir_p) $(DESTDIR)($bindir)
++	$(mkdir_p) $(DESTDIR)$(bindir)
+ 	@[ -f $(DESTDIR)$(bindir)/qmv ] || (echo $(LN_S) qcmd $(DESTDIR)$(bindir)/qmv ; $(LN_S) qcmd $(DESTDIR)$(bindir)/qmv)
+ 	@[ -f $(DESTDIR)$(bindir)/qcp ] || (echo $(LN_S) qcmd $(DESTDIR)$(bindir)/qcp ; $(LN_S) qcmd $(DESTDIR)$(bindir)/qcp)
+ 	@[ -f $(DESTDIR)$(bindir)/imv ] || (echo $(LN_S) icmd $(DESTDIR)$(bindir)/imv ; $(LN_S) icmd $(DESTDIR)$(bindir)/imv)

--- a/sysutils/renameutils/files/patch-use_coreutils.diff
+++ b/sysutils/renameutils/files/patch-use_coreutils.diff
@@ -25,23 +25,14 @@
  /* This list should be up to date with mv and cp!
   * It was last updated on 2007-11-30 for
   * Debian coreutils 5.97-5.4 in unstable.
---- src/list.c.orig
-+++ src/list.c
-@@ -311,7 +311,7 @@ list_files(char **args)
-     ls_args_list = llist_clone(ls_options);	/* llist_add_all! */
-     llist_add_last(ls_args_list, "--");
-     llist_add_first(ls_args_list, "--quoting-style=c");
--    llist_add_first(ls_args_list, "ls");
-+    llist_add_first(ls_args_list, "gls");
+--- src/qcmd.c.orig
++++ src/qcmd.c
+@@ -239,7 +239,7 @@ main(int argc, char **argv)
+     editor_program = xstrdup(editor_program);
  
-     if (llist_contains(ls_options, "--directory")) {
- 	firstdir = ".";
-@@ -411,7 +411,7 @@ run_ls(char **args, pid_t *ls_pid, int *ls_fd)
- 	    die(_("cannot close file: %s"), errstr);
- 	if (dup2(child_pipe[1], STDOUT_FILENO) == -1)
- 	    die(_("cannot duplicate file descriptor: %s"), errstr);
--	execvp("ls", args);
-+	execvp("gls", args);
- 	die(_("cannot execute `ls': %s"), errstr);
-     }
-     *ls_pid = child_pid;
+     if (ls_program == NULL)
+-        ls_program = xstrdup("ls");
++        ls_program = xstrdup("gls");
+ 
+     /* Parse format options */
+     if (format_options != NULL && !format->parse_options(format_options))


### PR DESCRIPTION
#### Description

 - update to version 0.12.0
 - update patch
 - add patch for syntax error in `Makefile.in`

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
update

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.11.6 15G22010
Xcode 8.2 8C38 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
