### PR TITLE
Add php 7.3 support for php-xdebug

### DIFF
--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -12,7 +12,7 @@ license                 Xdebug-1.01
 homepage                https://xdebug.org
 master_sites            ${homepage}/files/
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
 php.extensions.zend     xdebug
 
 if {[vercmp ${php.branch} 7.1] >= 0} {

--- a/php/php-xdebug/Portfile
+++ b/php/php-xdebug/Portfile
@@ -15,7 +15,12 @@ master_sites            ${homepage}/files/
 php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2
 php.extensions.zend     xdebug
 
-if {[vercmp ${php.branch} 7.0] >= 0} {
+if {[vercmp ${php.branch} 7.1] >= 0} {
+    version             2.7.0
+    revision            0
+    checksums           sha256  e896da91ce0373f5fd8f4ca392c68da8593932ad51b2ec5eb3ee032b50d4b2d6 \
+                        size    230326
+} elseif {[vercmp ${php.branch} 7.0] >= 0} {
     version             2.6.1
     revision            0
     checksums           rmd160  961b2d6abdd8d235f9d30e93cdcd25ddcdacd083 \


### PR DESCRIPTION
#### Description

Add php 7.3 support for php-xdebug

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.x
php 7.3
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
