### PR TITLE
tkdnd: update to 2.9

### DIFF
--- a/x11/tkdnd/Portfile
+++ b/x11/tkdnd/Portfile
@@ -3,9 +3,10 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
+PortGroup           github 1.0
 
-name                tkdnd
-version             2.8
+github.setup        petasis tkdnd tkdnd-release-test-v2.9.1
+version             2.9
 platforms           darwin
 categories          x11
 license             BSD
@@ -13,14 +14,10 @@ maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description         an extension that adds native drag & drop capabilities to the tk toolkit
 long_description    Tk Drag & Drop: tkdnd is an extension that adds native drag & drop capabilities to the tk toolkit.
 homepage            http://www.ellogon.org/petasis/index.php/tcltk-projects/tkdnd
-master_sites        sourceforge
 
-checksums           rmd160  34b98d9f4f6df891af3e767e41515b5a8bed171c \
-                    sha256  5e76266adaf381f0c6797b2a15a77c162c2fe718f887d973d61316ded802ca78 \
-                    size    185025
-
-distname            ${name}${version}-src
-worksrcdir          ${name}${version}
+checksums           rmd160  264942ed1772ee64d0a41515e65ef911a2c35bba \
+                    sha256  9faafb0110bf5f7b966462ea22c36e13cb6ac35816cde72a0785007f60d7fcde \
+                    size    568910
 
 cmake.install_prefix ${prefix}/lib
 
@@ -72,4 +69,6 @@ pre-configure {
     }
 }
 
-livecheck.regex     "/tkdnd(\\d+(?:\\.\\d+)*)-src${extract.suffix}"
+livecheck.version   ${version}
+livecheck.url       https://github.com/petasis/tkdnd/releases
+livecheck.regex     {tkdnd-(\d+\.\d+)}


### PR DESCRIPTION
Using GitHub PortGroup as [releases will no longer be posted to SourceForge](https://github.com/petasis/tkdnd/issues/24#issuecomment-449709883).

~~I did not finish updating the livecheck. The current release tag name doesn't look as if it is following a set convention; should the project be asked how releases plan to be named? Should the update be merged and the livecheck issue addressed later?~~

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
