### PR TITLE
py-oct2py: phase out Python 3.4 and 3.5 support

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -220,6 +220,7 @@ py-ntplib               0.3.1_1     26
 py-numexpr              2.6.6_1     26 33
 py-nvchecker            1.1_1       36
 py-obspy                1.1.0       34
+py-oct2py               4.2.0_1     34 35
 py-openopt              0.29_2      26
 py-packaging            17.1_1      26 33
 py-parsing              2.2.0_1     26 33

--- a/python/py-oct2py/Portfile
+++ b/python/py-oct2py/Portfile
@@ -6,10 +6,11 @@ PortGroup           python 1.0
 
 name                py-oct2py
 
-python.versions     27 34 35 36 37
+python.versions     27 36 37
 python.default_version 27
 
 github.setup        blink1073 oct2py 4.2.0 v
+revision            1
 checksums           rmd160 a064ac2ff4ef0e593abe23ce80de0fb387d027f0 \
                     sha256 d7ab841ea786b7704f44b90b95cf3055731cda487d8fb4769682f5140509f2be \
                     size   438823


### PR DESCRIPTION
#### Description

py-metakernel no longer supports Python 3.4 and 3.5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
N/A
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->