### PR TITLE
man-db and libpipeline: new ports

### DIFF
--- a/devel/libpipeline/Portfile
+++ b/devel/libpipeline/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libpipeline
+version             1.5.1
+categories          devel
+platforms           darwin linux
+license             GPL-3+
+maintainers         {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
+description         C library for manipulating pipelines of subprocesses.
+homepage            http://libpipeline.nongnu.org
+master_sites        https://download.savannah.nongnu.org/releases/libpipeline/
+
+long_description    libpipeline is a C library for manipulating pipelines of \
+    subprocesses in a flexible and convenient way. It is available in at least \
+    the following Linux distributions: Arch, Debian, Dragora, Fedora, Gentoo,  \
+    and Ubuntu.
+
+checksums           rmd160   3995daf434462ebd7df67652019d084e8648f8f8 \
+                    sha256   d633706b7d845f08b42bc66ddbe845d57e726bf89298e2cee29f09577e2f902f \
+                    size     987822
+
+configure.args      --prefix=${prefix}

--- a/textproc/man-db/Portfile
+++ b/textproc/man-db/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                man-db
+version             2.8.5
+categories          textproc
+platforms           darwin linux
+license             GPL-3+
+maintainers         {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
+description         Modern, featureful implementation of the Unix man page system.
+homepage            http://man-db.nongnu.org
+master_sites        https://download.savannah.nongnu.org/releases/man-db/
+use_xz              yes
+
+long_description    man-db is an implementation of the standard Unix documentation \
+    system accessed using the man command. It uses a Berkeley DB database in place \
+    of the traditional flat-text whatis databases. man-db is used by several popular \
+    Linux distributions, including: Arch, Debian, Dragora, Fedora, Gentoo, openSUSE, \
+    and Ubuntu.
+
+checksums           rmd160   20caab5f9584a27487f117802a3601e7d0a28525 \
+                    sha256   b64d52747534f1fe873b2876eb7f01319985309d5d7da319d2bc52ba1e73f6c1 \
+                    size     1787244
+
+depends_lib         port:libpipeline
+depends_build       port:pkgconfig
+
+configure.args      --prefix=${prefix} \
+                    --with-systemdtmpfilesdir=no \
+                    --with-systemdsystemunitdir=no \
+                    --disable-cache-owner \
+                    --disable-setuid
+
+build.args-append CFLAGS="-Wl,-flat_namespace,-undefined,suppress"


### PR DESCRIPTION
#### Description

This adds 2 new ports. One is [`man-db`,](http://man-db.nongnu.org/) the man page system used on Linux. The other is a library which `man-db` depends on called [`libpipeline`.](http://libpipeline.nongnu.org/)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
