### PR TITLE
arpack: restore build on Tiger

### DIFF
--- a/math/arpack/Portfile
+++ b/math/arpack/Portfile
@@ -70,11 +70,6 @@ configure.args-append LDFLAGS=''
 pre-configure {
     configure.args-append --with-blas="-L${prefix}/lib ${linalglib}"
 
-    if {${os.platform} eq "darwin" && ${os.major} < 9} {
-        ui_error "${name} ${version} requires Mac OS X 10.5 or greater"
-        return -code error "incompatible Mac OS X version"
-    }
-
     if {[mpi_variant_isset]} {
         configure.args-delete  --disable-mpi
         configure.args-append  --enable-mpi


### PR DESCRIPTION
confirmed that arpack builds and passes all tests on Tiger without issues

(Intel and PPC)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
macOS 10.4.11 8S165
Xcode DevToolsSupport-794.0-->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
