### PR TITLE
graphviz-gui: work around build error with xcode10

### DIFF
--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -328,6 +328,16 @@ subport graphviz-gui${thisbranch} {
     xcode.build.settings        PREFIX=${prefix}
     
     xcode.destroot.settings     ${xcode.build.settings}
+
+    # fix build with Xcode 10+
+    if {${os.platform} eq "darwin" && ([vercmp $xcodeversion 10.0] > 0)} {
+        # build phase just repeats build unnecessarily, and also causes destroot to fail on Mojave
+        build {}
+        # setting DerivedDataPath doesn't work with this build as it requires a scheme
+        xcode.destroot.settings-append -UseModernBuildSystem=NO
+        # cannot target os older than 10.6
+        patchfiles-append       patch-graphviz-gui-mojave.diff
+    }
 }
 
 subport gvedit${thisbranch} {

--- a/graphics/graphviz/files/patch-graphviz-gui-mojave.diff
+++ b/graphics/graphviz/files/patch-graphviz-gui-mojave.diff
@@ -1,0 +1,53 @@
+diff --git macosx/English.lproj/Attributes.xib macosx/English.lproj/Attributes.xib
+index e75ef53..a3127c8 100644
+--- macosx/English.lproj/Attributes.xib
++++ macosx/English.lproj/Attributes.xib
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9B18</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949</string>
+diff --git macosx/English.lproj/Document.xib macosx/English.lproj/Document.xib
+index 117e457..0e3b12c 100644
+--- macosx/English.lproj/Document.xib
++++ macosx/English.lproj/Document.xib
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9C7010</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949.26</string>
+diff --git macosx/English.lproj/Export.xib macosx/English.lproj/Export.xib
+index 1ae8aa4..315dd2a 100644
+--- macosx/English.lproj/Export.xib
++++ macosx/English.lproj/Export.xib
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9C7010</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949.26</string>
+diff --git macosx/English.lproj/MainMenu.xib macosx/English.lproj/MainMenu.xib
+index dc01a03..4365902 100644
+--- macosx/English.lproj/MainMenu.xib
++++ macosx/English.lproj/MainMenu.xib
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.01">
+ 	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
++		<int key="IBDocument.SystemTarget">1060</int>
+ 		<string key="IBDocument.SystemVersion">9E17</string>
+ 		<string key="IBDocument.InterfaceBuilderVersion">629</string>
+ 		<string key="IBDocument.AppKitVersion">949.33</string>
+


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/57830
closes: https://trac.macports.org/ticket/57382

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
