### PR TITLE
asymptote: update to 2.48

### DIFF
--- a/graphics/asymptote/Portfile
+++ b/graphics/asymptote/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                asymptote
-version             2.47
+version             2.48
 
 categories          graphics
 maintainers         {mojca @mojca} openmaintainer
@@ -27,9 +27,9 @@ set python.bin      ${prefix}/bin/python${python.branch}
 master_sites        sourceforge:asymptote
 extract.suffix      .src.tgz
 
-checksums           rmd160  6f0adc5bbc5e56351e573c052db4f61d454b5d9c \
-                    sha256  e1a4e5a36f87f62986f86bc4cff5ae922c8aa71bd3e17b5975ad7fbe8525827d \
-                    size    3621676
+checksums           rmd160  ff7a770ac1927f59f8c5678ff52b4f85ccf735d9 \
+                    sha256  4f0fbe96d22832a93ce4a6cbec99b6c9d1d6e974d79e481dd60a9ddef24e1221 \
+                    size    3729763
 
 patchfiles          patch-Makefile.diff
 
@@ -65,6 +65,7 @@ depends_build       port:ghostscript \
 
 depends_lib         port:readline \
                     port:fftw-3 \
+                    port:glm \
                     port:gsl \
                     port:libsigsegv \
                     port:ncurses \

--- a/graphics/asymptote/files/patch-Makefile.diff
+++ b/graphics/asymptote/files/patch-Makefile.diff
@@ -8,7 +8,7 @@
 +GCLIBS = $(GCPPLIB) $(GCLIB) -lgccpp
  LFLAGS = @LDFLAGS@
  LIBS = $(LFLAGS) @PTHREAD_LIBS@ @LIBS@ $(GCLIBS)
- DOSLIBS = $(subst -lncurses, -ltermcap, $(LIBS)) -s -static
+ DOSLIBS = $(subst -lncurses, -ltermcap, $(LIBS)) -lgdi32 -lwinmm -s -static
 #@@ -110,7 +110,7 @@ endif
 # export prefix docdir exampledir mandir infodir INSTALL MAKE DESTDIR TEXI2DVI
 # 
@@ -18,7 +18,7 @@
 # 	if test -n "$(MSDOS)"; then \
 #           $(CXX) $(OPTS) -o $(NAME) $(FILES:=.o) revision.o asy.o $(DOSLIBS); \
 # 	else \
-@@ -128,7 +128,7 @@ version: $(GCLIB) $(FILES:=.o) $(UIFILES:.ui=.py)
+@@ -130,7 +130,7 @@ version: $(GCLIB) $(FILES:=.o) $(UIFILES:.ui=.py)
  	echo @set VERSION $(revision) > doc/version.texi
  	echo @set Datadir @datadir@ >> doc/version.texi
  


### PR DESCRIPTION
#### Description

I noticed that `glm` is a header-only library. Can it be declared as `depends_build` instead?

Other than that, feel free to merge if it builds correctly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? (yes, but without trace mode)
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->