### PR TITLE
vifm: update to 0.10

### DIFF
--- a/sysutils/vifm/Portfile
+++ b/sysutils/vifm/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                vifm
-version             0.9.1
+version             0.10
 categories          sysutils
 platforms           darwin
 license             GPL-2+
@@ -20,9 +20,9 @@ homepage            https://vifm.info
 master_sites        sourceforge:project/vifm/vifm
 use_bzip2           yes
 
-checksums           rmd160  8aa4632177f012131e0de257ffa773850fa01449 \
-                    sha256  28b9a4b670d9ddc9af8c9804dc22fa93f4fd0adabce94d43ebedc157a5dce7b3 \
-                    size    1002758
+checksums           rmd160  fc331d5e3b0abcf2715149859bd32bfa9ccd9528 \
+                    sha256  e05a699f58279f69467d75d8cd3d6c8d2f62806c467fd558eda45ae9590768b8 \
+                    size    1054361
 
 depends_lib         port:libmagic \
                     port:ncurses


### PR DESCRIPTION
#### Description

vifm: update to 0.10

###### Tested on

macOS 10.12.6
Xcode None

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
