### PR TITLE
XviD: new livecheck URL

### DIFF
--- a/multimedia/XviD/Portfile
+++ b/multimedia/XviD/Portfile
@@ -74,5 +74,5 @@ post-destroot {
 use_parallel_build  no
 
 livecheck.type      regex
-livecheck.url       ${homepage}Downloads.43.0.html
+livecheck.url       ${master_sites}
 livecheck.regex     xvidcore-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/58001

In response to a post on their mailing list (http://list.xvid.org/pipermail/xvid-devel/2019-February/006460.html), XviD now lists all released versions at https://downloads.xvid.com/downloads/ , which appears usable from `curl`:

```
$ port -d livecheck xvid
…
DEBUG: Port (livecheck) version is 1.3.5
DEBUG: Fetching https://downloads.xvid.com/downloads/
DEBUG: The regex is "xvidcore-([0-9.]+).tar.bz2"
…
DEBUG: The regex matched "xvidcore-1.3.5.tar.bz2", extracted "1.3.5"
XviD seems to be up to date
```

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
