### PR TITLE
py-sphinx-[gallery|-bootstrap-theme]: New ports.

### DIFF
--- a/python/py-sphinx-bootstrap-theme/Portfile
+++ b/python/py-sphinx-bootstrap-theme/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        ryan-roemer sphinx-bootstrap-theme v0.7.1
+name                py-sphinx-bootstrap-theme
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         Sphinx bootstrap theme.
+long_description    ${description}
+
+checksums \
+    rmd160  b57d6742d215223f9b4e995b3456ff00ae0c32ec \
+    sha256  df0cafc62db5768f2b595a0709099d2ff65bf19b1c19855bdfd9e1d6a1af6bfb \
+    size    1253883
+
+python.versions     27 36 37
+
+if {${subport} ne ${name}} {
+    depends_build       port:py${python.version}-setuptools
+    livecheck.type      none
+
+    post-destroot {
+        set DOCDIR "${destroot}${prefix}/share/doc/${subport}"
+        xinstall -d ${DOCDIR}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt ${DOCDIR}
+    }
+}
+

--- a/python/py-sphinx-gallery/Portfile
+++ b/python/py-sphinx-gallery/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        sphinx-gallery sphinx-gallery 0.3.1 v
+name                py-sphinx-gallery
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Extension for automatic generation of an example gallery
+long_description    ${description}
+
+checksums \
+    rmd160  e1171e7d9d86f8c3c104574edcde8bbdfeef1cb8 \
+    sha256  bd8dea86dacf48091229c2d7737bbf6efa5a9dd5b49060f232d0c232cfbcc563 \
+    size    383518
+
+python.versions     27 36 37
+
+if {${subport} ne ${name}} {
+    depends_build       port:py${python.version}-setuptools \
+                        port:py${python.version}-pytest-runner
+    livecheck.type      none
+
+    post-destroot {
+        set DOCDIR "${destroot}${prefix}/share/doc/${subport}"
+        xinstall -d ${DOCDIR}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE ${DOCDIR}
+    }
+}
+


### PR DESCRIPTION
#### Description

Two new sphinx support modules.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->