### PR TITLE
SourceKitten: Update to 0.22.0

### DIFF
--- a/devel/SourceKitten/Portfile
+++ b/devel/SourceKitten/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           xcodeversion 1.0
 
-github.setup        jpsim SourceKitten 0.17.6
+github.setup        jpsim SourceKitten 0.22.0
 categories          devel
 platforms           darwin
 
@@ -22,15 +23,17 @@ use_configure       no
 # everything is built during the prefix_install target
 build               {}
 
-destroot {
-    file mkdir ${destroot}${prefix}/Frameworks/
-    system -W ${worksrcpath} "${build.cmd} prefix_install PREFIX=${destroot}${prefix} TEMPORARY_FOLDER=${destroot} XCODEFLAGS=\"-workspace 'SourceKitten.xcworkspace' -scheme 'sourcekitten' DSTROOT=${destroot} -IDECustomDerivedDataLocation=${worksrcpath}/custombuild OTHER_LDFLAGS='-Wl,-headerpad_max_install_names'\""
+minimum_xcodeversions {17 10 18 10}
+
+platform darwin {
+    if {${os.major} < 17} {
+        pre-fetch {
+            ui_error "SourceKitten requires 10.13 and Xcode 10 to build."
+            return -code error "incompatible macOS version"
+        }
+    }
 }
 
-post-destroot {
-    delete ${destroot}${prefix}/var
-    xinstall -d ${destroot}${prefix}/Library
-    move ${destroot}${prefix}/Frameworks ${destroot}${prefix}/Library/
-    system -W ${destroot}${prefix}/bin "install_name_tool -add_rpath @executable_path/../Library/Frameworks sourcekitten"
-    system -W ${destroot}${prefix}/bin "install_name_tool -add_rpath @executable_path/../Library/Frameworks/SourceKittenFramework.framework/Versions/Current/Frameworks sourcekitten"
+destroot {
+    system -W ${worksrcpath} "${build.cmd} prefix_install PREFIX=${destroot}${prefix} TEMPORARY_FOLDER=${destroot}"
 }


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

Apparently SourceKitten no links against its own framework by default (or even builds it), so I've removed the `post-destroot` steps because they're no longer necessary.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E184e
Xcode 10.2 10P91b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->