### PR TITLE
sqlite3-tools: remove pre-activate block

### DIFF
--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -115,16 +115,4 @@ subport ${name}-tools {
         xinstall -m 755 ${worksrcpath}/sqldiff ${destroot}${prefix}/bin
         xinstall -m 755 ${worksrcpath}/sqlite3_analyzer ${destroot}${prefix}/bin
     }
-    pre-activate {
-        # tcl previously conflicted because it installed files now provided by sqlite3-tools
-        if {![catch {set installed [lindex [registry_active tcl] 0]}]} {
-            set _version [lindex $installed 1]
-            set _revision [lindex $installed 2]
-            set _cmp866 [vercmp $_version 8.6.6]
-            if {($_cmp866 < 0) || ($_cmp866 == 0 && $_revision < 1)} {
-                # tcl used to install some files now provided by sqlite3-tools in versions < 8.6.6_1
-                registry_deactivate_composite tcl "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }


### PR DESCRIPTION
Was added in 83dd502623, alongside `tcl` @8.6.6_1 in 2ed3be5416, to resolve a conflict with tcl. Over two years have passed since this conflict was resolved.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
