### PR TITLE
gitlab-runner: update to 11.9.1

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.9.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 11.9.1 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  8850b74a097120a8b47d33d6b4286f434b30b1b5 \
-                    sha256  57dad370a3883d435b27b497de43eb3402b0e64dfc421a81ac99c9ddb04f0d45 \
-                    size    27054559
+checksums           rmd160  145205394e859ad5de3391d30a2a335d814566d2 \
+                    sha256  b1a6a82c747a8d948bccd7d261ed0d476263afd9f2ec582b4a9ce5707189d67f \
+                    size    27052321
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 11.9.1.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?