### PR TITLE
SoapySDR: add variants for python bindings

### DIFF
--- a/science/SoapySDR/Portfile
+++ b/science/SoapySDR/Portfile
@@ -19,3 +19,78 @@ description         A fresh and clean vendor neutral and platform independent SD
 long_description    SoapySDR is an open-source generalized C/C++ API and runtime library for interfacing with SDR devices. With SoapySDR, you can instantiate, configure, and stream with an SDR device in a variety of environments. Both osmosdr and uhd devices are available within SoapySDR. In addition, vendors can directly support their hardware using SoapySDR device modules. There are wrappers for both gr-osmosdr, uhd, and gr-uhd to bring an ecosystem of existing applications to SoapySDR devices. And SoapySDR has support for powerful platforms like GNU Radio and Pothos.
 
 homepage            https://github.com/pothosware/SoapySDR/wiki
+
+configure.args-append \
+    -DENABLE_PYTHON=OFF \
+    -DENABLE_PYTHON3=OFF
+
+# specify the Python dependencies; these are checked for at configure,
+# then used for building, but not at runtime.
+
+set pythons2_suffixes {27}
+set pythons3_suffixes {36 37}
+
+set pythons_ports {}
+foreach s ${pythons2_suffixes} {
+    lappend pythons_suffixes ${s}
+    lappend pythons2_ports python${s}
+}
+foreach s ${pythons3_suffixes} {
+    lappend pythons_suffixes ${s}
+    lappend pythons3_ports python${s}
+}
+
+proc python_dir {} {
+    global pythons_suffixes
+    foreach s ${pythons_suffixes} {
+        if {[variant_isset python${s}]} {
+            set p python[string index ${s} 0].[string index ${s} 1]
+            return [file normalize [exec ${p} -c "import sys; print(sys.prefix)"]/lib/${p}/site-packages]
+        }
+    }
+    error "Python support not enabled."
+}
+
+foreach s ${pythons2_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${pythons2_ports} ${p}]
+    set c [lreplace ${pythons2_ports} ${i} ${i}]
+    variant ${p} description "Build SoapySDR using Python ${v}" conflicts {*}${c} "
+    # required Python
+    depends_lib-append \
+        port:${p}
+    depends_build-append \
+        port:swig-python
+    # specify the Python version to use
+    configure.args-delete \
+        -DENABLE_PYTHON=OFF
+    configure.args-append \
+        -DENABLE_PYTHON=ON \
+        -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/${v}/bin/python${v} \
+        -DPYTHON_CONFIG_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/${v}/bin/python${v}-config \
+        -DPYTHON_INSTALL_DIR=${frameworks_dir}/Python.framework/Versions/${v}/lib/python${v}/site-packages
+    "
+}
+
+foreach s ${pythons3_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${pythons3_ports} ${p}]
+    set c [lreplace ${pythons3_ports} ${i} ${i}]
+    variant ${p} description "Build SoapySDR using Python ${v}" conflicts {*}${c} "
+    # required Python
+    depends_lib-append \
+        port:${p}
+    depends_build-append \
+        port:swig-python
+    # specify the Python version to use
+    configure.args-delete \
+        -DENABLE_PYTHON3=OFF
+    configure.args-append \
+        -DENABLE_PYTHON3=ON \
+        -DPYTHON3_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/${v}/bin/python${v} \
+        -DPYTHON3_CONFIG_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/${v}/bin/python${v}-config \
+        -DPYTHON3_INSTALL_DIR=${frameworks_dir}/Python.framework/Versions/${v}/lib/python${v}/site-packages
+    "
+}


### PR DESCRIPTION
#### Description

Add variants to build python bindings for SoapySDR.

@michaelld

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.1 10B61

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?