### PR TITLE
py-Pillow: roll back py34 subport to previous working version 5.4.1

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -40,6 +40,16 @@ if {${name} ne ${subport}} {
                             size    10814666
     }
 
+    if {[lsearch {34} ${python.version}] != -1} {
+        version             5.4.1
+        revision            1
+        master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+        distname            Pillow-${version}
+        checksums           rmd160  457ab4a946c80d739faba6af822258f2fd962014 \
+                            sha256  5233664eadfa342c639b9b9977190d64ad7aca4edc51a966394d7e08e7f38a9f \
+                            size    16016153
+    }
+
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_lib-append  port:py${python.version}-tkinter \
@@ -54,6 +64,8 @@ if {${name} ne ${subport}} {
 
     if {[lsearch {26 33} ${python.version}] != -1} {
         patchfiles          patch-setup-3.4.2.py.diff
+    } elseif {[lsearch {34} ${python.version}] != -1} {
+        patchfiles          patch-setup-5.4.1.py.diff
     } else {
         patchfiles          patch-setup.py.diff
     }

--- a/python/py-Pillow/files/patch-setup-5.4.1.py.diff
+++ b/python/py-Pillow/files/patch-setup-5.4.1.py.diff
@@ -1,0 +1,47 @@
+--- setup.py.orig	2019-01-05 09:33:50.000000000 -0800
++++ setup.py	2019-04-10 22:38:03.000000000 -0700
+@@ -373,42 +373,8 @@
+                                         sys.version[:3], "config"))
+ 
+         elif sys.platform == "darwin":
+-            # attempt to make sure we pick freetype2 over other versions
+-            _add_directory(include_dirs, "/sw/include/freetype2")
+-            _add_directory(include_dirs, "/sw/lib/freetype2/include")
+-            # fink installation directories
+-            _add_directory(library_dirs, "/sw/lib")
+-            _add_directory(include_dirs, "/sw/include")
+-            # darwin ports installation directories
+-            _add_directory(library_dirs, "/opt/local/lib")
+-            _add_directory(include_dirs, "/opt/local/include")
+-
+-            # if Homebrew is installed, use its lib and include directories
+-            try:
+-                prefix = subprocess.check_output(['brew', '--prefix']).strip(
+-                ).decode('latin1')
+-            except Exception:
+-                # Homebrew not installed
+-                prefix = None
+-
+-            ft_prefix = None
+-
+-            if prefix:
+-                # add Homebrew's include and lib directories
+-                _add_directory(library_dirs, os.path.join(prefix, 'lib'))
+-                _add_directory(include_dirs, os.path.join(prefix, 'include'))
+-                ft_prefix = os.path.join(prefix, 'opt', 'freetype')
+-
+-            if ft_prefix and os.path.isdir(ft_prefix):
+-                # freetype might not be linked into Homebrew's prefix
+-                _add_directory(library_dirs, os.path.join(ft_prefix, 'lib'))
+-                _add_directory(include_dirs,
+-                               os.path.join(ft_prefix, 'include'))
+-            else:
+-                # fall back to freetype from XQuartz if
+-                # Homebrew's freetype is missing
+-                _add_directory(library_dirs, "/usr/X11/lib")
+-                _add_directory(include_dirs, "/usr/X11/include")
++            _add_directory(library_dirs, "@prefix@/lib")
++            _add_directory(include_dirs, "@prefix@/include")
+ 
+         elif sys.platform.startswith("linux") or \
+                 sys.platform.startswith("gnu") or \


### PR DESCRIPTION
Fixes build failure caused by the removal of support for python 3.4 in version 6.0.0.

See https://github.com/python-pillow/Pillow/commit/6eab984b0f925794210f2bf4b350550e8dbdd7e2

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
