### PR TITLE
ffmpeg: Update to 4.1.3

### DIFF
--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -10,7 +10,7 @@ name                ffmpeg
 conflicts           ffmpeg-devel
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 epoch               1
-version             4.1.2
+version             4.1.3
 license             LGPL-2.1+
 categories          multimedia
 maintainers         {devans @dbevans} {jeremyhu @jeremyhu} openmaintainer
@@ -52,9 +52,9 @@ master_sites        ${homepage}releases/
 
 use_xz              yes
 
-checksums           rmd160  75f44fe24f6399862ea47489c11c15c142221a32 \
-                    sha256  b95f0ae44798ab1434155ac7f81f30a7e9760a02282e4b5898372c22a335347b \
-                    size    8892696
+checksums           rmd160  bdc1bef58ea91e33b8851527de85f78e59cf5c67 \
+                    sha256  0c3020452880581a8face91595b239198078645e7d7184273b8bcc7758beb63d \
+                    size    8895988
 
 depends_build       port:pkgconfig \
                     port:gmake \


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F96h
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
