### PR TITLE
notmuch: changed nomaintainer to rseichter

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -8,7 +8,7 @@ version             0.28.3
 categories          mail
 platforms           darwin
 license             GPL-3+
-maintainers         nomaintainer
+maintainers         {seichter.de:macports @rseichter} openmaintainer
 description         The mail indexer
 long_description    \"Not much mail\" is what Notmuch thinks about your email \
                     collection, even if you receive 12000 messages per month or have on the \


### PR DESCRIPTION
Added myself as the designated maintainer for the Notmuch port. Please see [here](https://github.com/macports/macports-ports/pull/3971#issuecomment-478351749) for reference.
