### PR TITLE
socat: update to 1.7.3.3 and fix livecheck

### DIFF
--- a/sysutils/socat/Portfile
+++ b/sysutils/socat/Portfile
@@ -28,3 +28,7 @@ use_bzip2 yes
 
 depends_lib     port:readline \
                 path:lib/libssl.dylib:openssl
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"

--- a/sysutils/socat/Portfile
+++ b/sysutils/socat/Portfile
@@ -3,8 +3,8 @@
 PortSystem 1.0
 
 name            socat
-version         1.7.3.2
-revision        2
+version         1.7.3.3
+revision        0
 categories      sysutils net
 license         {GPL-2 OpenSSLException}
 maintainers     {g5pw @g5pw} openmaintainer
@@ -21,13 +21,16 @@ long_description        \
 homepage        http://www.dest-unreach.org/socat/
 master_sites    http://www.dest-unreach.org/socat/download/
 
-checksums       rmd160  765c88c8cfdcda48bec5093b812cabfce99f25b5 \
-                sha256  e3561f808739383eb10fada1e5d4f26883f0311b34fd0af7837d0c95ef379251
+checksums       rmd160  692b2d350b38355ad4d9d50c32ee7eb076e85b0e \
+                sha256  0dd63ffe498168a4aac41d307594c5076ff307aa0ac04b141f8f1cec6594d04a \
+                size    489901
 
 use_bzip2 yes
 
 depends_lib     port:readline \
                 path:lib/libssl.dylib:openssl
+
+patchfiles      patch-xio-termios.h.diff
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/sysutils/socat/files/patch-xio-termios.h.diff
+++ b/sysutils/socat/files/patch-xio-termios.h.diff
@@ -1,0 +1,11 @@
+--- xio-termios.h.old	2019-05-01 16:06:12.000000000 +0200
++++ xio-termios.h	2019-05-01 16:04:56.000000000 +0200
+@@ -148,7 +148,7 @@
+ extern int xiotermios_value(int fd, int word, tcflag_t mask, tcflag_t value);
+ extern int xiotermios_char(int fd, int n, unsigned char c);
+ #ifdef HAVE_TERMIOS_ISPEED
+-extern int xiotermios_speed(int fd, int n, unsigned int speed);
++extern int xiotermios_speed(int fd, int n, speed_t speed);
+ #endif
+ extern int xiotermios_spec(int fd, int optcode);
+ extern int xiotermios_flush(int fd);


### PR DESCRIPTION
#### Description

Livecheck was scraping homepage which does not contain full names of all available versions, now it searches the download page as it should. Provided regex omits releases with suffix after version number - in this case all 2.* beta releases.

For example it will match `socat-1.7.3.3.tar.bz2`, and won't match `socat-2.0.0-b9.tar.bz2`.

In the second commit I updated 1.7.3.2 -> 1.7.3.3 but build failed due to a bug found in the source code - I've added a patch fixing this issue.


###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
