### PR TITLE
i386-elf-binutils: port abandoned

### DIFF
--- a/cross/i386-elf-binutils/Portfile
+++ b/cross/i386-elf-binutils/Portfile
@@ -4,6 +4,6 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 crossbinutils.setup i386-elf 2.32
-maintainers         gmail.com:jinksys
+maintainers         nomaintainer
 
 configure.args-append --disable-werror


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58020

When merging please unassign https://trac.macports.org/ticket/18161

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
