### PR TITLE
fldigi: fix build error on macOS < 10.9

### DIFF
--- a/science/fldigi/Portfile
+++ b/science/fldigi/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                fldigi
 version             4.1.02
+revision            1
 # same sources but with different version
 set version_flarq   4.3.7
 categories          science
@@ -35,7 +36,8 @@ depends_lib-append \
 
 # remove when upstream accept it
 patchfiles-append \
-    patch-info.plist.diff
+    patch-info.plist.diff \
+    patch-FreqControl.cxx.diff
 
 configure.args-append \
     --without-pulseaudio
@@ -74,3 +76,6 @@ default_variants-append +bundle
 livecheck.type      regex
 livecheck.url       ${master_sites}
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+
+test.run            yes
+test.cmd            ./src/fldigi --version

--- a/science/fldigi/files/patch-FreqControl.cxx.diff
+++ b/science/fldigi/files/patch-FreqControl.cxx.diff
@@ -1,0 +1,31 @@
+--- src/rigcontrol/FreqControl.cxx
++++ src/rigcontrol/FreqControl.cxx
+@@ -131,7 +131,7 @@ cFreqControl::cFreqControl(int x, int y, int w, int h, const char *lbl):
+ 	color(OFFCOLOR);
+ 
+ 	minVal = 0;
+-	double fmaxval = (pow(10, nD) - 1) * precision;
++	double fmaxval = (pow(10.0, nD) - 1) * precision;
+ 	long int UMAX = maximum();
+ 	if (fmaxval > UMAX) fmaxval = UMAX;
+ 	maxVal = fmaxval;
+@@ -341,7 +341,7 @@ void cFreqControl::value(long lv)
+ 
+ long int cFreqControl::maximum(void)
+ {
+-	return (long int)(pow(2, 31) - 1);
++	return (long int)(pow(2.0, 31) - 1);
+ }
+ 
+ 
+@@ -618,8 +618,8 @@ void cFreqControl::set_ndigits(int nbr)
+ 	int xpos;
+ 
+ 	minVal = 0;
+-	double fmaxval = (pow(10, nD) - 1) * precision;
+-	long int UMAX = (long int)(pow(2, 31) - 1);
++	double fmaxval = (pow(10.0, nD) - 1) * precision;
++	long int UMAX = (long int)(pow(2.0, 31) - 1);
+ 	if (fmaxval > UMAX) fmaxval = UMAX;
+ 	maxVal = fmaxval;
+ 	fmaxval /= 1000.0;


### PR DESCRIPTION
#### Description

fix the build of fldigi on macOS < 10.9
libs do not allow for pos(int,int)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->