### PR TITLE
Soapy*: fix cxx11 requirements

### DIFF
--- a/science/SoapySDR/Portfile
+++ b/science/SoapySDR/Portfile
@@ -3,12 +3,13 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.0
+PortGroup           cxx11 1.1
 
 github.setup        pothosware SoapySDR 0.7.1 soapy-sdr-
 checksums           rmd160 001438d71837437474b2f9aa6f953d3a8577c3ba \
                     sha256 5dde70cbd75849e5aa7d357cdf5b4c6b940febb09ce0cdd40589ef009acb33f4 \
                     size   124554
-revision            0
+revision            1
 
 platforms           darwin macosx
 categories          science

--- a/science/SoapySDRPlay/Portfile
+++ b/science/SoapySDRPlay/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
 
 name                SoapySDRPlay
 platforms           darwin macosx
@@ -17,7 +18,7 @@ github.setup        pothosware SoapySDRPlay 0.2.0 soapy-sdrplay-
 checksums           rmd160  d1ffd21319d7ffe5604ab6e4ff433da31e88eb3d \
                     sha256  58ba22649564c403215ef568e106b5f2ac5a690845718ddd029960bbbb95a88c \
                     size    13566
-revision            0
+revision            1
 
 depends_lib-append \
     port:SoapySDR \


### PR DESCRIPTION
#### Description

add cxx11 group to SoapySDR and SoapySDRPlay. Should fix build failure on old macOS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->