### PR TITLE
gcc{9,10}: Better test for cctools active llvm variant

### DIFF
--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -3,6 +3,7 @@
 PortSystem                                      1.0
 PortGroup           select                      1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           active_variants             1.1
 
 epoch               3
 name                gcc10
@@ -95,17 +96,31 @@ configure.env-append \
                     OTOOL=${prefix}/bin/otool \
                     OTOOL64=${prefix}/bin/otool
 
-# Make sure the MP clang version used by cctool's 'as' is available at
-# build time and used. Versions here must match those in cctools port.
-if       { ${os.major} == 12 || ${os.major} == 13 } {
-    depends_build-append port:clang-3.7
-    configure.compiler macports-clang-3.7
-} elseif { ${os.major} == 10 || ${os.major} == 11 } {
-    depends_build-append port:clang-3.4
-    configure.compiler macports-clang-3.4
-} elseif { ${os.major} >= 14 } {
-    depends_build-append port:clang-7.0
-    configure.compiler macports-clang-7.0
+# Make sure the MP clang version used by cctool's 'as' is available at build time and used.
+if { ${os.major} > 10 } {
+    if {![catch {set installed [lindex [registry_active cctools] 0]}]} {
+        # cctools already installed, so figure out from registry what variant to use
+        # list here must have all possible variants from cctools in it
+        foreach {llvm_v llvm_v_nodot} {3.4 34 3.7 37 3.9 39 4.0 40 5.0 50 6.0 60 7.0 70 8.0 80 devel dev} {
+            if {[active_variants cctools llvm${llvm_v_nodot} ""]} {
+                depends_build-append port:clang-${llvm_v}
+                configure.compiler macports-clang-${llvm_v}
+                break
+            }
+        }
+    } else {
+        # cctools is not yet installed, so have to play 'guess the default variant' :(
+        # Logic here needs to match that used in cctools port.
+        if { ${os.major} <= 11 } {
+            set llvm_v 3.4
+        } elseif { ${os.major} <= 13 } {
+            set llvm_v 3.7
+        } else {
+            set llvm_v 7.0
+        }
+        depends_build-append port:clang-${llvm_v}
+        configure.compiler macports-clang-${llvm_v}
+    }
 }
 
 pre-configure {

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -3,6 +3,7 @@
 PortSystem                                      1.0
 PortGroup           select                      1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           active_variants             1.1
 
 epoch               2
 name                gcc9
@@ -100,17 +101,31 @@ configure.env-append \
                     OTOOL=${prefix}/bin/otool \
                     OTOOL64=${prefix}/bin/otool
 
-# Make sure the MP clang version used by cctool's 'as' is available at
-# build time and used. Versions here must match those in cctools port.
-if       { ${os.major} == 12 || ${os.major} == 13 } {
-    depends_build-append port:clang-3.7
-    configure.compiler macports-clang-3.7
-} elseif { ${os.major} == 10 || ${os.major} == 11 } {
-    depends_build-append port:clang-3.4
-    configure.compiler macports-clang-3.4
-} elseif { ${os.major} >= 14 } {
-    depends_build-append port:clang-7.0
-    configure.compiler macports-clang-7.0
+# Make sure the MP clang version used by cctool's 'as' is available at build time and used.
+if { ${os.major} > 10 } {
+    if {![catch {set installed [lindex [registry_active cctools] 0]}]} {
+        # cctools already installed, so figure out from registry what variant to use
+        # list here must have all possible variants from cctools in it
+        foreach {llvm_v llvm_v_nodot} {3.4 34 3.7 37 3.9 39 4.0 40 5.0 50 6.0 60 7.0 70 8.0 80 devel dev} {
+            if {[active_variants cctools llvm${llvm_v_nodot} ""]} {
+                depends_build-append port:clang-${llvm_v}
+                configure.compiler macports-clang-${llvm_v}
+                break
+            }
+        }
+    } else {
+        # cctools is not yet installed, so have to play 'guess the default variant' :(
+        # Logic here needs to match that used in cctools port.
+        if { ${os.major} <= 11 } {
+            set llvm_v 3.4
+        } elseif { ${os.major} <= 13 } {
+            set llvm_v 3.7
+        } else {
+            set llvm_v 7.0
+        }
+        depends_build-append port:clang-${llvm_v}
+        configure.compiler macports-clang-${llvm_v}
+    }
 }
 
 pre-configure {


### PR DESCRIPTION
Improved logic for how `gcc{9,10}` determine which clang version to used based on active variant used by the `cctools` package.