### PR TITLE
youtube-dl: update to 2019.04.01

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                youtube-dl
-version             2019.03.18
+version             2019.04.01
 revision            0
-checksums           rmd160  d21b89e541fd65926bd4488c532226dd924f5e79 \
-                    sha256  074688b416e97aff5ae9ce3764e313b9d6433bb34a16b206775fbc37e4c16164 \
-                    size    3122206
+checksums           rmd160  c325fa070c2ad7dbfb5aa253aa9511ccec8e1b7b \
+                    sha256  55833cc88532d1b9b16a5a808da7879857eff1b3d0eeee57cf08810b2601306b \
+                    size    3129663
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

- bump version to 2019.04.01

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->