### PR TITLE
Add new py-spaCy port (+ new dependencies)

### DIFF
--- a/python/py-blis/Portfile
+++ b/python/py-blis/Portfile
@@ -1,0 +1,61 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                                      1.0
+PortGroup           python                      1.0
+PortGroup           cxx11                       1.1
+PortGroup           github                      1.0
+PortGroup           compiler_blacklist_versions 1.0
+
+name                py-blis
+version             0.3.0
+revision            0
+github.setup        explosion cython-blis ${version} v
+
+checksums           rmd160  2eb5c8a0e13a8b8fb2095ba9ace21236c130a956 \
+                    sha256  6331325269afd959c57c093bf1c9f02eb6be28cbcacc9279d6de4436464cc90f \
+                    size    1663871
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Fast matrix-multiplication as a self-contained Python library
+long_description    ${description}
+
+# Support python versions
+python.versions     35 36 37
+
+# Compiler selection
+compiler.blacklist-append *gcc* {clang < 900} macports-clang-3.3 macports-clang-3.4 \
+                          macports-clang-3.7 macports-clang-4.0 macports-clang-3.9
+compiler.whitelist clang macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
+
+# Pass selected compiler to BLIS
+build.env-append    BLIS_COMPILER=${configure.cc}
+destroot.env-append BLIS_COMPILER=${configure.cc}
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:py${python.version}-cython \
+        port:py${python.version}-numpy
+
+    depends_test-append \
+        port:py${python.version}-pytest \
+        port:py${python.version}-hypothesis
+
+    post-extract {
+        # Set cython version
+        set PythonVersionWithDot [join [split ${python.version} ""] "."]
+        reinplace "s|\'cython\'|\'cython-${PythonVersionWithDot}\'|g" ${worksrcpath}/bin/cythonize.py
+    }
+
+    livecheck.type none 
+
+}

--- a/python/py-cymem/Portfile
+++ b/python/py-cymem/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                           1.0
+PortGroup           python           1.0
+PortGroup           github           1.0
+
+name                py-cymem
+version             2.0.2
+revision            0
+github.setup        explosion cymem ${version} v
+
+checksums           rmd160  9b3bc82d8c696504e6935491b0c75ed599d9b647 \
+                    sha256  4413934f014db60571ee70c86774e9bd8d1ff872641f15e53f6331d4c59065f9 \
+                    size    9882
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Cython memory pool for RAII-style memory management
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools \
+        port:py${python.version}-wheel
+
+    depends_lib-append \
+        port:py${python.version}-cython
+
+    depends_test-append \
+        port:py${python.version}-pytest
+
+    post-extract {
+        # Fix hard-coded dep ...
+        reinplace "s|0.33.0|0.33.2|g" ${worksrcpath}/setup.py
+    }
+
+    livecheck.type none 
+
+}

--- a/python/py-murmurhash/Portfile
+++ b/python/py-murmurhash/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                           1.0
+PortGroup           python           1.0
+PortGroup           github           1.0
+
+name                py-murmurhash
+version             1.0.2
+revision            0
+github.setup        explosion murmurhash ${version} v
+
+checksums           rmd160  e1d5a50c401728b57f0aab1b620c3e884136bfda \
+                    sha256  41a38de2da50b53479536e733d5802a6e49b59b13cec461a87632a310afe5d7b \
+                    size    15129
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Cython bindings for MurmurHash2
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools \
+        port:py${python.version}-wheel
+
+    depends_lib-append \
+        port:py${python.version}-cython
+
+    depends_test-append \
+        port:py${python.version}-pytest
+
+    post-extract {
+        # Fix hard-coded dep ...
+        reinplace "s|0.33.0|0.33.2|g" ${worksrcpath}/setup.py
+    }
+    
+    livecheck.type none
+    
+}

--- a/python/py-plac/Portfile
+++ b/python/py-plac/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                           1.0
+PortGroup           python           1.0
+PortGroup           github           1.0
+
+name                py-plac
+version             1.0.0
+revision            0
+github.setup        micheles plac ${version} plac-
+
+checksums           rmd160  2a5cc1594701dbb7310662f623cb39cf9acc4fb2 \
+                    sha256  f6a7633468b58f9dcb5c96bf771661f879b7b73ba9734c7aff2994a35766de9e \
+                    size    151859
+
+platforms           darwin
+supported_archs     noarch
+
+license             BSD
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Plac: Parsing the Command Line the Easy Way
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    livecheck.type none 
+
+}

--- a/python/py-preshed/Portfile
+++ b/python/py-preshed/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                         1.0
+PortGroup           python         1.0
+PortGroup           github         1.0
+
+name                py-preshed
+version             2.0.1
+revision            0
+github.setup        explosion preshed ${version} v
+
+checksums           rmd160  564efcef997496964bfa086acd46e1cc73ee4320 \
+                    sha256  f1e2a0eee837e04f196b6513e7acf2db8849283a5c419ff5e4d02d1079113663 \
+                    size    13707
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Cython hash tables that assume keys are pre-hashed
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools \
+        port:py${python.version}-wheel
+
+    depends_lib-append \
+        port:py${python.version}-cython \
+        port:py${python.version}-cymem
+
+    depends_test-append \
+        port:py${python.version}-pytest
+
+    post-extract {
+        # Fix hard-coded dep ...
+        reinplace "s|0.33.0|0.33.2|g" ${worksrcpath}/setup.py
+    }
+
+    livecheck.type none 
+
+}

--- a/python/py-spaCy-models/Portfile
+++ b/python/py-spaCy-models/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                         1.0
+PortGroup           python         1.0
+
+name                py-spaCy-models
+version             2.1.0a7
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Models for the spaCy Natural Language Processing (NLP) library
+long_description    ${description}
+
+homepage            https://spacy.io
+
+# Support python versions
+python.versions     35 36 37
+
+patchfiles
+distfiles
+build {}
+
+if {${name} ne ${subport}} {
+
+    depends_lib-append \
+        port:py${python.version}-spaCy
+    
+    destroot.cmd "${python.bin} -m spacy download en"
+    destroot.args " "
+    destroot.pre_args " "
+
+    livecheck.type none 
+
+}

--- a/python/py-spaCy/Portfile
+++ b/python/py-spaCy/Portfile
@@ -1,0 +1,82 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                                      1.0
+PortGroup           python                      1.0
+PortGroup           cxx11                       1.1
+PortGroup           github                      1.0
+PortGroup           mpi                         1.0
+PortGroup           compiler_blacklist_versions 1.0
+
+name                py-spaCy
+version             2.1.0a13
+revision            0
+github.setup        explosion spaCy ${version} v
+
+checksums           rmd160  0c59088115a90f5590eee9cccc6b1bed3805f51d \
+                    sha256  74aef9a26c7e22988a1590a9f6fe14f66504742c0e096aa9873370f31dcb17e9 \
+                    size    27225747
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Industrial-strength Natural Language Processing (NLP) with Python and Cython
+long_description    ${description}
+
+homepage            https://spacy.io
+
+# Support python versions
+python.versions     35 36 37
+
+mpi.setup           -gcc44 -gcc45 -clang33 -clang34 -clang37 -clang38 -clang39 -clang40 -gfortran -g95
+
+# Compiler selection
+compiler.blacklist-append *gcc* {clang < 900} macports-clang-3.3 macports-clang-3.4 \
+                          macports-clang-3.7 macports-clang-4.0 macports-clang-3.9
+compiler.whitelist clang macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
+
+if {${name} ne ${subport}} {
+
+    set PythonVersionWithDot [join [split ${python.version} ""] "."]
+
+    depends_build-append \
+        port:cctools \
+        port:py${python.version}-setuptools \
+        port:py${python.version}-wheel
+
+    depends_lib-append \
+        port:py${python.version}-pip \
+        port:py${python.version}-cython \
+        port:py${python.version}-mmh3 \
+        port:py${python.version}-numpy \
+        port:py${python.version}-cymem \
+        port:py${python.version}-preshed \
+        port:py${python.version}-thinc \
+        port:py${python.version}-requests \
+        port:py${python.version}-blis \
+        port:py${python.version}-wasabi \
+        port:py${python.version}-plac \
+        port:py${python.version}-srsly \
+        port:py${python.version}-jsonschema \
+        port:py${python.version}-murmurhash
+
+    depends_test-append \
+        port:py${python.version}-pytest \
+        port:py${python.version}-regex \
+        port:py${python.version}-mock \
+        port:py${python.version}-flake8
+    
+    post-extract {
+        reinplace "s|\"cython\"|\"cython-${PythonVersionWithDot}\"|g" ${worksrcpath}/bin/cythonize.py
+        reinplace "s|python|${python.bin}|g" bin/spacy
+        reinplace "s|python \-m|${python.bin} \-m|g" spacy/cli/validate.py
+    }
+    
+    build.cmd    "${python.bin} setup.py build_ext --inplace"
+
+    livecheck.type none 
+
+}

--- a/python/py-srsly/Portfile
+++ b/python/py-srsly/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                           1.0
+PortGroup           python           1.0
+PortGroup           github           1.0
+
+name                py-srsly
+version             0.0.5
+revision            0
+github.setup        explosion srsly ${version} v
+
+checksums           rmd160  f9eba8646d9fffc805c9469ce2c72b7bd7011d04 \
+                    sha256  f24a72e25fd1d3484a97a87002faaa80fa8c7a3ec2b0a38910bb70e8972defa2 \
+                    size    238156
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         Modern high-performance serialization utilities for Python
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools 
+
+    depends_lib-append \
+        port:py${python.version}-cython \
+        port:py${python.version}-numpy 
+
+    depends_test-append \
+        port:py${python.version}-pytest \
+        port:py${python.version}-mock \
+        port:py${python.version}-tz
+
+    livecheck.type none 
+
+}

--- a/python/py-thinc/Portfile
+++ b/python/py-thinc/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                                      1.0
+PortGroup           python                      1.0
+PortGroup           cxx11                       1.1
+PortGroup           github                      1.0
+PortGroup           compiler_blacklist_versions 1.0
+
+name                py-thinc
+version             7.0.3
+revision            0
+github.setup        explosion thinc ${version} v
+
+checksums           rmd160  9b44e80fd2a7ce2ccab0c98b27e879dcc6ffa147 \
+                    sha256  58615763d6af89b19fdcbde91ac94574d1e9eac9e48a4b1ca720f42391534c64 \
+                    size    232776
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         spaCy's Machine Learning library for NLP in Python
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+# Compiler selection
+compiler.blacklist-append *gcc* {clang < 900} macports-clang-3.3 macports-clang-3.4 \
+                          macports-clang-3.7 macports-clang-4.0 macports-clang-3.9
+compiler.whitelist clang macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    depends_lib-append \
+        port:py${python.version}-cython \
+        port:py${python.version}-cymem \
+        port:py${python.version}-murmurhash \
+        port:py${python.version}-numpy \
+        port:py${python.version}-tqdm \
+        port:py${python.version}-blis \
+        port:py${python.version}-plac \
+        port:py${python.version}-srsly \
+        port:py${python.version}-wasabi \
+        port:py${python.version}-mock \
+        port:py${python.version}-preshed
+
+    depends_test-append \
+        port:py${python.version}-hypothesis \
+        port:py${python.version}-flake8 
+        
+    post-extract {
+        # Set cython version
+        set PythonVersionWithDot [join [split ${python.version} ""] "."]
+        reinplace "s|\'cython\'|\'cython-${PythonVersionWithDot}\'|g" ${worksrcpath}/bin/cythonize.py
+    }
+
+    livecheck.type none 
+
+}

--- a/python/py-torchtext/Portfile
+++ b/python/py-torchtext/Portfile
@@ -37,6 +37,12 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
         port:py${python.version}-nltk
+
+    if {${python.version} > 30} {
+        depends_lib-append \
+            port:py${python.version}-spaCy \
+            port:py${python.version}-spaCy-models
+    }
     
     build.cmd    "${python.bin} setup.py"
     destroot.cmd "${python.bin} setup.py install"

--- a/python/py-wasabi/Portfile
+++ b/python/py-wasabi/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                           1.0
+PortGroup           python           1.0
+PortGroup           github           1.0
+
+name                py-wasabi
+version             0.1.3
+revision            0
+github.setup        ines wasabi ${version} v
+
+checksums           rmd160  6d996c999013babcd105743cfd82b9c5f4e95069 \
+                    sha256  de33d4d3754f62bf96c9b01df463a89cf5354defd22ce811ff0aaec246f3388f \
+                    size    15125
+
+platforms           darwin
+supported_archs     x86_64
+
+license             MIT
+
+maintainers         {jonesc @cjones051073} openmaintainer
+
+description         A lightweight console printing and formatting toolkit
+long_description    ${description}
+
+# Support python versions
+python.versions     27 35 36 37
+
+if {${name} ne ${subport}} {
+
+    depends_build-append \
+        port:py${python.version}-setuptools
+
+    livecheck.type none 
+
+}


### PR DESCRIPTION
#### Description

A bunch of new ports to add py-spaCy.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.14.3 18D109
Xcode 10.1 10B61 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->