### PR TITLE
bash-completion-devel: remove obsolete port

### DIFF
--- a/sysutils/bash-completion/Portfile
+++ b/sysutils/bash-completion/Portfile
@@ -5,7 +5,6 @@ PortGroup       github 1.0
 
 github.setup    scop bash-completion 2.8
 epoch           1
-conflicts       bash-completion-devel
 categories      sysutils
 platforms       darwin
 supported_archs noarch
@@ -67,14 +66,4 @@ if {${os.platform} eq "darwin" && ${os.subplatform} eq "macosx"} {
         above will not modify your shell environment and no extended completion
         will be available.
     "
-}
-
-subport bash-completion-devel {
-    PortGroup   obsolete 1.0
-
-    # This port is obsolete and can be removed after 2019-03-27
-
-    epoch 0
-    conflicts
-    replaced_by bash-completion
 }


### PR DESCRIPTION
Port was scheduled for removal in e588416d78

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
