### PR TITLE
websvn: fix license

### DIFF
--- a/www/websvn/Portfile
+++ b/www/websvn/Portfile
@@ -8,7 +8,7 @@ set file_id                 49056
 categories                  www
 platforms                   darwin
 maintainers                 {ryandesign @ryandesign} openmaintainer
-license                     GPL-2
+license                     GPL-2+
 supported_archs             noarch
 homepage                    https://websvnphp.github.io
 master_sites                http://websvn.tigris.org/files/documents/1380/${file_id}


### PR DESCRIPTION
See https://trac.macports.org/ticket/23279 (when merged, please remove `websvn` from the ticket)

#### Description

According to the [source files for websvn 2.3.3 (and later)](https://github.com/websvnphp/websvn/blob/03c9abb8d5) it is licensed under GPL v2 or later. 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
