### PR TITLE
recoll: use modern qt5 syntax

### DIFF
--- a/textproc/recoll/Portfile
+++ b/textproc/recoll/Portfile
@@ -2,6 +2,9 @@
 
 PortSystem          1.0
 PortGroup           app 1.0
+PortGroup           qt5 1.0
+
+qt5.depends_component qtwebkit
 
 name                recoll
 version             1.24.4
@@ -22,8 +25,6 @@ checksums rmd160 5ad33e308a759f588cea3cdb1646e928ad0d474f \
     size 2674060
 
 depends_lib         port:xapian-core \
-                    port:qt5 \
-                    port:qt5-qtwebkit \
                     port:aspell \
                     port:libiconv \
                     port:zlib


### PR DESCRIPTION
this allows the qt5 PG to properly select the correct
version of qt5 for the build system, and to properly
request the needed components according to current usage
