### PR TITLE
paraview: requires qt5-qtxmlpatterns

### DIFF
--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -38,7 +38,7 @@ checksums           sha256  64561f34c4402b88f3cb20a956842394dde5838efd7ebb301157
 
 depends_build-append    port:readline \
     port:netcdf \
-    port:qt5-sqlite-plugin port:qt5-qttools 
+    port:qt5-sqlite-plugin port:qt5-qttools port:qt5-qtxmlpatterns
 
 patchfiles patch-incomplete-types.patch
 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/57884

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
