### PR TITLE
gdb: Change uint64_t to ULONGEST to fix +multiarch

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -38,6 +38,8 @@ checksums       rmd160  a92cabfd5da3e358e16aa424a4a3d8de63366614 \
                 sha256  0107985f1edb8dddef6cdd68a4f4e419f5fec0f488cc204f0b7d482c0c6c9282 \
                 size    37601384
 
+patchfiles      patch-gdb-aarch64-linux-tdep.c.diff
+
 # these dependencies are listed under depends_lib rather than depends_build
 # because gdb will link with libraries they provide if installed.
 # there may be more. See variable host_libs in configure.ac.

--- a/devel/gdb/files/patch-gdb-aarch64-linux-tdep.c.diff
+++ b/devel/gdb/files/patch-gdb-aarch64-linux-tdep.c.diff
@@ -1,0 +1,13 @@
+diff --git gdb/aarch64-linux-tdep.c gdb/aarch64-linux-tdep.c
+index dc2b89121a6..42cd49e0154 100644
+--- gdb/aarch64-linux-tdep.c
++++ gdb/aarch64-linux-tdep.c
+@@ -316,7 +316,7 @@  aarch64_linux_supply_sve_regset (const struct regset *regset,
+      passed in SVE regset or a NEON fpregset.  */
+ 
+   /* Extract required fields from the header.  */
+-  uint64_t vl = extract_unsigned_integer (header + SVE_HEADER_VL_OFFSET,
++  ULONGEST vl = extract_unsigned_integer (header + SVE_HEADER_VL_OFFSET,
+ 					  SVE_HEADER_VL_LENGTH, byte_order);
+   uint16_t flags = extract_unsigned_integer (header + SVE_HEADER_FLAGS_OFFSET,
+ 					     SVE_HEADER_FLAGS_LENGTH,


### PR DESCRIPTION
#### Description
<!-- Note: it is best make pull requests from a branch rather than from master -->

macOS uses `unsigned long long` for `uint64_t` which causes
`gdb/aarch64-linux-6dep.c` to fail to build.

This commit applies the patch from
https://patches-gcc.linaro.org/patch/10133/ (which does nothing but
change the type of a local variable from `uint64_t` to `ULONGEST`).

Closes: https://trac.macports.org/ticket/57998

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G5019
Xcode 10.1 10B61
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
