### PR TITLE
rsp_tcp: new port

### DIFF
--- a/science/rsp_tcp/Portfile
+++ b/science/rsp_tcp/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+name                rsp_tcp
+platforms           darwin macosx
+categories          science
+license             GPL-3.0
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+
+description         RSP TCP Server for SDRPlay devices.
+long_description    ${description} This is a fork of the original \
+    rsp_tcp by F4FHH Nicolas with extensions to support all current \
+    RSP devices. Use the extended mode to access the full bit rate \
+    of the RSP and all of the RSP specific controls. By default the \
+    server supports the RTL TCP protocol.
+
+github.setup        SDRplay RSPTCPServer 0.1-beta v
+checksums           rmd160  b21b417f636808d801e6b1f8fde926b0328e54e3 \
+                    sha256  be6f925627b25b5737353beee65ed9ed256fe25bb70a71130215ebe5a4a8fcc7 \
+                    size    37983
+revision            0
+
+depends_lib-append \
+    port:SDRplay
+
+# PR opened upstream 30 days ago without any answer
+# so I put here the patch until upstream
+patch.pre_args -p1
+patchfiles-append \
+    patch-version.diff

--- a/science/rsp_tcp/files/patch-version.diff
+++ b/science/rsp_tcp/files/patch-version.diff
@@ -1,0 +1,161 @@
+From cf762649f1a74454cb43225e2534ac87b1e75660 Mon Sep 17 00:00:00 2001
+Date: Mon, 15 Apr 2019 14:55:41 +0200
+Subject: [PATCH 1/3] fix version consistency
+
+---
+ rsp_tcp.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/rsp_tcp.c b/rsp_tcp.c
+index a3f7b39..ca4302a 100644
+--- a/rsp_tcp.c
++++ b/rsp_tcp.c
+@@ -115,9 +115,6 @@ static int llbuf_num = 500;
+ 
+ static volatile int do_exit = 0;
+ 
+-#define RSP_TCP_VERSION_MAJOR (1)
+-#define RSP_TCP_VERSION_MINOR (0)
+-
+ #define MAX_DECIMATION_FACTOR (64)
+ #define MAX_DEVS 4
+ #define WORKER_TIMEOUT_SEC 3
+@@ -1441,9 +1438,7 @@ int init_rsp_device(unsigned int sr, unsigned int freq, int enable_bias_t, unsig
+ void usage(void)
+ {
+ 	printf("rsp_tcp, an I/Q spectrum server for SDRPlay receivers "
+-#ifdef SERVER_VERSION
+ 		"VERSION "SERVER_VERSION
+-#endif
+ 		"\n\n"
+ 		"Usage:\t[-a listen address]\n"
+ 		"\t[-p listen port (default: 1234)]\n"
+@@ -1500,7 +1495,7 @@ int main(int argc, char **argv)
+ 	struct sigaction sigact, sigign;
+ #endif
+ 
+-	printf("rsp_tcp version %d.%d\n\n", RSP_TCP_VERSION_MAJOR, RSP_TCP_VERSION_MINOR);
++	printf("rsp_tcp version %s\n\n", SERVER_VERSION);
+ 
+ 	while ((opt = getopt(argc, argv, "a:p:f:b:s:n:d:P:TvADBFRE")) != -1) {
+ 		switch (opt) {
+
+From 258a27957e276653e040121db0f15138ec195a25 Mon Sep 17 00:00:00 2001
+Date: Mon, 15 Apr 2019 15:06:26 +0200
+Subject: [PATCH 2/3] fix usage()
+
+- fix ./rsp_tcp: option requires an argument -- h
+- remove double header when request help
+---
+ CMakeLists.txt |  1 +
+ rsp_tcp.c      | 49 +++++++++++++++++++++++++++----------------------
+ 2 files changed, 28 insertions(+), 22 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed46c99..0bb114b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,6 +22,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ set(CMAKE_C_FLAGS "-Wall")
+ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb")
+ add_definitions(-D_GNU_SOURCE)
++add_definitions(-DSERVER_NAME="${PROJECT_NAME}")
+ add_definitions(-DSERVER_VERSION="${PROJECT_VERSION}")
+ include_directories(${LIBSDRPLAY_INCLUDE_DIRS})
+ 
+diff --git a/rsp_tcp.c b/rsp_tcp.c
+index ca4302a..7b19d3e 100644
+--- a/rsp_tcp.c
++++ b/rsp_tcp.c
+@@ -1437,25 +1437,29 @@ int init_rsp_device(unsigned int sr, unsigned int freq, int enable_bias_t, unsig
+ 
+ void usage(void)
+ {
+-	printf("rsp_tcp, an I/Q spectrum server for SDRPlay receivers "
+-		"VERSION "SERVER_VERSION
++	printf(SERVER_NAME", an I/Q spectrum server for SDRPlay receivers, "
++		"version "SERVER_VERSION
+ 		"\n\n"
+-		"Usage:\t[-a listen address]\n"
+-		"\t[-p listen port (default: 1234)]\n"
+-		"\t[-d RSP device to use (default: 1, first found)]\n"
+-		"\t[-P Antenna Port select* (0/1/2, default: 0, Port A)]\n"
+-		"\t[-T Bias-T enable* (default: disabled)]\n"
+-		"\t[-R Refclk output enable* (default: disabled)]\n"
+-		"\t[-f frequency to tune to [Hz]]\n"
+-		"\t[-s samplerate in Hz (default: 2048000 Hz)]\n"
+-		"\t[-n max number of linked list buffers to keep (default: 500)]\n"
+-		"\t[-v Verbose output (debug) enable (default: disabled)]\n"
+-		"\t[-E RSP extended mode enable (default: rtl_tcp compatible mode)\n"
+-		"\t[-A AM notch enable (default: disabled)\n"
+-		"\t[-B Broadcast notch enable (default: disabled)\n"
+-		"\t[-D DAB notch enable (default: disabled)\n"
+-		"\t[-F RF notch enable (default: disabled)\n"
+-		"\t[-b Sample bit-depth (8/16 default: 8)\n");
++		"Usage:\n"
++		"\t"SERVER_NAME" [OPTIONS]\n\n"
++		"Options:\n"
++		"\t-a listen address\n"
++		"\t-p listen port (default: 1234)\n"
++		"\t-d RSP device to use (default: 1, first found)\n"
++		"\t-P Antenna Port select* (0/1/2, default: 0, Port A)\n"
++		"\t-T Bias-T enable* (default: disabled)\n"
++		"\t-R Refclk output enable* (default: disabled)\n"
++		"\t-f frequency to tune to [Hz]\n"
++		"\t-s samplerate in Hz (default: 2048000 Hz)\n"
++		"\t-n max number of linked list buffers to keep (default: 500)\n"
++		"\t-v Verbose output (debug) enable (default: disabled)\n"
++		"\t-E RSP extended mode enable (default: rtl_tcp compatible mode)\n"
++		"\t-A AM notch enable (default: disabled)\n"
++		"\t-B Broadcast notch enable (default: disabled)\n"
++		"\t-D DAB notch enable (default: disabled)\n"
++		"\t-F RF notch enable (default: disabled)\n"
++		"\t-b Sample bit-depth (8/16 default: 8)\n"
++		"\t-h This help\n");
+ 	exit(1);
+ }
+ 
+@@ -1495,9 +1499,7 @@ int main(int argc, char **argv)
+ 	struct sigaction sigact, sigign;
+ #endif
+ 
+-	printf("rsp_tcp version %s\n\n", SERVER_VERSION);
+-
+-	while ((opt = getopt(argc, argv, "a:p:f:b:s:n:d:P:TvADBFRE")) != -1) {
++	while ((opt = getopt(argc, argv, "a:p:f:b:s:n:d:P:TvADBFREh")) != -1) {
+ 		switch (opt) {
+ 		case 'd':
+ 			device = atoi(optarg) - 1;
+@@ -1550,11 +1552,14 @@ int main(int argc, char **argv)
+ 		case 'F':
+ 			notch |= RSP_TCP_NOTCH_RF;
+ 			break;
++		case 'h':
+ 		default:
+ 			usage();
+ 			break;
+ 		}
+-}
++	}
++
++	printf(SERVER_NAME" version %s\n\n", SERVER_VERSION);
+ 
+ 	if (bit_depth != 8 && bit_depth != 16) {
+ 		usage();
+
+From 978c57fb4c39f6d6e02423391116b22b38f9cd69 Mon Sep 17 00:00:00 2001
+Date: Mon, 15 Apr 2019 15:08:19 +0200
+Subject: [PATCH 3/3] add build/ to .gitignore
+
+---
+ .gitignore | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..567609b
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1 @@
++build/


### PR DESCRIPTION
#### Description

RSP TCP Server for SDRPlay devices. This is a fork of the original rsp_tcp by F4FHH Nicolas with extensions to support all current RSP devices. Use the extended mode to access the full bit rate of the RSP and all of the RSP specific controls. By default the server supports the RTL TCP protocol.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->