### PR TITLE
py-urllib3: update to 1.25.1

### DIFF
--- a/python/py-urllib3/Portfile
+++ b/python/py-urllib3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-urllib3
-version             1.25
+version             1.25.1
 revision            0
 categories-append   devel net
 platforms           darwin
@@ -22,9 +22,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  9c04450c03fb4df101335259d735479e37295b22 \
-                    sha256  f03eeb431c77b88cf8747d47e94233a91d0e0fdae1cf09e0b21405a885700266 \
-                    size    409895
+checksums           rmd160  b3651884c317e5b79531f9f621405b0b6a0760a1 \
+                    sha256  904bd981d6371bb95a200c0ec9dba5ba7cc980f2d6b125bd793fefe3293be388 \
+                    size    670490
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
Update py-urllib3 to 1.25.1

This fixes a crash when py-brotli is installed:
https://github.com/urllib3/urllib3/pull/1572

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->