### PR TITLE
Update plumed 2.5.1

### DIFF
--- a/python/py-plumed/Portfile
+++ b/python/py-plumed/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        plumed plumed2 2.5.0 v
+github.setup        plumed plumed2 2.5.1 v
 name                py-plumed
 categories          python
 
@@ -18,9 +18,9 @@ long_description    ${description} They allow the plumed library to be directly 
 
 homepage            http://www.plumed.org
 
-checksums           rmd160  3873e9d48500bd01353396c0c85723a46b7c0ca9 \
-                    sha256  196aec82920bc6759ac66e32a8673f17e72b6c942bc84aadfd347182c5d9bedf \
-                    size    66557971
+checksums           rmd160  403aed6e2bfb1d90c97246642f98d1b67e7a31d9 \
+                    sha256  a9d96faab8163d0c876786feebb134befa03a65a5fbf1c7da3aa0332f53f7377 \
+                    size    69102770
 
 python.versions     27 36 37
 
@@ -36,11 +36,12 @@ if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-cython \
                             port:py${python.version}-setuptools
 
-    depends_lib-append      port:py${python.version}-numpy \
-                            path:${prefix}/lib/libplumedKernel.dylib:plumed
+    depends_lib-append      path:${prefix}/lib/libplumedKernel.dylib:plumed
 
     depends_test-append     port:py${python.version}-nose
     test.cmd                nosetests-${python.branch}
+# needed since the module is placed in something like ${worksrcpath}/build/lib.macosx-10.11-x86_64-3.7
+    test.env                PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
     test.target
     test.run                yes
 }

--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -9,7 +9,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.5.0 v
+github.setup        plumed plumed2 2.5.1 v
 name                plumed
 
 categories          science
@@ -28,9 +28,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  3873e9d48500bd01353396c0c85723a46b7c0ca9 \
-                    sha256  196aec82920bc6759ac66e32a8673f17e72b6c942bc84aadfd347182c5d9bedf \
-                    size    66557971
+checksums           rmd160  403aed6e2bfb1d90c97246642f98d1b67e7a31d9 \
+                    sha256  a9d96faab8163d0c876786feebb134befa03a65a5fbf1c7da3aa0332f53f7377 \
+                    size    69102770
 
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
@@ -111,14 +111,14 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 df002798ae5334739213f428bdf6d99bf9803293
-    version             2.6-20181219
+    github.setup        plumed plumed2 afd6c0dd5f0a8a0ccaa4e1abf8809b2e22e732ae
+    version             2.6-20190401
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  9ea9c10c61d3062b974722405950cc2319ec402b \
-                        sha256  53ade51c71db2b2f43533bb9597d9f731381b76c235b6173c3cc59b220a4b7b5 \
-                        size    66556856
+    checksums           rmd160  d1db3b121ce03efd5a00ebf246571d181f4480a7 \
+                        sha256  46840393daac73a7dc6d0392b7f379bdfb8b26dd6eb5386524ddb84db99af44b \
+                        size    69595932
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

I updated plumed, plumed-devel subport, and py-plumed to version 2.5.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
