### PR TITLE
php4: mark apache22 variant as obsolete

### DIFF
--- a/lang/php4/Portfile
+++ b/lang/php4/Portfile
@@ -128,12 +128,9 @@ variant apache2 conflicts apache22 no_web description {Add Apache 2.4 web server
 }
 
 variant apache22 conflicts apache2 no_web description {Add Apache 2.2 web server module} {
-    require_active_variants apache22 preforkmpm
-    destroot.violate_mtree  yes
-    depends_lib-append \
-        port:apache22
-    configure.args-append \
-        --with-apxs2=${prefix}/apache22/bin/apxs
+    # remove after 2020-04-30
+    ui_error "Please do not install this variant since Apache 2.2 is obsolete."
+    return -code error
 }
 
 variant fastcgi conflicts no_web description {Add FastCGI web server binary} {
@@ -236,7 +233,7 @@ variant xslt description {Add XSLT support using Sablotron} {
 }
 
 if {![variant_isset apache2] && ![variant_isset apache22] && ![variant_isset fastcgi] && ![variant_isset no_web]} {
-    default_variants +apache22
+    default_variants +apache2
 }
 
 variant readline description {Add GNU readline functions} {


### PR DESCRIPTION
See: https://trac.macports.org/ticket/58404

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] EOL of dependency

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
N/A
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
