### PR TITLE
mercurial: update to 4.9

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -7,7 +7,7 @@ PortGroup           bitbucket 1.0
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             4.7.2
+version             4.9
 categories          devel python
 license             GPL-2+
 maintainers         nomaintainer
@@ -29,9 +29,9 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 homepage            http://www.mercurial-scm.org
 platforms           darwin
 master_sites        https://www.mercurial-scm.org/release/
-checksums           rmd160  772218d91d26fa934b03632e4841a86d3f44a446 \
-                    sha256  97f0594216f2348a2e37b2ad8a56eade044e741153fee8c584487e9934ca09fb \
-                    size    6481684
+checksums           rmd160  bc8e47451a25be0f431262318cb2c3c84503b764 \
+                    sha256  0f600c5c7e44d4318bedc1754a70b920f7ecd278e4089b0f6ac96f460c012f06 \
+                    size    7075692
 
 depends_build       port:py27-docutils
 


### PR DESCRIPTION
#### Description

- bump version to 4.9

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->