### PR TITLE
openjdk12: update to 12.0.1

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -62,10 +62,10 @@ subport openjdk11-openj9-large-heap {
 }
 
 subport openjdk12 {
-    version      12
+    version      12.0.1
     revision     0
 
-    set build    33
+    set build    12
     set major    12
 }
 
@@ -227,9 +227,9 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
 
-    checksums    rmd160  d05c73f6e7f390f42d61d69b5a4065aa279643aa \
-                 sha256  985036459d4ef0867a3fe83b0bf87877d8e66a121c7b9c145bb97bd921aaf3f1 \
-                 size    198099074
+    checksums    rmd160  b17d9deca70b2f6f6fa614314937c9fa4f5438e3 \
+                 sha256  dcb2ab681247298eda018df24166ba01674127083fb02892acf087e6181d8c56 \
+                 size    198112975
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk12-openj9"} {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 12.0.1.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?