### PR TITLE
fish: move to cmake build

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -2,9 +2,12 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
+PortGroup               cmake 1.1
 PortGroup               cxx11 1.1
+PortGroup               legacysupport 1.0
 
 github.setup            fish-shell fish-shell 3.0.2
+revision                1
 name                    fish
 license                 GPL-2
 categories              shells
@@ -26,26 +29,30 @@ depends_lib             port:libiconv \
                         port:ncurses \
                         port:gettext
 
-patchfiles              patch-share_config_fish.diff
-
-# fix build on Tiger
-if { ${os.platform} eq "darwin" && ${os.major} == 8 } {
-    configure.cxxflags-append -D__DARWIN_UNIX03=1
-
-    # src/wutil.h:138:1: error: 'locale_t' does not name a type
-    # forcing this define fixes this issue on Tiger
-    configure.cxxflags-append -DHAVE_XLOCALE_H=1
-}
-
+# remove unguarded-availability flag, accepted only on new clangs
+# set pipefail only if the bash version is sufficiently new to accept it
+patchfiles              patch-remove-unguarded-availability.diff \
+                        patch-share_config_fish.diff \
+                        patch-tests-bash-check.diff
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}/bin|g"     "${worksrcpath}/share/config.fish"
 }
 
-# doxygen appears to only regenerate html files and not install man pages
-configure.args-append   --without-doxygen
+# doxygen appears to only regenerate html files and is not needed to install man pages
+configure.args-append   -DBUILD_DOCS=OFF
 
-# disable silent rules
-build.args              V=1
+platform darwin 8 {
+    #/opt/local/var/macports/build/_opt_myports_shells_fish/fish/work/fish-3.0.2/src/env.cpp:436:31: error: invalid conversion from 'char*' to 'int'
+    configure.cxxflags-append -D__DARWIN_UNIX03
+
+    depends_test-append port:bash
+    test.env-append     SHELL=${prefix}/bin/bash
+}
+
+depends_test-append     port:expect
+test.env-append         TERM=nsterm  #other possible options are ansi, dtterm, rxvt, vt52, vt100, vt102, xterm
+test.run                yes
+test.target             test
 
 notes "
 To set MacPorts' ${name} as default login shell, run:

--- a/shells/fish/files/patch-remove-unguarded-availability.diff
+++ b/shells/fish/files/patch-remove-unguarded-availability.diff
@@ -1,0 +1,14 @@
+--- cmake/ConfigureChecks.cmake.orig	2019-03-03 11:43:32.000000000 -0800
++++ cmake/ConfigureChecks.cmake	2019-03-03 11:43:46.000000000 -0800
+@@ -9,11 +9,6 @@
+ ENDIF()
+ FIND_PACKAGE(Threads REQUIRED)
+ 
+-IF(APPLE)
+-  # 10.7+ only.
+-  SET(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} "-Werror=unguarded-availability")
+-ENDIF()
+-
+ # Detect WSL. Does not match against native Windows/WIN32.
+ if (CMAKE_HOST_SYSTEM_VERSION MATCHES ".*-Microsoft")
+   SET(WSL 1)

--- a/shells/fish/files/patch-tests-bash-check.diff
+++ b/shells/fish/files/patch-tests-bash-check.diff
@@ -1,0 +1,13 @@
+--- tests/invocation.sh.orig	2019-03-03 15:53:20.000000000 -0800
++++ tests/invocation.sh	2019-03-03 15:54:49.000000000 -0800
+@@ -58,7 +58,9 @@
+ set -e
+ 
+ # If any command in the pipeline fails report the rc of the first fail.
+-set -o pipefail
++if [ "${BASH_VERSINFO[0]}" -ge 3 ]; then
++	set -o pipefail
++fi
+ 
+ # If nothing matches a glob expansion, return nothing (not the glob
+ # itself)


### PR DESCRIPTION
this is now the recommended fish build system
fixes build on system < 10.9
add testing support

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4.11, 10.5.8, 10.13, 10.14
Xcode various

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@l2dy  -- want to take a look over this and see if I did anything stupid? I think you use fish as you've been updating it quite a bit lately.