### PR TITLE
virt-manager: update to 2.1.0

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        virt-manager virt-manager 1.5.1 v
+github.setup        virt-manager virt-manager 2.1.0 v
 categories          gnome emulators
 supported_archs     noarch
 maintainers         {danchr @danchr} openmaintainer
@@ -27,16 +27,16 @@ long_description \
     \
     The primary use on macOS is for remote administration of Linux boxes.
 
-checksums           rmd160  720822cf863071b646a02fc487ea0082e5959097 \
-                    sha256  ee889d59110986391a394077f004f68125e01e216a5e7cfc29adb6ae49ab2dab \
-                    size    2796831
+checksums           rmd160  2e9190ca7d04146650ef9dee832300a4c852a2cc \
+                    sha256  34ea069a6565f1f1860a0741e5a5029e8b45c779e81f16d27fb4d767fd4403d4 \
+                    size    2617988
 
 platforms           darwin
 
-python.default_version  27
+python.default_version  37
 
 post-patch {
-    reinplace -W ${worksrcpath} "s|/usr/bin/env python2|${python.bin}|" \
+    reinplace -W ${worksrcpath} "s|/usr/bin/env python3|${python.bin}|" \
         virt-clone virt-convert virt-install virt-manager virt-xml
 }
 
@@ -49,17 +49,17 @@ depends_run \
     port:py${python.version}-gobject3 \
     port:py${python.version}-libvirt \
     port:py${python.version}-libxml2 \
-    port:py${python.version}-ipaddr \
     port:py${python.version}-requests \
     port:libvirt-glib \
     port:vte \
     port:gtk-vnc \
+    port:gtk2 \
     port:spice-gtk \
     port:libosinfo
 
 use_configure       yes
 configure.cmd       ${build.cmd} configure
-configure.args       --prefix ${python.prefix}
+configure.args      --prefix ${python.prefix}
 
 # stubs for checking dependencies in trace mode
 #test.run             yes


### PR DESCRIPTION
#### Description

* version push to 2.1.0
* changed default Python version from 2.7 to 3.7
* should fix issue introduced with #1463 (see https://trac.macports.org/ticket/56158)

Fixes: https://trac.macports.org/ticket/56158

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.3 18D109
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
