### PR TITLE
cpprestsdk: update to 2.10.11

### DIFF
--- a/www/cpprestsdk/Portfile
+++ b/www/cpprestsdk/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
-github.setup        Microsoft cpprestsdk 2.10.10 v
+github.setup        Microsoft cpprestsdk 2.10.11 v
 revision            0
 categories          www devel
 platforms           darwin
@@ -19,9 +19,9 @@ long_description    The C++ REST SDK is a Microsoft project for cloud-based \
                     client-server communication in native code using a modern \
                     asynchronous C++ API design.
 
-checksums           rmd160  f859bee62977046c1cab6a99010ea54e15a717d7 \
-                    sha256  b3d3bdba6301dede05c6bb2acc5e3c1e00950926b91aeec1709180011bd59069 \
-                    size    1755589
+checksums           rmd160  96528d84dba9efa5f36a61f901df965f405ab8c4 \
+                    sha256  1b28f98b6773a50c5d19e38098bc9ec971ac1850a77682b9648266ac8e3d956d \
+                    size    1757340
 
 depends_lib-append  port:boost \
                     port:libiconv \
@@ -31,9 +31,6 @@ depends_lib-append  port:boost \
 configure.args-append -DBUILD_SAMPLES=OFF -DBUILD_TESTS=OFF
 
 variant tests description {build tests.} {
-    post-extract {
-        system -W ${worksrcpath} "echo 'enable_testing()' >> CMakeLists.txt"
-    }
     configure.args-replace      -DBUILD_TESTS=OFF -DBUILD_TESTS=ON
     configure.post_args-append  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
     test.run                    yes


### PR DESCRIPTION
###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?