### PR TITLE
fldigi - flrig: new ports

### DIFF
--- a/science/fldigi/Portfile
+++ b/science/fldigi/Portfile
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                fldigi
+version             4.1.02
+# same sources but with different version
+set version_flarq   4.3.7
+categories          science
+platforms           darwin macosx
+license             GPL-3
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         Fast Light Digital Modem Application
+long_description    Fldigi (Fast Light Digital Modem Application), is a \
+    cross-platform modem program that supports most of the peer-to-peer \
+    (live keyboard) digital modes used on the amateur radio bands.
+homepage            http://www.w1hkj.com
+master_sites        http://www.w1hkj.com/files/${name}/
+
+checksums           rmd160  3eade162052641401bfbf5628816a897d96257b9 \
+                    sha256  ed5320619594911e8b7a887a8a098ee2b08bd25a594cd0e7be8c5834ea99d224 \
+                    size    4681621
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    path:lib/libfltk.dylib:fltk \
+    port:hamlib \
+    port:libpng \
+    port:libsamplerate \
+    port:libsndfile \
+    port:portaudio
+
+# remove when upstream accept it
+patchfiles-append \
+    patch-info.plist.diff
+
+configure.args-append \
+    --without-pulseaudio
+
+# We put this into a pre-configure block so it can be evaluated _after_ platform selection.
+pre-configure {
+    # enable optimization (SSE3) on all Intel hardwares
+    if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
+        configure.args-append \
+            --enable-optimizations=sse3
+    }
+
+    # Fix building for older macOS versions via MACOSX_DEPLOYMENT_TARGET
+    # from http://www.w1hkj.com/doku/doku.php?id=howto:building_on_os_x
+    if {${os.platform} eq "darwin" && [vercmp $macosx_deployment_target 10.12] < 0} {
+        configure.args-append \
+            --without-clock_gettime
+        configure.env-append \
+            MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
+    }
+}
+
+variant bundle description {Enable the optional macOS bundle of fldigi/flarq} {
+    patchfiles-append \
+        patch-mkappbundle.sh.diff
+    build.target    appbundle
+    post-destroot {
+        xinstall -d -m 0755 ${destroot}${applications_dir}
+        copy ${workpath}/${name}-${version}/src/${name}-${version}/${name}-${version}.app ${destroot}${applications_dir}/${name}.app
+        copy ${workpath}/${name}-${version}/src/${name}-${version}/flarq-${version_flarq}.app ${destroot}${applications_dir}/flarq.app
+    }
+}
+
+default_variants-append +bundle
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}

--- a/science/fldigi/files/patch-info.plist.diff
+++ b/science/fldigi/files/patch-info.plist.diff
@@ -1,0 +1,14 @@
+--- data/mac/Info.plist.in
++++ data/mac/Info.plist.in
+@@ -40,5 +40,11 @@
+ 
+ 	<key>NSHumanReadableCopyright</key>
+ 	<string>Copyright (c) 2006-2008 Dave Freese W1HKJ and others</string>
++
++        <key>NSPrincipalClass</key>
++        <string>NSApplication</string>
++
++        <key>NSMicrophoneUsageDescription</key>
++        <string>Allow for using Sound input devices</string>
+ </dict>
+ </plist>

--- a/science/fldigi/files/patch-mkappbundle.sh.diff
+++ b/science/fldigi/files/patch-mkappbundle.sh.diff
@@ -1,0 +1,16 @@
+--- scripts/mkappbundle.sh.old	2019-04-13 12:59:43.000000000 +0200
++++ scripts/mkappbundle.sh	2019-04-13 13:04:38.000000000 +0200
+@@ -59,7 +59,6 @@
+ 
+ 	$mkinstalldirs "$appname/Contents/Frameworks"
+ 	cd "$appname/Contents"
+-	copy_libs "MacOS/$binary"
+ }
+ 
+ if [ $# -ne 2 ]; then
+@@ -125,5 +124,3 @@
+ 
+ cd "$build"
+ 
+-echo "creating disk image"
+-hdiutil create -ov -srcfolder "$bundle_dir" -format UDZO -tgtimagekey zlib-level=9 "${APPBUNDLE}.dmg"

--- a/science/flrig/Portfile
+++ b/science/flrig/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                flrig
+version             1.3.43
+categories          science
+platforms           darwin macosx
+license             GPL-3
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         FLRIG is a transceiver control program
+long_description    FLRIG is a transceiver control program designed to be \
+    used either stand alone or as an adjunct to FLDIGI. The supported \
+    transceivers all have some degree of CAT. The FLRIG user interface \
+    changes to accommodate the degree of CAT support available for the \
+    transceiver in use.
+homepage            http://www.w1hkj.com
+master_sites        http://www.w1hkj.com/files/${name}/
+
+checksums           rmd160  38a96670d6278405c6d4adf01c33f3f0bc620cd8 \
+                    sha256  61c29f71e44a417f7a6b0ec35d465a585acda6c57dacddff83edfc25b73e24c7 \
+                    size    792283
+
+depends_build-append \
+    port:pkgconfig
+
+depends_lib-append \
+    path:lib/libfltk.dylib:fltk \
+    port:libpng
+
+# waiting upstream merge
+patchfiles-append \
+    patch-info.plist.diff \
+    patch-timeops.cxx.diff
+
+# We put this into a pre-configure block so it can be evaluated _after_ platform selection.
+pre-configure {
+    # enable optimization (SSE3) on all Intel hardwares
+    if {${build_arch} eq "i386" || ${build_arch} eq "x86_64"} {
+        configure.args-append \
+            --enable-optimizations=sse3
+    }
+
+    # Fix building for older macOS versions via MACOSX_DEPLOYMENT_TARGET
+    # from http://www.w1hkj.com/doku/doku.php?id=howto:building_on_os_x
+    if {${os.platform} eq "darwin" && [vercmp $macosx_deployment_target 10.12] < 0} {
+        configure.args-append \
+            --without-clock_gettime
+        configure.env-append \
+            MACOSX_DEPLOYMENT_TARGET=${macosx_deployment_target}
+    }
+}
+
+variant bundle description {Enable the optional macOS bundle of fldigi/flarq} {
+    patchfiles-append \
+        patch-mkappbundle.sh.diff
+    build.target    appbundle
+    post-destroot {
+        xinstall -d -m 0755 ${destroot}${applications_dir}
+        copy ${workpath}/${name}-${version}/src/${name}-${version}/${name}-${version}.app ${destroot}${applications_dir}/${name}.app
+    }
+}
+
+default_variants-append +bundle
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}

--- a/science/flrig/files/patch-info.plist.diff
+++ b/science/flrig/files/patch-info.plist.diff
@@ -1,0 +1,11 @@
+--- data/mac/Info.plist.in
++++ data/mac/Info.plist.in
+@@ -40,5 +40,8 @@
+ 
+ 	<key>NSHumanReadableCopyright</key>
+ 	<string>Copyright (c) 2009 Dave Freese W1HKJ</string>
++
++        <key>NSPrincipalClass</key>
++        <string>NSApplication</string>
+ </dict>
+ </plist>

--- a/science/flrig/files/patch-mkappbundle.sh.diff
+++ b/science/flrig/files/patch-mkappbundle.sh.diff
@@ -1,0 +1,22 @@
+--- scripts/mkappbundle.sh.old	2019-04-13 15:04:01.000000000 +0200
++++ scripts/mkappbundle.sh	2019-04-13 15:04:20.000000000 +0200
+@@ -64,8 +64,6 @@
+ 	$mkinstalldirs "$appname/Contents/Frameworks"
+ 	cd "$appname/Contents"
+ 
+-	copy_libs "MacOS/$binary"
+-
+ }
+ 
+ #=======================================================================
+@@ -117,10 +115,3 @@
+ bundle
+ 
+ cd "$build"
+-
+-echo "creating disk image"
+-
+-echo "    source: " $bundle_dir
+-echo "    target: " ${APPBUNDLE}.dmg
+-
+-hdiutil create -ov -srcfolder "$bundle_dir" -format UDZO -tgtimagekey zlib-level=9 "${APPBUNDLE}.dmg"

--- a/science/flrig/files/patch-timeops.cxx.diff
+++ b/science/flrig/files/patch-timeops.cxx.diff
@@ -1,0 +1,18 @@
+--- src/support/timeops.cxx.old	2019-04-18 16:26:23.000000000 +0200
++++ src/support/timeops.cxx	2019-04-18 16:26:49.000000000 +0200
+@@ -34,12 +34,14 @@
+ #if !HAVE_CLOCK_GETTIME
+ #  ifdef __APPLE__
+ #    include <mach/mach_time.h>
++#    define CLOCK_REALTIME 0
++#    define CLOCK_MONOTONIC 6
+ #  endif
+ #  if TIME_WITH_SYS_TIME
+ #    include <sys/time.h>
+ #  endif
+ #  include <errno.h>
+-int clock_gettime(clockid_t clock_id, struct timespec* tp)
++int clock_gettime(clock_id_t clock_id, struct timespec* tp)
+ {
+ 	if (clock_id == CLOCK_REALTIME) {
+ 		struct timeval t;


### PR DESCRIPTION
#### Description

this PR have two new ports:
- fldigi: Fast Light Digital Modem Application
- flrig: a transceiver control program

two programs used by many HAM radio.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->