### PR TITLE
php-mysql-xdevapi: Adding new Pecl extension MySQL X DevAPI for PHP

### DIFF
--- a/php/php-mysql-xdevapi/Portfile
+++ b/php/php-mysql-xdevapi/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               php 1.1
+
+name                    php-mysql-xdevapi
+set cap_name            mysql_xdevapi
+categories-append       net devel
+platforms               darwin freebsd openbsd
+maintainers             nomaintainer
+license                 PHP-3.01
+categories              php devel
+
+homepage                https://dev.mysql.com/doc/x-devapi-userguide/en
+
+php.branches            7.1 7.2 7.3
+php.pecl                yes
+
+
+version                 8.0.15
+checksums               rmd160  563c690c4005e031db9905242d186043c82036d8 \
+                        sha256  ebafba923ec3a2f9a1cce7ba3c855338053a8ebf47f47c8fd66b6391029d8eed \
+                        size    443751
+
+distname                ${cap_name}-${version}
+
+description             MySQL X DevAPI for PHP
+
+long_description        The X DevAPI is the new common API for MySQL Connectors built on the X Protocol introduced in MySQL 5.7.12.
+
+depends_build-append    port:boost
+depends_lib-append      port:protobuf3-cpp
+
+configure.args          --with-boost=${prefix}/include


### PR DESCRIPTION
#### Description
MySQL X DevAPI for PHP 
Here is how test it
```bash
php -r '$session = \mysql_xdevapi\getSession("mysqlx://root:123123qa@127.0.0.1"); print_r($session->getSchemas());'
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac 58210](https://trac.macports.org/ticket/58210#ticket) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
