### PR TITLE
emacs: update to 26.2 and update -devel

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -72,12 +72,12 @@ platform darwin {
 }
 
 if {$subport eq $name || $subport eq "emacs-app"} {
-    version         26.1
-    revision        2
+    version         26.2
+    revision        0
 
-    checksums       rmd160  f13fe104345738c853bcce2e3e061dbfb8692bc5 \
-                    sha256  760382d5e8cdc5d0d079e8f754bce1136fbe1473be24bb885669b0e38fc56aa3 \
-                    size    65007481
+    checksums       rmd160  3d9f5d7772e23425bcba7a6edb3183ce58bbb737 \
+                    sha256  4f99e52a38a737556932cc57479e85c305a37a8038aaceb5156625caf102b4eb \
+                    size    65202886
 
     patchfiles      patch-configure.diff
 
@@ -88,11 +88,11 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     epoch           1
-    version         20190301
+    version         20190413
 
     fetch.type      git
     git.url         http://git.savannah.gnu.org/r/emacs.git
-    git.branch      8eb94161b3419f3dd345871928ea37d986791963
+    git.branch      f9694a713824d402bcba01064ac2f95156bf4161
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"


### PR DESCRIPTION
#### Description

* emacs-26.2

** introduces:

  - Emacs modules can now be built outside of the Emacs tree source.
  - Emacs is now compliant with the latest version 11.0 of the Unicode Standard.
  - In Dired, the 'Z' command on a directory name compresses all of its files.

** fixes:

  - support hunspell 1.7
  - bug#31904 and bug#32812 (Make all NS drawing be done from
    drawRect) on emacs-app

Full news at https://www.gnu.org/software/emacs/news/NEWS.26.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->