### PR TITLE
gitlab-runner: update to 11.9.2

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.9.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 11.9.2 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  145205394e859ad5de3391d30a2a335d814566d2 \
-                    sha256  b1a6a82c747a8d948bccd7d261ed0d476263afd9f2ec582b4a9ce5707189d67f \
-                    size    27052321
+checksums           rmd160  9bab00023212f2323422c343c6a4ae01367275ec \
+                    sha256  48ebf08a4911f2ea220b4ad87a86ef35ad677b8d0691f6e7305e6651a87fd414 \
+                    size    27053661
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 11.9.2.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?