### PR TITLE
the_silver_searcher: fix build on older systems

### DIFF
--- a/textproc/the_silver_searcher/Portfile
+++ b/textproc/the_silver_searcher/Portfile
@@ -1,6 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.0
+
+# requires legacysupport
+# src/main.c:81:30: error: '_SC_NPROCESSORS_ONLN' undeclared (first use in this function)
 
 name                the_silver_searcher
 version             2.2.0
@@ -24,6 +29,18 @@ depends_lib         port:pcre \
                     port:xz
 
 build.args-append   V=1
+
+# requires basic thread-local storage
+# src/print.c:34: error: thread-local storage not supported for this target
+compiler.blacklist-append *gcc-3.* *gcc-4.*
+compiler.blacklist-append { clang < 318 } macports-clang-3.3
+platform darwin i386 {
+    compiler.fallback-append  macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+}
+platform darwin powerpc {
+    compiler.fallback-append macports-gcc-6 macports-gcc-7 macports-gcc-5
+}
+
 
 post-destroot {
     xinstall -d -m 755 ${destroot}${prefix}/share/bash-completion/completions


### PR DESCRIPTION
requires thread_local storage
requires legacysupport for num_proc_online

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4.11 PPC
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

I can't seem to make the tests work; the test suite uses `cram`, but even when installed, it doesn't seem to find the tests. Perhaps there is more to download for those to work.