### PR TITLE
Arduino: improve fetch phase

### DIFF
--- a/devel/Arduino/Portfile
+++ b/devel/Arduino/Portfile
@@ -11,11 +11,14 @@ version             1.8.8-git
 java.version        1.8
 java.fallback       openjdk8
 
-revision            0
+revision            1
 categories          devel electronics java lang
 platforms           darwin
 maintainers         {gmail.com:giansalvo.gusinu @giansalvo} openmaintainer
 license             GPL-2
+
+# I'm not sure how to set the supported_archs keyword
+#supported_archs         noarch
 
 description         Arduino Software (IDE) makes it easy to write code and upload it to the board.
 
@@ -28,13 +31,232 @@ long_description \
 
 homepage            https://www.arduino.cc/
 
-checksums           rmd160  79434c36d66d117f775359d5b8b5033d13005200 \
+#####
+# These files are missing from the lists of master_sites and distfiles because filenames are duplicated.
+# They will be fetched during build phase
+#   https://github.com/arduino-libraries/TFT/archive/1.0.6.zip"
+#   https://github.com/arduino-libraries/RobotIRremote/archive/2.0.0.zip
+#   https://github.com/arduino-libraries/Esplora/archive/1.0.4.zip
+#   https://github.com/arduino-libraries/Mouse/archive/1.0.1.zip
+#   https://github.com/arduino-libraries/Servo/archive/1.1.3.zip
+#####
+master_sites-append https://downloads.arduino.cc/tools/:t1 \
+                    https://downloads.arduino.cc/:t2 \
+                    https://downloads.arduino.cc/cores/:t3 \
+                    https://github.com/arduino-libraries/Ethernet/archive/:t4 \
+                    https://github.com/arduino-libraries/GSM/archive/:t5 \
+                    https://github.com/arduino-libraries/Stepper/archive/:t6 \
+                    https://github.com/arduino-libraries/WiFi/archive/:t7 \
+                    https://github.com/firmata/arduino/archive/:t8 \
+                    https://github.com/arduino-libraries/Bridge/archive/:t9 \
+                    https://github.com/arduino-libraries/Robot_Control/archive/:t10 \
+                    https://github.com/arduino-libraries/Robot_Motor/archive/:t11 \
+                    https://github.com/arduino-libraries/SpacebrewYun/archive/:t12 \
+                    https://github.com/arduino-libraries/Temboo/archive/:t13 \
+                    https://github.com/arduino-libraries/Esplora/archive/:t14 \
+                    https://github.com/arduino-libraries/Keyboard/archive/:t15 \
+                    https://github.com/arduino-libraries/SD/archive/:t16 \
+                    https://github.com/arduino-libraries/LiquidCrystal/archive/:t17 \
+                    https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/:t18 \
+                    https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.10.5/:t19 \
+                    https://downloads.arduino.cc/liblistSerials/:t20 \
+                    https://github.com/arduino-libraries/TFT/archive/1.0.6.zip&dummy=
+                    
+
+distfiles-append    arduino-builder-macosx-1.4.3.tar.bz2:t1 \
+                    avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2:t1 \
+                    appbundler-1.0ea-arduino4.jar.zip:t2 \
+                    avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2:t1 \
+                    arduinoOTA-1.2.1-darwin_amd64.tar.bz2:t1 \
+                    avr-1.6.23.tar.bz2:t3 \
+                    reference-1.6.6-3.zip:t2 \
+                    Galileo_help_files-1.6.2.zip:t2 \
+                    Edison_help_files-1.6.2.zip:t2 \
+                    2.0.0.zip:t4 \
+                    1.0.6.zip:t5 \
+                    1.1.3.zip:t6 \
+                    1.2.7.zip:t7 \
+                    2.5.8.zip:t8 \
+                    1.7.0.zip:t9 \
+                    1.0.4.zip:t10 \
+                    1.0.3.zip:t11 \
+                    1.0.1.zip:t12 \
+                    1.2.1.zip:t13 \
+                    1.0.4.zip:t14 \
+                    1.0.2.zip:t15 \
+                    1.2.3.zip:t16 \
+                    1.0.7.zip:t17 \
+                    1.8.1.zip:t18 \
+                    WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip:t19 \
+                    libastylej-2.05.1-4.zip:t2 \
+                    liblistSerials-1.4.2.zip:t20 \
+                    arduino-builder-macosx-1.4.3.tar.bz2:t1
+                    
+checksums           ${github.project}-${github.version}.tar.gz \
+                    rmd160  79434c36d66d117f775359d5b8b5033d13005200 \
                     sha256  117da12bd853164b4ba74b6bc5b7a7289a84b973dae754513ebb61c76309e392 \
-                    size    38714163
+                    size    38714163 \
+                    arduino-builder-macosx-1.4.3.tar.bz2 \
+                    rmd160  ac4f4a8ff50333a03b48f7ca7bfe1aa7241a5f6e \
+                    sha256  d9c8cb4f9135fc7c8d7b139c2f5f6a60e24962ca84f648e4c8e641d61ed3e07e \
+                    size    12495655 \
+                    avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2 \
+                    rmd160  dd67195080be79dd1b72d53caa8922f43e74d092 \
+                    sha256  abc50137543ba73e227b4d1b8510fff50a474bacd24f2c794f852904963849f8 \
+                    size    31894498 \
+                    appbundler-1.0ea-arduino4.jar.zip \
+                    rmd160  1e6cb261a1f3f464e677eb7e288b29abd0e552b9 \
+                    sha256  1f995153a6bd506f059cb4c08fc2e56eac5f7bfea396ee8f6bd831ab507ae0ef \
+                    size    158991 \
+                    avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2 \
+                    rmd160  2b870ad372ca051f3014cdced4ad98a9fda2ebbe \
+                    sha256  47d03991522722ce92120c60c4118685b7861909d895f34575001137961e4a63 \
+                    size    256917 \
+                    arduinoOTA-1.2.1-darwin_amd64.tar.bz2 \
+                    rmd160  86dc1bb98a81315e903ce7c6e8266b45b02fcbba \
+                    sha256  93a6d9f9c0c765d237be1665bf7a0a8e2b0b6d2a8531eae92db807f5515088a7 \
+                    size    2244088 \
+                    avr-1.6.23.tar.bz2 \
+                    rmd160  316c71d3bbfecf7c480816da5f79a2f684b65b2e \
+                    sha256  18618d7f256f26cd77c35f4c888d5d1b2334f07925094fdc99ac3188722284aa \
+                    size    5001988 \
+                    reference-1.6.6-3.zip \
+                    rmd160  45ff96d56c55640f4aadc0a451bc47d2a0c6f4bf \
+                    sha256  c3bfb7f9b408fd99a4a1c0f3b022f0a8b10abae6dc28e35d38b4a0df62903685 \
+                    size    7004842 \
+                    Galileo_help_files-1.6.2.zip \
+                    rmd160  58467865038438adde4f21e2541765cfd01fbc0e \
+                    sha256  1c70276e4783286d59c8ac0132c3286e7dcf6825bea65e25747a94416b07aa61 \
+                    size    4352077 \
+                    Edison_help_files-1.6.2.zip \
+                    rmd160  e0ec35db2f41acae36ff05af6d9421edf2d2c0eb \
+                    sha256  56718ce5b2b090d79dae298f6ff9a09c8c1a77f74e3594a951f7035877cc45f4 \
+                    size    3321743 \
+                    2.0.0.zip \
+                    rmd160  9c3c2382ff51c93b69d47fde20cab65afb12b720 \
+                    sha256  a8a650774a613f6eaeae49e2b32f003e42b65be4adc479944b9d071b98214d41 \
+                    size    61899 \
+                    1.0.6.zip \
+                    rmd160  fbc210553b2529e79bfa3f96a62c118f52e7a432 \
+                    sha256  737187d301a6d6eade181488106d3826f6466a926f570fa1d5dfb303729fb1ce \
+                    size    148529 \
+                    1.1.3.zip \
+                    rmd160  d25e4d1e9eddac8d5741d03c96056e6a29c9049a \
+                    sha256  9bdc308d1b4a0bafde01123c80aa25458bc6bd22609fd3d13f50ae0aeb32dbcf \
+                    size    10096 \
+                    1.2.7.zip \
+                    rmd160  a3421c52a0a4eed62778bc55ef3ef3101380df60 \
+                    sha256  c61d68237742a39b7d5843496749e123c6721083bd002bcbdd118a630416b2ba \
+                    size    5277242 \
+                    2.5.8.zip \
+                    rmd160  14643ceccdbcdbc5556a10471fecd52439bb7bf3 \
+                    sha256  429cdb6f0a4c6b8cadb2d3a3ecb6a50cb083833454332827f67abac26dc6b44a \
+                    size    200166 \
+                    1.7.0.zip \
+                    rmd160  2f772bb86e460d7a1458ca80f8899776d4191745 \
+                    sha256  4823cca4e0a60311c0a5bb75a8bced780a99987ccd86f91926559e23ab58f6e2 \
+                    size    64839 \
+                    1.0.4.zip \
+                    rmd160  da524287da060f113da7df720649c48b0e986f2e \
+                    sha256  077f70f2672c75b8c9c75bf4623db4025407d7e43b9cd281a1088e0e5f5e6ade \
+                    size    119715 \
+                    1.0.3.zip \
+                    rmd160  e884fafcb0c67aa22d67cad905f3557aab15982d \
+                    sha256  7cf64dc179931da6104f136e78283310940d53f10151f27583599ef36acc7bde \
+                    size    15106 \
+                    1.0.1.zip \
+                    rmd160  6bf70922153a55fc4a1cc029be30ba457afaebdf \
+                    sha256  20e9d17b08413fc5412fa2549a112b088b92371bcd7450337dcb18fe69f546ff \
+                    size    12100 \
+                    1.2.1.zip \
+                    rmd160  00ea10babe2886e6842ef8c82309c2e34bb1b911 \
+                    sha256  1dd15dc3a0ea5eaa6f9a9ddcfc2d22f40b4a15736bd585b59257b2a56174dfbb \
+                    size    187499 \
+                    1.0.4.zip \
+                    rmd160  da524287da060f113da7df720649c48b0e986f2e \
+                    sha256  077f70f2672c75b8c9c75bf4623db4025407d7e43b9cd281a1088e0e5f5e6ade \
+                    size    119715 \
+                    1.0.2.zip \
+                    rmd160  34ec6dc1c0de022cee4523009d4d78fa0e385561 \
+                    sha256  a34c261f4746d658647e5632e4bae8641d8055ed354f820f5aeec4904b92ce9f \
+                    size    5934 \
+                    1.2.3.zip \
+                    rmd160  2822115da7b7d83fef316c9b2edd321c9b99f8db \
+                    sha256  82cbdb98835ff18d8dcc1dee61f40ee5b0995dfeff70d4fb7330eb5c6159b044 \
+                    size    61145 \
+                    1.0.7.zip \
+                    rmd160  3f600bbb77229a07b6b354a3bec9d0393a8cb351 \
+                    sha256  36f513107a565655766647657252f43407755abb6709156492d9133b3ece3df3 \
+                    size    19035 \
+                    1.8.1.zip \
+                    rmd160  2d836bda12dfa6ab03297b0633057c0c83337e4a \
+                    sha256  18057700fda112993139a220e1bd3148ded735df918e75a1364e1046fa2582ba \
+                    size    478197 \
+                    WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip \
+                    rmd160  b60051b5edbbc4677e61b98cd5d325869170b3b2 \
+                    sha256  c19369e28ca982f59fc993b06124af0c8f3880a45a8b6e5e64f9ab069ec4a037 \
+                    size    3026473 \
+                    libastylej-2.05.1-4.zip \
+                    rmd160  193e7b0ac35823782e67222884893d6277c991f2 \
+                    sha256  3a8d98e85c344ca945790f05ff8b1b0f2a3cfcc2939001e58f47ad5ed03a6060 \
+                    size    655108 \
+                    liblistSerials-1.4.2.zip \
+                    rmd160  7957debdf77b93ffef89736c5f8e09d0af6e5dc6 \
+                    sha256  75a89f408f3ecd4796ac173eaddd3c7e55021af030aee7f85b59a4190459a8dc \
+                    size    553389 \
+                    arduino-builder-macosx-1.4.3.tar.bz2 \
+                    rmd160  ac4f4a8ff50333a03b48f7ca7bfe1aa7241a5f6e \
+                    sha256  d9c8cb4f9135fc7c8d7b139c2f5f6a60e24962ca84f648e4c8e641d61ed3e07e \
+                    size    12495655
+
+extract.only        ${github.project}-${github.version}.tar.gz
 
 depends_lib         port:apache-ant
 
 use_configure       no
+
+# Arduino builds only for macOS 10.8 or greater, but
+# I'm not sure how to check platform, the following lines don't seem to work.
+#
+#platform darwin 12 {
+#    pre-fetch {
+#        ui_error "${name} requires Mac OS X 10.8 or greater."
+#    }
+#}
+
+post-extract {
+    file copy -force ${distpath}/appbundler-1.0ea-arduino4.jar.zip                              ${worksrcpath}/build/macosx
+    file copy -force ${distpath}/avr-gcc-5.4.0-atmel3.6.1-arduino2-i386-apple-darwin11.tar.bz2  ${worksrcpath}/build/macosx
+    file copy -force ${distpath}/avrdude-6.3.0-arduino14-i386-apple-darwin11.tar.bz2            ${worksrcpath}/build/macosx
+    file copy -force ${distpath}/arduinoOTA-1.2.1-darwin_amd64.tar.bz2                          ${worksrcpath}/build/macosx
+    file copy -force ${distpath}/avr-1.6.23.tar.bz2                                             ${worksrcpath}/build/
+    file copy -force ${distpath}/reference-1.6.6-3.zip                                          ${worksrcpath}/build/shared/
+    file copy -force ${distpath}/Galileo_help_files-1.6.2.zip                                   ${worksrcpath}/build/shared/
+    file copy -force ${distpath}/Edison_help_files-1.6.2.zip                                    ${worksrcpath}/build/shared/
+    file copy -force ${distpath}/2.0.0.zip                                                      ${worksrcpath}/build/Ethernet-2.0.0.zip
+    file copy -force ${distpath}/1.0.6.zip                                                      ${worksrcpath}/build/GSM-1.0.6.zip
+    file copy -force ${distpath}/1.1.3.zip                                                      ${worksrcpath}/build/Stepper-1.1.3.zip
+    #file copy -force ${distpath}/1.0.6.zip                                                      ${worksrcpath}/build/TFT-1.0.6.zip
+    file copy -force ${distpath}/1.2.7.zip                                                      ${worksrcpath}/build/WiFi-1.2.7.zip
+    file copy -force ${distpath}/2.5.8.zip                                                      ${worksrcpath}/build/Firmata-2.5.8.zip
+    file copy -force ${distpath}/1.7.0.zip                                                      ${worksrcpath}/build/Bridge-1.7.0.zip
+    file copy -force ${distpath}/1.0.4.zip                                                      ${worksrcpath}/build/Robot_Control-1.0.4.zip
+    file copy -force ${distpath}/1.0.3.zip                                                      ${worksrcpath}/build/Robot_Motor-1.0.3.zip
+    #file copy -force ${distpath}/2.0.0.zip                                                      ${worksrcpath}/build/RobotIRremote-2.0.0.zip
+    file copy -force ${distpath}/1.0.1.zip                                                      ${worksrcpath}/build/SpacebrewYun-1.0.1.zip
+    file copy -force ${distpath}/1.2.1.zip                                                      ${worksrcpath}/build/Temboo-1.2.1.zip
+    #file copy -force ${distpath}/1.0.4.zip                                                      ${worksrcpath}/build/Esplora-1.0.4.zip
+    #file copy -force ${distpath}/1.0.1.zip                                                      ${worksrcpath}/build/Mouse-1.0.1.zip
+    file copy -force ${distpath}/1.0.2.zip                                                      ${worksrcpath}/build/Keyboard-1.0.2.zip
+    file copy -force ${distpath}/1.2.3.zip                                                      ${worksrcpath}/build/SD-1.2.3.zip
+    #file copy -force ${distpath}/1.1.3.zip                                                      ${worksrcpath}/build/Servo-1.1.3.zip
+    file copy -force ${distpath}/1.0.7.zip                                                      ${worksrcpath}/build/LiquidCrystal-1.0.7.zip
+    file copy -force ${distpath}/1.8.1.zip                                                      ${worksrcpath}/build/Adafruit_Circuit_Playground-1.8.1.zip
+    file copy -force ${distpath}/WiFi101-Updater-ArduinoIDE-Plugin-0.10.5.zip                   ${worksrcpath}/build/shared/
+    file copy -force ${distpath}/libastylej-2.05.1-4.zip                                        ${worksrcpath}/build/
+    file copy -force ${distpath}/liblistSerials-1.4.2.zip                                       ${worksrcpath}/build/
+    file copy -force ${distpath}/arduino-builder-macosx-1.4.3.tar.bz2                           ${worksrcpath}/build/
+}
 
 build {
     set ::env(JAVA_HOME) [exec /usr/libexec/java_home -v ${java.version}]
@@ -47,3 +269,9 @@ destroot {
 
     file copy ${worksrcpath}/build/macosx/work/${name}.app ${destroot}${applications_dir}
 }
+
+# This doesn't work for 1.8.8-git because we're not on a release snapshot
+# but it's ready for when upstream will release 1.8.9
+livecheck.type      regex
+livecheck.url       https://github.com/arduino/Arduino/releases
+livecheck.regex     "Release (\\d+(?:\\.\\d+)*)"


### PR DESCRIPTION
* move (most) downloads to fetch phase
* add livecheck

some files are still fetched during the build process. See https://trac.macports.org/ticket/58117

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.4 17E202
Xcode 9.3.1 9E501

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
