### PR TITLE
redis: update to 5.0.4

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                redis
-version             5.0.3
+version             5.0.4
 categories          databases
 platforms           darwin
 license             BSD
@@ -17,9 +17,9 @@ long_description    ${description}
 homepage            https://redis.io/
 master_sites        http://download.redis.io/releases/
 
-checksums           rmd160  676d1db2d5e606047a8ed6a0ffdccbcea3aa89bc \
-                    sha256  e290b4ddf817b26254a74d5d564095b11f9cd20d8f165459efa53eb63cd93e02 \
-                    size    1959445
+checksums           rmd160  9b483e4b08553b075d037d2014714b7b77429339 \
+                    sha256  3ce9ceff5a23f60913e1573f6dfcd4aa53b42d4a2789e28fa53ec2bd28c987dd \
+                    size    1966337
 
 patchfiles          patch-redis.conf.diff
 


### PR DESCRIPTION
#### Description
Upstream release notes: https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
