### PR TITLE
rrdtool: switch to using Perl 5.28

### DIFF
--- a/net/rrdtool/Portfile
+++ b/net/rrdtool/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                rrdtool
 version             1.7.0
-revision            2
+revision            3
 categories          net
 license             GPL-2+
 platforms           darwin
@@ -21,7 +21,7 @@ checksums           rmd160  8816c971189a60e190d15a5b3827697c299ffce3 \
                     sha256  f97d348935b91780f2cd80399719e20c0b91f0a23537c0a85f9ff306d4c5526b \
                     size    2849994
 
-perl5.branches      5.26
+perl5.branches      5.28
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/58361

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 
Perl 5.28.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
Just `rrdtool` so far.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
