### PR TITLE
python37: add lookahead assertion to livecheck re

### DIFF
--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -197,4 +197,4 @@ variant optimizations description {Compile with LTO and PGO. Build time greatly 
 
 livecheck.type      regex
 livecheck.url       ${homepage}downloads/source/
-livecheck.regex     Python (${branch}\[.0-9\]+)
+livecheck.regex     Python (${branch}\[.0-9\]+)(?!rc)


### PR DESCRIPTION
Don't match on release candidate (rc) versions

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
