### PR TITLE
packer: update to 1.3.5

### DIFF
--- a/sysutils/packer/Portfile
+++ b/sysutils/packer/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        hashicorp packer 1.3.4 v
+github.setup        hashicorp packer 1.3.5 v
 
 # NOTE: github.fetch is used as packer's Makefile has several lines that
 #       expect to be run from a git repo.
@@ -29,6 +29,7 @@ long_description    ${description} \
 homepage            https://www.packer.io
 
 use_configure       no
+installs_libs       no
 
 worksrcdir          ${distname}/src/github.com/hashicorp/packer
 
@@ -37,7 +38,8 @@ pre-build {
 }
 
 depends_build       port:go \
-                    port:govendor
+                    port:govendor \
+                    port:realpath
 
 build.env           GOPATH=${workpath}/${distname} \
                     XC_ARCH=amd64 \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
