### PR TITLE
py-robotframework-ride: update to 1.7.3.1

### DIFF
--- a/python/py-robotframework-ride/Portfile
+++ b/python/py-robotframework-ride/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           wxWidgets 1.0
 
+github.setup        robotframework RIDE 1.7.3.1 v
 name                py-robotframework-ride
-set internal_name   robotframework-ride
-
-version             1.5.2.1
 
 license             Apache-2
 
@@ -16,45 +15,35 @@ maintainers         nomaintainer
 description         Robot Framework test case editor
 long_description    ${description}
 
-homepage            https://code.google.com/p/${internal_name}
-
 platforms           darwin
+# support for python 2 will be dropped, but we don't yet have wxPython 4 available
 python.versions     27
 
-master_sites        pypi:r/${internal_name}
-distname            ${internal_name}-${version}
-
-checksums           rmd160  7698d06de28271c1909dcaffb90f08a2b37bcb44 \
-                    sha256  50c929f2629b0e86fc39d45887061df784a4ac9df39ccfcb87660c49897d1862
+checksums           rmd160  69e75ae79cd32aa76109181d28a3606ad00228ae \
+                    sha256  1a652edf4012bb21d8aad750c60bcbdc4cc84afeda524363fb872e536e1e2b1a \
+                    size    951470
 
 if {${name} ne ${subport}} {
-    build.cmd           ${python.bin} setup.py
-    destroot.cmd        ${python.bin} setup.py
-    depends_lib-append  port:py${python.version}-robotframework \
-                        port:py${python.version}-paver
+    depends_build-append \
+                    port:py${python.version}-setuptools
+    depends_run-append \
+                    port:py${python.version}-robotframework \
+                    port:py${python.version}-wxpython-3.0
 
-    post-extract {
-        reinplace "s/pybot/pybot-${python.branch}/g" $worksrcpath/src/robotide/contrib/testrunner/runprofiles.py
-    }
+## more effort is needed to enable testing
+#
+#   depends_test-append \
+#                   port:py${python.version}-invoke \
+#                   port:py${python.version}-mockito \
+#                   port:py${python.version}-nose \
+#                   port:py${python.version}-rellu
+#
+#   test.run        yes
+#   test.cmd        invoke-${python.branch}
 
-    variant wxpython30 conflicts wxpython28 description {Use wxPython 3.0 with Cocoa (experimental)} {
-        depends_lib-append  port:py${python.version}-wxpython-3.0
-        notes-append "Warning: wxPython 3.0 is not fully compatible with robotframework-ride.\n"
-    }
+    patchfiles      patch-setup.py.diff
 
-    variant wxpython28 conflicts wxpython30 description {Use wxPython 2.8 with GTK} {
-        depends_lib-append  port:py${python.version}-wxpython-2.8
-    }
-
-    if {![variant_isset wxpython30] && ![variant_isset wxpython28]} {
-        default_variants    +wxpython28
-    }
-}
-
-if {${name} eq ${subport}} {
-    livecheck.type      regex
-    livecheck.url      https://pypi.python.org/pypi/${internal_name}
-    livecheck.regex     ${internal_name} (\[0-9.\]+)\<
+    livecheck.type  none
 } else {
-    livecheck.type      none
+    livecheck.regex {archive/v([0-9.]+)\.tar\.gz}
 }

--- a/python/py-robotframework-ride/files/patch-setup.py.diff
+++ b/python/py-robotframework-ride/files/patch-setup.py.diff
@@ -1,0 +1,11 @@
+--- setup.py
++++ setup.py
+@@ -59,8 +59,6 @@ class CustomInstallCommand(install):
+     """Customized setuptools install command - prints a friendly greeting."""
+     def run(self):
+         install.run(self)
+-        _ = sys.stderr.write("Creating Desktop Shortcut to RIDE...\n")
+-        os.system("ride_postinstall.py -install")
+ 
+ setup(
+     name='robotframework-ride',


### PR DESCRIPTION
I have absolutely no clue how to test this and hope that @jyrkiwahlstedt can provide some insight and testing (and hopefully take the port over?). I just wanted to get rid of dependency on wxWidgets 2.8. Unit tests require some module that was only introduced in Python 3.4. I tried testing with 3.7, but then we miss a bunch of python packages that would need to be ported first before we can run the tests.

They say that this is the last or pre-last version with support for python 2.7. On the other hand I failed to port wxPhoenix multiple times in the past, so we don't yet have an alternative to switch to python 3.

* Update to 1.7.3.1
* Switch to github.
* Remove dependency on wxWidgets 2.8.
* Unfinished attempt to run tests.

See: https://trac.macports.org/ticket/46351

See also #4236.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->