### PR TITLE
wxWidgets-3.2: add support for c++11

### DIFF
--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -9,7 +9,7 @@ name                saga
 categories          gis
 license             GPL
 version             7.2.0
-#revision            0
+revision            1
 #set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 maintainers         {vince @Veence} openmaintainer

--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cxx11           1.1
 PortGroup           github          1.0
 PortGroup           select          1.0
 PortGroup           wxWidgets       1.0
@@ -72,6 +73,7 @@ configure.args      --prefix=${wxWidgets.prefix} \
                     --without-sdl \
                     --enable-aui \
                     --disable-sdltest \
+                    --enable-cxx11 \
                     --enable-display \
                     --enable-xrc \
                     --enable-graphics_ctx \
@@ -125,19 +127,6 @@ variant stdlib description {add support for various standard library features} {
                             --enable-std_iostreams \
                             --enable-std_string \
                             --enable-std_string_conv_in_wxstring
-}
-
-# handle C++11 support
-if {${configure.cxx_stdlib} eq "libstdc++"} {
-    # when using libstdc++ for the c++ runtime, require C++11
-    PortGroup cxx11 1.1
-    configure.args-append --enable-cxx11
-} else {
-    # when using libc++ for the c++ runtime, make C++11 an optional variant
-    variant cxx11 description {add support for C++11} {
-        PortGroup cxx11 1.1
-        configure.args-append --enable-cxx11
-    }
 }
 
 configure.ldflags-append -stdlib=${configure.cxx_stdlib}

--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -50,7 +50,8 @@ depends_lib-append  port:jpeg \
 depends_run         port:wxWidgets-common \
                     port:wxWidgets_select
 
-patchfiles          patch-configure.diff
+patchfiles          patch-configure.diff \
+                    patch-configure-stdlib.diff
 
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${patch.dir}/configure
@@ -98,12 +99,6 @@ variant compat30 description {enable wxWidgets 3.0 compatibility (will become de
 
 # notes:
 #   --enable-unicode (already default)
-#   --enable-cxx11   (figure out how to use this switch)
-
-if {[string match *clang* ${configure.cxx}]} {
-    configure.ldflags-append \
-                    -stdlib=${configure.cxx_stdlib}
-}
 
 post-destroot {
     set confscript ${wxWidgets.prefix}/lib/wx/config/${wxtype}-unicode-${branch}
@@ -131,5 +126,20 @@ variant stdlib description {add support for various standard library features} {
                             --enable-std_string \
                             --enable-std_string_conv_in_wxstring
 }
+
+# handle C++11 support
+if {${configure.cxx_stdlib} eq "libstdc++"} {
+    # when using libstdc++ for the c++ runtime, require C++11
+    PortGroup cxx11 1.1
+    configure.args-append --enable-cxx11
+} else {
+    # when using libc++ for the c++ runtime, make C++11 an optional variant
+    variant cxx11 description {add support for C++11} {
+        PortGroup cxx11 1.1
+        configure.args-append --enable-cxx11
+    }
+}
+
+configure.ldflags-append -stdlib=${configure.cxx_stdlib}
 
 livecheck.regex     {archive/v([0-9.]+).tar.gz}

--- a/graphics/wxWidgets-3.2/files/patch-configure-stdlib.diff
+++ b/graphics/wxWidgets-3.2/files/patch-configure-stdlib.diff
@@ -1,0 +1,13 @@
+--- configure.orig
++++ configure
+@@ -20214,10 +20214,6 @@
+     retest_macosx_linking=yes
+ fi
+ 
+-if test "$HAVE_CXX11" = "1" ; then
+-                        eval "CXX=\"$CXX -stdlib=libc++\""
+-fi
+-
+ if test "x$retest_macosx_linking" = "xyes"; then
+     ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'

--- a/multimedia/mediainfo/Portfile
+++ b/multimedia/mediainfo/Portfile
@@ -36,7 +36,7 @@ subport MediaInfo-gui {
     PortGroup           app 1.0
     PortGroup           wxWidgets 1.0
     wxWidgets.use       wxWidgets-3.2
-    revision            0
+    revision            1
 
     description         Identifies audio and video codecs in a media file. GUI
     long_description    MediaInfo supplies technical and tag information about a \

--- a/science/CubicSDR/Portfile
+++ b/science/CubicSDR/Portfile
@@ -23,7 +23,7 @@ version             20190417-[string range ${github.version} 0 7]
 checksums           rmd160 9e54b818c5777fefce428995e99f8ee60a7249f7 \
                     sha256 a13e9a5b0b0f09dfa26395a5f4d63662999bdfea85e99f638cce05c7aada1a52 \
                     size   36027266
-revision            2
+revision            3
 
 wxWidgets.use       wxWidgets-3.2
 

--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -25,7 +25,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160 fb0f93d784b41f59d68de3b485eb81e86453688c \
                     sha256 24b523bc91ede7a6e1f0f0438828136b9ff56004f725000dfac0dcfe5f1764c3 \
                     size   5348853
-    revision        0
+    revision        1
 
     name            limesuite-devel
     long_description ${long_description} This port is kept up with the LimeSuite \
@@ -38,7 +38,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  6286e1ec881b5944d9913f802cba2b8236908917 \
                     sha256  bf0ca8225e9eacf44cee7383504e699eb9be5cc47293fb9c08baaf8d5e3163c9 \
                     size    5347689
-    revision        4
+    revision        5
 
     conflicts       limesuite-devel
     configure.args-append -DLIME_SUITE_EXTVER=release


### PR DESCRIPTION
#### Description

wxWidgets-3.2: add support for c++11

+ optional variant if stdlib is libc++
+ required if stdlib is macports-libstdc++

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Actual boot into 10.7 through 10.14 & latest Xcode for each. Tested on 10.9+ with and without +cxx11 variant.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
