### PR TITLE
diskus: new port

### DIFF
--- a/sysutils/diskus/Portfile
+++ b/sysutils/diskus/Portfile
@@ -1,0 +1,86 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        sharkdp diskus 0.5.0 v
+
+categories          sysutils
+platforms           darwin linux
+maintainers         {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
+license             {MIT Apache-2}
+
+description         A minimal, fast alternative to 'du -sb'
+
+long_description    diskus is a very simple program that computes the apparent \
+    size of the current directory. It is a parallelized version of du -sb. On \
+    the developer's 8-core laptop, it is about 10x faster than du with a cold \
+    disk cache and more than 3x faster with a warm disk cache. Currently, it \
+    only computes apparent size, not resident size.
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  69e85911b6c2facd4078563df55d10d7a705f6e2 \
+                    sha256  51f102e43e155f5c7550451170085b5bbfddacdf522eaa8219b3850d67a3f1e3 \
+                    size    14981
+
+cargo.crates \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    arrayvec                         0.4.8  f405cc4c21cd8b784f6c8fc2adf9bc00f59558f0049b5ec21517f875963040cc \
+    atty                            0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
+    bitflags                         1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
+    cfg-if                           0.1.6  082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
+    clap                            2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
+    cloudabi                         0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    crossbeam-channel                0.3.2  0ac88e108fa40799b39c08eb2a93bedf4cc99a9e5577f08ddf6dd6134ae65bf0 \
+    crossbeam-deque                  0.2.0  f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3 \
+    crossbeam-epoch                  0.3.1  927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150 \
+    crossbeam-epoch                  0.6.1  2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8 \
+    crossbeam-utils                  0.6.1  c55913cc2799171a550e307918c0a360e8c16004820291bf3b638969b4a01816 \
+    crossbeam-utils                  0.2.2  2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9 \
+    diskus                           0.5.0  074c7500ad38ee274d1324d559d3671ef2b6f28d9114deda3d8a19d305e8d125 \
+    either                           1.5.0  3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0 \
+    fuchsia-zircon                   0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+    fuchsia-zircon-sys               0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+    humansize                        1.1.0  b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e \
+    kernel32-sys                     0.2.2  7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
+    lazy_static                      1.2.0  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
+    libc                            0.2.44  10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311 \
+    lock_api                         0.1.5  62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
+    memoffset                        0.2.1  0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3 \
+    nodrop                          0.1.13  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
+    num_cpus                         1.8.0  c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30 \
+    owning_ref                       0.4.0  49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13 \
+    parking_lot                      0.6.4  f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
+    parking_lot_core                 0.3.1  ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c \
+    rand                             0.5.5  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
+    rand_core                        0.2.2  1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372 \
+    rand_core                        0.3.0  0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db \
+    rayon                            1.0.3  373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473 \
+    rayon-core                       1.4.1  b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356 \
+    redox_syscall                   0.1.42  cf8fb82a4d1c9b28f1c26c574a5b541f5ffb4315f6c9a791fa47b6a04438fe93 \
+    redox_termios                    0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+    scopeguard                       0.3.3  94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
+    semver                           0.9.0  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+    semver-parser                    0.7.0  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+    smallvec                         0.6.6  622df2d454c29a4d89b30dc3b27b42d7d90d6b9e587dbf8f67652eb7514da484 \
+    stable_deref_trait               1.1.1  dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8 \
+    strsim                           0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
+    term_size                        0.3.1  9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327 \
+    termion                          1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
+    textwrap                        0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+    unicode-width                    0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unreachable                      1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+    vec_map                          0.8.1  05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a \
+    void                             1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+    winapi                           0.2.8  167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
+    winapi                           0.3.6  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
+    winapi-build                     0.1.1  2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/diskus ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/libdiskus.rlib ${destroot}${prefix}/lib/
+}


### PR DESCRIPTION
#### Description

This adds a port for [`diskus`,](https://github.com/sharkdp/diskus) a faster alternative to `du -sb`. Despite its misleading description on Github, [it *is* an alternative for `du -sb` and *not* `du -sh`.](https://github.com/sharkdp/diskus/issues/11#issuecomment-435411963)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
