### PR TITLE
mysql57: fixes to allow build

### DIFF
--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -35,7 +35,7 @@ if {$subport eq $name} {
     set boost_distver   [join [split ${boost_version} .] _]
     set boost_distname  boost_${boost_distver}
 
-    conflicts_build     boost
+    conflicts_build     boost protobuf3-cpp protobuf-cpp
 
     distfiles           ${distname}${extract.suffix}:mysql \
                         ${boost_distname}${extract.suffix}:boost
@@ -64,7 +64,8 @@ if {$subport eq $name} {
                     patch-cmake-install_layout.cmake-yassl.diff \
                     patch-configure.cmake.diff \
                     patch-innodb_memcached-daemon_memcached-include-memcached-util.h.diff \
-                    patch-lockpool.diff
+                    patch-lockpool.diff \
+                    patch-cmake-fix-test-env.diff
 
     post-patch {
         reinplace "s|@NAME@|${name_mysql}|g" \

--- a/databases/mysql57/files/patch-cmake-fix-test-env.diff
+++ b/databases/mysql57/files/patch-cmake-fix-test-env.diff
@@ -1,0 +1,21 @@
+--- a/libmysql/CMakeLists.txt	2019-02-18 20:33:19.000000000 -0500
++++ b/libmysql/CMakeLists.txt	2019-02-18 20:33:13.000000000 -0500
+@@ -367,8 +367,17 @@
+   TARGET_LINK_LIBRARIES(libmysql_api_test libmysql)
+ ENDIF()
+ 
++set(COM_ENV "")
++if(UNIX)
++   set(LD_PATH_VAR "LD_LIBRARY_PATH")
++   if(APPLE)
++       set(LD_PATH_VAR "DYLD_LIBRARY_PATH")
++   endif()
++   set(COM_ENV ${CMAKE_COMMAND} -E env "${LD_PATH_VAR}=${CMAKE_CURRENT_BINARY_DIR}")
++endif(UNIX)
++
+ # Verify that libmysql_api_test runs OK
+ ADD_CUSTOM_COMMAND(TARGET libmysql_api_test POST_BUILD
+-  COMMAND $<TARGET_FILE:libmysql_api_test>
++  COMMAND ${COM_ENV} $<TARGET_FILE:libmysql_api_test>
+   > ${CMAKE_CURRENT_BINARY_DIR}/libmysql_api_test.out
+   )


### PR DESCRIPTION
#### Description

2 fixes that should allow mysql57 to build properly.
Hopefully closes: https://trac.macports.org/ticket/58091

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
