### PR TITLE
New ports py-pytorch, py-mkl{-include}

### DIFF
--- a/python/py-mkl/Portfile
+++ b/python/py-mkl/Portfile
@@ -1,0 +1,90 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-mkl
+version             2019.0
+revision            0
+platforms           darwin
+supported_archs     noarch
+
+# https://software.intel.com/en-us/license/intel-simplified-software-license
+license             Restrictive/Distributable
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Math library for Intel and compatible processors
+long_description    ${description}
+
+extract.suffix      .whl
+extract.only
+
+python.versions     27 35 36 37
+
+# Intel only supports 10.12 and newer
+if { ${os.major} <= 15 } {
+    pre-fetch {
+        ui_error "${name} is not supported on this OSX release."
+        return -code error "Unsupported OSX version"
+    }
+}
+
+# add sub-ports for headers
+foreach _py ${python.versions} {
+    subport py${_py}-mkl-include { }
+}
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-pip
+
+    build { }
+
+    if {[string match "*-include" $subport]} {
+
+        homepage       https://pypi.org/project/mkl-include/
+        
+        master_sites   https://files.pythonhosted.org/packages/4f/49/c24113b33981a2c3e6915eb94f50c56ea61639963339e03eaed37787cc81/
+        distname       mkl_include-${version}-py2.py3-none-macosx_10_12_intel.macosx_10_12_x86_64
+        checksums      rmd160  097dd5bcbcc0a704e065cbdc629c7a10bf9e0b71 \
+                       sha256  dd9e2224dcdbede569c996f971e663f64f184a432ccb01f2dceca768a77cb2b4 \
+                       size    871122
+
+        depends_lib-append port:py${python.version}-mkl
+        
+    } else {
+
+        homepage       https://pypi.org/project/mkl/
+
+        master_sites   https://files.pythonhosted.org/packages/ac/1e/c713b011b90cd238023df1c0025130c40bc40870a46273d942e89114233c/
+        distname       mkl-${version}-py2.py3-none-macosx_10_12_intel.macosx_10_12_x86_64
+
+        checksums      rmd160  62011c74574b354c8996edfdd1d6b3d5e1aa2623 \
+                       sha256  23c8e8ba2cac703d8bc357d2bf10519e91dc4371e7dd1decf461f70db20b9783 \
+                       size    193800193
+
+        depends_lib-append port:tbb port:libomp
+        
+        post-destroot {
+            set PythonVersionWithDot [join [split ${python.version} ""] "."]
+            set py_lib_root ${prefix}/Library/Frameworks/Python.framework/Versions/${PythonVersionWithDot}/lib
+            foreach dlib [glob -directory ${destroot}${py_lib_root} *.dylib] {
+                system "install_name_tool -add_rpath ${prefix}/lib        ${dlib}"
+                system "install_name_tool -add_rpath ${prefix}/lib/libomp ${dlib}"
+            }
+        }
+
+    }
+
+    destroot.cmd  pip-${python.branch}
+    destroot.args          \
+        --no-cache-dir     \
+        --no-dependencies  \
+        --root ${destroot} \
+        ${distpath}/${distfiles}
+    destroot.post_args
+
+    livecheck.type      none
+}

--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -1,0 +1,105 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                                      1.0
+PortGroup           python                      1.0
+PortGroup           cxx11                       1.1
+PortGroup           github                      1.0
+PortGroup           mpi                         1.0
+PortGroup           compiler_blacklist_versions 1.0
+
+name                py-pytorch
+version             1.0.1
+revision            0
+github.setup        pytorch pytorch ${version} v
+
+fetch.type          git
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+platforms           darwin
+supported_archs     x86_64
+
+license             BSD
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Tensors and dynamic neural networks in Python with strong GPU acceleration
+long_description    ${description}
+
+homepage            https://pytorch.org/
+
+github.livecheck.regex  {([0-9.]+)}
+
+# Support python versions
+python.versions     27 35 36 37
+
+patch.pre_args      -p1
+
+mpi.setup           -gcc44 -gcc45 -clang33 -clang34 -clang37 -clang38 -clang39 -clang40 -gfortran -g95
+
+# Compiler selection
+compiler.blacklist-append *gcc* {clang < 800} macports-clang-3.3 macports-clang-3.4 \
+                          macports-clang-3.7 macports-clang-4.0 macports-clang-3.9
+compiler.whitelist clang macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
+
+variant mkl description {Enable Intel Math Kernel Library support} { }
+# enable MKL by default on 10.12 and newer
+if {${os.major} >= 16} {
+    default_variants-append +mkl
+}
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:cctools \
+        port:cmake \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:eigen3 \
+        port:gmp \
+        port:mpfr \
+        port:OpenBLAS \
+        port:opencv \
+        port:zmq \
+        port:zstd \
+        port:py${python.version}-cffi \
+        port:py${python.version}-gmpy \
+        port:py${python.version}-numpy \
+        port:py${python.version}-pybind11 \
+        port:py${python.version}-yaml
+    
+    if {${python.version} < 35} {
+        depends_lib-append \
+            port:py${python.version}-typing
+    }
+
+    set t_build_env "USE_OPENCV=ON USE_OPENMP=ON USE_CUDA=OFF USE_ZSTD=ON USE_ZMQ=ON CMAKE_LIBRARY_PATH=${prefix}:${prefix}/libomp LIBRARY_PATH=${prefix}:${prefix}/libomp"
+
+    set PythonVersionWithDot [join [split ${python.version} ""] "."]
+    set py_lib_root ${prefix}/Library/Frameworks/Python.framework/Versions/${PythonVersionWithDot}
+
+    # Use Intel Math kernel Library 
+    if {[variant_isset mkl]} {
+        patchfiles-append FindMKL-OMP.patch
+        pre-build {
+            # Hacks to get search paths into builds
+            reinplace "s|/opt/intel/mkl|${py_lib_root}|g"     cmake/Modules/FindMKL.cmake
+            reinplace "s|mklvers \"intel64\"|mklvers \"\"|g"  cmake/Modules/FindMKL.cmake
+            reinplace "s|MACPORTS_PREFIX|${prefix}|g"         cmake/Modules/FindMKL.cmake
+        }
+        depends_lib-append \
+            port:py${python.version}-mkl \
+            port:py${python.version}-mkl-include
+    }
+    
+    build.cmd    "${t_build_env} ${python.bin} setup.py"
+    destroot.cmd "${t_build_env} ${python.bin} setup.py install"
+
+    post-destroot {
+        set py_torch_root ${py_lib_root}/lib/python${PythonVersionWithDot}/site-packages/torch
+        system "install_name_tool -add_rpath ${py_torch_root}/lib ${destroot}${py_torch_root}/_C.cpython-${python.version}m-darwin.so"
+    }
+
+}

--- a/python/py-pytorch/files/FindMKL-OMP.patch
+++ b/python/py-pytorch/files/FindMKL-OMP.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/Modules/FindMKL.cmake b/cmake/Modules/FindMKL.cmake
+index 1b1423988..d7c359c53 100644
+--- a/cmake/Modules/FindMKL.cmake
++++ b/cmake/Modules/FindMKL.cmake
+@@ -102,6 +102,9 @@ IF (EXISTS ${INTEL_MKL_DIR})
+   ENDIF()
+ ENDIF()
+ 
++SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "MACPORTS_PREFIX/lib")
++SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "MACPORTS_PREFIX/lib/libomp")
++
+ # Try linking multiple libs
+ MACRO(CHECK_ALL_LIBRARIES LIBRARIES _name _list _flags)
+   # This macro checks for the existence of the combination of libraries given by _list.


### PR DESCRIPTION
#### Description

Adds three sets of new ports

py{XY}-pytorch - PyTorch machine learning package
py{XY}-mkl - Intel Math Kernel library (using PyPi builds}
py{XY}-mkl-include - Headers for Intel math Kernel library (using PyPi builds).

- [x] enhancement

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61 

macOS 10.13.6 17G5019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->