### PR TITLE
xar: patch deprecated openssl function

### DIFF
--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -23,6 +23,7 @@ depends_lib         port:bzip2 \
                     path:lib/libssl.dylib:openssl \
                     port:zlib
 
-patchfiles	        patch-ext2.c
+patchfiles          patch-ext2.c \
+                    patch-configure.ac
 
 use_autoconf        yes

--- a/archivers/xar/files/patch-configure.ac
+++ b/archivers/xar/files/patch-configure.ac
@@ -1,0 +1,26 @@
+From bab8837fd993385115d58763e15487dc8cc13f97 Mon Sep 17 00:00:00 2001
+From: Erik Goldman <erik.goldman@gmail.com>
+Date: Mon, 30 Apr 2018 22:02:39 -0700
+Subject: [PATCH] fix https://github.com/mackyle/xar/issues/18
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git configure.ac configure.ac
+index 812b5ff..1b70c06 100644
+--- configure.ac
++++ configure.ac
+@@ -329,7 +329,11 @@ dnl Configure libcrypto (part of OpenSSL).
+ dnl 
+ have_libcrypto="1"
+ AC_CHECK_HEADERS([openssl/evp.h], , [have_libcrypto="0"])
+-AC_CHECK_LIB([crypto], [OpenSSL_add_all_ciphers], , [have_libcrypto="0"])
++AC_CHECK_LIB([crypto], [OpenSSL_add_all_ciphers], , [have_libcrypto_ossl10="0"])
++AC_CHECK_LIB([crypto], [OPENSSL_init_crypto], , [have_libcrypto_ossl11="0"])
++if test "x${have_libcrypto_ossl10}" = "x0" -a "x${have_libcrypto_ossl11}" = "x0" ; then
++  have_libcrypto="0"
++fi
+ if test "x${have_libcrypto}" = "x0" ; then
+   AC_MSG_ERROR([Cannot build without libcrypto (OpenSSL)])
+ fi


### PR DESCRIPTION
#### Description

OpenSSL 1.1.0 deprecated OpenSSL_add_all_algorithms and replaced with
OPENSSL_init_crypto.

Ref: https://github.com/mackyle/xar/issues/18
Ref: https://trac.macports.org/ticket/52101

PS. This patch is cherry-picked from https://github.com/aque/macports-ports/commit/bf24a701ce2072fa88c237fa0fc2291758dd1bac

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?