### PR TITLE
php: update to php72 to 7.2.15 and php73 to 7.3.2

### DIFF
--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -133,19 +133,19 @@ switch ${subport_branch} {
     }
     7.2 {
         epoch           2
-        version         7.2.14
+        version         7.2.15
         use_xz          yes
-        checksums       rmd160  eb26f2a6d305fa8279cefee91a0f71bc2523470e \
-                        sha256  ee3f1cc102b073578a3c53ba4420a76da3d9f0c981c02b1664ae741ca65af84f \
-                        size    12156460
+        checksums       rmd160  6067fc9f21a66e65495db83caa132a8ef7d4b102 \
+                        sha256  75e90012faef700dffb29311f3d24fa25f1a5e0f70254a9b8d5c794e25e938ce \
+                        size    12164460
     }
     7.3 {
         epoch           2
-        version         7.3.1
+        version         7.3.2
         use_xz          yes
-        checksums       rmd160  9f81e9d7544948e070bccb82cee1cabe5d5e8601 \
-                        sha256  cfe93e40be0350cd53c4a579f52fe5d8faf9c6db047f650a4566a2276bf33362 \
-                        size    11944376
+        checksums       rmd160  66e5db5e21c1539f11307a65ea79ae0b73f1ca62 \
+                        sha256  010b868b4456644ae227d05ad236c8b0a1f57dc6320e7e5ad75e86c5baf0a9a8 \
+                        size    11966760
     }
     7.4 {
         # When this becomes a stable version, remove the overrides for homepage,
@@ -341,8 +341,8 @@ subport ${php} {
         5.6.40              {revision 1}
         7.0.33              {revision 1}
         7.1.26              {revision 1}
-        7.2.14              {revision 1}
-        7.3.1               {revision 1}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
     
     depends_run             port:php_select
@@ -471,8 +471,8 @@ subport ${php}-apache2handler {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
     
     description             ${php} Apache 2 Handler SAPI
@@ -520,8 +520,8 @@ subport ${php}-cgi {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     description             ${php} CGI SAPI
@@ -559,8 +559,8 @@ subport ${php}-fpm {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     description             ${php} FPM SAPI
@@ -627,8 +627,8 @@ subport ${php}-calendar {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     description             a PHP extension for converting between different \
@@ -646,8 +646,8 @@ subport ${php}-curl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       net www
@@ -671,8 +671,8 @@ subport ${php}-dba {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       databases
@@ -702,8 +702,8 @@ subport ${php}-enchant {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc devel
@@ -740,8 +740,8 @@ subport ${php}-exif {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       graphics
@@ -760,8 +760,8 @@ subport ${php}-ftp {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       net
@@ -785,8 +785,8 @@ subport ${php}-gd {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       graphics
@@ -834,8 +834,8 @@ subport ${php}-gettext {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       devel
@@ -859,8 +859,8 @@ subport ${php}-gmp {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       devel math
@@ -889,8 +889,8 @@ subport ${php}-iconv {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc
@@ -914,8 +914,8 @@ subport ${php}-imap {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       mail
@@ -943,8 +943,8 @@ subport ${php}-intl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
     
     categories-append       devel
@@ -967,8 +967,8 @@ subport ${php}-ipc {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          shmop sysvmsg sysvsem sysvshm
@@ -988,8 +988,8 @@ subport ${php}-ldap {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       databases
@@ -1016,8 +1016,8 @@ subport ${php}-mbstring {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc
@@ -1094,8 +1094,8 @@ subport ${php}-mysql {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          mysqli pdo_mysql
@@ -1256,8 +1256,8 @@ subport ${php}-odbc {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          odbc pdo_odbc
@@ -1299,8 +1299,8 @@ if {[vercmp ${branch} 5.5] >= 0} {
             5.6.40              {revision 0}
             7.0.33              {revision 0}
             7.1.26              {revision 0}
-            7.2.14              {revision 0}
-            7.3.1               {revision 0}
+            7.2.15              {revision 0}
+            7.3.2               {revision 0}
         }
 
         php.extensions.zend opcache
@@ -1330,8 +1330,8 @@ subport ${php}-openssl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       devel security
@@ -1363,8 +1363,8 @@ subport ${php}-oracle {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          oci8 pdo_oci
@@ -1400,8 +1400,8 @@ subport ${php}-pcntl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       sysutils
@@ -1428,8 +1428,8 @@ subport ${php}-posix {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       sysutils
@@ -1450,8 +1450,8 @@ subport ${php}-postgresql {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          pgsql pdo_pgsql
@@ -1556,8 +1556,8 @@ subport ${php}-pspell {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc
@@ -1581,8 +1581,8 @@ subport ${php}-snmp {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       sysutils
@@ -1606,8 +1606,8 @@ subport ${php}-soap {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       net
@@ -1630,8 +1630,8 @@ subport ${php}-sockets {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       net
@@ -1645,8 +1645,8 @@ subport ${php}-sockets {
 if {[vercmp ${branch} 7.2] >= 0} {
 subport ${php}-sodium {
     switch -- ${version} {
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          sodium
@@ -1673,8 +1673,8 @@ subport ${php}-sqlite {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     php.extensions          sqlite sqlite3 pdo_sqlite
@@ -1712,8 +1712,8 @@ subport ${php}-tidy {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
     
     categories-append       www
@@ -1741,8 +1741,8 @@ subport ${php}-wddx {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc
@@ -1767,8 +1767,8 @@ subport ${php}-xmlrpc {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc
@@ -1800,8 +1800,8 @@ subport ${php}-xsl {
         5.6.40              {revision 0}
         7.0.33              {revision 0}
         7.1.26              {revision 0}
-        7.2.14              {revision 0}
-        7.3.1               {revision 0}
+        7.2.15              {revision 0}
+        7.3.2               {revision 0}
     }
 
     categories-append       textproc


### PR DESCRIPTION
See: http://php.net/ChangeLog-7.php#7.2.15
See: http://php.net/ChangeLog-7.php#7.3.2

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (for version 7.2)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
