### PR TITLE
py-biggles: update to 1.72

### DIFF
--- a/python/py-biggles/Portfile
+++ b/python/py-biggles/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup github 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
 
 github.setup        nolta biggles 1.6.7 v
-
 name                py-biggles
 revision            1
+
 categories-append   graphics math science
 platforms           darwin
 license             GPL-2
@@ -22,13 +22,15 @@ homepage            http://biggles.sourceforge.net/
 checksums           md5     a6c7c07ecbfc142024c9c17cb20b7249 \
                     sha1    d29e56a7d11efcd249c54a82a9f86d82936e6428 \
                     rmd160  08172f51bfad355f2067f8a9ab86e75a0b73e201
-                    
+
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_lib-append      port:plotutils port:py${python.version}-numpy \
-                            port:xorg-libXaw
-    
+    depends_lib-append \
+                    port:plotutils \
+                    port:py${python.version}-numpy \
+                    port:xorg-libXaw
+
     build.target    build_ext
     build.args      -I${prefix}/include
 }

--- a/python/py-biggles/Portfile
+++ b/python/py-biggles/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
+PortGroup           active_variants 1.1
 
-github.setup        nolta biggles 1.6.7 v
+github.setup        biggles-plot biggles 1.7.2 v
 name                py-biggles
-revision            1
+revision            0
 
 categories-append   graphics math science
 platforms           darwin
@@ -17,20 +18,27 @@ description         Creates 2D scientific plots
 long_description    Biggles is a Python module for the creation of \
                     publication-quality 2D scientific plots.
 
-homepage            http://biggles.sourceforge.net/
+homepage            https://biggles-plot.github.io/
 
-checksums           md5     a6c7c07ecbfc142024c9c17cb20b7249 \
-                    sha1    d29e56a7d11efcd249c54a82a9f86d82936e6428 \
-                    rmd160  08172f51bfad355f2067f8a9ab86e75a0b73e201
+checksums           rmd160  ab9e498ba91a89dba179c33083a2a0dc05ec80cd \
+                    sha256  3806d9b64e6e0ad40bf9f7ed81b0477ba2d31688865c123de3d2a01bae13b81f \
+                    size    215231
 
-python.versions     27
+python.versions     27 37
 
 if {${name} ne ${subport}} {
+    require_active_variants \
+                    port:plotutils x11
+
     depends_lib-append \
                     port:plotutils \
                     port:py${python.version}-numpy \
-                    port:xorg-libXaw
 
-    build.target    build_ext
-    build.args      -I${prefix}/include
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}/examples
+        xinstall -m 0644 -W ${worksrcpath} CHANGELOG COPYING CREDITS README.rst \
+            ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 {*}[glob -types f ${worksrcpath}/examples/*] \
+            ${destroot}${prefix}/share/doc/${subport}/examples
+    }
 }


### PR DESCRIPTION
#### Description
- update to latest version
- update dependencies (remove ```xorg-libXaw```, but it requires ```plotutils``` to be installed with the  ```+x11``` variant)
- add py37 subport
- update homepage
- install files in post-destroot

Please note: CI tests will likely fail because a non-default variant of ```plotutils``` is required.
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->