### PR TITLE
gtest: Update to 1.8.1

### DIFF
--- a/devel/gtest/Portfile
+++ b/devel/gtest/Portfile
@@ -1,11 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       cmake 1.0
+PortGroup       cmake 1.1
 PortGroup       github 1.0
 
-github.setup    google googletest 1.8.0 release-
-revision        1
+github.setup    google googletest 1.8.1 release-
+revision        0
+checksums       rmd160  9ed5294c99d0eb2c962f9ae87d8ffc53d8c9d2d0 \
+                sha256  8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84 \
+                size    992337
+
 name            gtest
 categories      devel
 maintainers     {blair @blair}
@@ -23,12 +27,14 @@ long_description \
 
 platforms       darwin
 
-checksums       rmd160  fd6ff05f0b287e23dae59d30e6b7f1a27377c049 \
-                sha256  d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568
-
-cmake.out_of_source     yes
 configure.optflags      -g
 configure.args-append   -Dgtest_build_tests=ON
+
+# Prevent MacPorts headers from being used. They're not needed since
+# googletest has no dependencies, and if a different version of googletest
+# was already installed, its headers could cause the build to fail.
+configure.cppflags-delete -I${prefix}/include
+compiler.cpath
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/src/


### PR DESCRIPTION
#### Description

gtest: Update to 1.8.1

Closes: https://trac.macports.org/ticket/58408

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
