### PR TITLE
GPXSee: update to 7.4

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.3
+github.setup        tumic0 GPXSee 7.4
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  99ed1c483d643bd41ed13afb59453d361e19c9d5 \
-                    sha256  7edbb97481b094975138c79dc88d80b29df111ce510f098c2530c0884f236f38 \
-                    size    4297267
+checksums           rmd160  a8ffdde5b9f3c0b2c95595ab3c99eaf1efff90bb \
+                    sha256  f6cabbd69956b3f01bc4de91a238e7ccd3ee7e945103e7ed6301d0de547ed604 \
+                    size    4301199
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.4

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for TwoNav RMaps.
>   * Fixed broken projection equations (multiple corner cases).
>   * Fixed IGC date handling issues.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
