### PR TITLE
cpprestsdk: update to 2.10.10

### DIFF
--- a/www/cpprestsdk/Portfile
+++ b/www/cpprestsdk/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
-github.setup        Microsoft cpprestsdk 2.10.6 v
-revision            1
+github.setup        Microsoft cpprestsdk 2.10.10 v
+revision            0
 categories          www devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -19,17 +19,21 @@ long_description    The C++ REST SDK is a Microsoft project for cloud-based \
                     client-server communication in native code using a modern \
                     asynchronous C++ API design.
 
-checksums           rmd160  c1b27cd17c3d1c6f89f9592db3ae0d5c16051a7d \
-                    sha256  884098022b09bf490dfdac6218824b5de8bcbef77da843445d9c98d4105bb5ab \
-                    size    2069638
+checksums           rmd160  f859bee62977046c1cab6a99010ea54e15a717d7 \
+                    sha256  b3d3bdba6301dede05c6bb2acc5e3c1e00950926b91aeec1709180011bd59069 \
+                    size    1755589
 
 depends_lib-append  port:boost \
                     port:libiconv \
-                    path:lib/libssl.dylib:openssl
+                    path:lib/libssl.dylib:openssl \
+                    port:websocketpp
 
 configure.args-append -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF
 
 variant tests description {build tests.} {
+    post-extract {
+        system -W ${worksrcpath} "echo 'enable_testing()' >> CMakeLists.txt"
+    }
     configure.args-replace      -DBUILD_TESTS=OFF -DBUILD_TESTS=ON
     configure.post_args-append  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
     test.run                    yes


### PR DESCRIPTION
#### Description
Fixes: https://trac.macports.org/ticket/57999
Depends on #3865.
`post-extract` can be removed when Microsoft/cpprestsdk#1064 is merged.

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?