### PR TITLE
qemu: disable capstone to avoid stealth linking

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -2,6 +2,7 @@ PortSystem 1.0
 
 name                    qemu
 version                 3.0.0
+revision                1
 categories              emulators
 license                 GPL-2+
 platforms               darwin
@@ -54,6 +55,7 @@ configure.args-append   --iasl=/usr/bin/false
 # Select features
 configure.args-append   --disable-cocoa \
                         --disable-curses \
+                        --disable-capstone \
                         --disable-sdl \
                         --disable-gtk \
                         --disable-opengl \


### PR DESCRIPTION
#### Description
Fixes: https://trac.macports.org/ticket/58068

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
