### PR TITLE
bind9: fix build on older systems

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -35,6 +35,10 @@ depends_lib		path:lib/libssl.dylib:openssl  \
 use_parallel_build	no
 universal_variant	no
 
+compiler.blacklist	gcc-4.2
+
+patchfiles		atomics.patch
+
 test.run		yes
 test.target		test
 

--- a/net/bind9/files/atomics.patch
+++ b/net/bind9/files/atomics.patch
@@ -1,0 +1,41 @@
+--- configure.orig	2019-03-20 16:57:56.000000000 +1100
++++ configure	2019-04-02 02:36:21.000000000 +1100
+@@ -18020,10 +18020,27 @@
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <inttypes.h>
++
++#if !defined(__has_feature)
++#define __has_feature(x) 0
++#endif
++
++#if !defined(__has_extension)
++#define __has_extension(x) __has_feature(x)
++#endif
++
++#if __has_extension(c_atomic) || __has_extension(cxx_atomic)
++#define __CLANG_ATOMICS
++#endif
++
+ int
+ main ()
+ {
++#ifdef __CLANG_ATOMICS
++int32_t val = 0; __c11_atomic_fetch_add(&val, 1, __ATOMIC_RELAXED);
++#else
+ int32_t val = 0; __atomic_fetch_add(&val, 1, __ATOMIC_RELAXED);
++#endif
+ 
+   ;
+   return 0;
+--- lib/isc/unix/include/isc/stdatomic.h.orig	2019-03-20 16:57:56.000000000 +1100
++++ lib/isc/unix/include/isc/stdatomic.h	2019-04-02 03:33:45.000000000 +1100
+@@ -32,7 +32,7 @@
+ #endif
+ 
+ #if !defined(__CLANG_ATOMICS) && !defined(__GNUC_ATOMICS)
+-#if __has_extension(c_atomic) || __has_extension(cxx_atomic)
++#if defined(HAVE___ATOMIC) && (__has_extension(c_atomic) || __has_extension(cxx_atomic))
+ #define __CLANG_ATOMICS
+ #elif __GNUC_PREREQ__(4, 7)
+ #define __GNUC_ATOMICS


### PR DESCRIPTION
gcc-4.2 lacks immintrin.h. Then there's a lot wrong with the selection
of atomic primitives. If stdatomic.h is not present, configure checks
for the existence of the GNU __atomic builtins, but then the C code
ignores the configure result and does its own checks. It uses clang's
__c11_atomic builtins if available, but they are not compatible with
the way the code actually uses them (at least in some versions of
clang) which makes the build fail.

Instead, make the configure check match what the C actually does, and
actually use the result to decide whether the clang builtins are
usable. This works fine for our purposes, though a patch suitable for
upstream should probably be a bit more sophisticated (the configure
output doesn't necessarily match what actually ends up happening, for
example).

###### Type(s)
- [x] bugfix

###### Tested on
macOS 10.14, 10.7, 10.6
Xcode 10.2, 4.6.3, 3.2.6
