### PR TITLE
nodejs6: fix build on older systems

### DIFF
--- a/devel/nodejs6/Portfile
+++ b/devel/nodejs6/Portfile
@@ -49,6 +49,11 @@ configure.python ${prefix}/bin/python2.7
 patchfiles              patch-common.gypi.diff \
                         patch-tools-gyp-pylib-gyp-generator-make.py.diff
 
+if { ${configure.cxx_stdlib} eq "libc++" } {
+    # libc++ headers don't put this in <tr1/>
+    patchfiles-append   patch-nodejs6-old-tr1-calls.diff
+}
+
 post-patch {
     foreach f [concat ${worksrcpath}/configure \
                    ${worksrcpath}/tools/gyp/gyp \
@@ -63,6 +68,12 @@ post-patch {
     }
     reinplace "s|python|${configure.python}|" ${worksrcpath}/deps/v8/build/toolchain.gypi
     reinplace "s|/usr/bin/env node|${prefix}/bin/node|" ${worksrcpath}/tools/doc/node_modules/marked/bin/marked
+}
+
+# We'll use the system libuv instead, as it is fixed for older systems
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
 
 configure.args-append   --without-npm
@@ -203,13 +214,6 @@ destroot {
         LICENSE \
         README.md \
         ${docdir}
-}
-
-if {${os.major} < 11} {
-    pre-fetch {
-        ui_error "${name} ${version} requires Mac OS X 10.7 or greater."
-        return -code error "incompatible Mac OS X version"
-    }
 }
 
 livecheck.url       ${homepage}dist/

--- a/devel/nodejs6/files/patch-nodejs6-old-tr1-calls.diff
+++ b/devel/nodejs6/files/patch-nodejs6-old-tr1-calls.diff
@@ -1,0 +1,19 @@
+--- src/util.h.orig	2019-04-21 18:08:50.000000000 -0700
++++ src/util.h	2019-04-21 18:10:53.000000000 -0700
+@@ -12,16 +12,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-// OSX 10.9 defaults to libc++ which provides a C++11 <type_traits> header.
+-#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1090
+-#define USE_TR1_TYPE_TRAITS
+-#endif
+-
+-#ifdef USE_TR1_TYPE_TRAITS
+-#include <tr1/type_traits>  // NOLINT(build/c++tr1)
+-#else
+ #include <type_traits>  // std::remove_reference
+-#endif
+ 
+ namespace node {
+ 


### PR DESCRIPTION
allows build on < 10.7

The logic in this header test for which systems use <tr1/type_traits> is faulty. <tr1/type_traits> exists on systems that use the gcc headers, but not on systemes that use the libc++ headers. With the libc++ headers, you just use <type_traits> directly.

Our systems can be configured to libc++ even < 10.9, so rather than try to sort out a very complicated header test that is no longer relevant, just change the include based on whether we're building against libc++.

Adding the legacysupport PG fixes the build on < 10.7.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 3.2.6, 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->