### PR TITLE
Update bindfs to 1.13.11

### DIFF
--- a/fuse/bindfs/Portfile
+++ b/fuse/bindfs/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                bindfs
-version             1.11
-revision            1
+version             1.13.11
+revision            0
 categories          fuse
 license             GPL-2+
 platforms           darwin
@@ -18,8 +18,8 @@ long_description    bindfs is a FUSE filesystem for mirroring a directory to ano
 homepage            https://bindfs.org/
 master_sites        ${homepage}downloads/
 
-checksums           rmd160  0ea6a6f4082f45678c164e11394de7142cc523f8 \
-                    sha256  3a6c916140337e2bc1734be5bbf45c22c9427ffbd4d37d647bd70c36fbbd498e
+checksums           rmd160  18f53d46060b30ef12c4755d4387b077a322cb43 \
+                    sha256  ab0063092badd0e5f1ffaa115ae49cdd26727d243ecf062c502b48c3286fca2b
 
 depends_build       port:pkgconfig
 depends_lib         port:osxfuse


### PR DESCRIPTION
Update bindfs version to 1.13.11

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (no tests available)
- [ ] tried a full install with `sudo port -vst install`?
`:error:archivefetch realpath failed: Permission denied` 🤷‍♂️ 
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
