### PR TITLE
QtPBFImagePlugin: update to 1.4

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 1.3
+github.setup        tumic0 QtPBFImagePlugin 1.4
 categories          graphics
 platforms           darwin
 license             LGPL-3
@@ -13,9 +13,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  98ee141c2ea52c111fbd6e6fe3c59d4c07dfeae2 \
-                    sha256  a78d4d84467360f94e90cddb3f91ca2c51b7de22834a09ea2239298439930803 \
-                    size    195087
+checksums           rmd160  16c6a09359cb6bbca59c18aa857c4075fda8d5d4 \
+                    sha256  5aa0665b57a06811fbb3c935e0159e8dfe10448b6ec527de89c00e7d09d397a4 \
+                    size    195579
 
 configure.args-append \
                     PROTOBUF=${prefix} ZLIB=${prefix}


### PR DESCRIPTION
#### Description

QtPBFImagePlugin - Update to 1.4

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
