### PR TITLE
OpenBlas*: blacklist  non-thread_local compilers

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -22,6 +22,10 @@ archive_sites
 # be better to use the cxx11 1.1 PG, but it conflicts with the
 # compilers 1.0 PG & so just block compilers instead.
 compiler.blacklist-append cc {*gcc-3*} {*gcc-4.[0-7]} {clang < 800.0.38}
+platform darwin i386 {
+    compiler.blacklist-append {macports-clang-[3-4].*}
+    compiler.fallback-append macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+}
 
 subport OpenBLAS-devel {}
 if {[string first "-devel" $subport] > 0} {


### PR DESCRIPTION
These compilers don't support thread_local on all systems
Add some working fallback compilers

This appears to work correctly, but it's ugly. I can't believe this is what we need to do to get thread_local compatible compilers...I look forward to this being resolved in base someday.