### PR TITLE
itstool: update to 2.0.5

### DIFF
--- a/textproc/itstool/Portfile
+++ b/textproc/itstool/Portfile
@@ -3,12 +3,8 @@
 PortSystem          1.0
 
 name                itstool
-# reverted from version 2.0.3 to 2.0.2
-# 2.0.3 has severe memory usage/performance issues
-# 2.0.4 crashes due to improper libxml2 memory management issues
-# upstream looking to 2.0.5 for a (yet undetermined) fix
-version             2.0.2
-revision            3
+version             2.0.5
+revision            0
 epoch               1
 license             GPL-3+
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -26,8 +22,9 @@ master_sites        http://files.itstool.org/${name}
 
 use_bzip2           yes
 
-checksums           rmd160  04531d2a4a8c5fef3b77888cb267063af2cb2917 \
-                    sha256  bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a
+checksums           rmd160  e46f5697195741bc755794ccaacd7cbebfea8d3a \
+                    sha256  100506f8df62cca6225ec3e631a8237e9c04650c77495af4919ac6a100d4b308 \
+                    size    102751
 
 supported_archs     noarch
 installs_libs       no

--- a/textproc/itstool/files/patch-configure.diff
+++ b/textproc/itstool/files/patch-configure.diff
@@ -1,25 +1,24 @@
---- configure.orig	2014-02-26 10:38:45.000000000 -0800
-+++ configure	2014-02-26 10:38:53.000000000 -0800
+diff -Naur itstool-2.0.5-old/configure itstool-2.0.5/configure
+--- configure     2018-10-28 16:57:57.000000000 -0400
++++ configure     2019-03-11 10:34:01.280761580 -0400
 @@ -2466,9 +2466,9 @@
- 
- 
- 
+
+
+
 -  PYTHON_PREFIX='${prefix}'
 +  PYTHON_PREFIX=`$PYTHON -c 'import sys; print(sys.prefix);'`
- 
+
 -  PYTHON_EXEC_PREFIX='${exec_prefix}'
 +  PYTHON_EXEC_PREFIX=`$PYTHON -c 'import sys; print(sys.exec_prefix);'`
- 
- 
- 
-@@ -2600,8 +2600,8 @@
- 
+
+
+
+@@ -2600,7 +2600,7 @@
+
  py_module=libxml2
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for python module $py_module" >&5
 -$as_echo_n "checking for python module $py_module... " >&6; }
--echo "import $py_module" | python - &>/dev/null
 +$as_echo_n "checking for python module $py_module using $PYTHON... " >&6; }
-+echo "import $py_module" | $PYTHON - &>/dev/null
+ echo "import $py_module" | $PYTHON - &>/dev/null
  if test $? -ne 0; then
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
- $as_echo "not found" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5


### PR DESCRIPTION
#### Description
The upstream changelog says the big libxml2 memory leak is fixed.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
