### PR TITLE
burp: remove pre-activate block

### DIFF
--- a/sysutils/burp/Portfile
+++ b/sysutils/burp/Portfile
@@ -45,18 +45,6 @@ post-destroot {
 
 destroot.keepdirs ${destroot}${prefix}/etc/burp/CA-client
 
-pre-activate {
-    # Prevent activation failure for upgrades. This can be removed after January 2019.
-    # See https://trac.macports.org/ticket/55671
-    foreach filepath "${prefix}/etc/burp/CA-client/.turd_${subport}" {
-        if {[file exists ${filepath}] && [registry_file_registered ${filepath}] == "0"} {
-            if {[catch {delete ${filepath}}]} {
-                ui_warn "Cannot delete ${filepath}; please remove it manually"
-            }
-        }
-    }
-}
-
 livecheck.url ${homepage}/download.html
 livecheck.regex {<li>([0-9.]+): Stable$}
 


### PR DESCRIPTION
Block added in a85edb86e0; can now be removed

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
