### PR TITLE
google-cloud-sdk: update to 241.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             240.0.0
+version             241.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  909bfb21c3eb66016d19fae816a3011d2d9dccdd \
-                    sha256  06855ef91cd90a5e50ebc0937fd90437f6f153bd6e0f2f873e841724b5b44a64 \
-                    size    19012063
+checksums           rmd160  d2e5586ff33883e537e6d6ffd0acad09b9580636 \
+                    sha256  32543fabf3ee117285ec153b9b6359c58991401cf97e01909be3da8d6e6024f1 \
+                    size    19342461
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 241.0.0.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?