### PR TITLE
nodejs6: use bundled openssl

### DIFF
--- a/devel/nodejs6/Portfile
+++ b/devel/nodejs6/Portfile
@@ -5,6 +5,7 @@ PortGroup               compiler_blacklist_versions 1.0
 
 name                    nodejs6
 version                 6.17.1
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -33,8 +34,7 @@ distname                node-v${version}
 depends_build           port:pkgconfig
 
 depends_lib             port:icu \
-                        port:python27 \
-                        path:lib/libssl.dylib:openssl
+                        port:python27
 
 proc rec_glob {basedir pattern} {
     set files [glob -directory $basedir -nocomplain -type f $pattern]
@@ -78,9 +78,6 @@ if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
 
 configure.args-append   --without-npm
 configure.args-append   --with-intl=system-icu
-configure.args-append   --shared-openssl
-configure.args-append   --shared-openssl-includes=${prefix}/include/openssl
-configure.args-append   --shared-openssl-libpath=${prefix}/lib
 
 # V8 only supports ARM and IA-32 processors
 supported_archs         i386 x86_64


### PR DESCRIPTION
#### Description

This is a preparation step for OpenSSL 1.1 migration. Node.js 6 does not
build with OpenSSL 1.1:
```
:info:build ../src/node_crypto.h:91:40: error: invalid application of 'sizeof' to an incomplete type 'SSL_CTX' (aka 'ssl_ctx_st')
```
I switched to bundled openssl instead of using the openssl10 port to
lower the maintenance burden. nodejs6 is EOL'ed upstream and will be
considered to be dropped once nodejs8 works on OS X 10.6, anyway.

nodejs8 is not touched as it works with OpenSSL 1.1: 

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
The `https.request` example at https://nodejs.org/api/https.html#https_https_request_options_callback works fine.
