### PR TITLE
php4: remove duplicate revision line

### DIFF
--- a/lang/php4/Portfile
+++ b/lang/php4/Portfile
@@ -5,8 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    php4
 version                 4.4.9
-revision                1
-revision                19
+revision                20
 set major               [lindex [split ${version} .] 0]
 set my_name             php${major}
 dist_subdir             ${my_name}


### PR DESCRIPTION
#### Description

Noticed this when I'm working on OpenSSL 1.1 migration https://github.com/macports/macports-ports/pull/3822

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
