### PR TITLE
tcl: add dtrace variant

### DIFF
--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -71,6 +71,10 @@ variant memdebug description {enable memory debugging support} {
     configure.args-append --enable-symbols=mem
 }
 
+variant dtrace description {Enable DTrace static probes} {
+    configure.args-append --enable-dtrace
+}
+
 platform darwin {
     configure.args-append tcl_cv_type_64bit="long long"
 }


### PR DESCRIPTION
Based on @DanielO's five-year-old patch from https://trac.macports.org/ticket/42931

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
I have only tried compiling dtrace support though; I have not tried using it.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
