### PR TITLE
tkimg: update to 1.4.9

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -4,7 +4,7 @@ PortSystem            1.0
 PortGroup             active_variants 1.1
 
 name                  tkimg
-version               1.4.7
+version               1.4.9
 categories            graphics
 license               Tcl/Tk
 maintainers           {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -15,11 +15,12 @@ long_description      The \"Img\" package adds a lot of image formats to Tcl/Tk.
 platforms             darwin
 
 master_sites          sourceforge:tkimg/tkimg/[join [lrange [split ${version} .] 0 1] .]/tkimg%20${version}
-distname              Img-Source-${version}
+distname              Img-${version}-Source
+worksrcdir            Img-${version}
 
-checksums             rmd160  0a3cb000acb2488b540fe74a0b540e99a1390d92 \
-                      sha256  5e513e0913e1f36f6802abf60cf9b8bfd6810bcc4b5a27c340e53bb4d12ab2ee \
-                      size    7259144
+checksums             rmd160  6580f462a5729b1e3060c2b97603bf34427bdc42 \
+                      sha256  89aa029d9352de02c483857bc85b27af52f1b77907ee276047e13e894d1e3629 \
+                      size    7702460
 
 # ensure tkimg works when tk is installed +quartz
 patchfiles-append     patch-quartz.diff

--- a/graphics/tkimg/files/patch-quartz.diff
+++ b/graphics/tkimg/files/patch-quartz.diff
@@ -1,5 +1,5 @@
---- pixmap/pixmapUnix.c.orig	2017-12-30 09:09:00.000000000 -0700
-+++ pixmap/pixmapUnix.c	2018-11-11 21:31:49.000000000 -0700
+--- pixmap/pixmapUnix.c.orig	2014-12-27 15:05:29.000000000 -0600
++++ pixmap/pixmapUnix.c	2019-03-09 15:40:56.000000000 -0600
 @@ -13,11 +13,15 @@
  
  #include "pixmapInt.h"
@@ -18,8 +18,8 @@
  #endif
  
  typedef struct PixmapData {
---- window/window.c.orig	2017-12-30 09:09:03.000000000 -0700
-+++ window/window.c	2018-11-11 21:40:25.000000000 -0700
+--- window/window.c.orig	2018-09-14 08:53:49.000000000 -0500
++++ window/window.c	2019-03-09 15:32:57.000000000 -0600
 @@ -13,13 +13,14 @@
  
  #include "init.c"


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Note that the patch-quartz.diff file is not materially different; the distfile for 1.4.9 has files with CRLF line endings instead of LF as in 1.4.7. Not sure if there's a better way of handling this, or if it poses a problem for keeping in this repository.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
