### PR TITLE
python38-devel: update to 3.8.0a2

### DIFF
--- a/lang/python38-devel/Portfile
+++ b/lang/python38-devel/Portfile
@@ -1,13 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup select 1.0
+PortSystem          1.0
+PortGroup           select 1.0
 
 name                python38-devel
 
-version             20180919
+version             3.8.0a2
+epoch               1
+revision            0
+set major           [lindex [split $version .] 0]
+set branch          [join [lrange [split ${version} .] 0 1] .]
 
-set branch          3.8
 categories          lang
 license             PSF
 platforms           darwin
@@ -18,18 +21,13 @@ long_description    Python is an interpreted, interactive, object-oriented \
                     programming language.
 
 homepage            https://www.python.org/
-master_sites        https://github.com/python/cpython/archive
+master_sites        ${homepage}ftp/python/3.8.0/
 
-set commit          b3b8cb419e496629873fa7dda82a01863f58617a
-
-distname            ${commit}
-use_zip             yes
-checksums           md5     a74a616ede440d2737c261c9eccfb51a \
-                    rmd160  a78f6aa52369606989152a57ccd3beeecfd06854 \
-                    sha256  ad62eac8962df550c0f531404762ad8a4948631b650682a8a28d3cf94b4d91af \
-                    size    25324108
-
-worksrcdir          cpython-${commit}
+distname            Python-${version}
+use_xz              yes
+checksums           rmd160  c8d69aaf673167a30f409a9bbce34b152d644d10 \
+                    sha256  64f08ef60c86474d1390917841c1b618391e6ba01a42cf33977414bd602e8b5d \
+                    size    17201560
 
 patchfiles          patch-setup.py.diff \
                     patch-Lib-cgi.py.diff \
@@ -198,3 +196,6 @@ variant optimizations description {Compile with LTO and PGO. Build time greatly 
     configure.args-append   --enable-optimizations
 }
 
+livecheck.type      regex
+livecheck.url       ${homepage}downloads/source/
+livecheck.regex     Python (${branch}\[.0-9abrc\]+)


### PR DESCRIPTION
#### Description
- update to latest development release
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
