### PR TITLE
p5-json-xs, p5-json: update to version 4.0+

### DIFF
--- a/perl/p5-json-xs/Portfile
+++ b/perl/p5-json-xs/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.26 5.28
-perl5.setup         JSON-XS 3.04
+perl5.setup         JSON-XS 4.01
 license             {Artistic-1 GPL}
 maintainers         {nottwo @nottwo} openmaintainer
 
@@ -15,8 +15,9 @@ long_description    This module converts Perl data structures to JSON and \
                     secondary goal is to be *fast*.  To reach the latter goal \
                     it was written in C.
 
-checksums           rmd160  e0a40a2900af4eac2b1312ca31028396d080306d \
-                    sha256  65d8836bd8ea6f0b7bffc70b2212156adc3e2ffa587e27e548d576893f097c2c
+checksums           rmd160  9592b6bfba989f1085405a30e80cc89e800e9858 \
+                    sha256  cc1062e39a1fd6ff8bd9df84a102e8572468cea29d43190672a10f9c39973e5c \
+                    size    86264
 
 platforms           darwin
 

--- a/perl/p5-json/Portfile
+++ b/perl/p5-json/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         JSON 2.97001 ../../authors/id/I/IS/ISHIGAKI
+perl5.setup         JSON 4.02 ../../authors/id/I/IS/ISHIGAKI
 license             {Artistic-1 GPL}
 platforms           darwin
 maintainers         nomaintainer
@@ -16,8 +16,9 @@ long_description    This module converts between JSON \
                     into each other. For JSON, See to \
                     http://www.crockford.com/JSON/.
 
-checksums           rmd160  3733e22f34e55d0f15e351158d3edb2807480c44 \
-                    sha256  e277d9385633574923f48c297e1b8acad3170c69fa590e31fa466040fc6f8f5a
+checksums           rmd160  a2809c2e5666590afdd355c243194594160807f6 \
+                    sha256  444a88755a89ffa2a5424ab4ed1d11dca61808ebef57e81243424619a9e8627c \
+                    size    90374
 
 if {${perl5.major} != ""} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

SECURITY IMPLICATION: these updates (both p5-json-xs and p5-json) enable allow_nonref by default for compatibility with RFC 7159 and newer.
    
See "OLD" VS. "NEW" JSON (RFC4627 VS. RFC7159) under SECURITY CONSIDERATIONS
at https://metacpan.org/pod/JSON::XS#SECURITY-CONSIDERATIONS.
    
All tests of MacPorts dependents pass using these updates so I think they are ready (and safe) to merge.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
