### PR TITLE
gdub: update to ebe14f110153f05 to support Kotlin-based gradle.build.kts files

### DIFF
--- a/devel/gdub/Portfile
+++ b/devel/gdub/Portfile
@@ -3,7 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dougborg gdub 0.1.0 v
+github.setup        dougborg gdub ebe14f110153f05f3a50e7ff2eaa8d2704cde9d9
+# Note: gdub does not have a release tag as of 2019-04-14, so an artificial version is used here
+# Consider using upstream versions when available (see https://github.com/dougborg/gdub/issues/30)
+# 0.1.0.1 is greater than upstream's 0.1.0, and 0.1.0.1 is likely to be less than any futher upstream versions.
+version             0.1.0.1
 categories          devel java groovy
 platforms           darwin
 supported_archs     noarch
@@ -19,8 +23,8 @@ long_description    gdub (gw on the command line) is a gradle / gradlew wrapper.
 
 homepage            http://www.gdub.rocks/
 
-checksums           rmd160  fa612e31fd2f32e429225338ff5361184b82b318 \
-                    sha256  76d9a81ba295cf8a4024bde845cd8e36bb01e3465ed09221fb69d7627150afbc
+checksums           rmd160  9100f5eca0cff7050d0acf774d8bc8f7df2167af \
+                    sha256  0651ae907fec2fe0d386259bd5e30c89a7974cbf85d3a811a922deecf8688aab
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

This brings Kotlin-based build scripts support to `gdub` port.
Unfortunately there's no git tag in the upstream, so I just use the SHA.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
