### PR TITLE
xorg-server: enable automake 'subdir-objects'

### DIFF
--- a/x11/xorg-server-1.18/Portfile
+++ b/x11/xorg-server-1.18/Portfile
@@ -94,6 +94,10 @@ patchfiles \
         5004-fb-Revert-fb-changes-that-broke-XQuartz.patch \
         5005-fb-Revert-fb-changes-that-broke-XQuartz.patch
 
+# enables the automake option "subdir-objects" so that automake
+# doesn't complain about subdirectory *.in replacement files usage.
+patchfiles-append 2001-enable-automake-subdir-objects.patch
+
 patch.pre_args -p1
 
 platform darwin 8 {

--- a/x11/xorg-server-1.18/files/0003-os-connection-Improve-abstraction-for-launchd-secure.patch
+++ b/x11/xorg-server-1.18/files/0003-os-connection-Improve-abstraction-for-launchd-secure.patch
@@ -28,7 +28,7 @@ index a901ebf..ac7d12b 100644
  #ifndef WIN32
  #include <sys/socket.h>
  
-@@ -1112,15 +1114,34 @@ MakeClientGrabPervious(ClientPtr client)
+@@ -1267,15 +1269,34 @@
  void
  ListenOnOpenFD(int fd, int noxauth)
  {

--- a/x11/xorg-server-1.18/files/1001-XQuartz-Hack-around-an-issue-that-can-occur-on-macOS.patch
+++ b/x11/xorg-server-1.18/files/1001-XQuartz-Hack-around-an-issue-that-can-occur-on-macOS.patch
@@ -16,7 +16,7 @@ diff --git a/hw/xquartz/X11Application.m b/hw/xquartz/X11Application.m
 index 768eecf68..821e1c5a1 100644
 --- a/hw/xquartz/X11Application.m
 +++ b/hw/xquartz/X11Application.m
-@@ -275,13 +275,32 @@ message_kit_thread(SEL selector, NSObject *arg)
+@@ -276,13 +276,32 @@
              if (_x_active) [self activateX:NO];
          }
          else if ([self modalWindow] == nil) {

--- a/x11/xorg-server-1.18/files/2001-enable-automake-subdir-objects.patch
+++ b/x11/xorg-server-1.18/files/2001-enable-automake-subdir-objects.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -31,7 +31,7 @@
+ RELEASE_NAME="Skordalia"
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_MACRO_DIR([m4])
+-AM_INIT_AUTOMAKE([foreign dist-bzip2])
++AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+ # Require xorg-macros minimum of 1.14 for XORG_COMPILER_BRAND in XORG_DEFAULT_OPTIONS

--- a/x11/xorg-server-devel/Portfile
+++ b/x11/xorg-server-devel/Portfile
@@ -109,6 +109,10 @@ patchfiles-append \
 # https://bugzilla.freedesktop.org/show_bug.cgi?id=107555
 patchfiles-append 5008-fix-calloc-free-mis-match-bug.patch
 
+# enables the automake option "subdir-objects" so that automake
+# doesn't complain about subdirectory *.in replacement files usage.
+patchfiles-append 2001-enable-automake-subdir-objects.patch
+
 patch.pre_args -p1
 
 platform darwin 8 {

--- a/x11/xorg-server-devel/files/0001-os-connection-Improve-abstraction-for-launchd-secure.patch
+++ b/x11/xorg-server-devel/files/0001-os-connection-Improve-abstraction-for-launchd-secure.patch
@@ -29,7 +29,7 @@ index a901ebf..0d42184 100644
  #ifndef WIN32
  #include <sys/socket.h>
  
-@@ -1112,15 +1114,34 @@ MakeClientGrabPervious(ClientPtr client)
+@@ -992,15 +994,34 @@
  void
  ListenOnOpenFD(int fd, int noxauth)
  {

--- a/x11/xorg-server-devel/files/0002-randr-Initialize-RandR-even-if-there-are-currently-n.patch
+++ b/x11/xorg-server-devel/files/0002-randr-Initialize-RandR-even-if-there-are-currently-n.patch
@@ -33,7 +33,7 @@ diff --git a/randr/randr.c b/randr/randr.c
 index 0138dc1..efd3859 100644
 --- a/randr/randr.c
 +++ b/randr/randr.c
-@@ -387,9 +387,6 @@ RRExtensionInit(void)
+@@ -414,9 +414,6 @@
  {
      ExtensionEntry *extEntry;
  

--- a/x11/xorg-server-devel/files/2001-enable-automake-subdir-objects.patch
+++ b/x11/xorg-server-devel/files/2001-enable-automake-subdir-objects.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -31,7 +31,7 @@
+ RELEASE_NAME="Chestnut Tortelloni"
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_MACRO_DIR([m4])
+-AM_INIT_AUTOMAKE([foreign dist-bzip2])
++AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+ # Require xorg-macros minimum of 1.14 for XORG_COMPILER_BRAND in XORG_DEFAULT_OPTIONS

--- a/x11/xorg-server-devel/files/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
+++ b/x11/xorg-server-devel/files/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
@@ -17,7 +17,7 @@ diff --git a/hw/xfree86/Makefile.am b/hw/xfree86/Makefile.am
 index 85bd0be..6de7c10 100644
 --- a/hw/xfree86/Makefile.am
 +++ b/hw/xfree86/Makefile.am
-@@ -48,8 +48,7 @@ DIST_SUBDIRS = common ddc i2c x86emu int10 fbdevhw os-support \
+@@ -52,8 +52,7 @@
  bin_PROGRAMS = Xorg
  nodist_Xorg_SOURCES = sdksyms.c
  
@@ -27,7 +27,7 @@ index 85bd0be..6de7c10 100644
  	-I$(srcdir)/ddc -I$(srcdir)/i2c -I$(srcdir)/modes -I$(srcdir)/ramdac \
  	-I$(srcdir)/dri -I$(srcdir)/dri2 -I$(top_srcdir)/dri3
  
-@@ -137,7 +136,7 @@ CLEANFILES = sdksyms.c sdksyms.dep Xorg.sh
+@@ -142,7 +141,7 @@
  EXTRA_DIST += sdksyms.sh
  
  sdksyms.dep sdksyms.c: sdksyms.sh

--- a/x11/xorg-server-devel/files/5001-Revert-dix-Restore-PaintWindow-screen-hook.patch
+++ b/x11/xorg-server-devel/files/5001-Revert-dix-Restore-PaintWindow-screen-hook.patch
@@ -24,7 +24,7 @@ diff --git a/composite/compwindow.c b/composite/compwindow.c
 index 344138a..77bdfa2 100644
 --- a/composite/compwindow.c
 +++ b/composite/compwindow.c
-@@ -104,7 +104,7 @@ compRepaintBorder(ClientPtr pClient, void *closure)
+@@ -105,7 +105,7 @@
  
          RegionNull(&exposed);
          RegionSubtract(&exposed, &pWindow->borderClip, &pWindow->winSize);
@@ -59,7 +59,7 @@ diff --git a/hw/xquartz/quartz.c b/hw/xquartz/quartz.c
 index c8b6f96..2def8e3 100644
 --- a/hw/xquartz/quartz.c
 +++ b/hw/xquartz/quartz.c
-@@ -300,8 +300,8 @@ QuartzUpdateScreens(void)
+@@ -280,8 +280,8 @@
  
      quartzProcs->UpdateScreen(pScreen);
  
@@ -98,7 +98,7 @@ index 2e617c4..a627fe7 100644
  typedef void (*CopyWindowProcPtr) (WindowPtr /*pWindow */ ,
                                     DDXPointRec /*ptOldOrg */ ,
                                     RegionPtr /*prgnSrc */ );
-@@ -502,7 +498,6 @@ typedef struct _Screen {
+@@ -544,7 +540,6 @@
      ClearToBackgroundProcPtr ClearToBackground;
      ClipNotifyProcPtr ClipNotify;
      RestackWindowProcPtr RestackWindow;

--- a/x11/xorg-server-devel/files/5003-Use-old-miTrapezoids-and-miTriangles-routines.patch
+++ b/x11/xorg-server-devel/files/5003-Use-old-miTrapezoids-and-miTriangles-routines.patch
@@ -22,7 +22,7 @@ diff --git a/fb/fbpict.c b/fb/fbpict.c
 index 7ea0b66..434d890 100644
 --- a/fb/fbpict.c
 +++ b/fb/fbpict.c
-@@ -508,10 +508,8 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+@@ -498,10 +498,8 @@
      ps->UnrealizeGlyph = fbUnrealizeGlyph;
      ps->CompositeRects = miCompositeRects;
      ps->RasterizeTrapezoid = fbRasterizeTrapezoid;

--- a/x11/xorg-server-devel/files/5004-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/x11/xorg-server-devel/files/5004-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -24,7 +24,7 @@ diff --git a/fb/fb.h b/fb/fb.h
 index c687aa7..256a1ee 100644
 --- a/fb/fb.h
 +++ b/fb/fb.h
-@@ -1321,8 +1321,7 @@ fbFillRegionSolid(DrawablePtr pDrawable,
+@@ -1149,8 +1149,7 @@
                    RegionPtr pRegion, FbBits and, FbBits xor);
  
  extern _X_EXPORT pixman_image_t *image_from_pict(PicturePtr pict,
@@ -67,7 +67,7 @@ index 434d890..be8274b 100644
      }
  
      free_pixman_pict(pSrc, src);
-@@ -289,20 +284,22 @@ create_conical_gradient_image(PictGradient * gradient)
+@@ -279,20 +274,22 @@
  }
  
  static pixman_image_t *
@@ -97,7 +97,7 @@ index 434d890..be8274b 100644
                                       stride * sizeof(FbStride));
  
      if (!image)
-@@ -321,28 +318,21 @@ create_bits_picture(PicturePtr pict, Bool has_clip, int *xoff, int *yoff)
+@@ -311,28 +308,21 @@
          if (pict->clientClip)
              pixman_image_set_has_client_clip(image, TRUE);
  
@@ -128,7 +128,7 @@ index 434d890..be8274b 100644
                                                  Bool is_alpha_map);
  
  static void image_destroy(pixman_image_t *image, void *data)
-@@ -351,32 +341,13 @@ static void image_destroy(pixman_image_t *image, void *data)
+@@ -341,32 +331,13 @@
  }
  
  static void
@@ -163,7 +163,7 @@ index 434d890..be8274b 100644
      }
  
      switch (pict->repeatType) {
-@@ -404,10 +375,8 @@ set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+@@ -394,10 +365,8 @@
       * as the alpha map for this operation
       */
      if (pict->alphaMap && !is_alpha_map) {
@@ -175,7 +175,7 @@ index 434d890..be8274b 100644
  
          pixman_image_set_alpha_map(image, alpha_map, pict->alphaOrigin.x,
                                     pict->alphaOrigin.y);
-@@ -445,8 +414,7 @@ set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+@@ -435,8 +404,7 @@
  }
  
  static pixman_image_t *
@@ -185,7 +185,7 @@ index 434d890..be8274b 100644
  {
      pixman_image_t *image = NULL;
  
-@@ -454,7 +422,7 @@ image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+@@ -444,7 +412,7 @@
          return NULL;
  
      if (pict->pDrawable) {
@@ -194,7 +194,7 @@ index 434d890..be8274b 100644
      }
      else if (pict->pSourcePict) {
          SourcePict *sp = pict->pSourcePict;
-@@ -472,19 +440,17 @@ image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+@@ -462,19 +430,17 @@
              else if (sp->type == SourcePictTypeConical)
                  image = create_conical_gradient_image(gradient);
          }

--- a/x11/xorg-server-devel/files/5005-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/x11/xorg-server-devel/files/5005-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -23,7 +23,7 @@ diff --git a/fb/fb.h b/fb/fb.h
 index 256a1ee..8e87498 100644
 --- a/fb/fb.h
 +++ b/fb/fb.h
-@@ -1111,9 +1111,6 @@ extern _X_EXPORT void
+@@ -952,9 +952,6 @@
  extern _X_EXPORT Bool
   fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats);
  
@@ -190,7 +190,7 @@ index be8274b..66dd633 100644
  static pixman_image_t *
  create_solid_fill_image(PicturePtr pict)
  {
-@@ -470,8 +324,7 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+@@ -460,8 +314,7 @@
          return FALSE;
      ps = GetPictureScreen(pScreen);
      ps->Composite = fbComposite;
@@ -204,7 +204,7 @@ diff --git a/fb/fbpict.h b/fb/fbpict.h
 index 5cb8663..110f32d 100644
 --- a/fb/fbpict.h
 +++ b/fb/fbpict.h
-@@ -65,20 +65,11 @@ fbTrapezoids(CARD8 op,
+@@ -60,20 +60,11 @@
               INT16 xSrc, INT16 ySrc, int ntrap, xTrapezoid * traps);
  
  extern _X_EXPORT void

--- a/x11/xorg-server/Portfile
+++ b/x11/xorg-server/Portfile
@@ -103,6 +103,10 @@ patchfiles-append \
 # https://bugzilla.freedesktop.org/show_bug.cgi?id=107555
 patchfiles-append 5008-fix-calloc-free-mis-match-bug.patch
 
+# enables the automake option "subdir-objects" so that automake
+# doesn't complain about subdirectory *.in replacement files usage.
+patchfiles-append 2001-enable-automake-subdir-objects.patch
+
 patch.pre_args -p1
 
 platform darwin 8 {

--- a/x11/xorg-server/files/0001-os-connection-Improve-abstraction-for-launchd-secure.patch
+++ b/x11/xorg-server/files/0001-os-connection-Improve-abstraction-for-launchd-secure.patch
@@ -29,7 +29,7 @@ index a901ebf..0d42184 100644
  #ifndef WIN32
  #include <sys/socket.h>
  
-@@ -1112,15 +1114,34 @@ MakeClientGrabPervious(ClientPtr client)
+@@ -992,15 +994,34 @@
  void
  ListenOnOpenFD(int fd, int noxauth)
  {

--- a/x11/xorg-server/files/0002-randr-Initialize-RandR-even-if-there-are-currently-n.patch
+++ b/x11/xorg-server/files/0002-randr-Initialize-RandR-even-if-there-are-currently-n.patch
@@ -33,7 +33,7 @@ diff --git a/randr/randr.c b/randr/randr.c
 index 0138dc1..efd3859 100644
 --- a/randr/randr.c
 +++ b/randr/randr.c
-@@ -387,9 +387,6 @@ RRExtensionInit(void)
+@@ -414,9 +414,6 @@
  {
      ExtensionEntry *extEntry;
  

--- a/x11/xorg-server/files/2001-enable-automake-subdir-objects.patch
+++ b/x11/xorg-server/files/2001-enable-automake-subdir-objects.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -31,7 +31,7 @@
+ RELEASE_NAME="Chestnut Tortelloni"
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_MACRO_DIR([m4])
+-AM_INIT_AUTOMAKE([foreign dist-bzip2])
++AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+ # Require xorg-macros minimum of 1.14 for XORG_COMPILER_BRAND in XORG_DEFAULT_OPTIONS

--- a/x11/xorg-server/files/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
+++ b/x11/xorg-server/files/5000-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
@@ -17,7 +17,7 @@ diff --git a/hw/xfree86/Makefile.am b/hw/xfree86/Makefile.am
 index 85bd0be..6de7c10 100644
 --- a/hw/xfree86/Makefile.am
 +++ b/hw/xfree86/Makefile.am
-@@ -48,8 +48,7 @@ DIST_SUBDIRS = common ddc i2c x86emu int10 fbdevhw os-support \
+@@ -52,8 +52,7 @@
  bin_PROGRAMS = Xorg
  nodist_Xorg_SOURCES = sdksyms.c
  
@@ -27,7 +27,7 @@ index 85bd0be..6de7c10 100644
  	-I$(srcdir)/ddc -I$(srcdir)/i2c -I$(srcdir)/modes -I$(srcdir)/ramdac \
  	-I$(srcdir)/dri -I$(srcdir)/dri2 -I$(top_srcdir)/dri3
  
-@@ -137,7 +136,7 @@ CLEANFILES = sdksyms.c sdksyms.dep Xorg.sh
+@@ -142,7 +141,7 @@
  EXTRA_DIST += sdksyms.sh
  
  sdksyms.dep sdksyms.c: sdksyms.sh

--- a/x11/xorg-server/files/5001-Revert-dix-Restore-PaintWindow-screen-hook.patch
+++ b/x11/xorg-server/files/5001-Revert-dix-Restore-PaintWindow-screen-hook.patch
@@ -24,7 +24,7 @@ diff --git a/composite/compwindow.c b/composite/compwindow.c
 index 344138a..77bdfa2 100644
 --- a/composite/compwindow.c
 +++ b/composite/compwindow.c
-@@ -104,7 +104,7 @@ compRepaintBorder(ClientPtr pClient, void *closure)
+@@ -105,7 +105,7 @@
  
          RegionNull(&exposed);
          RegionSubtract(&exposed, &pWindow->borderClip, &pWindow->winSize);
@@ -59,7 +59,7 @@ diff --git a/hw/xquartz/quartz.c b/hw/xquartz/quartz.c
 index c8b6f96..2def8e3 100644
 --- a/hw/xquartz/quartz.c
 +++ b/hw/xquartz/quartz.c
-@@ -300,8 +300,8 @@ QuartzUpdateScreens(void)
+@@ -280,8 +280,8 @@
  
      quartzProcs->UpdateScreen(pScreen);
  
@@ -98,7 +98,7 @@ index 2e617c4..a627fe7 100644
  typedef void (*CopyWindowProcPtr) (WindowPtr /*pWindow */ ,
                                     DDXPointRec /*ptOldOrg */ ,
                                     RegionPtr /*prgnSrc */ );
-@@ -502,7 +498,6 @@ typedef struct _Screen {
+@@ -544,7 +540,6 @@
      ClearToBackgroundProcPtr ClearToBackground;
      ClipNotifyProcPtr ClipNotify;
      RestackWindowProcPtr RestackWindow;

--- a/x11/xorg-server/files/5003-Use-old-miTrapezoids-and-miTriangles-routines.patch
+++ b/x11/xorg-server/files/5003-Use-old-miTrapezoids-and-miTriangles-routines.patch
@@ -22,7 +22,7 @@ diff --git a/fb/fbpict.c b/fb/fbpict.c
 index 7ea0b66..434d890 100644
 --- a/fb/fbpict.c
 +++ b/fb/fbpict.c
-@@ -508,10 +508,8 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+@@ -498,10 +498,8 @@
      ps->UnrealizeGlyph = fbUnrealizeGlyph;
      ps->CompositeRects = miCompositeRects;
      ps->RasterizeTrapezoid = fbRasterizeTrapezoid;

--- a/x11/xorg-server/files/5004-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/x11/xorg-server/files/5004-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -24,7 +24,7 @@ diff --git a/fb/fb.h b/fb/fb.h
 index c687aa7..256a1ee 100644
 --- a/fb/fb.h
 +++ b/fb/fb.h
-@@ -1321,8 +1321,7 @@ fbFillRegionSolid(DrawablePtr pDrawable,
+@@ -1149,8 +1149,7 @@
                    RegionPtr pRegion, FbBits and, FbBits xor);
  
  extern _X_EXPORT pixman_image_t *image_from_pict(PicturePtr pict,
@@ -67,7 +67,7 @@ index 434d890..be8274b 100644
      }
  
      free_pixman_pict(pSrc, src);
-@@ -289,20 +284,22 @@ create_conical_gradient_image(PictGradient * gradient)
+@@ -279,20 +274,22 @@
  }
  
  static pixman_image_t *
@@ -97,7 +97,7 @@ index 434d890..be8274b 100644
                                       stride * sizeof(FbStride));
  
      if (!image)
-@@ -321,28 +318,21 @@ create_bits_picture(PicturePtr pict, Bool has_clip, int *xoff, int *yoff)
+@@ -311,28 +308,21 @@
          if (pict->clientClip)
              pixman_image_set_has_client_clip(image, TRUE);
  
@@ -128,7 +128,7 @@ index 434d890..be8274b 100644
                                                  Bool is_alpha_map);
  
  static void image_destroy(pixman_image_t *image, void *data)
-@@ -351,32 +341,13 @@ static void image_destroy(pixman_image_t *image, void *data)
+@@ -341,32 +331,13 @@
  }
  
  static void
@@ -163,7 +163,7 @@ index 434d890..be8274b 100644
      }
  
      switch (pict->repeatType) {
-@@ -404,10 +375,8 @@ set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+@@ -394,10 +365,8 @@
       * as the alpha map for this operation
       */
      if (pict->alphaMap && !is_alpha_map) {
@@ -175,7 +175,7 @@ index 434d890..be8274b 100644
  
          pixman_image_set_alpha_map(image, alpha_map, pict->alphaOrigin.x,
                                     pict->alphaOrigin.y);
-@@ -445,8 +414,7 @@ set_image_properties(pixman_image_t * image, PicturePtr pict, Bool has_clip,
+@@ -435,8 +404,7 @@
  }
  
  static pixman_image_t *
@@ -185,7 +185,7 @@ index 434d890..be8274b 100644
  {
      pixman_image_t *image = NULL;
  
-@@ -454,7 +422,7 @@ image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+@@ -444,7 +412,7 @@
          return NULL;
  
      if (pict->pDrawable) {
@@ -194,7 +194,7 @@ index 434d890..be8274b 100644
      }
      else if (pict->pSourcePict) {
          SourcePict *sp = pict->pSourcePict;
-@@ -472,19 +440,17 @@ image_from_pict_internal(PicturePtr pict, Bool has_clip, int *xoff, int *yoff,
+@@ -462,19 +430,17 @@
              else if (sp->type == SourcePictTypeConical)
                  image = create_conical_gradient_image(gradient);
          }

--- a/x11/xorg-server/files/5005-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/x11/xorg-server/files/5005-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -23,7 +23,7 @@ diff --git a/fb/fb.h b/fb/fb.h
 index 256a1ee..8e87498 100644
 --- a/fb/fb.h
 +++ b/fb/fb.h
-@@ -1111,9 +1111,6 @@ extern _X_EXPORT void
+@@ -952,9 +952,6 @@
  extern _X_EXPORT Bool
   fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats);
  
@@ -190,7 +190,7 @@ index be8274b..66dd633 100644
  static pixman_image_t *
  create_solid_fill_image(PicturePtr pict)
  {
-@@ -470,8 +324,7 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+@@ -460,8 +314,7 @@
          return FALSE;
      ps = GetPictureScreen(pScreen);
      ps->Composite = fbComposite;
@@ -204,7 +204,7 @@ diff --git a/fb/fbpict.h b/fb/fbpict.h
 index 5cb8663..110f32d 100644
 --- a/fb/fbpict.h
 +++ b/fb/fbpict.h
-@@ -65,20 +65,11 @@ fbTrapezoids(CARD8 op,
+@@ -60,20 +60,11 @@
               INT16 xSrc, INT16 ySrc, int ntrap, xTrapezoid * traps);
  
  extern _X_EXPORT void


### PR DESCRIPTION
#### Description

enable automake 'subdir-objects' option to stop configuration warnings. These warnings do not impact the build or install, so no rev-upgrade needed.

also clean up current patches so that they apply cleanly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

and

macOS 10.4.11 8S165 (PPC)
Xcode 2.4.1 8M1910 (for 10.4 PPC only)

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
