### PR TITLE
vlc: fix build against libssh2

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -173,7 +173,8 @@ compiler.blacklist-append \
                     gcc-4.2 llvm-gcc-4.2 macports-clang-3.8 {clang < 300}
 
 patchfiles-append   configure.ac-no-arch.patch \
-                    patch-soundfont-path.diff
+                    patch-soundfont-path.diff  \
+                    patch-vlc-fix-libssh2.diff
 
 if {![info exists replaced_by]} {
     post-patch {

--- a/multimedia/VLC/files/patch-vlc-fix-libssh2.diff
+++ b/multimedia/VLC/files/patch-vlc-fix-libssh2.diff
@@ -1,0 +1,11 @@
+--- ./modules/access/sftp.c.orig	2019-03-31 23:09:07.000000000 -0700
++++ ./modules/access/sftp.c	2019-03-31 23:09:26.000000000 -0700
+@@ -306,7 +306,7 @@
+         case LIBSSH2_HOSTKEY_TYPE_DSS:
+             knownhost_fingerprint_algo = LIBSSH2_KNOWNHOST_KEY_SSHDSS;
+             break;
+-#if LIBSSH2_VERSION_NUM >= 0x010801
++#if LIBSSH2_VERSION_NUM >= 0x010900
+         case LIBSSH2_HOSTKEY_TYPE_ECDSA_256:
+             knownhost_fingerprint_algo = LIBSSH2_KNOWNHOST_KEY_ECDSA_256;
+             break;


### PR DESCRIPTION
an expected #define in v 1.8.1 of libssh2 was not
actually present. change test to block use

closes: https://trac.macports.org/ticket/58283

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
