### PR TITLE
fzy: Update to 1.0

### DIFF
--- a/devel/fzy/Portfile
+++ b/devel/fzy/Portfile
@@ -2,7 +2,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jhawthorn fzy 0.9
+github.setup        jhawthorn fzy 1.0
 categories          devel
 platforms           darwin
 license             MIT
@@ -14,8 +14,9 @@ long_description    fzy tries to find the result the user intended. It does \
                     starts of words. This allows matching using acronyms or \
                     different parts of the path.
 
-checksums           sha256 f5e122251d41527007c0675276f414534337b5814d1bb6d23587f7a3dcc91de4 \
-                    rmd160 e278ef08985c476c7c70c6f870ea301abaecc6c9
+checksums           sha256  e27f6f65ced83615b95885f85f18af64a86810c98c457acc456a2cffdf0a7809 \
+                    rmd160  2ede1ebddd76596fbc49d4b57c9843ad8e192a89 \
+                    size    47458
 
 use_configure       no
 build.args-append   CC="${configure.cc} [get_canonical_archflags cc]"


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E205e
Xcode 10.2 10P107d 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->