### PR TITLE
GPXSee: update to 7.3

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.2
+github.setup        tumic0 GPXSee 7.3
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  4682f14e57c966b1db6041cfb5827b42aad6b00c \
-                    sha256  de4cc2a3fa9c56f5be601756e198b44fe363e733a1992ffd082bc3fde4e9ce74 \
-                    size    4282092
+checksums           rmd160  99ed1c483d643bd41ed13afb59453d361e19c9d5 \
+                    sha256  7edbb97481b094975138c79dc88d80b29df111ce510f098c2530c0884f236f38 \
+                    size    4297267
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.3

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for area (polygon) objects.
>   * Added support for track segments.
>   * Added support for oblique stereographic projections.
>   * Added the "Show cursor coordinates" option.
>   * Added Portuguese (Brazil) localization.
>   * Minor bug fixes (GPX parser, GUI).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
