### PR TITLE
borgbackup: update to 1.1.9

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                borgbackup
-version             1.1.7
-revision            1
+version             1.1.9
 categories          sysutils
 platforms           darwin
 license             BSD
@@ -24,9 +23,9 @@ long_description    BorgBackup (short: Borg) is a deduplicating backup \
 homepage            https://borgbackup.github.io/
 master_sites        pypi:b/borgbackup
 
-checksums           rmd160  3595743aa68582ea408939c83ab86f716dfbca9f \
-                    sha256  f7b51a132e9edfbe1cacb4f478b28caf3622d79fffcb369bdae9f92d8c8a7fdc \
-                    size    3446832
+checksums           rmd160  b40a6bf068d557bd7359ca77da53417fe403092e \
+                    sha256  7d0ff84e64c4be35c43ae2c047bb521a94f15b278c2fe63b43950c4836b42575 \
+                    size    3468259
 
 patchfiles          patch-msgpack.diff
 
@@ -53,7 +52,7 @@ post-build {
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}/html
-        xinstall -d ${docdir}
+    xinstall -d ${docdir}
 
     xinstall -m 0644 ${worksrcpath}/docs/_build/man/borg.1 \
         ${destroot}${prefix}/share/man/man1/
@@ -71,5 +70,3 @@ post-destroot {
     xinstall -m 0644 ${worksrcpath}/scripts/shell_completions/zsh/_borg \
         ${destroot}${zsh_compl_path}
 }
-
-livecheck.type      pypi


### PR DESCRIPTION
#### Description

- bump version to 1.1.9
- remove livecheck.type because pypi is autoselected

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->