### PR TITLE
Support -devel ports

### DIFF
--- a/science/SoapyHackRF/Portfile
+++ b/science/SoapyHackRF/Portfile
@@ -24,7 +24,7 @@ depends_build-append \
 
 depends_lib-append \
     port:SoapySDR \
-    port:hackrf
+    path:lib/libhackrf.dylib:hackrf
 
 configure.args-append \
     -DCMAKE_BUILD_TYPE=Release

--- a/science/gr-limesdr/Portfile
+++ b/science/gr-limesdr/Portfile
@@ -46,9 +46,10 @@ depends_build-append \
     port:swig-python \
     port:pkgconfig
 
-depends_lib         port:boost \
-                    path:lib/libgnuradio-runtime.dylib:gnuradio \
-                    port:limesuite
+depends_lib-append \
+    port:boost \
+    path:lib/libgnuradio-runtime.dylib:gnuradio \
+    path:lib/libLimeSuite.dylib:limesuite
 
 # remove top-level library path, such that internal libraries are used
 # instead of any already-installed ones.


### PR DESCRIPTION
#### Description

- gr-limesuite: support limesuite and limesuite-devel
- SoapyHackRF: support hackrf and hackrf-devel

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->