### PR TITLE
ossp-uuid: use Perl 5.28 by default

### DIFF
--- a/devel/ossp-uuid/Portfile
+++ b/devel/ossp-uuid/Portfile
@@ -80,7 +80,7 @@ post-destroot {
 
 perl5.conflict_variants yes
 perl5.branches 5.26 5.28
-perl5.default_branch  5.26
+perl5.default_branch  5.28
 perl5.create_variants ${perl5.branches}
 
 if {[variant_isset perl5_26] || [variant_isset perl5_28]} {


### PR DESCRIPTION
See: https://trac.macports.org/ticket/58361

#### Description

Q: Should the revision be incremented?

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
