### PR TITLE
dependents of hidapi: revbump

### DIFF
--- a/cross/openocd/Portfile
+++ b/cross/openocd/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                openocd
 version             0.10.0
+revision            1
 categories          cross devel
 license             GPL
 maintainers         {snc @nerdling} openmaintainer

--- a/devel/mspdebug/Portfile
+++ b/devel/mspdebug/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dlbeer mspdebug 0.25 v
-revision            1
+revision            2
 maintainers         {g5pw @g5pw} openmaintainer
 categories          devel cross
 description         MSPDebug is a free debugger for use with MSP430 MCUs.

--- a/security/libu2f-host/Portfile
+++ b/security/libu2f-host/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                libu2f-host
 version             1.1.7
+revision            1
 categories          security
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer


### PR DESCRIPTION
#### Description

Needed due to renaming of `hidapi-devel` to `hidapi`.
See https://github.com/macports/macports-ports/pull/4164#pullrequestreview-231642203
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
