### PR TITLE
py-simplekml: new port, version 1.3.1

### DIFF
--- a/python/py-simplekml/Portfile
+++ b/python/py-simplekml/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-simplekml
+version             1.3.1
+revision            0
+categories-append   gis
+platforms           darwin
+supported_archs     noarch
+license             LGPL-3+
+
+maintainers         nomaintainer
+
+description         A Simple KML creator
+long_description    ${description}
+
+homepage            https://readthedocs.org/projects/simplekml/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  527dd4a0e5cc26b028282405387ea3dc5ee1827d \
+                    sha256  30c121368ce1d73405721730bf766721e580cae6fbb7424884c734c89ec62ad7 \
+                    size    37070
+
+python.versions     27 37
+
+if {${name} ne ${subport}} {
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.txt \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description
As requested in https://trac.macports.org/ticket/56067

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
