### PR TITLE
openjdk8: add openjdk12 subport

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -61,6 +61,14 @@ subport openjdk11-openj9-large-heap {
     set openj9_version 0.12.1
 }
 
+subport openjdk12 {
+    version      12
+    revision     0
+
+    set build    33
+    set major    12
+}
+
 subport openjdk12-openj9 {
     version      12
     revision     0
@@ -215,6 +223,15 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads. \
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+} elseif {${subport} eq "openjdk12"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
+
+    checksums    rmd160  d05c73f6e7f390f42d61d69b5a4065aa279643aa \
+                 sha256  985036459d4ef0867a3fe83b0bf87877d8e66a121c7b9c145bb97bd921aaf3f1 \
+                 size    198099074
+
+    worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk12-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}


### PR DESCRIPTION
#### Description

Add AdoptOpenJDK 12 with HotSpot VM.

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?