### PR TITLE
nginx: add stream_ssl_preread module

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                nginx
 version             1.15.10
-revision            0
+revision            1
 categories          www mail
 platforms           darwin
 license             BSD
@@ -121,7 +121,7 @@ notes "\
     Additionally, the files [join ${auto_activate_confs} ", "] have been copied to ${nginx_confdir} if they didn't exist yet.\n\
     Adjust these files to your needs before starting nginx."
 
-default_variants +mp4 +flv +secure_link +ssl +http2
+default_variants +mp4 +flv +secure_link +ssl +http2 +stream
 
 variant auth_request description {Add client authorization based on the result of a subrequest} {
     configure.args-append   --with-http_auth_request_module
@@ -240,7 +240,8 @@ variant substitution description {Replace text in pages} {
 variant stream description {Enable ngx_stream_core_module for generic TCP proxying and load balancing (install with +ssl to enable ngx_stream_ssl_module)} {
     configure.args-append   --with-stream
     if {[variant_isset ssl]} {
-        configure.args-append   --with-stream_ssl_module
+        configure.args-append \
+            --with-stream_ssl_module --with-stream_ssl_preread_module
     }
 }
 


### PR DESCRIPTION
#### Description
Also make +stream a default variant.
Closes: https://trac.macports.org/ticket/58147

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.3 18D109
Xcode 10.2 10E125

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?