### PR TITLE
nethack: update to 3.6.1, keep 3.4.3 as coexisting subport

### DIFF
--- a/games/nethack/Portfile
+++ b/games/nethack/Portfile
@@ -1,110 +1,185 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
+PortSystem         1.0
 
-name                nethack
-version             3.4.3
-revision            4
-categories          games
-maintainers         @Nax
-description         Classic dungeon adventure game.
-long_description    ${description}
-homepage            http://nethack.sourceforge.net/
-platforms           darwin freebsd
-license             Copyleft
+name               nethack
+version            3.6.1
+categories         games
+platforms          darwin
+license            Copyleft
+maintainers        @Nax
+description        Classic dungeon adventure game.
+long_description   NetHack is a single-player, display-oriented Dungeons & \
+    Dragons(tm)-like game, in development since 1987. It runs on a wide \
+    variety of computer systems and graphical interfaces, although the text \
+    interface is the most popular. Your goal is to grab as much treasure as \
+    you can, retrieve the Amulet of Yendor, and escape the Mazes of Menace \
+    alive.
 
-master_sites        sourceforge
-distname            ${name}-343-src
-extract.suffix      .tgz
-checksums           ${distfiles} md5 21479c95990eefe7650df582426457f9 \
-                    ${distfiles} sha1 c26537093c38152bc0fbcec20468d975b35f59fd \
-                    ${distfiles} rmd160 42f600d24715a0b7e631b357c135761410b3ca95
+homepage           https://www.nethack.org/
+master_sites       sourceforge \
+                   ${homepage}download/${version}/
+distname           ${name}-[string map {{.} {}} ${version}]-src
+extract.suffix     .tgz
+checksums          sha256 4b8cbf1cc3ad9f6b9bae892d44a9c63106d44782a210906162a7c3be65040ab6 \
+                   rmd160 6f7a0fbcf5754e8df8d3257c711d72d4abb5f673 \
+                   size 4640769
 
-depends_lib         port:ncurses
+depends_lib        port:ncurses
+worksrcdir         ${name}-${version}
 
-worksrcdir          ${name}-${version}
-
-patch.args          -p1
-patchfiles          patch-sys__unix__Makefile.doc.diff \
-                    patch-sys__unix__Makefile.src.diff \
-                    patch-sys__unix__Makefile.top.diff \
-                    patch-win__tty__termcap.c.diff
-
+patch.pre_args     -p1
+patchfiles         patch-gamestate-dir.diff \
+                   patch-manpage-dir.diff
 post-patch {
-    reinplace "s|__PREFIX__|${prefix}|" \
-        "${worksrcpath}/sys/unix/Makefile.doc" \
-        "${worksrcpath}/sys/unix/Makefile.top"
+    if {${subport} eq "nethack"} {
+        reinplace "s|__PREFIX__|${prefix}|" \
+            "${worksrcpath}/sys/unix/Makefile.doc" \
+            "${worksrcpath}/sys/unix/hints/macosx10.10"
+    }
 }
 
-configure.dir       ${worksrcpath}/sys/unix
-configure.cmd       /bin/sh
-configure.pre_args  setup.sh
+configure.dir      ${worksrcpath}/sys/unix
+configure.cmd      ./setup.sh
+configure.pre_args hints/macosx10.10
 
-build.args-append   CC=${configure.cc} \
-                    CXX=${configure.cxx} \
-                    CPP=${configure.cpp} \
-                    CFLAGS="-O2 -I../include"
+use_parallel_build no
+build.args-append  CC=${configure.cc} \
+                   CXX=${configure.cxx} \
+                   CPP=${configure.cpp}
 
 pre-destroot {
-    file mkdir "${destroot}${prefix}/share/man/man6"
-    file mkdir "${destroot}${prefix}/share/nethackdir/save"
+    xinstall -d "${destroot}${prefix}/share/man/man6"
+    if {${subport} ne "nethack"} {
+        xinstall -d "${destroot}${prefix}/share/nethackdir/save"
+    }
 }
 
-destroot.target     install manpages
-destroot.keepdirs   "${destroot}${prefix}/share/nethackdir/save/"
+destroot.target    all install manpages
+destroot.keepdirs  "${destroot}${prefix}/var/games/nethack/save/"
 
 post-destroot {
-    reinplace "s|${destroot}||" "${destroot}${prefix}/bin/nethack"
+    if {${subport} eq "nethack"} {
+        reinplace "s|${destroot}||" "${destroot}${prefix}/bin/nethack"
 
-    # Don't overwrite existing preference files
-    foreach f { logfile record } {
-        file rename ${destroot}${prefix}/share/nethackdir/${f} ${destroot}${prefix}/share/nethackdir/${f}.dist
+        # Prevent existing preferences files being overwritten.
+        foreach f { logfile record sysconf } {
+            file rename ${destroot}${prefix}/var/games/nethack/${f} \
+                ${destroot}${prefix}/var/games/nethack/${f}.dist
+        }
     }
 }
 
 post-activate {
-    # Make sure initial preference files exist
-    foreach f { logfile record } {
-        if {![file exists ${prefix}/share/nethackdir/${f}]} {
-            file copy ${prefix}/share/nethackdir/${f}.dist ${prefix}/share/nethackdir/${f}
+    if {${subport} eq "nethack"} {
+        # Make initially-missing preferences files from earlier versions.
+        foreach f { logfile record sysconf } {
+            if {![file exists ${prefix}/var/games/nethack/${f}]} {
+                file copy ${prefix}/var/games/nethack/${f}.dist \
+                    ${prefix}/var/games/nethack/${f}
+            }
         }
     }
 }
 
 variant x11 {
-    patchfiles-append \
-        x11/patch-include__config.h.diff \
-        x11/patch-sys__unix__Makefile.src.diff \
-        x11/patch-sys__unix__Makefile.top.diff
+    if {${subport} eq "nethack"} {
+        patchfiles-append  x11/patch-x11-interface.diff
+    } else {
+        patchfiles-append \
+            x11/patch-include__config.h.diff \
+            x11/patch-sys__unix__Makefile.src.diff \
+            x11/patch-sys__unix__Makefile.top.diff
+    }
     depends_lib-append port:xorg-libXaw
 }
 
-variant autopickup_exceptions description { Automatically pick up things onto which you move } {
-    patchfiles-append patch-include__config.h.diff
-}
+subport nethack343 {
+    version             3.4.3
+    description         Classic dungeon adventure game (previous version).
+    platforms           darwin freebsd
 
-#variant paranoid {
-#        patch_sites-append http://www.netsonic.fi/~walker/nh/
-#        patchfiles-append paranoid-343.diff
-#        checksums-append paranoid-343.diff md5 ade00f9cb51f1b0140557d329d56844c
-#}
+    master_sites        sourceforge:nethack
+    distname            nethack-343-src
+    checksums           sha256 bb39c3d2a9ee2df4a0c8fdde708fbc63740853a7608d2f4c560b488124866fe4 \
+                        rmd160 42f600d24715a0b7e631b357c135761410b3ca95 \
+                        size 3497458
 
-#variant deathexplore {
-#        patch_sites-append http://www.netsonic.fi/~walker/nh/
-#        patchfiles-append dthexp-343.diff
-#        checksums-append dthexp-343.diff md5 ade00f9cb51f1b0140557d329d56844c
-#}
+    worksrcdir          nethack-${version}
 
-#variant sortloot {
-#        patch_sites-append http://www.netsonic.fi/~walker/nh/
-#        patchfiles-append sortloot-343.diff
-#        checksums-append sortloot-343.diff md5 ade00f9cb51f1b0140557d329d56844c
-#}
+    patchfiles          patch-doc__nethack.6.diff \
+                        patch-sys__unix__Makefile.doc.diff \
+                        patch-sys__unix__Makefile.src.diff \
+                        patch-sys__unix__Makefile.top.diff \
+                        patch-win__tty__termcap.c.diff
 
-variant menucolors description { Allows the user to define in what color menus are shown } {
-    patch_sites-append http://bilious.alt.org/~paxed/nethack
-    patchfiles-append nh343-menucolor.diff
-    checksums-append nh343-menucolor.diff md5 ade00f9cb51f1b0140557d329d56844c
-    build.args-delete CFLAGS="-O2 -I../include"
-    build.args-append CFLAGS="-O2 -I../include -DMENU_COLOR_REGEX_POSIX"
+    post-patch {
+        reinplace "s|__PREFIX__|${prefix}|" \
+            "${worksrcpath}/sys/unix/Makefile.doc" \
+            "${worksrcpath}/sys/unix/Makefile.top"
+    }
+
+    configure.dir       ${worksrcpath}/sys/unix
+    configure.cmd       /bin/sh
+    configure.pre_args  setup.sh
+
+    build.args-append   CC=${configure.cc} \
+                        CXX=${configure.cxx} \
+                        CPP=${configure.cpp} \
+                        CFLAGS="-O2 -I../include"
+
+    destroot.target     install manpages
+    destroot.keepdirs   "${destroot}${prefix}/share/nethackdir/save/"
+
+    post-destroot {
+        reinplace "s|${destroot}||" "${destroot}${prefix}/bin/nethack343"
+
+        # Don't overwrite existing preference files
+        foreach f { logfile record } {
+            file rename ${destroot}${prefix}/share/nethackdir/${f} \
+                ${destroot}${prefix}/share/nethackdir/${f}.dist
+        }
+    }
+
+    post-activate {
+        # Make sure initial preference files exist
+        foreach f { logfile record } {
+            if {![file exists ${prefix}/share/nethackdir/${f}]} {
+                file copy ${prefix}/share/nethackdir/${f}.dist \
+                    ${prefix}/share/nethackdir/${f}
+            }
+        }
+    }
+
+    variant autopickup_exceptions description \
+        { Automatically pick up things onto which you move } {
+        patchfiles-append patch-include__config.h.diff
+    }
+
+    variant menucolors description \
+        { Allows the user to define in what color menus are shown } {
+        patch_sites-append http://bilious.alt.org/~paxed/nethack
+        patchfiles-append nh343-menucolor.diff
+        checksums-append nh343-menucolor.diff md5 ade00f9cb51f1b0140557d329d56844c
+        build.args-delete CFLAGS="-O2 -I../include"
+        build.args-append CFLAGS="-O2 -I../include -DMENU_COLOR_REGEX_POSIX"
+    }
+
+    #variant paranoid {
+    #        patch_sites-append http://www.netsonic.fi/~walker/nh/
+    #        patchfiles-append paranoid-343.diff
+    #        checksums-append paranoid-343.diff md5 ade00f9cb51f1b0140557d329d56844c
+    #}
+
+    #variant deathexplore {
+    #        patch_sites-append http://www.netsonic.fi/~walker/nh/
+    #        patchfiles-append dthexp-343.diff
+    #        checksums-append dthexp-343.diff md5 ade00f9cb51f1b0140557d329d56844c
+    #}
+
+    #variant sortloot {
+    #        patch_sites-append http://www.netsonic.fi/~walker/nh/
+    #        patchfiles-append sortloot-343.diff
+    #        checksums-append sortloot-343.diff md5 ade00f9cb51f1b0140557d329d56844c
+    #}
 }

--- a/games/nethack/files/patch-doc__nethack.6.diff
+++ b/games/nethack/files/patch-doc__nethack.6.diff
@@ -1,0 +1,25 @@
+--- nethack-3.4.3/doc/nethack.6.orig	2003-12-07 17:39:13.000000000 -0600
++++ nethack-3.4.3/doc/nethack.6	2019-03-03 16:27:52.000000000 -0600
+@@ -1,11 +1,11 @@
+-.TH NETHACK 6 "9 August 2002"
++.TH NETHACK343 6 "9 August 2002"
+ .UC 4
+ .SH NAME
+ nethack \- Exploring The Mazes of Menace
+ .SH SYNOPSIS
+ .na
+ .hy 0
+-.B nethack
++.B nethack343
+ [
+ .B \-d
+ .I directory
+@@ -35,7 +35,7 @@
+ .B \-ibm
+ ]
+ .PP
+-.B nethack
++.B nethack343
+ [
+ .B \-d
+ .I directory

--- a/games/nethack/files/patch-gamestate-dir.diff
+++ b/games/nethack/files/patch-gamestate-dir.diff
@@ -1,0 +1,35 @@
+--- nethack-3.6.1/sys/unix/hints/macosx10.10.orig	2019-02-28 15:12:58.000000000 -0600
++++ nethack-3.6.1/sys/unix/hints/macosx10.10	2019-02-28 15:13:53.000000000 -0600
+@@ -50,8 +50,8 @@
+ #	   administered this may not be what you (or your admin) want.
+ #	   Consider a non-shared install (WANT_SHARE_INSTALL=0) instead.
+ #	- 'make install' must be run as "sudo make install"    
+-#WANT_SHARE_INSTALL=1
+-GAMEUID  = $(USER)
++WANT_SHARE_INSTALL=1
++GAMEUID  = root
+ GAMEGRP  = games
+ # build to run in the source tree - primarily for development.  Build with "make all"
+ #WANT_SOURCE_INSTALL=1
+@@ -73,7 +73,7 @@
+ #CFLAGS+=-Wunreachable-code
+ 
+ # XXX -g vs -O should go here, -I../include goes in the makefile
+-CFLAGS+=-g -I../include
++CFLAGS+=-O2 -I../include
+ # older binaries use NOCLIPPING, but that disables SIGWINCH
+ #CFLAGS+=-DNOCLIPPING
+ CFLAGS+= -DNOMAIL -DNOTPARMDECL -DHACKDIR=\"$(HACKDIR)\"
+@@ -139,9 +139,9 @@
+ # if $GAMEUID is root, we install into roughly proper Mac locations, otherwise
+ # we install into ~/nethackdir
+ ifeq ($(GAMEUID),root)
+-PREFIX:=/Library/NetHack
+-SHELLDIR=/usr/local/bin
+-HACKDIR=$(PREFIX)/nethackdir
++PREFIX:=$(DESTDIR)__PREFIX__
++SHELLDIR=$(PREFIX)/bin
++HACKDIR=$(PREFIX)/var/games/nethack
+ CHOWN=chown
+ CHGRP=chgrp
+ # We run sgid so the game has access to both HACKDIR and user preferences.

--- a/games/nethack/files/patch-manpage-dir.diff
+++ b/games/nethack/files/patch-manpage-dir.diff
@@ -1,0 +1,11 @@
+--- nethack-3.6.1.OLD/sys/unix/Makefile.doc	2018-04-27 12:07:22.000000000 +0000
++++ nethack-3.6.1/sys/unix/Makefile.doc	2019-02-22 17:38:49.000000000 +0000
+@@ -62,7 +62,7 @@
+ 
+ 
+ GAME	= nethack
+-MANDIR	= /usr/man/man6
++MANDIR	= $(DESTDIR)__PREFIX__/share/man/man6
+ MANEXT	= 6
+ 
+ # manual installation for most BSD-style systems

--- a/games/nethack/files/patch-sys__unix__Makefile.doc.diff
+++ b/games/nethack/files/patch-sys__unix__Makefile.doc.diff
@@ -1,5 +1,5 @@
---- nethack-3.4.3/sys/unix/Makefile.doc.orig	2005-09-02 13:49:04.000000000 -0700
-+++ nethack-3.4.3/sys/unix/Makefile.doc	2005-09-02 13:49:13.000000000 -0700
+--- nethack-3.4.3/sys/unix/Makefile.doc.orig	2003-12-07 17:39:13.000000000 -0600
++++ nethack-3.4.3/sys/unix/Makefile.doc	2019-03-03 15:56:26.000000000 -0600
 @@ -41,7 +41,7 @@
  
  
@@ -9,3 +9,20 @@
  MANEXT	= 6
  
  # manual installation for most BSD-style systems
+@@ -58,11 +58,11 @@
+ # DLBMANCREATE = nroff -man dlb.6 >
+ 
+ manpages:
+-	-$(GAMEMANCREATE) $(MANDIR)/$(GAME).$(MANEXT)
+-	-$(LEVMANCREATE) $(MANDIR)/lev_comp.$(MANEXT)
+-	-$(DGNMANCREATE) $(MANDIR)/dgn_comp.$(MANEXT)
+-	-$(RCVRMANCREATE) $(MANDIR)/recover.$(MANEXT)
+-	-$(DLBMANCREATE) $(MANDIR)/dlb.$(MANEXT)
++	-$(GAMEMANCREATE) $(MANDIR)/$(GAME)343.$(MANEXT)
++	-$(LEVMANCREATE) $(MANDIR)/lev_comp343.$(MANEXT)
++	-$(DGNMANCREATE) $(MANDIR)/dgn_comp343.$(MANEXT)
++	-$(RCVRMANCREATE) $(MANDIR)/recover343.$(MANEXT)
++	-$(DLBMANCREATE) $(MANDIR)/dlb343.$(MANEXT)
+ 
+ # manual creation for distribution
+ DISTRIB = Guidebook.txt nethack.txt lev_comp.txt dgn_comp.txt recover.txt dlb.txt

--- a/games/nethack/files/patch-sys__unix__Makefile.top.diff
+++ b/games/nethack/files/patch-sys__unix__Makefile.top.diff
@@ -1,5 +1,5 @@
---- nethack-3.4.3/sys/unix/Makefile.top.orig	2003-12-07 15:39:13.000000000 -0800
-+++ nethack-3.4.3/sys/unix/Makefile.top	2005-09-02 13:59:43.000000000 -0700
+--- nethack-3.4.3/sys/unix/Makefile.top.orig	2003-12-07 17:39:13.000000000 -0600
++++ nethack-3.4.3/sys/unix/Makefile.top	2019-03-03 15:52:44.000000000 -0600
 @@ -14,7 +14,7 @@
  # MAKE = make
  
@@ -21,9 +21,12 @@
  
  # per discussion in Install.X11 and Install.Qt
  VARDATND = 
-@@ -191,27 +191,21 @@
+@@ -189,29 +189,23 @@
+ 	sed -e 's;/usr/games/lib/nethackdir;$(GAMEDIR);' \
+ 		-e 's;HACKDIR/nethack;HACKDIR/$(GAME);' \
  		< sys/unix/nethack.sh \
- 		> $(SHELLDIR)/$(GAME)
+-		> $(SHELLDIR)/$(GAME)
++		> $(SHELLDIR)/$(GAME)343
  # set up their permissions
 -	-( cd $(GAMEDIR) ; $(CHOWN) $(GAMEUID) $(GAME) recover ; \
 -			$(CHGRP) $(GAMEGRP) $(GAME) recover )
@@ -31,7 +34,8 @@
  	chmod $(EXEPERM) $(GAMEDIR)/recover
 -	-$(CHOWN) $(GAMEUID) $(SHELLDIR)/$(GAME)
 -	$(CHGRP) $(GAMEGRP) $(SHELLDIR)/$(GAME)
- 	chmod $(EXEPERM) $(SHELLDIR)/$(GAME)
+-	chmod $(EXEPERM) $(SHELLDIR)/$(GAME)
++	chmod $(EXEPERM) $(SHELLDIR)/$(GAME)343
  
  dofiles-dlb: check-dlb
  	( cd dat ; cp nhdat $(DATNODLB) $(GAMEDIR) )

--- a/games/nethack/files/x11/patch-x11-interface.diff
+++ b/games/nethack/files/x11/patch-x11-interface.diff
@@ -1,0 +1,28 @@
+--- nethack-3.6.1/sys/unix/hints/macosx10.10.orig	2019-03-07 14:49:25.000000000 -0600
++++ nethack-3.6.1/sys/unix/hints/macosx10.10	2019-03-07 14:55:10.000000000 -0600
+@@ -19,9 +19,11 @@
+ 
+ # 1. Which window system(s) should be included in this binary?
+ WANT_WIN_TTY=1
+-#WANT_WIN_X11=1
++WANT_WIN_X11=1
+ #WANT_WIN_QT=1
+ 
++PREFIX:=$(DESTDIR)__PREFIX__
++
+ # 1a. What is the default window system?
+ WANT_DEFAULT=tty
+ #WANT_DEFAULT=x11
+@@ -100,10 +102,10 @@
+ WINSRC += $(WINX11SRC)
+ WINOBJ += $(WINX11OBJ)
+ WINLIB += $(WINX11LIB)
+-LFLAGS=-L/opt/X11/lib
++LFLAGS=-L$(PREFIX)/lib
+ VARDATND = x11tiles NetHack.ad pet_mark.xbm pilemark.xbm
+ POSTINSTALL+= bdftopcf win/X11/nh10.bdf > $(HACKDIR)/nh10.pcf; (cd $(HACKDIR); mkfontdir);
+-CFLAGS += -DX11_GRAPHICS -I/opt/X11/include
++CFLAGS += -DX11_GRAPHICS -I$(PREFIX)/include/X11
+ # avoid repeated complaints about _X_NONNULL(args...) in <X11/Xfuncproto.h>
+ CFLAGS += -Wno-variadic-macros
+ endif	# WANT_WIN_X11


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
