### PR TITLE
ipe: Bump version and fix qhull linking

### DIFF
--- a/graphics/ipe/Portfile
+++ b/graphics/ipe/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup               cxx11 1.1
 
 name                    ipe
-version                 7.2.7
+version                 7.2.11
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              graphics
 maintainers             {gmail.com:m7.thon @m7thon} openmaintainer
@@ -22,9 +22,9 @@ master_sites            https://dl.bintray.com/otfried/generic/ipe/${branch}
 distname                ${name}-${version}-src
 worksrcdir              ${name}-${version}/src
 
-checksums           sha1    58410e29c04e7a7c3978bd9afe6d25a7924bd30d \
-                    rmd160  6d68ad7831923d04ba07086f3dde2be9830d756a \
-                    sha256  d66d3f2619e3e6ff617f42c2e3695c3db6e2a64adcc3d7613214e5fd14c49f22
+checksums           rmd160  eaa2b9fc1a923a78b14e1c1c27f8ffc139febe0e \
+                    sha256  a22dcae9cb660f466678a6b568e9fed1b12a3830e49465594d65fc789b0ba725 \
+                    size    1950071
 
 depends_build-append    port:pkgconfig
 
@@ -49,7 +49,7 @@ variant qt5 conflicts qt4 description {Build using Qt5 based gui} {
 
 variant qvoronoi description {Add qvoronoi ipelet} {
     depends_lib-append  port:qhull
-    build.args-append   IPEQVORONOI=1 QHULL_CFLAGS=-I${prefix}/include/qhull
+    build.args-append   IPEQVORONOI=1 QHULL_CFLAGS=-I${prefix}/include/libqhull_r
     destroot.post_args  IPEQVORONOI=1
 }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
