### PR TITLE
maven3: update to 3.6.1

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup select 1.0
 
 name            maven3
-version         3.6.0
+version         3.6.1
 
 categories      java devel
 license         Apache-2
@@ -33,9 +33,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160 bf72ea3d4d91af2d6f29db3c28dc2a7e20c2dd68 \
-                sha256 6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637 \
-                size   9063587
+checksums       rmd160 22eb28a53e5cfe44ed8fd08ff5cc92ee8bdaadde \
+                sha256 2528c35a99c30f8940cc599ba15d34359d58bec57af58c1075519b8cd33b69e7 \
+                size   9136463
 
 depends_run     port:maven_select \
                 bin:java:kaffe


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.6.1.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?