### PR TITLE
dcmtk: revert change to PACKAGE_VERSION name

### DIFF
--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -39,7 +39,7 @@ cmake.out_of_source     yes
 
 compiler.blacklist      *gcc* {clang < 137}
 
-# Still puts ${prefix}/include at the head of the -I list... 
+# Still puts ${prefix}/include at the head of the -I list...
 conflicts_build         ${name}
 
 depends_lib             port:zlib \
@@ -64,7 +64,7 @@ patch {
     # defined, rather than some more unique name. We'll just change that for
     # them...
     set replstring \
-      {s/[[:<:]](PACKAGE_(VERSION(_SUFFIX|_NUMBER)?|DATE|NAME|STRING))[[:>:]]/\1_DCMTK/g} 
+      {s/[[:<:]](PACKAGE_(VERSION(_SUFFIX|_NUMBER)?|DATE|NAME|STRING))[[:>:]]/\1_DCMTK/g}
     # Yes, yes, reinplace etc. There are some files that sed chokes on if I
     # just iterate over all of them. Plus this is much faster.
     system -W ${worksrcpath} \

--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               muniversal 1.0

--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -4,12 +4,12 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               muniversal 1.0
 PortGroup               conflicts_build 1.0
-PortGroup               cmake 1.0
+PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 github.setup            DCMTK dcmtk 3.6.4 DCMTK-
 
-revision                1
+revision                2
 set unpatched_version   [lindex [split ${version} _] 0]
 set stripped_version    [string map {. ""} ${unpatched_version}]
 categories              graphics
@@ -36,8 +36,6 @@ checksums \
     rmd160  3cec9851ec086d4bbb7087310e0ee087bf013fbb \
     sha256  6ae2dbae581ad5ea799d4c4546c6bad8a1782e7acd06a6497c7fb4f2f4bfee42 \
     size    6199593
-
-cmake.out_of_source     yes
 
 compiler.blacklist      *gcc* {clang < 137}
 

--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -9,7 +9,7 @@ PortGroup               github 1.0
 
 github.setup            DCMTK dcmtk 3.6.4 DCMTK-
 
-revision                2
+revision                3
 set unpatched_version   [lindex [split ${version} _] 0]
 set stripped_version    [string map {. ""} ${unpatched_version}]
 categories              graphics
@@ -58,18 +58,6 @@ configure.args-append   -DDCMTK_WITH_TIFF=OFF \
                         -DDCMTK_WITH_SNDFILE=OFF \
                         -DDCMTK_WITH_WRAP=ON \
                         -DDCMTK_ENABLE_CXX11=OFF
-
-patch {
-    # DCMTK by default installs headers with PACKAGE_VERSION and friends
-    # defined, rather than some more unique name. We'll just change that for
-    # them...
-    set replstring \
-      {s/[[:<:]](PACKAGE_(VERSION(_SUFFIX|_NUMBER)?|DATE|NAME|STRING))[[:>:]]/\1_DCMTK/g}
-    # Yes, yes, reinplace etc. There are some files that sed chokes on if I
-    # just iterate over all of them. Plus this is much faster.
-    system -W ${worksrcpath} \
-      "grep --null -lr PACKAGE_ . | xargs -0 sed -i '' -E '${replstring}'"
-}
 
 post-configure {
     # 7921b2e in base creates symlinks, bypassing the github portgroup's move

--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -30,7 +30,7 @@ long_description        DCMTK is a collection of libraries and applications    \
                         and C++. It comes in complete source code and is made  \
                         available as "open source" software.
 
-homepage                http://dicom.offis.de/dcmtk
+homepage                https://dicom.offis.de/dcmtk
 
 checksums \
     rmd160  3cec9851ec086d4bbb7087310e0ee087bf013fbb \
@@ -148,5 +148,5 @@ test.cmd                env DYLD_LIBRARY_PATH=${cmake.build_dir}/lib make
 test.target             -j 1 test
 
 livecheck.type          regex
-livecheck.url           http://dicom.offis.de/dcmtk.php.en
+livecheck.url           https://dicom.offis.de/dcmtk.php.en
 livecheck.regex         ${name}-(\[0-9._\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3
Xcode 10.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->