### PR TITLE
lyx: depend on port:aspell

### DIFF
--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -21,14 +21,14 @@ long_description    LyX is an advanced open source document processor \
 
 platforms           darwin
 
-depends_build-append    port:bison port:gawk port:cctools \
-                        port:aspell port:hunspell
+depends_build-append    port:bison port:gawk port:cctools
 depends_lib-append      port:enchant \
                         bin:latex:texlive \
                         port:ImageMagick \
                         port:boost \
                         port:hunspell \
-                        port:libmagic
+                        port:libmagic \
+                        port:aspell
 
 use_xz              yes
 distname            lyx-${version}


### PR DESCRIPTION
#### Description

lyx is dynamically linked against libaspell, so the dependency is required at runtime as well:

```
otool -L  /Applications/MacPorts/LyX.app/Contents/MacOS/lyx|grep spell
/opt/local/lib/libhunspell-1.7.0.dylib (compatibility version 1.0.0, current version 1.1.0)
/opt/local/lib/libaspell.15.dylib (compatibility version 17.0.0, current version 17.5.0)
```

Right now, doing a `port reclaim` when no other port depends on aspell, leads do an endless cycle of uninstalling aspell and rebuilding lyx, reinstalling aspell.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
