### PR TITLE
ditaa: Update to version 0.11.0

### DIFF
--- a/java/ditaa/Portfile
+++ b/java/ditaa/Portfile
@@ -1,62 +1,47 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                ditaa
-version             0.9
-revision            3
+github.setup        stathissideris ditaa 0.11.0 v
 categories          java editors
 platforms           darwin
-supported_archs     noarch
 license             GPL-2+
-maintainers         nomaintainer
 
-description         ditaa is a small command-line utility written in Java \
-                    that can convert diagrams drawn using ascii art
+maintainers         {gmail.com:slewsys @slewsys} openmaintainer
 
-long_description    ${description}
+description         Java ASCII art to bitmap graphics conversion utility
 
-homepage            http://ditaa.sourceforge.net
-master_sites        sourceforge
-distfiles           ${name}[strsed ${version} {/\./_/}]-src.zip
-use_zip             yes
+long_description    \
+    ditaa is a small command-line utility, written in Java, that can convert \
+    diagrams drawn using ASCII art (i.e., 'drawings' that contain characters \
+    that resemble lines like | / - ) into proper bitmap graphics.
 
-checksums           md5     d7230273bf4c28c5029d350842278cf9 \
-                    sha1    570893b57cb29efbc919c7a36f119a0db11c46ce \
-                    rmd160  84222a7ded4680d3d0b2b7fac79e19c8983c6233
+github.tarball_from releases
 
-depends_build       bin:ant:apache-ant
+distname            ${name}-${version}-standalone.jar
 
+checksums           rmd160  16aa67b0501ceef9553f981c9fbdffec5fecd08e \
+                    sha256  9418aa63ff6d89c5d2318396f59836e120e75bea7a5930c4d34aa10fe7a196a9 \
+                    size    12621318
+
+extract.suffix
 extract.mkdir       yes
+extract.cmd         cp
+extract.pre_args
+extract.post_args   ${worksrcpath}/
 
 post-extract {
     xinstall -m 755 -d ${worksrcpath}/bin
+    xinstall -m 755 ${filespath}/${name}.sh ${worksrcpath}/
+    reinplace "s|@JARFILE@|${prefix}/share/java/${distname}|" ${name}.sh
 }
 
 use_configure       no
-
-build.cmd           ant
-build.args          -buildfile build/release.xml
-build.target        compile release-jar
+build {}
 
 destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/java/
-    xinstall -m 644 ${worksrcpath}/releases/${name}[strsed ${version} {/\./_/}].jar \
-        ${destroot}${prefix}/share/java/
-
-    set docdir ${destroot}${prefix}/share/doc/${name}
-    xinstall -d ${docdir}
-    xinstall -m 644 -W ${worksrcpath} \
-        COPYING \
-        HISTORY \
-        ${docdir}
-
-    if {[variant_isset emacs]} {
-        xinstall -m 755 -d ${destroot}${prefix}/share/emacs/contrib/scripts/
-        xinstall -m 644 ${worksrcpath}/releases/${name}[strsed ${version} {/\./_/}].jar \
-            ${destroot}${prefix}/share/emacs/contrib/scripts/ditaa.jar
-    }
-}
-
-variant emacs description {Link it into emacs} {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java
+    xinstall -m 755 ${worksrcpath}/${distname} ${destroot}${prefix}/share/java/
+    xinstall -m 755 ${worksrcpath}/${name}.sh ${destroot}${prefix}/bin/${name}
 }

--- a/java/ditaa/files/ditaa.sh
+++ b/java/ditaa/files/ditaa.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec java  -jar @JARFILE@ "$@"


### PR DESCRIPTION
#### Description
ditaa: Update to version 0.11.0.

NB: Prior Portfile attempted to build from Java source.  Attempting to do fails for me with Oracle's Java 10 compiler.  This Portfile instead installs a pre-compiled JAR file from the upstream repository.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G4015
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->