### PR TITLE
ngspice: update to version 30, add openmp variant

### DIFF
--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 
 name            ngspice
-version         28
+version         30
 license         BSD
 categories      science cad
 maintainers     {@mguthaus ucsc.edu:mrg+openram} openmaintainer
@@ -18,9 +18,9 @@ long_description \
 homepage        http://ngspice.sourceforge.net/
 master_sites    sourceforge:project/ngspice/ng-spice-rework/${version}
 
-checksums       rmd160  2925b2af9dec0b1fcfeff6a4c9b9a9746d8bc08e \
-                sha256  94804fa78c8db2f90f088902e8c27f7b732a66767a58c70f37612bff5a16df66 \
-                size    6737636
+checksums       rmd160  965684c859955a42218c3d9f6deb2ed7cbe0cf6a \
+                sha256  08fe0e2f3768059411328a33e736df441d7e6e7304f8dad0ed5f28e15d936097 \
+                size    7147044
 
 set docdir      ${prefix}/share/doc/${name}
 
@@ -57,8 +57,23 @@ if {${name} eq ${subport}} {
     }
     
     variant manual description {Legacy compatibility variant} {
-        depends_run-append  port:ngspice-docs
+        depends_run-append       port:ngspice-docs
     }
+    
+    variant openmp description {Add OpenMP support variant} {
+        depends_lib-append       port:libomp 
+        
+        configure.args-append    --enable-openmp
+
+        compiler.whitelist       macports-clang-7.0 macports-clang-6.0 macports-clang-5.0 \
+                                 macports-clang-4.0 macports-clang-3.9 macports-clang-3.7 \
+                                 macports-gcc-8 macports-gcc-7 macports-gcc-6 macports-gcc-5 \
+                                 macports-gcc-4.8 macports-gcc-4.7 macports-gcc-4.6 macports-gcc-4.5 \
+                                 macports-gcc-4.4 macports-gcc-4.3
+        compiler.fallback        macports-clang-7.0
+    }
+
+    default_variants    +openmp +manual
     
     livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
 } else {
@@ -74,9 +89,9 @@ subport ngspice-docs {
     extract.suffix
     extract.only
  
-    checksums           rmd160  42278f891baea9cfd21cc419b417e47e08d6805e \
-                        sha256  af11dd48b59a7dc9b5126ce5fec4e71d7dd1f7e93e21f16bb6f6636197c62a56 \
-                        size    3390805
+    checksums           rmd160  a9848930d0789c0e73b12dcea7d0548c11dd9f0e \
+                        sha256  d9658d5e52f27822ef852063599d81a7f647fa03db993fca5b90f4677e0a8257 \
+                        size    2131163
     
     use_configure       no
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Update to version 30 of ngspice.
Add default variant to include OpenMP support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [ X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ X] checked your Portfile with `port lint`?
- [ X] tried existing tests with `sudo port test`?
- [ X] tried a full install with `sudo port -vst install`?
- [X ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
