### PR TITLE
glslang: fix builds on older macOS & add category

### DIFF
--- a/graphics/glslang/Portfile
+++ b/graphics/glslang/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.0
+PortGroup           cxx11 1.1
 
 github.setup        KhronosGroup glslang 7.11.3113
 
-categories          graphics
+categories          graphics devel
 platforms           darwin
 license             {BSD Permissive}
 


### PR DESCRIPTION
#### Description

I think this should fix 10.8 and older, unsure as I don't have a way to test it other than the build bot (which apparently only tests once it is committed).

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->