### PR TITLE
mythtv.28: build fix for x264 build 153+

### DIFF
--- a/multimedia/mythtv.28/Portfile
+++ b/multimedia/mythtv.28/Portfile
@@ -153,7 +153,9 @@ if {$subport eq "mythtv-core${majorversion}"} {
     patchfiles-append   patch-mythwidgets_osx_focus.diff
     # https://code.mythtv.org/trac/ticket/13001
     patchfiles-append   patch_01_typlayer_qsp_ua_detection.diff
-    
+    # backport ffmpeg upstream patch for compatibility with x264 build 153+
+    patchfiles-append   patch-x264-build-153.diff
+
     post-patch {
         set sedPath ${worksrcpath}/mythtv/
         ui_info "Make Myth utils use MacPorts Perl"

--- a/multimedia/mythtv.28/files/patch-x264-build-153.diff
+++ b/multimedia/mythtv.28/files/patch-x264-build-153.diff
@@ -1,0 +1,116 @@
+Backported from ffmpeg commit c6558e8840fbb2386bf8742e4d68dd6e067d262e
+Author: Luca Barbato <lu_zero@gentoo.org>
+Date:   Tue Dec 26 12:32:42 2017 +0100
+
+    x264: Support version 153
+    
+    It has native simultaneus 8 and 10 bit support.
+
+--- mythtv/external/FFmpeg/libavcodec/libx264.c.orig	2018-02-01 04:00:06.000000000 -0800
++++ mythtv/external/FFmpeg/libavcodec/libx264.c	2019-03-17 01:17:29.000000000 -0700
+@@ -268,7 +268,11 @@
+ 
+     x264_picture_init( &x4->pic );
+     x4->pic.img.i_csp   = x4->params.i_csp;
++#if X264_BUILD >= 153
++    if (x4->params.i_bitdepth > 8)
++#else
+     if (x264_bit_depth > 8)
++#endif
+         x4->pic.img.i_csp |= X264_CSP_HIGH_DEPTH;
+     x4->pic.img.i_plane = avfmt2_num_planes(ctx->pix_fmt);
+ 
+@@ -496,6 +500,9 @@
+     x4->params.p_log_private        = avctx;
+     x4->params.i_log_level          = X264_LOG_DEBUG;
+     x4->params.i_csp                = convert_pix_fmt(avctx->pix_fmt);
++#if X264_BUILD >= 153
++    x4->params.i_bitdepth           = av_pix_fmt_desc_get(avctx->pix_fmt)->comp[0].depth;
++#endif
+ 
+     PARSE_X264_OPT("weightp", wpredp);
+ 
+@@ -858,6 +865,7 @@
+     return 0;
+ }
+ 
++#if X264_BUILD < 153
+ static const enum AVPixelFormat pix_fmts_8bit[] = {
+     AV_PIX_FMT_YUV420P,
+     AV_PIX_FMT_YUVJ420P,
+@@ -892,15 +900,45 @@
+ #endif
+     AV_PIX_FMT_NONE
+ };
++#else
++static const enum AVPixelFormat pix_fmts_all[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUVJ420P,
++    AV_PIX_FMT_YUV422P,
++    AV_PIX_FMT_YUVJ422P,
++    AV_PIX_FMT_YUV444P,
++    AV_PIX_FMT_YUVJ444P,
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_NV21,
++    AV_PIX_FMT_YUV420P10,
++    AV_PIX_FMT_YUV422P10,
++    AV_PIX_FMT_YUV444P10,
++    AV_PIX_FMT_NV20,
++    AV_PIX_FMT_NONE
++};
++#endif
++#if CONFIG_LIBX264RGB_ENCODER
++static const enum AVPixelFormat pix_fmts_8bit_rgb[] = {
++    AV_PIX_FMT_BGR0,
++    AV_PIX_FMT_BGR24,
++    AV_PIX_FMT_RGB24,
++    AV_PIX_FMT_NONE
++};
++#endif
+ 
+ static av_cold void X264_init_static(AVCodec *codec)
+ {
++#if X264_BUILD < 153
+     if (x264_bit_depth == 8)
+         codec->pix_fmts = pix_fmts_8bit;
+     else if (x264_bit_depth == 9)
+         codec->pix_fmts = pix_fmts_9bit;
+     else if (x264_bit_depth == 10)
+         codec->pix_fmts = pix_fmts_10bit;
++#else
++    codec->pix_fmts = pix_fmts_all;
++#endif
+ }
+ 
+ #define OFFSET(x) offsetof(X264Context, x)
+@@ -1035,13 +1073,6 @@
+     .version    = LIBAVUTIL_VERSION_INT,
+ };
+ 
+-static const AVClass rgbclass = {
+-    .class_name = "libx264rgb",
+-    .item_name  = av_default_item_name,
+-    .option     = options,
+-    .version    = LIBAVUTIL_VERSION_INT,
+-};
+-
+ AVCodec ff_libx264_encoder = {
+     .name             = "libx264",
+     .long_name        = NULL_IF_CONFIG_SMALL("libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10"),
+@@ -1058,6 +1089,15 @@
+     .caps_internal    = FF_CODEC_CAP_INIT_THREADSAFE |
+                         FF_CODEC_CAP_INIT_CLEANUP,
+ };
++#endif
++
++#if CONFIG_LIBX264RGB_ENCODER
++static const AVClass rgbclass = {
++    .class_name = "libx264rgb",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
+ 
+ AVCodec ff_libx264rgb_encoder = {
+     .name           = "libx264rgb",


### PR DESCRIPTION
As of build 153, x264 now supports multibitdepth builds, with a slightly changed API to
request bitdepth during initialization. The previous global variable, x264_bit_depth,
used by mythtv, was removed.

Current x264 build is 157.

This PR backports the upstream ffmpeg fix for x264 153+ to the older embedded
copy of ffmpeg in mythtv.28.

See https://github.com/FFmpeg/FFmpeg/commit/c6558e8840fbb2386bf8742e4d68dd6e067d262e

Author: Luca Barbato <lu_zero@gentoo.org>
Date:   Tue Dec 26 12:32:42 2017 +0100

    x264: Support version 153

    It has native simultaneus 8 and 10 bit support.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.2 10P107d 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
