### PR TITLE
rdesktop: update to 1.8.4, moved to GitHub [1]

### DIFF
--- a/net/rdesktop/Portfile
+++ b/net/rdesktop/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem          1.0
+PortGroup           github 1.0
 
-name                rdesktop
-version             1.8.3
-revision            1
+github.setup        rdesktop rdesktop 1.8.4 v
+revision            0
 categories          net
 license             GPL-3+
 maintainers         nomaintainer
@@ -21,7 +21,7 @@ long_description    \
 platforms           darwin freebsd
 
 homepage            https://www.rdesktop.org/
-master_sites        sourceforge
+github.tarball_from releases
 
 universal_variant   no
 
@@ -42,9 +42,9 @@ configure.args      --mandir=${prefix}/share/man \
 
 build.target        rdesktop
 
-checksums \
-    rmd160  c278b54be54f434d79e0f07a9cdc2cca62286103 \
-    sha256  88b20156b34eff5f1b453f7c724e0a3ff9370a599e69c01dc2bf0b5e650eece4
+checksums           rmd160  5ad95433c369a9cff11b765e181d97ac41bf8582 \
+                    sha256  9b98b8e73aa83e93aa1d9ae82ce38c08395f64b67799edc24821bb26a84dcd2d \
+                    size    321448
 
 variant w2k_license_hack description {will announce the client as Windows 2000 machine} {
     patchfiles patch-licence.c


### PR DESCRIPTION
#### Description
[1] http://sourceforge.net/p/rdesktop/mailman/message/34389893

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
