### PR TITLE
libssh2: update to 1.8.1

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libssh2
-version             1.8.0
+version             1.8.1
 categories          devel net
 platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer
@@ -20,8 +20,9 @@ license             BSD
 homepage            https://www.libssh2.org/
 master_sites        ${homepage}download/
 
-checksums           rmd160  84c91d81503510673386714b30630fb3cb169725 \
-                    sha256  39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
+checksums           rmd160  312c85af0b98b86abf1750a76c67e921b7d14f95 \
+                    sha256  40b517f35b1bb869d0075b15125c7a015557f53a5a3a6a8bffb89b69fd70f159 \
+                    size    858088
 
 depends_lib         path:lib/libssl.dylib:openssl port:zlib
 


### PR DESCRIPTION
#### Description
From `[oss-security] [SECURITY ADVISORIES] libssh2`:
> I'm writing you to announce the release of nine separate security advisories concerning libssh2.
> 
> All these fixes are also included in the brand new libssh2 1.8.1 release, just shipped and available on https://www.libssh2.org/
> 
> CVE-2019-3855
>  Possible integer overflow in transport read allows out-of-bounds write
>  URL: https://www.libssh2.org/CVE-2019-3855.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3855.patch
> 
> CVE-2019-3856
>  Possible integer overflow in keyboard interactive handling allows
>  out-of-bounds write
>  URL: https://www.libssh2.org/CVE-2019-3856.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3856.patch
> 
> CVE-2019-3857
>  Possible integer overflow leading to zero-byte allocation and out-of-bounds
>  write
>  URL: https://www.libssh2.org/CVE-2019-3857.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3857.patch
> 
> CVE-2019-3858
>  Possible zero-byte allocation leading to an out-of-bounds read
>  URL: https://www.libssh2.org/CVE-2019-3858.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3858.patch
> 
> CVE-2019-3859
>  Out-of-bounds reads with specially crafted payloads due to unchecked use of
>  `_libssh2_packet_require` and `_libssh2_packet_requirev`
>  URL: https://www.libssh2.org/CVE-2019-3859.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3859.patch
> 
> CVE-2019-3860
>  Out-of-bounds reads with specially crafted SFTP packets
>  URL: https://www.libssh2.org/CVE-2019-3860.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3860.patch
> 
> CVE-2019-3861
>  Out-of-bounds reads with specially crafted SSH packets
>  URL: https://www.libssh2.org/CVE-2019-3861.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3861.patch
> 
> CVE-2019-3862
>  Out-of-bounds memory comparison
>  URL: https://www.libssh2.org/CVE-2019-3862.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3862.patch
> 
> CVE-2019-3863
>  Integer overflow in user authenicate keyboard interactive allows
>  out-of-bounds writes
>  URL: https://www.libssh2.org/CVE-2019-3863.html
>  Patch: https://libssh2.org/1.8.0-CVE/CVE-2019-3863.txt
> 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
