### PR TITLE
x2goclient: Update linking for libssh 0.8.0.

### DIFF
--- a/aqua/x2goclient/Portfile
+++ b/aqua/x2goclient/Portfile
@@ -5,7 +5,7 @@ PortGroup               qt4 1.0
 
 name                    x2goclient
 version                 4.1.2.1
-revision                0
+revision                1
 checksums               sha256  1c18981f0a39929624de9472b0e6c3fa2ac7842837dd306db318af54c5fff2af \
                         rmd160  9391d1e69547eaaf154388749dfd013446c4a91b \
                         size    2735905
@@ -39,6 +39,11 @@ depends_run             port:pulseaudio \
                         port:xauth
 
 #patchfiles             none
+post-patch {
+    # libssh has dropped libssh_thread in 0.8.0 library.
+    # https://bugs.x2go.org/cgi-bin/bugreport.cgi?bug=1320
+    reinplace "s/ -lssh_threads//" x2goclient.pro
+}
 
 pre-configure {
     file mkdir "${worksrcpath}/client_build"


### PR DESCRIPTION
#### Description

As reported [upstream](https://bugs.x2go.org/cgi-bin/bugreport.cgi?bug=1320), libssh since 0.8.0 does not have a separate libssh_threads. Remove the attempt to link against this library.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->