### PR TITLE
dvisvgm: keep using GitHub releases distfile

### DIFF
--- a/graphics/dvisvgm/Portfile
+++ b/graphics/dvisvgm/Portfile
@@ -25,7 +25,7 @@ if {${subport} eq ${name}} {
                  size   3037242
     revision     1
 
-    # github.tarball_from releases
+    github.tarball_from releases
     conflicts    ${name}-devel
 
     long_description ${description}: \


### PR DESCRIPTION
`github.tarball_from releases` was commented out in bf528304dd, causing a checksum mismatch error.

Fixes: https://trac.macports.org/ticket/58371

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
~~Xcode 8.x~~

I have successfully tried `port checksum dvisvgm` and `port checksum dvisvgm-devel` (forcing fetch from github.com).

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
