### PR TITLE
heirloom-doctools: new port

### DIFF
--- a/textproc/heirloom-doctools/Portfile
+++ b/textproc/heirloom-doctools/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        n-t-roff heirloom-doctools 160308
+version             2016-03-08
+categories          textproc
+platforms           darwin
+license             CDDL-1.1
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         troff, nroff, and related utilities
+
+long_description    The Heirloom Documentation Tools package provides troff, \
+                    nroff, and related utilities to format manual pages and \
+                    other documents for output on terminals and printers.
+
+homepage            https://n-t-roff.github.io/heirloom/doctools
+
+checksums           rmd160  59a272638523a598e97d3ad52c1adbf38bdd4217 \
+                    sha256  a891bb230a62592d0dcd212f533190d5f43f2e2a7759beaed7fbfb96d645ac80 \
+                    size    4627021
+
+conflicts           groff
+
+patchfiles          patch-grap-print.diff
+
+configure.pre_args
+
+build.target
+build.args          ROOT=${destroot} \
+                    PREFIX=${prefix} \
+                    BINDIR=${prefix}/bin \
+                    MANDIR=${prefix}/share/man \
+                    LIBDIR=${prefix}/libexec/${name} \
+                    PUBDIR=${prefix}/share/${name}/pub \
+                    MACDIR=${prefix}/share/${name}/tmac \
+                    FNTDIR=${prefix}/share/${name}/font \
+                    TABDIR=${prefix}/share/${name}/nterm \
+                    HYPDIR=${prefix}/share/${name}/hyphen \
+                    REFDIR=${prefix}/share/${name}/reftools
+
+use_parallel_build  no
+
+destroot.args       ${build.args}

--- a/textproc/heirloom-doctools/files/patch-grap-print.diff
+++ b/textproc/heirloom-doctools/files/patch-grap-print.diff
@@ -1,0 +1,11 @@
+--- grap/print.c.orig	2019-04-10 10:09:24.000000000 +0400
++++ grap/print.c	2019-04-10 10:10:10.000000000 +0400
+@@ -189,7 +189,7 @@
+ {
+ 	extern int lib;
+ 	extern char *lib_defines;
+-	static char buf[50], buf1[50];	/* static because pbstr uses them */
++	static char buf[50], buf1[50+FILENAME_MAX] ;  /* static because pbstr uses them */
+ 	FILE *fp;
+ 	extern int getpid(void);
+ 


### PR DESCRIPTION
###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?