### PR TITLE
mlterm: update to version 3.8.8

### DIFF
--- a/x11/mlterm/Portfile
+++ b/x11/mlterm/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                mlterm
-version             3.8.2
+version             3.8.8
 categories          x11
 platforms           darwin
 maintainers         nomaintainer
@@ -26,8 +26,9 @@ long_description    mlterm is a multi-lingual terminal emulator written from \
 homepage            http://mlterm.sourceforge.net/
 master_sites        sourceforge:project/mlterm/01release/mlterm-${version}
 
-checksums           rmd160  f7d4fd18d290108eb828370f782590cbf285dab8 \
-                    sha256  30278fc4b43bf66eebd8ff728f943674554e7593a3989d0f3ea68c4b34270399
+checksums           rmd160  9a7675a86999541b57742099a5e9eac8a539b580 \
+                    sha256  f3eca9ddafcc463e4723be1fabe7ffe0993c3d050dc93f6f745f43ccc57603cb \
+                    size    4035215
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

This patch updates the port to the latest version
This update includes several bugfixes and security enhancements. Especially since version 3.8.2 (previous one on the tree) a lot has happened.

More info available on upstream's change-log: https://bitbucket.org/arakiken/mlterm/raw/rel-3_8_8/doc/en/ReleaseNote

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.3 18D109
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
