### PR TITLE
bwping: fix build on mac os x 10.6

### DIFF
--- a/net/bwping/Portfile
+++ b/net/bwping/Portfile
@@ -23,4 +23,6 @@ checksums               md5     24645a3c60e63ad48369c9e90eb11e3d \
                         sha256  79f84a7e7dc787931de578fe5fe53c17daa9cb009f25f0eb198db2504b48e054 \
                         size    103462
 
+patchfiles              patch-gcc-pedantic.diff
+
 configure.args          --mandir=${prefix}/share/man/

--- a/net/bwping/files/patch-gcc-pedantic.diff
+++ b/net/bwping/files/patch-gcc-pedantic.diff
@@ -1,0 +1,29 @@
+--- Makefile.am.orig	2019-04-22 21:58:15.000000000 +0300
++++ Makefile.am	2019-04-22 21:58:30.000000000 +0300
+@@ -3,10 +3,10 @@
+ sbin_PROGRAMS = bwping bwping6
+ 
+ bwping_SOURCES = include/cygwin.h include/features.h src/bwping.c
+-bwping_CFLAGS  = -DBUILD_BWPING -Wall -Wextra -Wpedantic
++bwping_CFLAGS  = -DBUILD_BWPING -Wall -Wextra -pedantic
+ 
+ bwping6_SOURCES = include/cygwin.h include/features.h src/bwping.c
+-bwping6_CFLAGS  = -DBUILD_BWPING6 -Wall -Wextra -Wpedantic
++bwping6_CFLAGS  = -DBUILD_BWPING6 -Wall -Wextra -pedantic
+ 
+ man_MANS   = man/bwping.8 man/bwping6.8
+ EXTRA_DIST = man/bwping.8 man/bwping6.8
+--- Makefile.in.orig	2019-04-22 21:58:35.000000000 +0300
++++ Makefile.in	2019-04-22 21:58:51.000000000 +0300
+@@ -488,9 +488,9 @@
+ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = subdir-objects
+ bwping_SOURCES = include/cygwin.h include/features.h src/bwping.c
+-bwping_CFLAGS = -DBUILD_BWPING -Wall -Wextra -Wpedantic
++bwping_CFLAGS = -DBUILD_BWPING -Wall -Wextra -pedantic
+ bwping6_SOURCES = include/cygwin.h include/features.h src/bwping.c
+-bwping6_CFLAGS = -DBUILD_BWPING6 -Wall -Wextra -Wpedantic
++bwping6_CFLAGS = -DBUILD_BWPING6 -Wall -Wextra -pedantic
+ man_MANS = man/bwping.8 man/bwping6.8
+ EXTRA_DIST = man/bwping.8 man/bwping6.8
+ dist_check_SCRIPTS = tests/bwping tests/bwping6


### PR DESCRIPTION
#### Description

Older GCC versions on older Mac OS X doesn't support -Wpedantic yet, so replace it with -pedantic.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
