### PR TITLE
openjdk8: add subport openjdk12-openj9

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -61,6 +61,15 @@ subport openjdk11-openj9-large-heap {
     set openj9_version 0.12.1
 }
 
+subport openjdk12-openj9 {
+    version      12
+    revision     0
+
+    set build    33
+    set major    12
+    set openj9_version 0.13.0
+}
+
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -197,6 +206,23 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads. \
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+} elseif {${subport} eq "openjdk12-openj9"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${major}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+
+    checksums    rmd160  2ccbe2f0daef752c884e5a0ceb1d2fb88e23d3c5 \
+                 sha256  f5ea6c011b1b064e2604830a804519417cd8178b0feaaa23a145cf8a76990db1 \
+                 size    197143869
+
+    worksrcdir   jdk-${version}+${build}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads.
 }
 
 use_configure    no


### PR DESCRIPTION
#### Description

Add subport `openjdk12-openj9` based on AdoptOpenJDK 12 with Eclipse OpenJ9 VM.

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?