### PR TITLE
py-pyobjc[-*]: update to 5.2

### DIFF
--- a/python/py-pyobjc-cocoa/Portfile
+++ b/python/py-pyobjc-cocoa/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pyobjc-cocoa
 python.rootname     pyobjc-framework-Cocoa
-version             5.1.2
+version             5.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -15,14 +15,13 @@ maintainers         nomaintainer
 description         cocoa wrappers for PyObjC
 long_description    This port provides the CoreFoundation, Foundation \
                     and AppKit wrappers for use with PyObjC.
-homepage            https://pythonhosted.org/pyobjc/
+homepage            https://pyobjc.readthedocs.io
 
 master_sites        pypi:p/${python.rootname}/
 distname            ${python.rootname}-${version}
-
-checksums           rmd160  28fd8ad8bb32fd01b618589a5cfb446aaa8c2875 \
-                    sha256  a13f451071b7bd00e773874ddf5de4618c121448312d3409dac93a0bcc71962e \
-                    size    3787306
+checksums           rmd160  149b539c8b517ee5d5fc6f19f79e4c2ff4981b6c \
+                    sha256  561785bbc4dd2f05cc836464733382ef6a69cb13338a7bc5f8297f5cd021d0bd \
+                    size    3787060
 
 python.versions     27 34 35 36 37
 

--- a/python/py-pyobjc-fsevents/Portfile
+++ b/python/py-pyobjc-fsevents/Portfile
@@ -5,7 +5,7 @@ PortGroup           python  1.0
 
 name                py-pyobjc-fsevents
 python.rootname     pyobjc-framework-FSEvents
-version             5.1.2
+version             5.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -14,14 +14,14 @@ maintainers         nomaintainer
 
 description         FSEvents wrapper for PyObjC
 long_description    This port provides the FSEvents wrapper for use with PyObjC
-homepage            https://pythonhosted.org/pyobjc/
+homepage            https://pyobjc.readthedocs.io/
 
 master_sites        pypi:p/${python.rootname}/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  4e34a14da11717ddf869fde4a71631e3d51dcb79 \
-                    sha256  c86e84ebb536b5ace8b3c39535ede01bdbe2c14664f70b2baeea180a15d7c2c8 \
-                    size    24981
+checksums           rmd160  220c1f7139102980e42bcb7c6f8ab78365770a5c \
+                    sha256  4ee7e9ac83b6b2684c5a587bc07c972e4bb414059ae84abd56672a90ba2682a1 \
+                    size    25025
 
 python.versions     27 34 35 36 37
 

--- a/python/py-pyobjc-qtkit/Portfile
+++ b/python/py-pyobjc-qtkit/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pyobjc-qtkit
 python.rootname     pyobjc-framework-QTKit
-version             5.1.2
+version             5.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -18,14 +18,14 @@ long_description    This port provides wrappers for the QTKit framework for \
                     framework for working with QuickTime media in Cocoa \
                     applications, and is a replacement for the older \
                     Carbon-based Quicktime framework.
-homepage            https://pythonhosted.org/pyobjc/
+homepage            https://pyobjc.readthedocs.io/
 
 master_sites        pypi:p/${python.rootname}/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  8cf7f79095698bbf374bf970f90bd71a2493b220 \
-                    sha256  9c290a2ba950a42c1e2e80d25852d93cd59b78b01ba8b8014cd8d8ad2b8d16f2 \
-                    size    118050
+checksums           rmd160  0606d8ef5f9582507d45e7dc4dd0c3d0b1929aca \
+                    sha256  35a9c4e66f24723094cba7ec32aaa45559c025da55fa2f04634afbabc7dc6ce1 \
+                    size    118084
 
 python.versions     27 34 35 36 37
 

--- a/python/py-pyobjc-quartz/Portfile
+++ b/python/py-pyobjc-quartz/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pyobjc-quartz
 python.rootname     pyobjc-framework-Quartz
-version             5.1.2
+version             5.2
 revision            0
 categories-append   devel
 platforms           darwin
@@ -17,14 +17,14 @@ long_description    This port provides the CoreGraphics, ImageIO, \
                     QuartzComposer, QuartzCore, QuartzFilters, ImageKit, \
                     PDFKit and CoreVideo framework wrappers \
                     for use with PyObjC.
-homepage            https://pythonhosted.org/pyobjc/
+homepage            https://pyobjc.readthedocs.io/
 
 master_sites        pypi:p/${python.rootname}/
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  977190becfc230676e401912e3dca182b8b585a4 \
-                    sha256  79ca11ab1285533852585854398be6e7f2ef209f9f3ad5d0a2bec90a77d654d7 \
-                    size    3353862
+checksums           rmd160  c8e9a5810520d0155bb440415f57850757bd6407 \
+                    sha256  89d41e86b075788deb65695e32001de488412ae9b60191294a3fd31e8b3d2613 \
+                    size    3353568
 
 python.versions     27 34 35 36 37
 

--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -4,11 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyobjc
-version             5.1.2
-checksums           rmd160  b74806ee8b66a141a6f96303ecc56448808a1ccb \
-                    sha256  db8836da2401e63d8bdaff7052fdc6113b7527d12d84e58fe075e69ff590e8fd \
-                    size    794290
-revision            1
+version             5.2
+revision            0
 
 categories-append   devel
 license             MIT
@@ -23,14 +20,18 @@ long_description    The PyObjC project aims to provide a bridge between \
                     and the Objective-C programmer transparent access to \
                     Python based functionality.
 
-homepage            https://pythonhosted.org/pyobjc/
+homepage            https://pyobjc.readthedocs.io
 master_sites        pypi:p/pyobjc-core/
 distname            pyobjc-core-${version}
+checksums           rmd160  7509b54b44db3f1d5da4c1908ef38aef8d8acee3 \
+                    sha256  cd13a2e9be890064a6dd11db7790bbf38502350c532a9a9d05511abb8683b8ea \
+                    size    797936
 
-python.versions 27 34 35 36 37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_lib     port:libffi \
+    depends_lib-append \
+                    port:libffi \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-py2app
 


### PR DESCRIPTION
#### Description
- update all ```py-pyobjc[-*]``` ports to version 5.2

From reading the [changelog](https://pyobjc.readthedocs.io/en/latest/changelog.html), it should be a straightforward update. Indeed, it installs fine for me and I haven't noticed any issues; just submitting a PR to make sure it builds on older systems as well, and for interested parties to take a look before committing.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
