### PR TITLE
py-markupsafe: update to 1.1.1

### DIFF
--- a/python/py-markupsafe/Portfile
+++ b/python/py-markupsafe/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-markupsafe
-version             1.1.0
+version             1.1.1
 categories-append   textproc
 platforms           darwin
 license             BSD
@@ -20,9 +20,9 @@ homepage            https://palletsprojects.com/p/markupsafe/
 master_sites        pypi:M/MarkupSafe
 distname            MarkupSafe-${version}
 
-checksums           rmd160  e6c0a61abb702197a59746c01d7747c661364996 \
-                    sha256  4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3 \
-                    size    18938
+checksums           rmd160  9f974f85c9d7b4c1d52fffce1c73406d57f55a0a \
+                    sha256  29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b \
+                    size    19151
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -36,6 +36,13 @@ if {${name} ne ${subport}} {
     test.run        yes
     test.cmd        py.test-${python.branch}
     test.target
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.rst README.rst \
+            CHANGES.rst ${destroot}${docdir}
+    }
 
     livecheck.type  none
 } else {


### PR DESCRIPTION
#### Description
- update to latest version
- install files in post-destroot
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
