### PR TITLE
py-robotframework: minor changes

### DIFF
--- a/python/py-robotframework/Portfile
+++ b/python/py-robotframework/Portfile
@@ -33,6 +33,9 @@ distname            ${internal_name}-${version}
 
 
 if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
     post-destroot {
         reinplace "s;${destroot};;" ${destroot}${python.prefix}/bin/robot
         reinplace "s;${destroot};;" ${destroot}${python.prefix}/bin/rebot

--- a/python/py-robotframework/Portfile
+++ b/python/py-robotframework/Portfile
@@ -40,12 +40,10 @@ if {${name} ne ${subport}} {
         reinplace "s;${destroot};;" ${destroot}${python.prefix}/bin/robot
         reinplace "s;${destroot};;" ${destroot}${python.prefix}/bin/rebot
     }
-}
 
-if {${name} eq ${subport}} {
+    livecheck.type     none
+} else {
     livecheck.type     regex
     livecheck.url      https://pypi.python.org/pypi/robotframework
     livecheck.regex    ${internal_name}-(\[3-9\]\\.\[0-9.\]+)\\.tar\\.\[bg\]z
-} else {
-    livecheck.type     none
 }


### PR DESCRIPTION
#### Description

Minor cosmetic change + addition of setuptools to allow the port to build in trace mode.

@jyrkiwahlstedt: would you be willing to also take over `py-robotframework-ride`?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->