### PR TITLE
py-pycares: add missing py-cffi dependency

### DIFF
--- a/python/py-pycares/Portfile
+++ b/python/py-pycares/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-pycares
 version             3.0.0
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -29,6 +30,8 @@ checksums           rmd160  31c2c0ed413735d562663d56b175e6be19c3fc56 \
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
+
+    depends_lib-append      port:py${python.version}-cffi
 
     livecheck.type          none
 } else {


### PR DESCRIPTION
#### Description
- add missing dependency on ```py-cffi```

This is causing a build failure for [```py-discordpy```](https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/28230/steps/install-dependencies/logs/stdio) that will eventually link to the failure of  [```py-pycares```](https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/25418/steps/install-port/logs/stdio)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
