### PR TITLE
nethack: open maintainer; reduce main/subport redundancy

### DIFF
--- a/games/nethack/Portfile
+++ b/games/nethack/Portfile
@@ -7,7 +7,9 @@ version            3.6.1
 categories         games
 platforms          darwin
 license            Copyleft
-maintainers        @Nax
+maintainers        @Nax \
+                   {@jflude hotmail.com:justin_flude} \
+                   openmaintainer
 description        Classic dungeon adventure game.
 long_description   NetHack is a single-player, display-oriented Dungeons & \
     Dragons(tm)-like game, in development since 1987. It runs on a wide \
@@ -36,6 +38,10 @@ post-patch {
         reinplace "s|__PREFIX__|${prefix}|" \
             "${worksrcpath}/sys/unix/Makefile.doc" \
             "${worksrcpath}/sys/unix/hints/macosx10.10"
+    } else {
+        reinplace "s|__PREFIX__|${prefix}|" \
+            "${worksrcpath}/sys/unix/Makefile.doc" \
+            "${worksrcpath}/sys/unix/Makefile.top"
     }
 }
 
@@ -58,26 +64,28 @@ pre-destroot {
 destroot.target    all install manpages
 destroot.keepdirs  "${destroot}${prefix}/var/games/nethack/save/"
 
-post-destroot {
-    if {${subport} eq "nethack"} {
-        reinplace "s|${destroot}||" "${destroot}${prefix}/bin/nethack"
+# We want to avoid overwriting any existing game-state files.  So after
+# destroot we rename the new versions to something safe and after
+# activation only install them if old versions do not already exist.
+if {${subport} eq "nethack"} {
+    set state_files { logfile record sysconf }
+    set state_dir ${prefix}/var/games/nethack
+} else {
+    set state_files { logfile record }
+    set state_dir ${prefix}/share/nethackdir
+}
 
-        # Prevent existing preferences files being overwritten.
-        foreach f { logfile record sysconf } {
-            file rename ${destroot}${prefix}/var/games/nethack/${f} \
-                ${destroot}${prefix}/var/games/nethack/${f}.dist
-        }
+post-destroot {
+    reinplace "s|${destroot}||" "${destroot}${prefix}/bin/${subport}"
+    foreach f ${state_files} {
+        file rename ${destroot}${state_dir}/${f} ${destroot}${state_dir}/${f}.dist
     }
 }
 
 post-activate {
-    if {${subport} eq "nethack"} {
-        # Make initially-missing preferences files from earlier versions.
-        foreach f { logfile record sysconf } {
-            if {![file exists ${prefix}/var/games/nethack/${f}]} {
-                file copy ${prefix}/var/games/nethack/${f}.dist \
-                    ${prefix}/var/games/nethack/${f}
-            }
+    foreach f ${state_files} {
+        if {![file exists ${state_dir}/${f}]} {
+            file copy ${state_dir}/${f}.dist ${state_dir}/${f}
         }
     }
 }
@@ -113,12 +121,6 @@ subport nethack343 {
                         patch-sys__unix__Makefile.top.diff \
                         patch-win__tty__termcap.c.diff
 
-    post-patch {
-        reinplace "s|__PREFIX__|${prefix}|" \
-            "${worksrcpath}/sys/unix/Makefile.doc" \
-            "${worksrcpath}/sys/unix/Makefile.top"
-    }
-
     configure.dir       ${worksrcpath}/sys/unix
     configure.cmd       /bin/sh
     configure.pre_args  setup.sh
@@ -131,33 +133,13 @@ subport nethack343 {
     destroot.target     install manpages
     destroot.keepdirs   "${destroot}${prefix}/share/nethackdir/save/"
 
-    post-destroot {
-        reinplace "s|${destroot}||" "${destroot}${prefix}/bin/nethack343"
-
-        # Don't overwrite existing preference files
-        foreach f { logfile record } {
-            file rename ${destroot}${prefix}/share/nethackdir/${f} \
-                ${destroot}${prefix}/share/nethackdir/${f}.dist
-        }
-    }
-
-    post-activate {
-        # Make sure initial preference files exist
-        foreach f { logfile record } {
-            if {![file exists ${prefix}/share/nethackdir/${f}]} {
-                file copy ${prefix}/share/nethackdir/${f}.dist \
-                    ${prefix}/share/nethackdir/${f}
-            }
-        }
-    }
-
     variant autopickup_exceptions description \
-        { Automatically pick up things onto which you move } {
+        { Control which things to automatically pick up } {
         patchfiles-append patch-include__config.h.diff
     }
 
     variant menucolors description \
-        { Allows the user to define in what color menus are shown } {
+        { Allow customization of the color of menus } {
         patch_sites-append http://bilious.alt.org/~paxed/nethack
         patchfiles-append nh343-menucolor.diff
         checksums-append nh343-menucolor.diff md5 ade00f9cb51f1b0140557d329d56844c


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
