### PR TITLE
adtpro: fix license

### DIFF
--- a/emulators/adtpro/Portfile
+++ b/emulators/adtpro/Portfile
@@ -8,7 +8,7 @@ set my_name             ADTPro
 version                 1.1.9
 categories              emulators
 maintainers             ryandesign
-license                 GPL-2
+license                 GPL-2+
 homepage                http://adtpro.sourceforge.net/
 master_sites            sourceforge:project/adtpro/adtpro/ADTPro-${version}
 platforms               darwin


### PR DESCRIPTION
See https://trac.macports.org/ticket/23279 (when merged, please remove `adtpro` from the ticket)

#### Description
According to source files in [adtpro 1.1.9 (and later)](https://github.com/ADTPro/adtpro/blob/82c1216aae180d14b3e054f40bea463ff11124a8/org/adtpro/ADTPro.java), it is licensed under GPL v2 or later.

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
