### PR TITLE
rtaudio: use_autoreconf

### DIFF
--- a/audio/rtaudio/Portfile
+++ b/audio/rtaudio/Portfile
@@ -24,13 +24,10 @@ checksums           rmd160  a9f5f7e602f9c7de6fa94e164706df32d33905ab \
 revision            0
 
 depends_build-append \
-    port:pkgconfig \
-    port:autoconf \
-    port:automake \
-    port:libtool
+    port:pkgconfig
 
-# new versions will use cmake
-configure.cmd       ./autogen.sh
+# future versions will use cmake
+use_autoreconf      yes
 configure.args      --with-core
 
 build.args-append   \


### PR DESCRIPTION
#### Description

- use_autoreconf instead of the command

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->