### PR TITLE
mplayer: patch internal ffmpeg for libx264

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                MPlayer
 version             1.3.0
-revision            3
+revision            4
 categories          multimedia
 license             GPL-2+
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -78,6 +78,9 @@ configure.args-append \
 
 patchfiles configure.x11.patch configure.vorbis.patch
 patchfiles-append patch-libvo-osx-objc-common-opengl-headers.diff
+
+# https://trac.macports.org/ticket/58055
+patchfiles-append patch-mplayer-libx264-updated.diff
 
 post-patch {
     # https://trac.macports.org/ticket/38935

--- a/multimedia/MPlayer/files/patch-mplayer-libx264-updated.diff
+++ b/multimedia/MPlayer/files/patch-mplayer-libx264-updated.diff
@@ -1,0 +1,64 @@
+diff --git ffmpeg/libavcodec/libx264.c ffmpeg/libavcodec/libx264.c
+index 5030d65..18ea6c6 100644
+--- ffmpeg/libavcodec/libx264.c
++++ ffmpeg/libavcodec/libx264.c
+@@ -268,7 +268,7 @@ static int X264_frame(AVCodecContext *ctx, AVPacket *pkt, const AVFrame *frame,
+ 
+     x264_picture_init( &x4->pic );
+     x4->pic.img.i_csp   = x4->params.i_csp;
+-    if (x264_bit_depth > 8)
++    if (X264_BIT_DEPTH > 8)
+         x4->pic.img.i_csp |= X264_CSP_HIGH_DEPTH;
+     x4->pic.img.i_plane = avfmt2_num_planes(ctx->pix_fmt);
+ 
+@@ -745,6 +745,9 @@ FF_ENABLE_DEPRECATION_WARNINGS
+ 
+     x4->params.i_width          = avctx->width;
+     x4->params.i_height         = avctx->height;
++#if X264_BUILD >= 153
++    x4->params.i_bitdepth       = av_pix_fmt_desc_get(avctx->pix_fmt)->comp[0].depth;
++#endif
+     av_reduce(&sw, &sh, avctx->sample_aspect_ratio.num, avctx->sample_aspect_ratio.den, 4096);
+     x4->params.vui.i_sar_width  = sw;
+     x4->params.vui.i_sar_height = sh;
+@@ -858,6 +861,25 @@ FF_ENABLE_DEPRECATION_WARNINGS
+     return 0;
+ }
+ 
++static const enum AVPixelFormat pix_fmts[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUVJ420P,
++    AV_PIX_FMT_YUV422P,
++    AV_PIX_FMT_YUVJ422P,
++    AV_PIX_FMT_YUV444P,
++    AV_PIX_FMT_YUVJ444P,
++    AV_PIX_FMT_YUV420P10,
++    AV_PIX_FMT_YUV422P10,
++    AV_PIX_FMT_YUV444P10,
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_NV20,
++#ifdef X264_CSP_NV21
++    AV_PIX_FMT_NV21,
++#endif
++    AV_PIX_FMT_NONE
++};
++
+ static const enum AVPixelFormat pix_fmts_8bit[] = {
+     AV_PIX_FMT_YUV420P,
+     AV_PIX_FMT_YUVJ420P,
+@@ -895,11 +917,11 @@ static const enum AVPixelFormat pix_fmts_8bit_rgb[] = {
+ 
+ static av_cold void X264_init_static(AVCodec *codec)
+ {
+-    if (x264_bit_depth == 8)
++    if (X264_BIT_DEPTH == 8)
+         codec->pix_fmts = pix_fmts_8bit;
+-    else if (x264_bit_depth == 9)
++    else if (X264_BIT_DEPTH == 9)
+         codec->pix_fmts = pix_fmts_9bit;
+-    else if (x264_bit_depth == 10)
++    else if (X264_BIT_DEPTH == 10)
+         codec->pix_fmts = pix_fmts_10bit;
+ }
+ 


### PR DESCRIPTION
backport of minor upstream patch for new API
bump revision to rebuild against new libx264

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
