### PR TITLE
QtPBFImagePlugin: update to 1.3

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 1.2
+github.setup        tumic0 QtPBFImagePlugin 1.3
 categories          graphics
 platforms           darwin
 license             LGPL-3
@@ -13,9 +13,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  e7c856165f736dbd727d2b23e77a351adeb1aac8 \
-                    sha256  b3134181786aab74aeeed2790ea34f440f8de1a436eb2be09695a36f0e0be457 \
-                    size    194900
+checksums           rmd160  98ee141c2ea52c111fbd6e6fe3c59d4c07dfeae2 \
+                    sha256  a78d4d84467360f94e90cddb3f91ca2c51b7de22834a09ea2239298439930803 \
+                    size    195087
 
 configure.args-append \
                     PROTOBUF=${prefix} ZLIB=${prefix}


### PR DESCRIPTION
#### Description

QtPBFImagePlugin - Update to 1.3

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.0

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
