### PR TITLE
multimon-ng: new port

### DIFF
--- a/science/multimon-ng/Portfile
+++ b/science/multimon-ng/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        EliasOenal multimon-ng 1.1.7
+
+platforms           darwin
+categories          science comms
+license             GPL-2.0
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         multimon-ng decodes radio digital transmission signals
+long_description    multimon-ng is the successor of multimon. \
+    It decodes the following digital transmission modes: \
+    POCSAG512 POCSAG1200 POCSAG2400 FLEX EAS UFSK1200 CLIPFSK \
+    AFSK1200 AFSK2400 AFSK2400_2 AFSK2400_3 HAPN4800 FSK9600 \
+    DTMF ZVEI1 ZVEI2 ZVEI3 DZVEI PZVEI EEA EIA CCIR MORSE_CW X10
+
+checksums           rmd160  c4fbc0b7bf6557e6669cf5df43b94b6fb794202f \
+                    sha256  91bbe6f39bac840fea3e64e84b9ec7461ba1e74048369532591a31dcce84d94c \
+                    size    2430248
+
+configure.args-append \
+    -DPULSE_AUDIO_SUPPORT=0 \
+    -DX11_SUPPORT=0
+
+variant pulseaudio description {Enable Pulseaudio support} {
+    depends_lib-append \
+        port:pulseaudio
+
+    configure.args-replace \
+        -DPULSE_AUDIO_SUPPORT=0  -DPULSE_AUDIO_SUPPORT=1
+}
+
+variant x11 {
+    depends_lib-append \
+        port:xorg-libsm \
+        port:xorg-libice \
+        port:xorg-libX11
+
+    configure.args-replace \
+        -DX11_SUPPORT=0 -DX11_SUPPORT=1
+}
+
+#  add some examples and documentation
+post-destroot {
+    xinstall -d ${destroot}${prefix}/etc/${name}
+    file copy ${worksrcpath}/example ${destroot}${prefix}/etc/${name}/
+}
+
+test.run    yes
+test.cmd    ./multimon-ng


### PR DESCRIPTION
#### Description

multimon-ng is the successor of multimon.
It decodes the following digital transmission modes: POCSAG512
POCSAG1200 POCSAG2400 FLEX EAS UFSK1200 CLIPFSK AFSK1200 AFSK2400
AFSK2400_2 AFSK2400_3 HAPN4800 FSK9600 DTMF ZVEI1 ZVEI2 ZVEI3 DZVEI
PZVEI EEA EIA CCIR MORSE_CW X10.

Closes: https://trac.macports.org/ticket/48785

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->