### PR TITLE
chromedriver: update to version 2.46

### DIFF
--- a/www/chromedriver/Portfile
+++ b/www/chromedriver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                chromedriver
-version             2.44
+version             2.46
 categories          www
 platforms           darwin
 maintainers         nomaintainer
@@ -24,9 +24,9 @@ dist_subdir         ${name}/${version}
 distname            ${name}_mac64
 use_zip             yes
 
-checksums           rmd160  c8359d13c080003c59e555c98de478174f316f70 \
-                    sha256  3fd49c2782a5f93cb48ff2dee021004d9a7fb393798e4c4807b391cedcd30ed9 \
-                    size    6909780
+checksums           rmd160  00b6ac50b0de0bd63d260cc7472c6e6af44b1240 \
+                    sha256  2aa256d17e4b2cc21f888b0e1b9ed211b925bf40f371d369fa0b9fbecf4bc52d \
+                    size    7057233
 
 extract.mkdir       yes
 


### PR DESCRIPTION
Changed Portfile version, checksums and tarball size for chromedriver upstream release 2.46.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->