### PR TITLE
minio[-mc]: Update to latest.

### DIFF
--- a/www/minio-mc/Portfile
+++ b/www/minio-mc/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 # UPDATE THESE IN SYNC!
-set version         2019-01-10T00-38-22Z
-set commit          0854af6e6d3e9f79e8d9c98db5e0d133a527923b 
+set version         2019-02-13T19-48-27Z
+set commit          bc1a108e5c8f3c2a9e25ed34ff221985987b3fed 
 
 set relversion      [regsub {(T..)-(..)-(..Z)} $version {\1:\2:\3}]
 # This is not used for fetching, but is compiled into the executable
@@ -23,9 +23,9 @@ long_description \
 license             Apache-2
 
 checksums \
-    rmd160  ea373b8b3130fbb3c0b37231ed415507208819e3 \
-    sha256  30773b0f5bded84acf8e92aa3de75a0a9cf1992363b16b8ae686905478a45b71 \
-    size    1791045
+    rmd160  4530e849c2fcc1d56b6f2cf904918efa44a9852d \
+    sha256  49f63b907e1c15d1c0fcdfdd2c06ef79b73ed5ff50685a05802b12e4d9644454 \
+    size    2981551
 
 set goproj          github.com/${github.author}/${github.project}
 

--- a/www/minio/Portfile
+++ b/www/minio/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 # UPDATE THESE IN SYNC!
-set version         2019-01-16T21-44-08Z
-set commit          8766c5eb22c1dc59721ad8a2c4c6fcf37bb2aad2
+set version         2019-02-12T21-58-47Z
+set commit          ee5b3622a580a6a037269746c9ef77e68df1b879
 
 set relversion      [regsub {(T..)-(..)-(..Z)} $version {\1:\2:\3}]
 # This is not used for fetching, but is compiled into the executable
@@ -25,9 +25,9 @@ long_description \
 license             Apache-2
 
 checksums \
-    rmd160  47120f897245918e2ae3368c0f355fac6b7320a8 \
-    sha256  dd6e133b700702d84100a7892d5b3f5b4166bb4127aeb21c7e91195f7cffb8d1 \
-    size    9283180
+    rmd160  e1471a27dc3787861d304d7b194310492ad9726c \
+    sha256  63a7c03b846ed63141eb440580d0d9fd28ad30560232e80dc0032012a573318c \
+    size    9140271
 
 set goproj          github.com/${github.author}/${github.project}
 


### PR DESCRIPTION
Maintainer updates.

Includes security update: https://github.com/minio/minio/releases/tag/RELEASE.2019-02-12T21-58-47Z