### PR TITLE
crystal: update to 0.27.2

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 0.27.0
+github.setup        crystal-lang crystal 0.27.2
 revision            0
 categories          lang
 platforms           darwin
@@ -38,16 +38,17 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-${build_arch}${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  9a3eed38c62b8a8d293f0fbf32f1fe84b8654261 \
-                    sha256  1608026ab08dfab002e98631fb56845cff2a280db578177ab010456c2a26794c \
-                    size    2026765 \
+                    rmd160  a235fe9128e09cda28bfc96957ede3833b9f2633 \
+                    sha256  2be4039d912dc1150b81624c078af256c98fc45ab3ee0e7761e35c7842503e42 \
+                    size    2061826 \
                     ${name}-${cr_full_ver}-${os.platform}-${build_arch}${extract.suffix} \
-                    rmd160  a82381f5c48d20fadf5f8a7387bfac4c04bf39a5 \
-                    sha256  f34bb10357ce5a31ed37066750ee35443ed8cf5fc3f37d3490b984a4bfb1ee51 \
-                    size    15280881
+                    rmd160  87aa8d75d973c87f5785103f7dc07672d88ccc68 \
+                    sha256  2fcd11a3c3d12176004c13aa90d8ca15acde7d1ffa9a82cbaadcd526984a8691 \
+                    size    15340333
 
 patchfiles          patch-compiler.diff patch-readline.diff \
-                    patch-crypto.diff patch-ssl.diff patch-xml.diff
+                    patch-crypto.diff patch-ssl.diff patch-xml.diff \
+                    patch-xml-reader.diff ; # Remove on next release
 
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     pre-fetch {

--- a/lang/crystal/files/patch-xml-reader.diff
+++ b/lang/crystal/files/patch-xml-reader.diff
@@ -1,0 +1,10 @@
+--- src/xml/reader.cr.orig	2019-03-16 02:39:46.000000000 +0400
++++ src/xml/reader.cr	2019-03-16 02:40:23.000000000 +0400
+@@ -129,6 +129,7 @@
+ 
+   # Returns the XML for the node and its content including subtrees.
+   def read_outer_xml
++    return "" if node_type.none?
+     xml = LibXML.xmlTextReaderReadOuterXml(@reader)
+     xml ? String.new(xml) : ""
+   end


### PR DESCRIPTION
#### Description
Temporary patch is necessary as some tests fail due to an issue with `libxml2` (see crystal-lang/crystal#7476).

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?