### PR TITLE
google-cloud-sdk: update to 239.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             237.0.0
+version             239.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  7ab1618effffd4aecba299ac03883e494ed04cd5 \
-                    sha256  dff491b29c8712b4a3600ebf2ec3417d2655ded6602e9c4cfe1c40ea3eecd5ae \
-                    size    18678946
+checksums           rmd160  67932736689c242fdf290f55be849d36b1e99489 \
+                    sha256  4867c21d93552b6da46d5d55b97682725105eeef61f1b0baadadf5fe2ed2bd76 \
+                    size    18911252
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 239.0.0.

###### Tested on

macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?