### PR TITLE
moltenvk: update to 1.0.33

### DIFF
--- a/graphics/MoltenVK/Portfile
+++ b/graphics/MoltenVK/Portfile
@@ -6,53 +6,53 @@ PortGroup           github 1.0
 PortGroup           xcode 1.0
 PortGroup           xcodeversion 1.0
 
-github.setup        KhronosGroup MoltenVK 1.0.27 v
+github.setup        KhronosGroup MoltenVK 1.0.33 v
 set submodules {
                     USCiLab cereal 51cbda5f30e56c801c07fe3d3aba5d7fb9e6cca4 cereal
-                    KhronosGroup Vulkan-Headers 114c3546e195819bd53a34b39f5194b2989a5b12 Vulkan-Headers
-                    KhronosGroup SPIRV-Cross ea6bdacd056b77ec1004822482d08b6f31473f25 SPIRV-Cross
-                    KhronosGroup glslang 1bc601c674aecc2fee0dee8ff7a118db76b4c439 glslang
-                    KhronosGroup SPIRV-Tools a29a9947ac96d811b310f481b24e293f67fedf32 glslang/External/spirv-tools
-                    KhronosGroup SPIRV-Headers a2c529b5dda18838ab4b52f816acfebd774eaab3 glslang/External/spirv-tools/external/spirv-headers
-                    KhronosGroup Vulkan-Tools d74a02234851dfacf6b140c1ab4d81becf704098 Vulkan-Tools
-                    LunarG VulkanSamples 1a849458db984f77c9ecfa79041ede550094c2f2 VulkanSamples
+                    KhronosGroup Vulkan-Headers 8e2c4cd554b644592a6d904f2c8000ebbd4aa77f Vulkan-Headers
+                    KhronosGroup SPIRV-Cross d9ed3dcc7a7e62e5f95fd8f24e3d35e7e402ae92 SPIRV-Cross
+                    KhronosGroup glslang 5432f0dd8f331f15182681664d7486681e8514e6 glslang
+                    KhronosGroup SPIRV-Tools 5994ae2a045015004cce24802dc47c33736486ea glslang/External/spirv-tools
+                    KhronosGroup SPIRV-Headers 79b6681aadcb53c27d1052e5f8a0e82a981dbf2f glslang/External/spirv-tools/external/spirv-headers
+                    KhronosGroup Vulkan-Tools d43b22f0859f42c5fd71a530278ffa504ce95b7f Vulkan-Tools
+                    LunarG VulkanSamples 9ce6ece9d86b9501c1a8a4adbd4e0e60a5ae8456 VulkanSamples
 }
 checksums           ${distfiles} \
-                    rmd160  bf730c3309e9ffe7a86b51cf12f134bc0408772e \
-                    sha256  1ea200d81efd22ffdda8f9b4d85d6f0396c6c84359a369fa72bc05b5bb580333 \
-                    size    1141156 \
+                    rmd160  ef0b9fb5fccb545d20e122d73b7af99f513864d4 \
+                    sha256  76573e97c05657416ad2fb5d290940034c28c425556d40c01007c08a0959958d \
+                    size    1182656 \
                     cereal-51cbda5f30e56c801c07fe3d3aba5d7fb9e6cca4.tar.gz \
                     rmd160  33a8f9bd682f36387d3d589410113c6dd1e18bc4 \
                     sha256  26361b539fe50eee308b564faa2742166d2922a7ab0bd4870ac55708581228c8 \
                     size    336138 \
-                    Vulkan-Headers-114c3546e195819bd53a34b39f5194b2989a5b12.tar.gz \
-                    rmd160  dbc97e37760758f0902faab9ad5185e1115db293 \
-                    sha256  c95bf023ee271378c340307f079e15b8b54061cdbe051e3a82c80ed08eefd7dd \
-                    size    541278 \
-                    SPIRV-Cross-ea6bdacd056b77ec1004822482d08b6f31473f25.tar.gz \
-                    rmd160  9655067d18c6201cad14bb93d64a7b6257311e24 \
-                    sha256  21bd2d4a3841c0b492328a9d31044dd29a56d1ef694c2a071f3890231b31ed33 \
-                    size    612660 \
-                    glslang-1bc601c674aecc2fee0dee8ff7a118db76b4c439.tar.gz \
-                    rmd160  0e87e789a80e270e4fded2d051fc1a1c318c438a \
-                    sha256  856b5532cd40585fe5037ce7c33fe4775d37f68cfce0ca09e40f33e1dbc0e5e3 \
-                    size    2442979 \
-                    SPIRV-Tools-a29a9947ac96d811b310f481b24e293f67fedf32.tar.gz \
-                    rmd160  0a93dad3f73154555361a3d4a46d5a5b833d0393 \
-                    sha256  3e04ab9623891e571ae65efcc3f18405f3f749d1eece4a89484c28adfdd2f167 \
-                    size    1412706 \
-                    SPIRV-Headers-a2c529b5dda18838ab4b52f816acfebd774eaab3.tar.gz \
-                    rmd160  ec8e6ac15f35273c9e68842378df42991ac88d78 \
-                    sha256  ff732d21622bb7b2180c794949a5ad2cda71850e2f46cce70b02556d7c789342 \
-                    size    319089 \
-                    Vulkan-Tools-d74a02234851dfacf6b140c1ab4d81becf704098.tar.gz \
-                    rmd160  c17e293680fc7ad0320a3a119629a6c76f18dcd2 \
-                    sha256  f40d3dead03236779f906c80e14bf2356a820d4851c38e9e6510c6ad36d6d2b9 \
-                    size    344326 \
-                    VulkanSamples-1a849458db984f77c9ecfa79041ede550094c2f2.tar.gz \
-                    rmd160  0decf1f6db2b337a1f034b6f3222876c2da7d89d \
-                    sha256  4b435a60259cc188680bbb0c2bf1ad81fe6a3979861fb11b17c73382d86517f9 \
-                    size    3832089
+                    Vulkan-Headers-8e2c4cd554b644592a6d904f2c8000ebbd4aa77f.tar.gz \
+                    rmd160  af8df87c5c3a67a9b854a04535b579aaadd6861f \
+                    sha256  9c2b2fd219b24838e586fafce5bad9cdcf5eda10b00d838656d20c31ac25cc62 \
+                    size    556510 \
+                    SPIRV-Cross-d9ed3dcc7a7e62e5f95fd8f24e3d35e7e402ae92.tar.gz \
+                    rmd160  f011f5eef7ce9aa235f37bb008e22b9a3076e555 \
+                    sha256  423165b6f684acac69dace27b533f8862c98e4e8d1e4ac980700cb21eb7dde5f \
+                    size    655839 \
+                    glslang-5432f0dd8f331f15182681664d7486681e8514e6.tar.gz \
+                    rmd160  7340974330b698872bb3fa43721d142b04d5d9bf \
+                    sha256  2c482fa3bd39df7791251fe52f7554745a35b77d446b76de7ce638ef74530dda \
+                    size    2504908 \
+                    SPIRV-Tools-5994ae2a045015004cce24802dc47c33736486ea.tar.gz \
+                    rmd160  371842a8b8425f965f0acde5982087b2b4e8bbad \
+                    sha256  5ed96848aaf3089f074823d93ae6fcc1b010764356de50f9960547a733b484f2 \
+                    size    1537554 \
+                    SPIRV-Headers-79b6681aadcb53c27d1052e5f8a0e82a981dbf2f.tar.gz \
+                    rmd160  cf769e51da66d52aa6132ce80d28206ed4256980 \
+                    sha256  de2d156572153675729350745b886a8081284a7dc56fbd66c832e764183de47b \
+                    size    332580 \
+                    Vulkan-Tools-d43b22f0859f42c5fd71a530278ffa504ce95b7f.tar.gz \
+                    rmd160  3a69fa0dac466d81a1fc30fa28dcc8c73c878aeb \
+                    sha256  19271b9e7f58da72dd465ef7e41cac840980cbb965fd0780dbcad34a35728c62 \
+                    size    351676 \
+                    VulkanSamples-9ce6ece9d86b9501c1a8a4adbd4e0e60a5ae8456.tar.gz \
+                    rmd160  3dd157211163eb62d763c06f3ca737a2ab5015af \
+                    sha256  57a8846c7e8890304a8cf12633c4735b903ef11d65d9a4aa8694e3ce120fd1ac \
+                    size    3830381
 
 categories          graphics
 maintainers         {ryandesign @ryandesign} openmaintainer
@@ -110,11 +110,10 @@ build.pre_args      -derivedDataPath ./DerivedData
 
 xcode.configuration Release
 xcode.scheme        "MoltenVK Package (macOS only)"
+xcode.project       "MoltenVKPackaging.xcodeproj"
 
 pre-build {
-    set build_dir ${worksrcpath}/External/glslang/build
-    file mkdir ${build_dir}
-    system -W ${build_dir} "${prefix}/bin/cmake -DCMAKE_BUILD_TYPE=MacPorts -DCMAKE_INSTALL_PREFIX=install -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib -DCMAKE_C_COMPILER=\"${configure.cc}\" -DCMAKE_CXX_COMPILER=\"${configure.cxx}\" -DCMAKE_OSX_ARCHITECTURES=\"[join [get_canonical_archs] \;]\" -DCMAKE_VERBOSE_MAKEFILE=ON .. && make -j${build.jobs} VERBOSE=ON && make install/fast"
+    system -W ${worksrcpath} ./fetchDependencies
 }
 
 destroot {


### PR DESCRIPTION
#### Description

Pinging @ryandesign as he is maintainer of this port. Disclaimer: I'm pretty new to how macports works, and I'm unsure if what I've done is the right way, but it builds correctly and fixes the ICD deadlock I was running into in 1.0.27 (current macports version). I tried to avoid using the `./fetchDependencies` script initially (as far as I can tell it will still use the already downloaded dependencies but check the commit out again) but ran into many issues so the current solution is the only one which I got to work.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->