### PR TITLE
CubicSDR: new port

### DIFF
--- a/science/CubicSDR/Portfile
+++ b/science/CubicSDR/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+PortGroup           github 1.0
+PortGroup           wxWidgets 1.0
+
+name                CubicSDR
+categories          science comms
+platforms           darwin macosx
+license             GPL-2
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+description         Cross-Platform Software-Defined Radio Application
+long_description    CubicSDR is the software portion of Software Defined \
+    Radio. By Using hardware that converts RF spectrum into a digital \
+    stream we are able to build complex radios to do many types of \
+    functions in software instead of traditional hardwre.
+homepage            https://www.cubicsdr.com
+
+github.setup        cjcliffe CubicSDR c27e1e65140f5968ad0df65ce25a6e94580517d2
+version             20190319
+checksums           rmd160  41baeb9d6bbd2bbc576ba1d314e6247e8171862c \
+                    sha256  b925133b86a47fdf1437c81befbbd18d7730c1e778be593128cfc9672f271097 \
+                    size    36014378
+revision            0
+
+wxWidgets.use       wxWidgets-3.2
+
+depends_lib-append \
+    port:liquid-dsp \
+    port:${wxWidgets.port} \
+    port:SoapySDR
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DwxWidgets_CONFIG_EXECUTABLE=${wxWidgets.wxconfig}
+
+variant hamlib description {Support hamlib for radio control functions} {
+    depends_lib-append      port:hamlib
+    configure.args-append   -DUSE_HAMLIB=1
+}
+
+variant bundle description {Enable the optional macOS bundle of CubicSDR} {
+    configure.args-append   -DBUNDLE_APP=1 \
+        -DCPACK_BINARY_DRAGNDROP=0
+
+    # avoid cpack
+    destroot {}
+
+    post-destroot {
+        xinstall -d -m 0755 ${destroot}${applications_dir}
+        copy ${workpath}/build/x64/CubicSDR.app ${destroot}${applications_dir}
+    }
+}
+
+default_variants-append +bundle
+
+# from documentation
+if {${os.platform} eq "darwin" && ${os.major} < 13} {
+    pre-fetch {
+        ui_error "${subport} @${version} requires OS X 10.9 or newer"
+        return -code error "unsupported Mac OS X version"
+    }
+}


### PR DESCRIPTION
#### Description

CubicSDR is a Cross-Platform Software-Defined Radio Application

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->