### PR TITLE
bfg: new port

### DIFF
--- a/java/bfg/Portfile
+++ b/java/bfg/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           java 1.0
+
+name                bfg
+version             1.13.0
+
+categories          java devel
+license             GPL-3.0
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+platforms           darwin
+supported_archs     noarch
+
+description         Removes large or troublesome blobs like git-filter-branch does, but faster.
+long_description    The BFG is a simpler, faster alternative to git-filter-branch for cleansing \
+                    bad data out of your Git repository history: \n \
+                      - Removing Crazy Big Files \n \
+                      - Removing Passwords, Credentials & other Private data
+homepage            https://rtyley.github.io/bfg-repo-cleaner/
+
+master_sites        https://search.maven.org/remotecontent?filepath=com/madgag/${name}/${version}/
+distfiles           ${name}-${version}.jar
+distname            ${name}-${version}
+worksrcdir          ${name}-${version}
+
+checksums           rmd160  6f692650684b52f5f78801d57fddd2bc1d4d7595 \
+                    sha256  bf22bab9dd42d4682b490d6bc366afdad6c3da99f97521032d3be8ba7526c8ce \
+                    size    13465496
+
+java.fallback       openjdk8
+java.version        1.7+
+
+use_configure       no
+
+extract {
+    file copy ${distpath}/${distname}.jar ${workpath}
+}
+
+build {}
+
+destroot {
+    set javadir ${destroot}${prefix}/share/java
+    xinstall -d -m 755 -d ${javadir}/${name}
+    xinstall -m 644 ${workpath}/${distname}.jar ${javadir}/${name}/${name}.jar
+
+    # Install the wrapper script
+    xinstall -m 755 ${filespath}/bfg ${destroot}${prefix}/bin/bfg
+    reinplace "s|_PREFIX_|${prefix}|g" ${destroot}${prefix}/bin/bfg
+}
+
+livecheck.type      regex
+livecheck.url       https://repo1.maven.org/maven2/com/madgag/${name}/maven-metadata.xml
+livecheck.regex     >(\\d+\\.\\d+(\\.\\d+)*)</
+
+test.run            yes
+test.cmd            java -jar ${distname}.jar

--- a/java/bfg/files/bfg
+++ b/java/bfg/files/bfg
@@ -1,0 +1,4 @@
+#!/bin/sh
+PREFIX=_PREFIX_
+
+java -jar ${PREFIX}/share/java/bfg/bfg.jar "$@"


### PR DESCRIPTION
#### Description

The BFG is a simpler, faster alternative to git-filter-branch for
cleansing bad data out of your Git repository history:

- Removing Crazy Big Files
- Removing Passwords, Credentials & other Private data

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->