### PR TITLE
weechat: use upstream tarball

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,12 +9,15 @@ name                weechat
 
 if {${name} eq ${subport}} {
     conflicts       weechat-devel
-    github.setup    weechat weechat 2.3 v
+    name            weechat
+    version         2.3
     revision        1
+    master_sites    https://weechat.org/files/src/
+    use_bzip2       yes
 
-    checksums       rmd160  722fa7f1520947664ae429f6b658674d797eaad3 \
-                    sha256  fe36851c8557cdb946e6983ef42c3243a11324a74f3ba327cec45cfea3949e45 \
-                    size    4090411
+    checksums       rmd160  3aade16f5f1bbda0b790d1305b7ba951499f3018 \
+                    sha256  3c5919c23feb40368fae08f3581448c707e1bdb14c835c06c31b78ebadbb2456 \
+                    size    2913883
 }
 
 subport weechat-devel {


### PR DESCRIPTION
#### Description
GitHub generated tarball is not immutable, so we prefer upstream tarballs instead.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
