### PR TITLE
MacVim: Pass MACOSX_DEPLOYMENT_TARGET to build.

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -77,7 +77,7 @@ build.args          XCODEFLAGS="CACHE_ROOT=${workpath}/caches"
 
 # this port does not build with the new xcode build system at present
 if {[vercmp ${xcodeversion} 10.0] >= 0} {
-    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO"
+    build.args    XCODEFLAGS="CACHE_ROOT=${workpath}/caches -UseNewBuildSystem=NO MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}"
 }
 
 destroot {


### PR DESCRIPTION
#### Description

If I don't do this when building on my 10.13 / Xcode 10.1 system, I end up with a 10.14-minimum executable.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->