### PR TITLE
py-pytest-runner: update to 4.4

### DIFF
--- a/python/py-pytest-runner/Portfile
+++ b/python/py-pytest-runner/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-runner
-version             4.2
+version             4.4
+revision            0
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -20,15 +21,16 @@ homepage            https://github.com/pytest-dev/pytest-runner
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  594dd82bf0ee027ebbdebde75f8056e985577499 \
-                    sha256  d23f117be39919f00dd91bffeb4f15e031ec797501b717a245e377aee0f577be \
-                    size    11947
+checksums           rmd160  fb011c07f52722e4bf05c808ceb7526c88203b97 \
+                    sha256  00ad6cd754ce55b01b868a6d00b77161e4d2006b3918bde882376a0a884d0df4 \
+                    size    11936
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools \
-                            port:py${python.version}-setuptools_scm
+    depends_build-append    port:py${python.version}-setuptools_scm
+
+    depends_lib-append      port:py${python.version}-setuptools
 
     livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to latest version
- setuptools is a runtime dependency

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
