### PR TITLE
py-argcomplete: new port

### DIFF
--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-argcomplete
+version             1.9.4
+platforms           darwin
+license             Apache-2
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Bash tab completion for argparse
+long_description    ${description}
+
+homepage            https://argcomplete.readthedocs.io
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  13866fe7923744e726c843da97a807616296d2d2 \
+                    sha256  06c8a54ffaa6bfc9006314498742ec8843601206a3b94212f82657673662ecf1 \
+                    size    47471
+
+python.versions     27 37
+
+if {${name} ne ${subport}} {
+    depends_build   port:py${python.version}-setuptools
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
Need this to port [2ndquadrant-it/barman](https://github.com/2ndquadrant-it/barman).

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?