### PR TITLE
limesuite: update -devel

### DIFF
--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -20,11 +20,11 @@ homepage            https://myriadrf.org/projects/lime-suite/
 subport limesuite-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup    myriadrf LimeSuite 43df46bc2237369ee4ec105620e5aa26df9dbb49
-    version         20190403
-    checksums       rmd160 16da59a360b027ec5c7d5e748d198c2613fbb5d7 \
-                    sha256 ed589f4033f431110464f96f7d95d4af6471d773d8c09098cbbf50109a3bc0ac \
-                    size   5348374
+    github.setup    myriadrf LimeSuite aa1aacdc316aa14ee39a50ff7e24840f16259d0b
+    version         20190404
+    checksums       rmd160  5ca2b4ba5491bdd47f200c10cd637400f9fcd621 \
+                    sha256  14e3bebd7df6d28df6b769ce60897c4b30fef68bbb075f5840a745ff4137bafd \
+                    size    5348349
     revision        0
 
     name            limesuite-devel
@@ -38,10 +38,15 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  6286e1ec881b5944d9913f802cba2b8236908917 \
                     sha256  bf0ca8225e9eacf44cee7383504e699eb9be5cc47293fb9c08baaf8d5e3163c9 \
                     size    5347689
-    revision        3
+    revision        4
 
     conflicts       limesuite-devel
     configure.args-append -DLIME_SUITE_EXTVER=release
+
+    # the REGEX used to determine image files to download is too broad;
+    # make it more restrictive so-as to get just image files.
+    # REMOVE with next release version
+    patchfiles-append patch-fix-images-download-regex.diff
 
 }
 
@@ -88,12 +93,3 @@ default_variants +wxgui +soapy
 patchfiles-append patch-src_CMakeLists.txt.diff
 patch.pre_args -p1
 
-# the REGEX used to determine image files to download is too broad;
-# make it more restrictive so-as to get just image files.
-patchfiles-append patch-fix-images-download-regex.diff
-
-post-destroot {
-    # remove images that won't get used on OSX
-    file delete {*}[glob ${destroot}${prefix}/share/LimeSuite/images/*/*.dll]
-    file delete {*}[glob ${destroot}${prefix}/share/LimeSuite/images/*/*windows*]
-}

--- a/science/limesuite/files/patch-fix-images-download-regex.diff
+++ b/science/limesuite/files/patch-fix-images-download-regex.diff
@@ -1,13 +1,17 @@
 diff --git a/cmake/DownloadImages.cmake b/cmake/DownloadImages.cmake
-index 46c390c..f43f3f9 100644
+index 46c390c..1a98c06 100644
 --- a/cmake/DownloadImages.cmake
 +++ b/cmake/DownloadImages.cmake
-@@ -15,7 +15,7 @@ message(STATUS "######################################################")
- set(SOURCE_URL "http://downloads.myriadrf.org/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}")
+@@ -12,10 +12,10 @@ message(STATUS "## DOWNLOAD_IMAGES=${DOWNLOAD_IMAGES} specified; syncing images.
+ message(STATUS "######################################################")
+ 
+ #download support constants
+-set(SOURCE_URL "http://downloads.myriadrf.org/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}")
++set(SOURCE_URL "https://downloads.myriadrf.org/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}")
  set(TEMP_DEST "${CMAKE_CURRENT_BINARY_DIR}/images/${VERSION_MAJOR}.${VERSION_MINOR}")
  set(INSTALL_DEST "share/LimeSuite/images/${VERSION_MAJOR}.${VERSION_MINOR}")
 -set(HREF_MATCHER "href=\\\"([\\._A-Za-z_0-9-]+)\\\"")
-+set(HREF_MATCHER "href=\\\"/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}/([\\._A-Za-z_0-9-]+)\\\"")
++set(HREF_MATCHER "href=\\\"/project/limesuite/${VERSION_MAJOR}.${VERSION_MINOR}/([\\._A-Za-z_0-9-]+(.rpd|.rbf|.img))\\\"")
  
  #conditional download when file is missing
  function(DOWNLOAD_URL url file)


### PR DESCRIPTION
#### Description

Sent upstream the patch that download the images during cmake.
-devel has already that patch; with next release
patch-fix-images-download-regex.diff can be removed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->