### PR TITLE
gcc9: Update to production 9.1 release, provide default libgcc runtime

### DIFF
--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -4,11 +4,11 @@ PortSystem                                      1.0
 PortGroup           select                      1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-epoch               2
-name                gcc9
-version             9.1.0
+epoch               3
+name                gcc10
+version             9-20190428
 revision            0
-subport             libgcc9 { revision 0 }
+subport             libgcc-devel { revision 2 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -20,21 +20,16 @@ long_description    The GNU compiler collection, including front ends for \
                     This is a prerelease BETA version!
 
 homepage            https://gcc.gnu.org/
-master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/releases/gcc-${version}/ \
-                    http://mirror.koddos.net/gcc/releases/gcc-${version}/ \
-                    https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-${version}/ \
-                    https://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.gnu.org/gcc/gcc-${version}/ \
-                    ftp://ftp.gwdg.de/pub/linux/gcc/releases/gcc-${version}/ \
-                    ftp://gcc.ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${version}/ \
-                    ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
-                    gnu:gcc/gcc-${version}
+master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/snapshots/${version}/ \
+                    ftp://gcc.gnu.org/pub/gcc/snapshots/${version}/ \
+                    http://mirror.koddos.net/gcc/snapshots/${version}/
 
 distname            gcc-${version}
 use_xz              yes
 
-checksums           rmd160  b9dd53082905c4ca2f7f8291af1e4d015bc97d39 \
-                    sha256  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0 \
-                    size    70546856
+checksums           rmd160  57abc9782257357318747b4db7fe211f86597252 \
+                    sha256  6b75ad6fedcc1c4fad77283d440a2816cccc859200d98329949d2eb1397fa590 \
+                    size    68747260
 
 depends_lib         port:cctools \
                     port:gmp \
@@ -45,7 +40,7 @@ depends_lib         port:cctools \
                     port:mpfr \
                     port:zlib
 depends_run         port:gcc_select \
-                    path:lib/libgcc/libgcc_s.1.dylib:libgcc
+                    port:libgcc-devel
 
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
@@ -162,36 +157,19 @@ pre-fetch {
     }
 }
 
-# List of dylibs to be installed 
+# dylibs to install
 # Note that we really don't want to include libgcc_ext.10.[45].dylib here, but install_name_tool
 # doesn't know how to change the id of stubs, and it's easier than recreating them for each
 # gcc port.
 set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.5.dylib libubsan.1.dylib libatomic.1.dylib}
 
-if {${subport} eq "libgcc9"} {
+if {${subport} eq "libgcc-devel"} {
 
-    # Always provides primary runtime so always in conflict
-    conflicts libgcc-devel
-
-    # Activate hack for new libgcc
-    # https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active libgcc8] 0]}]} {
-            # Extract the epoch of the installed libgcc8
-            set _epoch [lindex $installed 5]
-            # If < 4 need to deactivate
-            if {[vercmp $_epoch 4] < 0} {
-                registry_deactivate_composite libgcc8 "" [list ports_nodepcheck 1]
-            }
-        }
-        if {![catch {set installed [lindex [registry_active libgcc-devel] 0]}]} {
-            # Extract the epoch of the installed libgcc-devel
-            set _epoch [lindex $installed 5]
-            # If < 3 need to deactivate
-            if {[vercmp $_epoch 3] < 0} {
-                registry_deactivate_composite libgcc-devel "" [list ports_nodepcheck 1]
-            }
-        }
+    # Set conflict against port providing primary runtime
+    if { ${os.major} < 10 } {
+        conflicts libgcc7
+    } else {
+        conflicts libgcc9
     }
 
     # http://trac.macports.org/ticket/35770
@@ -237,7 +215,9 @@ if {${subport} eq "libgcc9"} {
         
         file mkdir ${destroot}${prefix}/lib/libgcc.merged
 
+        # loop over libs to install
         foreach dylib ${dylibs} {
+            
             # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
             # https://trac.macports.org/ticket/40098
             # https://trac.macports.org/ticket/40100
@@ -278,7 +258,7 @@ if {${subport} eq "libgcc9"} {
     }
 
 } else {
-    
+
     post-destroot {
 
         file delete ${destroot}${prefix}/share/info/dir
@@ -290,6 +270,7 @@ if {${subport} eq "libgcc9"} {
             file rename ${file} ${newfile}
         }
 
+        # loop over libs to install
         foreach dylib ${dylibs} {
             # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
             # https://trac.macports.org/ticket/40098
@@ -308,6 +289,7 @@ if {${subport} eq "libgcc9"} {
                 }
             }
         }
+
     }
 
     select.group        gcc

--- a/lang/gcc10/files/mp-gcc10
+++ b/lang/gcc10/files/mp-gcc10
@@ -1,0 +1,7 @@
+bin/gcc-mp-10
+bin/cpp-mp-10
+bin/c++-mp-10
+bin/g++-mp-10
+-
+bin/gcov-mp-10
+bin/gfortran-mp-10

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup select 1.0
-PortGroup compiler_blacklist_versions 1.0
-PortGroup xcodeversion 1.0
+PortSystem                             1.0
+PortGroup select                       1.0
+PortGroup compiler_blacklist_versions  1.0
+PortGroup xcodeversion                 1.0
 
 name                gcc7
 epoch               3
@@ -23,6 +23,8 @@ long_description    The GNU compiler collection, including front ends for \
 
 homepage            https://gcc.gnu.org/
 master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/releases/gcc-${version}/ \
+                    http://mirror.koddos.net/gcc/releases/gcc-${version}/ \
+                    https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-${version}/ \
                     ftp://ftp.gwdg.de/pub/linux/gcc/releases/gcc-${version}/ \
                     ftp://gcc.ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${version}/ \
                     ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
@@ -176,6 +178,9 @@ use_parallel_build  yes
 
 destroot.target     install install-info-host
 
+# List of all dylibs to possibly be installed
+set alldylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.4.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.4.dylib libubsan.0.dylib libcilkrts.5.dylib libatomic.1.dylib}
+
 if {${subport} eq "libgcc7"} {
 
     # If providing the primary runtime, add conflict against libgcc-devel
@@ -249,7 +254,7 @@ if {${subport} eq "libgcc7"} {
         # gcc port.
         if { ${isLastSupported} } {
             # Install all
-            set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.4.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.4.dylib libubsan.0.dylib libcilkrts.5.dylib libatomic.1.dylib}
+            set dylibs ${alldylibs}
         } else {
             # Only install those not in newer libgcc builds
             set dylibs {libgfortran.4.dylib libquadmath.0.dylib libasan.4.dylib libubsan.0.dylib libcilkrts.5.dylib}
@@ -314,7 +319,7 @@ if {${subport} eq "libgcc7"} {
             file rename ${file} ${newfile}
         }
 
-        foreach dylib {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.4.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.4.dylib libubsan.0.dylib libcilkrts.5.dylib libatomic.1.dylib} {
+        foreach dylib ${alldylibs} {
             # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
             # https://trac.macports.org/ticket/40098
             # https://trac.macports.org/ticket/40100

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -1,17 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup select 1.0
-PortGroup compiler_blacklist_versions 1.0
-PortGroup xcodeversion 1.0
+PortSystem                             1.0
+PortGroup select                       1.0
+PortGroup compiler_blacklist_versions  1.0
+PortGroup xcodeversion                 1.0
 
-epoch               3
+epoch               4
 name                gcc8
 version             8.3.0
-# warning : Due to past problems avoid revisions 1 and 2 with 8.3.0.
-# If this version needs to be bumped in the future, go to 3.
-revision            0
-subport             libgcc8 { revision 0 }
+revision            3
+subport             libgcc8 { revision 3 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -23,6 +21,8 @@ long_description    The GNU compiler collection, including front ends for \
 
 homepage            https://gcc.gnu.org/
 master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/releases/gcc-${version}/ \
+                    http://mirror.koddos.net/gcc/releases/gcc-${version}/ \
+                    https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-${version}/ \
                     ftp://ftp.gwdg.de/pub/linux/gcc/releases/gcc-${version}/ \
                     ftp://gcc.ftp.nluug.nl/mirror/languages/gcc/releases/gcc-${version}/ \
                     ftp://gcc.gnu.org/pub/gcc/releases/gcc-${version}/ \
@@ -35,6 +35,12 @@ checksums           rmd160  59396f7136301466d0ec15eb7307558c0da692df \
                     sha256  64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c \
                     size    63694700
 
+# Check if this is the last supported gcc version for this system.
+# If it is, libgcc8 installs a full runtime, otherwise it only installs
+# what is missing from newer libgccX builds.
+# NOTE : The logic here must match that in the libgcc port.
+set isLastSupported [ expr ${os.major} < 11 ]
+
 depends_lib         port:cctools \
                     port:gmp \
                     path:lib/pkgconfig/isl.pc:isl \
@@ -43,8 +49,12 @@ depends_lib         port:cctools \
                     port:libmpc \
                     port:mpfr \
                     port:zlib
-depends_run         port:gcc_select \
-                    path:lib/libgcc/libgcc_s.1.dylib:libgcc
+depends_run         port:gcc_select 
+if { ${isLastSupported} } {
+    depends_run-append  path:lib/libgcc/libgcc_s.1.dylib:libgcc
+} else {
+    depends_run-append  port:libgcc8
+}
 
 depends_skip_archcheck-append gcc_select ld64 cctools
 license_noconflict  gmp mpfr ppl libmpc zlib
@@ -163,120 +173,127 @@ pre-build {
     }
 }
 
+# list of dylibs to be installed
+# Note that we really don't want to include libgcc_ext.10.[45].dylib here, but install_name_tool
+# doesn't know how to change the id of stubs, and it's easier than recreating them for each
+# gcc port.
+set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.5.dylib libubsan.1.dylib libatomic.1.dylib}
+
 if {${subport} eq "libgcc8"} {
 
-    # Always provides primary runtime so always in conflict
-    conflicts libgcc-devel
-
-    # Activate hack for new libgcc
-    # https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active libgcc] 0]}]} {
-            # Extract the epoch of the installed libgcc
-            set _epoch [lindex $installed 5]
-            # If < 3 need to deactivate
-            if {[vercmp $_epoch 3] < 0} {
-                registry_deactivate_composite libgcc "" [list ports_nodepcheck 1]
-            }
-        }
-        if {![catch {set installed [lindex [registry_active libgcc-devel] 0]}]} {
-            # Extract the epoch of the installed libgcc-devel
-            set _epoch [lindex $installed 5]
-            # If < 2 need to deactivate
-            if {[vercmp $_epoch 2] < 0} {
-                registry_deactivate_composite libgcc-devel "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-
-    # http://trac.macports.org/ticket/35770
-    # http://trac.macports.org/ticket/38814
-    # While there can be multiple versions of these runtimes in a single
-    # process, it is not possible to pass objects between different versions,
-    # so we simplify this by having the libgcc port provide the newest version
-    # of these runtimes for all versions of gcc to use.
-    #
-    # If there is a binary incompatible change to the runtime in a future
-    # version of gcc, then the latest version of gcc to provide a given ABI
-    # version should continue to provide a subport for that and older gcc
-    # versions.
-
-    depends_run
-    depends_lib-delete   port:zlib
-    depends_build-append {*}${depends_lib}
-    depends_lib          port:zlib
-
-    configure.args-replace \
-        --libdir=${prefix}/lib/${name} \
-        --libdir=${prefix}/lib/libgcc
-
-    # see https://trac.macports.org/ticket/54766
-    configure.args-replace \
-        --includedir=${prefix}/include/${name} \
-        --includedir=${prefix}/include/gcc
-
-    configure.args-replace \
-        --with-gxx-include-dir=${prefix}/include/${name}/c++/ \
-        --with-gxx-include-dir=${prefix}/include/gcc/c++/
-
-    # TODO: Possibly disable bootstrap with appropriate configure flags.
-    #       the problem is that libstdc++'s configure script tests for tls support
-    #       using the running compiler (not gcc for which libstdc++ is being built).
-    #       Thus when we build with clang, we get a mismatch
-    # http://trac.macports.org/ticket/36116
-    #compiler.blacklist-append {clang < 425}
-    #configure.args-append --disable-bootstrap
-    #build.target        all
-
-    post-destroot {
-        file mkdir ${destroot}${prefix}/lib/libgcc.merged
-
-        # Note that we really don't want to include libgcc_ext.10.[45].dylib here, but install_name_tool
-        # doesn't know how to change the id of stubs, and it's easier than recreating them for each
-        # gcc port.
-        set dylibs {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.5.dylib libubsan.1.dylib libatomic.1.dylib}
-
-        foreach dylib ${dylibs} {
-            # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
-            # https://trac.macports.org/ticket/40098
-            # https://trac.macports.org/ticket/40100
-            if {! [file exists ${destroot}${prefix}/lib/libgcc/${dylib}]} {
-                continue
-            }
-
-            move ${destroot}${prefix}/lib/libgcc/${dylib} ${destroot}${prefix}/lib/libgcc.merged
-            if {[variant_isset universal]} {
-                foreach archdir [glob ${destroot}${prefix}/lib/libgcc/*/] {
-                    set archdir_nodestroot [string map "${destroot}/ /" ${archdir}]
-                    if {[file exists ${archdir}/${dylib}]} {
-                        system "install_name_tool -id ${prefix}/lib/libgcc/${dylib} ${archdir}/${dylib}"
-                        foreach link [glob -tails -directory ${archdir} *.dylib] {
-                            system "install_name_tool -change ${archdir_nodestroot}${link} ${prefix}/lib/libgcc/${link} ${archdir}/${dylib}"
+    # Are we providing the full main runtime ?
+    if { ${isLastSupported} } {
+        
+        # Always provides primary runtime so always in conflict
+        conflicts libgcc-devel
+        
+        # http://trac.macports.org/ticket/35770
+        # http://trac.macports.org/ticket/38814
+        # While there can be multiple versions of these runtimes in a single
+        # process, it is not possible to pass objects between different versions,
+        # so we simplify this by having the libgcc port provide the newest version
+        # of these runtimes for all versions of gcc to use.
+        #
+        # If there is a binary incompatible change to the runtime in a future
+        # version of gcc, then the latest version of gcc to provide a given ABI
+        # version should continue to provide a subport for that and older gcc
+        # versions.
+        
+        depends_run
+        depends_lib-delete   port:zlib
+        depends_build-append {*}${depends_lib}
+        depends_lib          port:zlib
+        
+        configure.args-replace \
+            --libdir=${prefix}/lib/${name} \
+            --libdir=${prefix}/lib/libgcc
+        
+        # see https://trac.macports.org/ticket/54766
+        configure.args-replace \
+            --includedir=${prefix}/include/${name} \
+            --includedir=${prefix}/include/gcc
+        
+        configure.args-replace \
+            --with-gxx-include-dir=${prefix}/include/${name}/c++/ \
+            --with-gxx-include-dir=${prefix}/include/gcc/c++/
+        
+        # TODO: Possibly disable bootstrap with appropriate configure flags.
+        #       the problem is that libstdc++'s configure script tests for tls support
+        #       using the running compiler (not gcc for which libstdc++ is being built).
+        #       Thus when we build with clang, we get a mismatch
+        # http://trac.macports.org/ticket/36116
+        #compiler.blacklist-append {clang < 425}
+        #configure.args-append --disable-bootstrap
+        #build.target        all
+        
+        post-destroot {
+            
+            file mkdir ${destroot}${prefix}/lib/libgcc.merged
+            
+            foreach dylib ${dylibs} {
+                # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
+                # https://trac.macports.org/ticket/40098
+                # https://trac.macports.org/ticket/40100
+                if {! [file exists ${destroot}${prefix}/lib/libgcc/${dylib}]} {
+                    continue
+                }
+                
+                move ${destroot}${prefix}/lib/libgcc/${dylib} ${destroot}${prefix}/lib/libgcc.merged
+                if {[variant_isset universal]} {
+                    foreach archdir [glob ${destroot}${prefix}/lib/libgcc/*/] {
+                        set archdir_nodestroot [string map "${destroot}/ /" ${archdir}]
+                        if {[file exists ${archdir}/${dylib}]} {
+                            system "install_name_tool -id ${prefix}/lib/libgcc/${dylib} ${archdir}/${dylib}"
+                            foreach link [glob -tails -directory ${archdir} *.dylib] {
+                                system "install_name_tool -change ${archdir_nodestroot}${link} ${prefix}/lib/libgcc/${link} ${archdir}/${dylib}"
+                            }
+                            system "lipo -create -output ${destroot}${prefix}/lib/libgcc.merged/${dylib}~ ${destroot}${prefix}/lib/libgcc.merged/${dylib} ${archdir}/${dylib} && mv ${destroot}${prefix}/lib/libgcc.merged/${dylib}~ ${destroot}${prefix}/lib/libgcc.merged/${dylib}"
                         }
-                        system "lipo -create -output ${destroot}${prefix}/lib/libgcc.merged/${dylib}~ ${destroot}${prefix}/lib/libgcc.merged/${dylib} ${archdir}/${dylib} && mv ${destroot}${prefix}/lib/libgcc.merged/${dylib}~ ${destroot}${prefix}/lib/libgcc.merged/${dylib}"
                     }
                 }
+                
+                # strip debug symbols to supress debugger warnings:
+                # http://trac.macports.org/attachment/ticket/34831
+                if {! [string match *libgcc_ext* ${dylib}]} {
+                    system "strip -x ${destroot}${prefix}/lib/libgcc.merged/${dylib}"
+                }
             }
-
-            # strip debug symbols to supress debugger warnings:
-            # http://trac.macports.org/attachment/ticket/34831
-            if {! [string match *libgcc_ext* ${dylib}]} {
-                system "strip -x ${destroot}${prefix}/lib/libgcc.merged/${dylib}"
-            }
+            
+            file delete -force ${destroot}${prefix}/bin
+            file delete -force ${destroot}${prefix}/share
+            file delete -force ${destroot}${prefix}/lib/libgcc
+            file delete -force ${destroot}${prefix}/libexec
+            
+            move ${destroot}${prefix}/lib/libgcc.merged ${destroot}${prefix}/lib/libgcc
+            
+            # For binary compatibility with binaries that linked against the old libstdcxx port
+            ln -s libgcc/libstdc++.6.dylib ${destroot}${prefix}/lib/libstdc++.6.dylib
+        }
+        
+    } else {
+        
+        # gcc8 runtime versions are identical to that in gcc9, so libgcc8 does not
+        # need to provide anything, hence do not build anything.
+        # port still defined as needed to satisfy dependency tree
+        
+        depends_run port:libgcc9
+        depends_lib
+        
+        fetch.type    none
+        build         { }
+        use_configure no
+        patchfiles
+        
+        destroot {
+            set doc_dir ${destroot}${prefix}/share/doc/${name}
+            xinstall -m 755 -d ${doc_dir}
+            system "echo ${subport} provides no runtime > ${doc_dir}/README"
         }
 
-        file delete -force ${destroot}${prefix}/bin
-        file delete -force ${destroot}${prefix}/share
-        file delete -force ${destroot}${prefix}/lib/libgcc
-        file delete -force ${destroot}${prefix}/libexec
-
-        move ${destroot}${prefix}/lib/libgcc.merged ${destroot}${prefix}/lib/libgcc
-
-        # For binary compatibility with binaries that linked against the old libstdcxx port
-        ln -s libgcc/libstdc++.6.dylib ${destroot}${prefix}/lib/libstdc++.6.dylib
     }
 
 } else {
+
     post-destroot {
         file delete ${destroot}${prefix}/share/info/dir
 
@@ -287,7 +304,7 @@ if {${subport} eq "libgcc8"} {
             file rename ${file} ${newfile}
         }
 
-        foreach dylib {libgcc_ext.10.4.dylib libgcc_ext.10.5.dylib libgcc_s.1.dylib libgfortran.5.dylib libquadmath.0.dylib libstdc++.6.dylib libobjc-gnu.4.dylib libgomp.1.dylib libitm.1.dylib libssp.0.dylib libasan.5.dylib libubsan.1.dylib libatomic.1.dylib} {
+        foreach dylib ${dylibs} {
             # Different OS versions (e.g. Leopard) or architectures (e.g. PPC) don't produce all the dylibs
             # https://trac.macports.org/ticket/40098
             # https://trac.macports.org/ticket/40100

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -1,11 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup select 1.0
+PortSystem          1.0
+PortGroup select    1.0
 
 epoch               3
 name                libgcc
-version             1.0
+version             2.0
+
+conflicts           libgcc-devel
 
 categories          lang
 maintainers         nomaintainer
@@ -27,9 +29,13 @@ homepage            https://www.macports.org/
 # Pick the gcc version that provides the primary runtime.
 # NOTE : The logic here must match that in the gccX ports.
 if { ${os.major} < 10 } {
-   set gcc_version 7
+    set gcc_version 7
 } else {
-   set gcc_version 8
+    if { ${os.major} < 11 } {
+        set gcc_version 8
+    } else {
+        set gcc_version 9
+    }
 }
 depends_lib port:libgcc${gcc_version}
 


### PR DESCRIPTION

```
gcc10        : New 'development' gcc snapshot port
libgcc-devel : Migrated to be based on gcc10 build
gcc9         : Update to production 9.1 release
libgcc9      : New runtime support library port, provides primary runtime on macOS10.7 and newer
gcc8         : Updated to only provide primary runtime on macOS10.6
gcc7         : Cosmetic improvements
libgcc       : Updated to use libgcc9 on macOS10.7 and newer, libgcc8 on macOS10.6 and libgcc7 on macOS10.5 and older.
```

Tested on macOS 10.14, 10.13, 10.7, 10.6.