### PR TITLE
curl: security update to version 7.64.0

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -3,7 +3,7 @@
 PortSystem                      1.0
 
 name                            curl
-version                         7.63.0
+version                         7.64.0
 categories                      net www
 platforms                       darwin freebsd
 maintainers                     {ryandesign @ryandesign}
@@ -26,14 +26,14 @@ set curl_distfile               ${distfiles}
 distfiles                       ${curl_distfile}:curl
 
 checksums                       ${curl_distfile} \
-                                rmd160  6985390ee929d95cd0a3e7d929f6084996669031 \
-                                sha256  9600234c794bfb8a0d3f138e9294d60a20e7a5f10e35ece8cf518e2112d968c4 \
-                                size    2390408
+                                rmd160  40806b3ea50ddab9d2f063dad37e81fdf6b04a17 \
+                                sha256  2f2f13fa34d44aa29cb444077ad7dc4dc6d189584ad552e0aaeb06e608af6001 \
+                                size    2398904
 
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    4
+    revision                    0
 
     depends_build               port:pkgconfig
 


### PR DESCRIPTION
fixes CVE-2018-16890, CVE-2019-3822 and CVE-2019-3823
See: https://curl.haxx.se/changes.html

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
