### PR TITLE
fzf: new port

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/junegunn/fzf 0.17.5
+revision            0
+checksums           rmd160  81e89373ec1cd79236a668c0ad453276160c457c \
+                    sha256  3b420dc394dba800b74e93d1b0d0e12c579e209fabb183528254013c3823890d \
+                    size    140397
+
+categories          sysutils
+platforms           darwin
+license             MIT
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+description         A command-line fuzzy finder written in Go
+long_description    ${description}
+
+build.env-append    GO111MODULE=on
+
+destroot {
+    # install fzf
+    xinstall -d ${destroot}${prefix}/bin
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    # install fzf-tmux (has a failover if tmux isn't installed)
+    xinstall -m 755 ${worksrcpath}/bin/${name}-tmux ${destroot}${prefix}/bin/${name}-tmux
+}
+
+post-destroot {
+    # install documentation
+    xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE README-VIM.md README.md ${destroot}${prefix}/share/doc/${name}
+
+    # install man pages
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 {*}[glob ${worksrcpath}/man/man1/*.1] ${destroot}${prefix}/share/man/man1/
+
+    # install shell completion (bash, zsh)
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions/
+    xinstall -m 644 ${worksrcpath}/shell/completion.bash ${destroot}${prefix}/share/bash-completion/completions/${name}
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions/
+    xinstall -m 644 ${worksrcpath}/shell/completion.zsh ${destroot}${prefix}/share/zsh/site-functions/${name}
+
+    # make other files available, but not enabled
+    xinstall -d ${destroot}${prefix}/share/fzf/shell/
+    xinstall -m 0644 {*}[glob ${worksrcpath}/shell/key-bindings.*] ${destroot}${prefix}/share/fzf/shell/
+    xinstall -d ${destroot}${prefix}/share/fzf/vim/doc/
+    xinstall -m 644 ${worksrcpath}/doc/${name}.txt ${destroot}${prefix}/share/fzf/vim/doc/${name}.txt
+    xinstall -d ${destroot}${prefix}/share/fzf/vim/plugin/
+    xinstall -m 644 ${worksrcpath}/plugin/${name}.vim ${destroot}${prefix}/share/fzf/vim/plugin/${name}.vim
+}
+
+notes "
+Shell key bindings for bash and zsh are located in:
+
+    ${prefix}/share/fzf/shell
+
+The Vim plugin is located in:
+
+    ${prefix}/share/fzf/vim
+
+Enable the Vim plugin by adding the following to your
+Vim configuration file (default: ~/.vimrc):
+
+    set rtp+=${prefix}/share/fzf/vim
+
+Documentation for fzf and the Vim plugin is located in:
+
+    ${prefix}/share/doc/fzf
+"


### PR DESCRIPTION
#### Description

`fzf` is a command-line fuzzy finder written in Go.

Closes https://trac.macports.org/ticket/55874.

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?