### PR TITLE
wireguard-go: update to 0.0.20190409

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 
 name                wireguard-go
 version             0.0.20190409
-revision            0
-checksums           rmd160  4dd58796e763ed0d9c9c0eba4edf26e66e2248d8 \
-                    sha256  b5f83c190d91e187aa9e9f040206a98d07468bb6de214193465cd1a09d200095 \
-                    size    66392
+revision            1
+checksums           rmd160  3f3ead66c45dd636d03143fc5b2373a50de91f4b \
+                    sha256  bd7305d69435438ece56df62695197c38469fd0be8c9b6fe56484b6347bf05d6 \
+                    size    66364
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description

Upstream tag was revised after previous PR https://github.com/macports/macports-ports/pull/4044, breaking all the builds. This PR updates the checksums and bumps the revision.

###### Type

- [x] bugfix

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?