### PR TITLE
vislcg3: update maintainer

### DIFF
--- a/textproc/vislcg3/Portfile
+++ b/textproc/vislcg3/Portfile
@@ -7,7 +7,7 @@ version                 0.9.7.5129
 revision                9
 categories              textproc
 platforms               darwin
-maintainers             gmail.com:p.ixiemotion
+maintainers             {tinodidriksen.com:consult @TinoDidriksen}
 
 description             Constraint Grammar parser for the VISL CG-3 formalism
 


### PR DESCRIPTION
See https://trac.macports.org/ticket/37773. The currently listed maintainer no longer maintains the port.

@TinoDidriksen, are you still interested in adopting maintainership of this port? I have used the email address from the patch submitted in the ticket, let us know if it is correct. I have also added your GitHub handle.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
