### PR TITLE
gcc8,libgcc8: Add upstream patch to fix builds on macOS10.14

### DIFF
--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -3,6 +3,7 @@
 PortSystem 1.0
 PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
+PortGroup xcodeversion 1.0
 
 epoch               3
 name                gcc8
@@ -52,6 +53,15 @@ set major           [lindex [split ${version} .-] 0]
 
 platform darwin {
     configure.pre_args-append --build=${build_arch}-apple-darwin${os.major}
+}
+
+if {[vercmp ${xcodeversion} 10.2] >= 0} {
+    # https://trac.macports.org/ticket/58260
+    # Patch for Xcode bug, taken from
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864#c43
+    # https://github.com/Homebrew/homebrew-core/pull/39134/files
+    # This should be removed in the next release of GCC
+    patchfiles-append   xcode-bug-_Atomic-fix.patch 
 }
 
 configure.dir       ${workpath}/build
@@ -142,6 +152,14 @@ pre-fetch {
     if { ${os.major} < 10 } {
         ui_error "${name} ${version} is not supported on Darwin ${os.major}"
         return -code error "incompatible OS X version"
+    }
+}
+
+pre-build {
+    # gcc cannot build if libunwind-headers is active
+    if { ![catch {set vers [lindex [registry_active libunwind-headers] 0]}] } {
+        ui_error "${name} cannot be built whilst libunwind-headers is installed."
+        return -code error "build error"
     }
 }
 

--- a/lang/gcc8/files/xcode-bug-_Atomic-fix.patch
+++ b/lang/gcc8/files/xcode-bug-_Atomic-fix.patch
@@ -1,0 +1,104 @@
+
+diff -r -u gcc-8.3.0/fixincludes/fixincl.x gcc-8.3.0-patch/fixincludes/fixincl.x
+--- fixincludes/fixincl.x.orig	2018-02-23 01:12:26.000000000 +0900
++++ fixincludes/fixincl.x	2019-04-11 12:37:25.000000000 +0900
+@@ -3222,6 +3222,44 @@
+ 
+ /* * * * * * * * * * * * * * * * * * * * * * * * * *
+  *
++ *  Description of Darwin_Ucred__Atomic fix
++ */
++tSCC zDarwin_Ucred__AtomicName[] =
++     "darwin_ucred__Atomic";
++
++/*
++ *  File name selection pattern
++ */
++tSCC zDarwin_Ucred__AtomicList[] =
++  "sys/ucred.h\0";
++/*
++ *  Machine/OS name selection pattern
++ */
++tSCC* apzDarwin_Ucred__AtomicMachs[] = {
++        "*-*-darwin18*",
++        (const char*)NULL };
++
++/*
++ *  content selection pattern - do fix if pattern found
++ */
++tSCC zDarwin_Ucred__AtomicSelect0[] =
++       "_Atomic";
++
++#define    DARWIN_UCRED__ATOMIC_TEST_CT  1
++static tTestDesc aDarwin_Ucred__AtomicTests[] = {
++  { TT_EGREP,    zDarwin_Ucred__AtomicSelect0, (regex_t*)NULL }, };
++
++/*
++ *  Fix Command Arguments for Darwin_Ucred__Atomic
++ */
++static const char* apzDarwin_Ucred__AtomicPatch[] = {
++    "wrap",
++    "# define _Atomic volatile\n",
++    "# undef _Atomic\n",
++    (char*)NULL };
++
++/* * * * * * * * * * * * * * * * * * * * * * * * * *
++ *
+  *  Description of Dec_Intern_Asm fix
+  */
+ tSCC zDec_Intern_AsmName[] =
+@@ -10099,9 +10137,9 @@
+  *
+  *  List of all fixes
+  */
+-#define REGEX_COUNT          287
++#define REGEX_COUNT          288
+ #define MACH_LIST_SIZE_LIMIT 187
+-#define FIX_COUNT            249
++#define FIX_COUNT            250
+ 
+ /*
+  *  Enumerate the fixes
+@@ -10183,6 +10221,7 @@
+     DARWIN_STDINT_5_FIXIDX,
+     DARWIN_STDINT_6_FIXIDX,
+     DARWIN_STDINT_7_FIXIDX,
++    DARWIN_UCRED__ATOMIC_FIXIDX,
+     DEC_INTERN_ASM_FIXIDX,
+     DJGPP_WCHAR_H_FIXIDX,
+     ECD_CURSOR_FIXIDX,
+@@ -10739,6 +10778,11 @@
+      DARWIN_STDINT_7_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
+      aDarwin_Stdint_7Tests,   apzDarwin_Stdint_7Patch, 0 },
+ 
++  {  zDarwin_Ucred__AtomicName,    zDarwin_Ucred__AtomicList,
++     apzDarwin_Ucred__AtomicMachs,
++     DARWIN_UCRED__ATOMIC_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
++     aDarwin_Ucred__AtomicTests,   apzDarwin_Ucred__AtomicPatch, 0 },
++
+   {  zDec_Intern_AsmName,    zDec_Intern_AsmList,
+      apzDec_Intern_AsmMachs,
+      DEC_INTERN_ASM_TEST_CT, FD_MACH_ONLY,
+diff -r -u gcc-8.3.0/fixincludes/inclhack.def gcc-8.3.0-patch/fixincludes/inclhack.def
+--- fixincludes/inclhack.def.orig	2018-02-23 01:12:26.000000000 +0900
++++ fixincludes/inclhack.def	2019-04-11 12:37:59.000000000 +0900
+@@ -1592,6 +1592,19 @@
+ 		"#define UINTMAX_C(v) (v ## ULL)";
+ };
+ 
++/*  XCode 10.2 <sys/ucred.h> uses the C _Atomic keyword in C++ code.
++*/
++fix = {
++    hackname  = darwin_ucred__Atomic;
++    mach      = "*-*-darwin18*";
++    files     = sys/ucred.h;
++    select    = "_Atomic";
++    c_fix     = wrap;
++    c_fix_arg = "# define _Atomic volatile\n";
++    c_fix_arg = "# undef _Atomic\n";
++    test_text = "_Atomic";
++};
++
+ /*
+  *  Fix <c_asm.h> on Digital UNIX V4.0:
+  *  It contains a prototype for a DEC C internal asm() function,


### PR DESCRIPTION
Fixes gcc8 build using Xcode 10.2+

https://trac.macports.org/ticket/58260