### PR TITLE
avahi: fix typo in comment

### DIFF
--- a/net/avahi/Portfile
+++ b/net/avahi/Portfile
@@ -86,7 +86,7 @@ configure.args      --disable-autoipd \
                     --with-avahi-user=${avahi_user} \
                     --with-avahi-group=${avahi_group}
 
-# __APPLE_USE_RFC_2292 should be removed once avhi is updated to support RFC 3542
+# __APPLE_USE_RFC_2292 should be removed once avahi is updated to support RFC 3542
 configure.cppflags-append   -L${prefix}/lib -D__APPLE_USE_RFC_2292
 
 set daemon_uniquename   org.freedesktop.avahi-daemon


### PR DESCRIPTION
Q: this flag has been present since 26132378faabd4dc43a4a7947e4f1f798ca447a6, is it still needed?

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
