### PR TITLE
meson: enable test suite

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -71,6 +71,11 @@ pre-test {
 }
 
 test.run            yes
-test.env-append     configure.env{*}
+test.env            CXX="${configure.cxx}" \
+                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    CC="${configure.cc}" \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    LDFLAGS="${configure.ldflags}  [get_canonical_archflags ld]" \
+                    PREFIX=${prefix}
 test.cmd            ./run_tests.py
 test.target

--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -50,3 +50,27 @@ post-destroot {
     ln -s  ${python_prefix}/bin/meson ${destroot}${prefix}/bin/meson
     ln -s  ${python_prefix}/share/man/man1/meson.1 ${destroot}${prefix}/share/man/man1
 }
+
+# the following block avoids requiring users to 'sudo port select python3 python37'
+# doing a file test for ${prefix}/bin/python3 and requiring this 
+# to be honest would have been much simpler, but not the "MacPorts way"
+pre-test {
+    reinplace "s|/usr/bin/env python3|/usr/bin/env python3.7|" \
+        ${worksrcpath}/run_tests.py \
+        ${worksrcpath}/run_cross_test.py \
+        ${worksrcpath}/run_meson_command_tests.py \
+        ${worksrcpath}/run_project_tests.py \
+        ${worksrcpath}/run_unittests.py
+
+    set testpath "${worksrcpath}/test\\ cases"
+    fs-traverse f ${testpath} {
+        if { [string match *.py ${f}] } {
+            reinplace "s|/usr/bin/env python3|/usr/bin/env python3.7|" ${f}
+        }
+    }
+}
+
+test.run            yes
+test.env-append     configure.env{*}
+test.cmd            ./run_tests.py
+test.target


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

As part of working on the Tiger fix for meson today I spent some time figuring out how to run the test suite for meson, so I thought I'd add it to the Portfile and see if it found purchase.

It's easiest to require users to `sudo port select python3 python37` -- but we don't like to require that, so I sorted out the reinplace block to force python3.7 instead.

For your consideration. PS -- both Tiger and Mojave have lots of errors on the test suite.