### PR TITLE
Black: new port

### DIFF
--- a/python/black/Portfile
+++ b/python/black/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                black
+version             19.3b0
+platforms           darwin
+license             MIT
+maintainers         {danchr @danchr} openmaintainer
+
+description         The uncompromising code formatter for Python.
+long_description \
+    By using Black, you agree to cede control over minutiae of \
+    hand-formatting your Python source code. In return, Black gives \
+    you speed, determinism, and freedom from pycodestyle nagging about \
+    formatting. You will save time and mental energy for more \
+    important matters. \
+    \
+    Black makes code review faster by producing the smallest diffs \
+    possible. Blackened code looks the same regardless of the project \
+    you’re reading. Formatting becomes transparent after a while and \
+    you can focus on the content instead.
+
+homepage            https://${name}.readthedocs.io/
+master_sites        pypi:[string index ${name} 0]/${name}
+distname            ${name}-${version}
+
+checksums           rmd160  2d323c434fdfdccc1aa6a2b68f18e2012e21a5a2 \
+                    sha256  68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c \
+                    size    155556
+
+python.version      37
+
+depends_build-append    port:py${python.version}-setuptools
+depends_lib-append \
+    port:py${python.version}-click \
+    port:py${python.version}-attrs \
+    port:py${python.version}-appdirs \
+    port:py${python.version}-toml
+
+livecheck.type  pypi


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
This adds a port for the Black code formatter for Python. Since it requires `py-toml`, I updated its list of supported pythons so that Black could run in Python 3.6 as well.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
