### PR TITLE
valgrind: fix build on lion

### DIFF
--- a/devel/valgrind/Portfile
+++ b/devel/valgrind/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           mpi 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                valgrind
 categories          devel
@@ -19,6 +20,15 @@ long_description \
 
 homepage            http://valgrind.org
 master_sites        https://sourceware.org/pub/valgrind/
+
+# older clangs identify as applellvm-4.2 and are rejected
+# https://trac.macports.org/ticket/53525
+compiler.blacklist-append \
+                    { clang < 426 }
+
+# priv/guest_s390_toIR.c:2056:39: error: invalid suffix "b00010000" on integer constant
+compiler.blacklist-append \
+                    llvm-gcc-4.2
 
 compilers.choose    cc cxx
 mpi.setup           -gcc44 -gcc45 -gcc46


### PR DESCRIPTION
tweak compiler selection to find compatible compilers
on lion this blacklisting leads to clang-3.4, which works

closes: https://trac.macports.org/ticket/53525

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
