### PR TITLE
ranger: update to 1.9.2

### DIFF
--- a/sysutils/ranger/Portfile
+++ b/sysutils/ranger/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        ranger ranger 1.9.1 v
+github.setup        ranger ranger 1.9.2 v
 maintainers         {g5pw @g5pw} openmaintainer
 
 categories          sysutils
@@ -20,8 +20,9 @@ supported_archs     noarch
 
 homepage            https://ranger.github.io
 
-checksums           rmd160  6e782e3023d86fba95a157bade1c2591f495c245 \
-                    sha256  8df52717d2e5a20850e377d30d9444c5e6de07a408e0a5cf9604283e39992c41
+checksums           rmd160  48b1c16779bc4e1806237f8542232626860bb6ec \
+                    sha256  51b1a0b6370e0b03e6428895daba9e0386909da729e6a8fd92850dc9fc777a73 \
+                    size    265320
 
 post-destroot {
     ln -s "${python.prefix}/share/man/man1/${name}.1" "${destroot}${prefix}/share/man/man1/${name}.1"


### PR DESCRIPTION
#### Description

Update ranger to the latest version.

###### Tested on

macOS 10.12.6


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
