### PR TITLE
xorg-xcb-proto: install xcbgen to the canonical path

### DIFF
--- a/devel/automake/Portfile
+++ b/devel/automake/Portfile
@@ -10,6 +10,7 @@ name                automake
 # from the older version of automake.
 # cf: ${prefix}/share/libtool/aclocal.m4
 version             1.16.1
+revision            1
 
 categories          devel
 platforms           darwin freebsd
@@ -33,7 +34,8 @@ master_sites        gnu
 checksums           rmd160  3bada190697e5683d5a0353e1a39bfc24e883061 \
                     sha256  608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8
 
-patchfiles          test-glibtool.patch
+patchfiles          test-glibtool.patch \
+                    patch-issue57329.diff
 
 # It should be safe to use the system Perl, since Automake only uses
 # core modules. The configure script recommends 5.8.2 or later, and

--- a/devel/automake/files/patch-issue57329.diff
+++ b/devel/automake/files/patch-issue57329.diff
@@ -1,0 +1,30 @@
+diff --git m4/python.m4 m4/python.m4
+index 63c0a0e04..f81684378 100644
+--- m4/python.m4
++++ m4/python.m4
+@@ -147,10 +147,10 @@ except ImportError:
+      am_cv_python_pythondir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
++    sitedir = sysconfig.get_path('purelib')
+ else:
+     from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
++    sitedir = sysconfig.get_python_lib(0, 0)
+ sys.stdout.write(sitedir)"`
+      case $am_cv_python_pythondir in
+      $am_py_prefix*)
+@@ -189,10 +189,10 @@ sys.stdout.write(sitedir)"`
+      am_cv_python_pyexecdir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_prefix'})
++    sitedir = sysconfig.get_path('platlib')
+ else:
+     from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_prefix')
++    sitedir = sysconfig.get_python_lib(1, 0)
+ sys.stdout.write(sitedir)"`
+      case $am_cv_python_pyexecdir in
+      $am_py_exec_prefix*)

--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libtool
 version             2.4.6
-revision            5
+revision            6
 categories          devel sysutils
 platforms           darwin freebsd
 # Scripts are GPL-2+, libltdl is LGPL-2+, but all parts that tend to be

--- a/x11/xorg-xcb-proto/Portfile
+++ b/x11/xorg-xcb-proto/Portfile
@@ -4,6 +4,7 @@ PortSystem      1.0
 
 name            xorg-xcb-proto
 version         1.13
+revision        1
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -21,6 +22,8 @@ checksums       rmd160  d085d1be1844009f08442113a83b7fdffeae8325 \
                 size    151981
 
 use_bzip2       yes
+
+use_autoreconf  yes
 
 depends_run     port:libxml2
 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/57329

/cc @larryv: I'm not sure if I should revbump libtool for a patch towards automake. Could you give an advice?

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
     * xorg-libxcb still builds fine