### PR TITLE
micronaut: update to 1.0.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.0.4 v
+github.setup    micronaut-projects micronaut-core 1.0.5 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  74ff2db67abeeb47426bd3194427c14c26b2f829 \
-                sha256  d537a774ba1e073dbeca14611a0fc9fc296e1231e128d9f62577537f46373151 \
-                size    12758784
+checksums       rmd160  39a05233eb46caae6eab4679876003eea83e0d4c \
+                sha256  4a7ab0a1bd094ff19cd47fbe6382f7470f91ead146497090109ea202af35ff41 \
+                size    12758786
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.0.5.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?