### PR TITLE
mariadb-10.1: Update to v10.1.38

### DIFF
--- a/databases/mariadb-10.1/Portfile
+++ b/databases/mariadb-10.1/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mariadb-10.1
 set name_mysql      ${name}
-version             10.1.31
+version             10.1.38
 set version_branch  [join [lrange [split ${version} .] 0 1] .]
 # Please set revision_client and revision_server to 0 if you bump version.
 set revision_client 1
@@ -45,9 +45,9 @@ if {$subport eq $name} {
     patchfiles          patch-cmake-install_layout.cmake.diff \
                         patch-CMakeLists.txt.diff
 
-    checksums           rmd160  12729deb32211e6de058c77c535949f35fc67e35 \
-                        sha256  ab7641c2fe4e5289da6141766a9c3350e013def56fafd6f1377080bc8048b2e6 \
-                        size    67982786
+    checksums           rmd160  f22762fdffcb86365ad1683f68bfb8aaf59106a9 \
+                        sha256  caf1f4fc237d143343995b6625375aef911dfc366433645d400727e7063f077f \
+                        size    63535685
 
     depends_lib-append  port:zlib port:tcp_wrappers port:ncurses port:judy
     depends_run-append  port:mysql_select
@@ -169,7 +169,7 @@ if {$subport eq $name} {
     }
 
     variant system_readline description {Use system readline instead of bundled readline} {
-    
+
         # Add readline support.
         # "-DWITH_READLINE:BOOL=OFF" has the peculiar meaning "do not use the bundled copy
         # of readline but use the system's (i.e. MacPorts') copy of readline"
@@ -240,7 +240,7 @@ subport ${name_mysql}-server {
         reinplace "s|@GROUP@|${mysqluser}|g" \
             ${workpath}/org.macports.${subport}.plist
     }
-    
+
     use_configure       no
 
     build {}


### PR DESCRIPTION
* update MariaDB 10.1 to v10.1.38

#### Description

Updating MariaDB 10.1 to latest available release.

Closes: https://trac.macports.org/ticket/56838

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [x] security fix
CVE-2019-2537
CVE-2019-2529

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->