### PR TITLE
minizip2: New port, version 2.8.6

### DIFF
--- a/archivers/minizip2/Portfile
+++ b/archivers/minizip2/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        nmoinvaz minizip 2.8.6
+revision            0
+checksums           rmd160  27595f9ae617be748d3c95e408bfac07f70a7c6e \
+                    sha256  99b72da1330fa61e2f30141e0857111a5e7a2905add2aa58d433393e6e55ba4e \
+                    size    746609
+
+name                minizip2
+categories          archivers
+platforms           darwin
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             zlib
+
+description         Minizip2 zip file manipulation library
+
+long_description    ${description}
+
+depends_lib         port:bzip2 \
+                    port:libiconv \
+                    port:zlib
+
+patchfiles-append   DYLD_LIBRARY_PATH.patch
+patchfiles-append   minizip2.patch
+
+configure.args      -DBUILD_SHARED_LIBS=ON \
+                    -DBZIP2_LIBRARY_RELEASE=${prefix}/lib/libbz2.dylib \
+                    -DIconv_LIBRARY=${prefix}/lib/libiconv.dylib \
+                    -DMZ_BUILD_TEST=ON \
+                    -DMZ_BUILD_UNIT_TEST=ON \
+                    -DZLIB_LIBRARY_RELEASE=${prefix}/lib/libz.dylib
+
+# Disable minizip1 compatibility mode because it would install headers
+# that conflict with the libzip port. This could possibly be fixed by
+# moving them into a minizip2 subdirectory, if I can figure out how to
+# modify CMakeLists.txt to do that.
+configure.args-append \
+                    -DMZ_COMPAT=OFF
+
+test.run            yes

--- a/archivers/minizip2/files/DYLD_LIBRARY_PATH.patch
+++ b/archivers/minizip2/files/DYLD_LIBRARY_PATH.patch
@@ -1,0 +1,90 @@
+Set DYLD_LIBRARY_PATH so the test runner can find and use the library
+that was just built.
+--- CMakeLists.txt.orig	2019-04-08 15:26:32.000000000 -0500
++++ CMakeLists.txt	2019-04-28 19:49:53.000000000 -0500
+@@ -685,30 +685,44 @@
+                      COMMAND minizip_cmd ${COMPRESS_METHOD_ARG} -o ${EXTRA_ARGS}
+                         result.zip test.c test.h empty.txt random.bin uniform.bin fuzz
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(${COMPRESS_METHOD_NAME}-zip-${EXTRA_NAME}
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             add_test(NAME ${COMPRESS_METHOD_NAME}-list-${EXTRA_NAME}
+                      COMMAND minizip_cmd -l ${EXTRA_ARGS} result.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(${COMPRESS_METHOD_NAME}-list-${EXTRA_NAME}
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             if(NOT MZ_COMPRESS_ONLY)
+                 add_test(NAME ${COMPRESS_METHOD_NAME}-unzip-${EXTRA_NAME}
+                          COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out result.zip
+                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++                set_tests_properties(${COMPRESS_METHOD_NAME}-unzip-${EXTRA_NAME}
++                                     PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             endif()
+             add_test(NAME ${COMPRESS_METHOD_NAME}-append-${EXTRA_NAME}
+                     COMMAND minizip_cmd ${COMPRESS_METHOD_ARG} -a ${EXTRA_ARGS}
+                         result.zip single.txt
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(${COMPRESS_METHOD_NAME}-append-${EXTRA_NAME}
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             if(NOT MZ_COMPRESS_ONLY)
+                 add_test(NAME ${COMPRESS_METHOD_NAME}-append-unzip-${EXTRA_NAME}
+                             COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out result.zip
+                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++                set_tests_properties(${COMPRESS_METHOD_NAME}-append-unzip-${EXTRA_NAME}
++                                     PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             endif()
+             add_test(NAME ${COMPRESS_METHOD_NAME}-erase-${EXTRA_NAME}
+                     COMMAND minizip_cmd -o -e result.zip test.c test.h
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(${COMPRESS_METHOD_NAME}-erase-${EXTRA_NAME}
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             if(NOT MZ_COMPRESS_ONLY)
+                 add_test(NAME ${COMPRESS_METHOD_NAME}-erase-unzip-${EXTRA_NAME}
+                          COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out result.zip
+                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++                set_tests_properties(${COMPRESS_METHOD_NAME}-erase-unzip-${EXTRA_NAME}
++                                     PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+             endif()
+         endforeach()
+     endfunction()
+@@ -734,30 +748,40 @@
+                      COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out
+                         fuzz/unzip_fuzzer_seed_corpus/tiny.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(unzip-tiny
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+         endif()
+         if(MZ_BZIP2)
+             add_test(NAME unzip-bzip2
+                      COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out
+                         fuzz/unzip_fuzzer_seed_corpus/bzip2.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(unzip-bzip2
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+         endif()
+         if(MZ_LZMA)
+             add_test(NAME unzip-lzma
+                      COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out
+                         fuzz/unzip_fuzzer_seed_corpus/lzma.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(unzip-lzma
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+         endif()
+         if(MZ_PKCRYPT)
+             add_test(NAME unzip-pkcrypt
+                      COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out -p test123
+                         fuzz/unzip_fuzzer_seed_corpus/encrypted_pkcrypt.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(unzip-pkcrypt
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+         endif()
+         if(MZ_WZAES)
+             add_test(NAME unzip-wzaes
+                      COMMAND minizip_cmd -x -o ${EXTRA_ARGS} -d out -p test123
+                         fuzz/unzip_fuzzer_seed_corpus/encrypted_wzaes.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
++            set_tests_properties(unzip-wzaes
++                                 PROPERTIES ENVIRONMENT DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{DYLD_LIBRARY_PATH})
+         endif()
+     endif()
+ 

--- a/archivers/minizip2/files/minizip2.patch
+++ b/archivers/minizip2/files/minizip2.patch
@@ -1,0 +1,80 @@
+Rename to minizip2. It seems to be agreed that this is what package managers
+should do (so that we can offer minizip and minizip2 at the same time, since
+they are not compatible) and yet upstream does not provide a way to do it.
+
+I hope I've renamed everything I was supposed to rename.
+
+https://github.com/nmoinvaz/minizip/issues/333
+--- CMakeLists.txt.orig	2019-04-08 15:26:32.000000000 -0500
++++ CMakeLists.txt	2019-04-28 16:39:33.000000000 -0500
+@@ -52,9 +52,9 @@
+ set(INSTALL_INC_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR} CACHE PATH "Installation directory for headers")
+ set(INSTALL_MAN_DIR ${CMAKE_INSTALL_FULL_MANDIR} CACHE PATH "Installation directory for manual pages")
+ set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+-set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/minizip" CACHE PATH "Installation directory for cmake files.")
++set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/minizip2" CACHE PATH "Installation directory for cmake files.")
+ 
+-set(MINIZIP_PC ${CMAKE_CURRENT_BINARY_DIR}/minizip.pc)
++set(MINIZIP_PC ${CMAKE_CURRENT_BINARY_DIR}/minizip2.pc)
+ configure_file(minizip.pc.cmakein ${MINIZIP_PC} @ONLY)
+ 
+ # Check if zlib installation is present
+@@ -580,6 +580,7 @@
+ set_target_properties(${PROJECT_NAME} PROPERTIES
+                         VERSION ${VERSION}
+                         SOVERSION ${SOVERSION}
++                        OUTPUT_NAME ${PROJECT_NAME}2
+                         LINKER_LANGUAGE C
+                         DEFINE_SYMBOL "MZ_EXPORTS"
+                         POSITION_INDEPENDENT_CODE 1)
+@@ -643,7 +644,7 @@
+ # Build test executable
+ if(MZ_BUILD_TEST)
+     add_executable(minizip_cmd "minizip.c" "test/test.c" "test/test.h")
+-    set_target_properties(minizip_cmd PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
++    set_target_properties(minizip_cmd PROPERTIES OUTPUT_NAME ${PROJECT_NAME}2)
+     target_link_libraries(minizip_cmd ${PROJECT_NAME})
+ 
+     if(NOT SKIP_INSTALL_BINARIES AND NOT SKIP_INSTALL_ALL)
+--- minizip.c.orig	2019-04-08 15:26:32.000000000 -0500
++++ minizip.c	2019-04-29 16:21:26.000000000 -0500
+@@ -62,14 +62,14 @@
+ 
+ int32_t minizip_banner(void)
+ {
+-    printf("Minizip %s - https://github.com/nmoinvaz/minizip\n", MZ_VERSION);
++    printf("Minizip2 %s - https://github.com/nmoinvaz/minizip\n", MZ_VERSION);
+     printf("---------------------------------------------------\n");
+     return MZ_OK;
+ }
+ 
+ int32_t minizip_help(void)
+ {
+-    printf("Usage : minizip [-x -d dir|-l|-e] [-o] [-c codepage] [-a] [-j] [-0 to -9] [-b|-m] [-k 512] [-p pwd] [-s] file.zip [files]\n\n" \
++    printf("Usage : minizip2 [-x -d dir|-l|-e] [-o] [-c codepage] [-a] [-j] [-0 to -9] [-b|-m] [-k 512] [-p pwd] [-s] file.zip [files]\n\n" \
+            "  -x  Extract files\n" \
+            "  -l  List files\n" \
+            "  -d  Destination directory\n" \
+--- minizip.pc.cmakein.orig	2019-04-08 15:26:32.000000000 -0500
++++ minizip.pc.cmakein	2019-04-28 16:43:41.000000000 -0500
+@@ -1,13 +1,13 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=@INSTALL_LIB_DIR@
+-sharedlibdir=@INSTALL_LIB_DIR@
+-includedir=@INSTALL_INC_DIR@
++exec_prefix=${prefix}
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
+ 
+-Name: minizip
+-Description: Minizip zip file manipulation library
++Name: minizip2
++Description: Minizip2 zip file manipulation library
+ Version: @VERSION@
+ 
+ Requires: zlib
+-Libs: -L${libdir} -L${sharedlibdir} -lminizip
++Libs: -L${libdir} -lminizip2
++Libs.private: -lbz2 -liconv -lz
+ Cflags: -I${includedir}


### PR DESCRIPTION
#### Description

minizip2: New port, version 2.8.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
