### PR TITLE
jmol: update to 14.29.35

### DIFF
--- a/science/jmol/Portfile
+++ b/science/jmol/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                jmol
-version             14.29.28
+version             14.29.35
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science
 platforms           darwin
@@ -23,9 +23,9 @@ master_sites        sourceforge:project/jmol/Jmol/Version%20${branch}/Jmol%20${v
 
 distname            Jmol-${version}-binary
 
-checksums           rmd160  806568a8aec982cef70501e9ee8ebaa4b4f86a66 \
-                    sha256  e005e003744275a07431f37e24b16cf99fef4944477929cf3d8069ab71e1e254 \
-                    size    86896639
+checksums           rmd160  b5b6bb1dec38ac38ffd146f97be814b6a24c7800 \
+                    sha256  9beaaccc9c707639133a979911e41273c3ed3143be6f59f531f36f2b7bc4c26d \
+                    size    83702451
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
Bug fixes, and new features, see 
https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.29/Jmol%2014.29.35/README-14.29.35.properties/download 
for details.

#### Description

Upstream update
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G6030
Xcode 10.1 10B61 
Java 1.8.0_152

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
