### PR TITLE
py-backports.weakref: declare py34/py35/py36 obsolete

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -66,7 +66,6 @@ py-backports            1.0_1       33
 py-backports-ssl_match_hostname \
                         3.5.0.1_1   33
 py-backports_abc        0.5_1       33
-py-backports.weakref    1.0.post1_1 34 35 36
 py-barnaba              0.1.6       34 35
 py-bcolz                1.2.1_1     34
 py-beaker               1.10.0_1    26


### PR DESCRIPTION
#### Description
When trying to fix [ticket 58004](https://trac.macports.org/ticket/58004) I moved the subports incorrectly to py-graveyard, which set them to be replaced_by py37-backports.weakref. Instead they should be set to obsolete. 

I *think* this PR fixes this, but I am not 100% sure that this is the suggested/correct approach and whether removing the port from py-graveyard has any unwanted/unexpected consequences. Perhaps @ryandesign or someone else wants to comment before merging this?

Closes: https://trac.macports.org/ticket/58038

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [ ] tried a full install with `sudo port -vst install`? N/A
- [ ] tested basic functionality of all binary files? N/A

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
