### PR TITLE
Fix tests

### DIFF
--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -41,6 +41,8 @@ if {${name} ne ${subport}} {
 
     depends_test-append port:py${python.version}-nose
     test.run            yes
+    test.cmd            nosetests-${python.branch}
+    test.target
 }
 
 

--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -39,6 +39,8 @@ if {${name} ne ${subport}} {
                          path:${prefix}/lib/libplumedKernel.dylib:plumed
 
     depends_test-append port:py${python.version}-nose
+    test.cmd            nosetests-${python.branch}
+    test.target
     test.run            yes
 }
 

--- a/python/py-setuptools_scm_git_archive/Portfile
+++ b/python/py-setuptools_scm_git_archive/Portfile
@@ -29,5 +29,10 @@ checksums           rmd160  665c374d66941d878284e72dcd40125fb88debd3 \
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools_scm
 
+    depends_test-append port:py${python.version}-pytest
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target         tests.py
+
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description

I fixed the configuration of tests in a few ports that I maintain.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
