### PR TITLE
[WIP] Xymon ports: update to 4.3.28

### DIFF
--- a/net/xymon-client/Portfile
+++ b/net/xymon-client/Portfile
@@ -3,10 +3,15 @@
 PortSystem              1.0
 
 name                    xymon-client
+
+# Server and client use same distfile
 set shortname           xymon
+
+# Server already includes client
 conflicts               xymon-server
-version                 4.3.26
-revision                2
+
+version                 4.3.28
+revision                0
 categories              net
 platforms               darwin
 license                 {GPL-2 OpenSSLException}
@@ -20,13 +25,14 @@ long_description        Xymon is a system for monitoring of hosts and networks, 
                         availability reports and performance graphs. \
                         Xymon was previously known as \"Hobbit\".
 
-homepage                http://www.xymon.com/
+homepage                https://www.xymon.com/
 master_sites            sourceforge:project/xymon/Xymon/${version}
 distname                ${shortname}-${version}
 dist_subdir             ${shortname}
 
-checksums               sha256  cbd0586c77378c92d9866497c8e5ddc64ec9973e4078e44860f572258f8521c5 \
-                        rmd160  c43ac804be298dca61d0f310bd599caea0b804de
+checksums               sha256  68cb33eb48d1bb212a1bbafd9fdea8c682ae1b69077cd5fb03676e0af39cbf80 \
+                        rmd160  7d2426a6639c52b0a1f6e3d2e5c4e4607090809d \
+                        size    3966200
 
 depends_lib             port:rrdtool \
                         port:fping \
@@ -133,6 +139,6 @@ You can start,stop and restart the xymon client with:
 use_parallel_build  no
 
 livecheck.type      regex
-livecheck.url       http://sourceforge.net/projects/${shortname}/files/
+livecheck.url       https://sourceforge.net/projects/${shortname}/files/
 livecheck.regex     ${shortname}-(\[0-9.\]+)\\.tar.gz
 

--- a/net/xymon-server/Portfile
+++ b/net/xymon-server/Portfile
@@ -3,11 +3,16 @@
 PortSystem              1.0
 
 name                    xymon-server
+
+# Server and client use same distfile
 set shortname           xymon
+
+# Server already includes client
 conflicts               xymon-client
+
 epoch                   1
-version                 4.3.26
-revision                2
+version                 4.3.28
+revision                0
 categories              net
 platforms               darwin
 license                 {GPL-2 OpenSSLException}
@@ -21,13 +26,14 @@ long_description        Xymon is a system for monitoring of hosts and networks, 
                         availability reports and performance graphs. \
                         Xymon was previously known as \"Hobbit\".
 
-homepage                http://www.xymon.com/
+homepage                https://www.xymon.com/
 master_sites            sourceforge:project/xymon/Xymon/${version}
 distname                ${shortname}-${version}
 dist_subdir             ${shortname}
 
-checksums               sha256  cbd0586c77378c92d9866497c8e5ddc64ec9973e4078e44860f572258f8521c5 \
-                        rmd160  c43ac804be298dca61d0f310bd599caea0b804de
+checksums               sha256  68cb33eb48d1bb212a1bbafd9fdea8c682ae1b69077cd5fb03676e0af39cbf80 \
+                        rmd160  7d2426a6639c52b0a1f6e3d2e5c4e4607090809d \
+                        size    3966200
 
 depends_lib             port:rrdtool \
                         port:fping \
@@ -170,7 +176,7 @@ Full install instructions here: http://trac.macports.org/wiki/howto/SetupXymonSe
 use_parallel_build  no
 
 livecheck.type      regex
-livecheck.url       http://sourceforge.net/projects/${shortname}/files/
+livecheck.url       https://sourceforge.net/projects/${shortname}/files/
 livecheck.regex     ${shortname}-(\[0-9.\]+)\\.tar.gz
 
 variant snmp description {add integrated SNMP support} {


### PR DESCRIPTION
Use HTTPS homepage and livecheck URLs

Add comments clarifying usage of `shortname`, `conflicts`

Supersedes previous maintainer's attempt to update to 4.3.27: https://trac.macports.org/ticket/50963 and https://trac.macports.org/ticket/50964

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
`xymon-server` fails to build, see comment below
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
