### PR TITLE
py-pyqt5 and py-spyder[-devel]

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -21,9 +21,12 @@ checksums               rmd160  bfe5376baf97bde0ebad0fd7f109e23ff3242975 \
                         sha256  3718ce847d824090fd5f95ff3f13847ee75c2507368d4cbaeb48338f506e59bf \
                         size    3147086
 
-
 python.versions 27 34 35 36 37
 subport "${name}-common" {}
+
+foreach py_ver ${python.versions} {
+    subport "py${py_ver}-pyqt5-webengine" {}
+}
 
 if {${subport} eq "${name}-common"} {
     description-append          (.sip sourcefiles)
@@ -41,6 +44,37 @@ if {${subport} eq "${name}-common"} {
         file copy {*}[glob -directory ${worksrcpath}/sip/ Q*] ${destroot}${prefix}/share/sip/PyQt5
         file copy ${worksrcpath}/sip/Enginio ${destroot}${prefix}/share/sip/PyQt5
     }
+
+} elseif {[string first "webengine" ${subport}] != -1} {
+    PortGroup           qmake5 1.0
+
+    description         PyQt5 Webengine bindings
+    long_description    ${description}
+    master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}
+    distname            PyQtWebEngine_gpl-${version}
+    checksums           rmd160  5e0c3cd69448b8dee042ba6565c823e266c22a14 \
+                        sha256  860704672ea1b616e1347be1f347bc1c749e64ed378370863fe209e84e9bd473 \
+                        size    42474
+
+    depends_lib-append  port:py${python.version}-pyqt5
+    qt5.depends_component \
+                        qtwebengine
+    use_configure       yes
+    configure.pre_args
+    configure.cmd       "${python.bin} configure.py"
+    qt5.spec_cmd        --spec=
+    configure.args-append \
+                        -q ${qt_qmake_cmd} \
+                        --verbose \
+                        --sip=${prefix}/bin/sip-${python.branch} \
+                        --no-qsci-api \
+                        --no-dist-info
+
+    build.cmd           make
+    build.target        all
+    destroot.cmd        ${build.cmd}
+    destroot.destdir    DESTDIR=${destroot}
+
 } elseif {${name} ne ${subport}} {
     PortGroup           qmake5 1.0
 

--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -105,9 +105,6 @@ if {${subport} eq "${name}-common"} {
                         --no-qsci-api \
                         --disable=QtWebKit \
                         --disable=QtWebKitWidgets \
-                        --disable=QtWebEngine \
-                        --disable=QtWebEngineCore \
-                        --disable=QtWebEngineWidgets \
                         --no-dist-info
 
     # using --dbus means the compiler will find dbus-python.h but not
@@ -143,11 +140,12 @@ if {${subport} eq "${name}-common"} {
         }
     }
 
-    variant webengine conflicts universal description {Build QtWebEngine module} {
-        qt5.depends_component   qtwebengine
-        configure.args-delete   --disable=QtWebEngine \
-                                --disable=QtWebEngineCore \
-                                --disable=QtWebEngineWidgets
+    # variant is obsolete since py-pyqt5 version 5.12.1, remove after March 26, 2020
+    variant webengine description {Build QtWebEngine module (obsolete, use the py-pyqt5-webengine port)} {
+        notes "
+        The +webengine variant is obsolete because PyQtWebEngine is not included anymore in the PyQt5 bindings.\
+        If you need PyQtWebEngine, please install the py-pyqt5-webengine port.
+        "
     }
 
     variant webkit description {Build QtWebKit module} {

--- a/python/py-spyder-devel/Portfile
+++ b/python/py-spyder-devel/Portfile
@@ -9,7 +9,7 @@ PortGroup           select 1.0
 
 github.setup        spyder-ide spyder a8b9d43
 version             3.3.0-20190321
-revision            0
+revision            1
 name                py-spyder-devel
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
@@ -42,7 +42,6 @@ checksums           rmd160  58caed0ecff761caaa67468784bd56b2185e2834 \
                     size    4150846
 
 if {${name} ne ${subport}} {
-    require_active_variants py${python.version}-pyqt5 webengine
     require_active_variants py${python.version}-qtpy qt5
 
     conflicts   py${python.version}-spyder
@@ -63,6 +62,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-pygments \
         port:py${python.version}-pylint \
         port:py${python.version}-pyqt5 \
+        port:py${python.version}-pyqt5-webengine \
         port:py${python.version}-qdarkstyle \
         port:py${python.version}-qtawesome \
         port:py${python.version}-qtconsole \

--- a/python/py-spyder/Portfile
+++ b/python/py-spyder/Portfile
@@ -9,7 +9,7 @@ PortGroup           select 1.0
 
 github.setup        spyder-ide spyder 3.3.3 v
 name                py-spyder
-revision            0
+revision            1
 # Preference on mailing list is to use small numbers for epoch.
 # This is already a date code, so sticking with dates.
 epoch               20111202
@@ -44,7 +44,6 @@ checksums           rmd160  466bde67cee4632054b09b947736947578adaf44 \
                     size    3946956
 
 if {${name} ne ${subport}} {
-    require_active_variants py${python.version}-pyqt5 webengine
     require_active_variants py${python.version}-qtpy qt5
 
     conflicts       py${python.version}-spyder-devel
@@ -66,6 +65,7 @@ if {${name} ne ${subport}} {
         port:py${python.version}-pygments \
         port:py${python.version}-pylint \
         port:py${python.version}-pyqt5 \
+        port:py${python.version}-pyqt5-webengine \
         port:py${python.version}-qtawesome \
         port:py${python.version}-qtconsole \
         port:py${python.version}-qtpy \


### PR DESCRIPTION
#### Description
The latest ```py-pyqt5``` release does no longer include PyQtWebEngine and, therefore, the ```webengine``` variant doesn't do anything anymore. This causes issue with ```py-spyder[-devel]``` that require this variant. 

As discussed in [ticket 58237](https://trac.macports.org/ticket/58237), this PR adds the ```py-pyqt5-webengine``` subport to ```py-pyqt5```, removes the no-longer-existing configure arguments, and obsoletes the ```webengine``` variant.

Finally, the ```py-spyder[-devel]``` ports are updated so that they now depend on the new ```py-pyqt5-webengine``` port. The additional benefit is that ports providing Spyder do not rely on non-default variants anymore, which should allow them to finish in CI runs and to build on the buildbot.

@mamoll for your consideration/testing; @mf2k this should fix your Spyder issues.
 
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
