### PR TITLE
Fix tuntaposx build for Mojave

### DIFF
--- a/net/tuntaposx/Portfile
+++ b/net/tuntaposx/Portfile
@@ -69,6 +69,10 @@ if {${os.major} <= 9} {
     patchfiles-append patch-leopard.diff
 }
 
+if {${os.major} >= 18} {
+    patchfiles-append patch-mojave.diff
+}
+
 platform darwin 10 {
     # Kernel can be 32-bit or 64-bit, so build both
     default_variants +universal

--- a/net/tuntaposx/files/patch-mojave.diff
+++ b/net/tuntaposx/files/patch-mojave.diff
@@ -1,0 +1,22 @@
+--- src/tun/Makefile.orig	2014-10-20 20:59:47.000000000 +0200
++++ src/tun/Makefile	2019-02-20 20:25:21.000000000 +0100
+@@ -20,7 +20,7 @@
+ BUNDLE_PACKAGETYPE = KEXT
+ BUNDLE_VERSION = $(TUN_KEXT_VERSION)
+ 
+-INCLUDE = -I.. -I/System/Library/Frameworks/Kernel.framework/Headers
++INCLUDE = -I.. -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers
+ CFLAGS = -Wall -Werror -mkernel -force_cpusubtype_ALL \
+ 	-nostdinc -fno-builtin -fno-stack-protector -msoft-float -fno-common \
+ 	-arch x86_64 \
+--- src/tap/Makefile.orig	2014-10-20 20:59:30.000000000 +0200
++++ src/tap/Makefile	2019-02-20 20:25:52.000000000 +0100
+@@ -19,7 +19,7 @@
+ BUNDLE_PACKAGETYPE = KEXT
+ BUNDLE_VERSION = $(TAP_KEXT_VERSION)
+ 
+-INCLUDE = -I.. -I/System/Library/Frameworks/Kernel.framework/Headers
++INCLUDE = -I.. -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers
+ CFLAGS = -Wall -Werror -mkernel -force_cpusubtype_ALL \
+ 	-nostdinc -fno-builtin -fno-stack-protector -msoft-float -fno-common \
+ 	-arch x86_64 \


### PR DESCRIPTION
#### Description
The bug: https://trac.macports.org/ticket/57723
Apparently the kernel sdk path has changed in Mojave. This PR adds a patch for tuntaposx makefiles to use the new include path.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.2 18C54
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
