### PR TITLE
libstemmer: Upgrade version and add libstemmer.dylib

### DIFF
--- a/textproc/libstemmer/Portfile
+++ b/textproc/libstemmer/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        snowballstem snowball e87eced
+github.setup        snowballstem snowball d29510a
 name                libstemmer
-version             0.1-20170303
+version             0.1-20181121
 categories          textproc
 platforms           darwin
 maintainers         nomaintainer
@@ -23,8 +23,9 @@ long_description    Snowball is a language in which stemming algorithms can \
 
 homepage            http://snowballstem.org/
 
-checksums           rmd160  576e781bcb8f1e1eca462bcb544d7fe3be92daae \
-                    sha256  9114126684b75b9aaaa27bf596968e8d4d77d8080c7898d34e2e8ea00cf8c80d
+checksums           rmd160  259e70f4041253cbbda86b754e52eaa189874689 \
+                    sha256  5ec4afcfbb9e4c70fe65a6d4acc603e7cc34752507615a69614abaabd19adb74 \
+                    size    163868
 
 use_configure       no
 
@@ -36,11 +37,13 @@ build.args-append   CC="${configure.cc} [get_canonical_archflags cc]"
 post-build {
     copy ${worksrcpath}/libstemmer.o ${worksrcpath}/libstemmer.a
     system -W ${worksrcpath} "ranlib libstemmer.a"
+    system -W ${worksrcpath} "clang -fpic -shared -Wl,-all_load libstemmer.a -o libstemmer.dylib"
 }
 
 destroot {
     # install header files
     xinstall -m 644 -W ${worksrcpath}/include libstemmer.h ${destroot}${prefix}/include
     # install libraries
+    xinstall -m 644 -W ${worksrcpath} libstemmer.dylib ${destroot}${prefix}/lib
     xinstall -m 644 -W ${worksrcpath} libstemmer.a ${destroot}${prefix}/lib
 }


### PR DESCRIPTION
#### Description

Upgrade to the latest version and add libstemmer.dylib dynamic library.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->