### PR TITLE
newsboat: update to version 2.14.1

### DIFF
--- a/net/newsboat/Portfile
+++ b/net/newsboat/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           cxx11 1.1
+PortGroup           cargo_fetch 1.0
 
 name                newsboat
-version             2.13
+version             2.14.1
 categories          net www
 platforms           darwin
 license             MIT
@@ -17,12 +18,381 @@ master_sites        https://newsboat.org/releases/${version}/
 
 use_xz              yes
 
-checksums           rmd160  3c6d62fef4221bc6aecb9685f1530ed074454f38 \
-                    sha256  c73613b4f08c875bae2c4e7828e67291e7599e9cabed528089f8378f520b335e \
-                    size 460076
+cargo.crates        aho-corasick 0.6.9 1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
+                    argon2rs 0.2.5 3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392 \
+                    arrayvec 0.4.9 d18513977c2d8261c448511c5c53dc66b26dfccbc3d4446672dea1e71a7d8a26 \
+                    autocfg 0.1.1 4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727 \
+                    backtrace 0.3.13 b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5 \
+                    backtrace-sys 0.1.26 3fcce89e5ad5c8949caa9434501f7b55415b3e7ad5270cb88c75a8d35e8f1279 \
+                    bitflags 1.0.4 228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
+                    blake2-rfc 0.2.18 5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400 \
+                    cc 1.0.26 389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02 \
+                    cfg-if 0.1.6 082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
+                    chrono 0.4.6 45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878 \
+                    cloudabi 0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+                    constant_time_eq 0.1.3 8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e \
+                    dirs 1.0.4 88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a \
+                    failure 0.1.3 6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7 \
+                    failure_derive 0.1.3 64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596 \
+                    fuchsia-zircon 0.3.3 2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+                    fuchsia-zircon-sys 0.3.3 3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+                    idna 0.1.5 38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
+                    lazy_static 1.2.0 a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
+                    libc 0.2.45 2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74 \
+                    lock_api 0.1.5 62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
+                    matches 0.1.8 7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+                    memchr 2.1.2 db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9 \
+                    nodrop 0.1.13 2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
+                    num-integer 0.1.39 e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea \
+                    num-traits 0.2.6 0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1 \
+                    once_cell 0.1.6 d7ce3535d54560c937c1652ba4a0da66bfc63e0f8e07bed127483afb6e5ee925 \
+                    parking_lot 0.6.4 f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
+                    parking_lot_core 0.3.1 ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c \
+                    percent-encoding 1.0.1 31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
+                    proc-macro2 0.4.24 77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09 \
+                    quote 0.6.10 53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c \
+                    rand 0.4.3 8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
+                    rand 0.5.5 e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
+                    rand 0.6.1 ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a \
+                    rand_chacha 0.1.0 771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a \
+                    rand_core 0.2.2 1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372 \
+                    rand_core 0.3.0 0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db \
+                    rand_hc 0.1.0 7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+                    rand_isaac 0.1.1 ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+                    rand_pcg 0.1.1 086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05 \
+                    rand_xorshift 0.1.0 effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3 \
+                    redox_syscall 0.1.44 a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70 \
+                    redox_users 0.2.0 214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26 \
+                    regex 1.1.0 37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
+                    regex-syntax 0.6.4 4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1 \
+                    remove_dir_all 0.5.1 3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
+                    rustc-demangle 0.1.11 01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7 \
+                    rustc_version 0.2.3 138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+                    scoped_threadpool 0.1.9 1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
+                    scopeguard 0.3.3 94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
+                    semver 0.9.0 1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+                    semver-parser 0.7.0 388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+                    smallvec 0.6.7 b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db \
+                    syn 0.15.23 9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc \
+                    synstructure 0.10.1 73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015 \
+                    tempfile 3.0.5 7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2 \
+                    thread_local 0.3.6 c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+                    time 0.1.41 847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c \
+                    ucd-util 0.1.3 535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
+                    unicode-bidi 0.3.4 49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+                    unicode-normalization 0.1.7 6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25 \
+                    unicode-width 0.1.5 882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+                    unicode-xid 0.1.0 fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+                    unreachable 1.0.0 382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+                    url 1.7.2 dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
+                    utf8-ranges 1.0.2 796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+                    version_check 0.1.5 914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+                    void 1.0.2 6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+                    winapi 0.3.6 92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
+                    winapi-i686-pc-windows-gnu 0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+                    winapi-x86_64-pc-windows-gnu 0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+
+checksums           ${name}-${version}.tar.xz \
+                    rmd160  76f09fdc7ba7b9032fa50b395eb6cce9c7486c8c \
+                    sha256  4bd0d3b1901a3fc7e0ef73b800587c28181a57b175c36b547dbd84636330df66 \
+                    size    500096 \
+                    aho-corasick-0.6.9.crate \
+                    rmd160  142faa94cfdadb1f547c9aca2409e8f869b6044f \
+                    sha256  1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e \
+                    size    25979 \
+                    argon2rs-0.2.5.crate \
+                    rmd160  50d84e37d2513e8fa2787f642327ac88a825b10e \
+                    sha256  3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392 \
+                    size    353096 \
+                    arrayvec-0.4.9.crate \
+                    rmd160  04a4323c49c6e19124c6a7938d6e687e5c3bcc37 \
+                    sha256  d18513977c2d8261c448511c5c53dc66b26dfccbc3d4446672dea1e71a7d8a26 \
+                    size    26103 \
+                    autocfg-0.1.1.crate \
+                    rmd160  035241c8c510e551f7232115701e65eaa7c061e2 \
+                    sha256  4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727 \
+                    size    10044 \
+                    backtrace-0.3.13.crate \
+                    rmd160  a732c613b1d4f99711de81dae33f17b6409d7764 \
+                    sha256  b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5 \
+                    size    34101 \
+                    backtrace-sys-0.1.26.crate \
+                    rmd160  af70a032f299c02ce314c2be724b6ff7bf53467b \
+                    sha256  3fcce89e5ad5c8949caa9434501f7b55415b3e7ad5270cb88c75a8d35e8f1279 \
+                    size    522529 \
+                    bitflags-1.0.4.crate \
+                    rmd160  fd720dba692f079a1c6662e43677533bb68654de \
+                    sha256  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
+                    size    15282 \
+                    blake2-rfc-0.2.18.crate \
+                    rmd160  9c0e4ee7978a071709a9ab1e92dc585f70e582d8 \
+                    sha256  5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400 \
+                    size    15676 \
+                    cc-1.0.26.crate \
+                    rmd160  a7512bdbfd8a58ea5cb4273b0754d871db3798a2 \
+                    sha256  389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02 \
+                    size    42350 \
+                    cfg-if-0.1.6.crate \
+                    rmd160  f190c1846549b3ad88559ae471cf2828c0bf44d1 \
+                    sha256  082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4 \
+                    size    7411 \
+                    chrono-0.4.6.crate \
+                    rmd160  9ddf038c956cb3db217fcd375fa159a03cb7b610 \
+                    sha256  45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878 \
+                    size    133108 \
+                    cloudabi-0.0.3.crate \
+                    rmd160  4da7ab080c1d18e5881dbcb419d250d0c38387eb \
+                    sha256  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+                    size    22156 \
+                    constant_time_eq-0.1.3.crate \
+                    rmd160  42322b052eba5c2311f41bdd60f98d385b981eac \
+                    sha256  8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e \
+                    size    1279 \
+                    dirs-1.0.4.crate \
+                    rmd160  46232082ab3e3600b562fb8c1add2c96aa5d5c29 \
+                    sha256  88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a \
+                    size    12844 \
+                    failure-0.1.3.crate \
+                    rmd160  0e17e145e6045d1dc9aa0b7ffac8ae2bf0a07630 \
+                    sha256  6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7 \
+                    size    34107 \
+                    failure_derive-0.1.3.crate \
+                    rmd160  487996ef3aea5b083af10f7613655600888089e6 \
+                    sha256  64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596 \
+                    size    4349 \
+                    fuchsia-zircon-0.3.3.crate \
+                    rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
+                    sha256  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
+                    size    22565 \
+                    fuchsia-zircon-sys-0.3.3.crate \
+                    rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
+                    sha256  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
+                    size    7191 \
+                    idna-0.1.5.crate \
+                    rmd160  e4049ab9ac2f8338e23c55d1f948c55a7f265d02 \
+                    sha256  38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
+                    size    258735 \
+                    lazy_static-1.2.0.crate \
+                    rmd160  92005f698356b188b35ae897b821137e61642966 \
+                    sha256  a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1 \
+                    size    10840 \
+                    libc-0.2.45.crate \
+                    rmd160  c17367aca854ffad6538751f8a0a00f6d3442416 \
+                    sha256  2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74 \
+                    size    349425 \
+                    lock_api-0.1.5.crate \
+                    rmd160  ba1a2e7fc818e0cdef3386da54a0041444173327 \
+                    sha256  62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
+                    size    16967 \
+                    matches-0.1.8.crate \
+                    rmd160  dc8239e015b64fbc488e1ea9ff74aad38f872a72 \
+                    sha256  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+                    size    2216 \
+                    memchr-2.1.2.crate \
+                    rmd160  1973ab2a3624060a2aa1990ccc9b8e4a5b7988df \
+                    sha256  db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9 \
+                    size    19520 \
+                    nodrop-0.1.13.crate \
+                    rmd160  6478a3dead0c72da1d32615205d0c2f4ab17734a \
+                    sha256  2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
+                    size    7508 \
+                    num-integer-0.1.39.crate \
+                    rmd160  a72bc9c1474befe5ad6ff0e427d2c09cdf736bb2 \
+                    sha256  e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea \
+                    size    17881 \
+                    num-traits-0.2.6.crate \
+                    rmd160  b9711ea18adbc559a892b0741877f5a5a840e3e8 \
+                    sha256  0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1 \
+                    size    39923 \
+                    once_cell-0.1.6.crate \
+                    rmd160  031a78c61b481fc6342427b6745673657e46a844 \
+                    sha256  d7ce3535d54560c937c1652ba4a0da66bfc63e0f8e07bed127483afb6e5ee925 \
+                    size    12432 \
+                    parking_lot-0.6.4.crate \
+                    rmd160  90c4e6cec322cb5cbbdeb7755c1fcdbfb0c22625 \
+                    sha256  f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
+                    size    31890 \
+                    parking_lot_core-0.3.1.crate \
+                    rmd160  4f36cfbdd51c74d67574835a5feb7fb16decaff3 \
+                    sha256  ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c \
+                    size    26635 \
+                    percent-encoding-1.0.1.crate \
+                    rmd160  68898d3983e831ac02ae8d440a5c6f5a8e395695 \
+                    sha256  31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
+                    size    10057 \
+                    proc-macro2-0.4.24.crate \
+                    rmd160  bbd92a79ca663073f20126fdabdc0edd386d0557 \
+                    sha256  77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09 \
+                    size    30970 \
+                    quote-0.6.10.crate \
+                    rmd160  baf3e1f9cce4dd4e92a8ae20c4b5ce8ed768b63f \
+                    sha256  53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c \
+                    size    15795 \
+                    rand-0.4.3.crate \
+                    rmd160  0911fc63ee17323176b7806d7ed6db412b32ac0f \
+                    sha256  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
+                    size    76094 \
+                    rand-0.5.5.crate \
+                    rmd160  09a484f5c5e3501d87ec80eb4be990fcb421b9a9 \
+                    sha256  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
+                    size    137359 \
+                    rand-0.6.1.crate \
+                    rmd160  bc44e065c78ffa042de1bf9e12284ec14f1dc9f5 \
+                    sha256  ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a \
+                    size    126613 \
+                    rand_chacha-0.1.0.crate \
+                    rmd160  9498af8a4982ffb828ad321616558f8e31ec5c43 \
+                    sha256  771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a \
+                    size    11637 \
+                    rand_core-0.2.2.crate \
+                    rmd160  333621510560ad7e8e982e5d6ef1dd5d2b932afb \
+                    sha256  1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372 \
+                    size    15450 \
+                    rand_core-0.3.0.crate \
+                    rmd160  a19a998a918f95fcd70748ddd120089a022deda5 \
+                    sha256  0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db \
+                    size    20581 \
+                    rand_hc-0.1.0.crate \
+                    rmd160  067ca62839fb5cde9dc018dc0c95db5b6eb3387b \
+                    sha256  7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+                    size    11644 \
+                    rand_isaac-0.1.1.crate \
+                    rmd160  5d0f0a1a2b0385cd7901ceeda695d31cfacd0cac \
+                    sha256  ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+                    size    16020 \
+                    rand_pcg-0.1.1.crate \
+                    rmd160  533f5f25ebbaa1a055a09242d0b79246d8dd4933 \
+                    sha256  086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05 \
+                    size    10881 \
+                    rand_xorshift-0.1.0.crate \
+                    rmd160  73d49641dd7df6353bd3dcdf00afa56de5f58010 \
+                    sha256  effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3 \
+                    size    9194 \
+                    redox_syscall-0.1.44.crate \
+                    rmd160  6f095223ff38aacfd3e0d7cad2ee344409901300 \
+                    sha256  a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70 \
+                    size    15254 \
+                    redox_users-0.2.0.crate \
+                    rmd160  4480a564575eefcc3e4bc80a09ed88a80f0a5362 \
+                    sha256  214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26 \
+                    size    11104 \
+                    regex-1.1.0.crate \
+                    rmd160  30c1df865aa99c31b45fcb92df7c2d0454d4f481 \
+                    sha256  37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f \
+                    size    241219 \
+                    regex-syntax-0.6.4.crate \
+                    rmd160  732c501a0998ae07b9e9387c0ef95ad4ff80bbc3 \
+                    sha256  4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1 \
+                    size    272048 \
+                    remove_dir_all-0.5.1.crate \
+                    rmd160  13b7dcf0ae8c4100d53134d45c32539b7a4debfb \
+                    sha256  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
+                    size    8726 \
+                    rustc-demangle-0.1.11.crate \
+                    rmd160  05d7b2b197b90dcce9159866a78f387a4a125dbe \
+                    sha256  01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7 \
+                    size    11579 \
+                    rustc_version-0.2.3.crate \
+                    rmd160  6ca6aa5c736a1f88dd7579eb78d097ec40663173 \
+                    sha256  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
+                    size    10210 \
+                    scoped_threadpool-0.1.9.crate \
+                    rmd160  64a6e9903a469630a2c664fbfece56a6d4add650 \
+                    sha256  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
+                    size    7800 \
+                    scopeguard-0.3.3.crate \
+                    rmd160  e77508e3d64bc39c22ac5c87f8937906d160019e \
+                    sha256  94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
+                    size    9605 \
+                    semver-0.9.0.crate \
+                    rmd160  f3ba6d2359a3690d316a22586db785538b0e09ac \
+                    sha256  1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
+                    size    17344 \
+                    semver-parser-0.7.0.crate \
+                    rmd160  63f826b792b17493186d587b9887efd93121294b \
+                    sha256  388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
+                    size    10268 \
+                    smallvec-0.6.7.crate \
+                    rmd160  5d41c043dd309a5529c38e38d66e54d18e250d84 \
+                    sha256  b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db \
+                    size    21450 \
+                    syn-0.15.23.crate \
+                    rmd160  c1b6a1478ccf857727cf522d3b89b3385e936376 \
+                    sha256  9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc \
+                    size    145369 \
+                    synstructure-0.10.1.crate \
+                    rmd160  93582be7ce86406df4aeafce645bae173e7bec8c \
+                    sha256  73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015 \
+                    size    17836 \
+                    tempfile-3.0.5.crate \
+                    rmd160  508e325878dc220f9b09aca8145d6a329bc5d553 \
+                    sha256  7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2 \
+                    size    23272 \
+                    thread_local-0.3.6.crate \
+                    rmd160  58db38e54f31dc4c247aae31770f73047b17a7db \
+                    sha256  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+                    size    12388 \
+                    time-0.1.41.crate \
+                    rmd160  b10dddebb7bc21556f278d9e79a0f7d366b9f269 \
+                    sha256  847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c \
+                    size    29991 \
+                    ucd-util-0.1.3.crate \
+                    rmd160  c9eeb795a73b8facbf7679e3877689eb2551fb90 \
+                    sha256  535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
+                    size    25897 \
+                    unicode-bidi-0.3.4.crate \
+                    rmd160  7c16a80cb62bef8cc6d73eb6126d496b46dbad1d \
+                    sha256  49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
+                    size    32228 \
+                    unicode-normalization-0.1.7.crate \
+                    rmd160  4cbee8c9b2979aa0aa93f5a222fd0b72c46e97c6 \
+                    sha256  6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25 \
+                    size    330545 \
+                    unicode-width-0.1.5.crate \
+                    rmd160  360df9e831a6e20931c240d13747f3711dc568d9 \
+                    sha256  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+                    size    15761 \
+                    unicode-xid-0.1.0.crate \
+                    rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
+                    sha256  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+                    size    16000 \
+                    unreachable-1.0.0.crate \
+                    rmd160  00c79ce6e523b3b09978db8766e3110a637c23ec \
+                    sha256  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
+                    size    6355 \
+                    url-1.7.2.crate \
+                    rmd160  c46442b7903a874b0556861845d5121bfc3b5397 \
+                    sha256  dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
+                    size    68597 \
+                    utf8-ranges-1.0.2.crate \
+                    rmd160  472c5b94c5ca826c8788d2e6629b713a9df70fd6 \
+                    sha256  796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+                    size    8510 \
+                    version_check-0.1.5.crate \
+                    rmd160  0806190559062dc843ecf13393f6c1319367eac1 \
+                    sha256  914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
+                    size    8173 \
+                    void-1.0.2.crate \
+                    rmd160  5d76f91beb625f5b645c156ca45ee5138e984e80 \
+                    sha256  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
+                    size    2356 \
+                    winapi-0.3.6.crate \
+                    rmd160  549ef0ff7cd1a0f2aabf915ae603ed2c3c920ab6 \
+                    sha256  92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
+                    size    1029391 \
+                    winapi-i686-pc-windows-gnu-0.4.0.crate \
+                    rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
+                    sha256  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+                    size    2918815 \
+                    winapi-x86_64-pc-windows-gnu-0.4.0.crate \
+                    rmd160  300417853d251d91cadb9650992a6aa98248619f \
+                    sha256  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+                    size    2947998
 
 depends_build       port:asciidoc \
                     port:docbook-xsl-nons \
+                    port:rust \
+                    port:cargo \
                     port:pkgconfig
 
 depends_lib         port:curl \

--- a/net/newsboat/files/patch-config.sh.diff
+++ b/net/newsboat/files/patch-config.sh.diff
@@ -1,11 +1,11 @@
 --- config.sh
 +++ config.sh
-@@ -105,7 +105,7 @@ check_pkg "stfl" || fail "stfl"
+@@ -106,7 +106,7 @@
  ( check_pkg "json" "" 0.11 || check_pkg "json-c" "" 0.11 ) || fail "json-c"
  
  if [ `uname -s` = "Darwin" ]; then
 -	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"
-+	check_pkg "ncursesw" || fail "ncursesw"
- elif [ `uname -s` != "OpenBSD" ]; then
- 	check_pkg "ncursesw" || \
- 	check_custom "ncursesw5" "ncursesw5-config" || \
++        check_pkg "ncursesw" || fail "ncursesw"
+     # rand crate needs Security framework, and rustc doesn't (can't) link it
+     # into libnewsboat.a
+     echo 'LDFLAGS+=-framework Security' >> config.mk


### PR DESCRIPTION
* update to version 2.14.1
* add cargo and rust dependencies
* use cargo_fetch PortGroup

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
