### PR TITLE
py-notebook: update to 5.7.5

### DIFF
--- a/python/py-notebook/Portfile
+++ b/python/py-notebook/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-notebook
-version             5.7.4
+version             5.7.5
 revision            0
 categories-append   devel science
 platforms           darwin
@@ -23,9 +23,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  29c92f292c99e0c1211562499a730e51f6baffb4 \
-                    sha256  d908673a4010787625c8952e91a22adf737db031f2aa0793ad92f6558918a74a \
-                    size    13389469
+checksums           rmd160  23e38c099915107bad3b2375136b6903ad15e02b \
+                    sha256  c5011449a1a6d9f96bf65c4c2d6713802a21125476312b39c99010ccd7a2e2ed \
+                    size    13369251
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \


### PR DESCRIPTION
#### Description
This update fixes compatibility with py-tornado 6. See:
https://github.com/jupyter/notebook/issues/4439
https://github.com/jupyter/notebook/issues/4437

Version 5.7.4 right now is non-functional.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

(only version py37-notebook though)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?