### PR TITLE
qsynth: new port, version 0.5.6

### DIFF
--- a/audio/qsynth/Portfile
+++ b/audio/qsynth/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qt5 1.0
+PortGroup           cmake 1.1
+
+name                qsynth
+version             0.5.6
+maintainers         {gmail.com:rjvbertin @RJVB} {mojca @mojca} openmaintainer
+categories          audio
+platforms           darwin
+license             GPL-2+
+
+description         A fluidsynth GUI front-end application
+long_description    Qsynth is a fluidsynth GUI front-end application, written in C++ using the Qt framework. \
+                    Eventually it may evolve into a softsynth management application allowing the user to \
+                    control and manage a variety of command line softsynths.
+
+homepage            https://qsynth.sourceforge.io
+master_sites        sourceforge:project/${name}/${name}/${version}
+
+checksums           rmd160  0bd16d01c5f2b346f5bd5ab22f17952d54f15081 \
+                    sha256  a6eb404778fad87bb37fa1fb4caf1d80f24a324f9c3a22b669df2f8c94849040 \
+                    size    269583
+
+qt5.depends_build_component \
+                    qttools
+
+depends_lib-append \
+                    port:fluidsynth
+
+variant gm description {Use the MIDI instrument patches from port:fluid-soundfont} {
+    depends_run-append \
+                    port:fluid-soundfont
+}
+variant gu description {Use the MIDI instrument patches from port:generaluser-soundfont} {
+    depends_run-append \
+                    port:generaluser-soundfont
+}
+default_variants    +gu
+
+patchfiles-append   patch-src-CMakeLists.txt.diff
+
+configure.args-append \
+                    -DBUNDLE_INSTALL_DIR=${qt_apps_dir}
+
+if {${os.platform} eq "darwin"} {
+    # https://sourceforge.net/p/qsynth/tickets/19/
+    depends_build-append \
+                    port:makeicns
+
+    post-extract {
+        system -W ${worksrcpath}/src/images "${prefix}/bin/makeicns -in qsynth.png -out qsynth.icns"
+    }
+
+    post-destroot {
+        if {[info procs qt5.add_app_wrapper] ne ""} {
+           qt5.add_app_wrapper qsynth
+        }
+    }
+} else {
+    cmake.install_rpath-prepend \
+                    ${qt_libs_dir} \
+                    ${prefix}/lib/${build_arch}-linux-gnu
+}

--- a/audio/qsynth/files/patch-src-CMakeLists.txt.diff
+++ b/audio/qsynth/files/patch-src-CMakeLists.txt.diff
@@ -1,0 +1,37 @@
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -106,7 +106,16 @@ if (WIN32)
+ endif ()
+ 
+ if (APPLE)
+-  set_target_properties ( qsynth PROPERTIES MACOSX_BUNDLE true )
++  set_target_properties ( qsynth PROPERTIES
++    MACOSX_BUNDLE true
++    MACOSX_BUNDLE_GUI_IDENTIFIER "org.rncbc.qsynth"
++    MACOSX_BUNDLE_BUNDLE_NAME "Qsynth"
++    MACOSX_BUNDLE_DISPLAY_NAME "Qsynth"
++    MACOSX_BUNDLE_INFO_STRING "Qsynth, a FluidSynth Qt GUI Interface"
++    MACOSX_BUNDLE_LONG_VERSION_STRING "Qsynth ${VERSION}"
++    MACOSX_BUNDLE_SHORT_VERSION_STRING "${VERSION}"
++    MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION}"
++    MACOSX_BUNDLE_COPYRIGHT "Copyright (C) 2003-2016, rncbc aka Rui Nuno Capela. All rights reserved.")
+ endif ()
+ 
+ target_link_libraries ( qsynth
+@@ -129,12 +138,13 @@ set ( TRANSLATIONS
+ qt5_add_translation ( QM_FILES ${TRANSLATIONS} )
+ add_custom_target( translations ALL DEPENDS ${QM_FILES} )
+ 
+-if (UNIX AND NOT APPLE)
++if (UNIX)
+   install ( TARGETS qsynth
+-     RUNTIME DESTINATION bin )
++     RUNTIME DESTINATION bin
++     BUNDLE DESTINATION ${BUNDLE_INSTALL_DIR} )
+   install ( FILES ${QM_FILES}
+      DESTINATION share/qsynth/translations )
+-  install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/qsynth.desktop
++  install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/qsynth.desktop
+      DESTINATION share/applications )
+   install ( FILES images/qsynth.png
+      DESTINATION share/pixmaps )


### PR DESCRIPTION
I took the port from https://github.com/RJVB/macstrop/tree/master/audio/qsynth after getting user's request for the port and made some modifications.

~There is one Qt build dependency missing to translate files. (fixed)~

When I open the app, it fails with
```
Qsynth1: Failed to create the audio driver (jack).

Cannot continue without it.
```

I might need @RJVB's help for that.

(Also, for a strange reason I cannot use `makeicns` in trace mode. But I leave that mystery for another time.)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
