### PR TITLE
update various unmaintained Python ports to their latest version

### DIFF
--- a/python/py-anytree/Portfile
+++ b/python/py-anytree/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-anytree
-version             2.5.0
+version             2.6.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -24,9 +24,9 @@ master_sites        pypi:a/anytree
 
 distname            anytree-${version}
 
-checksums           rmd160  6c8c3d458028d44fd7bc2e22cb760eaa57bd391f \
-                    sha256  409ccb966d759952648d5e5656bc311ab63a1f4a7d5ed9fc0e9715343ca2aa74 \
-                    size    18820
+checksums           rmd160  3ab619604e838f6d013612ae90b774cd20aa1ee6 \
+                    sha256  a221b6a603c3a5d5e417894dc48eaa8b1eab04056e1f5bb509bcfff0e7a47883 \
+                    size    19092
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -2,9 +2,12 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           select 1.0
+
 
 name                py-awscli
-version             1.16.67
+version             1.16.107
+revision            0
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
@@ -17,16 +20,13 @@ homepage            https://aws.amazon.com/cli/
 master_sites        pypi:a/awscli
 distname            awscli-${version}
 
-checksums           rmd160 982dbead0e4ee1cbccb74f323d02efb2bdb1b958 \
-                    sha256 7d34d3adef43e27cc2c7b945239455d48e5f5ac2b9494c9c9ca881cef2bfa7ee \
-                    size   642653
+checksums           rmd160  534a5e7f263447b06f4d1458b563b06963df65b9 \
+                    sha256  583019f071866d158d25c6a4c0e9658ea9ea683add2c4179fe74cbc9deb676aa \
+                    size    667982
 
 python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
-
-    PortGroup           select 1.0
-
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_lib-append \

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-botocore
-version             1.12.57
+version             1.12.97
+revision            0
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
@@ -19,9 +20,9 @@ homepage            https://github.com/boto/botocore
 master_sites        pypi:b/botocore
 distname            ${python.rootname}-${version}
 
-checksums           rmd160 74d6f3bd33f8730656010c19c383b4d004251904 \
-                    sha256 9dac7753d81e8a725b9a169fd63b43d2a3caeceb51de3fafd5e5bd10e25589cb \
-                    size   5247450
+checksums           rmd160  0d1f9e9446fdd51b896852dc139c4a2b9c318c3b \
+                    sha256  f326778f4b6e1b668625478ef062d173d1ed69ff39c0f4d326d4faaf87b2d010 \
+                    size    5412446
 
 python.versions     27 35 36 37
 
@@ -32,6 +33,8 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-jmespath \
                             port:py${python.version}-urllib3
 
+    depends_test-append port:py${python.version}-mock
     test.run            yes
+
     livecheck.type      none
 }

--- a/python/py-bson/Portfile
+++ b/python/py-bson/Portfile
@@ -3,11 +3,9 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           bson
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             0.4.3
+name                py-bson
+version             0.5.7
+revision            0
 categories-append   devel databases
 platforms           darwin
 supported_archs     noarch
@@ -20,28 +18,24 @@ description         BSON codec for Python that independent on MongoDB
 long_description    \
     Independent BSON codec for Python that does not depend on MongoDB.
 
-homepage            https://pypi.python.org/pypi/${_name}
+homepage            https://github.com/py-bson/bson
 
-distname            ${_name}-${version}
-master_sites        pypi:${_n}/${_name}/
+distname            ${python.rootname}-${version}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}/
 
-checksums           md5     be14a8e89f86970e873f9b64822412e3 \
-                    rmd160  f86ad4349e4b465bdc6a7e9bdf3f98534653309b \
-                    sha256  b3fe82fb5cd4ac5958b5839d211ae35d2a29418a588a63fa054f9916173324a4
+checksums           rmd160  c8f54841fdbed5c6f26ff155ca68028a3cd84d5c \
+                    sha256  19396624cbd30b7d74fff7bcc1a8db1c3d92b6469fce8a5bdab175dd0129a710 \
+                    size    10139
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     conflicts               py${python.version}-pymongo
 
     depends_build-append    port:py${python.version}-setuptools
 
-    depends_lib-append      port:py${python.version}-six \
-                            port:py${python.version}-tz
+    depends_lib-append      port:py${python.version}-dateutil \
+                            port:py${python.version}-six
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
 }

--- a/python/py-buzhug/Portfile
+++ b/python/py-buzhug/Portfile
@@ -1,5 +1,8 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
+
 name                py-buzhug
 version             1.8
 revision            1
@@ -22,13 +25,12 @@ master_sites        sourceforge:buzhug
 distname            buzhug-${version}
 use_zip             yes
 
-checksums           md5     a5c15b484c91a55db35e71447d2e709c \
-                    sha1    412bfef5a7c5468d62e98ded59b09e19378084af \
-                    rmd160  86aca59cc734cdd2b871f05bb13f050acc45f8f1
+checksums           rmd160  86aca59cc734cdd2b871f05bb13f050acc45f8f1 \
+                    sha256  0f8453de32424abd2e0dea963a1d0adc7ec893c6c1311887d3ce87231a8e62a7 \
+                    size    26529
 
-python.versions          27
+python.versions     27
 
-livecheck.type      regex
-livecheck.url       http://sourceforge.net/projects/buzhug/files/buzhug/
-livecheck.regex     buzhug-(\[0-9\\.\]+)
-
+if {${name} ne ${subport}} {
+    livecheck.type  none
+}

--- a/python/py-cdb/Portfile
+++ b/python/py-cdb/Portfile
@@ -4,7 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cdb
-version             0.34
+python.rootname     python-cdb
+version             0.35
+revision            0
+
 platforms           darwin
 license             GPL-2+
 maintainers         nomaintainer
@@ -18,29 +21,20 @@ long_description    The python-cdb extension module is an adaptation of \
                     utilities, cdb(get|dump|make), via convenient, \
                     high-level Python objects.
 
-homepage            https://pilcrow.madison.wi.us/
-master_sites        ${homepage}/python-cdb/
-distname            python-cdb-${version}
+homepage            https://github.com/acg/python-cdb
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5 bda23cd135c9d71bede98929bc18b36f \
-                    sha1 6c5ef1f27fe0e5c2e9a4a032435ebf58c82639f2 \
-                    rmd160 02519e7c03aae5798823ab4cd0388b6afaf1908a
+checksums           rmd160  c067f06959b59d71846c82f3348c9ca471402f94 \
+                    sha256  c6cdc195c30f6ad638267f232d89b491598037910307e8b46ac6e39f622160fe \
+                    size    19573
 
 python.versions     27
 
 if {${name} ne ${subport}} {
     post-destroot {
-        xinstall -m 644 -W ${worksrcpath} COPYING ChangeLog README \
+        xinstall -m 0644 -W ${worksrcpath} COPYING ChangeLog README Example\
             ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 ${worksrcpath}/Example \
-            ${destroot}${prefix}/share/doc/${subport}/examples/example.py
     }
+    livecheck.type  none
 }
-
-# Local Variables:
-# mode:tcl
-# tab-width: 4
-# indent-tabs-mode: nil
-# c-basic-offset:4
-# indent-tabs-mode:nil
-# End:

--- a/python/py-checker/Portfile
+++ b/python/py-checker/Portfile
@@ -3,39 +3,46 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-name			    py-checker
-version			    0.8.18
-revision		    1
-platforms		    darwin freebsd
-supported_archs	    noarch
-license			    BSD
-maintainers		    nomaintainer
+name                py-checker
+version	            0.8.19
+revision            0
+platforms           darwin freebsd
+supported_archs     noarch
+license	            BSD
+maintainers         nomaintainer
 
-description		    python source code checker for finding bugs
-long_description	PyChecker is a tool for finding bugs in python \
+description         python source code checker for finding bugs
+long_description    PyChecker is a tool for finding bugs in python \
                     source code. It finds problems that are typically \
                     caught by a compiler for less dynamic languages, \
                     like C and C++.  It is similar to lint.  Because \
                     of the dynamic nature of python, some warnings may \
                     be incorrect. However, spurious warnings should be \
                     fairly infrequent.
-homepage		    http://pychecker.sourceforge.net/
+homepage            http://pychecker.sourceforge.net/
 
-master_sites		sourceforge:pychecker
-distname		    pychecker-${version}
-checksums		    md5     ef156a631df46de150a364912f2e36c8
+master_sites        sourceforge:pychecker
+distname            pychecker-${version}
 
-python.versions	    27
+checksums           rmd160  7c401f3d2025dec1438c623b161359ef9721d0bf \
+                    sha256  44fb26668f74aca3738f02d072813762a37ce1242f50dbff573720fa2e953279 \
+                    size    99783
+
+python.versions     27
 
 if {${name} ne ${subport}} {
-    patchfiles		patch-setup.py.diff
+    patchfiles      patch-setup.py.diff
+
     post-patch {
         reinplace "s|PYTHONLIB|${python.pkgd}|g" ${worksrcpath}/setup.py
+        reinplace "s|0.8.18|${version}|g" ${worksrcpath}/pychecker/Config.py
     }
 
     post-destroot {
-        xinstall -m 644 -W ${worksrcpath} CHANGELOG COPYRIGHT KNOWN_BUGS \
+        xinstall -m 0644 -W ${worksrcpath} CHANGELOG COPYRIGHT KNOWN_BUGS \
             MAINTAINERS README TODO VERSION pycheckrc \
             ${destroot}${prefix}/share/doc/${subport}
     }
+
+    livecheck.type  none
 }

--- a/python/py-checker/files/patch-setup.py.diff
+++ b/python/py-checker/files/patch-setup.py.diff
@@ -9,12 +9,3 @@
        if sys.platform == "win32":
           script_str = "%s %s %%*\n" % (sys.executable, checker_path)
        else:
-@@ -258,7 +258,7 @@
-         'author'           : "Neal Norwitz",
-         'author_email'     : "nnorwitz@gmail.com",
-         'url'              : "http://pychecker.sourceforge.net/",
--        'packages'         : [ 'pychecker', ],
-+        'packages'         : [ 'pychecker', 'pychecker2', ],
-         'scripts'          : [ "pychecker" ],   # note: will be replaced by customized action
-         'data_files'       : [ ( "pychecker", DATA_FILES, ) ], 
-         'long_description' : LONG_DESCRIPTION,

--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -322,6 +322,7 @@ py-suds-jurko           0.6_1       26 33
 py-svipc                0.14_2      26
 py-swap                 3.1.3       26 33 34 35
 py-s3fs                 0.2.0_1     34
+py-s3transfer           0.1.13_1    34
 py-tahchee              0.9.8_1     26
 py-taskw                0.8.6_1     33
 py-tc                   0.7.2_1     26

--- a/python/py-s3transfer/Portfile
+++ b/python/py-s3transfer/Portfile
@@ -20,7 +20,7 @@ checksums           md5     b7437bbbd3195e916f9e992b78721067 \
                     sha256  90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1 \
                     size    103335
 
-python.versions     27 34 35 36 37
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
- py-anytree: update to 2.6.0
- py-awscli: update to 1.16.107
- py-botocore: update to 1.12.97
- py-s3transfer: remove py34 subport as it is missing dependencies (see https://trac.macports.org/ticket/56234)
- py-bson: update to 0.5.7, add py37
- py-buzhug: fix livecheck, modernize Portfile
- py-cdb: update to 0.35, switch to PyPI
 - py-checker: update to 0.8.19 

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
