### PR TITLE
Add http_violations variant

### DIFF
--- a/net/squid4/Portfile
+++ b/net/squid4/Portfile
@@ -148,6 +148,12 @@ variant kerberos description "Enable MIT kerberos support" {
     configure.args-append --enable-auth-negotiate
 }
 
+variant http_violations \
+    description "Enable HTTP Violations" {
+    configure.args-append       --enable-http-violations
+}
+
+
 livecheck.type  regex
 livecheck.url   http://www.squid-cache.org/Versions/v4/
 livecheck.regex "squid-(\[0-9.\]+)-RELEASENOTES\\.html"


### PR DESCRIPTION
#### Description

Add `http_violations` variant to `Portfile`. Configures `squid` using `--with-http-violations`.

See https://trac.macports.org/ticket/58019

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->