### PR TITLE
zabbix4: Update to 4.0.5; win32 agent no longer included.

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -3,7 +3,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                zabbix4
-version             4.0.4
+version             4.0.5
 revision            0
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
@@ -32,9 +32,9 @@ master_sites \
 dist_subdir         zabbix4
 
 checksums \
-    rmd160  5df95ab3f18c64fb6c452420b5bb23e9523758d2 \
-    sha256  f8e50559e250dc2e732919a9b52d629226d2b442ce9be93d3ab2086dd26f3c19 \
-    size    18045463
+    rmd160  f112fc35d24b169cd0c3c7691df7b04487c7bb1b \
+    sha256  55e7e218e170dd085ae1d642d4e90dc3576011fa3ce72407425cb73003c31906 \
+    size    17098529
 
 patchfiles          log_and_pid_locations.patch
 
@@ -301,10 +301,6 @@ post-destroot {
         #file copy ${worksrcpath}/upgrades \
         #    ${destroot}${prefix}/share/zabbix/
 
-        xinstall -d -m 755 -d \
-            ${destroot}${prefix}/share/zabbix/zabbix_agent_win32
-        xinstall -m 755 ${worksrcpath}/bin/win32/zabbix_agentd.exe \
-            ${destroot}${prefix}/share/zabbix/zabbix_agent_win32
         # Set permissions for etc (protect passwords) 
         system "chmod ug+rwX,o-rwx ${destroot}${prefix}/etc/zabbix4/*"
         system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix4"
@@ -410,11 +406,7 @@ if { ${subport} eq "zabbix4-agent" } {
     sudo port load zabbix4
 
 
-5) A Win32 agent is in ${prefix}/share/zabbix/zabbix_agent_win32 for\
-   installation on Windows.
-
-
-6) Read the fine manual at http://www.zabbix.com/documentation/
+5) Read the fine manual at http://www.zabbix.com/documentation/
 
 
 #### End ZABBIX4 local server installation section   ####


### PR DESCRIPTION
Maintainer update.