### PR TITLE
gcc9: bump to latest snapshot, no more "Atomic" error

### DIFF
--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 epoch               2
 name                gcc9
-version             9-20190331
+version             9-20190428
 revision            1
 subport             libgcc-devel { revision 1 }
 platforms           darwin
@@ -27,9 +27,9 @@ master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/sn
 distname            gcc-${version}
 use_xz              yes
 
-checksums           rmd160  be4713f095d688bed310da7f573fb4fd27cad80e \
-                    sha256  d9d5a0f42bd2fe4a942452d1699d3f0310d8bcf5e7068e29003a73161d32b055 \
-                    size    68658900
+checksums           rmd160  57abc9782257357318747b4db7fe211f86597252 \
+                    sha256  6b75ad6fedcc1c4fad77283d440a2816cccc859200d98329949d2eb1397fa590 \
+                    size    68747260
 
 depends_lib         port:cctools \
                     port:gmp \


### PR DESCRIPTION
* updates gcc9 snapshot to 20190428
* no more build errors on Mojave and Xcode 10.2+
* updated checksums

This is probably a low priority issue, so I'll keep
this short: relevant discussions linked below.
    fixes: https://trac.macports.org/ticket/58260

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
[Portfile-gcc9.txt](https://github.com/macports/macports-ports/files/3136595/Portfile-gcc9.txt)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->