### PR TITLE
paraview: use qt5.depends_component syntax

### DIFF
--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -37,8 +37,10 @@ checksums           sha256  64561f34c4402b88f3cb20a956842394dde5838efd7ebb301157
                     size    51418473
 
 depends_build-append    port:readline \
-    port:netcdf \
-    port:qt5-sqlite-plugin port:qt5-qttools port:qt5-qtxmlpatterns
+    port:netcdf
+
+qt5.depends_component  sqlite-plugin qttools qtxmlpatterns
+qt5.min_version        5.6
 
 patchfiles patch-incomplete-types.patch
 


### PR DESCRIPTION
and set the current qt5 min version required
this is 5.6 as of 20190427
