### PR TITLE
libaes_siv: new port

### DIFF
--- a/security/libaes_siv/Portfile
+++ b/security/libaes_siv/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        dfoxfranke libaes_siv 1.0.0 v
+revision            0
+categories          security devel
+maintainers         {fwright.net:fw @fhgwright} openmaintainer
+
+description         A C implementation of AES-SIV
+
+long_description    This is an RFC5297-compliant C implementation of AES-SIV, \
+                    written by Daniel Franke on behalf of Akamai Technologies \
+                    and published under the Apache License (v2.0). It uses \
+                    OpenSSL for the underlying AES and CMAC implementations \
+                    and follows a similar interface style.
+
+license             apache-2
+platforms           darwin
+
+# This project's release tarballs are in the 'archive' subdirectory.
+# Using the default master_sites gets a slightly different tarball.
+github.master_sites ${github.homepage}/archive/${git.branch}
+
+checksums           rmd160  c9e247100cb462650a16bd18aee05677adca8751 \
+                    sha256  a974406dc3e3addbecdc0f0c1e2050bede1c7b4394595e9536094a87dac617c9 \
+                    size    18829
+
+default_variants    +doc
+
+variant doc description {Build manpages (depends on asciidoc)} {
+    depends_build-append    port:asciidoc
+}
+if {![variant_isset doc]} {
+    configure.args-append   -DDISABLE_DOCS=1
+}
+
+# NOTE: doesn't work with libressl
+depends_lib-append  port:openssl
+
+patchfiles          patch-cmake.diff
+
+# NOTE: upstream code doesn't build correctly out of source
+cmake.out_of_source no
+
+test.run            yes

--- a/security/libaes_siv/files/patch-cmake.diff
+++ b/security/libaes_siv/files/patch-cmake.diff
@@ -1,0 +1,28 @@
+--- CMakeLists.txt.orig	2017-02-28 14:56:44.000000000 -0800
++++ CMakeLists.txt	2019-02-15 19:07:22.000000000 -0800
+@@ -23,19 +23,24 @@ set(CMAKE_C_FLAGS_MINSIZEREL "-Wall -Wco
+ endif(CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL AppleClang)
+ 
+ find_package(OpenSSL 1.0.1 REQUIRED COMPONENTS Crypto)
+-find_program(A2X a2x)
++if(NOT DISABLE_DOCS)
++  find_program(A2X a2x)
++endif(NOT DISABLE_DOCS)
+ 
+ configure_file(config.h.in config.h)
+ 
+ add_library(aes_siv SHARED aes_siv.c)
++target_include_directories(aes_siv PUBLIC ${OPENSSL_INCLUDE_DIR})
+ target_link_libraries(aes_siv ${OPENSSL_CRYPTO_LIBRARY})
+ set_target_properties(aes_siv PROPERTIES VERSION "1.0.0" SOVERSION 1)
+ 
+ add_library(aes_siv_static STATIC aes_siv.c)
++target_include_directories(aes_siv_static PUBLIC ${OPENSSL_INCLUDE_DIR})
+ target_link_libraries(aes_siv_static ${OPENSSL_CRYPTO_LIBRARY})
+ set_target_properties(aes_siv_static PROPERTIES OUTPUT_NAME aes_siv)
+ 
+ add_executable(runtests aes_siv_test.c tests.c)
++target_include_directories(runtests PUBLIC ${OPENSSL_INCLUDE_DIR})
+ target_link_libraries(runtests ${OPENSSL_CRYPTO_LIBRARY})
+ if(ENABLE_COVERAGE)
+   target_compile_options(runtests PRIVATE "--coverage")


### PR DESCRIPTION
A C implementation of AES-SIV.

This is likely to become a dependency of ntpsec.

The patches here have already been accepted upstream.

TESTED:
Ran 'test' and 'install' on a Mac Pro 10.9 and 10.14, a MacBook Pro
10.9, a PowerBook 10.5, and VMs for 10-5-10.13, both with and without
the 'doc' variant.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
