### PR TITLE
openjdk8: add openjdk12-openj9-large-heap subport

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -70,6 +70,15 @@ subport openjdk12-openj9 {
     set openj9_version 0.13.0
 }
 
+subport openjdk12-openj9-large-heap {
+    version      12
+    revision     0
+
+    set build    33
+    set major    12
+    set openj9_version 0.13.0
+}
+
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 platforms        darwin
@@ -207,7 +216,7 @@ if {${subport} eq "openjdk8"} {
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
 } elseif {${subport} eq "openjdk12-openj9"} {
-    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${major}%2B${build}_openj9-${openj9_version}/
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
     checksums    rmd160  2ccbe2f0daef752c884e5a0ceb1d2fb88e23d3c5 \
@@ -223,6 +232,25 @@ if {${subport} eq "openjdk8"} {
                  OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
                  VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
                  suitable for running all workloads.
+} elseif {${subport} eq "openjdk12-openj9-large-heap"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+
+    checksums    rmd160  1cf6bc2957546b68efa99aabbd7ff02420a65d24 \
+                 sha256  231a667079c0811ec03a19d06d3ed0800ec19f7c08f6a6c78b579079d8ee5508 \
+                 size    197141791
+
+    worksrcdir   jdk-${version}+${build}
+
+    description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
+    long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
+                 open-source set of build scripts and infrastructure. \
+                 \
+                 OpenJ9 is the virtual machine from the Eclipse community. It is an enterprise-grade \
+                 VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is \
+                 suitable for running all workloads. \
+                 \
+                 This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
 }
 
 use_configure    no


### PR DESCRIPTION
#### Description

Add subport for AdoptOpenJDK 12 with Eclipse OpenJ9 VM with Large Heap support.

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?