### PR TITLE
nano: bugfix building for nano v4

### DIFF
--- a/editors/nano/Portfile
+++ b/editors/nano/Portfile
@@ -17,7 +17,7 @@ long_description \
     internationalization support, and filename tab completion.
 
 homepage        https://www.nano-editor.org
-master_sites    ${homepage}dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
+master_sites    ${homepage}/dist/v[strsed ${version} {/\.[0-9]*$//}]/ gnu
 
 checksums           rmd160  7d5800084e8cab53d50c118ec2258a5c7d6f0321 \
                     sha256  5b3f67d7d187e9feb980e1482ba38c1bc424bace5282c6bbe85b4bb98371ef1e \


### PR DESCRIPTION
#### Description

Added missing slash in base GNU nano url

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.4 18E220a
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
