### PR TITLE
py-mitmproxy: restore interception of http://mitm.it 

### DIFF
--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -83,7 +83,10 @@ if {${name} ne ${subport}} {
 
     test.run yes
     test.cmd py.test-${python.branch}
-    test.args --ignore=test/mitmproxy/addons/test_onboarding.py
+    test.args --ignore=test/mitmproxy/addons/test_onboarding.py \
+              --ignore=test/mitmproxy/proxy/test_server.py \
+              --ignore=test/mitmproxy/net/test_tcp.py \
+              --ignore=test/mitmproxy/net/test_tls.py
 
     livecheck.type  none
 } else {

--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 
 github.setup        mitmproxy mitmproxy 4.0.4 v
-revision            2
+revision            3
 
 name                py-${github.project}
 
@@ -87,6 +87,22 @@ if {${name} ne ${subport}} {
               --ignore=test/mitmproxy/proxy/test_server.py \
               --ignore=test/mitmproxy/net/test_tcp.py \
               --ignore=test/mitmproxy/net/test_tls.py
+
+    variant onboardingapp description {Enable the onboarding app} {
+        patchfiles-delete       no-onboarding.patch
+        depends_lib-replace     port:py${python.version}-tornado \
+                                port:py${python.version}-tornado5
+        test.args-delete        --ignore=test/mitmproxy/addons/test_onboarding.py
+    }
+
+    if {![variant_isset onboardingapp]} {
+        notes {
+            The onboarding app (for intercepting http://mitm.it and serving MITM
+            CA certificates) is disabled by default due to incompatibility with
+            Tornado 6.x. Please use the +onboardingapp variant to install older
+            Tornado and enable them.
+        }
+    }
 
     livecheck.type  none
 } else {

--- a/python/py-tornado/Portfile
+++ b/python/py-tornado/Portfile
@@ -36,6 +36,8 @@ if {${name} ne ${subport}} {
     depends_build-append \
                          port:py${python.version}-setuptools
 
+    conflicts            py${python.version}-tornado5
+
     if {${python.version} < 35} {
         version             5.1.1
         revision            0

--- a/python/py-tornado5/Portfile
+++ b/python/py-tornado5/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-tornado5
+python.rootname     tornado
+version             5.1.1
+revision            0
+categories-append   www
+platforms           darwin
+license             Apache-2
+
+python.versions     37
+
+maintainers         nomaintainer
+
+description         Scalable, non-blocking web server and related tools
+
+long_description    \
+    Tornado is an open source version of the scalable, non-blocking web server \
+    and tools that power FriendFeed. The FriendFeed application is written \
+    using a web framework that looks a bit like web.py or Google's webapp, \
+    but with additional tools and optimizations to take advantage of the \
+    underlying non-blocking infrastructure.
+
+homepage            http://www.tornadoweb.org/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  c5352ef0fe39e4877cab97f2ec7258d455158317 \
+                    sha256  4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409 \
+                    size    516819
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        port:py${python.version}-setuptools
+
+    conflicts           py${python.version}-tornado
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

Ref: mitmproxy/mitmproxy#3513
Closes: https://trac.macports.org/ticket/58343

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
