### PR TITLE
SoapySDR modules

### DIFF
--- a/audio/rtaudio/Portfile
+++ b/audio/rtaudio/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+platforms           darwin macosx
+categories          audio
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         A set of C++ classes that provide a common API for realtime audio input/output
+long_description    RtAudio is a set of C++ classes that provides a \
+    common API (Application Programming Interface) for realtime audio \
+    input/output across Linux (native ALSA, JACK, PulseAudio and OSS), \
+    Macintosh OS X and Windows (DirectSound, ASIO and WASAPI) operating \
+    systems. RtAudio significantly simplifies the process of interacting \
+    with computer audio hardware.
+homepage            http://www.music.mcgill.ca/~gary/rtaudio/
+
+github.setup        thestk rtaudio 5.0.0
+checksums           rmd160  a9f5f7e602f9c7de6fa94e164706df32d33905ab \
+                    sha256  6929fb7b396de8e20333ba7169a270c31b541a0fb04eaa8bea7d1c4231afba20 \
+                    size    211315
+revision            0
+
+depends_build-append \
+    port:pkgconfig \
+    port:autoconf \
+    port:automake \
+    port:libtool
+
+# new versions will use cmake
+configure.cmd       ./autogen.sh
+configure.args      --with-core
+
+build.args-append   \
+    CC=${configure.cc} \
+    CXX=${configure.cxx} \
+    CPP=${configure.cpp}

--- a/science/SoapyAirspy/Portfile
+++ b/science/SoapyAirspy/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR plugin for Airspy
+long_description    ${description}
+
+github.setup        pothosware SoapyAirspy 0.1.2 soapy-airspy-
+checksums           rmd160  ec4fae8409fce242040b49f277cc00b49eaa2976 \
+                    sha256  bbbc235c3bc0a9864d6b194c61ddb0b6d1ab9e2d4702a1176f93516ce5357b80 \
+                    size    11544
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:airspy
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyAirspyHF/Portfile
+++ b/science/SoapyAirspyHF/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR plugin for AirspyHF+
+long_description    ${description}
+
+github.setup        pothosware SoapyAirspyHF 0.1.0 soapy-airspyhf-
+checksums           rmd160  f60fa7fc552cf840f97094cde78e7cbf49612bf0 \
+                    sha256  23bbe99fbf2694eebb500d4aec6ff512c7ed9936db455ccade3df3816d4b04e6 \
+                    size    9408
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:airspyhf
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyAudio/Portfile
+++ b/science/SoapyAudio/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR plugin for Audio devices
+long_description    ${description}
+
+github.setup        pothosware SoapyAudio 0.1.0 soapy-audio-
+checksums           rmd160  d63f01e8ba4b7961642972a86e7c0c814996c3ed \
+                    sha256  6ee256f3c7595e1d1e09e6ced45f5871de7b8ef9c615951562667516bd9a2968 \
+                    size    90312
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:hamlib \
+    port:rtaudio
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyBladeRF/Portfile
+++ b/science/SoapyBladeRF/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             LGPL-2.1
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR plugin for Blade RF
+long_description    ${description}
+
+github.setup        pothosware SoapyBladeRF 0.4.1 soapy-bladerf-
+checksums           rmd160  763f4f31e8573ffd511e6e41464f9fa44bfd786e \
+                    sha256  6b90befee4372ff0011445c471c348b18f1998ae0d5b833c0026f088031c8a72 \
+                    size    29195
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:bladeRF
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyHackRF/Portfile
+++ b/science/SoapyHackRF/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR module for Hack RF
+long_description    ${description}
+
+github.setup        pothosware SoapyHackRF 0.3.3 soapy-hackrf-
+checksums           rmd160  f84ccc9da7005042caa7e18ca7783e150b7407f6 \
+                    sha256  0f1a8bb8ebd0337916b4a6a9d4a57f09853fd1a4f0e43c77f1e4ec3529f72977 \
+                    size    15845
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:hackrf
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyPlutoSDR/Portfile
+++ b/science/SoapyPlutoSDR/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             LGPL-2.1
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR module for Pluto SDR
+long_description    ${description}
+
+github.setup        pothosware SoapyPlutoSDR 0.1.0 soapy-plutosdr-
+checksums           rmd160  537d48e31d9daeba8a92debc1a12e0078c4349e8 \
+                    sha256  b19cbdbac9f6da16a9a91fe90d4e000736294c20aa179a77048c2e93497679ec \
+                    size    18392
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:libiio \
+    port:libad9361-iio
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyRTLSDR/Portfile
+++ b/science/SoapyRTLSDR/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
 
 platforms           darwin macosx
 categories          science
@@ -17,6 +18,9 @@ checksums           rmd160  88bb56f7842b9ce4de9f32fe1df0545c543a6724 \
                     sha256  5fe2841548af43011381ef3da3f75be134245ccc215c12b0fea7f900760ce98f \
                     size    14389
 revision            0
+
+depends_build-append \
+    port:pkgconfig
 
 depends_lib-append \
     port:SoapySDR \

--- a/science/SoapyRedPitaya/Portfile
+++ b/science/SoapyRedPitaya/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             GPL-3.0
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR plugins for Red Pitaya
+long_description    ${description}
+
+github.setup        pothosware SoapyRedPitaya 0.1.1 soapy-redpitaya-
+checksums           rmd160  6d772ff767264d2f331c6fcdadf76aa31cab1e0e \
+                    sha256  bb30dbe8170a131dd7650dfe745e37c872635313fab8849217acd57b667f9251 \
+                    size    17901
+revision            0
+
+depends_lib-append \
+    port:SoapySDR \
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyRemote/Portfile
+++ b/science/SoapyRemote/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             Boost-1
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR module for use any Soapy SDR remotely
+long_description    ${description}
+
+github.setup        pothosware SoapyRemote 0.5.1 soapy-remote-
+checksums           rmd160  59cbec7102a4f5bf81351ac7e98d51580b34f4a4 \
+                    sha256  0561c03dd7cc6bda11dbfcfe4578541803955e2e801e5bbeeecfb19d026a683e \
+                    size    72656
+revision            0
+
+depends_lib-append \
+    port:SoapySDR
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/SoapyUHD/Portfile
+++ b/science/SoapyUHD/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             GPL-3.0
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         Soapy SDR plugins for UHD devices
+long_description    ${description}
+
+github.setup        pothosware SoapyUHD 0.3.5 soapy-uhd-
+checksums           rmd160  35161c55e199394c6294e080bd627f3a081ae561 \
+                    sha256  3e100e7058d9ada7cd017619d65eec032b1441df335a85b2fa7bda58b0750d4d \
+                    size    32351
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    port:SoapySDR \
+    port:uhd \
+    port:boost
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/science/airspyhf/Portfile
+++ b/science/airspyhf/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          science
+license             BSD
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         User mode driver for Airspy HF+
+long_description    ${description}
+
+github.setup        airspy airspyhf 1.1.5
+checksums           rmd160  0a4627b33b46e196ccb7c509623a9a7b3867bde0 \
+                    sha256  037d52aef7ce327ab587678d15c4e0b2fe1398f8d1cc0f2788abac7e5caea74b \
+                    size    21934
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    path:lib/libusb.dylib:libusb


### PR DESCRIPTION
#### Description

Support for the following devices on SoapySDR:
- SoapyPlutoSDR
- SoapyRemote
- SoapyBladeRF
- SoapyAirspyHF
- SoapyAudio
- SoapyAirspy
- SoapyHackRF
- SoapyUHD
- SoapyRedPitaya

In this way you can use those devices with clients that support SoapySDR API, like CubicSDR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->