### PR TITLE
[WIP] itstool: update to version 2.0.5 for testing.

### DIFF
--- a/textproc/itstool/Portfile
+++ b/textproc/itstool/Portfile
@@ -3,12 +3,7 @@
 PortSystem          1.0
 
 name                itstool
-# reverted from version 2.0.3 to 2.0.2
-# 2.0.3 has severe memory usage/performance issues
-# 2.0.4 crashes due to improper libxml2 memory management issues
-# upstream looking to 2.0.5 for a (yet undetermined) fix
-version             2.0.2
-revision            3
+version             2.0.5
 epoch               1
 license             GPL-3+
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -26,19 +21,36 @@ master_sites        http://files.itstool.org/${name}
 
 use_bzip2           yes
 
-checksums           rmd160  04531d2a4a8c5fef3b77888cb267063af2cb2917 \
-                    sha256  bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a
+checksums           rmd160  e46f5697195741bc755794ccaacd7cbebfea8d3a \
+                    sha256  100506f8df62cca6225ec3e631a8237e9c04650c77495af4919ac6a100d4b308 \
+                    size    102751
 
 supported_archs     noarch
 installs_libs       no
 
 depends_build       port:gawk
 
-depends_lib         port:py27-libxml2
-
 patchfiles          patch-configure.diff
 
-configure.python    ${prefix}/bin/python2.7
+variant python27 conflicts python37 description {Use Python 2.7} {
+    configure.python \
+                    ${prefix}/bin/python2.7
+
+    depends_lib-append \
+                    port:py27-libxml2
+}
+
+variant python37 conflicts python27 description {Use Python 3.7} {
+    configure.python \
+                    ${prefix}/bin/python3.7
+    
+    depends_lib-append \
+                    port:py37-libxml2
+}
+
+if {![variant_isset python27] && ![variant_isset python37]} {
+    default_variants +python27
+}
 
 livecheck.type      regex
 livecheck.url       http://itstool.org/download/

--- a/textproc/itstool/files/patch-configure.diff
+++ b/textproc/itstool/files/patch-configure.diff
@@ -1,5 +1,5 @@
---- configure.orig	2014-02-26 10:38:45.000000000 -0800
-+++ configure	2014-02-26 10:38:53.000000000 -0800
+--- configure.orig	2018-10-28 13:57:57.000000000 -0700
++++ configure	2019-01-11 13:10:27.000000000 -0800
 @@ -2466,9 +2466,9 @@
  
  
@@ -12,14 +12,3 @@
  
  
  
-@@ -2600,8 +2600,8 @@
- 
- py_module=libxml2
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for python module $py_module" >&5
--$as_echo_n "checking for python module $py_module... " >&6; }
--echo "import $py_module" | python - &>/dev/null
-+$as_echo_n "checking for python module $py_module using $PYTHON... " >&6; }
-+echo "import $py_module" | $PYTHON - &>/dev/null
- if test $? -ne 0; then
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
- $as_echo "not found" >&6; }


### PR DESCRIPTION
Submitting this update as WIP to get wider testing using both python2 and python3. Currently only itstool 2.0.2 works with all ports that depend on it so need to hold up on merging this until the various issues have been resolved upstream.

See https://github.com/macports/macports-ports/pull/3839 for issues outstanding.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
