### PR TITLE
npm6: update to 6.8.0

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm6
-version             6.7.0
+version             6.8.0
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -25,10 +25,10 @@ distname            npm-${version}
 extract.suffix      .tgz
 
 # Please keep the sha1 - users can use it to validate sha values published on npmjs.org for the package
-checksums           sha1    a563d6e6806913b2afa4c713ba63047cb7c63ea4 \
-                    rmd160  599787b048701f45368e385fb32a5403c3dfde30 \
-                    sha256  6ce036f070fe8fe602577fd80c103c3d7684077b0f567fdc8792c9ec65d35685 \
-                    size    5138996
+checksums           sha1    62996dd6aa235dac175b13968a6d7f815ebf8257 \
+                    rmd160  60e9f61cd015bd9973895ab9b3e3b1dc4af7e75b \
+                    sha256  216f33e0cb87886f5601b4878302bd4ae822a8eeb06887fdb8986f64b4ede980 \
+                    size    5171533
 
 worksrcdir          "package"
 


### PR DESCRIPTION
#### Description
Tested with `npm i` in a decently sized angular project, and I also did your `port -q contents npm6 | xargs head -n1 | fgrep -B1 '/usr/bin/env node'` and that didn't turn up any files that needed to be updated.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
