### PR TITLE
gitlab-runner: update to 11.9.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.8.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 11.9.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  1a89a723036a691e4a15045f7ba8e68cab351498 \
-                    sha256  b334e446c996441937b8f2f5b995da2687f9b52c29fb87ba76a9ae4a9614b68a \
-                    size    27034342
+checksums           rmd160  8850b74a097120a8b47d33d6b4286f434b30b1b5 \
+                    sha256  57dad370a3883d435b27b497de43eb3402b0e64dfc421a81ac99c9ddb04f0d45 \
+                    size    27054559
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 11.9.0.

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?