### PR TITLE
openhantek: new port

### DIFF
--- a/science/openhantek/Portfile
+++ b/science/openhantek/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+PortGroup           github 1.0
+PortGroup           qt5 1.0
+
+github.setup        Ho-Ro openhantek 2.0 v
+
+platforms           darwin macosx
+categories          science
+license             GPL-3.0
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         DSO software for Hantek USB digital signal oscilloscopes
+long_description    OpenHantek is a free software for Hantek and compatible \
+    (Voltcraft/Darkwire/Protek/Acetech) USB digital signal oscilloscopes
+homepage            https://ho-ro.github.io/openhantek/
+
+checksums           rmd160  f590e57e75dc6f6e5159951207483e7dd3b6880c \
+                    sha256  91c1893e67a7e0a20adf17b566c360af496a2342dd2b3d62f1f0a77e616dcf57 \
+                    size    11408913
+
+depends_lib-append \
+    path:lib/libusb.dylib:libusb \
+    port:fftw-3


### PR DESCRIPTION
#### Description

OpenHantek is a DSO software for Hantek USB digital signal
oscilloscopes, especially Hantek 6022BE (and BL)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->