### PR TITLE
OpenBLAS: add PowerPC support

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -37,7 +37,8 @@ if {[string first "-devel" $subport] > 0} {
     conflicts       OpenBLAS
 
     patchfiles      patch-libnoarch.devel.diff \
-                    patch-linkLib.devel.diff
+                    patch-linkLib.devel.diff \
+                    patch-openblas-powermac970-fix.diff
 
     github.livecheck.branch develop
 
@@ -51,7 +52,9 @@ if {[string first "-devel" $subport] > 0} {
     conflicts       OpenBLAS-devel
 
     patchfiles      patch-libnoarch.release.diff \
-                    patch-linkLib.release.diff 
+                    patch-linkLib.release.diff  \
+                    patch-darwin-powerpc.diff \
+                    patch-openblas-powermac970-fix.diff
 }
 
 compilers.choose    fc 
@@ -140,6 +143,15 @@ pre-build {
 
 depends_build-append port:cctools
 build.args          "AR=${prefix}/bin/ar RANLIB=${prefix}/bin/ranlib"
+
+platform darwin 8 {
+    depends_build-append    port:gmake
+    build.cmd               ${prefix}/bin/gmake
+    
+    depends_test-append     port:gmake
+    test.cmd                build.cmd
+}
+
 
 destroot.args       "PREFIX=${prefix}"
 

--- a/math/OpenBLAS/files/patch-darwin-powerpc.diff
+++ b/math/OpenBLAS/files/patch-darwin-powerpc.diff
@@ -1,0 +1,11 @@
+--- ctest.c.orig	2019-03-06 19:25:30.000000000 -0800
++++ ctest.c	2019-03-06 19:26:06.000000000 -0800
+@@ -113,7 +113,7 @@
+ ARCH_X86_64
+ #endif
+ 
+-#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER)
++#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER) || defined(__POWERPC__)
+ ARCH_POWER
+ #endif
+ 

--- a/math/OpenBLAS/files/patch-openblas-powermac970-fix.diff
+++ b/math/OpenBLAS/files/patch-openblas-powermac970-fix.diff
@@ -1,0 +1,26 @@
+diff --git common_power.h common_power.h
+index e3a1a7ae..68087b07 100644
+--- common_power.h
++++ common_power.h
+@@ -241,7 +241,7 @@ static inline int blas_quickdivide(blasint x, blasint y){
+ #define HAVE_PREFETCH
+ #endif
+ 
+-#if defined(POWER3) || defined(POWER6) || defined(PPCG4) || defined(CELL) || defined(POWER8)
++#if defined(POWER3) || defined(POWER6) || defined(PPCG4) || defined(CELL) || defined(POWER8) || ( defined(PPC970) && defined(OS_DARWIN) )
+ #define DCBT_ARG	0
+ #else
+ #define DCBT_ARG	8
+diff --git param.h param.h
+index 3cc400b5..48b7ef38 100644
+--- param.h
++++ param.h
+@@ -1999,7 +1999,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #define ZGEMM_DEFAULT_UNROLL_M 2
+ #define ZGEMM_DEFAULT_UNROLL_N 2
+ 
+-#ifdef OS_LINUX
++#if defined(OS_LINUX) || defined(OS_DARWIN)
+ #if L2_SIZE == 1024976
+ #define SGEMM_DEFAULT_P 320
+ #define DGEMM_DEFAULT_P 256


### PR DESCRIPTION
These patches and the small change to force a newer `make` on Tiger fix the build of OpenBLAS on PowerPC macs.

It looks like these changes are acceptable to upstream, and these patches should be integrated into the next release of OpenBLAS.

PowerPC forever!