### PR TITLE
swig: drop php 5.2 variant 

### DIFF
--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -93,15 +93,7 @@ subport swig-php {
     # patch to fix finding of "php-configXY"
     patchfiles-append patch-configure.diff
 
-    variant php52 conflicts php53 php54 php55 php56 php70 php71 php72 description {build using PHP 5.2} {
-        depends_lib-delete port:php72
-        depends_lib-append port:php52
-        configure.args-delete --with-php=${prefix}/bin/php72
-        configure.args-delete --without-php5
-        configure.args-append --with-php5=${prefix}/bin/php52 --without-php
-    }
-
-    variant php53 conflicts php52 php54 php55 php56 php70 php71 php72 description {build using PHP 5.3} {
+    variant php53 conflicts php54 php55 php56 php70 php71 php72 description {build using PHP 5.3} {
         depends_lib-delete port:php72
         depends_lib-append port:php53
         configure.args-delete --with-php=${prefix}/bin/php72
@@ -109,7 +101,7 @@ subport swig-php {
         configure.args-append --with-php5=${prefix}/bin/php53 --without-php
     }
 
-    variant php54 conflicts php52 php53 php55 php56 php70 php71 php72 description {build using PHP 5.4} {
+    variant php54 conflicts php53 php55 php56 php70 php71 php72 description {build using PHP 5.4} {
         depends_lib-delete port:php72
         depends_lib-append port:php54
         configure.args-delete --with-php=${prefix}/bin/php72
@@ -117,7 +109,7 @@ subport swig-php {
         configure.args-append --with-php5=${prefix}/bin/php54 --without-php
     }
 
-    variant php55 conflicts php52 php53 php54 php56 php70 php71 php72 description {build using PHP 5.5} {
+    variant php55 conflicts php53 php54 php56 php70 php71 php72 description {build using PHP 5.5} {
         depends_lib-delete port:php72
         depends_lib-append port:php55
         configure.args-delete --with-php=${prefix}/bin/php72
@@ -125,7 +117,7 @@ subport swig-php {
         configure.args-append --with-php5=${prefix}/bin/php55 --without-php
     }
 
-    variant php56 conflicts php52 php53 php54 php55 php70 php71 php72 description {build using PHP 5.6} {
+    variant php56 conflicts php53 php54 php55 php70 php71 php72 description {build using PHP 5.6} {
         depends_lib-delete port:php72
         depends_lib-append port:php56
         configure.args-delete --with-php=${prefix}/bin/php72
@@ -133,32 +125,32 @@ subport swig-php {
         configure.args-append --with-php5=${prefix}/bin/php56 --without-php
     }
 
-    variant php70 conflicts php52 php53 php54 php55 php56 php71 php72 description {build using PHP 7.0} {
+    variant php70 conflicts php53 php54 php55 php56 php71 php72 description {build using PHP 7.0} {
         depends_lib-delete port:php72
         depends_lib-append port:php70
         configure.args-delete --with-php=${prefix}/bin/php72
         configure.args-append --with-php=${prefix}/bin/php70
     }
 
-    variant php71 conflicts php52 php53 php54 php55 php56 php70 php72 description {build using PHP 7.1} {
+    variant php71 conflicts php53 php54 php55 php56 php70 php72 description {build using PHP 7.1} {
         depends_lib-delete port:php72
         depends_lib-append port:php71
         configure.args-delete --with-php=${prefix}/bin/php72
         configure.args-append --with-php=${prefix}/bin/php71
 }
 
-    variant php72 conflicts php52 php53 php54 php55 php56 php70 php71 description {build using PHP 7.2} {}
+    variant php72 conflicts php53 php54 php55 php56 php70 php71 description {build using PHP 7.2} {}
 
-    if {![variant_isset php52] && ![variant_isset php53] &&
-        ![variant_isset php54] && ![variant_isset php55] &&
-        ![variant_isset php56] && ![variant_isset php70] &&
-        ![variant_isset php71] && ![variant_isset php72]} {
+    if {![variant_isset php53] && ![variant_isset php54] &&
+        ![variant_isset php55] && ![variant_isset php56] &&
+        ![variant_isset php70] && ![variant_isset php71] &&
+        ![variant_isset php72]} {
         default_variants +php72
     }
-    if {![variant_isset php52] && ![variant_isset php53] &&
-        ![variant_isset php54] && ![variant_isset php55] &&
-        ![variant_isset php56] && ![variant_isset php70] &&
-        ![variant_isset php71] && ![variant_isset php72]} {
+    if {![variant_isset php53] && ![variant_isset php54] &&
+        ![variant_isset php55] && ![variant_isset php56] &&
+        ![variant_isset php70] && ![variant_isset php71] &&
+        ![variant_isset php72]} {
         ui_error "\n\nA +phpXY variant must be selected; the variant '-php72' cannot be used alone.\n"
         return -code error "Invalid variant selection"
     }


### PR DESCRIPTION
#### Description

PHP 5.2 is dead on 6 Jan 2011 [1]. Nobody should use it anymore.

This PR extends #4252. I leave php53 or newer untouched as some php ports are not marked as compatible with PHP 5.4+ (e.g., php-colorer, php-crack, php-eaccelerator).

[1] https://www.php.net/eol.php

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?

https://trac.macports.org/ticket/26384 and https://trac.macports.org/ticket/21871 affect more PHP versions than php52.

- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
