### PR TITLE
VLC, libVLC: fix build against new libx264

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -163,6 +163,10 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     patchfiles-append \
                         patch-ffmpeg4-compat.diff
 
+    # libx264 api changed slightly
+    patchfiles-append \
+                        patch-modules-codec-x264-new-api.diff
+
     post-patch {
         if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} == "libc++"} {
             reinplace "s:-lstdc\+\+:-lc++:" \

--- a/multimedia/VLC/files/patch-modules-codec-x264-new-api.diff
+++ b/multimedia/VLC/files/patch-modules-codec-x264-new-api.diff
@@ -1,0 +1,13 @@
+diff --git modules/codec/x264.c modules/codec/x264.c
+index 872269a..3d220c5 100644
+--- modules/codec/x264.c
++++ modules/codec/x264.c
+@@ -847,7 +847,7 @@ static int  Open ( vlc_object_t *p_this )
+     char *psz_profile = var_GetString( p_enc, SOUT_CFG_PREFIX "profile" );
+     if( psz_profile )
+     {
+-        const int mask = x264_bit_depth > 8 ? X264_CSP_HIGH_DEPTH : 0;
++        const int mask = X264_BIT_DEPTH > 8 ? X264_CSP_HIGH_DEPTH : 0;
+ 
+ 
+ # ifdef MODULE_NAME_IS_x26410b


### PR DESCRIPTION
minor API change
closes: https://trac.macports.org/ticket/58073

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
