### PR TITLE
tor-devel: update to 0.4.0.3-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.0.2-alpha
+version             0.4.0.3-alpha
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  ee9222a5829aecf200b3bf8235034ba3889f0a40 \
-                    sha256  6d2c6fbf975be2cb7c677102fa5f29c4ad23457ec1871f6ba50f8060fecd60b6 \
-                    size    7156129
+checksums           rmd160  e03812fa8cc136100329f67a5ae47cc973cb3ae4 \
+                    sha256  b0956065d29de182ea0dee95274bccaecc4f81208762c31f6f88dd5a04a99dc5 \
+                    size    7173481
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description
tor-devel: update to 0.4.0.3-alpha

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on
macOS 10.13.6 17G6028
Xcode 10.1 10B61 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tested basic functionality of all binary files?