### PR TITLE
mercurial: update to 4.9.1

### DIFF
--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -7,7 +7,7 @@ PortGroup           bitbucket 1.0
 name                mercurial
 # don't forget to update dependents for mercurial:
 # port echo rdepends:mercurial and \( name:hg or name:mercurial \) | grep -v 'py[[:digit:]]'
-version             4.9
+version             4.9.1
 categories          devel python
 license             GPL-2+
 maintainers         nomaintainer
@@ -29,9 +29,9 @@ long_description    Mercurial is a fast, lightweight Source Control Management \
 homepage            http://www.mercurial-scm.org
 platforms           darwin
 master_sites        https://www.mercurial-scm.org/release/
-checksums           rmd160  bc8e47451a25be0f431262318cb2c3c84503b764 \
-                    sha256  0f600c5c7e44d4318bedc1754a70b920f7ecd278e4089b0f6ac96f460c012f06 \
-                    size    7075692
+checksums           rmd160  4be4ff74ee183936b52774dfeeb9ab02df70e25b \
+                    sha256  1bdd21bb87d1e05fb5cd395d488d0e0cc2f2f90ce0fd248e31a03595da5ccb47 \
+                    size    7076867
 
 depends_build       port:py27-docutils
 

--- a/python/py-hggit/Portfile
+++ b/python/py-hggit/Portfile
@@ -6,10 +6,10 @@ PortGroup               bitbucket 1.0
 
 epoch                   20130201
 
-bitbucket.setup         durin42 hg-git 8d00fde45adbc6c3c0ccab8e362b5f5c36c171e6
+bitbucket.setup         durin42 hg-git c8fea7a921634bda3d4e68e2c7a0d73b7447dea4
 name                    py-hggit
-version                 0.8.12
-revision                1
+version                 0.8.12-git-20190402
+revision                0
 
 categories-append       devel
 license                 GPL-2
@@ -25,9 +25,9 @@ long_description        This is the Hg-Git plugin for Mercurial, adding the abil
                         or use a Git server as a collaboration point for a team with \
                         developers using both Git and Mercurial.
 
-checksums               rmd160  610e35c34231f728e198ea4161de26b1e9e4a61c \
-                        sha256  2cca8042dd5dabccb91a1a34c11b3b2d8cc1d2f64ccd8b0e8f775795d3db6e09 \
-                        size    137713
+checksums               rmd160  ad084c9e4a315909665eaef6f1aaac868c8b4d51 \
+                        sha256  a0d6d94b92a353f778f1c44ef00260e494b0cc6b1d9e410f709cc28b530d220d \
+                        size    138396
 
 # can't set python.versions before adding custom subports
 subport py-hggit-devel {}


### PR DESCRIPTION
#### Description

- bump version to 4.9.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->