### PR TITLE
SoapySDRPlay: new port

### DIFF
--- a/science/SoapySDRPlay/Portfile
+++ b/science/SoapySDRPlay/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+name                SoapySDRPlay
+platforms           darwin macosx
+categories          science
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR module for SDRPlay
+long_description    ${description}
+
+github.setup        pothosware SoapySDRPlay 0.2.0 soapy-sdrplay-
+checksums           rmd160  d1ffd21319d7ffe5604ab6e4ff433da31e88eb3d \
+                    sha256  58ba22649564c403215ef568e106b5f2ac5a690845718ddd029960bbbb95a88c \
+                    size    13566
+revision            0
+
+depends_lib-append \
+    port:SoapySDR \
+    port:SDRplay
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
#### Description

Soapy SDR module for SDRPlay

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->