### PR TITLE
LyX: fix build on older systems

### DIFF
--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11 1.1
 
 name                LyX
@@ -42,6 +43,9 @@ checksums           rmd160  369d5f0be707436ccafe0d454db95de0a4744449 \
                     size    15791748
 
 configure.args      --disable-silent-rules
+
+compiler.blacklist-append { clang < 800 }
+patchfiles-append   patch-lyx-applescriptproxy-add-stringh.diff
 
 post-configure {
     reinplace \

--- a/aqua/LyX/files/patch-lyx-applescriptproxy-add-stringh.diff
+++ b/aqua/LyX/files/patch-lyx-applescriptproxy-add-stringh.diff
@@ -1,0 +1,10 @@
+--- src/support/AppleScriptProxy.cpp.orig	2019-04-20 11:01:31.000000000 -0700
++++ src/support/AppleScriptProxy.cpp	2019-04-20 11:09:34.000000000 -0700
+@@ -23,6 +23,7 @@
+ #include "support/debug.h"
+ 
+ #include <stdlib.h>
++#include <string.h>
+ 
+ using namespace std;
+ using namespace lyx;


### PR DESCRIPTION
add missing header that seems to manifest only with the gcc headers
(when using stdlib=macports-libstdc++)

blacklist clang version that can't build this this port

closes: https://trac.macports.org/ticket/58379