### PR TITLE
py-keyring: update to 19.0.0

### DIFF
--- a/python/py-keyring/Portfile
+++ b/python/py-keyring/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keyring
-version             18.0.0
+version             19.0.0
 revision            0
 categories-append   security
 
@@ -17,23 +17,34 @@ long_description    The Python keyring lib provides a easy way to access the sys
                     supports the Keychain service in Mac OS X.
 
 platforms           darwin
+supported_archs     noarch
 
 homepage            https://github.com/jaraco/keyring
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  a419899468cef2a2212a61edee30eff940bf7101 \
-                    sha256  12833d2b05d2055e0e25931184af9cd6a738f320a2264853cabbd8a3a0f0b65d \
-                    size    48509
+checksums           rmd160  82ba99a30e70b0560ab6bad1c8c3b8a8b6efc0ee \
+                    sha256  070c8e52ffa7589653a61045dfcbefc41b4ba1de3d02c4e9fcb37ef95dd0ee4d \
+                    size    47650
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools_scm
+    if {${python.version} in "27 34"} {
+        version     18.0.0
+        revision    0
+        distname    ${python.rootname}-${version}
+        checksums   rmd160  a419899468cef2a2212a61edee30eff940bf7101 \
+                    sha256  12833d2b05d2055e0e25931184af9cd6a738f320a2264853cabbd8a3a0f0b65d \
+                    size    48509
+    }
 
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-entrypoints
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+    depends_lib-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-entrypoints
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -42,5 +53,5 @@ if {${name} ne ${subport}} {
             ${destroot}${docdir}
     }
 
-    livecheck.type      none
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to latest version, pin py27/py34 to version 18.0.0
- add "supported_archs noarch"
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
