### PR TITLE
libLASi: switch livecheck to generic sourceforge

### DIFF
--- a/print/libLASi/Portfile
+++ b/print/libLASi/Portfile
@@ -41,6 +41,4 @@ configure.ldflags-delete -L${prefix}/lib
 
 cmake.out_of_source     yes
 
-livecheck.type          regex
-livecheck.url           ${homepage}
-livecheck.regex         {New Release Announcement: libLASi-([0-9]+\.[0-9]+\.[0-9]+)}
+livecheck.distname      ${name}


### PR DESCRIPTION
#### Description
Fix the livecheck

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
