### PR TITLE
wxWidgets-3.0: add upstream patch for strings

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -8,6 +8,7 @@ PortGroup           wxWidgets       1.0
 
 github.setup        wxWidgets wxWidgets 3.0.4 v
 github.tarball_from releases
+revision            1
 
 name                wxWidgets-3.0
 # ugly workaround to allow some C++11-only applications to be built on < 10.9
@@ -32,7 +33,7 @@ if {${subport} eq ${name}} {
 } elseif {${subport} eq "wxPython-3.0"} {
     wxWidgets.use   wxPython-3.0
     version         3.0.2
-    revision        5
+    revision        6
 } elseif {${subport} eq "wxgtk-3.0"} {
     # with satisfactory Cocoa support there is no real need for GTK-based wxWidgets any more
     # wxgtk-3.0 is here mainly for testing purposes
@@ -83,7 +84,8 @@ depends_lib         port:jpeg \
 depends_run         port:wxWidgets-common \
                     port:wxWidgets_select
 
-patchfiles-append   patch-configure.diff
+patchfiles-append   patch-configure.diff \
+                    patch-upstream-strvararg.diff
 
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${patch.dir}/configure

--- a/graphics/wxWidgets-3.0/files/patch-upstream-strvararg.diff
+++ b/graphics/wxWidgets-3.0/files/patch-upstream-strvararg.diff
@@ -1,0 +1,52 @@
+https://trac.wxwidgets.org/ticket/18355
+https://github.com/wxWidgets/wxWidgets/pull/1252.diff
+
+From b5e3ac742101c20668c8f802f4f32474af2d5e5b Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Fri, 8 Mar 2019 16:13:00 +0100
+Subject: [PATCH] Add support for passing nullptr to wx pseudo-vararg functions
+
+Allow passing literal nullptr as an argument corresponding to "%p" in
+the format string.
+
+Closes #18355.
+---
+ include/wx/strvararg.h   | 6 ++++++
+ tests/strings/vararg.cpp | 7 +++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/include/wx/strvararg.h b/include/wx/strvararg.h
+index 57429045d4a..7d7afb58a7b 100644
+--- include/wx/strvararg.h
++++ include/wx/strvararg.h
+@@ -436,6 +436,12 @@ wxFORMAT_STRING_SPECIFIER(int*, wxFormatString::Arg_IntPtr | wxFormatString::Arg
+ wxFORMAT_STRING_SPECIFIER(short int*, wxFormatString::Arg_ShortIntPtr | wxFormatString::Arg_Pointer)
+ wxFORMAT_STRING_SPECIFIER(long int*, wxFormatString::Arg_LongIntPtr | wxFormatString::Arg_Pointer)
+ 
++// Support for nullptr is available since MSVS 2010, even though it doesn't
++// define __cplusplus as a C++11 compiler.
++#if __cplusplus >= 201103 || wxCHECK_VISUALC_VERSION(10)
++wxFORMAT_STRING_SPECIFIER(nullptr_t, wxFormatString::Arg_Pointer)
++#endif
++
+ #undef wxFORMAT_STRING_SPECIFIER
+ 
+ 
+diff --git a/tests/strings/vararg.cpp b/tests/strings/vararg.cpp
+index 14eaa88333e..413cb2e4c69 100644
+--- tests/strings/vararg.cpp
++++ tests/strings/vararg.cpp
+@@ -213,6 +213,13 @@ void VarArgTestCase::ArgsValidation()
+     wxString::Format("a string(%s,%s), ptr %p, int %i",
+                      wxString(), "foo", "char* as pointer", 1);
+ 
++#if __cplusplus >= 201103 || wxCHECK_VISUALC_VERSION(10)
++    // Unfortunately we can't check the result as different standard libraries
++    // implementations format it in different ways, so just check that it
++    // compiles.
++    wxString::Format("null pointer is %p", nullptr);
++#endif
++
+     // Microsoft has helpfully disabled support for "%n" in their CRT by
+     // default starting from VC8 and somehow even calling
+     // _set_printf_count_output() doesn't help here, so don't use "%n" at all


### PR DESCRIPTION
See: https://trac.wxwidgets.org/ticket/18355
See: https://github.com/wxWidgets/wxWidgets/pull/1251
See: https://github.com/macports/macports-ports/pull/3804

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Needed for 3.2 as well, but I plan to wait for a new release instead

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->