### PR TITLE
notmuch: update to version 0.28.3

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           conflicts_build 1.0
 
 name                notmuch
-version             0.28
-revision            1
+version             0.28.3
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -20,9 +19,9 @@ long_description    \"Not much mail\" is what Notmuch thinks about your email \
 homepage            https://notmuchmail.org
 master_sites        ${homepage}/releases/
 
-checksums           rmd160  9a413645c3f9cf7e16007d7937a7220492ef2672 \
-                    sha256  acca75cec91651ccd2a7e31f7004e2ae14eff4ae38e375b8a88414c464cd0a37 \
-                    size    921069
+checksums           rmd160  17d98c379b9cf26606280709a6a3af940d0b97ef \
+                    sha256  4e212d8b4ae30da04edb05d836dcdb569488ff6760706cecb882488eb1710eec \
+                    size    921920
 
 depends_build       port:pkgconfig \
                     port:python37 \


### PR DESCRIPTION
#### Description
Changed Portfile version, checksums and tarball size for Notmuch upstream release 0.28.3.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.2 10E125

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
