### PR TITLE
pgcli: update to 2.1.0 and fix dependencies

### DIFF
--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        dbcli pgcli 2.0.2 v
+github.setup        dbcli pgcli 2.1.0 v
 revision            0
 
 categories          databases python
@@ -17,9 +17,9 @@ long_description    ${description}
 
 homepage            https://pgcli.com
 
-checksums           rmd160  1d508c4b6232928b96e6f2961b76fc2d7d332e10 \
-                    sha256  e3264edfd37fce23cb8b007888e01b0eb2fe537d6938ce660e82fdc109d764b5 \
-                    size    432372
+checksums           rmd160  5766d6c41d8dde41e4a7ef7e787d0dce446838ec \
+                    sha256  1ba3b23267e0f9cc361573f61d661792302d2d012ac17c597efa52124075716b \
+                    size    433647
 
 variant python27 conflicts python34 python35 python36 python37 description "Use Python 2.7" {}
 variant python34 conflicts python27 python35 python36 python37 description "Use Python 3.4" {}
@@ -46,6 +46,10 @@ if {[variant_isset python27] || [variant_isset python34]} {
     checksums       rmd160  d7631dd973be421e664db9b6089106297ebce6c6 \
                     sha256  2c30dd068afdc8a0b15460d49b27962c55642154bb4cb4279e86b36d607c9590 \
                     size    430226
+
+    patchfiles          setup-1.11.0.py.diff
+} else {
+    patchfiles          setup.py.diff
 }
 
 depends_lib-append  port:py${python.version}-cli-helpers \

--- a/databases/pgcli/files/setup-1.11.0.py.diff
+++ b/databases/pgcli/files/setup-1.11.0.py.diff
@@ -1,0 +1,11 @@
+--- setup.py.orig	2019-04-19 22:22:43.000000000 +0200
++++ setup.py	2019-04-19 22:22:55.000000000 +0200
+@@ -16,7 +16,7 @@
+     'click >= 4.1',
+     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
+     'prompt_toolkit>=1.0.10,<1.1.0',
+-    'psycopg2 >= 2.7.4,<2.8',
++    'psycopg2 >= 2.7.4',
+     'sqlparse >=0.2.2,<0.3.0',
+     'configobj >= 5.0.6',
+     'humanize >= 0.5.1',

--- a/databases/pgcli/files/setup.py.diff
+++ b/databases/pgcli/files/setup.py.diff
@@ -1,0 +1,11 @@
+--- setup.py.orig	2019-04-19 21:43:16.000000000 +0200
++++ setup.py	2019-04-19 21:43:31.000000000 +0200
+@@ -16,7 +16,7 @@
+     'click >= 4.1',
+     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
+     'prompt_toolkit>=2.0.6,<2.1.0',
+-    'psycopg2 >= 2.7.4,<2.8',
++    'psycopg2 >= 2.7.4',
+     'sqlparse >=0.2.2,<0.3.0',
+     'configobj >= 5.0.6',
+     'humanize >= 0.5.1',

--- a/python/py-cli-helpers/Portfile
+++ b/python/py-cli-helpers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cli-helpers
-version             1.0.2
+version             1.2.0
 license             BSD
 platforms           darwin
 supported_archs     noarch
@@ -20,9 +20,9 @@ homepage            https://pypi.python.org/pypi/${python.rootname}/
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            cli_helpers-${version}
 
-checksums           rmd160  4e1f6bb54c161a0a4eb7dc9e27eb574470e2749c \
-                    sha256  f77837c5fbcbea39e0cb782506515459a0da75465489bae35e46da7f51c5b9fc \
-                    size    23557
+checksums           rmd160  1c466f1914accc5a5aeb308cac521090d56651b7 \
+                    sha256  d211192b4d5a61de0020c516213ba67bbf1662ccd8c0624e6696dedb1a9d3e5d \
+                    size    30843
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

Upstream pgcli does not support psycopg2 version above 2.8.0 since https://github.com/dbcli/pgcli/pull/859 because it requires build tools and libraries to compile instead of shipping compilled stuff in wheel.

Because macports already compile and install psycopg2 in version 2.8.2 I think its best choice is to simply apply patch to pgcli's dependencies.

Also updated py-cli-helpers as its required in newest version of pgcli.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
