### PR TITLE
openssl: update to 1.0.2r and bump dependent ports

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                openssl
 epoch               1
-version             1.0.2q
+version             1.0.2r
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -40,10 +40,10 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           sha1    692f5f2f1b114f8adaadaa3e7be8cce1907f38c5 \
-                    rmd160  2bae12f4c4a69316baf4ef23cb121e6700dc8cfb \
-                    sha256  5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684 \
-                    size    5345604
+checksums           sha1    b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d \
+                    rmd160  f268c8f87ee6b8ca1523761b064de575f6851ae0 \
+                    sha256  ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6 \
+                    size    5348369
 
 patchfiles          install-headers-HFS+.patch \
                     parallel-building.patch \

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                openssh
 version             7.6p1
-revision            6
+revision            7
 categories          net
 platforms           darwin
 maintainers         nomaintainer

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    freeradius
 version                 2.2.4
-revision                22
+revision                23
 categories              sysutils
 maintainers             nomaintainer
 homepage                http://www.freeradius.org/


### PR DESCRIPTION
#### Description

This release fixes CVE-2019-1559. See https://www.openssl.org/news/cl102.txt for details

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?