### PR TITLE
mediainfo: fix worksrcdir

### DIFF
--- a/multimedia/mediainfo/Portfile
+++ b/multimedia/mediainfo/Portfile
@@ -24,7 +24,11 @@ homepage            https://mediaarea.net
 depends_build       port:pkgconfig
 depends_lib         port:zenlib port:zlib port:mediainfolib
 
-worksrcdir          ${worksrcdir}/Project/GNU/CLI
+if {${name} eq ${subport}} {
+    worksrcdir     ${worksrcdir}/Project/GNU/CLI
+} else {
+    worksrcdir     ${worksrcdir}/Project/GNU/GUI
+}
 
 use_autoreconf      yes
 autoreconf.args-append  --force --install
@@ -43,8 +47,6 @@ subport MediaInfo-gui {
                         video or audio file via graphical utility
 
     depends_lib-append  port:${wxWidgets.port}
-
-    set worksrcpath     ${workpath}/${worksrcdir}/Project/GNU/GUI
 
     configure.args      --with-wx-config=${wxWidgets.wxconfig} \
                         --with-wx-prefix=${wxWidgets.prefix}


### PR DESCRIPTION
#### Description

A simple change to bring mediainfo-gui up to working again.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

and

macOS 10.10.5 14F2511
Xcode 7.2.1 7C1002

NOTE: This fix won't help if stdlib=libstdc++ ... that's a separate issue that I'm still working on.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
