### PR TITLE
extractpdfmark: update to version 1.1.0

### DIFF
--- a/textproc/extractpdfmark/Portfile
+++ b/textproc/extractpdfmark/Portfile
@@ -5,8 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
-github.setup        trueroad extractpdfmark 1.0.3 v
-revision            3
+github.setup        trueroad extractpdfmark 1.1.0 v
 categories          textproc
 platforms           darwin
 license             GPL-3+
@@ -23,9 +22,9 @@ long_description    This tool helps ghostscript circumvent a bug while \
 
 github.tarball_from releases
 
-checksums           rmd160  10604d733f3fbe20f3a39a496894a99d4615ee89 \
-                    sha256  af81f08604ea91162451d08d818f13d3f443c33832e8b9ab8ded033fde2b0298 \
-                    size    298040
+checksums           rmd160  8d6dd90de6f4f555012bd6edd8ac4e00dfc356fc \
+                    sha256  0935045084211fcf68a9faaba2b65c037d0adfd7fa27224d2b6c7ae0fd7964cb \
+                    size    308226
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
As of this version, extractpdfmark uses poppler's libpoppler-cpp
rather than the core libpoppler used in the past. This fixes the build
with poppler 0.76.0 and hopefully future versions of poppler as well.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
