### PR TITLE
mariadb-10.1: add legacysupport

### DIFF
--- a/databases/mariadb-10.1/Portfile
+++ b/databases/mariadb-10.1/Portfile
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.0
+legacysupport.newest_darwin_requires_legacy 10
 
 name                mariadb-10.1
 set name_mysql      ${name}


### PR DESCRIPTION
for strnlen() (and more?) on older systems

tested on 10.6.8