### PR TITLE
py-clang: remove obsolete variant +clang38

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -31,9 +31,6 @@ if {${name} ne ${subport}} {
      cfe-3.7.1.src.tar.xz \
       rmd160  185b0f75970bc50682766a21794440578db87b5d \
       sha256  56e2164c7c2a1772d5ed2a3e57485ff73ff06c97dff12edbeea1acc4412b0674 \
-     cfe-3.8.1.src.tar.xz \
-      rmd160  a280504a3ba3aa59274120305f68fc8f8b3aca9c \
-      sha256  4cd3836dfb4b88b597e075341cae86d61c63ce3963e45c7fe6a8bf59bb382cdf \
      cfe-3.9.1.src.tar.xz \
       rmd160  51930c2d55eacd44df28b49a84565771c94f418e \
       sha256  e6c4cebb96dee827fa0470af313dff265af391cb6da8d429842ef208c8f25e63 \
@@ -52,8 +49,8 @@ if {${name} ne ${subport}} {
 
     depends_build-append    port:py${python.version}-setuptools
 
-    set clanglist       {37    38    39    40    50    60    70}
-    set clangvlist      {3.7.1 3.8.1 3.9.1 4.0.1 5.0.2 6.0.1 7.0.1}
+    set clanglist       {37    39    40    50    60    70}
+    set clangvlist      {3.7.1 3.9.1 4.0.1 5.0.2 6.0.1 7.0.1}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install
@@ -81,7 +78,6 @@ if {${name} ne ${subport}} {
     }
 
     if {![variant_isset clang37] && 
-        ![variant_isset clang38] && 
         ![variant_isset clang39] && 
         ![variant_isset clang40] && 
         ![variant_isset clang50] && 
@@ -94,7 +90,6 @@ if {${name} ne ${subport}} {
         # Will never hit this when installing from packages, which is OK, as
         # they will have the default variant set above.
         if {![variant_isset clang37] && 
-            ![variant_isset clang38] && 
             ![variant_isset clang39] && 
             ![variant_isset clang40] && 
             ![variant_isset clang50] && 


### PR DESCRIPTION
Port clang-3.8 has been removed from MacPorts.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
