### PR TITLE
mercurial, tortoisehg etc.: update to 4.9 ...

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -7,7 +7,7 @@ PortGroup           bitbucket 1.0
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             4.7.2
+version             4.9
 categories          devel python
 license             GPL-2+
 maintainers         nomaintainer
@@ -29,9 +29,9 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 homepage            http://www.mercurial-scm.org
 platforms           darwin
 master_sites        https://www.mercurial-scm.org/release/
-checksums           rmd160  772218d91d26fa934b03632e4841a86d3f44a446 \
-                    sha256  97f0594216f2348a2e37b2ad8a56eade044e741153fee8c584487e9934ca09fb \
-                    size    6481684
+checksums           rmd160  bc8e47451a25be0f431262318cb2c3c84503b764 \
+                    sha256  0f600c5c7e44d4318bedc1754a70b920f7ecd278e4089b0f6ac96f460c012f06 \
+                    size    7075692
 
 depends_build       port:py27-docutils
 
@@ -41,22 +41,13 @@ patchfiles          patch-setup.py.diff
 
 python.default_version 27
 
-conflicts           mercurial-devel
-
 build.cmd           make
 build.target        all PYTHON=${python.bin}
 
+# obsolete 20190301
 subport mercurial-devel {
-    bitbucket.setup     seanfarley mercurial 2049a21c8396
-    name                mercurial-devel
-    version             4.6.99
-    revision            0
-
-    conflicts           mercurial
-    master_sites        ${bitbucket.master_sites}
-    checksums           rmd160  e743601beb6cf57447c388f8d68048f4ca462f79 \
-                        sha256  41d10394f36dcb80586f569552434063b7d0e50b9d6b6baa5ca5ddb937ffc20a \
-                        size    5969734
+    replaced_by         ${name}
+    PortGroup           obsolete 1.0
 }
 
 # chg is not installed by default yet
@@ -80,21 +71,17 @@ post-destroot {
 
     # install html docs
     xinstall -m 644 -W ${worksrcpath}/doc hg.1.html hgrc.5.html hgignore.5.html \
-            ${destroot}${prefix}/share/doc/mercurial
+        ${destroot}${prefix}/share/doc/mercurial
 
     # install man pages
     xinstall -m 644 -W ${worksrcpath}/doc hg.1 \
-            ${destroot}${prefix}/share/man/man1
+        ${destroot}${prefix}/share/man/man1
     xinstall -m 644 -W ${worksrcpath}/doc hgrc.5 hgignore.5 \
-            ${destroot}${prefix}/share/man/man5
+        ${destroot}${prefix}/share/man/man5
 
     # install contrib
     xinstall -d -m 755 ${destroot}${prefix}/share/mercurial
     file copy ${worksrcpath}/contrib ${destroot}${prefix}/share/mercurial/contrib
-
-    if {[string first "-devel" $subport] == 0} {
-        file copy ${worksrcpath}/contrib/mergetools.hgrc ${destroot}${prefix}/etc/mercurial/hgrc.d/mergetools.rc
-    }
 
     # copy hgweb.cgi hgwebdir.cgi
     file copy ${worksrcpath}/hgweb.cgi ${destroot}${prefix}/share/mercurial/

--- a/devel/tortoisehg/Portfile
+++ b/devel/tortoisehg/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           app 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     tortoisehg thg 4.7.2
+bitbucket.setup     tortoisehg thg 4.9
 name                tortoisehg
 categories          devel python
 platforms           darwin
@@ -18,23 +18,30 @@ description         A set of graphical tools for Mercurial
 long_description    A set of graphical tools for the Mercurial distributed \
                     source control management system.
 
-checksums           rmd160  9df80404cefa5567264913ea93ad778a4d971c70 \
-                    sha256  7c6d58b34678f237b0683dcac38707c91e10b46a28f918888fe6bb2c005c762c \
-                    size    8211370
+checksums           rmd160  bb915e3c207f82e19749b680bb0740c3fa9e5ca9 \
+                    sha256  5ae2cf9065bfbbd1491ff8bd4e895da92996da8622ef356a13b734e65199e62e \
+                    size    8219445
 
 python.default_version 27
 
-# Can use either mercurial or mercurial-devel.
-depends_lib         path:bin/hg:mercurial \
-                    port:py${python.version}-pyqt4 \
-                    port:py${python.version}-qscintilla-qt4 \
+# we use qt5 only if macOS is 10.12 or later
+# as defined on qt5 port
+if { ${os.major} < 16 } {
+    set qt_version 4
+} else {
+    set qt_version 5
+}
+
+depends_lib         port:mercurial \
+                    port:py${python.version}-pyqt${qt_version} \
+                    port:py${python.version}-qscintilla-qt${qt_version} \
                     port:py${python.version}-iniparse
 
 depends_build       port:py${python.version}-sphinx
 
 post-extract {
     copy ${filespath}/config.py ${worksrcpath}/tortoisehg/util/
-    reinplace -W ${worksrcpath} "s,pyrcc4,pyrcc4-2.7," setup.py
+    reinplace -W ${worksrcpath} "s,pyrcc${qt_version},pyrcc${qt_version}-${python.branch},g" setup.py
     delete file ${worksrcpath}/hgext3rd/__init__.py
 }
 

--- a/python/py-hgevolve/Portfile
+++ b/python/py-hgevolve/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               bitbucket 1.0
 
-bitbucket.setup         marmoute mutable-history 8.3.0
+bitbucket.setup         marmoute mutable-history 8.4.0
 name                    py-hgevolve
 
 categories-append       devel
@@ -17,35 +17,24 @@ description             Mutable history for mercurial
 long_description        This extension provides several commands to mutate history \
                         and deal with issues it may raise.
 
-checksums               rmd160  1f041e6bee9645e21ce92becddda3ecfe10c1512 \
-                        sha256  b14503707c75af80edb470602538c1b11d8ba57bc5120d64e2de75c1d93bacf2 \
-                        size    742402
+checksums               rmd160  a19225201ae4cf41dafd5219d072c4cf18d13734 \
+                        sha256  29dcd869823e8fde3e2b4e4520e5458d9739f7b6c41083e9ed6ad87b22005843 \
+                        size    748698
 
 # can't set python.versions before adding custom subports
 subport py-hgevolve-devel {}
 subport py27-hgevolve-devel {}
 
+# obsolete 20190301
 if {[string match "*-devel" $subport]} {
-    bitbucket.setup     marmoute mutable-history 45d4b49d81d9
-    bitbucket.livecheck default
-    name                py-hgevolve-devel
-    version             8.0.99
-    revision            1
-
-    checksums           rmd160  1f041e6bee9645e21ce92becddda3ecfe10c1512 \
-                        sha256  b14503707c75af80edb470602538c1b11d8ba57bc5120d64e2de75c1d93bacf2 \
-                        size    742402
+    replaced_by         ${name}
+    PortGroup           obsolete 1.0
 }
 
 python.versions         27
 
 if {${name} ne ${subport}} {
-    depends_lib         path:bin/hg:mercurial
-
-    conflicts           py${python.version}-hgevolve-devel
-    if {[string match "*-devel" $subport]} {
-        conflicts       py${python.version}-hgevolve
-    }
+    depends_lib         port:mercurial
 
     post-destroot {
         file delete ${destroot}${python.pkgd}/hgext3rd/__init__.py
@@ -60,8 +49,4 @@ To enable hgevolve, add the following to your ~/.hgrc:
 rebase =
 evolve =
 "
-
-    if {![string match "*-devel" $subport]} {
-        livecheck.type      none
-    }
 }

--- a/python/py-hgexperimental/Portfile
+++ b/python/py-hgexperimental/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     facebook hg-experimental c5da191d0af2
-version             0.0.20180223
+bitbucket.setup     facebook hg-experimental 05ed5d06b353
+version             0.0.20181109
 name                py-hgexperimental
 categories-append   devel
 platforms           darwin
@@ -18,17 +18,22 @@ description         This is a collection of proof-of-concept Mercurial \
                     backups, and fbamend.
 long_description    ${description}
 
-checksums           rmd160  39c43b4a1ac0635867de8d0c8bc04f0676bb492c \
-                    sha256  d28de8ed29f4ad6a4b680a9f05c21898fa17a8016cecda72d326fe741f92958d
+checksums           rmd160  b9214c19753f59e336239b1cfb255902fb5fc7b7 \
+                    sha256  ecb2095113b966074c3a2e1e0bdf36c9aba5afeafebe1dbc8308668a4fc1bad4 \
+                    size    935261
 
 python.versions     27
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         bin:cargo:cargo
-    depends_lib-append  path:bin/hg:mercurial \
+    depends_lib-append  port:mercurial \
                         port:py27-cython \
                         port:lz4
+
+    # fix error: 'register' storage class specifier is deprecated and incompatible with C++17
+    # see upstream issue https://bitbucket.org/facebook/hg-experimental/issues/15/build-fail-on-macos-1014
+    patchfiles-append   patch-setup.py.diff
 
     post-destroot {
         set sp ${destroot}${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages

--- a/python/py-hgexperimental/files/patch-setup.py.diff
+++ b/python/py-hgexperimental/files/patch-setup.py.diff
@@ -1,0 +1,18 @@
+--- setup.py.orig	2019-03-01 11:39:55.000000000 +0100
++++ setup.py	2019-03-01 11:54:55.000000000 +0100
+@@ -10,6 +10,7 @@
+ 
+ iswindows = os.name == 'nt'
+ WERROR = "/WX" if iswindows else "-Werror"
++WNOREGISTER = "" if iswindows else "-Wno-error=deprecated-register"
+ WSTRICTPROTOTYPES = None if iswindows else "-Werror=strict-prototypes"
+ WALL = "/Wall" if iswindows else "-Wall"
+ STDC99 = "" if iswindows else "-std=c99"
+@@ -86,6 +87,7 @@
+     cflags.extend([NOOPTIMIZATION, PRODUCEDEBUGSYMBOLS])
+ else:
+     cflags.append(WERROR)
++    cflags.append(WNOREGISTER)
+ 
+ def get_env_path_list(var_name, default=None):
+     '''Get a path list from an environment variable.  The variable is parsed as

--- a/python/py-hggit/Portfile
+++ b/python/py-hggit/Portfile
@@ -31,30 +31,17 @@ checksums               rmd160  4216bcfd288f8c86927ff8d72f3d1415788c9935 \
 subport py-hggit-devel {}
 subport py27-hggit-devel {}
 
+# obsolete 20190301
 if {[string match "*-devel" $subport]} {
-    bitbucket.setup     durin42 hg-git c651bb6fcf33
-    bitbucket.livecheck default
-    name                py-hggit-devel
-    version             0.8.99
-    revision            26
-
-    checksums           rmd160  4216bcfd288f8c86927ff8d72f3d1415788c9935 \
-                        sha256  66a589baa5c6734320f2737c486abfabfd9bb2bf96bedbfe991f0a5bec1160d2 \
-                        size    136783
+    replaced_by         ${name}
+    PortGroup           obsolete 1.0
 }
 
 python.versions         27
 
 if {${name} ne ${subport}} {
-    depends_lib-append  bin:hg:mercurial \
+    depends_lib-append  port:mercurial \
                         bin:dulwich-2.7:py${python.version}-dulwich
-
-    conflicts           py${python.version}-hggit-devel
-    if {[string match "*-devel" $subport]} {
-        conflicts       py${python.version}-hggit
-    } else {
-        livecheck.type      none
-    }
 
     notes               "
 To enable hggit, add the following to your ~/.hgrc:

--- a/python/py-hgsubversion/Portfile
+++ b/python/py-hgsubversion/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               bitbucket 1.0
 
-bitbucket.setup         durin42 hgsubversion 1.9.2
+bitbucket.setup         durin42 hgsubversion 1.9.3
 name                    py-hgsubversion
 
 categories-append       devel
@@ -17,35 +17,25 @@ description             hgsubversion is a Mercurial extension for \
                         working with Subversion (svn) repositories.
 long_description        ${description}
 
-checksums               rmd160  63318040765bbf016275dc98d2b65db70d03b897 \
-                        sha256  da3b4d0450579233bcec55c3b3c365e260d4b48bb53ad35ccc3ab3d0200a3383 \
-                        size    304824
+checksums               rmd160  08f1be76912ae81a56c8eb49e96d12bd47916742 \
+                        sha256  daec4abab484ec63956964e18af36f401ba5f5b12981ffd2858b8466aac5e7ab \
+                        size    306205
 
 # can't set python.versions before adding custom subports
 subport py-hgsubversion-devel {}
 subport py27-hgsubversion-devel {}
 
+# obsolete 20190301
 if {[string match "*-devel" $subport]} {
-    bitbucket.setup     seanfarley hgsubversion 704c4eced477
-    name                py-hgsubversion-devel
-    version             1.9.99
-    revision            0
-
-    checksums           rmd160  2b1ba2d8a5dcab2e8f0d67d307d34b39d3adc946 \
-                        sha256  620e213da296a181f89d1268a86251c04789141ec3fb5dc8b0fc158d378f8ac9
+    replaced_by         ${name}
+    PortGroup           obsolete 1.0
 }
 
 python.versions         27
 
 if {${name} ne ${subport}} {
-    depends_lib-append  path:bin/hg:mercurial \
+    depends_lib-append  port:mercurial \
                         port:subversion-python${python.version}bindings
-
-
-    conflicts           py${python.version}-hgsubversion-devel
-    if {[string match "*-devel" $subport]} {
-        conflicts       py${python.version}-hgsubversion
-    }
 
     notes               "
 To enable hgsubversion, add the following to your ~/.hgrc:
@@ -53,8 +43,4 @@ To enable hgsubversion, add the following to your ~/.hgrc:
 \[extensions\]
 hgsubversion =
 "
-
-    if {![string match "*-devel" $subport]} {
-        livecheck.type      none
-    }
 }

--- a/python/py-mercurial_extension_utils/Portfile
+++ b/python/py-mercurial_extension_utils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     Mekk mercurial-extension_utils 1.3.6
+bitbucket.setup     Mekk mercurial-extension_utils 1.3.7
 name                py-mercurial_extension_utils
 
 categories-append   devel
@@ -16,14 +16,14 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  dada50374b2f9c917661b930326b9dec15f8bf75 \
-                    sha256  907f870146fe9f944665623a95a991f6bcb49446a8ea4e3258fa2c370655295b \
-                    size    19986
+checksums           rmd160  2b2bfe7ea60453e92dedf999b0b2157e84d63bdf \
+                    sha256  7ba14ce4b37aa50e1d0c047e2733b242a1c737031fded177d7831734b681fb18 \
+                    size    20066
 
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_run         bin:hg:mercurial
+    depends_run         port:mercurial
 
     depends_build       port:py${python.version}-setuptools
 

--- a/python/py-mercurial_keyring/Portfile
+++ b/python/py-mercurial_keyring/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           bitbucket 1.0
 
-bitbucket.setup     Mekk mercurial_keyring 1.2.0
+bitbucket.setup     Mekk mercurial_keyring 1.2.1
 name                py-mercurial_keyring
 
 categories-append   devel
@@ -19,9 +19,9 @@ long_description \
 
 platforms           darwin
 
-checksums           rmd160  9be023041af0f0774ffe79e2788cf3f0afd17b90 \
-                    sha256  bc7526b30ff5745d404ad7c15f9ba3441642c548fee8dd211b952b3258e882fb \
-                    size    19898
+checksums           rmd160  694e31a5b9c1832ad042105ef2181f0e986e77af \
+                    sha256  c9502d469593c584d38a9001fabff6287c5fce1154aa003cb4a57769ddeeead9 \
+                    size    20104
 
 #not supporting 3x because py-keyring is broken on python 3.x
 python.versions     27
@@ -29,7 +29,7 @@ python.versions     27
 if {${name} ne ${subport}} {
     depends_run         port:py${python.version}-keyring \
                         port:py${python.version}-mercurial_extension_utils \
-                        bin:hg:mercurial
+                        port:mercurial
 
     depends_build       port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

I merely wanted to have TortoiseHg with Qt5, but I would really really like the maintainer to take a look.

Still to be done:
* TortoiseHg works with both Qt4 and Qt5, but I didn't know where to cut, so I didn't do anything yet. It would make sense to use Qt5 by default on newer OSes and Qt4 on older ones.
* I mostly didn't test other dependent ports of mercurial, I just updated them because of comment in mercurial.
* There are plenty development ports. Are those really needed? I didn't touch or update them, but we might be able to replace them by default ones. It makes no sense to have the development port at an older version than the main one.

I did not link to this ticket yet:
https://trac.macports.org/ticket/58062

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@lbschenkel @MarcusCalhoun-Lopez 