### PR TITLE
py-isort: update to 4.3.13

### DIFF
--- a/python/py-isort/Portfile
+++ b/python/py-isort/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-isort
-version             4.3.12
+version             4.3.13
 revision            0
 categories-append   devel
 platforms           darwin
@@ -28,9 +28,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            isort-${version}
 
-checksums           rmd160  b9866f203e3bd19b4bc19c122a7af4da85410366 \
-                    sha256  89041186651a9a6159683098f337eed0994d9d94e006f891c6e8cbeb8e65f1c7 \
-                    size    69432
+checksums           rmd160  3f0c06a2fa20ff5ff66f9bdec6950617c467fa0d \
+                    sha256  abbb2684aa234d5eb8a67ef36d4aa62ea080d46c2eba36ad09e2990ae52e4305 \
+                    size    67729
 
 if {${name} ne ${subport}} {
     depends_lib-append \
@@ -48,6 +48,14 @@ if {${name} ne ${subport}} {
             ACKNOWLEDGEMENTS.md CHANGELOG.md \
             ${destroot}${docdir}
     }
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+    test.run        yes
+    # two tests fail, but only when run under MacPorts; skip them for now
+    test.cmd        py.test-${python.branch} -k \"not test_other_file_encodings and not test_new_lines_are_preserved\"
+    test.target     test_isort.py
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to latest version
- enable tests (two tests, using temporary files, fail under MacPorts, but pass otherwise; disable them for now.)
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
