### PR TITLE
gnutls: remove conflicts_build on autoconf-archive

### DIFF
--- a/devel/gnutls/Portfile
+++ b/devel/gnutls/Portfile
@@ -39,11 +39,9 @@ use_xz          yes
 # deal with minor updates that extract to major version number
 worksrcdir      ${name}-${major}
 
-# see: https://trac.macports.org/ticket/57958 for autoconf-archive
 # see: https://trac.macports.org/ticket/57893
 # and https://github.com/macports/macports-ports/pull/3379 for autogen
-conflicts_build autoconf-archive \
-                autogen
+conflicts_build autogen
 
 depends_build-append \
                 port:gettext \


### PR DESCRIPTION
remove conflicts_build on autoconf-archive because it seems to be resolved somehow in an update to gnutls and/or autoconf-archive. I've tested this change on OSX 10.5 PPC & OSX 10.6-14 Intel (yes, all of them, as it turns out I made the change once & forgot about it while doing updates & gnutls updated correctly on every OSX version even with autoconf-archive installed and active LOL).