### PR TITLE
mongodb: license changed to SSPL since 4.0.4

### DIFF
--- a/databases/mongodb/Portfile
+++ b/databases/mongodb/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  df1a655f448f3f0edb13057e4c57060de0b03523 \
                     sha256  d967098fc91d105cdb0f400c8b837e5c2795c3638d7720392bc47afb1efe1c10 \
                     size    49507822
 
-license             {AGPL-3 OpenSSLException}
+license             SSPL
 categories          databases
 maintainers         {ryandesign @ryandesign}
 


### PR DESCRIPTION
#### Description
See: https://www.mongodb.com/community/licensing

> MongoDB, Inc.’s Server Side Public License (for all versions released after October 16, 2018, including patch fixes for prior versions).

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
