### PR TITLE
py-awscli: update to 1.16.136

### DIFF
--- a/python/py-awscli/Portfile
+++ b/python/py-awscli/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 
 name                py-awscli
-version             1.16.126
+version             1.16.136
 revision            0
 platforms           darwin
 supported_archs     noarch
@@ -20,9 +20,9 @@ homepage            https://aws.amazon.com/cli/
 master_sites        pypi:a/awscli
 distname            awscli-${version}
 
-checksums           rmd160  11ea057f0b946d5bd94db85c14f9fd074522d621 \
-                    sha256  67a9da9fe81980d2ce7c4490e6519e60de3a7d9e1541b58894b6fcd37bf625db \
-                    size    679971
+checksums           rmd160  1f4e88dbd31724195fb27e901b885d41972a3e2e \
+                    sha256  4ada0ab3fb0e018bab32b35ff84722cf49bc56c851dc9e1da0ac047418708e69 \
+                    size    680605
 
 python.versions     27 35 36 37
 


### PR DESCRIPTION
#### Description

- bump version to 1.16.136

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->