### PR TITLE
mplayer-devel: remove dirac variant

### DIFF
--- a/multimedia/mplayer-devel/Portfile
+++ b/multimedia/mplayer-devel/Portfile
@@ -85,8 +85,8 @@ configure.args-append \
     --disable-toolame --disable-twolame --disable-libmpeg2  --disable-xmms \
     --disable-musepack --disable-sdl --disable-aa \
     --disable-caca --disable-x11 --disable-xss --disable-gl --disable-arts \
-    --disable-esd --disable-lirc --disable-mng --disable-libdirac-lavc \
-    --disable-libschroedinger-lavc --disable-libvpx-lavc --disable-liba52  \
+    --disable-esd --disable-lirc --disable-mng \
+    --disable-libvpx-lavc --disable-liba52  \
     --disable-gif
 
 patchfiles configure.x11.patch configure.vorbis.patch
@@ -232,13 +232,6 @@ variant mng \
     configure.args-delete   --disable-mng
 }
 
-variant dirac \
-    description {Enable dirac codec support} {
-    depends_lib-append      port:dirac port:schroedinger
-    configure.args-delete   --disable-libdirac-lavc
-    configure.args-delete   --disable-libschroedinger-lavc
-}
-
 variant a52 \
     description {Enable AC-3 codec support} {
     depends_lib-append      port:a52dec
@@ -300,18 +293,23 @@ variant debug description {Compile with debugging symbols} {
     configure.args-append   --enable-debug=gdb3 --disable-altivec
 }
 
-# gcc-4.0 and older gcc-4.2 (< 5646) used to fail to build cpudetect.c properly, but it seems to work now (38007#comment:20)
-# llvm-gcc-4.2 macports-llvm-gcc-4.2 fail (38007#comment:19)
-# gcc-4.2 5577 fails to build cpudetect.c for x86_64
-compiler.blacklist-append gcc-3.3 {gcc-4.0 < 5493} {gcc-4.2 < 5666} llvm-gcc-4.2 macports-llvm-gcc-4.2
+# libavcodec/error_resilience.h:23:10: fatal error: 'stdatomic.h' file not found
+# this is a C11 feature; looking for compatible compilers, we find these references
+# https://stackoverflow.com/questions/26440606/xcode-and-c11-stdatomic-h
+# https://stackoverflow.com/questions/20326604/stdatomic-h-in-gcc-4-8
+# indicates compatible compilers are Xcode > Xcode 7, clang > 3.7, and gcc > 4.8
 
-if {[lsearch [get_canonical_archs] i386] != -1} {
-    # http://trac.macports.org/ticket/38248
-    compiler.blacklist-append {clang < 300}
+compiler.blacklist-append *gcc-3.* *gcc-4.*
+compiler.blacklist-append { clang < 700 } macports-clang-3.3 macports-clang-3.4
 
-    # clang-3.4 fails due to:
-    # libavcodec/x86/cabac.h:193:9 error: inline assembly requires more registers than available
-    compiler.blacklist-append macports-clang-3.4
+platform darwin i386 {
+    # clang-5.0 tested, and also likely installed on these systems
+    compiler.fallback-append  macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+}
+
+# untested as yet, but not many options at present
+platform darwin powerpc {
+    compiler.fallback-append macports-gcc-6 macports-gcc-7 macports-gcc-5
 }
 
 platform darwin 8 {


### PR DESCRIPTION
now rolled into ffmpeg

Now requires C11 stdatomic.h
so change blacklisting appropriately

closes: https://trac.macports.org/ticket/58066

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
