### PR TITLE
websocketpp: new port

### DIFF
--- a/net/websocketpp/Portfile
+++ b/net/websocketpp/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+github.setup        zaphoyd websocketpp 0.8.1
+categories          net devel
+platforms           darwin
+supported_archs     i386 x86_64
+license             BSD
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         C++ websocket client/server library
+
+long_description    WebSocket++ is a header only C++ library that implements \
+                    RFC6455 The WebSocket Protocol.
+
+checksums           rmd160  9cf3a0752de27fb802454df4d9732d2050c41f1d \
+                    sha256  d5e2d3c9091dc3db660aaa1fb0c0c10dec95dabbeb42066d9bddc78491606e10 \
+                    size    699502
+
+depends_lib-append  port:asio \
+                    port:openssl \
+                    port:zlib


### PR DESCRIPTION
#### Description
Required for updating `cpprestsdk` (see #3866).

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?