### PR TITLE
clang-8.0/devel : fix build on older systems

### DIFF
--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -171,7 +171,8 @@ if {${subport} eq "clang-${llvm_version}"} {
         3001-Fix-local-and-iterator-when-building-with-Lion-and-n.patch \
         3002-Fix-missing-long-long-math-prototypes-when-using-the.patch \
         3003-implement-atomic-using-mutex-lock_guard-for-64b-ops-.patch \
-        openmp-locations.patch
+        openmp-locations.patch \
+        patch-libcxx-cmakelists-reenable-10.6.8.diff
 
     # https://llvm.org/bugs/show_bug.cgi?id=25681
     if {${worksrcdir} eq "trunk" || ${worksrcdir} eq "release_${llvm_version_no_dot}"} {

--- a/lang/llvm-8.0/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
+++ b/lang/llvm-8.0/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
@@ -1,4 +1,4 @@
-From 1340c81077b70dce5ec0522986411f0d592795fd Mon Sep 17 00:00:00 2001
+From 129be7902cc13ee305724cd4e115b3a21d376fce Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Tue, 20 Dec 2016 12:41:21 -0800
 Subject: [PATCH 4/4] Fix build issues pre-Lion due to missing a strnlen
@@ -13,10 +13,10 @@ Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
  tools/obj2yaml/macho2yaml.cpp | 16 +++++++++++++++-
  2 files changed, 29 insertions(+), 1 deletion(-)
 
-diff --git llvm_release_80/lib/ObjectYAML/MachOYAML.cpp macports_release_80/lib/ObjectYAML/MachOYAML.cpp
+diff --git llvm_master/lib/ObjectYAML/MachOYAML.cpp macports_master/lib/ObjectYAML/MachOYAML.cpp
 index e00a4ea9307..0daba44573c 100644
---- llvm_release_80/lib/ObjectYAML/MachOYAML.cpp
-+++ macports_release_80/lib/ObjectYAML/MachOYAML.cpp
+--- llvm_master/lib/ObjectYAML/MachOYAML.cpp
++++ macports_master/lib/ObjectYAML/MachOYAML.cpp
 @@ -22,6 +22,20 @@
  #include <cstdint>
  #include <cstring>
@@ -38,10 +38,10 @@ index e00a4ea9307..0daba44573c 100644
  namespace llvm {
  
  MachOYAML::LoadCommand::~LoadCommand() = default;
-diff --git llvm_release_80/tools/obj2yaml/macho2yaml.cpp macports_release_80/tools/obj2yaml/macho2yaml.cpp
+diff --git llvm_master/tools/obj2yaml/macho2yaml.cpp macports_master/tools/obj2yaml/macho2yaml.cpp
 index fa81ce974ec..1e86f820437 100644
---- llvm_release_80/tools/obj2yaml/macho2yaml.cpp
-+++ macports_release_80/tools/obj2yaml/macho2yaml.cpp
+--- llvm_master/tools/obj2yaml/macho2yaml.cpp
++++ macports_master/tools/obj2yaml/macho2yaml.cpp
 @@ -15,7 +15,21 @@
  #include "llvm/Support/ErrorHandling.h"
  #include "llvm/Support/LEB128.h"
@@ -65,6 +65,28 @@ index fa81ce974ec..1e86f820437 100644
  
  using namespace llvm;
  
--- 
-2.20.1 (Apple Git-116)
+--- a/tools/llvm-readobj/ObjDumper.cpp.orig	2018-09-03 23:25:13.000000000 -0700
++++ b/tools/llvm-readobj/ObjDumper.cpp	2018-09-03 23:26:25.000000000 -0700
+@@ -27,6 +27,20 @@
+ ObjDumper::~ObjDumper() {
+ }
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
+ static void printAsPrintable(raw_ostream &W, const uint8_t *Start, size_t Len) {
+   for (size_t i = 0; i < Len; i++)
+     W << (isPrint(Start[i]) ? static_cast<char>(Start[i]) : '.');
+
 

--- a/lang/llvm-8.0/files/patch-libcxx-cmakelists-reenable-10.6.8.diff
+++ b/lang/llvm-8.0/files/patch-libcxx-cmakelists-reenable-10.6.8.diff
@@ -1,0 +1,12 @@
+--- a/projects/libcxx/lib/CMakeLists.txt.orig	2019-03-30 20:06:20.000000000 -0700
++++ b/projects/libcxx/lib/CMakeLists.txt	2019-03-30 20:07:28.000000000 -0700
+@@ -149,9 +149,6 @@
+   endif()
+ 
+   if ( CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "10.6" )
+-    message(FATAL_ERROR "Mac OSX 10.6 is not supported anymore as a deployment "
+-                        "target. If you need support for this, please contact "
+-                        "the libc++ maintainers.")
+   else()
+     if ("armv7" IN_LIST CMAKE_OSX_ARCHITECTURES)
+       set(RE_EXPORT_LIST "${CMAKE_CURRENT_SOURCE_DIR}/libc++sjlj-abi.exp")

--- a/lang/llvm-devel/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
+++ b/lang/llvm-devel/files/0004-Fix-build-issues-pre-Lion-due-to-missing-a-strnlen-d.patch
@@ -1,4 +1,4 @@
-From 1340c81077b70dce5ec0522986411f0d592795fd Mon Sep 17 00:00:00 2001
+From 129be7902cc13ee305724cd4e115b3a21d376fce Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Tue, 20 Dec 2016 12:41:21 -0800
 Subject: [PATCH 4/4] Fix build issues pre-Lion due to missing a strnlen
@@ -13,10 +13,10 @@ Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
  tools/obj2yaml/macho2yaml.cpp | 16 +++++++++++++++-
  2 files changed, 29 insertions(+), 1 deletion(-)
 
-diff --git llvm_release_80/lib/ObjectYAML/MachOYAML.cpp macports_release_80/lib/ObjectYAML/MachOYAML.cpp
+diff --git llvm_master/lib/ObjectYAML/MachOYAML.cpp macports_master/lib/ObjectYAML/MachOYAML.cpp
 index e00a4ea9307..0daba44573c 100644
---- llvm_release_80/lib/ObjectYAML/MachOYAML.cpp
-+++ macports_release_80/lib/ObjectYAML/MachOYAML.cpp
+--- llvm_master/lib/ObjectYAML/MachOYAML.cpp
++++ macports_master/lib/ObjectYAML/MachOYAML.cpp
 @@ -22,6 +22,20 @@
  #include <cstdint>
  #include <cstring>
@@ -38,10 +38,10 @@ index e00a4ea9307..0daba44573c 100644
  namespace llvm {
  
  MachOYAML::LoadCommand::~LoadCommand() = default;
-diff --git llvm_release_80/tools/obj2yaml/macho2yaml.cpp macports_release_80/tools/obj2yaml/macho2yaml.cpp
+diff --git llvm_master/tools/obj2yaml/macho2yaml.cpp macports_master/tools/obj2yaml/macho2yaml.cpp
 index fa81ce974ec..1e86f820437 100644
---- llvm_release_80/tools/obj2yaml/macho2yaml.cpp
-+++ macports_release_80/tools/obj2yaml/macho2yaml.cpp
+--- llvm_master/tools/obj2yaml/macho2yaml.cpp
++++ macports_master/tools/obj2yaml/macho2yaml.cpp
 @@ -15,7 +15,21 @@
  #include "llvm/Support/ErrorHandling.h"
  #include "llvm/Support/LEB128.h"
@@ -65,6 +65,28 @@ index fa81ce974ec..1e86f820437 100644
  
  using namespace llvm;
  
--- 
-2.20.1 (Apple Git-116)
+--- a/tools/llvm-readobj/ObjDumper.cpp.orig	2018-09-03 23:25:13.000000000 -0700
++++ b/tools/llvm-readobj/ObjDumper.cpp	2018-09-03 23:26:25.000000000 -0700
+@@ -27,6 +27,20 @@
+ ObjDumper::~ObjDumper() {
+ }
+ 
++#ifdef __APPLE__
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++static size_t strnlen(const char *s, size_t maxlen) {
++  size_t l = 0;
++  while (l < maxlen && *s) {
++    l++;
++    s++;
++  }
++  return l;
++}
++#endif
++#endif
++
+ static void printAsPrintable(raw_ostream &W, const uint8_t *Start, size_t Len) {
+   for (size_t i = 0; i < Len; i++)
+     W << (isPrint(Start[i]) ? static_cast<char>(Start[i]) : '.');
+
 

--- a/lang/llvm-devel/files/yosemite-no-clangd.patch
+++ b/lang/llvm-devel/files/yosemite-no-clangd.patch
@@ -1,10 +1,10 @@
 --- a/tools/clang/tools/extra/CMakeLists.txt	2018-04-03 01:26:00.000000000 -0700
 +++ b/tools/clang/tools/extra/CMakeLists.txt	2018-04-03 14:05:29.000000000 -0700
-@@ -10,7 +10,6 @@ add_subdirectory(change-namespace)
- add_subdirectory(clang-doc)
- add_subdirectory(clang-query)
+@@ -21,7 +21,6 @@
+ add_subdirectory(clang-include-fixer)
  add_subdirectory(clang-move)
+ add_subdirectory(clang-query)
 -add_subdirectory(clangd)
- add_subdirectory(include-fixer)
  add_subdirectory(pp-trace)
  add_subdirectory(tool-template)
+ 


### PR DESCRIPTION
update stale patches
add additional patch to re-enable clang-8.0 on < 10.7

Tested on 10.6.8