### PR TITLE
ragel: Avoid forcing use of libstdc++

### DIFF
--- a/devel/gnu-extension-headers/Portfile
+++ b/devel/gnu-extension-headers/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                gnu-extension-headers
+version             1.0
+
+categories          lang devel
+platforms           darwin
+license             GPL-3+
+
+maintainers         nomaintainer
+
+description         Provides versions of various GNU extension headers
+long_description    ${description}
+
+livecheck.type      none
+
+supported_archs     noarch 
+
+fetch.type          none
+use_configure       no
+build               {}
+
+destroot {
+    set doc_dir ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 755 -d ${doc_dir}
+    system "echo ${description} > ${doc_dir}/README"
+    set h_dir ${destroot}${prefix}/include/ext
+    xinstall -m 755 -d ${h_dir}
+    foreach f [glob ${filespath}/ext/*] {
+        xinstall -m 644 ${f} ${h_dir}/
+    }
+}

--- a/devel/gnu-extension-headers/files/ext/stdio_filebuf.h
+++ b/devel/gnu-extension-headers/files/ext/stdio_filebuf.h
@@ -1,0 +1,162 @@
+// File descriptor layer for filebuf -*- C++ -*-
+
+// Copyright (C) 2002, 2003, 2004, 2005 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 2, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING.  If not, write to the Free
+// Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+// USA.
+
+// As a special exception, you may use this file as part of a free software
+// library without restriction.  Specifically, if other files instantiate
+// templates or use macros or inline functions from this file, or you compile
+// this file and link it with other files to produce an executable, this
+// file does not by itself cause the resulting executable to be covered by
+// the GNU General Public License.  This exception does not however
+// invalidate any other reasons why the executable file might be covered by
+// the GNU General Public License.
+
+/** @file ext/stdio_filebuf.h
+ *  This file is a GNU extension to the Standard C++ Library.
+ */
+
+#ifndef _STDIO_FILEBUF_H
+#define _STDIO_FILEBUF_H 1
+
+#pragma GCC system_header
+
+#include <fstream>
+
+namespace __gnu_cxx {
+
+  /**
+   *  @brief Provides a layer of compatibility for C/POSIX.
+   *
+   *  This GNU extension provides extensions for working with standard C
+   *  FILE*'s and POSIX file descriptors.  It must be instantiated by the
+   *  user with the type of character used in the file stream, e.g.,
+   *  stdio_filebuf<char>.
+  */
+  template<typename _CharT, typename _Traits = std::char_traits<_CharT> >
+    class stdio_filebuf : public std::basic_filebuf<_CharT, _Traits>
+    {
+    public:
+      // Types:
+      typedef _CharT				        char_type;
+      typedef _Traits				        traits_type;
+      typedef typename traits_type::int_type		int_type;
+      typedef typename traits_type::pos_type		pos_type;
+      typedef typename traits_type::off_type		off_type;
+      typedef std::size_t                               size_t;
+
+    public:
+      /**
+       * deferred initialization
+      */
+      stdio_filebuf() : std::basic_filebuf<_CharT, _Traits>() {}
+
+      /**
+       *  @param  fd  An open file descriptor.
+       *  @param  mode  Same meaning as in a standard filebuf.
+       *  @param  size  Optimal or preferred size of internal buffer, in chars.
+       *
+       *  This constructor associates a file stream buffer with an open
+       *  POSIX file descriptor. The file descriptor will be automatically
+       *  closed when the stdio_filebuf is closed/destroyed.
+      */
+      stdio_filebuf(int __fd, std::ios_base::openmode __mode,
+		    size_t __size = static_cast<size_t>(BUFSIZ));
+
+      /**
+       *  @param  f  An open @c FILE*.
+       *  @param  mode  Same meaning as in a standard filebuf.
+       *  @param  size  Optimal or preferred size of internal buffer, in chars.
+       *                Defaults to system's @c BUFSIZ.
+       *
+       *  This constructor associates a file stream buffer with an open
+       *  C @c FILE*.  The @c FILE* will not be automatically closed when the
+       *  stdio_filebuf is closed/destroyed.
+      */
+      stdio_filebuf(FILE* __f, std::ios_base::openmode __mode,
+		    size_t __size = static_cast<size_t>(BUFSIZ));
+
+      /**
+       *  Closes the external data stream if the file descriptor constructor
+       *  was used.
+      */
+      virtual
+      ~stdio_filebuf();
+
+      /**
+       *  @return  The underlying file descriptor.
+       *
+       *  Once associated with an external data stream, this function can be
+       *  used to access the underlying POSIX file descriptor.  Note that
+       *  there is no way for the library to track what you do with the
+       *  descriptor, so be careful.
+      */
+      int
+      fd() { return this->_M_file.fd(); }
+
+      /**
+       *  @return  The underlying FILE*.
+       *
+       *  This function can be used to access the underlying "C" file pointer.
+       *  Note that there is no way for the library to track what you do
+       *  with the file, so be careful.
+       */
+      FILE*
+      file() { return this->_M_file.file(); }
+    };
+
+  template<typename _CharT, typename _Traits>
+    stdio_filebuf<_CharT, _Traits>::~stdio_filebuf()
+    { }
+
+  template<typename _CharT, typename _Traits>
+    stdio_filebuf<_CharT, _Traits>::
+    stdio_filebuf(int __fd, std::ios_base::openmode __mode, size_t __size)
+    {
+      this->_M_file.sys_open(__fd, __mode);
+      if (this->is_open())
+	{
+	  this->_M_mode = __mode;
+	  this->_M_buf_size = __size;
+	  this->_M_allocate_internal_buffer();
+	  this->_M_reading = false;
+	  this->_M_writing = false;
+	  this->_M_set_buffer(-1);
+	}
+    }
+
+  template<typename _CharT, typename _Traits>
+    stdio_filebuf<_CharT, _Traits>::
+    stdio_filebuf(FILE* __f, std::ios_base::openmode __mode,
+		  size_t __size)
+    {
+      this->_M_file.sys_open(__f, __mode);
+      if (this->is_open())
+	{
+	  this->_M_mode = __mode;
+	  this->_M_buf_size = __size;
+	  this->_M_allocate_internal_buffer();
+	  this->_M_reading = false;
+	  this->_M_writing = false;
+	  this->_M_set_buffer(-1);
+	}
+    }
+
+}
+
+#endif

--- a/lang/ragel/Portfile
+++ b/lang/ragel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ragel
 version             7.0.0.11
-revision            1
+revision            2
 categories          lang devel
 platforms           darwin
 license             MIT
@@ -27,10 +27,16 @@ checksums           rmd160  5f357270929cd5de16e81451b396e7605d2ec6b0 \
                     sha256  08bac6ff8ea9ee7bdd703373fe4d39274c87fecf7ae594774dfdc4f4dd4a5340 \
                     size    1531490
 
-depends_lib-append  port:colm
+# Needed for 'ext/stdio_filebuf.h'
+depends_build-append port:gnu-extension-headers
+# make sure gnu-extension-headers port is removed post installation
+post-install {
+    if { ![catch {set vers [lindex [registry_active gnu-extension-headers] 0]}] } {
+        registry_deactivate_composite gnu-extension-headers "" [list ports_nodepcheck 1]
+    }
+}
 
-# fatal error: 'ext/stdio_filebuf.h' file not found
-configure.cxx_stdlib libstdc++
+depends_lib-append  port:colm
 
 livecheck.type      regex
 livecheck.url       ${homepage}


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/58321

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G6030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
