### PR TITLE
wireguard-go: update to 0.0.20190409

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,7 +3,12 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20181222
+version             0.0.20190409
+revision            0
+checksums           rmd160  4dd58796e763ed0d9c9c0eba4edf26e66e2248d8 \
+                    sha256  b5f83c190d91e187aa9e9f040206a98d07468bb6de214193465cd1a09d200095 \
+                    size    66392
+
 categories          net
 platforms           darwin
 license             GPL-2
@@ -22,10 +27,6 @@ long_description    \
 homepage            https://www.wireguard.com/
 master_sites        https://git.zx2c4.com/wireguard-go/snapshot/
 use_xz              yes
-
-checksums           rmd160  8304150849896761b2febca58ef8fd5ba4c8b54e \
-                    sha256  53dc611524c40cddd242c972a9559f9793e128a0ce772483f12a2704c9f48c54 \
-                    size    53032
 
 depends_build       port:git \
                     port:go


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?