### PR TITLE
py-networkx: hold back to v2.2 for python 2.7

### DIFF
--- a/python/py-networkx/Portfile
+++ b/python/py-networkx/Portfile
@@ -4,8 +4,24 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-networkx
-version             2.3
-revision            0
+
+if {${subport} eq "py27-networkx"} {
+    # 2.2 is last version to support python2.7
+    version         2.2
+    revision        0
+    checksums       rmd160  5263d628b5e7e4407234575b68f06d9632e26b79 \
+                    sha256  8311ddef63cf5c5c5e7c1d0212dd141d9a1fe3f474915281b73597ed5f1d4e3d \
+                    size    1743914
+    notes-append    "${subport} is using an outdated version of ${name}. Consider upgrading \
+                    to a python 3.x variant for the current version."
+    } else {
+    version         2.3
+    revision        0
+    checksums       rmd160  5263d628b5e7e4407234575b68f06d9632e26b79 \
+                    sha256  8311ddef63cf5c5c5e7c1d0212dd141d9a1fe3f474915281b73597ed5f1d4e3d \
+                    size    1743914
+}
+
 categories-append   science
 platforms           darwin
 license             BSD
@@ -28,10 +44,6 @@ master_sites        pypi:n/networkx \
 distname            networkx-${version}
 
 use_zip             yes
-
-checksums           rmd160  5263d628b5e7e4407234575b68f06d9632e26b79 \
-                    sha256  8311ddef63cf5c5c5e7c1d0212dd141d9a1fe3f474915281b73597ed5f1d4e3d \
-                    size    1743914
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
perhaps this might be acceptable?
