### PR TITLE
mu: update to 1.2

### DIFF
--- a/mail/mu/Portfile
+++ b/mail/mu/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           elisp 1.0
 
-github.setup        djcb mu 1.0 v
-license             GPL-3
+name                mu
+platforms           darwin
 categories          mail
-maintainers         nomaintainer
+license             GPL-3
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
 description         Command-line tools to index and search email (aka maildir-utils)
 long_description \
    mu is a set of command-line tools for Linux/Unix that enable you to \
@@ -15,53 +15,55 @@ long_description \
    mu-index fills a database with information about all your e-mails. After \
    that, you can easily search for them, using mu-find and its dedicated \
    query language.
+homepage            https://www.djcbsoftware.nl/code/mu/
 
-platforms           darwin
+# obsolete 20190408
+subport ${name}-devel {
 
-homepage            http://www.djcbsoftware.nl/code/mu/
+    replaced_by     ${name}
+    PortGroup       obsolete 1.0
 
-checksums           rmd160  4928dbb7effc924da85b8df0da92f46412a6c9e7 \
-                    sha256  3eed4e1139d296089dcf685d6b4e8a5abe43e0f9cbae6663694250ab889f1291
-
-depends_build       port:pkgconfig
-depends_lib         port:gmime port:xapian-core port:guile
-
-use_autoreconf      yes
-configure.args      --disable-silent-rules --with-gui=none --disable-mu4e --disable-webkit --enable-guile
-
-# see https://github.com/djcb/mu/issues/380
-configure.cxxflags-delete -Os
-
-if {${os.platform} eq "darwin" && ${os.major} >= 13} {
-    # see https://github.com/djcb/mu/issues/332
-    macosx_deployment_target
 }
 
-variant emacs description {Build with emacs bindings} {
-    depends_lib-append    path:${emacs_binary}:${emacs_binary_provider}
-    configure.env-append  EMACS=${emacs_binary}
-    build.env-append      ELCFLAGS=-Q
-    configure.args-delete --disable-mu4e
-    configure.args-append --enable-mu4e
-}
+if {${subport} eq ${name}} {
 
-subport mu-devel {
-    github.setup    djcb mu 9bffb465bdd1
-    name            mu-devel
-    version         1.0.99
-    revision        2
+    PortGroup       github 1.0
+    PortGroup       elisp 1.0
 
-    depends_lib-append port:gmime3
+    github.setup    djcb mu 1.2
+    checksums       rmd160  30ff45c6f6009c15d731f8609ca5dc31943010c9 \
+                    sha256  b65827bc95c5a936374775e85d32cd02ec18fd072b8cd5013ce4d002ec06f315 \
+                    size    2297792
+    revision        0
 
-    checksums       rmd160  cc74ced2faa837276e9ef901eb558844a8699305 \
-                    sha256  e2cc2cf2667eba993e8a3ec20bbe7fb4e6a3da8f7d21e924986ffa78783aabd5 \
-                    size    2296425
+    depends_build-append \
+        port:pkgconfig
 
-    post-extract    {
-        # set the displayed version to a 6-character string since most releases
-        # are of the form 0.9.XX
-        set over    [string range $version 0 5]
-        set dver    $over-[string range ${github.version} 0 6]
-        reinplace   "s,$over,$dver,g" ${worksrcpath}/configure.ac
+    depends_lib-append \
+        port:gmime3 \
+        port:xapian-core
+
+    use_autoreconf  yes
+    configure.args  \
+        --disable-silent-rules \
+        --with-gui=none \
+        --disable-mu4e \
+        --disable-webkit \
+        --disable-guile
+
+    variant emacs description {Build with emacs bindings} {
+        depends_lib-append     path:${emacs_binary}:${emacs_binary_provider}
+        configure.env-append   EMACS=${emacs_binary}
+        build.env-append       ELCFLAGS=-Q
+        configure.args-replace --disable-mu4e --enable-mu4e
     }
+
+    variant guile description {Build with Guile/Scheme bindings} {
+        depends_lib-append     port:guile
+        configure.args-replace --disable-guile --enable-guile
+    }
+
+    # disable "-rc" versions for livecheck
+    github.livecheck.regex  {([0-9.]+)}
+
 }


### PR DESCRIPTION
#### Description

- bump version to 1.2
- obsolete mu-devel
- take maintainer
- create variant for guile
- removed fixes; seems useless now

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->