### PR TITLE
liquid-dsp: fix license

### DIFF
--- a/science/CubicSDR/Portfile
+++ b/science/CubicSDR/Portfile
@@ -23,7 +23,7 @@ version             20190417-[string range ${github.version} 0 7]
 checksums           rmd160 9e54b818c5777fefce428995e99f8ee60a7249f7 \
                     sha256 a13e9a5b0b0f09dfa26395a5f4d63662999bdfea85e99f638cce05c7aada1a52 \
                     size   36027266
-revision            0
+revision            1
 
 wxWidgets.use       wxWidgets-3.2
 

--- a/science/liquid-dsp/Portfile
+++ b/science/liquid-dsp/Portfile
@@ -17,7 +17,7 @@ long_description    ${description} Its purpose is to provide a set of extensible
 
 categories          science comms
 homepage            http://www.liquidsdr.org/
-license             GPL-3
+license             MIT
 platforms           darwin macosx
 
 depends_build-append \


### PR DESCRIPTION
#### Description

- liquid-dsp has MIT as license
- bump revision of CubicSDR to build the package after liquid-dsp license change (verified with `port_binary_distributable.tcl`)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->