### PR TITLE
kotlin: update to 1.3.31

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        JetBrains kotlin 1.3.30 v
+github.setup        JetBrains kotlin 1.3.31 v
 github.tarball_from releases
 distname            ${name}-compiler-${version}
 categories          lang java
@@ -21,9 +21,9 @@ long_description    Kotlin is a pragmatic programming language for JVM \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  be352d134031aae18d2e2e68f546fafde6a3dd86 \
-                    sha256  3d5c2219357ec0a247ccccba45377a5b544876871ce230da90e739953531bdec \
-                    size    41224316
+checksums           rmd160  51fe5eb73ea32a3510fefc853bc93f0c297f9486 \
+                    sha256  107325d56315af4f59ff28db6837d03c2660088e3efeb7d4e41f3e01bb848d6a \
+                    size    41254464
 
 depends_run         bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.3.31.

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?