### PR TITLE
tcpreplay: update to 4.3.1, update URLs

### DIFF
--- a/net/tcpreplay/Portfile
+++ b/net/tcpreplay/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                tcpreplay
 categories          net security
 license             BSD ISC
-version             4.3.0
+version             4.3.1
 platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer
 
@@ -20,11 +20,11 @@ long_description    \
     IPS's. Tcpreplay supports both single and dual NIC modes for testing both \
     sniffing and inline devices.
 
-homepage            http://tcpreplay.synfin.net
-master_sites        sourceforge
-checksums           rmd160  d1e09278b1988a7192dac4efc95f579084692201 \
-                    sha256  935c9f5483a9f0ffd5a5ad055b6c7be5c14a3bc9023d4e45ec80dd94857ac79f \
-                    size    3724668
+homepage            https://tcpreplay.appneta.com/
+master_sites        sourceforge:project/tcpreplay/tcpreplay/${version}
+checksums           rmd160  a71e5d7b85951ebc34c49c36d18e7abac67e2d4f \
+                    sha256  95ba661011689a4a6c03896ba7fa549470c2c2d4d0e907dd0c4a4580bbe25e34 \
+                    size    3725070
 
 # TODO use libpcapnav
 # libdnet is required for fragroute support


### PR DESCRIPTION
#### Description
> IMPORTANT: Tcpreplay development is now being done by AppNeta
> – http://tcpreplay.synfin.net/

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
