### PR TITLE
update various unmaintained Python ports to their latest version

### DIFF
--- a/python/py-axolotl-curve25519/Portfile
+++ b/python/py-axolotl-curve25519/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-axolotl-curve25519
-version             0.1
+python.rootname     python-axolotl-curve25519
+version             0.4.1.post2
 platforms           darwin
 license             GPL-3
 maintainers         nomaintainer
@@ -14,19 +15,17 @@ long_description \
     Python implementation of curve25519 with ed25519 signatures for py-axolotl
 
 homepage            https://github.com/tgalal/python-axolotl-curve25519
-master_sites        pypi:p/python-axolotl-curve25519
-distname            python-axolotl-curve25519-${version}
+master_sites        pypi:p/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5     f28d902df9044f0bf86a35a4bd2ec092 \
-                    rmd160  f543e7e6aec6621145de3a455437a01ec8a22446 \
-                    sha256  c559f6a5bf51e869325b36bd83c14cccd7dec1c6e7599e797f9ba27a72d339c0
+checksums           rmd160  31f9e2dc684d65ccd42e914ae303e5b2d2fb611a \
+                    sha256  0705a66297ebd2f508a60dc94e22881c754301eb81db93963322f6b3bdcb63a3 \
+                    size    79941
 
-python.versions     27 36
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-axolotl/Portfile
+++ b/python/py-axolotl/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-axolotl
-version             0.1.39
+python.rootname     python-axolotl
+version             0.1.42
+revision            0
 platforms           darwin
 license             GPL-3
 maintainers         nomaintainer
@@ -14,21 +16,25 @@ long_description    ${description}
 
 homepage            https://github.com/tgalal/python-axolotl
 master_sites        pypi:p/python-axolotl
-distname            python-axolotl-${version}
+distname            ${python.rootname}-${version}
 
-checksums           md5     136d37cf7aceb4b3e01fbb40ac592f3c \
-                    rmd160  ddd12e8c80eb39828ce6ca1404e5edcec5650ddf \
-                    sha256  9af9c937d0d05ebea414f1be79ecc7517cc3541a77101941e6a2a71bdd2b6e25
+checksums           rmd160  22988db6b833ced9b7f62401ae50a3076caf5de5 \
+                    sha256  ef78c2efabcd4c33741669334bdda04710a3ef0e00b653f00127acff6460a7f0 \
+                    size    39472
 
-python.versions     27 36
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
-    depends_run-append      port:py${python.version}-crypto \
+
+    depends_run-append      port:py${python.version}-cryptography \
                             port:py${python.version}-axolotl-curve25519 \
                             port:py${python.version}-protobuf3
 
+    depends_test-append     port:py${python.version}-nose
+    test.run        yes
+    test.cmd        nosetests-${python.branch}
+    test.target     axolotl.tests
+
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }

--- a/python/py-blessed/Portfile
+++ b/python/py-blessed/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-blessed
-version             1.14.1
+version             1.15.0
 platforms           darwin
 license             MIT
 maintainers         nomaintainer
@@ -17,10 +17,11 @@ homepage            https://github.com/jquast/blessed
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  5c2faf81f6fa6305e1acf74518677f5b792de5bb \
-                    sha256  58a289d833299944dc2f7b02aae522e3ed53ec0d43fbbfca5d9eeb9486b2c073
+checksums           rmd160  8adbc157f058e2a49fb706343b0824a6c2119f58 \
+                    sha256  777b0b6b5ce51f3832e498c22bc6a093b6b5f99148c7cbf866d26e2dec51ef21 \
+                    size    83832
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -28,7 +29,13 @@ if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-six \
                         port:py${python.version}-wcwidth
 
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}/docs
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+            ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 {*}[glob -types f ${worksrcpath}/docs/*] \
+            ${destroot}${prefix}/share/doc/${subport}/docs
+    }
+
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }

--- a/python/py-blessings/Portfile
+++ b/python/py-blessings/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-blessings
-set real_name       blessings
-version             1.6.1
+version             1.7
+revision            0
 maintainers         nomaintainer
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 description         A thin, practical wrapper around terminal formatting, positioning, and more
 long_description    ${description}
@@ -16,12 +16,24 @@ supported_archs     noarch
 license             MIT
 
 homepage            https://github.com/erikrose/blessings
-master_sites        pypi:b/${real_name}/
-distname            ${real_name}-${version}
-checksums           rmd160  56381887db40a66014ea3ce6ae2d9490c0669be4 \
-                    sha256  74919575885552e14bc24a68f8b539690bd1b5629180faa830b1a25b8c7fb6ea \
-                    size    20122
+master_sites        pypi:b/${python.rootname}/
+distname            ${python.rootname}-${version}
+checksums           rmd160  684c638f95ece792dac0e7b5d65d9c139cdb88f4 \
+                    sha256  98e5854d805f50a5b58ac2333411b0482516a8210f23f43308baeb58d77c157d \
+                    size    28194
 
 if {${name} ne ${subport}} {
-    depends_build  port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-six
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
+
+    livecheck.type  none
 }

--- a/python/py-bottle-sqlalchemy/Portfile
+++ b/python/py-bottle-sqlalchemy/Portfile
@@ -1,13 +1,11 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           bottle-sqlalchemy
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             0.3
+name                py-bottle-sqlalchemy
+version             0.4.3
+revision            0
 
 categories-append   databases devel
 license             MIT
@@ -22,19 +20,19 @@ platforms           darwin
 supported_archs     noarch
 
 homepage            https://github.com/iurisilvio/bottle-sqlalchemy
-master_sites        pypi:${_n}/${_name}/
-distname            ${_name}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
+distname            ${python.rootname}-${version}
 
-checksums           md5 b139d97424efcf917474f142851f0231 \
-                    sha256 197189c4aa92dad32c49fcb6e8a1c365679b1d024129640a4f30eee0b2db6b78
+checksums           sha256  ba6127f3aff2b78649781adbbee65518233dc481e9f9e32e3b050d1ad9551c17 \
+                    rmd160  eb205ca003feef2172a44c06dbe2f59e112d5c0c \
+                    size    2974
 
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_lib     port:py${python.version}-bottle
+    depends_lib-append \
+                    port:py${python.version}-bottle \
+                    port:py${python.version}-sqlalchemy
 
     livecheck.type  none
-} else {
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
 }


### PR DESCRIPTION
#### Description
- py-axolotl: update to 0.1.42, add py37, enable tests, update dependencies
- py-axolotl-curve25519: update to 0.4.1.post2, add py37 
- py-blessed: update to 1.15.0, add py37
- py-blessings: update to 1.7, add py37
- py-bottle-sqlalchemy: update to 0.4.3, update dependencies
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? Yes, where available.
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
