### PR TITLE
dart-sdk: update to 2.2.0

### DIFF
--- a/lang/dart-sdk/Portfile
+++ b/lang/dart-sdk/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dart-sdk
-version             2.1.0
+version             2.2.0
 categories          lang
 license             BSD
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ use_zip             yes
 dist_subdir         ${name}/${version}
 worksrcdir          ${name}
 
-checksums           rmd160  bb5cfe6d5d96d930005cc067bc2320d8928a24ab \
-                    sha256  5576013b2d5e03f3d8cb85a6cd8820fec2c9a856c1510c0666ff2157065aa76a \
-                    size    107771628
+checksums           rmd160  8c1bfdf7dfcb8d05679d21ffb57cd80c4b640bef \
+                    sha256  9438afb49b69ac655882036c214e343232fdcd5af24607e6058e2def33261197 \
+                    size    100646614
 
 use_configure       no
 build               {}


### PR DESCRIPTION
#### Description

There was a Dart language upgrade of the latest stable version about 2 weeks ago and there's still no update in MacPorts so I decided to do it.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
