### PR TITLE
ipcalc: require perl5.28.

### DIFF
--- a/net/ipcalc/Portfile
+++ b/net/ipcalc/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                ipcalc
 version             0.41
-revision            3
+revision            4
 categories          net
 license             GPL-2+
 platforms           darwin
@@ -25,7 +25,7 @@ master_sites        http://jodies.de/ipcalc-archive/
 checksums           rmd160  aaa21c1804d7498e2604c907a336c20dc9b4511d \
                     sha256  dda9c571ce3369e5b6b06e92790434b54bec1f2b03f1c9df054c0988aa4e2e8a
 
-perl5.branches      5.26
+perl5.branches      5.28
 
 depends_lib         port:perl${perl5.major}
 


### PR DESCRIPTION
#### Description

Switch `ipcalc` to `perl5.28`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.3
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?