### PR TITLE
update various unmaintained Python ports to their latest version

### DIFF
--- a/python/py-control/Portfile
+++ b/python/py-control/Portfile
@@ -3,15 +3,14 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set     package     control
-name                py-${package}
-version             0.6.6
+name                py-control
+version             0.8.1
+revision            0
 categories-append   science
 license             BSD
 platforms           darwin
 
-# other versions untested
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         nomaintainer
 
@@ -21,21 +20,36 @@ long_description    \
     implements basic operations for analysis and design of feedback control \
     systems.
 
-homepage            http://python-control.sourceforge.net
-master_sites        pypi:c/${package}/
+homepage            https://python-control.sourceforge.net
+master_sites        pypi:c/${python.rootname}/
 
-distname            ${package}-${version}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  245b3f2e0cc7250013f25f14d18daa0996a24616 \
-                    sha256  a078ce14574866dbdda3de5eef35ef1980f759c3e77831ea7bd500067fdb8aea
+checksums           rmd160  999a70fe5c0d8d04335d8ade089f280a58c4285f \
+                    sha256  d01d6dc14888bdfef6878b3e995a4b2b16bc021447291a9b740a9ab0983d34c9 \
+                    size    168701
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
-    depends_lib-append  port:py${python.version}-numpy \
-                        port:py${python.version}-scipy
+    depends_lib-append \
+                    port:py${python.version}-matplotlib \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-scipy
+
+    depends_test-append \
+                    port:py${python.version}-nose
+    test.run        yes
+    test.cmd        ${python.bin} setup.py
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} ChangeLog LICENSE Pending \
+            README.rst ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 {*}[glob ${worksrcpath}/examples/*] \
+            ${destroot}${prefix}/share/doc/${subport}/examples
+    }
+
+    livecheck.type  none
 }
-
-livecheck.type      regex
-livecheck.url       ${master_sites}
-livecheck.regex     "${package}-(\\d+(?:\\.\\d+)*)\\.\[tz]"

--- a/python/py-country/Portfile
+++ b/python/py-country/Portfile
@@ -1,11 +1,12 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
-# vim: set fileencoding=utf-8 tabstop=8 shiftwidth=4 softtabstop=4 filetype=tcl:
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-country
-version             18.5.26
+python.rootname     pycountry
+version             18.12.8
+revision            0
 license             LGPL-2.1
 platforms           darwin
 supported_archs     noarch
@@ -17,9 +18,9 @@ homepage            https://bitbucket.org/flyingcircus/pycountry
 master_sites        pypi:p/pycountry
 distname            pycountry-${version}
 
-checksums           rmd160  1e329727bebb5aa08feacc3604a4d5e86b164b1b \
-                    sha256  7f2aa2529c60f6575af3cd644688b201b97016822ce0ce1c4bcc0f7d08900997 \
-                    size    9779056
+checksums           rmd160  1aef86ce0594ec4f5b5f87cc56cf6c9e8c2be171 \
+                    sha256  8ec4020b2b15cd410893d573820d42ee12fe50365332e58c0975c953b60a16de \
+                    size    10026953
 
 python.versions     27 36 37
 
@@ -32,11 +33,14 @@ if {${name} ne ${subport}} {
 
     test.run            yes
     test.cmd            py.test-${python.branch}
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
     test.target
 
     post-destroot {
-        foreach f [glob -directory ${worksrcpath}/ *.txt] {
-            copy $f ${destroot}${prefix}/share/doc/${subport}/[file tail $f]
-        }
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} TODO.txt README LICENSE.txt \
+            HISTORY.txt ${destroot}${prefix}/share/doc/${subport}
     }
+
+    livecheck.type      none
 }

--- a/python/py-cx_Freeze/Portfile
+++ b/python/py-cx_Freeze/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-cx_Freeze
 version             5.1.1
+revision            0
 categories-append   devel
 platforms           darwin
 universal_variant   no
@@ -28,8 +29,4 @@ python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   ${homepage}
-    livecheck.regex <p>Version (\\d+\\.\\d+\\.\\d+), released
 }

--- a/python/py-decoratortools/Portfile
+++ b/python/py-decoratortools/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-decoratortools
 version             1.8
+revision            0
 categories-append   www
 platforms           darwin
 supported_archs     noarch
@@ -20,20 +21,19 @@ master_sites        pypi:D/DecoratorTools
 distname            DecoratorTools-${version}
 use_zip             yes
 checksums           rmd160  c4cc286a557588ec4d45ebbbc6d848fdee107a19 \
-                    sha256  da73f03a9fab80a205c8febcecee83f8a989eab8ce81affd7989210e4a3d9ea8
+                    sha256  da73f03a9fab80a205c8febcecee83f8a989eab8ce81affd7989210e4a3d9ea8 \
+                    size    29566
 
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+
     post-destroot {
-        xinstall -m 644 -W ${worksrcpath} \
+        xinstall -m 0644 -W ${worksrcpath} \
             README.txt ${destroot}${prefix}/share/doc/${subport}
     }
-    test.run        yes
+
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   ${master_sites}
-    livecheck.regex DecoratorTools-(\[0-9.\]+)${extract.suffix}
 }

--- a/python/py-demjson/Portfile
+++ b/python/py-demjson/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-demjson
-version             1.6
+version             2.2.4
+revision            0
 license             LGPL-3+
 platforms           darwin
 maintainers         nomaintainer
@@ -30,14 +31,19 @@ homepage            http://deron.meranda.us/python/demjson/
 master_sites        pypi:d/demjson/
 distname            demjson-${version}
 
-checksums           rmd160  42dc86629d1be2ace32d562680786c678c09c1bd \
-                    sha256  1d989c310e33569ecc178b8182e53bde8f748bf5ea10cfbc0e331f8c313f6e29
+checksums           rmd160  2d5f60a791671465dc91ab370a8ad7480ed81a26 \
+                    sha256  31de2038a0fdd9c4c11f8bf3b13fe77bc2a128307f965c8d5fb4dc6d6f6beb79 \
+                    size    131457
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
-}
 
-livecheck.type      regex
-livecheck.url       https://pypi.python.org/pypi/demjson/
-livecheck.regex     "/demjson/(\\d+(?:\\.\\d+)*)\""
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} README.txt LICENSE.txt \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-demjson/Portfile
+++ b/python/py-demjson/Portfile
@@ -1,42 +1,43 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem        1.0
-PortGroup         python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name              py-demjson
-version           1.6
-license           LGPL-3+
-platforms         darwin
-maintainers       nomaintainer
+name                py-demjson
+version             1.6
+license             LGPL-3+
+platforms           darwin
+maintainers         nomaintainer
 
-python.versions         27
+python.versions     27
 
-description       encoder, decoder, and validator for JSON compliant with RFC 4627
-long_description  encoder, decoder, and lint/validator for JSON (JavaScript \
-                  Object Notation) compliant with RFC 4627. This module \
-                  provides classes and functions for encoding or decoding data \
-                  represented in the language-neutral JSON format. This \
-                  implementation tries to be as compliant to the JSON \
-                  specification (RFC 4627) as possible, while still providing \
-                  many optional extensions to allow less restrictive \
-                  JavaScript syntax. It includes complete Unicode support, \
-                  including UTF-32, BOM, and surrogate pair processing. It can \
-                  also support JavaScript's NaN and Infinity numeric types as \
-                  well as its 'undefined' type. It also includes a lint-like \
-                  JSON syntax validator which tests JSON text for strict \
-                  compliance to the standard.
+description         encoder, decoder, and validator for JSON compliant with RFC 4627
+long_description    encoder, decoder, and lint/validator for JSON (JavaScript \
+                    Object Notation) compliant with RFC 4627. This module \
+                    provides classes and functions for encoding or decoding data \
+                    represented in the language-neutral JSON format. This \
+                    implementation tries to be as compliant to the JSON \
+                    specification (RFC 4627) as possible, while still providing \
+                    many optional extensions to allow less restrictive \
+                    JavaScript syntax. It includes complete Unicode support, \
+                    including UTF-32, BOM, and surrogate pair processing. It can \
+                    also support JavaScript's NaN and Infinity numeric types as \
+                    well as its 'undefined' type. It also includes a lint-like \
+                    JSON syntax validator which tests JSON text for strict \
+                    compliance to the standard.
 
-homepage          http://deron.meranda.us/python/demjson/
-master_sites      pypi:d/demjson/
-distname          demjson-${version}
+homepage            http://deron.meranda.us/python/demjson/
+master_sites        pypi:d/demjson/
+distname            demjson-${version}
 
-checksums         rmd160  42dc86629d1be2ace32d562680786c678c09c1bd \
-                  sha256  1d989c310e33569ecc178b8182e53bde8f748bf5ea10cfbc0e331f8c313f6e29
+checksums           rmd160  42dc86629d1be2ace32d562680786c678c09c1bd \
+                    sha256  1d989c310e33569ecc178b8182e53bde8f748bf5ea10cfbc0e331f8c313f6e29
 
 if {${name} ne ${subport}} {
-    depends_build-append port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
 }
 
-livecheck.type    regex
-livecheck.url     https://pypi.python.org/pypi/demjson/
-livecheck.regex   "/demjson/(\\d+(?:\\.\\d+)*)\""
+livecheck.type      regex
+livecheck.url       https://pypi.python.org/pypi/demjson/
+livecheck.regex     "/demjson/(\\d+(?:\\.\\d+)*)\""

--- a/python/py-diff-match-patch/Portfile
+++ b/python/py-diff-match-patch/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-diff-match-patch
-version             20121119
+version             20181111
+revision            0
 platforms           darwin
 license             Apache-2
 maintainers         nomaintainer
@@ -17,17 +18,21 @@ homepage            https://github.com/google/diff-match-patch
 master_sites        pypi:d/diff-match-patch
 distname            diff-match-patch-${version}
 
-checksums           rmd160  0279fd90a2ec4db1cd797db47862084e216083ed \
-                    sha256  9dba5611fbf27893347349fd51cc1911cb403682a7163373adacc565d11e2e4c \
-                    size    54113
+checksums           rmd160  e01dabf595cee36ea587bac9653bf21d4281346c \
+                    sha256  a809a996d0f09b9bbd59e9bbd0b71eed8c807922512910e05cbd3f9480712ddb \
+                    size    58554
 
-python.versions     27 36
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
 
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE CONTRIBUTING.md \
+            CODE_OF_CONDUCT.md README.md ${destroot}${prefix}/share/doc/${subport}
+    }
+
     livecheck.type      none
-} else {
-    livecheck.type      pypi
 }


### PR DESCRIPTION
#### Description
- py-control: update to 0.8.1, add py37
- py-country: update to 18.12.8
- py-cx_Freeze: use default PyPI livecheck 
- py-decoratortools: use default PyPI livecheck 
- py-demjson: update to 2.2.4 
- py-diff-match-patch: update to 20181111 

<!-- Note: it is best make pull requests from a branch rather than from master -->
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, where applicable
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->