### PR TITLE
hyperscan: Submission, Intel high-performance regex library

### DIFF
--- a/textproc/hyperscan/Portfile
+++ b/textproc/hyperscan/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem                                      1.0
+PortGroup           cmake                       1.1
+PortGroup           github                      1.0
+PortGroup           cxx11                       1.1
+
+github.setup        intel hyperscan 5.1.1 v
+revision            0
+
+categories          textproc
+license             BSD
+maintainers         nomaintainer
+platforms           darwin
+homepage            https://www.hyperscan.io/
+description         High-performance regular expression matching library.
+long_description    ${description}  It follows the regular expression syntax of the \
+                    commonly-used libpcre library, but is a standalone library with its \
+                    own C API. \
+                    Hyperscan uses hybrid automata techniques to allow simultaneous matching \
+                    of large numbers (up to tens of thousands) of regular expressions and for \
+                    the matching of regular expressions across streams of data. \
+                    Hyperscan is typically used in a DPI library stack.
+
+checksums           rmd160  d242ba7bae08734151dd627963068ecdd64c2140 \
+                    sha256  c78c5ec214196634bd484196eb24fce7cf8cf55e356c75ea5489f9dbda893d44 \
+                    size    1811524
+
+depends_build-append \
+    port:pkgconfig \
+    port:python37 \
+    port:ragel
+
+depends_lib-append \
+    port:boost \
+    port:pcre \
+    port:sqlite3
+
+# This flags adds -Werror, which causes compile errors with -Wshadow
+# Reference: https://github.com/intel/hyperscan/blob/master/CMakeLists.txt
+configure.pre_args-delete \
+    -DCMAKE_BUILD_TYPE=MacPorts
+
+configure.args-append \
+    -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7


### PR DESCRIPTION
hyperscan: Submission, High-performance regular expression matching 

* https://www.hyperscan.io/
* https://github.com/intel/hyperscan

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->