### PR TITLE
py-spyder-devel: update to a8b9d43 (20190321)

### DIFF
--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -7,8 +7,8 @@ PortGroup           qt5 1.0
 PortGroup           active_variants 1.1
 PortGroup           select 1.0
 
-github.setup        spyder-ide spyder 0615f01
-version             3.3.0-20190309
+github.setup        spyder-ide spyder a8b9d43
+version             3.3.0-20190321
 revision            0
 name                py-spyder-devel
 # Preference on mailing list is to use small numbers for epoch.
@@ -37,12 +37,9 @@ long_description    ${description}. \
 
 supported_archs     noarch
 
-#pyNN-scipy doesn't build universal
-universal_variant   no
-
-checksums           rmd160  5c7bfb37792aeba7e6a765b09c144b0caf61477c \
-                    sha256  2dddd11dd92cc39cd921247e057efe4f1696154cb7211a8ce663ed291c57a2e0 \
-                    size    4143562
+checksums           rmd160  58caed0ecff761caaa67468784bd56b2185e2834 \
+                    sha256  158cccd2d529c5dac00e1ff159e59a6a26b468544e37e5f4dad38b5095cea8fd \
+                    size    4150846
 
 if {${name} ne ${subport}} {
     require_active_variants py${python.version}-pyqt5 webengine

--- a/python/py-spyder-devel/files/patch-spyder_config_main.py.diff
+++ b/python/py-spyder-devel/files/patch-spyder_config_main.py.diff
@@ -1,6 +1,6 @@
---- spyder/config/main.py.orig	2019-03-09 09:56:47.000000000 -0500
-+++ spyder/config/main.py	2019-03-10 12:37:46.000000000 -0400
-@@ -678,7 +678,7 @@
+--- spyder/config/main.py.orig	2019-03-21 08:10:44.000000000 -0400
++++ spyder/config/main.py	2019-03-23 10:30:45.000000000 -0400
+@@ -680,7 +680,7 @@
              ('lsp-server', {
                  'python': {
                      'index': 0,


### PR DESCRIPTION
#### Description
- update to latest commit
- "universal_variant no" is redundant here since it already specifies "supported_archs noarch"
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
