### PR TITLE
rx_tools: new port

### DIFF
--- a/science/rx_tools/Portfile
+++ b/science/rx_tools/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+platforms           darwin macosx
+categories          science
+license             MIT
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         rx_fm, rx_power, and rx_sdr tools for \
+    receiving data from SDRs using SoapySDR
+long_description    ${description}
+
+github.setup        rxseger rx_tools 811b21c4c8a592515279bd19f7460c6e4ff0551c
+version             20190421-[string range ${github.version} 0 7]
+checksums           rmd160  be7ce358427be88112ba8c7a6f976fef3f5782ac \
+                    sha256  1c5037b7b204e184edb51151982cc1e4aab9293a6fff00445f37395f7b25586a \
+                    size    49248
+revision            0
+
+depends_lib-append \
+    port:SoapySDR


### PR DESCRIPTION
#### Description

rx_fm, rx_power, and rx_sdr tools for receiving data from SDRs using
SoapySDR

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->