### PR TITLE
update various unmaintained Python ports to their latest version

### DIFF
--- a/python/py-apipkg/Portfile
+++ b/python/py-apipkg/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-apipkg
-version             1.4
+version             1.5
+revision            0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -14,20 +15,27 @@ maintainers         nomaintainer
 description         namespace control and lazy-import mechanism
 long_description    ${description}
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/${version}
-master_sites        https://pypi.io/packages/source/[string index ${python.rootname} 0]/${python.rootname}
+homepage            https://github.com/pytest-dev/apipkg
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  ab2a3843243c828c9b3f823fdef616be039a9159 \
-                    sha256  2e38399dbe842891fe85392601aab8f40a8f4cc5a9053c326de35a1cc0297ac6
+checksums           rmd160  3a9c4097dab889b2047eddca849479e2a3568301 \
+                    sha256  37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6 \
+                    size    11186
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE CHANGELOG \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
 
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-arrow/Portfile
+++ b/python/py-arrow/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        crsmithdev arrow 0.10.0
+github.setup        crsmithdev arrow 0.13.0
 name                py-arrow
 platforms           darwin
 license             Apache-2
@@ -13,16 +13,29 @@ maintainers         nomaintainer
 description         Better dates and times for Python
 long_description    ${description}
 
-checksums           rmd160  c5ed26ded8fbb89ee8030a2588a040a1bbdcbc07 \
-                    sha256  73529b1886319f4f51761a6d6c2182083b89c8ea891abc93de3c6a4bc106e483
+checksums           rmd160  61f774812eb123f12cbca0972b4cfd9f4b5b53d7 \
+                    sha256  471029c5b49db1ac7616fc7d7b441ed32252de16c2e192bf890c851ae5d9aab5 \
+                    size    67011
 
 python.versions     27 36
 
 if {${name} ne ${subport}} {
-    depends_lib-append \
-                        port:py${python.version}-dateutil
     depends_build-append \
-                        port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-dateutil
+
+    if {${python.version} eq 27} {
+        depends_lib-append \
+                    port:py${python.version}-backports-functools_lru_cache
+    }
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE HISTORy.md \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
 
     livecheck.type      none
 }

--- a/python/py-execnet/Portfile
+++ b/python/py-execnet/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-execnet
-version             1.4.1
+version             1.5.0
+revision            0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -14,15 +15,16 @@ maintainers         nomaintainer
 description         rapid multi-Python deployment
 long_description    ${description}
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/${version}
-master_sites        https://pypi.io/packages/source/[string index ${python.rootname} 0]/${python.rootname}
+homepage            https://github.com/pytest-dev/execnet
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  7caded55c5decfa619e1e276021a22117ed8dd88 \
-                    sha256  f66dd4a7519725a1b7e14ad9ae7d3df8e09b2da88062386e08e941cafc0ef3e6
+checksums           rmd160  7eb5a884de11a73c4258c0427f51ddadf10145ff \
+                    sha256  a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a \
+                    size    168497
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \
@@ -30,7 +32,11 @@ if {${name} ne ${subport}} {
 
     depends_lib-append      port:py${python.version}-apipkg
 
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} CHANGELOG.rst ISSUES.txt LICENSE README.rst \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
+
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-pytest-forked/Portfile
+++ b/python/py-pytest-forked/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pytest-forked
+version             1.0.1
+categories-append   devel
+platforms           darwin
+license             MIT
+
+python.versions     27 34 35 36 37
+
+maintainers         nomaintainer
+
+description         run tests in isolated forked subprocesses
+long_description    ${description}
+
+homepage            https://github.com/pytest-dev/pytest-forked
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  59bea869caf0cdb2cd206a48fdaf94a92e2f47a7 \
+                    sha256  260d03fbd38d5ce41a657759e8d19bc7c8cfa6d0dcfa36c0bc9742d33bc30742 \
+                    size    6751
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
+
+    depends_lib-append \
+                    port:py${python.version}-pytest
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE CHANGELOG \
+            README.rst ${destroot}${docdir}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-pytest-xdist/Portfile
+++ b/python/py-pytest-xdist/Portfile
@@ -4,36 +4,42 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-xdist
-version             1.14
+version             1.26.1
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
 license             MIT
 maintainers         nomaintainer
 
-description         ${python.rootname} adds extends pytest with some unique test execution modes
+description         The ${python.rootname} plugin extends py.test with some unique test execution modes
 long_description    ${description}
 
-homepage            https://pypi.python.org/pypi/${python.rootname}/${version}
-master_sites        https://pypi.io/packages/source/[string index ${python.rootname} 0]/${python.rootname}
-
-use_zip             yes
+homepage            https://github.com/pytest-dev/pytest-xdist
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  adabee9f8df156188837348ab042f246daedbbf3 \
-                    sha256  4a5e1199122fa29e3017d8d189f59ccc5d82e841474ba2a1eec0e89606153623
+checksums           rmd160  37ca4772ee0149875d7523cb5c6221b5e53d42c6 \
+                    sha256  d03d1ff1b008458ed04fa73e642d840ac69b4107c168e06b71037c62d7813dd4 \
+                    size    64973
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \
                             port:py${python.version}-setuptools_scm
 
-    depends_lib-append      port:py${python.version}-pytest \
-                            port:py${python.version}-execnet
+    depends_lib-append      port:py${python.version}-execnet \
+                            port:py${python.version}-pytest \
+                            port:py${python.version}-pytest-forked \
+                            port:py${python.version}-setuptools \
+                            port:py${python.version}-six
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} CHANGELOG.rst README.rst LICENSE \
+            OVERVIEW.md ${destroot}${prefix}/share/doc/${subport}
+    }
 
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- py-apipkg: update to 1.5, add py37, update homepage/livecheck, install files in post-destroot
- py-execnet: update to 1.5.0, add py37, update homepage/livecheck, install files in post-destroot 
- py-pytest-xdist: update to 1.26.1, add py37, update homepage/livecheck, install files in post-destroot 
- py-pytest-forked: new port, version 1.0.1 (dependency of py-pytest-xdist)
- py-arrow: update to 0.13.0, update dependencies, install files in post-destroot

<!-- Note: it is best make pull requests from a branch rather than from master -->
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, were applicable
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
