### PR TITLE
micronaut: update to 1.1.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.0.5 v
+github.setup    micronaut-projects micronaut-core 1.1.0 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  39a05233eb46caae6eab4679876003eea83e0d4c \
-                sha256  4a7ab0a1bd094ff19cd47fbe6382f7470f91ead146497090109ea202af35ff41 \
-                size    12758786
+checksums       rmd160  49f1fc2d97d1bbbf9f1f03cb30ff8054c4012c78 \
+                sha256  21595867692f61317a20c8222c88c86a6599663461b2bed1d1922e6643cc84b9 \
+                size    12803339
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.1.0.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?