### PR TITLE
graphviz-gui: Fix build & install on Mojave

### DIFF
--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -322,6 +322,15 @@ subport graphviz-gui${thisbranch} {
     
     patchfiles                  patch-project.pbxproj.diff
     
+    # this port does not build with the new xcode build system at present
+    if {[vercmp ${xcodeversion} 10.0] >= 0} {
+        # Xcode10 will not build against an IBDocument.SystemTarget of 10.5
+        patchfiles-append    patch-xib-target.diff
+
+        build.pre_args      -UseNewBuildSystem=NO
+        destroot.pre_args   -UseNewBuildSystem=NO
+    }
+
     xcode.configuration         Release
     
     build.dir                   ${worksrcpath}/macosx

--- a/graphics/graphviz/files/patch-xib-target.diff
+++ b/graphics/graphviz/files/patch-xib-target.diff
@@ -1,0 +1,48 @@
+diff -Naur macosx.orig/English.lproj/Attributes.xib macosx/English.lproj/Attributes.xib
+--- macosx.orig/English.lproj/Attributes.xib	2016-08-09 23:02:10.000000000 +0200
++++ macosx/English.lproj/Attributes.xib	2019-02-18 13:44:23.000000000 +0100
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9B18</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949</string>
+diff -Naur macosx.orig/English.lproj/Document.xib macosx/English.lproj/Document.xib
+--- macosx.orig/English.lproj/Document.xib	2016-08-09 23:02:10.000000000 +0200
++++ macosx/English.lproj/Document.xib	2019-02-18 13:44:44.000000000 +0100
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9C7010</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949.26</string>
+diff -Naur macosx.orig/English.lproj/Export.xib macosx/English.lproj/Export.xib
+--- macosx.orig/English.lproj/Export.xib	2016-08-09 23:02:10.000000000 +0200
++++ macosx/English.lproj/Export.xib	2019-02-18 13:44:38.000000000 +0100
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9C7010</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949.26</string>
+diff -Naur macosx.orig/English.lproj/MainMenu.xib macosx/English.lproj/MainMenu.xib
+--- macosx.orig/English.lproj/MainMenu.xib	2016-08-09 23:02:10.000000000 +0200
++++ macosx/English.lproj/MainMenu.xib	2019-02-18 13:44:30.000000000 +0100
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9E17</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949.33</string>


### PR DESCRIPTION
#### Description

Installing graphviz-gui @2.40.1_0 with Xcode 10.1 on macOS 10.14 Mojave fails for two independent reasons, which are fixed by the attached commits.

- build step CompileXIB: “error: Compiling for earlier than macOS 10.6 is no longer supported.” (https://trac.macports.org/ticket/57830). This is fixed by raising the SystemTarget version in the xib files from 1050 to 1060. Compiling them then proceeds without errors and the resulting application appears to work fine.

- destroot step SymLink fails with the same error as for aquaterm in https://trac.macports.org/ticket/56895. I couldn’t quickly figure out what goes wrong in detail, so I just copied the fix from there, which appears to work fine.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.1 10B61 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?