### PR TITLE
wrk: update to 4.1.0

### DIFF
--- a/net/wrk/Portfile
+++ b/net/wrk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compilers 1.0
 
-github.setup        wg wrk 4.0.2
+github.setup        wg wrk 4.1.0
 
 categories          net
 platforms           darwin
@@ -14,14 +14,16 @@ description         wrk HTTP benchmarking tool
 long_description    wrk is a modern HTTP benchmarking tool with optional LuaJIT HTTP request generation.
 homepage            https://github.com/wg/wrk
 
-checksums           rmd160  cb6bab30379d5798d9c124ece099fcff631456c9 \
-                    sha256  67722d1066dae9e6bbead42f22065d4a5eb6f060b1b4bcbfb811132c7b06d530
+checksums           rmd160  66508bc4bea66d7731510164037beaac5fe44de5 \
+                    sha256  49c309c834c484243d1f381505e7723326c5a9b6e328d88adef9ead804c8d83e \
+                    size    6478150
 
 depends_build-append    port:perl5
 
 build.args-append       CC=${configure.cc} \
                         CXX=${configure.cxx} \
-                        CPP=${configure.cpp}
+                        CPP=${configure.cpp} \
+                        VER=${version}
 
 # Avoid configure phase
 use_configure no


### PR DESCRIPTION
#### Description

Updated to recent release and fixed issue with wrk not printing version when using `-v|--version` flag.

before:

```
wrk  [kqueue] Copyright (C) 2012 Will Glozer
...
```

now: 

```
wrk 4.1.0 [kqueue] Copyright (C) 2012 Will Glozer
...
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.4
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
