### PR TITLE
libpixman: update to 0.38.0

### DIFF
--- a/graphics/libpixman/Portfile
+++ b/graphics/libpixman/Portfile
@@ -9,10 +9,10 @@ PortGroup               muniversal 1.0
 name                    libpixman
 conflicts               libpixman-devel
 set my_name             pixman
-version                 0.36.0
-checksums               rmd160  1d10373ab966c20d2e9825d4f936569b2e7cf6d9 \
-                        sha256  fd92c0cc99183977e54a278d7c595ee094a8e75724c03faf3796d1e49f7780dc \
-                        size    739957
+version                 0.38.0
+checksums               rmd160  85045d35b5109c58fcdf577df36b61b32107fd99 \
+                        sha256  b768e3f7895ddebdc0f07478729d9cec4fe0a9d2201f828c900d67b0e5b436a8 \
+                        size    747654
 
 categories              graphics
 platforms               darwin


### PR DESCRIPTION
#### Description

Note: I didn't touch libpixman-devel here. I am wondering if this port is still relevant. Pixman development appears to have plateaued. There was not a single commit to the repository in all of 2017. Waiting for maintainer feedback on what to do with libpixman-devel.

I ran `port -d test libpixman` and the the tests passed.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?