### PR TITLE
Translate toolkit: use Python 3.7

### DIFF
--- a/python/py-levenshtein/Portfile
+++ b/python/py-levenshtein/Portfile
@@ -10,7 +10,7 @@ categories-append   textproc
 platforms           darwin freebsd
 license             GPL-2+
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/textproc/translate-toolkit/Portfile
+++ b/textproc/translate-toolkit/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        translate translate 2.3.1
+revision            1
 name                translate-toolkit
 categories          textproc
 platforms           darwin
@@ -24,7 +25,7 @@ checksums           rmd160  92544cbd5c1191e1906a5088d871cbf747bb9900 \
                     size    1132708
 
 python.default_version \
-                    36
+                    37
 
 depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
Simply changed the version to use latest stable Python. I had to add a `py37` subport for `py-levenshtein`.