### PR TITLE
wireshark-chmodbpf: new port

### DIFF
--- a/net/wireshark-chmodbpf/Portfile
+++ b/net/wireshark-chmodbpf/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                wireshark-chmodbpf
+version             1.0
+platforms           darwin macosx
+categories          net
+license             {GPL-2 GPL-3}
+maintainers         {@ra1nb0w irh.it:rainbow} {darkart.com:opendarwin.org @ghosthound} openmaintainer
+description         Enable Wireshark to acces macOS capture devices.
+long_description    An access_bpf group will be created and its members \
+    allowed access to BPF devices at boot to allow unprivileged packet \
+    captures. It is meant to support Wireshark where unprivileged access \
+    to macOS packet capture devices is desired.
+homepage            https://www.wireshark.org
+distfiles
+
+# name of the group used on /dev/bpf*
+set bpf_group       access_bpf
+
+patchfiles-append \
+    patch-wireshark-chmodbpf.diff
+
+use_configure       no
+build               {}
+supported_archs     noarch
+
+pre-destroot {
+    # create the group to access capture devices
+    addgroup ${bpf_group}
+}
+
+destroot {
+    reinplace s|@BPF_GROUP@|${bpf_group}|g ${worksrcpath}/sbin/${name}
+    xinstall -m 0755 -o root -g wheel ${worksrcpath}/sbin/${name} ${destroot}${prefix}/sbin/${name}
+}
+
+# create startup that run ${name} script
+startupitem.create      yes
+startupitem.name        wireshark.ChmodBPF
+startupitem.autostart   yes
+startupitem.executable  ${prefix}/sbin/${name}
+startupitem.pidfile     none
+
+notes "
+  To fully complete your installation and use Wireshare
+  with capture devices, like network interfaces, please run:
+
+    sudo dseditgroup -q -o edit -a \[USER\] -t user ${bpf_group}
+
+  and change \[USER\] with the user that need access
+  to the hardware. Then reboot.
+"

--- a/net/wireshark-chmodbpf/files/patch-wireshark-chmodbpf.diff
+++ b/net/wireshark-chmodbpf/files/patch-wireshark-chmodbpf.diff
@@ -1,0 +1,46 @@
+diff --git a/wireshark-chmodbpf b/wireshark-chmodbpf
+new file mode 100755
+index 0000000..8564790
+--- /dev/null
++++ sbin/wireshark-chmodbpf
+@@ -0,0 +1,40 @@
++#!/bin/bash
++
++#
++# Unfortunately, macOS's devfs is based on the old FreeBSD
++# one, not the current one, so there's no way to configure it
++# to create BPF devices with particular owners or groups. BPF
++# devices on macOS are also non-cloning, that is they can
++# be created on demand at any time. This startup item will
++# pre-create a number of BPF devices, then make them owned by
++# the access_bpf group, with permissions rw-rw----, so that
++# anybody in the access_bpf group can use programs that capture
++# or send raw packets.
++#
++# Change this as appropriate for your site, e.g. to make
++# it owned by a particular user without changing the permissions,
++# so only that user and the super-user can capture or send raw
++# packets, or give it the permissions rw-r-----, so that
++# only the super-user can send raw packets but anybody in the
++# admin group can capture packets.
++#
++
++# Pre-create BPF devices. Set to 0 to disable.
++FORCE_CREATE_BPF_MAX=10
++
++SYSCTL_MAX=$( sysctl -n debug.bpf_maxdevices )
++if [ "$FORCE_CREATE_BPF_MAX" -gt "$SYSCTL_MAX" ] ; then
++	FORCE_CREATE_BPF_MAX=$SYSCTL_MAX
++fi
++
++syslog -s -l notice "ChmodBPF: Forcing creation and setting permissions for /dev/bpf*"
++
++CUR_DEV=0
++while [ "$CUR_DEV" -lt "$FORCE_CREATE_BPF_MAX" ] ; do
++	# Try to do the minimum necessary to trigger the next device.
++	read -n 0 < /dev/bpf$CUR_DEV > /dev/null 2>&1
++	CUR_DEV=$(( $CUR_DEV + 1 ))
++done
++
++chgrp @BPF_GROUP@ /dev/bpf*
++chmod g+rw /dev/bpf*


### PR DESCRIPTION
#### Description

Enable Wireshark to acces macOS capture devices

Closes: https://trac.macports.org/ticket/48132

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->