### PR TITLE
litecli: new port

### DIFF
--- a/databases/litecli/Portfile
+++ b/databases/litecli/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        dbcli litecli 1.0.0 v
+revision            0
+
+categories          databases python
+maintainers         nomaintainer
+license             BSD
+platforms           darwin
+supported_archs     noarch
+description         CLI for SQLite Databases with auto-completion and syntax highlighting
+long_description    ${description}
+
+homepage            https://litecli.com/
+
+checksums           rmd160  a3fc906e63f010eb92dd2bd5d55cdf7d12525a81 \
+                    sha256  59d652d868ab7525126c7c72b6a39259857f850fdbbe7e2b95c3f4dcc42f1601 \
+                    size    881824
+
+variant python35 conflicts python36 python37 description "Use Python 3.5" {}
+variant python36 conflicts python35 python37 description "Use Python 3.6" {}
+variant python37 conflicts python35 python36 description "Use Python 3.7" {}
+
+if {[variant_isset python35]} {
+    python.default_version 35
+} elseif {[variant_isset python36]} {
+    python.default_version 36
+} else {
+    default_variants +python37
+    python.default_version 37
+}
+
+depends_lib-append  port:py${python.version}-cli-helpers \
+                    port:py${python.version}-click \
+                    port:py${python.version}-configobj \
+                    port:py${python.version}-prompt_toolkit \
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-sqlparse
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE changelog.md ${destroot}${docdir}
+}


### PR DESCRIPTION
#### Description

Another great DB cli from https://github.com/dbcli, this time for sqlite.

Original description:

> CLI for SQLite Databases with auto-completion and syntax highlighting

website: https://litecli.com, github: https://github.com/dbcli/litecli

I made this port available only with Python >=3.5 variants because litecli requires py-prompt_toolkit
in version 2.x from early stages and Python2.7 and 3.4 has this module pinned to 1.0.15.

py-promt_toolkit issue was discussed here: https://trac.macports.org/ticket/57933, and pinning was added in this PR #3845

@xeron you maintain both pgcli and mycli, would you like to be added as a maintainer to litecli as well?

###### Tested on

macOS 10.14.4
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
