### PR TITLE
ntfs-3g: Fix CVE-2019-9755

### DIFF
--- a/fuse/ntfs-3g/Portfile
+++ b/fuse/ntfs-3g/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                ntfs-3g
 version             2017.3.23
+revision            1
 categories          fuse
 platforms           darwin
 maintainers         nomaintainer
@@ -41,7 +42,8 @@ universal_variant   no
 # Use default PKG_CONFIG_PATH to avoid picking up a FUSE installation
 # in /usr/local (see #30537)
 patchfiles          patch-configure.diff \
-                    libntfs-3g_Makefile.in.patch
+                    libntfs-3g_Makefile.in.patch \
+                    patch-CVE-2019-9755.diff
 
 configure.args      --exec-prefix=${prefix} --with-fuse=external
 # do not try to use this function in macOS 10.13 to avoid compilation error

--- a/fuse/ntfs-3g/files/patch-CVE-2019-9755.diff
+++ b/fuse/ntfs-3g/files/patch-CVE-2019-9755.diff
@@ -1,0 +1,63 @@
+From 85c1634a26faa572d3c558d4cf8aaaca5202d4e9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jean-Pierre=20Andr=C3=A9?= <jean-pierre.andre@wanadoo.fr>
+Date: Wed, 19 Dec 2018 15:57:50 +0100
+Subject: [PATCH] Fixed reporting an error when failed to build the mountpoint
+
+The size check was inefficient because getcwd() uses an unsigned int
+argument.
+---
+ src/lowntfs-3g.c | 6 +++++-
+ src/ntfs-3g.c    | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git src/lowntfs-3g.c src/lowntfs-3g.c
+index 993867f..0660439 100644
+--- src/lowntfs-3g.c
++++ src/lowntfs-3g.c
+@@ -4411,7 +4411,8 @@ int main(int argc, char *argv[])
+ 	else {
+ 		ctx->abs_mnt_point = (char*)ntfs_malloc(PATH_MAX);
+ 		if (ctx->abs_mnt_point) {
+-			if (getcwd(ctx->abs_mnt_point,
++			if ((strlen(opts.mnt_point) < PATH_MAX)
++			    && getcwd(ctx->abs_mnt_point,
+ 				     PATH_MAX - strlen(opts.mnt_point) - 1)) {
+ 				strcat(ctx->abs_mnt_point, "/");
+ 				strcat(ctx->abs_mnt_point, opts.mnt_point);
+@@ -4419,6 +4420,9 @@ int main(int argc, char *argv[])
+ 			/* Solaris also wants the absolute mount point */
+ 				opts.mnt_point = ctx->abs_mnt_point;
+ #endif /* defined(__sun) && defined (__SVR4) */
++			} else {
++				free(ctx->abs_mnt_point);
++				ctx->abs_mnt_point = (char*)NULL;
+ 			}
+ 		}
+ 	}
+diff --git src/ntfs-3g.c src/ntfs-3g.c
+index 6ce89fe..4e0912a 100644
+--- src/ntfs-3g.c
++++ src/ntfs-3g.c
+@@ -4148,7 +4148,8 @@ int main(int argc, char *argv[])
+ 	else {
+ 		ctx->abs_mnt_point = (char*)ntfs_malloc(PATH_MAX);
+ 		if (ctx->abs_mnt_point) {
+-			if (getcwd(ctx->abs_mnt_point,
++			if ((strlen(opts.mnt_point) < PATH_MAX)
++			    && getcwd(ctx->abs_mnt_point,
+ 				     PATH_MAX - strlen(opts.mnt_point) - 1)) {
+ 				strcat(ctx->abs_mnt_point, "/");
+ 				strcat(ctx->abs_mnt_point, opts.mnt_point);
+@@ -4156,6 +4157,9 @@ int main(int argc, char *argv[])
+ 			/* Solaris also wants the absolute mount point */
+ 				opts.mnt_point = ctx->abs_mnt_point;
+ #endif /* defined(__sun) && defined (__SVR4) */
++			} else {
++				free(ctx->abs_mnt_point);
++				ctx->abs_mnt_point = (char*)NULL;
+ 			}
+ 		}
+ 	}
+-- 
+2.21.0
+


### PR DESCRIPTION
#### Description
https://security-tracker.debian.org/tracker/CVE-2019-9755

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
