### PR TITLE
py-hggit: update to 8d00fde for compatibility with mercurial 4.9

### DIFF
--- a/python/py-hggit/Portfile
+++ b/python/py-hggit/Portfile
@@ -6,8 +6,10 @@ PortGroup               bitbucket 1.0
 
 epoch                   20130201
 
-bitbucket.setup         durin42 hg-git 0.8.12
+bitbucket.setup         durin42 hg-git 8d00fde45adbc6c3c0ccab8e362b5f5c36c171e6
 name                    py-hggit
+version                 0.8.12
+revision                1
 
 categories-append       devel
 license                 GPL-2
@@ -23,9 +25,9 @@ long_description        This is the Hg-Git plugin for Mercurial, adding the abil
                         or use a Git server as a collaboration point for a team with \
                         developers using both Git and Mercurial.
 
-checksums               rmd160  4216bcfd288f8c86927ff8d72f3d1415788c9935 \
-                        sha256  66a589baa5c6734320f2737c486abfabfd9bb2bf96bedbfe991f0a5bec1160d2 \
-                        size    136783
+checksums               rmd160  610e35c34231f728e198ea4161de26b1e9e4a61c \
+                        sha256  2cca8042dd5dabccb91a1a34c11b3b2d8cc1d2f64ccd8b0e8f775795d3db6e09 \
+                        size    137713
 
 # can't set python.versions before adding custom subports
 subport py-hggit-devel {}


### PR DESCRIPTION
#### Description

Latest release (0.8.12) of `hg-git` is broken for Mercurial 4.8+. I have updated it to latest commit, which in my testing works with `hg` 4.9. This is very normal for `hg-git`: the latest official release most certainly won't work with the 1 or 2 newest feature releases of Mercurial.

I have just bumped the revision number because I'm not sure how you want to deal with versioning for this port, for dealing with cases like this. IMO just bumping revision should be simple and good enough, but I'm not the maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61 
Mercurial 4.9

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
