### PR TITLE
fpc: Update to 3.0.4 and improvements

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -3,94 +3,171 @@
 PortSystem          1.0
 
 name                fpc
-version             2.6.4
-revision            1
+version             3.0.4
 categories          lang
 platforms           darwin
 license             GPL-2 LGPL-2
 maintainers         nomaintainer
-description         free pascal
-long_description    Open source compiler for Pascal and Object Pascal
+description         Free Pascal, an open source Pascal and Object Pascal compiler.
+long_description    Free Pascal is a 32, 64 and 16 bit professional Pascal compiler. \
+                    It can target many processor architectures: Intel x86 (including 8086), \
+                    AMD64/x86-64, PowerPC, PowerPC64, SPARC, ARM, AArch64, MIPS and the JVM. \
+                    Supported operating systems include Linux, FreeBSD, Mac OS X/iOS/iPhoneSimulator/Darwin, \
+                    Win32, Win64, WinCE and Android.
 homepage            http://www.freepascal.org
 master_sites        sourceforge:freepascal
 
 set src             ${name}build-${version}.tar.gz
-set pp              universal-macosx-10.5-ppcuniversal.tar.bz2
+# the 3.0.0 bootstrap compiler
+set pp              x86_64-macosx-10.7-ppcx64.tar.bz2
 distfiles           ${src} ${pp}
 checksums           ${src} \
-                    rmd160  339b71d3c9983a720eed7c6bda1cfd330d89966f \
-                    sha256  8d9c3bcfa469d9b37c05663e2775d179809e4b3443604fac7d21aa64c9a56daa \
+                    rmd160  f9414fe72342cff4317029f3a83a90e8dc710389 \
+                    sha256  f66514e6f2c2e4e1bccccb4d554c24b77682ed61c87811ae5dd210f421855e76 \
+                    size    68908523 \
                     ${pp} \
-                    rmd160  0124c2f4447ba7f96e3db0a27e6bff459c5749f4 \
-                    sha256  e7243e83e6a04de147ebab7530754ec92cd1fbabbc9b6b00a3f90a796312f3e9
+                    rmd160  25fb3c2eb9fa364ee56a5f3c2667151143f39777 \
+                    sha256  a67ef5def356d122a4692e21b209c328f6d46deef4539f4d4506c3dc1eecb4b0 \
+                    size    1095556
+supported_archs     x86_64
+
+# doesn't install shared libraries
+installs_libs       no
 
 extract.only        ${src}
-                    
+
 use_configure       no
 universal_variant   no
 
-post-extract {
-    system -W ${workpath} "bzip2 -dc ${distpath}/${pp} | tar xf -"
-}
+set fpcbasepath     ${prefix}/libexec/${name}
 
-worksrcdir          ${name}build-${version}/fpcsrc
-set fpcbasepath     ${prefix}/lib/${name}
-build.env           PP=${workpath}/ppcuniversal \
-                    PREFIX=${destroot}${fpcbasepath}
-build.target        all
+subport "chmcmd-${name}" {
+    description     The FPC Pascal htmlhelp (CHM) compiler
+    long_description \
+                    chmcmd is an cross-platform utility to generate compressed HTML (.chm) \
+                    documentation, written in Free Pascal
 
-destroot.env        ${build.env}
-
-# Yosemite fix: fpc's build system checkes MACOSX_DEPLOYMENT_TARGET and halts if > 10.9
-platform darwin {
-    if {${os.major} > 13} {
-        macosx_deployment_target    10.9
+    depends_build-append \
+                    port:${name}
+    extract.post_args-append \
+                    ${name}build-${version}/fpcsrc/packages/chm \
+                    ${name}build-${version}/fpcsrc/packages/fcl-xml \
+                    ${name}build-${version}/fpcsrc/packages/fcl-base \
+                    ${name}build-${version}/fpcsrc/packages/fcl-process \
+                    ${name}build-${version}/fpcsrc/packages/fpmkunit \
+                    ${name}build-${version}/fpcsrc/packages/hash \
+                    ${name}build-${version}/fpcsrc/packages/iconvenc \
+                    ${name}build-${version}/fpcsrc/packages/libtar \
+                    ${name}build-${version}/fpcsrc/packages/paszlib \
+                    ${name}build-${version}/fpcsrc/packages/univint \
+                    ${name}build-${version}/fpcsrc/rtl
+    worksrcdir      ${name}build-${version}/fpcsrc/packages/chm
+    use_configure   yes
+    configure.cmd   ${fpcbasepath}/bin/fpcmake
+    configure.pre_args
+    configure.args  -r -v Makefile.fpc.fpcmake
+    configure.post_args
+    build.env       PREFIX=${prefix}
+    build.target
+    build.post_args-append \
+                    V=1 VERBOSE=1
+    destroot {
+        xinstall -m 755 ${build.dir}/chmcmd ${destroot}${prefix}/bin
     }
 }
 
-post-destroot {
-# create a symlink to the architecture dependent executable
+if {${subport} eq "${name}"} {
+    installs_libs       yes
+
+    post-extract {
+        system -W ${workpath} "bzip2 -dc ${distpath}/${pp} | tar xf -"
+    }
+
+
+# Fix filename issues in iso mode. Should be resolved in version 3.2
+    patchfiles          patch-transparent-filename.diff patch-iso-tmp.diff
+
+    post-patch {
+        # adjust the path "codfilepath" for plex from /usr/local to MacPort's prefix.
+        reinplace "s|/usr/local|${prefix}|g" \
+            ${worksrcpath}/utils/tply/pyacc.y \
+            ${worksrcpath}/utils/tply/pyacc.pas \
+            ${worksrcpath}/utils/tply/plex.pas
+    }
+
     switch ${build_arch} {
         "x86_64" {
             set b "ppcx64"
-        } 
-        "i386" {
-            set b "ppc386"
-        }
-        default {
-            set b "ppcppc"
         }
     }
-    ln -s ${fpcbasepath}/lib/${name}/${version}/${b} ${destroot}${fpcbasepath}/bin
-# generate a configuration file
-    xinstall -d ${destroot}${fpcbasepath}/etc
-    system "
-        ${destroot}${fpcbasepath}/bin/fpcmkcfg \
-            -d basepath=${fpcbasepath}/lib/${name}/${version} \
-            -o ${destroot}${fpcbasepath}/etc/fpc.cfg
-    "
-# install man
-    xinstall -d ${destroot}${fpcbasepath}/man
-    foreach d {1 5} {
-        file copy ${workpath}/${name}build-${version}/install/man/man${d} ${destroot}${fpcbasepath}/man
-        foreach f [glob ${destroot}${fpcbasepath}/man/man${d}/*.${d}] {
-            system "/usr/bin/gzip ${f}"
-        }
-    }
-    ln -s ${fpcbasepath}/man/man1/fpc.1.gz ${destroot}${prefix}/share/man/man1
-    ln -s ${fpcbasepath}/man/man5/fpc.cfg.5.gz ${destroot}${prefix}/share/man/man5
-}
 
-notes "
-    The compiler fpc looks for the fpc.cfg file in the following places: \n\
-    - The current directory. \n\
-    - Home directory, looks for .fpc.cfg \n\
-    - The directory specified in the environment variable PPC_CONFIG_PATH, \n\
-      and if it's not set under compilerdir/../etc. \n\
-    - If it is not yet found: in /etc. \n\
-    \n\
-    All the files of fpc are installed in ${fpcbasepath} and \n\
-    the executables are installed in ${fpcbasepath}/bin. \n\
-    The fpc.cfg is installed in ${fpcbasepath}/etc to make fpc find fpc.cfg. \n\
-    To customize, use ~/.fpc.cfg or /etc/fpc.cfg and call ${fpcbasepath}/bin/fpc directly.
-" 
+    worksrcdir          ${name}build-${version}/fpcsrc
+    build.env           PP=${workpath}/${b} \
+                        PREFIX=${destroot}${fpcbasepath}
+    build.target        all
+
+    destroot.env        ${build.env}
+
+    # Yosemite fix: fpc's build system checks MACOSX_DEPLOYMENT_TARGET and halts if > 10.9
+    platform darwin {
+        if {${os.major} > 13} {
+            macosx_deployment_target 10.9
+        }
+    }
+
+    # build the compiler utilities msgdif and msg2inc
+    post-build {
+        system -W ${worksrcpath}/compiler/utils \
+               "../ppcx64 -WM10.9 -Fu../../rtl/units/${build_arch}-darwin msgdif.pp && \
+                ../ppcx64 -WM10.9 -Fu../../rtl/units/${build_arch}-darwin msg2inc.pp"
+    }
+
+    post-destroot {
+        # create a symlink to the architecture dependent executable
+        ln -s ${fpcbasepath}/lib/${name}/${version}/${b} ${destroot}${fpcbasepath}/bin
+        # generate a configuration file
+        xinstall -d ${destroot}${fpcbasepath}/etc
+        system "
+            ${destroot}${fpcbasepath}/bin/fpcmkcfg \
+                -d basepath=${fpcbasepath}/lib/${name}/${version} \
+                -o ${destroot}${fpcbasepath}/etc/fpc.cfg
+        "
+        ln -s ${fpcbasepath}/etc/fpc.cfg ${destroot}${prefix}/etc
+
+        # install man
+        xinstall -d ${destroot}${fpcbasepath}/man
+        foreach d {1 5} {
+            file copy ${workpath}/${name}build-${version}/install/man/man${d} ${destroot}${fpcbasepath}/man
+            foreach f [glob ${destroot}${fpcbasepath}/man/man${d}/*.${d}] {
+                system "/usr/bin/gzip ${f}"
+            }
+        }
+        ln -s ${fpcbasepath}/man/man1/fpc.1.gz ${destroot}${prefix}/share/man/man1
+        ln -s ${fpcbasepath}/man/man5/fpc.cfg.5.gz ${destroot}${prefix}/share/man/man5
+
+        # chmcmd will be installed by the chmcmd-fpc subport
+        file delete -force ${destroot}${fpcbasepath}/bin/chmcmd
+        foreach b [glob -nocomplain ${destroot}${fpcbasepath}/bin/*] {
+            set n [file tail ${b}]
+            ln -s ${fpcbasepath}/bin/${n} ${destroot}${prefix}/bin
+
+        # install the compiler utilities msgdif and msg2inc
+        xinstall -m 755 ${worksrcpath}/compiler/utils/msgdif  ${destroot}${prefix}/bin
+        xinstall -m 755 ${worksrcpath}/compiler/utils/msg2inc ${destroot}${prefix}/bin
+        }
+    }
+
+    notes "
+        The compiler fpc looks for the fpc.cfg file in the following places: \n\
+        - The current directory. \n\
+        - Home directory, looks for .fpc.cfg \n\
+        - The directory specified in the environment variable PPC_CONFIG_PATH, \n\
+          and if it's not set under compilerdir/../etc. \n\
+        - If it is not yet found: in /etc. \n\
+        \n\
+        All the files of fpc are installed in ${fpcbasepath} and \n\
+        the executables are installed in ${fpcbasepath}/bin. \n\
+        The fpc.cfg is installed in ${fpcbasepath}/etc to make fpc find fpc.cfg. \n\
+        To customize, use ~/.fpc.cfg or /etc/fpc.cfg and call ${fpcbasepath}/bin/fpc directly.
+    "
+}

--- a/lang/fpc/files/patch-iso-tmp.diff
+++ b/lang/fpc/files/patch-iso-tmp.diff
@@ -1,0 +1,346 @@
+diff -Naur rtl/inc/iso7185.pp rtl-new/inc/iso7185.pp
+--- rtl/inc/iso7185.pp	2017-02-17 19:04:47.000000000 +0100
++++ rtl-new/inc/iso7185.pp	2017-02-18 10:38:58.000000000 +0100
+@@ -47,13 +47,160 @@
+ 
+   implementation
+ 
++{$IF defined(WINDOWS)}
++    type
++      isoLPWStr = PWideChar;
++      isoWinBool = LongBool;
++      TSysCharSet = set of AnsiChar;
++
++    function GetEnvironmentStringsW: isoLPWStr; stdcall; external 'kernel32' name 'GetEnvironmentStringsW';
++    function FreeEnvironmentStringsW(_para1 : isoLPWStr): isoWinBool; stdcall; external 'kernel32' name 'FreeEnvironmentStringsW';
++
++    function StrLen(p : PWideChar): sizeint; external name 'FPC_PWIDECHAR_LENGTH'; overload;
++
++    {$push}
++    {$checkpointer off}
++
++    function CharInSet(Ch : WideChar; const CSet : TSysCharSet): Boolean;
++    begin
++      CharInSet := (Ch <= #$FF) and (AnsiChar(byte(Ch)) in CSet);
++    end;
++
++    function InternalChangeCase(const S : UnicodeString; const Chars: TSysCharSet; const Adjustment: Longint): UnicodeString;
++      var
++        i : Integer;
++        p : PWideChar;
++        unique : Boolean;
++      begin
++        InternalChangeCase := S;
++        if InternalChangeCase = '' then
++          exit;
++        unique := false;
++        p := PWideChar(InternalChangeCase);
++        for i := 1 to Length(InternalChangeCase) do
++        begin
++          if CharInSet(p^, Chars) then
++          begin
++            if not unique then
++            begin
++              UniqueString(InternalChangeCase);
++              p := @InternalChangeCase[i];
++              unique := true;
++            end;
++            p^ := WideChar(Ord(p^) + Adjustment);
++          end;
++          inc(p);
++        end;
++      end;
++
++    function UpperCase(const s : UnicodeString) : UnicodeString;
++      begin
++        UpperCase := InternalChangeCase(s, ['a'..'z'], -32);
++      end;
++
++    function GetEnvironmentVariable(const EnvVar : UnicodeString) : UnicodeString;
++    var
++      s, upperenv : UnicodeString;
++      i : Longint;
++      hp, p : PWideChar;
++    begin
++      GetEnvironmentVariable := '';
++      p := GetEnvironmentStringsW;
++      hp := p;
++      upperenv := uppercase(envvar);
++      while hp^ <> #0 do
++      begin
++        s := hp;
++        i := pos('=', s);
++        if uppercase(copy(s,1,i-1)) = upperenv then
++        begin
++          GetEnvironmentVariable := copy(s, i+1, length(s)-i);
++          break;
++        end;
++        { next string entry }
++        hp := hp + strlen(hp) + 1;
++      end;
++      FreeEnvironmentStringsW(p);
++    end;
++
++    function getTempDir: String;
++    var
++      astringLength : Integer;
++    begin
++      getTempDir := GetEnvironmentVariable('TMP');
++      if getTempDir = '' then
++        getTempDir := GetEnvironmentVariable('TEMP');
++      astringlength := Length(getTempDir);
++      if (astringlength > 0) and (getTempDir[astringlength] <> DirectorySeparator) then
++        getTempDir := getTempDir + DirectorySeparator;
++    end;
++
++    {$pop}
++
++{$ELSEIF defined(UNIX)}
++
++  function getTempDir: string;
++    var
++      key: string;
++      value: string;
++      i_env, i_key, i_value: integer;
++    begin
++      value := '/tmp/';  (** default for UNIX **)
++      while (envp <> NIL) and assigned(envp^) do
++      begin
++        i_env := 0;
++        i_key := 1;
++        while not (envp^[i_env] in ['=', #0]) do
++        begin
++          key[i_key] := envp^[i_env];
++          inc(i_env);
++          inc(i_key);
++        end;
++        setlength(key, i_key - 1);
++        if (key = 'TEMP') or (key = 'TMP') or (key = 'TMPDIR') then
++        begin
++          inc(i_env);    (** skip '=' **)
++          i_value := 1;
++          while (envp^[i_env] <> #0) do
++          begin
++            value[i_value] := envp^[i_env];
++            inc(i_env);
++            inc(i_value);
++          end;
++          setlength(value, i_value - 1);
++        end;
++        inc(envp);
++      end;
++      i_value:=length(value);
++      if (i_value > 0) and (value[i_value] <> DirectorySeparator) then
++        value := value + DirectorySeparator;
++      getTempDir := value;
++    end;
++
++{$ELSE}  // neither unix nor windows
++
++  function getTempDir: string;
++  begin
++    getTempDir:='';
++  end;
++
++{$ENDIF}
++
+ {$i-}
+     procedure DoAssign(var t : Text);
++{$ifndef FPC_HAS_FEATURE_RANDOM}
++      const
++        NextIndex : Word = 1;
++{$endif FPC_HAS_FEATURE_RANDOM}
+       begin
+-        Assign(t,'fpc_'+HexStr(random(1000000000),8)+'.tmp');
++{$ifdef FPC_HAS_FEATURE_RANDOM}
++        Assign(t,getTempDir+'fpc_'+HexStr(random(1000000000),8)+'.tmp');
++{$else FPC_HAS_FEATURE_RANDOM}
++        Assign(t,getTempDir+'fpc_'+HexStr(NextIndex,4)+'.tmp');
++        Inc(NextIndex);
++{$endif FPC_HAS_FEATURE_RANDOM}
+       end;
+ 
+-
+     Procedure Rewrite(var t : Text);[IOCheck];
+       Begin
+         { create file name? }
+@@ -172,7 +319,9 @@
+ begin
+   { we shouldn't do this because it might confuse user programs, but for now it
+     is good enough to get pretty unique tmp file names }
++{$ifdef FPC_HAS_FEATURE_RANDOM}
+   Randomize;
++{$endif FPC_HAS_FEATURE_RANDOM}
+   { reset opens with read-only }
+   Filemode:=0;
+ end.
+diff -Naur rtl/inc/typefile.inc rtl-new/inc/typefile.inc
+--- rtl/inc/typefile.inc	2017-02-18 10:41:19.000000000 +0100
++++ rtl-new/inc/typefile.inc	2017-02-18 10:48:32.000000000 +0100
+@@ -68,12 +68,151 @@
+   Rewrite(UnTypedFile(f),Size);
+ End;
+ 
++{ this code is duplicated in the iso7185 unit }
++{$IF defined(WINDOWS)}
++    type
++      isoLPWStr = PWideChar;
++      isoWinBool = LongBool;
++      TSysCharSet = set of AnsiChar;
++
++    function GetEnvironmentStringsW: isoLPWStr; stdcall; external 'kernel32' name 'GetEnvironmentStringsW';
++    function FreeEnvironmentStringsW(_para1 : isoLPWStr): isoWinBool; stdcall; external 'kernel32' name 'FreeEnvironmentStringsW';
++
++    function StrLen(p : PWideChar): sizeint; external name 'FPC_PWIDECHAR_LENGTH'; overload;
++
++    {$push}
++    {$checkpointer off}
++
++    function CharInSet(Ch : WideChar; const CSet : TSysCharSet): Boolean;
++    begin
++      CharInSet := (Ch <= #$FF) and (AnsiChar(byte(Ch)) in CSet);
++    end;
++
++    function InternalChangeCase(const S : UnicodeString; const Chars: TSysCharSet; const Adjustment: Longint): UnicodeString;
++      var
++        i : Integer;
++        p : PWideChar;
++        unique : Boolean;
++      begin
++        InternalChangeCase := S;
++        if InternalChangeCase = '' then
++          exit;
++        unique := false;
++        p := PWideChar(InternalChangeCase);
++        for i := 1 to Length(InternalChangeCase) do
++        begin
++          if CharInSet(p^, Chars) then
++          begin
++            if not unique then
++            begin
++              UniqueString(InternalChangeCase);
++              p := @InternalChangeCase[i];
++              unique := true;
++            end;
++            p^ := WideChar(Ord(p^) + Adjustment);
++          end;
++          inc(p);
++        end;
++      end;
++
++    function UpperCase(const s : UnicodeString) : UnicodeString;
++      begin
++        UpperCase := InternalChangeCase(s, ['a'..'z'], -32);
++      end;
++
++    function GetEnvironmentVariable(const EnvVar : UnicodeString) : UnicodeString;
++    var
++      s, upperenv : UnicodeString;
++      i : Longint;
++      hp, p : PWideChar;
++    begin
++      GetEnvironmentVariable := '';
++      p := GetEnvironmentStringsW;
++      hp := p;
++      upperenv := uppercase(envvar);
++      while hp^ <> #0 do
++      begin
++        s := hp;
++        i := pos('=', s);
++        if uppercase(copy(s,1,i-1)) = upperenv then
++        begin
++          GetEnvironmentVariable := copy(s, i+1, length(s)-i);
++          break;
++        end;
++        { next string entry }
++        hp := hp + strlen(hp) + 1;
++      end;
++      FreeEnvironmentStringsW(p);
++    end;
++
++    function getTempDir: String;
++    var
++      astringLength : Integer;
++    begin
++      getTempDir := GetEnvironmentVariable('TMP');
++      if getTempDir = '' then
++        getTempDir := GetEnvironmentVariable('TEMP');
++      astringlength := Length(getTempDir);
++      if (astringlength > 0) and (getTempDir[astringlength] <> DirectorySeparator) then
++        getTempDir := getTempDir + DirectorySeparator;
++    end;
++
++    {$pop}
++
++{$ELSEIF defined(UNIX)}
++
++  function getTempDir: string;
++    var
++      key: string;
++      value: string;
++      i_env, i_key, i_value: integer;
++    begin
++      value := '/tmp/';  (** default for UNIX **)
++      while (envp <> NIL) and assigned(envp^) do
++      begin
++        i_env := 0;
++        i_key := 1;
++        while not (envp^[i_env] in ['=', #0]) do
++        begin
++          key[i_key] := envp^[i_env];
++          inc(i_env);
++          inc(i_key);
++        end;
++        setlength(key, i_key - 1);
++        if (key = 'TEMP') or (key = 'TMP') or (key = 'TMPDIR') then
++        begin
++          inc(i_env);    (** skip '=' **)
++          i_value := 1;
++          while (envp^[i_env] <> #0) do
++          begin
++            value[i_value] := envp^[i_env];
++            inc(i_env);
++            inc(i_value);
++          end;
++          setlength(value, i_value - 1);
++        end;
++        inc(envp);
++      end;
++      i_value:=length(value);
++      if (i_value > 0) and (value[i_value] <> DirectorySeparator) then
++        value := value + DirectorySeparator;
++      getTempDir := value;
++    end;
++
++{$ELSE}  // neither unix nor windows
++
++  function getTempDir: string;
++  begin
++    getTempDir:='';
++  end;
++
++{$ENDIF}
+ 
+ {$ifdef FPC_HAS_FEATURE_RANDOM}
+ { this code is duplicated in the iso7185 unit }
+ Procedure DoAssign(var t : TypedFile);
+ Begin
+-  Assign(t,'fpc_'+HexStr(random(1000000000),8)+'.tmp');
++  Assign(t,getTempDir+'fpc_'+HexStr(random(1000000000),8)+'.tmp');
+ End;
+ {$else FPC_HAS_FEATURE_RANDOM}
+ { this code is duplicated in the iso7185 unit }
+@@ -81,8 +220,12 @@
+ const
+   start : dword = 0;
+ Begin
+-  Assign(t,'fpc_'+HexStr(start,8)+'.tmp');
++ {$ifdef EXCLUDE_COMPLEX_PROCS}
++   runerror(219);
++ {$else EXCLUDE_COMPLEX_PROCS}
++  Assign(t,getTempDir+'fpc_'+HexStr(start,8)+'.tmp');
+   inc(start);
++ {$endif EXCLUDE_COMPLEX_PROCS}
+ End;
+ {$endif FPC_HAS_FEATURE_RANDOM}
+ 

--- a/lang/fpc/files/patch-transparent-filename.diff
+++ b/lang/fpc/files/patch-transparent-filename.diff
@@ -1,0 +1,93 @@
+diff -Naur compiler/globtype.pas compiler/globtype.pas
+--- compiler/globtype.pas	2017-02-18 11:41:40.000000000 +0100
++++ compiler/globtype.pas	2017-02-18 11:49:27.000000000 +0100
+@@ -179,6 +179,7 @@
+          { parameter switches }
+          cs_check_unit_name,cs_constructor_name,cs_support_exceptions,
+          cs_support_c_objectivepas,
++         cs_transparent_file_names,
+          { units }
+          cs_load_objpas_unit,
+          cs_load_gpc_unit,
+diff -Naur compiler/ngenutil.pas compiler/ngenutil.pas
+--- compiler/ngenutil.pas	2017-02-18 11:41:57.000000000 +0100
++++ compiler/ngenutil.pas	2017-02-18 11:48:51.000000000 +0100
+@@ -274,12 +274,22 @@
+        (tfiledef(tstaticvarsym(p).vardef).filetyp=ft_text) and
+        (tstaticvarsym(p).isoindex<>0) then
+        begin
+-         addstatement(stat^,ccallnode.createintern('fpc_textinit_iso',
+-           ccallparanode.create(
+-             cordconstnode.create(tstaticvarsym(p).isoindex,uinttype,false),
+-           ccallparanode.create(
+-             cloadnode.create(tstaticvarsym(p),tstaticvarsym(p).Owner),
+-           nil))));
++         if cs_transparent_file_names in current_settings.globalswitches then
++           addstatement(stat^,ccallnode.createintern('fpc_textinit_filename_iso',
++             ccallparanode.create(
++               cstringconstnode.createstr(tstaticvarsym(p).Name),
++             ccallparanode.create(
++               cordconstnode.create(tstaticvarsym(p).isoindex,uinttype,false),
++             ccallparanode.create(
++               cloadnode.create(tstaticvarsym(p),tstaticvarsym(p).Owner),
++             nil)))))
++         else
++           addstatement(stat^,ccallnode.createintern('fpc_textinit_iso',
++             ccallparanode.create(
++               cordconstnode.create(tstaticvarsym(p).isoindex,uinttype,false),
++             ccallparanode.create(
++               cloadnode.create(tstaticvarsym(p),tstaticvarsym(p).Owner),
++             nil))));
+        end;
+     end;
+ 
+diff -Naur compiler/options.pas compiler/options.pas
+--- compiler/options.pas	2017-02-18 11:42:12.000000000 +0100
++++ compiler/options.pas	2017-02-18 11:47:51.000000000 +0100
+@@ -1933,6 +1933,11 @@
+                            include(init_settings.moduleswitches,cs_support_macro);
+                        'o' : //an alternative to -Mtp
+                          SetCompileMode('TP',true);
++                       'r' :
++                         If UnsetBool(More, j, opt, false) then
++                           exclude(init_settings.globalswitches,cs_transparent_file_names)
++                         else
++                           include(init_settings.globalswitches,cs_transparent_file_names);
+ {$ifdef gpc_mode}
+                        'p' : //an alternative to -Mgpc
+                          SetCompileMode('GPC',true);
+diff -Naur rtl/inc/compproc.inc rtl/inc/compproc.inc
+--- rtl/inc/compproc.inc	2017-02-18 11:44:14.000000000 +0100
++++ rtl/inc/compproc.inc	2017-02-18 11:47:10.000000000 +0100
+@@ -411,6 +411,7 @@
+ Function fpc_get_input:PText;compilerproc;
+ Function fpc_get_output:PText;compilerproc;
+ Procedure fpc_textinit_iso(var t : Text;nr : DWord);compilerproc;
++Procedure fpc_textinit_filename_iso(var t : Text;nr : DWord;const filename : string);compilerproc;
+ Procedure fpc_textclose_iso(var t : Text);compilerproc;
+ Procedure fpc_Write_End(var f:Text); compilerproc;
+ Procedure fpc_Writeln_End(var f:Text); compilerproc;
+diff -Naur rtl/inc/text.inc rtl/inc/text.inc
+--- rtl/inc/text.inc	2017-02-18 11:44:36.000000000 +0100
++++ rtl/inc/text.inc	2017-02-18 11:46:23.000000000 +0100
+@@ -652,6 +652,20 @@
+ {$endif FPC_HAS_FEATURE_COMMANDARGS}
+ end;
+ 
++Procedure fpc_textinit_filename_iso(var t : Text;nr : DWord;const filename : string);compilerproc;
++begin
++{$ifdef FPC_HAS_FEATURE_COMMANDARGS}
++  if paramstr(nr)='' then
++    assign(t,filename+'.txt')
++  else
++    assign(t,paramstr(nr));
++{$else FPC_HAS_FEATURE_COMMANDARGS}
++  { primitive workaround for targets supporting no command line arguments,
++    invent some file name, try to avoid complex procedures like concating strings which might
++    pull-in bigger parts of the rtl }
++  assign(t,chr((nr mod 16)+65));
++{$endif FPC_HAS_FEATURE_COMMANDARGS}
++end;
+ 
+ Procedure fpc_textclose_iso(var t : Text);compilerproc;
+ begin


### PR DESCRIPTION
This update is based on ticket 53096 from trac (https://trac.macports.org/ticket/53096).
In addition the following patches are included.

2 patches for the file handling in iso mode
prefix path in pyacc and plex
build and install the tools msgdif and msg2inc

This second try fixes the previous build error with chmcmd.

I am asking for special attention as well as patience, since this is my first submission.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? No tests available
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
