### PR TITLE
qgis3: update to 3.4.5

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -7,7 +7,7 @@ PortGroup           cxx11   1.1
 PortGroup           github  1.0
 PortGroup           qt5     1.0
 
-github.setup        qgis QGIS 3_4_2 final-
+github.setup        qgis QGIS 3_4_5 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
 categories          gis
@@ -23,9 +23,9 @@ license             GPL-2+
 
 homepage            http://www.qgis.org/
 
-checksums           rmd160  564c1cc890b4c7f16e7ea673b466d48d23b7ee97 \
-                    sha256  846a4ebf14294072fc2799a189c28fa153bc9c254b1f2ac0cd7d910d4dada7d7 \
-                    size    88598606
+checksums           rmd160  d43b4243c47010b87b507e4a08754a099e33e6fd \
+                    sha256  f70062ad445d666581253f39e45db112b2affadcd539f215c4d7b641176ab097 \
+                    size    89924872
 
 # Qt version
 set                 QtVer   5


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
qgis3 3.4.5 fixes [build failure with sip 4.19.4](https://issues.qgis.org/issues/20930).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->