### PR TITLE
ripgrep: update to 11.0.1

### DIFF
--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        BurntSushi ripgrep 0.10.0
+github.setup        BurntSushi ripgrep 11.0.1
 categories          textproc
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -17,87 +17,83 @@ long_description    ripgrep is a command line search tool that combines the \
                     raw speed of GNU grep.
 
 cargo.crates \
-    aho-corasick                 0.6.8  68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a \
-    arrayvec                     0.4.7  a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef \
-    atty                         0.2.11  9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
-    base64                       0.9.2  85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9 \
-    bitflags                     1.0.4  228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-    bytecount                    0.3.2  f861d9ce359f56dbcb6e0c2a1cb84e52ad732cadb57b806adeb3c7668caccbd8 \
-    byteorder                    1.2.6  90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781 \
-    cc                           1.0.24  70f2a88c2e69ceee91c209d8ef25b81fc1a65f42c7f14dfd59d1fed189e514d1 \
-    cfg-if                       0.1.5  0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3 \
-    clap                         2.32.0  b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
-    cloudabi                     0.0.3  ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-    crossbeam-channel            0.2.4  6c0a94250b0278d7fc5a894c3d276b11ea164edc8bf8feb10ca1ea517b44a649 \
-    crossbeam-epoch              0.5.2  30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9 \
-    crossbeam-utils              0.5.0  677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015 \
-    encoding_rs                  0.8.6  2a91912d6f37c6a8fef8a2316a862542d036f13c923ad518b5aca7bcaac7544c \
-    encoding_rs_io               0.1.2  f222ff554d6e172f3569a2d7d0fd8061d54215984ef67b24ce031c1fcbf2c9b3 \
-    fnv                          1.0.6  2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
-    fuchsia-zircon               0.3.3  2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
-    fuchsia-zircon-sys           0.3.3  3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-    glob                         0.2.11  8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb \
-    itoa                         0.4.2  5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606 \
-    lazy_static                  1.1.0  ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7 \
-    libc                         0.2.43  76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d \
-    lock_api                     0.1.3  949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54 \
-    log                          0.4.5  d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f \
-    memchr                       2.0.2  a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d \
-    memmap                       0.6.2  e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff \
-    memoffset                    0.2.1  0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3 \
-    nodrop                       0.1.12  9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2 \
-    num_cpus                     1.8.0  c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30 \
-    owning_ref                   0.3.3  cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37 \
-    parking_lot                  0.6.4  f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5 \
-    parking_lot_core             0.3.0  06a2b6aae052309c2fd2161ef58f5067bc17bb758377a0de9d4b279d603fdd8a \
-    pcre2                        0.1.0  0c16ec0e30c17f938a2da8ff970ad9a4100166d0538898dcc035b55c393cab54 \
-    pcre2-sys                    0.1.1  a9027f9474e4e13d3b965538aafcaebe48c803488ad76b3c97ef061a8324695f \
-    pkg-config                   0.3.14  676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c \
-    proc-macro2                  0.4.18  afa4d377067cc02eb5e0b491d3f7cfbe145ad4da778535bfb13c444413dd35b9 \
-    quote                        0.6.8  dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5 \
-    rand                         0.4.3  8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd \
-    rand                         0.5.5  e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c \
-    rand_core                    0.2.1  edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2 \
-    redox_syscall                0.1.40  c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1 \
-    redox_termios                0.1.1  7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
-    regex                        1.0.5  2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341 \
-    regex-syntax                 0.6.2  747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d \
-    remove_dir_all               0.5.1  3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
-    ryu                          0.2.6  7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7 \
-    safemem                      0.2.0  e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f \
-    same-file                    1.0.3  10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c \
-    scopeguard                   0.3.3  94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
-    serde                        1.0.77  c6e67977d7523ce4d9284ed58918af99392de8edb6192c44afefcf634654ab7f \
-    serde_derive                 1.0.77  5569c52faae3e21b9abae2cc5cfbb56ed008bfcac480ad62bc241b828f0b0aee \
-    serde_json                   1.0.27  59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c \
-    simd                         0.2.2  ed3686dd9418ebcc3a26a0c0ae56deab0681e53fe899af91f5bbcee667ebffb1 \
-    smallvec                     0.6.5  153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d \
-    stable_deref_trait           1.1.1  dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8 \
-    strsim                       0.7.0  bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550 \
-    syn                          0.15.1  85fb2f7f9b7a4c8df2c913a852de570efdb40f0d2edd39c8245ad573f5c7fbcc \
-    tempdir                      0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
-    termcolor                    1.0.3  ff3bac0e465b59f194e7037ed404b0326e56ff234d767edc4c5cc9cd49e7a2c7 \
-    termion                      1.5.1  689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
-    textwrap                     0.10.0  307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
-    thread_local                 0.3.6  c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
-    ucd-util                     0.1.1  fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d \
-    unicode-width                0.1.5  882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
-    unicode-xid                  0.1.0  fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
-    unreachable                  1.0.0  382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56 \
-    utf8-ranges                  1.0.1  fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4 \
-    version_check                0.1.4  7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051 \
-    void                         1.0.2  6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d \
-    walkdir                      2.2.5  af464bc7be7b785c7ac72e266a6b67c4c9070155606f51655a650a6686204e35 \
-    winapi                       0.3.5  773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd \
-    winapi-i686-pc-windows-gnu   0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                  0.1.1  afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab \
-    winapi-x86_64-pc-windows-gnu 0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    wincolor                     1.0.1  561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba
+    aho-corasick                 0.7.3 e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c \
+    atty                         0.2.11 9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652 \
+    autocfg                      0.1.2 a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799 \
+    base64                       0.10.1 0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
+    bitflags                     1.0.4 228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
+    bstr                         0.1.2 6c8203ca06c502958719dae5f653a79e0cc6ba808ed02beffbf27d09610f2143 \
+    bytecount                    0.5.1 be0fdd54b507df8f22012890aadd099979befdba27713c767993f8380112ca7c \
+    byteorder                    1.3.1 a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb \
+    cc                           1.0.35 5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83 \
+    cfg-if                       0.1.7 11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4 \
+    clap                         2.33.0 5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
+    cloudabi                     0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
+    crossbeam-channel            0.3.8 0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b \
+    crossbeam-utils              0.6.5 f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c \
+    encoding_rs                  0.8.17 4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed \
+    encoding_rs_io               0.1.6 9619ee7a2bf4e777e020b95c1439abaf008f8ea8041b78a0552c4f1bcf4df32c \
+    fnv                          1.0.6 2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
+    fuchsia-cprng                0.1.1 a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    glob                         0.3.0 9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+    itoa                         0.4.3 1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b \
+    lazy_static                  1.3.0 bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14 \
+    libc                         0.2.51 bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917 \
+    log                          0.4.6 c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
+    memchr                       2.2.0 2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39 \
+    memmap                       0.7.0 6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b \
+    num_cpus                     1.10.0 1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba \
+    packed_simd                  0.3.3 a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220 \
+    pcre2                        0.2.0 a08c8195dd1d8a2a1b5e2af94bf0c4c3c195c2359930442a016bf123196f7155 \
+    pcre2-sys                    0.2.0 1e0092a7eae1c569cf7dbec61eef956516df93eb4afda8f600ccb16980aca849 \
+    pkg-config                   0.3.14 676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c \
+    proc-macro2                  0.4.27 4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915 \
+    quote                        0.6.12 faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db \
+    rand                         0.6.5 6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+    rand_chacha                  0.1.1 556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+    rand_core                    0.3.1 7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                    0.4.0 d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0 \
+    rand_hc                      0.1.0 7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+    rand_isaac                   0.1.1 ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
+    rand_jitter                  0.1.3 7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832 \
+    rand_os                      0.1.3 7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
+    rand_pcg                     0.1.2 abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
+    rand_xorshift                0.1.1 cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
+    rdrand                       0.4.0 678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                0.1.54 12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252 \
+    redox_termios                0.1.1 7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76 \
+    regex                        1.1.6 8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58 \
+    regex-automata               0.1.6 a25a7daa2eea48550e9946133d6cc9621020d29cc7069089617234bf8b6a8693 \
+    regex-syntax                 0.6.6 dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96 \
+    remove_dir_all               0.5.1 3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
+    ryu                          0.2.7 eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7 \
+    same-file                    1.0.4 8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267 \
+    serde                        1.0.90 aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4 \
+    serde_derive                 1.0.90 58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79 \
+    serde_json                   1.0.39 5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d \
+    smallvec                     0.6.9 c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be \
+    strsim                       0.8.0 8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+    syn                          0.15.31 d2b4cfac95805274c6afdb12d8f770fa2d27c045953e7b630a81801953699a9a \
+    tempfile                     3.0.7 b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a \
+    termcolor                    1.0.4 4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f \
+    termion                      1.5.1 689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096 \
+    textwrap                     0.11.0 d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+    thread_local                 0.3.6 c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b \
+    ucd-util                     0.1.3 535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86 \
+    unicode-width                0.1.5 882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
+    unicode-xid                  0.1.0 fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
+    utf8-ranges                  1.0.2 796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737 \
+    walkdir                      2.2.7 9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1 \
+    winapi                       0.3.7 f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770 \
+    winapi-i686-pc-windows-gnu   0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                  0.1.2 7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9 \
+    winapi-x86_64-pc-windows-gnu 0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    wincolor                     1.0.1 561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  516f501789426944c5629991094afe5e560041bf \
-                    sha256  41c28b6ca616f6842a2c632b565df1523a55f74db245663da2ad92258b773413 \
-                    size    428374
+                    rmd160  967d9aca3e79566bb429b809c526a118b95bc476 \
+                    sha256  9a94ebc7226d104a9fb88816383c3dc58baed688d0e23349033c9211169a72bd \
+                    size    460260 \
 
 depends_build-append \
                     port:asciidoc \


### PR DESCRIPTION
#### Description
There may be a ripgrep 11.0.2 in the next few days so it might be worth waiting until Monday to merge this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
