### PR TITLE
mplayer-devel: update to latest upstream commit

### DIFF
--- a/multimedia/mplayer-devel/Portfile
+++ b/multimedia/mplayer-devel/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                mplayer-devel
-version             37869
-revision            4
+version             38122
+revision            0
 categories          multimedia
 license             GPL-2+
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -13,7 +13,7 @@ platforms           darwin
 
 set dvdnav_ver      1294
 set ffmpeg_branch   master
-set ffmpeg_ver      81c3ce0855f144c89800b824db3e4e0dcdad9016
+set ffmpeg_ver      19565c6026016ee95a957ec95af0669103224ab5
 
 description         The MPlayer movie player built from SVN.
 long_description    ${description} It plays most MPEG/VOB, AVI, Ogg/OGM, \

--- a/multimedia/mplayer-devel/files/configure.vorbis.patch
+++ b/multimedia/mplayer-devel/files/configure.vorbis.patch
@@ -1,6 +1,6 @@
 --- configure.orig	2013-04-01 00:55:08.000000000 -0700
 +++ configure	2013-04-01 01:08:51.000000000 -0700
-@@ -6415,6 +6415,9 @@ if test "$_tremor" = auto; then
+@@ -6694,6 +6694,9 @@ if test "$_tremor" = auto; then
    _tremor=no
    statement_check tremor/ivorbiscodec.h 'vorbis_synthesis(0, 0)' -logg -lvorbisidec && _tremor=yes && _libvorbis=no
  fi

--- a/multimedia/mplayer-devel/files/configure.x11.patch
+++ b/multimedia/mplayer-devel/files/configure.x11.patch
@@ -1,6 +1,6 @@
 --- configure.orig	2011-06-23 11:42:26.000000000 -0700
 +++ configure	2011-06-23 13:34:17.000000000 -0700
-@@ -4297,6 +4297,9 @@ echores "$_x11_headers"
+@@ -4715,6 +4715,9 @@ echores "$_x11_headers"
  
  
  echocheck "X11"
@@ -10,7 +10,7 @@
  if test "$_x11" = auto && test "$_x11_headers" = yes ; then
    for I in "" -L/usr/X11R7/lib -L/usr/local/lib -L/usr/X11R6/lib -L/usr/lib/X11R6 \
             -L/usr/X11/lib -L/usr/lib32 -L/usr/openwin/lib -L/usr/local/lib64 -L/usr/X11R6/lib64 \
-@@ -6777,6 +6780,7 @@ fi
+@@ -7116,6 +7119,7 @@ fi
  if test "$_qtx" = yes ; then
      def_qtx='#define CONFIG_QTX_CODECS 1'
      win32 && _qtx_codecs_win32=yes && def_qtx_win32='#define CONFIG_QTX_CODECS_WIN32 1'


### PR DESCRIPTION
Latest upstream commit fixes a problem with FFmpeg and x264.
See https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/2a111c99a60fdf4fe5eea2b073901630190c6c93

The issue has arisen with MPlayer (see https://trac.macports.org/ticket/58055).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->