### PR TITLE
libvpx: restore build on Leopard Intel

### DIFF
--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -36,18 +36,6 @@ supported_archs     x86_64 i386
 
 depends_build-append port:yasm
 
-# support for 10.5 and earlier removed in version 1.5.0
-platform darwin {
-    if {${os.major} < 10} {
-        depends_lib
-        depends_build
-        pre-fetch {
-            ui_error "${name} @${version} does not build on Mac OS X 10.5 Leopard or earlier."
-            return -code error "unsupported platform"
-        }
-    }
-}
-
 patchfiles          patch-build-make-configure.sh.diff \
                     patch-configure.diff \
                     patch-Makefile.diff \
@@ -61,13 +49,22 @@ patchfiles          patch-build-make-configure.sh.diff \
 # vp9/encoder/x86/vp9_frame_scale_ssse3.c: In function ‘eight_tap_row_ssse3’:
 # vp9/encoder/x86/vp9_frame_scale_ssse3.c:93: internal compiler error: Segmentation fault
 # {standard input}:unknown:Undefined local symbol LC2
+
 compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 800} macports-clang-3.3 macports-clang-3.4 macports-clang-3.7
 # Make sure that mp-clang-3.9 is picked if all compilers were blacklisted.
 # Especially important for 10.6 on libc++, since the fallback list contains macports-clang-3.7
 # as the first, and thus selected, fallback option (even though it has been blacklisted earlier).
 compiler.fallback-append macports-clang-3.9
 
-license_noconflict  clang-3.9
+# on Leopard clang-3.9.1 fails, but newer clangs succeed (5.0 tested)
+# vpx/src/vpx_image.c.o vpx/src/vpx_image.c clang: error: unable to execute command: Bus error
+if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
+    compiler.blacklist-append macports-clang-3.9
+    compiler.fallback-delete macports-clang-3.9
+    compiler.fallback-append macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+}
+
+license_noconflict  clang-3.9 clang-5.0 clang-6.0 clang-7.0
 
 # As of 1.7.0: builds both static and shared libraries
 # doesn't install docs or examples correctly, so disable them.


### PR DESCRIPTION
builds with newer clangs

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8 9L34
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
