### PR TITLE
freetype: update to 2.10.0

### DIFF
--- a/print/freetype/Portfile
+++ b/print/freetype/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               muniversal 1.0
 
 name                    freetype
-version                 2.9.1
+version                 2.10.0
 categories              print graphics
 maintainers             {ryandesign @ryandesign}
 license                 {FreeType GPL-2}
@@ -34,13 +34,13 @@ distfiles               ${distname}${extract.suffix}:source \
                         ${docdistname}${extract.suffix}:docs
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  c01d82acf7062b07146f61f43a8d17d5805b9471 \
-                        sha256  db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d \
-                        size    1926385 \
+                        rmd160  502cb1d6c0e778fdbc2498d086ab3c1120dd3d5b \
+                        sha256  fccc62928c65192fff6c98847233b28eb7ce05f12d2fea3f6cc90e8b4e5fbe06 \
+                        size    2743740 \
                         ${docdistname}${extract.suffix} \
-                        rmd160  44d57b5e54ad1792565b36f9324944035beabb8b \
-                        sha256  aa2f835ef8f50072630ddc48b9eb65f1f456014ffa3b5adddcb6bf390a3c5828 \
-                        size    2130292
+                        rmd160  7e35ef7adc62ddc3b24b628770e171814118d334 \
+                        sha256  5fdc0fd118a0a82ff36054988b82ea2fc0da2302962b51d14ca2880ee4959fb2 \
+                        size    2130601
 
 patchfiles \
     freetype-config-no-pkg-config.patch \

--- a/print/freetype/files/patch-modules.cfg.diff
+++ b/print/freetype/files/patch-modules.cfg.diff
@@ -1,11 +1,9 @@
---- modules.cfg.orig	2018-04-22 04:41:36.000000000 -0500
-+++ modules.cfg	2018-08-30 03:05:50.000000000 -0500
-@@ -143,7 +143,7 @@
+--- modules.cfg.orig	2019-03-26 10:44:50.337019121 -0400
++++ modules.cfg	2019-03-26 10:45:05.664017701 -0400
+@@ -131,5 +131,5 @@
  # OpenType table validation.  Needs `ftotval.c' below.
  #
- # No FT_CONFIG_OPTION_PIC support.
 -# AUX_MODULES += otvalid
 +AUX_MODULES += otvalid
- 
+
  # Auxiliary PostScript driver component to share common code.
- #


### PR DESCRIPTION
#### Description
Tested basic functionality by using graphviz to render a dotfile to PNG.

I didn't have this close #48487, but it sounds like it was fixed with the release of freetype 2.7.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
