### PR TITLE
mackup: update to 0.8.23

### DIFF
--- a/sysutils/mackup/Portfile
+++ b/sysutils/mackup/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                mackup
-version             0.8.19
+version             0.8.23
 
-categories-append   sysutils
+categories-prepend  sysutils
 license             GPL-3
 maintainers         {gmail.com:newtonne.github @newtonne} openmaintainer
 platforms           darwin
@@ -22,9 +22,9 @@ long_description    Mackup backs ups your application settings in a safe \
 homepage            https://github.com/lra/mackup
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
-checksums           rmd160  56b4e84795fcd9f0a2d4ae35a2d9da2db34177a0 \
-                    sha256  715fc9780d4db99f7b17e0ff2bf110ad08655911b6b2001e8993c69f127a32d5 \
-                    size    41979
+checksums           rmd160  fab8f379f158988c21bc761a57848cda46a9b149 \
+                    sha256  4f3886cc5e0bf645c4dded8e3fb0d26076d4c7908dd1f6586f6dabac08e0b6bd \
+                    size    44262
 
 python.default_version 36
 


### PR DESCRIPTION
#### Description

Update mackup to 0.8.23. Also, `port lint` raised:
```
Error: Portfile parent directory sysutils does not match primary category python
```
Does the portfile need moving?

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4
Xcode 10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->