### PR TITLE
update py-prompt_toolkit and dependents

### DIFF
--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli mycli 1.17.0 v
+github.setup        dbcli mycli 1.19.0 v
+revision            0
 
 categories          databases python
 maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -14,11 +15,11 @@ supported_archs     noarch
 description         A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting
 long_description    ${description}
 
-homepage            http://mycli.net
+homepage            https://mycli.net
 
-checksums           rmd160  60e893719fe8a4182bd05426966637889cf29fa2 \
-                    sha256  ed4ca1b595a5b0d319f9743277c34039d7ab5440d042e8bfa22304b89ee0d5f9 \
-                    size    276803
+checksums           rmd160  851d8f6fd561b2bd9e4afcc3010ee9faf312169e \
+                    sha256  b58f4618e7d7b4da50e91c85fc6b65c0a96e47af354c959ffe52484600ca7fba \
+                    size    263253
 
 variant python27 conflicts python34 python35 python36 python37 description "Use Python 2.7" {}
 variant python34 conflicts python27 python35 python36 python37 description "Use Python 3.4" {}
@@ -26,20 +27,27 @@ variant python35 conflicts python27 python34 python36 python37 description "Use 
 variant python36 conflicts python27 python34 python35 python37 description "Use Python 3.6" {}
 variant python37 conflicts python27 python34 python35 python36 description "Use Python 3.7" {}
 
-if {[variant_isset python34]} {
+if {[variant_isset python27]} {
+    python.default_version 27
+} elseif {[variant_isset python34]} {
     python.default_version 34
 } elseif {[variant_isset python35]} {
     python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
-} elseif {[variant_isset python37]} {
-    python.default_version 37
 } else {
-    default_variants +python27
-    python.default_version 27
+    default_variants +python37
+    python.default_version 37
 }
 
-depends_build       port:py${python.version}-setuptools
+if {[variant_isset python27] || [variant_isset python34]} {
+    github.setup    dbcli mycli 1.18.0 v
+    revision        0
+    checksums       rmd160  5f33f57a8ac34cc72f3ce7be25aaf8bacf9b774a \
+                    sha256  d049a6504cfd9dff273714de448119144b99b210c62ae50555c685997b47f5c7 \
+                    size    278345
+}
+
 depends_lib-append  port:py${python.version}-cli-helpers \
                     port:py${python.version}-click \
                     port:py${python.version}-configobj \
@@ -47,4 +55,5 @@ depends_lib-append  port:py${python.version}-cli-helpers \
                     port:py${python.version}-prompt_toolkit \
                     port:py${python.version}-pygments \
                     port:py${python.version}-pymysql \
+                    port:py${python.version}-setuptools \
                     port:py${python.version}-sqlparse

--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli pgcli 1.10.3 v
+github.setup        dbcli pgcli 2.0.2 v
+revision            0
 
 categories          databases python
 maintainers         {g5pw @g5pw} {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -14,11 +15,11 @@ supported_archs     noarch
 description         Postgres CLI with autocompletion and syntax highlighting
 long_description    ${description}
 
-homepage            http://pgcli.com
+homepage            https://pgcli.com
 
-checksums           rmd160  61fbaba17dd699f0fa0faf1a042a4525c7dead23 \
-                    sha256  75a5012a43462bf12d48baeb6bf25378dc117f9380af837112c3cf95fd945ee3 \
-                    size    428744
+checksums           rmd160  1d508c4b6232928b96e6f2961b76fc2d7d332e10 \
+                    sha256  e3264edfd37fce23cb8b007888e01b0eb2fe537d6938ce660e82fdc109d764b5 \
+                    size    432372
 
 variant python27 conflicts python34 python35 python36 python37 description "Use Python 2.7" {}
 variant python34 conflicts python27 python35 python36 python37 description "Use Python 3.4" {}
@@ -26,27 +27,43 @@ variant python35 conflicts python27 python34 python36 python37 description "Use 
 variant python36 conflicts python27 python34 python35 python37 description "Use Python 3.6" {}
 variant python37 conflicts python27 python34 python35 python36 description "Use Python 3.7" {}
 
-if {[variant_isset python34]} {
+if {[variant_isset python27]} {
+    python.default_version 27
+} elseif {[variant_isset python34]} {
     python.default_version 34
 } elseif {[variant_isset python35]} {
     python.default_version 35
 } elseif {[variant_isset python36]} {
     python.default_version 36
-} elseif {[variant_isset python37]} {
-    python.default_version 37
 } else {
-    default_variants +python27
-    python.default_version 27
+    default_variants +python37
+    python.default_version 37
 }
 
-depends_build       port:py${python.version}-setuptools
+if {[variant_isset python27] || [variant_isset python34]} {
+    github.setup    dbcli pgcli 1.11.0 v
+    revision        0
+    checksums       rmd160  d7631dd973be421e664db9b6089106297ebce6c6 \
+                    sha256  2c30dd068afdc8a0b15460d49b27962c55642154bb4cb4279e86b36d607c9590 \
+                    size    430226
+}
+
 depends_lib-append  port:py${python.version}-cli-helpers \
                     port:py${python.version}-click \
                     port:py${python.version}-configobj \
                     port:py${python.version}-humanize \
+                    port:py${python.version}-keyring \
                     port:py${python.version}-pgspecial \
                     port:py${python.version}-prompt_toolkit \
                     port:py${python.version}-psycopg2 \
                     port:py${python.version}-pygments \
+                    port:py${python.version}-setuptools \
                     port:py${python.version}-setproctitle \
                     port:py${python.version}-sqlparse
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} changelog.rst README.rst \
+            LICENSE.txt DEVELOP.rst AUTHORS ${destroot}${docdir}
+    }

--- a/net/http-prompt/Portfile
+++ b/net/http-prompt/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        eliangcs http-prompt 1.0.0 v
+revision            1
 
 maintainers         {lbschenkel @lbschenkel}
 categories          net
@@ -18,6 +19,10 @@ checksums           rmd160  14fcbea963f715df4edaedc5d2fbbb26ab15f617 \
                     sha256  63e25c04e30ae419f5353df229825633d4f6222a39f0406a5893bd306359cdd0 \
                     size    323848
 
+patchfiles          patch-cli.py.diff \
+                    patch-utils.py.diff \
+                    patch-requirements.txt.diff
+
 # It MUST match default_version of httpie
 python.default_version 36
 
@@ -26,7 +31,24 @@ depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-prompt_toolkit \
                     port:py${python.version}-pygments \
                     port:py${python.version}-requests \
+                    port:py${python.version}-setuptools \
                     port:py${python.version}-six \
                     port:httpie
 
 python.link_binaries_suffix
+
+depends_test-append port:py${python.version}-mock \
+                    port:py${python.version}-pexpect \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-pytest-cov
+test.run            yes
+test.cmd            py.test-${python.branch}
+test.target
+test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE \
+        ${destroot}${docdir}
+}

--- a/net/http-prompt/files/patch-cli.py.diff
+++ b/net/http-prompt/files/patch-cli.py.diff
@@ -1,0 +1,76 @@
+--- http_prompt/cli.py.orig	2019-03-11 10:35:47.000000000 -0400
++++ http_prompt/cli.py	2019-03-11 10:36:10.000000000 -0400
+@@ -9,11 +9,11 @@
+ 
+ from httpie.plugins import FormatterPlugin  # noqa, avoid cyclic import
+ from httpie.output.formatters.colors import Solarized256Style
+-from prompt_toolkit import prompt, AbortAction
++from prompt_toolkit import prompt
+ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+ from prompt_toolkit.history import FileHistory
+-from prompt_toolkit.layout.lexers import PygmentsLexer
+-from prompt_toolkit.styles.from_pygments import style_from_pygments
++from prompt_toolkit.lexers import PygmentsLexer
++from prompt_toolkit.styles.pygments import style_from_pygments_cls
+ from pygments.styles import get_style_by_name
+ from pygments.util import ClassNotFound
+ from six.moves.http_cookies import SimpleCookie
+@@ -48,7 +48,7 @@
+     cookie = SimpleCookie(base_value)
+     for k, v in cookies.items():
+         cookie[k] = v
+-    return str(cookie.output(header='', sep=';').lstrip())
++    return cookie.output(header='', sep=';').lstrip()
+ 
+ 
+ class ExecutionListener(object):
+@@ -89,7 +89,7 @@
+               callback=normalize_url)
+ @click.option('--env', help="Environment file to preload.",
+               type=click.Path(exists=True))
+-@click.argument('url', default='')
++@click.argument('url', default='http://localhost:8000')
+ @click.argument('http_options', nargs=-1, type=click.UNPROCESSED)
+ @click.version_option(message='%(version)s')
+ def cli(spec, env, url, http_options):
+@@ -119,8 +119,7 @@
+         finally:
+             f.close()
+ 
+-    if url:
+-        url = fix_incomplete_url(url)
++    url = fix_incomplete_url(url)
+     context = Context(url, spec=spec)
+ 
+     output_style = cfg.get('output_style')
+@@ -135,7 +134,7 @@
+         style_class = get_style_by_name(cfg['command_style'])
+     except ClassNotFound:
+         style_class = Solarized256Style
+-    style = style_from_pygments(style_class)
++    style = style_from_pygments_cls(style_class)
+ 
+     listener = ExecutionListener(cfg)
+ 
+@@ -145,8 +144,8 @@
+     else:
+         if env:
+             load_context(context, env)
+-            if url:
+-                # Overwrite the env url if not default
++            if url != 'http://localhost:8000':
++                # overwrite the env url if not default
+                 context.url = url
+ 
+         if http_options:
+@@ -159,7 +158,9 @@
+             text = prompt('%s> ' % context.url, completer=completer,
+                           lexer=lexer, style=style, history=history,
+                           auto_suggest=AutoSuggestFromHistory(),
+-                          on_abort=AbortAction.RETRY, vi_mode=cfg['vi'])
++                          vi_mode=cfg['vi'])
++        except KeyboardInterrupt:
++            continue  # Control-C pressed
+         except EOFError:
+             break  # Control-D pressed
+         else:

--- a/net/http-prompt/files/patch-requirements.txt.diff
+++ b/net/http-prompt/files/patch-requirements.txt.diff
@@ -1,0 +1,10 @@
+--- requirements.txt.orig	2019-03-11 10:39:41.000000000 -0400
++++ requirements.txt	2019-03-11 10:39:52.000000000 -0400
+@@ -1,6 +1,6 @@
+ click>=5.0
+ httpie>=0.9.2
+ parsimonious>=0.6.2
+-prompt-toolkit>=1.0.0,<2.0.0
++prompt-toolkit>=2.0.0
+ Pygments>=2.1.0
+ six>=1.10.0

--- a/net/http-prompt/files/patch-utils.py.diff
+++ b/net/http-prompt/files/patch-utils.py.diff
@@ -1,0 +1,11 @@
+--- http_prompt/utils.py.orig	2019-03-11 10:36:49.000000000 -0400
++++ http_prompt/utils.py	2019-03-11 10:36:38.000000000 -0400
+@@ -3,7 +3,7 @@
+ import math
+ import re
+ 
+-from prompt_toolkit.shortcuts import create_output
++from prompt_toolkit.output.defaults import create_output
+ from six.moves import range
+ 
+ 

--- a/python/py-ipython/Portfile
+++ b/python/py-ipython/Portfile
@@ -5,7 +5,8 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-github.setup        ipython ipython 6.5.0
+github.setup        ipython ipython 7.3.0
+revision            0
 name                py-ipython
 categories-append   devel science
 platforms           darwin
@@ -19,42 +20,49 @@ maintainers         {aronnax @lpsinger} {stromnov @stromnov} openmaintainer
 description         An enhanced interactive Python shell.
 long_description    ${description}
 
-distname            ${python.rootname}-${version}
-
-checksums           rmd160  881dc388232c80c009009a97cbb68e074d330b20 \
-                    sha256  419d54a7396f3e80a5784c2ff3bd8bbf40fee6d1a5cb989acf6a70e94453d413 \
-                    size    5629753
+checksums           rmd160  4e3c0caba1ea1aabd10c63b6a62d51d370e70342 \
+                    sha256  2331e00b8cdf37454ff680adbfccedb8b55e7e6acb66b59f2baaab9ece5fe041 \
+                    size    5661596
 
 if {${name} ne ${subport}} {
     set python_major [string range ${python.version} 0 end-1]
 
-    depends_lib-append  port:ipython_select \
-                        port:ipython${python_major}_select \
-                        port:py${python.version}-setuptools \
-                        port:py${python.version}-decorator \
-                        port:py${python.version}-pickleshare \
-                        port:py${python.version}-simplegeneric \
-                        port:py${python.version}-traitlets \
-                        port:py${python.version}-pexpect \
-                        port:py${python.version}-appnope \
-                        port:py${python.version}-prompt_toolkit \
-                        port:py${python.version}-pygments
+    depends_run-append  port:ipython_select \
+                        port:ipython${python_major}_select
 
-    if {${python.version} == 27} {
-        github.setup        ipython ipython 5.4.0
-        checksums           rmd160  4b8147deacc9dd15a5d544555eb82da6e00ed468 \
-                            sha256  9822ea6b60c29e65e9078e71e2a61972b3fbff91a1bdac3ea4a2d87b14b555b3
+    depends_lib-append  port:py${python.version}-appnope \
+                        port:py${python.version}-backcall \
+                        port:py${python.version}-decorator \
+                        port:py${python.version}-jedi \
+                        port:py${python.version}-pexpect \
+                        port:py${python.version}-pickleshare \
+                        port:py${python.version}-prompt_toolkit \
+                        port:py${python.version}-pygments \
+                        port:py${python.version}-setuptools \
+                        port:py${python.version}-traitlets
+
+    if {${python.version} eq 27} {
+        github.setup        ipython ipython 5.5.0
+        revision            0
+        checksums           rmd160  abef0575ceba023d141f10f4ec9896bf00737cdc \
+                            sha256  dcfe933fe097347765a626748df54bce34f46009386f15f50702332335c41131 \
+                            size    5528093
 
         depends_lib-append  port:py${python.version}-backports-shutil_get_terminal_size \
                             port:py${python.version}-pathlib2 \
-                            port:py${python.version}-gnureadline
-    } else {
-        depends_lib-append  port:py${python.version}-jedi \
-                            port:py${python.version}-backcall
+                            port:py${python.version}-simplegeneric
 
-        if {${python.version} == 34} {
-            depends_lib-append  port:py${python.version}-typing
-        }
+        depends_lib-delete  port:py${python.version}-backcall \
+                            port:py${python.version}-jedi
+    }
+
+    if {${python.version} eq 34} {
+        github.setup        ipython ipython 6.5.0
+        revision            0
+        checksums           rmd160  881dc388232c80c009009a97cbb68e074d330b20 \
+                            sha256  419d54a7396f3e80a5784c2ff3bd8bbf40fee6d1a5cb989acf6a70e94453d413 \
+                            size    5629753
+        depends_lib-append  port:py${python.version}-typing
     }
 
     variant parallel description "Support for parallel computing (deprecated variant)" {

--- a/python/py-jupyter_console/Portfile
+++ b/python/py-jupyter_console/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jupyter_console
-version             5.2.0
+version             6.0.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -18,20 +18,30 @@ maintainers         {stromnov @stromnov} openmaintainer
 description         Jupyter terminal console.
 long_description    ${description}
 
-homepage            http://jupyter.org
+homepage            https://jupyter.org
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
-distname            ${python.rootname}-${version}
-
-checksums           rmd160  5cf2f6363e89b378be96463dea0e9214fbdd708e \
-                    sha256  545dedd3aaaa355148093c5609f0229aeb121b4852995c2accfa64fe3e0e55cd
+checksums           rmd160  49e131bc49f75029856ef101883119e02f1951ea \
+                    sha256  308ce876354924fb6c540b41d5d6d08acfc946984bf0c97777c1ddcb42e0b2f5 \
+                    size    27780
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-jupyter_client \
+    if {${python.version} in "27 34"} {
+        version     5.2.0
+        revision    0
+        checksums   rmd160  5cf2f6363e89b378be96463dea0e9214fbdd708e \
+                    sha256  545dedd3aaaa355148093c5609f0229aeb121b4852995c2accfa64fe3e0e55cd \
+                    size    27063
+    }
+
+    distname            ${python.rootname}-${version}
+
+    depends_lib-append  port:py${python.version}-ipykernel \
                         port:py${python.version}-ipython \
-                        port:py${python.version}-ipykernel \
+                        port:py${python.version}-jupyter_client \
                         port:py${python.version}-prompt_toolkit \
-                        port:py${python.version}-pygments
+                        port:py${python.version}-pygments \
+                        port:py${python.version}-setuptools
 
     livecheck.type      none
 }

--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -4,8 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-prompt_toolkit
-version             1.0.15
-license             Permissive
+version             2.0.9
+revision            0
+license             BSD
 platforms           darwin
 supported_archs     noarch
 maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
@@ -16,18 +17,43 @@ python.versions     27 34 35 36 37
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
 
-checksums           rmd160  195e01e80e62e631f7c4b12d4f2cd5d4481a0752 \
-                    sha256  858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917 \
-                    size    243734
+checksums           rmd160  8399ff42d9cb70cbc1f73c6b375fc6bc7d508ca3 \
+                    sha256  2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1 \
+                    size    348321
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-    depends_lib-append      port:py${python.version}-wcwidth \
-                            port:py${python.version}-pygments \
-                            port:py${python.version}-six
+    if {${python.version} in "27 34"} {
+        version     1.0.15
+        revision    0
+        checksums   rmd160  195e01e80e62e631f7c4b12d4f2cd5d4481a0752 \
+                    sha256  858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917 \
+                    size    243734
+    }
+    distname        ${python.rootname}-${version}
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-six \
+                    port:py${python.version}-wcwidth
+
+    depends_test-append \
+                    port:py${python.version}-pytest
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE AUTHORS.rst \
+            README.rst CHANGELOG ${destroot}${docdir}
+        copy ${worksrcpath}/examples ${destroot}${docdir}/examples
+    }
+
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
As discussed in [Trac ticket 57933](https://trac.macports.org/ticket/57933) there are some upgrade-issue related to ```py-prompt_toolkit``` and its non-compatible v1.x and v2.x branches. The version 2.x branch was released in June 2018 and at some point we'll have to deal with this... This PR attempts to resolve the issues as follows (I have tried to take the comments in above-mentioned ticked into account).

- ```py-prompt_toolkit```: update to 2.09, and pin to 1.0.15 for PY27 and PY34; this is mainly dictated by ```py-ipython``` its dependency requirements, but in my opinion also works well for other ports.

Ports that depend on ```py-prompt_toolkit``` and their changes:
- ```mycli```: update to 1.19.0 (requires v2), pin to 1.18.0 for py27/py34 (latest version that requires v1)
@xeron: it might be worth considering to update to ```default_variants +python37```?
- ```pgcli```: update to 2.02 (requires v2), pin to 1.11.0 for py27/py34 (latest version that requires v1)
@g5pw @xeron: it might be worth considering to update to ```default_variants +python37```?
- ```xonsh```: nothing to do, does not specify version caps on py-prompt_toolkit and the tests (on the projects GitHub page) pass with newer versions
@Schamschula: the port builds fine, but I haven't tested anything else - could you check?
- ```topydo```: nothing to do, requires >= 0.53, builds fine with the latest and tests pass on the projects GitHub page
- ```http-prompt```: added patches to work with py-prompt_toolkit v2 (see PR on projects GitHub page). The patches were submitted by the author of py-prompt_toolkit to help in the transition to v2. 
The packages builds fine and only one tests fails, I don't know if that's important (the test-suite doesn't pass with the previous py-prompt_toolkit either).
@lbschenkel @g5pw: can you please take a look?
- ```py-ipython```: update to 7.3.0 (requires v2), pin to earlier versions for py27/py34 (require v1)
- ```py-jupyter_console```: update to 6.0.0 (requires v2), pin to 5.2.0 for py27/py34 (requires v1)




<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? Yes, where available
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
