### PR TITLE
wireguard-tools: update to 0.0.20190406

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190227
+version             0.0.20190406
 revision            0
-checksums           rmd160  d5c4d5f1fb3dd713197869584534ace03d43ab9a \
-                    sha256  fcdb26fd2692d9e1dee54d14418603c38fbb973a06ce89d08fbe45292ff37f79 \
-                    size    323788
+checksums           rmd160  37074b9f42044c23ff2ecec5ff8626b665d6f944 \
+                    sha256  2f06f3adf70b95e74a7736a22dcf6e9ef623b311a15b7d55b5474e57c3d0415b \
+                    size    324112
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?