### PR TITLE
update various unmaintained Python ports to their latest version

### DIFF
--- a/python/py-chm/Portfile
+++ b/python/py-chm/Portfile
@@ -9,6 +9,7 @@ revision            1
 categories-append   textproc
 platforms           darwin
 maintainers         nomaintainer
+license             GPL-2+
 
 description         PyCHM is a set of Python bindings for Jed Wing's chmlib.
 long_description    ${description}
@@ -16,7 +17,10 @@ homepage            http://gnochm.sourceforge.net/pychm.html
 
 master_sites        sourceforge:gnochm
 distname            pychm-${version}
-checksums           sha1 73104f4a351dc1450a16f07680d772817b05442d
+checksums           sha1    73104f4a351dc1450a16f07680d772817b05442d \
+                    rmd160  0d7e5bc293b856fc0ac8f76acc7d18e63447c6f7 \
+                    sha256  84c99d7b28fb6862ee60a5d1d52fad0da4c95f1934e9c101d3293ee7e8b5357d \
+                    size    28803
 
 python.versions     27
 
@@ -29,7 +33,11 @@ if {${name} ne ${subport}} {
                     LDFLAGS=-L${prefix}/lib
 
     post-destroot {
-        xinstall -m 644 -W ${worksrcpath} COPYING ChangeLog NEWS README \
+        xinstall -m 0644 -W ${worksrcpath} COPYING ChangeLog NEWS README \
             ${destroot}${prefix}/share/doc/${subport}
     }
+
+    livecheck.type  none
+} else {
+    livecheck.regex "pychm/(\\d+(?:\\.\\d+)*)"
 }

--- a/python/py-cjson/Portfile
+++ b/python/py-cjson/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cjson
-version             1.1.0
+python.rootname     python-cjson
+version             1.2.1
+revision            0
 platforms           darwin
 license             LGPL
 maintainers         nomaintainer
@@ -19,19 +21,28 @@ long_description    This module implements a very fast JSON \
                     the operation and is the the range of 10-200 times \
                     for encoding operations and in the range of \
                     100-250 times for decoding operations.
-homepage            https://pypi.python.org/pypi/python-cjson/
+homepage            https://github.com/AGProjects/python-cjson
 
-master_sites        pypi:p/python-cjson/
-distname            python-cjson-${version}
-checksums           rmd160  335677e39817b89af34aa51b66f4c0eb8269a050 \
-                    sha256  a01fabb7593728c3d851e1cd9a3efbd18f72650a31a5aa8a74018640da3de8b3
-
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+checksums           rmd160  867ddc7312685999e966128893c2eeb11fa01f0a \
+                    sha256  52db2745264624768bfd9b604acb38f631bde5c2ec9b23861677d747e4558626 \
+                    size    12575
 python.versions     27
 
 if {${name} ne ${subport}} {
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README LICENSE ChangeLog ${destroot}${docdir}
+    }
+
+    pre-test {
+        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+    }
+    test.run        yes
+    test.cmd        ${python.bin} jsontest.py
+    test.target
+
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex {python-cjson (\d+(?:\.\d+)*)}
 }

--- a/python/py-clientform/Portfile
+++ b/python/py-clientform/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
 name                py-clientform
 version             0.2.9
@@ -26,11 +26,12 @@ checksums           md5 21e68d52cc5939ab3345b97e09f0a25a \
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_build       port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    test.run            yes
-    test.cmd            ${python.bin}
-    test.target         test.py
+    test.run        yes
+    test.cmd        ${python.bin}
+    test.target     test.py
 
     post-destroot {
         foreach f [glob -directory ${worksrcpath}/ *.txt *.html] {

--- a/python/py-clientform/Portfile
+++ b/python/py-clientform/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-clientform
-version             0.2.9
+python.rootname     ClientForm
+version             0.2.10
+revision            0
 categories-append   www
 license             {BSD ZPL-2.1}
 platforms           darwin
@@ -17,11 +19,11 @@ long_description    ClientForm is a Python module for handling HTML forms \
                     the server.
 
 homepage            http://wwwsearch.sourceforge.net/ClientForm/
-master_sites        ${homepage}/src/
-distname            ClientForm-${version}
-checksums           md5 21e68d52cc5939ab3345b97e09f0a25a \
-                    sha1 ab07cf5bc293ffa1676bb7f4c5c756cb2907d782 \
-                    rmd160 f82975f171ef3c673d78fa08f7ade3205a0cc87a
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+checksums           rmd160  85b2c0174b0bc1377f71cb13586f28c79554a6e3 \
+                    sha256  9507e7cf6464f30a0daf5153294fdd315e397939433ed08cccf9741de280cd37 \
+                    size    104094
 
 python.versions     27
 

--- a/python/py-clonedigger/Portfile
+++ b/python/py-clonedigger/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-clonedigger
-version             1.0.3-beta
+version             1.1.0
+revision            0
 platforms           darwin
 supported_archs     noarch
 license             GPL-3+
@@ -19,17 +20,14 @@ homepage            http://clonedigger.sourceforge.net/
 
 master_sites        pypi:c/clonedigger/
 distname            clonedigger-${version}
-checksums           md5     ac1883622ee2c20a2b91efbf5133b892 \
-                    sha1    f5a3854d2f5f0f0b997459d1b0f529e216fecb55 \
-                    rmd160  deaf039ca347181959fe54da1b88f6e932b15340
+checksums           rmd160  564d062490f642731ccc663ac9d966089386539a \
+                    sha256  83243929e4760ea2c2ef1e3ceb82265554351d372516db2ae1dc7f3045794124 \
+                    size    2595412
 
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-setuptools
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/clonedigger
-    livecheck.regex clonedigger-(.+?)${extract.suffix}
 }

--- a/python/py-cog/Portfile
+++ b/python/py-cog/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set realname        cogapp
-
 name                py-cog
-version             2.4
+python.rootname     cogapp
+version             2.5.1
+revision            0
 platforms           darwin
 supported_archs     noarch
 license             MIT
@@ -18,12 +18,13 @@ description         Cog is a code generation tool. It lets you use pieces of Pyt
 long_description    ${description}
 
 homepage            https://nedbatchelder.com/code/cog/
-master_sites        pypi:c/${realname}
+master_sites        pypi:c/${python.rootname}
 
-distname            ${realname}-${version}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  15e5bea87f033ceb603c95ac00b37dc7ef8fe8ad \
-                    sha256  5b71a8cfd8dcfd7c408d2ab0f25a4cd546a2d03f8cd99475f775ba79a75a7ba3
+checksums           rmd160  253834c2612eca68ac38d5618716768360e830dd \
+                    sha256  f8cf2288fb5a2087eb4a00d8b347ddc86e9058d4ab26b8c868433eb401adfe1c \
+                    size    22226
 
 python.versions     27 34 35 36
 
@@ -33,7 +34,4 @@ if {${name} ne ${subport}} {
     }
 
     livecheck.type      none
-} else {
-    livecheck.regex     ${realname}-(\[0-9.\]+)${extract.suffix}
-    livecheck.url       https://pypi.python.org/pypi/${realname}
 }

--- a/python/py-config/Portfile
+++ b/python/py-config/Portfile
@@ -17,7 +17,10 @@ long_description    powerful alternative to the ConfigParser module \
 homepage            http://config-py.sourceforge.net/
 master_sites        sourceforge:config-py
 distname            config-py-[string map {. -} ${version}]
-checksums           md5 0deb5f48cb3c3f1067f347b8093a1f78
+checksums           md5     0deb5f48cb3c3f1067f347b8093a1f78 \
+                    rmd160  7e024e13a39c71382730bc835e69d98a7b060a66 \
+                    sha256  9854d7fa3670dad9f0d638736252eb0aa16d3fec15196dfa6a328a3e9a9296f9 \
+                    size    17821
 
 python.versions     27
 
@@ -31,7 +34,11 @@ if {${name} ne ${subport}} {
     }
 
     post-destroot {
-        xinstall -m 644 -W ${worksrcpath} readme.txt \
+        xinstall -m 0644 -W ${worksrcpath} readme.txt \
             ${destroot}${prefix}/share/doc/${subport}
     }
+
+    livecheck.type  none
+} else {
+    livecheck.regex config-py/(\\d+(?:\\.\\d+)*)
 }

--- a/python/py-config/Portfile
+++ b/python/py-config/Portfile
@@ -1,34 +1,36 @@
-PortSystem 1.0
-PortGroup python 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			py-config
-version			1.2
-revision		1
-license			MIT
-platforms		darwin
-supported_archs	noarch
-maintainers		nomaintainer
-description		alternative ConfigParser module for python
-long_description	powerful alternative to the ConfigParser module \
-				already available in the standard Python.
+PortSystem          1.0
+PortGroup           python 1.0
 
-homepage		http://config-py.sourceforge.net/
-master_sites	sourceforge:config-py
-distname		config-py-[string map {. -} ${version}]
-checksums		md5 0deb5f48cb3c3f1067f347b8093a1f78
+name                py-config
+version             1.2
+revision            1
+license             MIT
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+description         alternative ConfigParser module for python
+long_description    powerful alternative to the ConfigParser module \
+                    already available in the standard Python.
 
-python.versions	27
+homepage            http://config-py.sourceforge.net/
+master_sites        sourceforge:config-py
+distname            config-py-[string map {. -} ${version}]
+checksums           md5 0deb5f48cb3c3f1067f347b8093a1f78
+
+python.versions     27
 
 if {${name} ne ${subport}} {
-    use_zip			yes
-    extract.mkdir	yes
+    use_zip         yes
+    extract.mkdir   yes
 
-    post-extract	{
+    post-extract {
         file copy ${filespath}/setup.py ${worksrcpath}
         reinplace "s|VERSION|${version}|" ${worksrcpath}/setup.py
     }
 
-    post-destroot	{
+    post-destroot {
         xinstall -m 644 -W ${worksrcpath} readme.txt \
             ${destroot}${prefix}/share/doc/${subport}
     }


### PR DESCRIPTION
#### Description
- py-chm: fix livecheck, add license, modernize checksums 
- py-cjson: update to 1.2.1, enable tests, default livecheck, update homepage, install files in post-destroot
- py-clientform: update to 0.2.10, switch to PyPI
- py-clonedigger: update to 1.1.0, fix dependency type, use default PyPI livecheck
- py-cog: update to 2.5.1, default PyPI livecheck
- py-config: fix livecheck, modernize checksums
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? Yes, where applicable.
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
