### PR TITLE
gnupg2: update to 2.2.13

### DIFF
--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 
 set my_name         gnupg
 name                ${my_name}2
-version             2.2.12
-revision            1
+version             2.2.13
 categories          mail security
 maintainers         {jann @roederja} {ionic @Ionic} openmaintainer
 license             GPL-3+
@@ -24,9 +23,9 @@ master_sites        ${my_name}:${my_name}
 
 use_bzip2           yes
 
-checksums           rmd160  4da4303a12a55111de9cd100ab0fdb30b28a4e00 \
-                    sha256  db030f8b4c98640e91300d36d516f1f4f8fe09514a94ea9fc7411ee1a34082cb \
-                    size    6682303
+checksums           rmd160  b24158d4a6b9ce00fc27f2f5b855793e5d15dc6a \
+                    sha256  76c787a955f9e6e0ead47c9be700bfb9d454f955a7b7c7e697aa719bac7b11d8 \
+                    size    6702712
 
 platform darwin {
     if {![variant_isset pinentry] && ![variant_isset pinentry_mac]} {


### PR DESCRIPTION
#### Description

- bump version to 2.2.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->