### PR TITLE
nccmp: new port

### DIFF
--- a/science/nccmp/Portfile
+++ b/science/nccmp/Portfile
@@ -26,5 +26,11 @@ checksums           rmd160  ac2a2ca3fc23ceea008d2652fd21c18c43733a74 \
 
 depends_lib         port:netcdf
 
+post-extract {
+    # Fix build when coreutils port is not installed.
+    # https://gitlab.com/remikz/nccmp/issues/7
+    file attributes ${worksrcpath}/install-sh -permissions a+x
+}
+
 test.run            yes
 test.target         check

--- a/science/nccmp/Portfile
+++ b/science/nccmp/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+# this port can optionally be built with cmake (but then tests are run in a different way)
+#PortGroup          cmake 1.1
+
+name                nccmp
+version             1.8.5.0
+categories          science
+maintainers         {noaa.gov:dave.allured @Dave-Allured} openmaintainer
+platforms           darwin
+license             GPL-2
+description         Tool for comparing NetCDF files
+long_description    nccmp compares two NetCDF files bitwise, semantically or \
+                    with a user defined tolerance. Highly recommended for regression testing \
+                    scientific models or datasets in a test-driven development environment.
+
+homepage            https://gitlab.com/remikz/nccmp
+master_sites        https://gitlab.com/remikz/nccmp/-/archive/${version}/
+use_bzip2           yes
+
+checksums           rmd160  ac2a2ca3fc23ceea008d2652fd21c18c43733a74 \
+                    sha256  bf5fa189a89d97973c868d7e7c57403790cb0ad3d9549f08a85c68c3cfb0fc78 \
+                    size    306586
+
+depends_lib         port:netcdf
+
+test.run            yes
+test.target         check


### PR DESCRIPTION
Tool for comparing NetCDF files

Closes: https://trac.macports.org/ticket/53118

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`? (two tests fail)
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@Dave-Allured: please test if this works as expected.