### PR TITLE
wireguard-tools: update to 0.0.20190227

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,8 +3,12 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190123
+version             0.0.20190227
 revision            0
+checksums           rmd160  d5c4d5f1fb3dd713197869584534ace03d43ab9a \
+                    sha256  fcdb26fd2692d9e1dee54d14418603c38fbb973a06ce89d08fbe45292ff37f79 \
+                    size    323788
+
 categories          net
 platforms           darwin
 license             GPL-2
@@ -21,10 +25,6 @@ homepage            https://www.wireguard.com/
 master_sites        https://git.zx2c4.com/WireGuard/snapshot/
 distname            WireGuard-${version}
 use_xz              yes
-
-checksums           rmd160  cfcfe52aec93a042129c0dabfdbaff2a0e10e95a \
-                    sha256  edd13c7631af169e3838621b1a1bff3ef73cf7bc778eec2bd55f7c1089ffdf9b \
-                    size    323052
 
 depends_run         port:bash \
                     port:wireguard-go


### PR DESCRIPTION
###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?