### PR TITLE
gradle: update to 5.2.1

### DIFF
--- a/devel/gradle/Portfile
+++ b/devel/gradle/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                gradle
-version             5.2
+version             5.2.1
 categories          devel java groovy
 license             Apache-2
 maintainers         {amake @amake} openmaintainer
@@ -20,9 +20,9 @@ platforms           darwin
 distname            ${name}-${version}-bin
 master_sites        https://services.gradle.org/distributions
 
-checksums           rmd160  ac95a48e2c480f0556f4075f465281e1f00eb1ac \
-                    sha256  ff322863250159595e93b5a4d17a6f0d21c59a1a0497c1e1cf1d53826485503f \
-                    size    87425679
+checksums           rmd160  3e67c0ba3f27884538782687134fa756ba76cc1a \
+                    sha256  748c33ff8d216736723be4037085b8dc342c6a0f309081acf682c9803e407357 \
+                    size    87430521
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Gradle 5.2.1.

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?