### PR TITLE
coreutils: fix build on older OSX (e.g., 10.5 PPC)

### DIFF
--- a/sysutils/coreutils/Portfile
+++ b/sysutils/coreutils/Portfile
@@ -35,6 +35,10 @@ depends_lib \
     port:gmp \
     port:libiconv
 
+# fix build on older OSs (e.g., OSX 10.5); won't hurt newer ones
+patchfiles-append patch-fix-strtod.c.diff
+patch.pre_args -p1
+
 configure.args  --disable-silent-rules \
                 --program-prefix=g
 

--- a/sysutils/coreutils/files/patch-fix-strtod.c.diff
+++ b/sysutils/coreutils/files/patch-fix-strtod.c.diff
@@ -1,0 +1,13 @@
+diff --git a/lib/strtod.c b/lib/strtod.c
+index b9eaa51..90d1c63 100644
+--- a/lib/strtod.c
++++ b/lib/strtod.c
+@@ -302,7 +302,7 @@ compute_minus_zero (void)
+ }
+ # define minus_zero compute_minus_zero ()
+ #else
+-DOUBLE minus_zero = -0.0;
++static DOUBLE minus_zero = -0.0;
+ #endif
+ 
+ /* Convert NPTR to a DOUBLE.  If ENDPTR is not NULL, a pointer to the


### PR DESCRIPTION
#### Description

Fix coreutils 8.31_0 build on older OSX (e.g., 10.5 PPC). This patch won't hurt newer OS builds.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.5.8 9L31a
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809
-and-
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
