### PR TITLE
supertuxkart: update to 1.0

### DIFF
--- a/games/supertuxkart/Portfile
+++ b/games/supertuxkart/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                supertuxkart
-version             0.9.3
+version             1.0
 categories          games
 license             GPL-3+
 platforms           darwin
@@ -19,9 +19,9 @@ use_xz              yes
 
 homepage            http://supertuxkart.sourceforge.net/
 
-checksums           md5     8de5455b8fdbb92679e302b76c9041cf \
-                    rmd160  4d32b61c99d6043c8007badd21bb79d38216cc4b \
-                    sha256  d8014e7106ba84f98b5ec5f146249dcffc284fc4083f8f237ff420b9e2219cb0
+checksums           rmd160  575b0cba4681795eee2ecdd439f6abec90c044cb \
+                    sha256  6d88f43f0de5202766ba305c87e3d9843103e81d31b7193059286098d2a5d980 \
+                    size    597012504
 
 master_sites        sourceforge:project/${name}/SuperTuxKart/${version}
 
@@ -45,25 +45,23 @@ if { ${os.platform} eq "darwin" && ${os.major} < 13 } {
 }
 
 depends_build-append \
-                    port:pkgconfig
+    port:pkgconfig
 
-depends_lib-append  port:freetype \
-                    port:curl \
-                    port:zlib \
-                    port:libogg \
-                    port:libvorbis
+depends_lib-append \
+    port:curl \
+    port:freetype \
+    port:fribidi \
+    port:glew \
+    port:libogg \
+    port:libvorbis \
+    port:nettle \
+    port:openal-soft \
+    port:zlib
 
 # clang: error: unknown argument: '-pipe -Os -DNDEBUG'
 patchfiles-append   patch-libpng-genout-flags.diff
 
-# force cmake to use MacPorts libogg
-patchfiles-append   patch-cmakelists-ogg.diff
-                    
 configure.args-append -DFREETYPE_INCLUDE_DIRS=${prefix}/include/freetype2
-                    
-# /opt/local/include/fribidi/fribidi-common.h:61:12: fatal error: 'glib.h' file not found
-# multiple attempts enable fribidi ineffective
-configure.args-append -DUSE_FRIBIDI:BOOL=OFF
 
 # supertuxkart fails to build with MacPorts angelscript
 # defaults to using bundled version


### PR DESCRIPTION
#### Description

- bump version to 1.0
- finally it supports network multiplayer ;-)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->