### PR TITLE
global: update to version 6.6.3

### DIFF
--- a/devel/global/Portfile
+++ b/devel/global/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                global
-version             6.6.2
+version             6.6.3
 categories          devel
 platforms           darwin
 maintainers         nomaintainer
@@ -22,8 +22,9 @@ long_description    GNU GLOBAL is a source code tag system that works the \
 homepage            https://www.gnu.org/software/global/
 master_sites        gnu
 
-checksums           rmd160  8019fac9289211f903b39659ae7bc549a9e08340 \
-                    sha256  43c64711301c2caf40dc56d7b91dd03d2b882a31fa31812bf20de0c8fb2e717f
+checksums           rmd160  226b67862b733e036305b35091629d517637c223 \
+                    sha256  cbee98ef6c1b064bc5b062d14a6d94dca67289e8374860817057db7688bc651c \
+                    size    2989668
 
 depends_lib         port:libtool \
                     port:ncurses


### PR DESCRIPTION
Changed Portfile version, checksums and added tarball size for global upstream release 6.6.3.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->