### PR TITLE
openssl11: new port, version 1.1.1b

### DIFF
--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -1,0 +1,111 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+
+name                openssl11
+version             1.1.1b
+
+# Please revbump these ports when updating OpenSSL.
+#  - freeradius (#43461)
+#  - openssh (#54990)
+
+categories          devel security
+platforms           darwin
+license             OpenSSL SSLeay
+maintainers         {yan12125 @yan12125} openmaintainer
+
+description         OpenSSL SSL/TLS cryptography library
+long_description    The OpenSSL Project is a collaborative effort to \
+                    develop a robust, commercial-grade, full-featured, \
+                    and Open Source toolkit implementing the Secure \
+                    Sockets Layer (SSL v2/v3) and Transport Layer \
+                    Security (TLS v1) protocols as well as \
+                    a full-strength general purpose cryptography \
+                    library.
+homepage            https://www.openssl.org
+
+conflicts           libressl libressl-devel openssl
+
+depends_lib         port:zlib
+
+distname            openssl-${version}
+# See https://www.openssl.org/source/mirror.html
+master_sites        ${homepage}/source \
+                    ftp://gd.tuwien.ac.at/infosys/security/openssl/source/ \
+                    http://mirror.switch.ch/ftp/mirror/openssl/source/ \
+                    ftp://ftp.fi.muni.cz/pub/openssl/source/ \
+                    ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
+                    http://artfiles.org/openssl.org/source/ \
+                    ftp://ftp.linux.hr/pub/openssl/source/ \
+                    ftp://guest.kuria.katowice.pl/pub/openssl/source/
+
+checksums           sha1    e9710abf5e95c48ebf47991b10cbb48c09dae102 \
+                    rmd160  2f6ab1216c04d089cf930f128f142d9e4a531535 \
+                    sha256  5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b \
+                    size    8213737
+
+# patchfiles
+
+configure.ccache    no
+configure.perl      /usr/bin/perl
+configure.cmd       ./Configure
+configure.args     -L${prefix}/lib \
+                  --openssldir=${prefix}/etc/openssl \
+                    shared \
+                    zlib
+# Use SDK if necessary.
+if {${configure.sdkroot} ne ""} {
+    configure.args-append   '-isysroot ${configure.sdkroot}' \
+                            -Wl,-syslibroot,${configure.sdkroot}
+}
+
+set merger_arch_compiler no
+array set merger_configure_args {
+    ppc     darwin-ppc-cc
+    i386    darwin-i386-cc
+    ppc64   darwin64-ppc-cc
+    x86_64  darwin64-x86_64-cc
+}
+platform darwin {
+    # Don't use i386 assembly on Tiger (#38015, #43303).
+    if {${os.major} <= 8} {
+        append merger_configure_args(i386) { no-asm}
+    }
+    # Don't use x86-64 assembly on Tiger or Leopard.
+    if {${os.major} <= 9} {
+        append merger_configure_args(x86_64) { no-asm}
+    }
+}
+# Don't pass --host to configure.
+array set merger_host {ppc {} i386 {} ppc64 {} x86_64 {}}
+
+if {![variant_isset universal]
+        && [info exists merger_configure_args(${configure.build_arch})]} {
+    configure.args-append $merger_configure_args(${configure.build_arch})
+}
+configure.universal_args-delete --disable-dependency-tracking
+
+# Parallel builds don't quite work (#46719).
+use_parallel_build  no
+
+test.run            yes
+
+if {[variant_isset universal]} {
+    pre-destroot {
+        global merger_dont_diff
+        if {[llength ${universal_archs_to_use}] > 2} {
+            lappend merger_dont_diff ${prefix}/include/openssl/opensslconf.h
+        }
+    }
+}
+
+destroot.args       MANDIR=${prefix}/share/man MANSUFFIX=ssl
+
+variant rfc3779 description {enable RFC 3779: X.509 Extensions for IP Addresses and AS Identifiers} {
+    configure.args-append   enable-rfc3779
+}
+
+livecheck.type      regex
+livecheck.url       [lindex ${master_sites} 0]
+livecheck.regex     ${name}-(\[0-9.\]+\[a-z\]?)\\.tar\\.gz


### PR DESCRIPTION
#### Description

To make migration from OpenSSL 1.0.2 simpler. See
https://trac.macports.org/ticket/52101

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?