### PR TITLE
libuv: bring 10.5 and 10.6 versions up to current

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -55,21 +55,23 @@ platform darwin {
         }
     } elseif { ${os.major} == 9 || ${os.major} == 10 } {
 
-        # peg at version 1.24.1 for 10.5 Leopard and 10.6 Snow Leopard
+        # peg at version 1.28.0 for 10.5 Leopard and 10.6 Snow Leopard
         # see https://trac.macports.org/ticket/57926
-        github.setup libuv libuv 1.24.1 v
-        checksums    rmd160 9f059f60d7350aa203f7864e3ccc685ef7da6f5e \
-                     sha256 838e167bef01136adda06cff9243c1c991607fe0d4220d6a7d042933d23d64a6 \
-                     size   1204246
+        github.setup libuv libuv 1.28.0 v
+        checksums    rmd160 021dfc555baec1572795c06b502228379146e580 \
+                     sha256 4a115f752fb8dd2f24f8ad5a3c1a975260b550c0fc3ef525c449eb382f182358 \
+                     size   1219212
         revision     0
+
+        patchfiles-append patch-libuv-fsevents-leopard.diff
 
         # deprecate the devel port, if installed
         # can be removed after 20201010
         subport libuv-devel {
             PortGroup   obsolete 1.0
             replaced_by libuv
-            version     1.24.1
-            revision    1
+            version     1.28.0
+            revision    0
             depends_build
             depends_lib
         }

--- a/devel/libuv/files/patch-libuv-fsevents-leopard.diff
+++ b/devel/libuv/files/patch-libuv-fsevents-leopard.diff
@@ -1,0 +1,35 @@
+diff --git src/unix/fsevents.c src/unix/fsevents.c
+index c430562..7ab55c1 100644
+--- src/unix/fsevents.c
++++ src/unix/fsevents.c
+@@ -40,6 +40,7 @@ void uv__fsevents_loop_delete(uv_loop_t* loop) {
+ 
+ #else /* TARGET_OS_IPHONE */
+ 
++
+ #include <dlfcn.h>
+ #include <assert.h>
+ #include <stdlib.h>
+@@ -48,6 +49,22 @@ void uv__fsevents_loop_delete(uv_loop_t* loop) {
+ #include <CoreFoundation/CFRunLoop.h>
+ #include <CoreServices/CoreServices.h>
+ 
++#if ( MAC_OS_X_VERSION_MAX_ALLOWED < 1070 )
++  #define  kFSEventStreamEventFlagItemCreated       0x00000100
++  #define  kFSEventStreamEventFlagItemRemoved       0x00000200
++  #define  kFSEventStreamEventFlagItemInodeMetaMod  0x00000400
++  #define  kFSEventStreamEventFlagItemRenamed       0x00000800
++  #define  kFSEventStreamEventFlagItemModified      0x00001000
++  #define  kFSEventStreamEventFlagItemFinderInfoMod 0x00002000
++  #define  kFSEventStreamEventFlagItemChangeOwner   0x00004000
++  #define  kFSEventStreamEventFlagItemXattrMod      0x00008000
++  #define  kFSEventStreamEventFlagItemIsFile        0x00010000
++  #define  kFSEventStreamEventFlagItemIsDir         0x00020000
++  #define  kFSEventStreamEventFlagItemIsSymlink     0x00040000
++  #define  kFSEventStreamCreateFlagFileEvents       0x00000010
++#endif
++
++
+ /* These are macros to avoid "initializer element is not constant" errors
+  * with old versions of gcc.
+  */


### PR DESCRIPTION
new patchfile for these versions

This was a pretty simple fix. A few specific tests do fail in the fsevents test suite, but most pass (and actually more than passed with 1.24.1). I might send this upstream if I can get the rest of the tests to pass...