### PR TITLE
gr-limesdr: new port

### DIFF
--- a/science/gr-limesdr/Portfile
+++ b/science/gr-limesdr/Portfile
@@ -1,0 +1,95 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+PortGroup           github 1.0
+
+name                gr-limesdr
+categories          science comms
+platforms           darwin macosx
+license             GPL-3+
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+description         GNU Radio block for LimeSDR-USB/LimeSDR-Mini boards
+long_description    ${description}
+homepage            https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio
+
+subport gr-limesdr-devel {}
+if {[string first "-devel" $subport] > 0} {
+
+    github.setup    myriadrf gr-limesdr 8f431215d51d8bdcfaacfcdf367082ea89e93f5b
+    version         20190226
+    checksums       rmd160  abec41991ca8a22361a98ddf8dccdf46ff9f1c86 \
+                    sha256  812e114920b3dc4beed644e223c2cd9d02f740952f80750d0527855bb174583b \
+                    size    3083978
+
+    name            gr-limesdr-devel
+    long_description ${description}. This port is kept up with the ${name} \
+        GIT 'master' branch, is typically updated weekly to monthly.
+
+    conflicts       gr-limesdr
+
+} else {
+
+    github.setup    myriadrf gr-limesdr 2.0.0 v
+    checksums       rmd160  c8b2b7a745a316bcc7c6b7b0a1121da2bddea05a \
+                    sha256  6f2fcf42dd45ca3893c914752f803dd811e046c21c567286fd1ad35a8d362f05 \
+                    size    3083984
+
+    conflicts       gr-limesdr-devel
+
+}
+
+depends_build-append \
+                    port:swig-python
+
+depends_lib         port:boost \
+                    path:lib/libgnuradio-runtime.dylib:gnuradio \
+                    port:limesuite
+
+# remove top-level library path, such that internal libraries are used
+# instead of any already-installed ones.
+configure.ldflags-delete -L${prefix}/lib
+
+# specify the Python dependencies
+depends_lib-append port:python27
+# specify that Python version to use
+configure.args-append \
+    -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/2.7/bin/python2.7 \
+    -DPYTHON_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/2.7/Headers \
+    -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/2.7/Python \
+    -DGR_PYTHON_DIR=${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
+
+# use C++11
+configure.args-append \
+    -DCMAKE_CXX_STANDARD=11
+
+configure.args-append \
+    -DDOXYGEN_DOT_EXECUTABLE= \
+    -DDOXYGEN_EXECUTABLE= \
+    -DCMAKE_MODULES_DIR=share/cmake
+
+variant docs description "Install ${name} documentation" {
+
+    depends_build-append \
+        port:doxygen \
+        path:bin/dot:graphviz
+
+    configure.args-delete \
+        -DDOXYGEN_DOT_EXECUTABLE= \
+        -DDOXYGEN_EXECUTABLE=
+
+    configure.args-append \
+        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
+        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+
+}
+
+default_variants +docs
+
+post-destroot {
+    # copy GNU Radio examples
+    xinstall -m 755 -d ${destroot}${prefix}/share/gr-limesdr
+    file copy ${worksrcpath}/examples \
+        ${destroot}${prefix}/share/gr-limesdr/examples
+}


### PR DESCRIPTION
GNU Radio block for LimeSDR-USB/LimeSDR-Mini boards

#### Description

GNU Radio block for LimeSDR-USB/LimeSDR-Mini boards

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->