### PR TITLE
DesktopManager: mark as deprecated

### DIFF
--- a/aqua/DesktopManager/Portfile
+++ b/aqua/DesktopManager/Portfile
@@ -1,5 +1,6 @@
 PortSystem		1.0
 PortGroup		xcode 1.0
+PortGroup		deprecated 1.0
 
 name			DesktopManager
 version			0.5.3
@@ -41,3 +42,5 @@ destroot {
 }
 
 livecheck.type	none
+
+deprecated.upstream_support no


### PR DESCRIPTION
[Port has been discontinued by its developer](https://github.com/tonyarnold/virtuedesktops#this-is-an-archive).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
