### PR TITLE
tclreadline: update to 2.3.5

### DIFF
--- a/devel/tclreadline/Portfile
+++ b/devel/tclreadline/Portfile
@@ -3,8 +3,8 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                flightaware tclreadline 2.3.1 v
-revision                    1
+github.setup                flightaware tclreadline 2.3.5 v
+revision                    0
 categories                  devel
 platforms                   darwin
 maintainers                 {dons.net.au:darius @DanielO}
@@ -24,9 +24,9 @@ long_description            The tclreadline package makes the GNU Readline \
                             command has to be called explicitly.
 
 
-checksums                   rmd160  7973aa63fa521c8437b43712ce1798c9f66b050b \
-                            sha256  d702e3b8acfebd588b93348e220fc98f4181346c7f9a56ea7aeda334f107bbc5 \
-                            size    153243
+checksums                   rmd160  0fd8e09ed57122683085dbccef4cbb7279cc44d8 \
+                            sha256  36e42a3912e6a41529d7c5447658c36414d0db167e937919f27addd382c955b0 \
+                            size    260109
 
 depends_lib                 port:readline \
                             port:tcl
@@ -34,4 +34,5 @@ depends_lib                 port:readline \
 use_autoreconf              yes
 
 configure.args-append       --with-tcl=${prefix}/lib/ \
+                            --with-tk=no \
                             --with-readline-includes=${prefix}/include/readline


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/58049 (the maintainer's earlier attempt to update to 2.3.2)

**Edit:** Add configuration option `--with-tk=no` as suggested by port maintainer

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
