### PR TITLE
logwatch: remove pre-activate block

### DIFF
--- a/security/logwatch/Portfile
+++ b/security/logwatch/Portfile
@@ -90,18 +90,6 @@ post-destroot {
     ln -sf ${prefix}/share/${name}/scripts/logwatch.pl ${destroot}${prefix}/bin/logwatch
 }
 
-pre-activate {
-    # This port used to create a symlink directly in ${prefix} which was fixed in 7.4.1_1.
-    # The old unregistered symlink needs to be deleted from ${prefix} so upgrades work; fixed in 7.4.1_4.
-    # This can eventually be removed. Originally added 2014-10-01; fixed 2016-02-03.
-    set badfile ${prefix}/bin/${name}
-    if {![catch {file type ${badfile}}] && [registry_file_registered ${badfile}] == "0"} {
-        if {[catch {delete ${badfile}}]} {
-            ui_warn "Cannot delete ${badfile}; please remove it manually"
-        }
-    }
-}
-
 notes "
 A startup item has been generated that will aid in
 starting logwatch with launchd. It is disabled


### PR DESCRIPTION
Was added in a9d72b06da, adjusted in 9baab5214b; over 3 years have passed since the issue necessitating the block was resolved.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
