### PR TITLE
iTerm2: update to 3.2.8

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -12,11 +12,11 @@ if {[vercmp ${os.version} 17.0.0] < 0} {
         size    11969144
     patchfiles          patch-Makefile.diff
 } else {
-    version             3.2.7
+    version             3.2.8
     checksums \
-        rmd160  82b3f206a23189319281c2512b456bb00a498b4d \
-        sha256  e798eb994638c30d8500b0f085c3edaf4bc51066b47df8f85153a9ec1275972f \
-        size    11849614
+        rmd160  4e8b5378f184c3342964ed3e2e90144135bc3f44 \
+        sha256  2bf18d30c5e56e2433a1110be4f0ec1f42ad7e26862ac424e9706293ce45aabf \
+        size    11857802
     patchfiles          patch-Makefile-XC10.diff
 }
 


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
