### PR TITLE
openjdk8: update to 8u212

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,28 +3,28 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u202
+version          8u212
 revision         0
 
-set build        08
+set build        03
 set major        8
 
 subport openjdk8-openj9 {
-    version      8u202
-    revision     1
+    version      8u212
+    revision     0
 
-    set build    08
+    set build    03
     set major    8
-    set openj9_version 0.12.1
+    set openj9_version 0.14.0
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u202
+    version      8u212
     revision     0
 
-    set build    08
+    set build    03
     set major    8
-    set openj9_version 0.12.1
+    set openj9_version 0.14.0
 }
 
 subport openjdk10 {
@@ -114,9 +114,9 @@ if {${subport} eq "openjdk8"} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  5b31b2248693d5ad51d4930fb646e384aa84f84d \
-                 sha256  35e8f9b18f6c7b627dba13a4c6f45e6266552ccd7156043d92391443db0d60d6 \
-                 size    101955034
+    checksums    rmd160  d3f4816a3ae147fc605db9e9c1ee222275b53241 \
+                 sha256  3d80857e1bb44bf4abe6d70ba3bb2aae412794d335abe46b26eb904ab6226fe0 \
+                 size    102150875
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -126,9 +126,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  32e58360c9a7ceb9db5f79c4f0580c69751ccb06 \
-                 sha256  9ed76d2e4885bc1c7d9c937abaaf3739bddd2cd7c6deca5a46b79e94d62d421e \
-                 size    114341255
+    checksums    rmd160  b58a4fe668fc41c74b0f240178dc970426fa4aa4 \
+                 sha256  c213a707ac19c80c563da2e2134766764895f0670c572baaa178b453c36f2f0b \
+                 size    113303200
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -143,11 +143,11 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  106ae8c2da187bebc357a4a4674f192acb3af87a \
-                 sha256  3d890c5de3b76928e65f634777fff14b0f141f176ade73ccd8bd52e113347596 \
-                 size    114333605
+    checksums    rmd160  920c2f7520504e3bf151e53fbec014e72846daab \
+                 sha256  98d0586b977e581ed84569d66477817b324f309ecf6b70fbe8bead7d5827d0ae \
+                 size    113292700
 
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}-openj9-${openj9_version}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
 
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u212.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?