### PR TITLE
scite: fix build on Mojave

### DIFF
--- a/editors/scite/Portfile
+++ b/editors/scite/Portfile
@@ -32,7 +32,8 @@ worksrcdir      ${name}
 
 patch.dir       ${workpath}
 
-patchfiles      patch-scite-makefile.diff
+patchfiles      patch-scite-makefile.diff \
+                patch-compile-error.diff
 
 # tidy's platform.h shadows scintilla's Platform.h on case-insensitive filesystems; see #28230
 if {[file exists ${prefix}/include/Platform.h]} {

--- a/editors/scite/files/patch-compile-error.diff
+++ b/editors/scite/files/patch-compile-error.diff
@@ -1,0 +1,35 @@
+diff -ur scintilla.orig/gtk/ScintillaGTK.cxx scintilla/gtk/ScintillaGTK.cxx
+--- scintilla.orig/gtk/ScintillaGTK.cxx	2012-06-01 10:26:24.000000000 +0200
++++ scintilla/gtk/ScintillaGTK.cxx	2019-02-23 17:31:54.000000000 +0100
+@@ -1612,7 +1612,7 @@
+  		NotifyURIDropped(ptr);
+ 		delete []ptr;
+ 	} else if ((TypeOfGSD(selection_data) == GDK_TARGET_STRING) || (TypeOfGSD(selection_data) == atomUTF8)) {
+-		if (TypeOfGSD(selection_data) > 0) {
++		if (LengthOfGSD(selection_data) > 0) {
+ 			SelectionText selText;
+ 			GetGtkSelectionText(selection_data, selText);
+ 			DropAt(posDrop, selText.s, false, selText.rectangular);
+diff -ur scintilla.orig/src/Editor.cxx scintilla/src/Editor.cxx
+--- scintilla.orig/src/Editor.cxx	2012-08-31 08:26:48.000000000 +0200
++++ scintilla/src/Editor.cxx	2019-02-23 17:33:20.000000000 +0100
+@@ -11,6 +11,7 @@
+ #include <ctype.h>
+ #include <assert.h>
+ 
++#include <cmath>
+ #include <string>
+ #include <vector>
+ #include <map>
+@@ -5868,9 +5869,9 @@
+ }
+ 
+ static bool Close(Point pt1, Point pt2) {
+-	if (abs(pt1.x - pt2.x) > 3)
++	if (std::abs(pt1.x - pt2.x) > 3)
+ 		return false;
+-	if (abs(pt1.y - pt2.y) > 3)
++	if (std::abs(pt1.y - pt2.y) > 3)
+ 		return false;
+ 	return true;
+ }


### PR DESCRIPTION
#### Description

Building scite @3.2.2_0 with Xcode 10.1 on macOS 10.14 Mojave fails with some compiler errors:
```
:info:build ../src/Editor.cxx:5871:6: error: call to 'abs' is ambiguous
:info:build         if (abs(pt1.x - pt2.x) > 3)
:info:build             ^~~
:info:build /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/stdlib.h:132:6: note: candidate function
:info:build int      abs(int) __pure2;
:info:build          ^
:info:build /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
:info:build inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
:info:build                                            ^
:info:build /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
:info:build inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
:info:build                                            ^
:info:build ../src/Editor.cxx:5873:6: error: call to 'abs' is ambiguous
:info:build         if (abs(pt1.y - pt2.y) > 3)
:info:build             ^~~
:info:build /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include/stdlib.h:132:6: note: candidate function
:info:build int      abs(int) __pure2;
:info:build          ^
:info:build /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
:info:build inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
:info:build                                            ^
:info:build /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
:info:build inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
:info:build                                            ^
```

```
:info:build ScintillaGTK.cxx:1615:33: error: ordered comparison between pointer and zero ('GdkAtom' (aka '_GdkAtom *') and 'int')
:info:build                 if (TypeOfGSD(selection_data) > 0) {
:info:build                     ~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~
```

This commit fixes them by applying some upstream patches:
https://sourceforge.net/p/scintilla/code/ci/f67672e53256e21fa272732b999ac6dcc7e41261/
https://sourceforge.net/p/scintilla/code/ci/21dd17a123ddfd901bef2c2ab656c09cb466dc12/

A better fix would probably be to upgrade to a newer upstream version, but that is something I don’t have time to undertake right now.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?