### PR TITLE
new port: nomad

### DIFF
--- a/net/nomad/Portfile
+++ b/net/nomad/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        hashicorp nomad 0.9.0 v
+homepage            https://www.nomadproject.io/
+
+platforms           darwin
+categories          net
+license             MPL-2
+installs_libs       no
+
+# Nomad's build process requires the git repository.
+fetch.type          git
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         Nomad is an open source scheduler for scheduling \
+                    virtualized, containerized, and standalone applications. 
+
+long_description    Nomad is a flexible container orchestration tool that \
+                    enables an organization to easily deploy and manage any \
+                    containerized or legacy application using a single, \
+                    unified workflow. Nomad can run a diverse workload of \
+                    Docker, non-containerized, microservice, and batch \
+                    applications.
+
+depends_build       port:go
+
+set proj_dir "${workpath}/src/github.com/${github.author}/${github.project}"
+
+# The "dev" build target must be used to build just the binary for this
+# platform, instead of for ALL platforms
+# - https://www.nomadproject.io/docs/install/index.html#compiling-from-source
+build.target        bootstrap
+build.post_args     dev
+build.dir           ${proj_dir}
+build.env           GOPATH=${workpath} PATH=$env(PATH):${workpath}/bin
+use_configure       no
+# Bootstrap target must run before dev, so we disable parallel building.
+use_parallel_build  no
+
+post-extract {
+    file mkdir [file dirname ${proj_dir}]
+    move ${worksrcpath} ${proj_dir}
+}
+
+destroot {
+    xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
New port, Hashicorp Nomad 0.9.0

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
