### PR TITLE
Fixed some softtabs and dependencies

### DIFF
--- a/python/py-barnaba/Portfile
+++ b/python/py-barnaba/Portfile
@@ -29,19 +29,19 @@ python.versions     27 36 37
 
 if {${name} ne ${subport}} {
 
-    depends_build-append port:py${python.version}-setuptools_scm \
-                         port:py${python.version}-setuptools_scm_git_archive
+    depends_build-append    port:py${python.version}-setuptools_scm \
+                            port:py${python.version}-setuptools_scm_git_archive
 
-    depends_lib-append  port:py${python.version}-mdtraj \
-                        port:py${python.version}-scipy \
-                        port:py${python.version}-numpy \
-                        port:py${python.version}-pandas \
-                        port:py${python.version}-scikit-learn \
-                        port:py${python.version}-future
+    depends_lib-append      port:py${python.version}-future \
+                            port:py${python.version}-mdtraj \
+                            port:py${python.version}-numpy \
+                            port:py${python.version}-pandas \
+                            port:py${python.version}-scikit-learn \
+                            port:py${python.version}-scipy
 
-    depends_test-append port:py${python.version}-nose
-    test.run            yes
-    test.cmd            nosetests-${python.branch}
+    depends_test-append     port:py${python.version}-nose
+    test.run                yes
+    test.cmd                nosetests-${python.branch}
     test.target
 }
 

--- a/python/py-mdtraj/Portfile
+++ b/python/py-mdtraj/Portfile
@@ -26,13 +26,13 @@ python.versions     27 36 37
 
 if {${name} ne ${subport}} {
 
-    depends_build-append port:py${python.version}-cython
+    depends_build-append    port:py${python.version}-cython \
+                            port:py${python.version}-setuptools
 
-    depends_lib-append port:py${python.version}-numpy \
-                       port:py${python.version}-scipy \
-                       port:py${python.version}-pandas \
-                       port:py${python.version}-setuptools \
-                       port:py${python.version}-tables
+    depends_lib-append      port:py${python.version}-numpy \
+                            port:py${python.version}-pandas \
+                            port:py${python.version}-scipy \
+                            port:py${python.version}-tables
 
 # tests cannot be implemented since they require too many packages
 # not available on MacPorts

--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -25,23 +25,24 @@ checksums           rmd160  3873e9d48500bd01353396c0c85723a46b7c0ca9 \
 python.versions     27 36 37
 
 # python setup is located in python subdir of plumed repository
-worksrcdir ${distname}/python
+worksrcdir  ${distname}/python
 
 if {${name} ne ${subport}} {
 
 # setup the wrappers so that by default they load MacPorts plumed library
-    build.env-append plumed_default_kernel=${prefix}/lib/libplumedKernel.dylib \
-                     plumed_macports=yes
+    build.env-append    plumed_default_kernel=${prefix}/lib/libplumedKernel.dylib \
+                        plumed_macports=yes
 
-    depends_build-append port:py${python.version}-cython
+    depends_build-append    port:py${python.version}-cython \
+                            port:py${python.version}-setuptools
 
-    depends_lib-append   port:py${python.version}-numpy \
-                         path:${prefix}/lib/libplumedKernel.dylib:plumed
+    depends_lib-append      port:py${python.version}-numpy \
+                            path:${prefix}/lib/libplumedKernel.dylib:plumed
 
-    depends_test-append port:py${python.version}-nose
-    test.cmd            nosetests-${python.branch}
+    depends_test-append     port:py${python.version}-nose
+    test.cmd                nosetests-${python.branch}
     test.target
-    test.run            yes
+    test.run                yes
 }
 
 notes "


### PR DESCRIPTION
#### Description

Based on some feedback I received in #3902, I fixed softtabs and dependencies on `py-setuptools` in a number of packages I maintain.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
