### PR TITLE
weechat: update to 2.4

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -10,23 +10,32 @@ name                weechat
 if {${name} eq ${subport}} {
     conflicts       weechat-devel
     name            weechat
-    version         2.3
-    revision        1
+    version         2.4
+    revision        0
+    checksums       rmd160  eed25333e05725fd2d1be1b08ac350d688be12fc \
+                    sha256  61a6afe9849b96e99c1f3cde612d1748a03c807059dad459e3a6acbc5cf100fd \
+                    size    2944811
+
+    # remove patch in version 2.5+
+    patchfiles      patch-fix-compilation.diff
+
     master_sites    https://weechat.org/files/src/
     use_bzip2       yes
-
-    checksums       rmd160  3aade16f5f1bbda0b790d1305b7ba951499f3018 \
-                    sha256  3c5919c23feb40368fae08f3581448c707e1bdb14c835c06c31b78ebadbb2456 \
-                    size    2913883
 }
 
 subport weechat-devel {
-    github.setup    weechat weechat ee82ba74616b9050346d01e27b452bee3c5f0afd
-    version         1.8-dev-20170327
-
     conflicts       weechat
-    checksums       rmd160  10d8d30f0e24d31e6f5260ab6d8bd41ce9449844 \
-                    sha256  7c3a0dcc02d8e045642d490100bb19a4b1b0c6a46c6be06f791b0ffbe3e4f8db
+    name            weechat-devel
+    version         2.5-dev-20190424
+    revision        0
+    checksums       rmd160  ef1b9219d799507e783f84aab90b163546184139 \
+                    sha256  00ca8188a67175e158fafa356a528731ed6520ae8b629627791653f1b204af1b \
+                    size    2952987
+
+    master_sites    https://weechat.org/files/src/devel/
+    use_bzip2       yes
+    distname        ${name}-20190424
+    worksrcdir      ${name}
 }
 
 homepage            https://weechat.org/

--- a/irc/weechat/files/patch-fix-compilation.diff
+++ b/irc/weechat/files/patch-fix-compilation.diff
@@ -1,0 +1,10 @@
+--- src/core/weechat.c.orig	2019-04-24 12:55:19.000000000 -0700
++++ src/core/weechat.c	2019-04-24 12:55:35.000000000 -0700
+@@ -39,6 +39,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <unistd.h>
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <stdio.h>


### PR DESCRIPTION
#### Description

weechat: update to 2.4
weechat-devel: update to 2.5-dev-20190424

###### Tested on
macOS 10.11.6 15G22010
Xcode 7.3 7D175

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?