### PR TITLE
Update tilp2 and associated ports

### DIFF
--- a/math/libticables2/Portfile
+++ b/math/libticables2/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                libticables2
-version             1.3.3
+version             1.3.5
 license             GPL-2
 categories          math
 maintainers         nomaintainer
@@ -14,9 +14,9 @@ master_sites        sourceforge:tilp
 
 use_bzip2           yes
 
-checksums           md5     1e412cd5b27fa38099cc4c5326ba99e0 \
-                    sha1    468fc783e07a6349f27185498f340f5ee6af565c \
-                    rmd160  0d8df15f82fe587caa235672c1ccf357e5066404
+checksums           rmd160  c982c0526652ab9d6735e813a256ae69ef97afc9 \
+                    sha256  0c6fb6516e72ccab081ddb3aecceff694ed93aec689ddd2edba9c7c7406c4522 \
+                    size    187416
 
 depends_build       port:pkgconfig
 
@@ -25,3 +25,8 @@ depends_lib         port:libticonv \
                     port:gettext \
                     path:lib/pkgconfig/glib-2.0.pc:glib2
 
+use_autoreconf      yes
+
+livecheck.type      regex
+livecheck.url       https://sourceforge.net/projects/tilp/rss?path=/tilp2-linux
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/math/libticalcs2/Portfile
+++ b/math/libticalcs2/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                libticalcs2
-version             1.1.7
+version             1.1.9
 categories          math
 platforms           darwin
 license             GPL-2
@@ -14,10 +14,12 @@ long_description    Utility libraries for TI related apps
 homepage            http://lpg.ticalc.org/prj_tilp
 
 master_sites        sourceforge:tilp
+
 use_bzip2           yes
-checksums           md5     bb88a1200e3bce4e58718a0284933e97 \
-                    sha1    cda1d356816b352618d25fc2d7afed59352a91ad \
-                    rmd160  c5bed4064c708489835dc591d04bbc7d7fa5a747
+
+checksums           rmd160  e29fa825014ae1cea3da4cc5b4c1a534c6c95a72 \
+                    sha256  76780788bc309b647f97513d38dd5f01611c335a72855e0bd10c7bdbf2e38921 \
+                    size    269963
 
 depends_build       port:pkgconfig
 
@@ -27,3 +29,9 @@ depends_lib         port:gettext \
                     port:libticonv \
                     port:libtifiles2 \
                     port:zlib
+
+use_autoreconf      yes
+
+livecheck.type      regex
+livecheck.url       https://sourceforge.net/projects/tilp/rss?path=/tilp2-linux
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/math/libticonv/Portfile
+++ b/math/libticonv/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                libticonv
-version             1.1.3
+version             1.1.5
 license             GPL-2
 categories          math
 maintainers         nomaintainer
@@ -14,9 +14,9 @@ master_sites        sourceforge:tilp
 
 use_bzip2           yes
 
-checksums           md5     c669598f9917a8f98b26eed1fa27242f \
-                    sha1    54ea00bf8123e1d8ea33d2a1adec3ffaf99317a0 \
-                    rmd160  5077248d2e878473d19999f0211b04d8f44a4f80
+checksums           rmd160  2865f8e23902154d2e6e0d6775066e5d88bc89d3 \
+                    sha256  316da6a73bf26b266dd23443882abc4c9fe7013edc3a53e5e301d525c2060878 \
+                    size    86036
 
 depends_build       port:pkgconfig
 
@@ -24,3 +24,11 @@ depends_lib         port:libiconv \
                     port:libusb-compat \
                     path:lib/pkgconfig/glib-2.0.pc:glib2
 
+use_autoreconf      yes
+
+configure.args      --enable-iconv
+configure.ldflags   -liconv
+
+livecheck.type      regex
+livecheck.url       https://sourceforge.net/projects/tilp/rss?path=/tilp2-linux
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/math/libtifiles2/Portfile
+++ b/math/libtifiles2/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                libtifiles2
-version             1.1.5
+version             1.1.7
 license             GPL-2
 categories          math
 maintainers         nomaintainer
@@ -14,14 +14,20 @@ master_sites        sourceforge:tilp
 
 use_bzip2           yes
 
-checksums           md5     3a0efc82d841a6c232837c34a18a8a24 \
-                    sha1    ed08600bd767cf878e56cbd55143e16d42ecd372 \
-                    rmd160  cdac8e83f70c1019d00ba0d7e230911d770ec173
+checksums           rmd160  62cc385c58ae847b3923c8fdbd90e796e3e9b1c0 \
+                    sha256  9ac63b49e97b09b30b37bbc84aeb15fa7967bceb944e56141c5cd5a528acc982 \
+                    size    122454
 
 depends_build       port:pkgconfig
 
 depends_lib         port:libticonv \
                     port:gettext \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:zlib
+                    port:zlib \
+                    port:libarchive
 
+use_autoreconf      yes
+
+livecheck.type      regex
+livecheck.url       https://sourceforge.net/projects/tilp/rss?path=/tilp2-linux
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/math/tilp2/Portfile
+++ b/math/tilp2/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                tilp2
-version             1.16
+version             1.18
 license             GPL-2
 categories          math
 maintainers         nomaintainer
@@ -12,13 +12,16 @@ platforms           darwin
 
 master_sites        sourceforge:tilp
 
-checksums           md5     eaea086a5041bb970977de7e65fd9bfa \
-                    sha1    61d26fb1ad4f76df1f8d46369692792da7f6e5a3 \
-                    rmd160  9bfd4ec998679e06b56b94901fce1ef765aa749e
+checksums           rmd160  433edb66a15f1cdb3487c34bbbd2b2ac31570fb7 \
+                    sha256  7b3ab363eeb52504d6ef5811c5d264f8016060bb7bd427be5a064c2ed7384e47 \
+                    size    536744
+
+patchfiles          patch-remove-kde.diff
 
 use_bzip2           yes
 
 depends_build       port:pkgconfig \
+                    port:intltool \
                     bin:groff:groff
 
 depends_lib         port:libiconv \
@@ -30,5 +33,10 @@ depends_lib         port:libiconv \
                     port:gtk2 \
                     port:libglade2
 
+use_autoreconf      yes
+
 configure.args      --without-kde
 
+livecheck.type      regex
+livecheck.url       https://sourceforge.net/projects/tilp/rss?path=/tilp2-linux
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)

--- a/math/tilp2/files/patch-remove-kde.diff
+++ b/math/tilp2/files/patch-remove-kde.diff
@@ -1,0 +1,93 @@
+--- configure.ac	2016-01-15 12:28:52.000000000 -0800
++++ configure.ac	2019-02-10 21:57:57.000000000 -0800
+@@ -118,24 +118,25 @@
+ CFLAGS="$CFLAGS $ARCH"
+ 
+ # KDE dialogs support
+-AC_ARG_WITH(kde, AC_HELP_STRING([--with-kde], [Compile with KDE support]), [kde=$withval], [kde=no])
+-if test "x$kde" = "xdefault"; then
+-  case $host_os in
+-    *mingw*)
+-      kde=no
+-      ;;
+-    *)
+-      kde=yes
+-      ;;
+-  esac
+-fi
+-if test "x$kde" = "xyes"; then
+-        AC_PROG_CXX
+-        AC_PATH_KDE
+-        AC_DEFINE(WITH_KDE, 1, [Use KDE support])
+-fi
+-AM_CONDITIONAL(USE_KDE, test "x$kde" = "xyes")
+-AC_SUBST(kde)
++#AC_ARG_WITH(kde, AC_HELP_STRING([--with-kde], [Compile with KDE support]), [kde=$withval], [kde=no])
++#if test "x$kde" = "xdefault"; then
++#  case $host_os in
++#    *mingw*)
++#      kde=no
++#      ;;
++#    *)
++#      kde=yes
++#      ;;
++#  esac
++#fi
++#if test "x$kde" = "xyes"; then
++#        AC_PROG_CXX
++#        AC_PATH_KDE
++#        AC_DEFINE(WITH_KDE, 1, [Use KDE support])
++#fi
++#AM_CONDITIONAL(USE_KDE, test "x$kde" = "xyes")
++#AC_SUBST(kde)
++AC_DEFINE(WITH_KDE, 0, [Use KDE support])
+ 
+ # Ensure MSVC-compatible struct packing convention is used when
+ # compiling for Win32 with gcc.
+--- src/Makefile.am	2016-03-14 12:55:57.000000000 -0700
++++ src/Makefile.am	2019-02-10 22:09:58.000000000 -0800
+@@ -9,16 +9,15 @@
+ tilp_CPPFLAGS = -I$(top_srcdir)/intl \
+ 	@TICABLES_CFLAGS@ @TIFILES_CFLAGS@ @TICALCS_CFLAGS@ @TICONV_CFLAGS@ \
+ 	@GLIB_CFLAGS@ @GTK_CFLAGS@ \
+-	@KDE_INCLUDES@ @QT_INCLUDES@ \
+ 	-DSHARE_DIR=\"$(pkgdatadir)\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+ 	-DGTK_DISABLE_DEPRECATED
++#	@KDE_INCLUDES@ @QT_INCLUDES@
+ tilp_LDFLAGS = -export-dynamic
+ tilp_LDADD = @TICABLES_LIBS@ @TIFILES_LIBS@ @TICALCS_LIBS@ @TICONV_LIBS@ \
+-	@GLIB_LIBS@ @GTK_LIBS@ \
+-	@LIB_KDECORE@ @LIB_KDEUI@ @LIB_KIO@ @LIB_QT@ @KDE_LDFLAGS@ \
+-	@QT_LDFLAGS@ @X_LDFLAGS@ @LIBZ@
++	@GLIB_LIBS@ @GTK_LIBS@ @LIBZ@
++#	@LIB_KDECORE@ @LIB_KDEUI@ @LIB_KIO@ @LIB_QT@ @KDE_LDFLAGS@ @QT_LDFLAGS@ @X_LDFLAGS@
+ tilp_SOURCES = *.h \
+ 	tilp_calcs.c tilp_cmdline.c tilp_config.c tilp_error.c \
+ 	tilp_files.c tilp_gif.c tilp_main.c \
+@@ -36,16 +35,16 @@
+   tilp_LDFLAGS += -Wl,../build/mingw/tilp-rc.o
+ endif
+ 
+-if USE_KDE
+-  tilp_SOURCES += kde.cpp
+-  nodist_tilp_SOURCES = kde-private.cpp
+-  CLEANFILES = kde-private.cpp
+-
+-  kde-private.cpp: kde-private.h
+-	  @MOC@ kde-private.h -o kde-private.cpp
+-else
+-  EXTRA_DIST = kde.cpp
+-endif
++#if USE_KDE
++#  tilp_SOURCES += kde.cpp
++#  nodist_tilp_SOURCES = kde-private.cpp
++#  CLEANFILES = kde-private.cpp
++#
++#  kde-private.cpp: kde-private.h
++#	  @MOC@ kde-private.h -o kde-private.cpp
++#else
++#  EXTRA_DIST = kde.cpp
++#endif
+ 


### PR DESCRIPTION
#### Description
tilp2 → 1.18
libticalcs2 → 1.1.9
libticables2 → 1.3.5
libtifiles → 1.1.7
libticonv → 1.1.5

tilp2 needed some small patches from upstream that haven't landed in a release yet, mainly to remove KDE support that we disabled anyways.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E184e
Xcode 10.2 10P91b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->