### PR TITLE
glm: bump to 0.9.9.4 and fix build on older systems

### DIFF
--- a/devel/glm/Portfile
+++ b/devel/glm/Portfile
@@ -1,8 +1,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        g-truc glm 0.9.9.3
+github.setup        g-truc glm 0.9.9.4
 categories          devel
 platforms           darwin
 supported_archs     noarch
@@ -13,9 +14,23 @@ long_description    OpenGL Mathematics (GLM) is a header only C++ \
                     mathematics library for graphics software based \
                     on the OpenGL Shading Language (GLSL) specification.
 homepage            http://glm.g-truc.net/
-checksums           rmd160  3d40d77aec5362b22e9fbda39e87b52215d41f6d \
-                    sha256  acfca8369b24d299882d0845a73878e21139e539c44e847f7671d93b5eecb4d5 \
-                    size    4580262
+checksums           rmd160  09c991cada3a89eb22745feb16085d1acf02f4b8 \
+                    sha256  64d1e88b6a8c1b0e5a4491155184440d4914a34b89a14327e5135f6393001958 \
+                    size    4580590
+
+# see https://trac.macports.org/ticket/57085 as to why the c++11 PG can't be used just now
+compiler.blacklist-append \
+                    {clang < 602} \
+                    {macports-clang-3.[3-4]} \
+                    *gcc-3.* *gcc-4.*
+platform darwin i386 {
+    # note -- NOT macports-clang-7.0 as it defaults to c++17 and we aren't
+    # covering that eventuality at present
+    compiler.fallback-append macports-clang-5.0 macports-clang-6.0
+}
+platform darwin powerpc {
+    compiler.fallback-append macports-gcc-6 macports-gcc-7
+}
 
 post-destroot {
     delete ${destroot}${prefix}/include/${name}/CMakeLists.txt


### PR DESCRIPTION
requires newer compilers, clang-3.4+, clang > 600.
cxx11 1.1 PG cannot fix this right now as linker segfaults
when trying to link this against macports-libstdc++

closes: https://trac.macports.org/ticket/57085

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
