### PR TITLE
ruby26: fix build on lion

### DIFF
--- a/lang/ruby26/Portfile
+++ b/lang/ruby26/Portfile
@@ -62,6 +62,20 @@ configure.args      --enable-shared \
                     --program-suffix=2.6 \
                     --with-rubylibprefix="${prefix}/lib/ruby2.6"
 
+platform darwin 11 {
+    # Build requires 10.8 SDK, even when targeting 10.7
+    # https://trac.macports.org/ticket/57986
+    set ten_eight_sdkpath ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
+    if {[file exists $ten_eight_sdkpath]} {
+        configure.sdkroot $ten_eight_sdkpath
+    } else {
+        pre-fetch {
+            error "Building $name @${version} on Mac OS X 10.7 requires the MacOSX10.8.sdk to be present in ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs"
+        }
+    }
+}
+
+
 platform darwin {
     if {${os.major} < 10} {
         configure.args-append --disable-dtrace


### PR DESCRIPTION
pulls in 10.8 SDK security features so build against
10.8 SDK (available on 10.7 by default)

closes: https://trac.macports.org/ticket/57986

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
