### PR TITLE
dssp: new port, version 3.0.6

### DIFF
--- a/science/dssp/Portfile
+++ b/science/dssp/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cxx11 1.1
+
+github.setup        cmbi xssp 3.0.6
+revision            0
+name                dssp
+
+categories          science
+license             Boost-1
+
+maintainers         {gmail.com:ottenr.work @reneeotten} openmaintainer
+
+description         DSSP automates protein secondary structure assignment.
+long_description    ${description}
+
+platforms           darwin
+
+checksums           rmd160  b66d81ce987f38feaa9a7082091ac20d0c97197e \
+                    sha256  cb578365774d5f015b2b590716ec7e8923fa3d8334a8efdca87fa41a9c742ae1 \
+                    size    167938
+
+# patch binPROGRAMS to only include mkdssp
+patchfiles-append   patch-Makefile.am.diff
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:bzip2 \
+                    port:libtool
+
+depends_lib-append  port:boost
+
+pre-configure {
+    reinplace "s|3.0.1|${version}|g" ${worksrcpath}/configure.ac
+}
+
+configure.cmd       ./autogen.sh && ./configure
+configure.args      --disable-silent-rules
+
+if {[vercmp [macports_version] 2.5.99] >= 0} {
+    build.env       CC=${configure.cc} \
+                    "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
+                    CPPFLAGS=${configure.cppflags} \
+                    CXX=${configure.cxx} \
+                    "CXXFLAGS=${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"
+} else {
+    build.env       CC="${configure.cc}" \
+                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
+                    CPPFLAGS="${configure.cppflags}" \
+                    CXX="${configure.cxx}" \
+                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
+}
+
+build.target        mkdssp
+destroot.target     install-binPROGRAMS
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} README.md LICENSE_1_0.txt \
+        INSTALL COPYING ${destroot}${docdir}
+}

--- a/science/dssp/files/patch-Makefile.am.diff
+++ b/science/dssp/files/patch-Makefile.am.diff
@@ -1,0 +1,8 @@
+--- Makefile.am.orig	2019-03-27 10:00:36.000000000 -0400
++++ Makefile.am	2019-03-27 10:00:48.000000000 -0400
+@@ -1,4 +1,4 @@
+-bin_PROGRAMS	=	mkdssp mkhssp hsspconv test_fasta test_conv test_readpdb
++bin_PROGRAMS	=	mkdssp
+ 
+ shared_LDADD =	$(BOOST_DATE_TIME_LIB) \
+ 								$(BOOST_FILESYSTEM_LIB) \


### PR DESCRIPTION
#### Description
I do not claim that I fully understand the build system... and perhaps there is a better way to make sure only ```mkdssp``` is installed than patching the ```bin_PROGRAMS```. But I have tried for a while without success and the current approach works.

I tried to set-up the ```build.env``` for the ```universal``` build, based on examples from other portfiles, but I am not sure how to test is because macOS Mojave cannot build universal. Since it uses only C++,  I guess there is no need to add CC/CFLAGS but it shouldn't hurt either right? Can someone take a look it this to see if this is about right and perhaps test on an older system to see if actually works? 

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
