### PR TITLE
xfractint: fix to build against MacPorts Xorg, not XQuartz

### DIFF
--- a/graphics/xfractint/Portfile
+++ b/graphics/xfractint/Portfile
@@ -26,6 +26,8 @@ post-patch {
     reinplace "s|__PREFIX__|${prefix}|" "${worksrcpath}/Makefile"
 }
 
+depends_lib-append  port:Xft2
+
 use_configure       no
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \

--- a/graphics/xfractint/files/patch-prefix-x11-dirs.diff
+++ b/graphics/xfractint/files/patch-prefix-x11-dirs.diff
@@ -1,11 +1,20 @@
 --- xfractint-20.04p14/Makefile.orig	2014-05-03 08:12:33.000000000 -0500
-+++ xfractint-20.04p14/Makefile	2019-03-05 16:22:26.000000000 -0600
-@@ -20,26 +20,21 @@
++++ xfractint-20.04p14/Makefile	2019-03-07 12:12:05.000000000 -0600
+@@ -2,6 +2,8 @@
+ STRIP = strip
+ INSTALL = /usr/bin/install
+ 
++PREFIX = $(DESTDIR)__PREFIX__
++
+ # Architecture
+ # automatic detection
+ ARCH = `uname -m | tr "_" "-"`
+@@ -20,26 +22,19 @@
  
  # Use Xft/fontconfig libraries
  WITHXFT = -DWITH_XFT
 -XFTHFD = /usr/include/freetype2
-+XFTHFD = /opt/X11/include/freetype2
++XFTHFD = $(PREFIX)/include/freetype2
  # Or not
  # WITHXFT =
  # XFTHFD =
@@ -16,8 +25,7 @@
 -ifndef DESTDIR
 -DESTDIR = $(PREFIX)
 -endif
-+PREFIX = $(DESTDIR)__PREFIX__
- 
+-
  # SRCDIR should be a path to the directory that will hold fractint.hlp
  # SRCDIR should also hold the .par, .frm, etc. files
 -SRCDIR = $(DESTDIR)/share/xfractint
@@ -36,7 +44,7 @@
  
  endif
  
-+CFLAGS += -I/opt/X11/include
++CFLAGS += -I$(PREFIX)/include/X11
 +
  # Gcc is often the only compiler that works for this
  # For HPUX, use CC = cc -Aa -D_HPUX_SOURCE
@@ -54,7 +62,7 @@
  LIBS = -L/usr/X11R6/lib -lX11 -lm
  endif
  
-+LIBS = -L/opt/X11/lib -lX11 -lm
++LIBS = -L$(PREFIX)/lib -lX11 -lm
 +
  ifeq ($(NCURSES),-DNCURSES)
  LIBS += -lncurses


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
