### PR TITLE
Update httpie, use Python 3.7

### DIFF
--- a/net/http-prompt/Portfile
+++ b/net/http-prompt/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        eliangcs http-prompt 1.0.0 v
-revision            1
+revision            2
 
 maintainers         {lbschenkel @lbschenkel}
 categories          net
@@ -24,7 +24,7 @@ patchfiles          patch-cli.py.diff \
                     patch-requirements.txt.diff
 
 # It MUST match default_version of httpie
-python.default_version 36
+python.default_version 37
 
 depends_lib-append  port:py${python.version}-click \
                     port:py${python.version}-parsimonious \

--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -20,7 +20,7 @@ platforms           darwin
 license             BSD
 homepage            http://httpie.org
 
-python.default_version      36
+python.default_version      37
 
 depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-pygments

--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jakubroztocil httpie 0.9.9
-revision            1
+github.setup        jakubroztocil httpie 1.0.2
 
 maintainers         {g5pw @g5pw} openmaintainer
 categories          net
@@ -26,8 +25,8 @@ python.default_version      36
 depends_lib-append  port:py${python.version}-requests \
                     port:py${python.version}-pygments
 
-checksums           rmd160  0eb2a3eaea84b170b530f22aedb6d5c5aa074b80 \
-                    sha256  5fd18496ff2ae460b701515b024a798b49ffe095edc52d4b535311b44b1628b3 \
-                    size    268665
+checksums           rmd160  65f7547a0f0e0d743e97c947fa397074f3f237e0 \
+                    sha256  0365f45af4e759593f0eb7ef335d3211029c4dbd4c739364dc9677d49b5eb1d0 \
+                    size    765206
 
 python.link_binaries_suffix

--- a/python/py-parsimonious/Portfile
+++ b/python/py-parsimonious/Portfile
@@ -12,7 +12,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         nomaintainer
 


### PR DESCRIPTION
As discussed on https://github.com/macports/macports-ports/pull/3845#issuecomment-472067142, now that the original PR has been merged I have updated `httpie` to the latest version and bumped Python to 3.7.

@g5pw