### PR TITLE
multiple ports: use HTTPS for VideoLAN sites

### DIFF
--- a/audio/libdca/Portfile
+++ b/audio/libdca/Portfile
@@ -12,13 +12,13 @@ platforms           darwin
 description         libdca is a free library for decoding DTS Coherent \
                     Acoustics streams.
 long_description    ${description}
-homepage            http://www.videolan.org/developers/libdca.html
+homepage            https://www.videolan.org/developers/libdca.html
 
 livecheck.type      regex
 livecheck.regex     {Current release is <a.*>libdca-(.*).tar.bz2</a>}
 livecheck.url       ${homepage}
 
-master_sites        http://download.videolan.org/pub/videolan/libdca/${version}/
+master_sites        https://download.videolan.org/pub/videolan/libdca/${version}/
 
 checksums           rmd160 9857d7b0379266d9400f271d6f8d788cfb2227ee \
                     sha256  98f98a9aa000a26b927c6facd15d18dcf664238adfc5db24f533c5932cdb1f40 \

--- a/devel/libdvbpsi/Portfile
+++ b/devel/libdvbpsi/Portfile
@@ -15,9 +15,9 @@ long_description \
     the Program specific Information ( PSI ) present in a MPEG2 TS or a \
     DVB stream. The two keywords are portability and simplicity .
 
-homepage            http://developers.videolan.org/libdvbpsi/
+homepage            https://www.videolan.org/developers/libdvbpsi.html
 platforms           darwin
-master_sites        http://download.videolan.org/pub/${name}/${version}/
+master_sites        https://download.videolan.org/pub/${name}/${version}/
 
 use_bzip2           yes
 
@@ -41,5 +41,5 @@ pre-configure {
 configure.args-append \
                     --disable-silent-rules --enable-release
 
-livecheck.url       http://download.videolan.org/pub/${name}/
+livecheck.url       https://download.videolan.org/pub/${name}/
 livecheck.regex     {>([0-9.]+)/<}

--- a/devel/libdvdcss/Portfile
+++ b/devel/libdvdcss/Portfile
@@ -15,8 +15,8 @@ long_description    libdvdcss is a simple library designed for accessing \
                     DVDs like a block device without having to bother \
                     about the decryption.
 
-homepage            http://www.videolan.org/developers/libdvdcss.html
-master_sites        http://download.videolan.org/pub/${name}/${version}/
+homepage            https://www.videolan.org/developers/libdvdcss.html
+master_sites        https://download.videolan.org/pub/${name}/${version}/
 use_bzip2           yes
 checksums           rmd160  745fd7ae3b2313a35b08b42040d0c020e3037501 \
                     sha256  78c2ed77ec9c0d8fbed7bf7d3abc82068b8864be494cfad165821377ff3f2575
@@ -31,5 +31,5 @@ post-destroot {
 }
 
 livecheck.type      regex
-livecheck.url       http://download.videolan.org/pub/${name}/
+livecheck.url       https://download.videolan.org/pub/${name}/
 livecheck.regex     {>([0-9.]+)/<}

--- a/devel/libdvdnav/Portfile
+++ b/devel/libdvdnav/Portfile
@@ -29,7 +29,7 @@ depends_lib         port:libdvdread
 use_autoreconf      yes
 
 homepage            http://dvdnav.mplayerhq.hu/
-master_sites        http://download.videolan.org/pub/videolan/${name}/${version}/
+master_sites        https://download.videolan.org/pub/videolan/${name}/${version}/
 use_bzip2           yes
 checksums           rmd160  0b972d4bb872135f8b6c206163373ee9b4454ea7 \
                     sha256  f0a2711b08a021759792f8eb14bb82ff8a3c929bf88c33b64ffcddaa27935618
@@ -49,5 +49,5 @@ post-destroot {
 }
 
 livecheck.type      regex
-livecheck.url       http://download.videolan.org/pub/videolan/${name}/
+livecheck.url       https://download.videolan.org/pub/videolan/${name}/
 livecheck.regex     {>([0-9.]+)/<}

--- a/devel/libdvdread/Portfile
+++ b/devel/libdvdread/Portfile
@@ -23,7 +23,7 @@ long_description \
        (nav_read.h/nav_types.h).
 
 homepage            http://dvdnav.mplayerhq.hu/
-master_sites        http://download.videolan.org/pub/videolan/${name}/${version}/
+master_sites        https://download.videolan.org/pub/videolan/${name}/${version}/
 
 use_bzip2           yes
 checksums           rmd160  a32f7cfc3dd55c35fa23ec19ff7a3854b730fab6 \
@@ -40,5 +40,5 @@ post-patch {
 configure.args-append   --disable-silent-rules
 
 livecheck.type      regex
-livecheck.url       http://download.videolan.org/pub/videolan/${name}/
+livecheck.url       https://download.videolan.org/pub/videolan/${name}/
 livecheck.regex     {>([0-9.]+)/<}

--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -17,7 +17,7 @@ long_description    VLC media player is a highly portable multimedia player for 
                     It can also be used as a server to stream in unicast or multicast \
                     in IPv4 or IPv6 on a high-bandwidth network.
 
-homepage            http://www.videolan.org
+homepage            https://www.videolan.org
 
 subport lib${name} {
     description     the core engine and interface to VLC's multimedia framework
@@ -26,7 +26,7 @@ subport lib${name} {
                     framework on which VLC media player is based.  It allows developers \
                     to create a wide range of multimedia applications using the VLC features.
     conflicts       ${name} VLC2
-    homepage        http://www.videolan.org/vlc/libvlc.html
+    homepage        https://www.videolan.org/vlc/libvlc.html
     # libVLC builds on 10.9 (Darwin 13)
     if {${os.major} < 13} {
         replaced_by libVLC2
@@ -56,7 +56,7 @@ license             GPL-2
 
 platforms           darwin
 
-master_sites        http://download.videolan.org/pub/videolan/vlc/${version}/
+master_sites        https://download.videolan.org/pub/videolan/vlc/${version}/
 dist_subdir         VLC
 distname            vlc-${version}
 use_xz              yes
@@ -233,7 +233,7 @@ if {${subport} ne "lib${name}"} {
     destroot.target install
 }
 
-livecheck.url       http://download.videolan.org/pub/videolan/vlc/
+livecheck.url       https://download.videolan.org/pub/videolan/vlc/
 livecheck.regex     <a href=\"(\\d\[\\d|\.|\\w\]+).*/\">
 
 # Other

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -17,7 +17,7 @@ long_description        VLC media player is a highly portable multimedia player 
                         It can also be used as a server to stream in unicast or multicast \
                         in IPv4 or IPv6 on a high-bandwidth network.
 
-homepage                http://www.videolan.org
+homepage                https://www.videolan.org
 
 subport lib${name} {
     description         the core engine and interface to VLC's multimedia framework
@@ -31,7 +31,7 @@ subport lib${name} {
         PortGroup       obsolete 1.0
         patch           {}
     }
-    homepage            http://www.videolan.org/vlc/libvlc.html
+    homepage            https://www.videolan.org/vlc/libvlc.html
 }
 
 if {${subport} eq ${name}} {
@@ -59,7 +59,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
 
     platforms           darwin
 
-    master_sites        http://download.videolan.org/pub/videolan/vlc/${version}/
+    master_sites        https://download.videolan.org/pub/videolan/vlc/${version}/
     distname            vlc-${version}
     use_xz              yes
 
@@ -208,7 +208,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     # live555 is installed to a weird location
     configure.cppflags-append -I${prefix}/lib/live/liveMedia/include
 
-    livecheck.url       http://download.videolan.org/pub/videolan/vlc/
+    livecheck.url       https://download.videolan.org/pub/videolan/vlc/
     livecheck.regex     <a href=\"(\\d\[\\d|\.|\\w\]+).*/\">
 
     # Other

--- a/multimedia/libaacs/Portfile
+++ b/multimedia/libaacs/Portfile
@@ -13,8 +13,8 @@ description         AACS support library for Blu-ray playback
 
 long_description    Implementation of the Advanced Access Content System Specification
 
-homepage            http://www.videolan.org/developers/libaacs.html
-master_sites        http://get.videolan.org/libaacs/${version}
+homepage            https://www.videolan.org/developers/libaacs.html
+master_sites        https://get.videolan.org/libaacs/${version}
 
 use_bzip2           yes
 

--- a/multimedia/libbdplus/Portfile
+++ b/multimedia/libbdplus/Portfile
@@ -13,8 +13,8 @@ description         an open-source library designed implement the BD+ System
 
 long_description    A research project designed to implement the BD+ System Specification that provides an open source library
 
-homepage            http://www.videolan.org/developers/libbdplus.html
-master_sites        http://get.videolan.org/libbdplus/${version}
+homepage            https://www.videolan.org/developers/libbdplus.html
+master_sites        https://get.videolan.org/libbdplus/${version}
 
 use_bzip2           yes
 

--- a/multimedia/libbluray/Portfile
+++ b/multimedia/libbluray/Portfile
@@ -12,8 +12,8 @@ description         an open-source library designed for Blu-Ray Discs playback
 
 long_description    ${description}
 
-homepage            http://www.videolan.org/developers/libbluray.html
-master_sites        http://get.videolan.org/libbluray/${version}
+homepage            https://www.videolan.org/developers/libbluray.html
+master_sites        https://get.videolan.org/libbluray/${version}
 
 use_bzip2           yes
 

--- a/multimedia/x264/Portfile
+++ b/multimedia/x264/Portfile
@@ -16,8 +16,8 @@ long_description    x264 is a free library for encoding H264/AVC video streams. 
                     Chen (vfw/nasm), Justin Clay(vfw), Måns Rullgård and Loren \
                     Merritt from scratch. It is released under the terms of the \
                     GPL license.
-homepage            http://www.videolan.org/x264.html
-master_sites        http://ftp.videolan.org/pub/videolan/x264/snapshots/
+homepage            https://www.videolan.org/x264.html
+master_sites        https://download.videolan.org/pub/videolan/x264/snapshots/
 
 dist_subdir         x264
 distname            ${name}-snapshot-${version}-2245-stable

--- a/multimedia/x265/Portfile
+++ b/multimedia/x265/Portfile
@@ -24,7 +24,7 @@ long_description    x265 is a free software library and application for \
                     compression format, and is released under the terms of the \
                     GNU GPL.
 homepage            https://www.videolan.org/developers/x265.html
-master_sites        http://ftp.videolan.org/pub/videolan/x265/
+master_sites        https://download.videolan.org/pub/videolan/x265/
 distname            ${name}_${version}
 worksrcdir          ${distname}/source
 


### PR DESCRIPTION
Change ftp.videolan.org to download.videolan.org

`libdvbpsi`: fix homepage

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
See https://github.com/macports/macports-ports/pull/3954#issuecomment-477027629

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
