### PR TITLE
npm6: Update to 6.9.0

### DIFF
--- a/devel/npm6/Portfile
+++ b/devel/npm6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                npm6
-version             6.8.0
+version             6.9.0
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -25,10 +25,10 @@ distname            npm-${version}
 extract.suffix      .tgz
 
 # Please keep the sha1 - users can use it to validate sha values published on npmjs.org for the package
-checksums           sha1    62996dd6aa235dac175b13968a6d7f815ebf8257 \
-                    rmd160  60e9f61cd015bd9973895ab9b3e3b1dc4af7e75b \
-                    sha256  216f33e0cb87886f5601b4878302bd4ae822a8eeb06887fdb8986f64b4ede980 \
-                    size    5171533
+checksums           sha1    5296720486814a64a7fb082de00c4b5cfd11211f \
+                    rmd160  cb019447dc43a7c0680b377a77773eaa8a250ae2 \
+                    sha256  d6194c36bf612f1b2a6fbe351a7cb6f44dfb9a87a1d5336b1303dc1c07e87276 \
+                    size    5175534
 
 worksrcdir          "package"
 


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

Unfortunately, I cannot get this to install with trace mode enabled, but this does not look like anything new–6.8.0 did not build with this either…

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E205e
Xcode 10.2 10P107d 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->