### PR TITLE
bash-completion: update to 2.9

### DIFF
--- a/sysutils/bash-completion/Portfile
+++ b/sysutils/bash-completion/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    scop bash-completion 2.8
+github.setup    scop bash-completion 2.9
 epoch           1
 categories      sysutils
 platforms       darwin
@@ -18,9 +18,9 @@ long_description \
 github.tarball_from releases
 use_xz yes
 
-checksums       rmd160  6ec05ded0b734ebeb9caf7d84bf09d937f923ddb \
-                sha256  c01f5570f5698a0dda8dc9cfb2a83744daa1ec54758373a6e349bd903375f54d \
-                size    286128
+checksums       rmd160  fc664ed3392570ed25150b4e8465fdce4effb243 \
+                sha256  d48fe378e731062f479c5f8802ffa9d3c40a275a19e6e0f6f6cc4b90fa12b2f5 \
+                size    305788
 
 depends_run     port:bash
 
@@ -40,6 +40,7 @@ post-patch {
 }
 
 use_autoreconf yes
+autoreconf.args --verbose --force --install
 
 post-destroot {
     xinstall -m 644 -W ${filespath} port launchctl \


### PR DESCRIPTION
#### Description
I went through the existing patches and they are are still relevant to the codebase. For testing, I saw that the changelog mentioned that .tbz2 are now recognized as bzip. I was able to successfully get an autocomplete suggestion for a .tbz2 file with `bzip -d`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
