### PR TITLE
proxychains-ng: update to 4.14

### DIFF
--- a/devel/proxychains-ng/Portfile
+++ b/devel/proxychains-ng/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rofl0r proxychains-ng 4.13 v
+github.setup        rofl0r proxychains-ng 4.14 v
 maintainers         nomaintainer
 categories          devel
 license             GPL-2
@@ -18,8 +18,8 @@ master_sites        ${homepage}/archive/
 distname            ${github.tag_prefix}${version}
 worksrcdir          ${name}-${version}
 
-checksums           rmd160  069a737a0a5ea796be5f6859c8c83e24522eac6d \
-                    sha256  ff15295efc227fec99c2b8131ad532e83e833a02470c7a48ae7e7f131e1b08bc \
-                    size    36592
+checksums           rmd160  05cb1de5e7c54ed2008cd4087c27fcf1764d5c94 \
+                    sha256  ab31626af7177cc2669433bb244b99a8f98c08031498233bb3df3bcc9711a9cc \
+                    size    37912
 
 destroot.target-append install-config


### PR DESCRIPTION
#### Description

- bump version to 4.14

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->