### PR TITLE
openjdk11: update to 11.0.3

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -36,29 +36,29 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.2
-    revision     1
+    version      11.0.3
+    revision     0
 
-    set build    9
+    set build    7
     set major    11
 }
 
 subport openjdk11-openj9 {
-    version      11.0.2
-    revision     1
+    version      11.0.3
+    revision     0
 
-    set build    9
+    set build    7
     set major    11
-    set openj9_version 0.12.1
+    set openj9_version 0.14.0
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.2
+    version      11.0.3
     revision     0
 
-    set build    9
+    set build    7
     set major    11
-    set openj9_version 0.12.1
+    set openj9_version 0.14.0
 }
 
 subport openjdk12 {
@@ -181,21 +181,21 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  6a45b422bff145fd38eef1e3982b5c0d5352d986 \
-                 sha256  fffd4ed283e5cd443760a8ec8af215c8ca4d33ec5050c24c1277ba64b5b5e81a \
-                 size    189838454
+    checksums    rmd160  609fb1032c738e1a3d819ca925741dda1632664d \
+                 sha256  5ca2a24f1827bd7c110db99854693bf418f51ee3093c31332db5cd605278faad \
+                 size    189888613
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk11-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  60049469d62bd69540fe5c8902ac9de0ea889317 \
-                 sha256  759c857b6fef2c44baadaa4245182e15c9ad1834cb0361358b13ac1f8fcb2692 \
-                 size    194722988
+    checksums    rmd160  a36734d89e5be4a5a3b80232fe086e786de383c7 \
+                 sha256  01045a99ff23bda354f82c0fd3fa6e8222e4a5acce7494e82495f47b30bc5e18 \
+                 size    194950697
 
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}_openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}_openj9-${openj9_version}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM
     long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \
@@ -207,12 +207,12 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  eb03ec6d873a35ef673621c6a05b1b800ed030aa \
-                 sha256  1e663b03258a3d30c0b77d745a4e8d30148f159ac15fc791d67bb35b22437d2a \
-                 size    194704380
+    checksums    rmd160  da40022d1f29edf6c4f5c5d6995cc151389e4398 \
+                 sha256  bf0c3db06381056b87511a4e9199b7245ea432dbf8b1d7cc4a4ad5c94e67bcc0 \
+                 size    194939687
 
-    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}-openj9-${openj9_version}
-    worksrcdir   jdk-${version}+${build}_openj9-${openj9_version}
+    distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
+    worksrcdir   jdk-${version}+${build}
 
     description  Open Java Development Kit ${major} (AdoptOpenJDK) with Eclipse OpenJ9 VM for large heap sizes
     long_description AdoptOpenJDK provides prebuilt OpenJDK binaries from a fully \


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.3.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?