### PR TITLE
libssh2: update to 1.8.2

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libssh2
-version             1.8.1
+version             1.8.2
 categories          devel net
 platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer
@@ -20,9 +20,9 @@ license             BSD
 homepage            https://www.libssh2.org/
 master_sites        ${homepage}download/
 
-checksums           rmd160  312c85af0b98b86abf1750a76c67e921b7d14f95 \
-                    sha256  40b517f35b1bb869d0075b15125c7a015557f53a5a3a6a8bffb89b69fd70f159 \
-                    size    858088
+checksums           rmd160  b2b84b3fe14e4e527db4a391abd8706a8e028e23 \
+                    sha256  088307d9f6b6c4b8c13f34602e8ff65d21c2dc4d55284dfe15d502c4ee190d67 \
+                    size    859587
 
 depends_lib         path:lib/libssl.dylib:openssl port:zlib
 


### PR DESCRIPTION
#### Description

- bump version to 1.8.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->