### PR TITLE
py-astroid: update to 2.2.3

### DIFF
--- a/python/py-astroid/Portfile
+++ b/python/py-astroid/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-astroid
-version             2.1.0
+version             2.2.3
+revision            0
 categories-append   devel
 platforms           darwin
 license             LGPL-2.1+
@@ -27,25 +28,28 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  d44ca4b42d075d31d45512c7ef7f8897a80c6d98 \
-                    sha256  35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22 \
-                    size    276196
+checksums           rmd160  f2c0b6bec675210dd5c0bcb713a21d527e2b69df \
+                    sha256  91f52b4e4645ee610a82841aacc7ecd0202f695375cc7b34bae43ab4ab359099 \
+                    size    281317
 
 if {${name} ne ${subport}} {
     depends_build-append \
+                        port:py${python.version}-pytest-runner \
                         port:py${python.version}-setuptools
-
-    if {${python.version} ne 27} {
-        depends_build-append \
-                        port:py${python.version}-pytest-runner
-    }
 
     depends_lib-append  port:py${python.version}-lazy_object_proxy \
                         port:py${python.version}-six \
+                        port:py${python.version}-typed-ast \
                         port:py${python.version}-wrapt
+
+    if {${python.version} eq 34} {
+        depends_lib-append \
+                        port:py${python.version}-typing
+    }
 
     if {${python.version} eq 27} {
         version         1.6.5
+        revision        0
         distname        ${python.rootname}-${version}
         checksums       rmd160  bba1d1e3582e557ecbe6a56ca83adef5b1d80506 \
                         sha256  fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a \
@@ -55,15 +59,20 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-enum34 \
                         port:py${python.version}-singledispatch \
                         port:py${python.version}-backports-functools_lru_cache
-    }
-    if {${python.version} ne 27 && ${python.version} ne 37} {
-        depends_lib-append \
+
+        depends_build-delete \
+                        port:py${python.version}-pytest-runner
+
+        depends_lib-delete \
                         port:py${python.version}-typed-ast
     }
-    if {${python.version} eq 34} {
-        depends_lib-append \
-                        port:py${python.version}-typing
-    }
+
+    depends_test-append \
+                        port:py${python.version}-pytest
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description
- update to latest version
- make use of depends_{lib/build}-delete to remove specific dependencies for Python 2.7
- enable tests
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
