### PR TITLE
makedepend: update to version 1.0.6

### DIFF
--- a/x11/makedepend/Portfile
+++ b/x11/makedepend/Portfile
@@ -1,8 +1,8 @@
 PortSystem          1.0
 
 name                makedepend
-version             1.0.5
-revision            1
+version             1.0.6
+revision            0
 categories          x11 devel
 license             X11
 installs_libs       no
@@ -22,9 +22,10 @@ homepage            https://www.x.org/
 master_sites        http://xorg.freedesktop.org/archive/individual/util/
 use_bzip2           yes
 
-checksums           sha1    2599afa039d2070bae9df6ce43da288b3a4adf97 \
-                    rmd160  d1ba5b107ae145608a5f3e932fa2794eec1ddd0a \
-                    sha256  f7a80575f3724ac3d9b19eaeab802892ece7e4b0061dd6425b4b789353e25425
+checksums           sha1    3f321f7b570ec98f1fabc441267d29347a2e1456 \
+                    rmd160  6e6aa137d6cc63ae03feea0d45b4c51d4105ee60 \
+                    sha256  d558a52e8017d984ee59596a9582c8d699a1962391b632bec3bb6804bf4d501c \
+                    size    147616
 
 depends_build       port:pkgconfig port:xorg-xorgproto
 


### PR DESCRIPTION
Changed Portfile version, checksums and added tarball size for release 1.0.6.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14 18A391
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->