### PR TITLE
dpkg: update to 1.19.4 and use perl5.28. Disable dselect.

### DIFF
--- a/sysutils/dpkg/Portfile
+++ b/sysutils/dpkg/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                dpkg
-version             1.18.24
-revision            1
+version             1.19.4
 platforms           darwin
 categories          sysutils archivers
 license             GPL-2+
@@ -21,10 +20,11 @@ worksrcdir          ${name}-${version}
 use_xz              yes
 extract.asroot      yes
 
-checksums           rmd160  0fe5e443ed2f25ecc401c16855f2e920152b963e \
-                    sha256  d853081d3e06bfd46a227056e591f094e42e78fa8a5793b0093bad30b710d7b4
+checksums           rmd160  4628134b3fc6d731c7397ef752a0af9ec5c3db63 \
+                    sha256  c15234e98655689586bff2d517a6fdc6135d139c54d52ae9cfa6a90007fee0ae \
+                    size    4645784
 
-perl5.branches      5.26
+perl5.branches      5.28
 
 depends_build-append \
                     port:pkgconfig \
@@ -59,7 +59,8 @@ configure.args-append \
                     --with-liblzma \
                     --disable-linker-optimizations \
                     --disable-silent-rules \
-                    --disable-start-stop-daemon
+                    --disable-start-stop-daemon \
+                    --disable-dselect
 
 compiler.blacklist-append cc gcc-3.3 gcc-4.0 apple-gcc-4.0
 


### PR DESCRIPTION
#### Description

* Update from `1.18.24` to `1.19.4`
* Use `perl5.28`
* Do not build `dselect`

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [x] update
- [ ] security fix

###### Tested on

macOS 10.14.3
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?