### PR TITLE
py-checker: correct case for file in post-destroot

### DIFF
--- a/python/py-checker/Portfile
+++ b/python/py-checker/Portfile
@@ -39,8 +39,8 @@ if {${name} ne ${subport}} {
     }
 
     post-destroot {
-        xinstall -m 0644 -W ${worksrcpath} CHANGELOG COPYRIGHT KNOWN_BUGS \
-            MAINTAINERS README TODO VERSION pycheckrc \
+        xinstall -m 0644 -W ${worksrcpath} ChangeLog COPYRIGHT KNOWN_BUGS \
+            NEWS MAINTAINERS README TODO VERSION pycheckrc \
             ${destroot}${prefix}/share/doc/${subport}
     }
 


### PR DESCRIPTION
#### Description
Sorry.... it installed fine on my local machine, but doesn't work on the buildbot (presumable case-sensitive filesystem).

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
