### PR TITLE
gegl-0.4: support legacy systems

### DIFF
--- a/graphics/gegl-0.4/Portfile
+++ b/graphics/gegl-0.4/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           gobject_introspection 1.0
+PortGroup           legacysupport 1.0
 
 name                gegl-0.4
 set gname           gegl
@@ -85,6 +86,13 @@ configure.python    ${prefix}/bin/python2.7
 configure.args      --disable-docs \
                     --disable-silent-rules \
                     --without-sdl
+
+# at present, luajit does not build on PowerPC
+platform darwin powerpc {
+    depends_lib-delete port:luajit
+    depends_lib-delete port:lua
+    configure.args-append --without-lua
+}
 
 # use version specific binary suffix to avoid conflict with gegl, gegl-0.3
 

--- a/graphics/gegl-devel/Portfile
+++ b/graphics/gegl-devel/Portfile
@@ -5,6 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
 PortGroup           gobject_introspection 1.0
+PortGroup           legacysupport 1.0
 
 name                gegl-devel
 conflicts           gegl-0.4
@@ -86,6 +87,13 @@ configure.python    ${prefix}/bin/python2.7
 configure.args      --disable-docs \
                     --disable-silent-rules \
                     --without-sdl
+
+# at present, luajit does not build on PowerPC
+platform darwin powerpc {
+    depends_lib-delete port:luajit
+    depends_lib-delete port:lua
+    configure.args-append --without-lua
+}
 
 # use version specific binary suffix to avoid conflict with gegl, gegl-0.3
 


### PR DESCRIPTION
gegl uses realpath with NULL buffer ptr
so needs legacysupport to support this

luajit presently does not build on PowerPC
gegl-0.4 builds through successfully without it

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
