### PR TITLE
OpenBLAS: enable build on Apple i386

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -41,7 +41,8 @@ if {[string first "-devel" $subport] > 0} {
     conflicts       OpenBLAS
 
     patchfiles      patch-libnoarch.devel.diff \
-                    patch-linkLib.devel.diff
+                    patch-linkLib.devel.diff \
+                    patch-OpenBLAS-i386-Apple.diff
 
     github.livecheck.branch develop
 
@@ -57,7 +58,8 @@ if {[string first "-devel" $subport] > 0} {
     patchfiles      patch-libnoarch.release.diff \
                     patch-linkLib.release.diff  \
                     patch-darwin-powerpc.diff \
-                    patch-openblas-powermac970-fix.diff
+                    patch-openblas-powermac970-fix.diff \
+                    patch-OpenBLAS-i386-Apple.diff
 }
 
 compilers.choose    fc

--- a/math/OpenBLAS/files/patch-OpenBLAS-i386-Apple.diff
+++ b/math/OpenBLAS/files/patch-OpenBLAS-i386-Apple.diff
@@ -1,0 +1,23 @@
+diff --git cpuid_x86.c cpuid_x86.c
+index eb986b6..c5c02f5 100644
+--- cpuid_x86.c
++++ cpuid_x86.c
+@@ -87,10 +87,6 @@ void cpuid_count(int op, int count, int *eax, int *ebx, int *ecx, int *edx)
+ 
+ #ifndef CPUIDEMU
+ 
+-#if defined(__APPLE__) && defined(__i386__)
+-void cpuid(int op, int *eax, int *ebx, int *ecx, int *edx);
+-void cpuid_count(int op, int count, int *eax, int *ebx, int *ecx, int *edx);
+-#else
+ static C_INLINE void cpuid(int op, int *eax, int *ebx, int *ecx, int *edx){
+ #if defined(__i386__) && defined(__PIC__)
+   __asm__ __volatile__
+@@ -116,7 +112,6 @@ static C_INLINE void cpuid_count(int op, int count ,int *eax, int *ebx, int *ecx
+     ("cpuid": "=a" (*eax), "=b" (*ebx), "=c" (*ecx), "=d" (*edx) : "0" (op), "2" (count) : "cc");
+ #endif
+ }
+-#endif
+ 
+ #else
+ 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/58263

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.5 i386, 10.6 i386, 10.6 x86_64, 10.13 x86_64, 10.14 x86_64
Xcode 3 to 10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
