### PR TITLE
p5-test-perltidy: update to version 20190305, dependencies

### DIFF
--- a/perl/p5-test-perltidy/Portfile
+++ b/perl/p5-test-perltidy/Portfile
@@ -4,22 +4,22 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Test-PerlTidy 20130104
-revision            1
+perl5.setup         Test-PerlTidy 20190305
+revision            0
 license             {Artistic-1 GPL}
 maintainers         {mps @Schamschula} openmaintainer
 description         Check that all your files are tidy.
 long_description    ${description}
 platforms           darwin
 
-checksums           rmd160  b6af481f1f1646d14e3fdb7d4ed86098834961d1 \
-                    sha256  3f15d9f3f4811e348594620312258d75095237925b491ada623fa73ac9d2b9c8 \
-                    size    7499
+checksums           rmd160  dfea3e000cbe5360d5791503acce1ee089677d38 \
+                    sha256  593c861b9fa3641cc4403efdf2edd2d3c905ca2c581c46b09b6810af21bd30dc \
+                    size    7862
 
 if {${perl5.major} != ""} {
     depends_lib-append \
                     port:p${perl5.major}-file-finder \
-                    port:p${perl5.major}-file-slurp \
+                    port:p${perl5.major}-path-tiny \
                     port:p${perl5.major}-perl-tidy \
                     port:p${perl5.major}-text-diff
 


### PR DESCRIPTION
Fixes test failures caused by changes in latest Perl::Tidy.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
