### PR TITLE
netpbm: disable parallel build on Tiger

### DIFF
--- a/graphics/netpbm/Portfile
+++ b/graphics/netpbm/Portfile
@@ -286,6 +286,7 @@ subport libnetpbm {
 platform darwin 8 {
     depends_build-append port:gmake
     build.cmd ${prefix}/bin/gmake
+    use_parallel_build  no
     pre-configure {
         set fl [open "| ${configure.cc} --version"]
         set data [read $fl]


### PR DESCRIPTION
parallel build on Tiger is fragile and fails
on multi-processor machines, perhaps due to the
use of gmake? disable parallel build fixes it

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
Tiger PPC

