### PR TITLE
update various unmaintained Python ports to their latest version

### DIFF
--- a/python/py-django-debug-toolbar/Portfile
+++ b/python/py-django-debug-toolbar/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
@@ -25,10 +27,11 @@ checksums           md5    85c1c70a31f0a3a646a603214d235e9f \
 python.versions     27
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools
-    livecheck.type      none
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+    livecheck.type  none
 } else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/django-debug-toolbar
-    livecheck.regex     "django-debug-toolbar-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+    livecheck.type  regex
+    livecheck.url   https://pypi.python.org/pypi/django-debug-toolbar
+    livecheck.regex "django-debug-toolbar-(\\d+(?:\\.\\d+)*)${extract.suffix}"
 }

--- a/python/py-django-debug-toolbar/Portfile
+++ b/python/py-django-debug-toolbar/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-django-debug-toolbar
-version             0.9.4
+version             1.11
+revision            0
 categories-append   www
 platforms           darwin
 supported_archs     noarch
@@ -20,18 +21,25 @@ homepage            https://github.com/django-debug-toolbar/django-debug-toolbar
 master_sites        pypi:d/django-debug-toolbar/
 distname            django-debug-toolbar-${version}
 
-checksums           md5    85c1c70a31f0a3a646a603214d235e9f \
-                    rmd160 ef7b0db00f1640787e6fefa611ae4e8643d5e7a3 \
-                    sha256 d6bc217b672ddf0e729f76da2df1d4a50d45f1c934239851f7f7ae6a51201f4b
+checksums           rmd160  ffb084f430359ef91c9b8b0c6a8b2720b7f55cd7 \
+                    sha256  89d75b60c65db363fb24688d977e5fbf0e73386c67acf562d278402a10fc3736 \
+                    size    108708
 
-python.versions     27
+python.versions     27 37
 
 if {${name} ne ${subport}} {
-    depends_lib-append \
+    depends_build-append \
                     port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-django \
+                    port:py${python.version}-sqlparse
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE CONTRIBUTING.md \
+            README.rst ${destroot}${prefix}/share/doc/${subport}
+    }
+
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/django-debug-toolbar
-    livecheck.regex "django-debug-toolbar-(\\d+(?:\\.\\d+)*)${extract.suffix}"
 }

--- a/python/py-django-extensions/Portfile
+++ b/python/py-django-extensions/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-django-extensions
-version             1.1.1
+version             2.1.5
+revision            0
 categories-append   www
 platforms           darwin
 supported_archs     noarch
@@ -17,13 +18,29 @@ homepage            https://github.com/django-extensions/django-extensions
 
 master_sites        pypi:d/django-extensions/
 distname            django-extensions-${version}
-checksums           md5    23b47b5fb8a4c494035a077a5df07562 \
-                    rmd160 e17de3ff65bc2c1e1713bb44d09a292b5c1e5302 \
-                    sha256 81d4f4dff21c52e84bdfbc56adf91f16c4082cf09a6fc858d91b71d0d40507c4
+checksums           rmd160  a72206529fe2ff6249a86246cba8704b58714f0b \
+                    sha256  a607459e5fa8c579a672131b63366fa52fab80adb2a862d362f5fb48cd2d2cac \
+                    size    485854
 
-python.versions     27
+python.versions     27 37
 
 if {${name} ne ${subport}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-six
+
+    if {${python.version} eq 27} {
+        depends_lib-append \
+                    port:py${python.version}-typing
+    }
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+             ${destroot}${prefix}/share/doc/${subport}
+    }
+
     livecheck.type  none
 }

--- a/python/py-django-nose/Portfile
+++ b/python/py-django-nose/Portfile
@@ -1,11 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           django-nose
-set _n              [string index ${_name} 0]
-
-name                py-${_name}
-version             1.2
+name                py-django-nose
+version             1.4.6
+revision            0
 
 categories-append   devel
 platforms           darwin
@@ -15,23 +15,30 @@ maintainers         nomaintainer
 description         Django test runner that uses nose
 long_description    ${description}
 
-homepage            https://github.com/jbalogh/${_name}
-master_sites        pypi:${_n}/${_name}
-distname            ${_name}-${version}
+homepage            https://github.com/django-nose/django-nose
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           md5     199d5358317a804b39fe05d806cab427 \
-                    rmd160  bdd535ec8bbd042eab00c47b605848ad67b14fdd \
-                    sha256  9aae16b562866a4ddaa5e8978729abadbbed544728d88e0b9c9af7b31dd072ed
+checksums           rmd160  684e90c76ab73095015dfa15e86ec20ea1693050 \
+                    sha256  58934a06a6932696e54c9e8af3fab49bf67ca9e9c840ad668cb7f51219808a07 \
+                    size    46410
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_lib     port:py${python.version}-django \
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-django \
                     port:py${python.version}-nose
 
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE CONTRIBUTING.rst \
+            AUTHORS.rst changelog.rst README.rst \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
+
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   [lindex ${master_sites} 0]
-    livecheck.regex ">${_name}-(\\d+(\\.\\d+)+)\\${extract.suffix}<"
 }

--- a/python/py-docker/Portfile
+++ b/python/py-docker/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        docker docker-py 3.5.1
+github.setup        docker docker-py 3.7.0
+revision            0
 name                py-docker
 categories-append   devel
 platforms           darwin
@@ -15,9 +16,9 @@ maintainers         nomaintainer
 description         An API client for docker written in Python
 long_description    $description
 
-checksums           rmd160  392e3c33730011c870bc167f16b53e03ea6f36c7 \
-                    sha256  c36e4cdfffcf2620a3dd92e1aa4937e0370ae2fc052bfde33b61ad66063a15f4 \
-                    size    209425
+checksums           rmd160  cb4cb8eef398b34e94b02cd2e6e4ed7d9aac61fc \
+                    sha256  466fefb5c9bfeab06b13511f0460040ee7ccf5683d4d731148e192ac29298b98 \
+                    size    220452
 
 python.versions     27 34 35 36 37
 
@@ -36,6 +37,12 @@ if {${subport} ne ${name}} {
     }
     if {${python.version} eq 27} {
         depends_lib-append  port:py${python.version}-ipaddress
+    }
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} CONTRIBUTING.md LICENSE \
+            MAINTAINERS README.md ${destroot}${prefix}/share/doc/${subport}
     }
 
     livecheck.type  none

--- a/python/py-docx/Portfile
+++ b/python/py-docx/Portfile
@@ -2,35 +2,46 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           github 1.0
 
+github.setup        python-openxml python-docx 0.8.9 v
 name                py-docx
-version             0.0.2
-revision            1
-categories-append   devel 
+revision            0
+categories-append   devel
 platforms           darwin
 license             MIT
 maintainers         nomaintainer
 
-description         The docx module creates, reads and writes Microsoft Office Word 2007 docx files
-long_description    \
-    The module was created when I was looking for a Python support for \
-    MS Word .doc files, but could only find various hacks involving COM \
-    automation, calling .net or Java, or automating OpenOffice or MS Office.
+description         Create and update Microsoft Word .docx files
+long_description    ${description}
 
-homepage            https://github.com/mikemaccana/python-docx
+checksums           rmd160  23cfea337911d7cd5a664384c652ca022d789485 \
+                    sha256  3eb8239cd12d50cbcb4728b3aa92b636cca54b0f2bfcb2a526bf6cefee5148b0 \
+                    size    45185886
 
-fetch.type          git
-git.url             ${homepage}.git
-git.branch          7f0781e7a86ba26d69f5e09850ef7e4fc35d3795
-
-python.versions     27
+python.versions     27 37
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-lxml
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-lxml
+
+    depends_lib-append \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-parsing \
+                    port:py${python.version}-pytest
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} HISTORY.rst LICENSE README.rst \
+            ${destroot}${prefix}/share/doc/${subport}
+    }
 
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://raw.github.com/mikemaccana/python-docx/master/setup.py
-    livecheck.regex {version='(\d+(?:\.\d+)*)'}
 }

--- a/python/py-dpkt/Portfile
+++ b/python/py-dpkt/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-dpkt
-version             1.8.8
+version             1.9.2
+revision            0
 categories-append   net
 license             BSD
 maintainers         nomaintainer
@@ -19,11 +20,18 @@ homepage            https://github.com/kbandla/dpkt
 master_sites        pypi:d/dpkt
 distname            dpkt-${version}
 
-checksums           rmd160  cb26e932fe407834370629f6857aab8295131e2b \
-                    sha256  d99525e534266818ecd122052f4086c684a88491c8073a848193bbf13ed69800
+checksums           rmd160  ac6490a6accb4533290914a5229089802f2ca115 \
+                    sha256  52a92ecd5ca04d5bd852bb11cb2eac4bbe38b42a7c472e0d950eeb9f82a81e54 \
+                    size    125532
 
-python.versions     27
+python.versions     27 37
 
 if {${name} ne ${subport}} {
+    post-destroot {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE CHANGES \
+            AUTHORS ${destroot}${prefix}/share/doc/${subport}
+    }
+
     livecheck.type  none
 }

--- a/python/py-dpkt/Portfile
+++ b/python/py-dpkt/Portfile
@@ -1,30 +1,29 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name                    py-dpkt
-version                 1.8.8
-categories-append       net
-license                 BSD
-maintainers             nomaintainer
-description             python packet creation and parsing library
-long_description        dpkt provides fast, simple packet creation and \
-                        parsing for python programs, with definitions for the \
-                        basic TCP/IP protocols.
-platforms               darwin
-supported_archs         noarch
+name                py-dpkt
+version             1.8.8
+categories-append   net
+license             BSD
+maintainers         nomaintainer
+description         python packet creation and parsing library
+long_description    dpkt provides fast, simple packet creation and \
+                    parsing for python programs, with definitions for the \
+                    basic TCP/IP protocols.
+platforms           darwin
+supported_archs     noarch
 
-homepage                https://github.com/kbandla/dpkt
-master_sites            pypi:d/dpkt
+homepage            https://github.com/kbandla/dpkt
+master_sites        pypi:d/dpkt
+distname            dpkt-${version}
 
-checksums               rmd160  cb26e932fe407834370629f6857aab8295131e2b \
-                        sha256  d99525e534266818ecd122052f4086c684a88491c8073a848193bbf13ed69800
+checksums           rmd160  cb26e932fe407834370629f6857aab8295131e2b \
+                    sha256  d99525e534266818ecd122052f4086c684a88491c8073a848193bbf13ed69800
 
-python.versions         27
+python.versions     27
 
 if {${name} ne ${subport}} {
-    livecheck.type      none
+    livecheck.type  none
 }
-
-distname                dpkt-${version}

--- a/python/py-dsv/Portfile
+++ b/python/py-dsv/Portfile
@@ -6,6 +6,7 @@ PortGroup           wxWidgets 1.0
 
 name                py-dsv
 version             1.4.1
+revision            0
 maintainers         nomaintainer
 description         Python module to import/export DSV files
 long_description    Python-DSV is a Python module for importing and exporting DSV \
@@ -21,18 +22,23 @@ master_sites        sourceforge:python-dsv
 distname            DSV-${version}
 
 checksums           rmd160  5aeb38aac9798ecebc622e22dc5e813ddfd56722 \
-                    sha256  5d0ec99c45f8ea91ea920dcd2cdf2cdc9e721985551ea80718519ce70dc98f15
+                    sha256  5d0ec99c45f8ea91ea920dcd2cdf2cdc9e721985551ea80718519ce70dc98f15 \
+                    size    14682
 
 python.versions     27
 
 if {${name} ne ${subport}} {
     post-destroot {
-        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath} README \
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}
+        xinstall -m 0644 -W ${worksrcpath} README \
             ${destroot}${prefix}/share/doc/${subport}
     }
 
     variant wx {
         depends_run-append  port:py${python.version}-wxpython-2.8
     }
+
+    livecheck.type  none
+} else {
+    livecheck.regex python-dsv/(\\d+(?:\\.\\d+)*)
 }


### PR DESCRIPTION
#### Description
- see commit messages for a description of the updates

<!-- Note: it is best make pull requests from a branch rather than from master -->
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D42
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, where applicable
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->