### PR TITLE
dnscrypt-proxy: update to version 2.0.22

### DIFF
--- a/net/dnscrypt-proxy/Portfile
+++ b/net/dnscrypt-proxy/Portfile
@@ -1,34 +1,52 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup github    1.0
 
-name                dnscrypt-proxy
-version             1.9.5
-revision            1
-categories          net
+github.setup        jedisct1 dnscrypt-proxy 2.0.22
 license             ISC
-maintainers         {mps @Schamschula} openmaintainer
+revision            0
+categories          net
+maintainers         nomaintainer
 description         A protocol for securing communications between a client and a DNS \
                     resolver.
 long_description    ${description}
 homepage            https://dnscrypt.org/
-master_sites        https://download.dnscrypt.org/dnscrypt-proxy/
-
 platforms           darwin
-depends_lib         port:libsodium
 
-checksums           rmd160  836062bba81ba84ce33981696796bb163f559440\
-                    sha256  64021fabb7d5bab0baf681796d90ecd2095fb81381e6fb317a532039025a9399
+depends_build       port:go
+
+github.tarball_from tags
+
+checksums           rmd160  058bbfc0229ce8cece57f847805952e44180af23\
+                    sha256  4eb6dc3875a37f6c43cd1e3ba4d843a71121c5ef202b5eee7a770e018a491e4c\
+                    size    2193346
+
+use_configure       no
+
+worksrcdir          ${distname}/${name}
+build.cmd           go build
+build.args          -ldflags="-s -w"
+build.target
+build.env           GOPATH=${workpath}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/sbin
+    xinstall -m 755 -d ${destroot}${prefix}/share/${name}
+    xinstall -m 640 -W ${worksrcpath} example-blacklist.txt example-cloaking-rules.txt example-dnscrypt-proxy.toml example-forwarding-rules.txt example-whitelist.txt ${destroot}${prefix}/share/${name}
+}
+
+post-activate {
+    if {![file exists ${prefix}/share/${name}/dnscrypt-proxy.toml]} {
+        file copy ${prefix}/share/${name}/example-dnscrypt-proxy.toml ${prefix}/share/${name}/dnscrypt-proxy.toml
+    }
+}
 
 startupitem.create      yes
 startupitem.netchange   yes
-startupitem.executable  ${prefix}/sbin/dnscrypt-proxy --local-address=127.0.0.1:53 --resolver-address=208.67.220.220:443 --provider-name=2.dnscrypt-cert.opendns.com --provider-key=B735:1140:206F:225D:3E2B:D822:D7FD:691E:A1C3:3CC8:D666:8D0C:BE04:BFAB:CA43:FB79
+startupitem.executable  ${prefix}/sbin/${name} -config ${prefix}/share/${name}/dnscrypt-proxy.toml
 
 notes "
 You need to update your DNS server settings to point to 127.0.0.1
 (in the Network Preference Pane -> Advanced... -> DNS tab)
 "
-
-livecheck.type      regex
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     ${name}-(\\d+\.\\d+.\\d)


### PR DESCRIPTION
#### Description

* Updated to version 2.0.22
* The new version was rewritten in go, so the port architecture has been
  reworked.
* The macports daemon now uses a configuration file instead of a fixed
  configuration.
* Set up a script to copy the example configuration to the daemon
  configuration if the daemon configuration file does not yet exist
  (inspired by how, e.g., stegbreak deals with this)

Closes: https://trac.macports.org/ticket/56208


<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
