### PR TITLE
dovecot2: Add GSSAPI variant

### DIFF
--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -88,6 +88,11 @@ if {${os.platform} eq "darwin" && [vercmp ${os.version} 10.7.0] < 0} {
 }
 configure.cppflags  -I${prefix}/include/openssl
 
+variant gssapi \
+    description "Enable GSSAPI authentication" {
+    configure.args-append       --with-gssapi=yes
+}
+
 variant postgresql82  \
     conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 \
     description "Enable PostgreSQL 8.2 support" {


### PR DESCRIPTION
#### Description

Add `gssapi` variant to `Portfile` for Kerberos authentication support.

> `sudo port install dovecot2 +gssapi`

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->