### PR TITLE
ccache: update to 3.7.1

### DIFF
--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
 name                ccache
-version             3.6
+github.setup        ccache ccache 3.7.1 v
 revision            0
-checksums           rmd160  9272beb4bdd5c6ed4bf66372c019306eb5a59c29 \
-                    sha256  a6b129576328fcefad00cb72035bc87bc98b6a76aec0f4b59bed76d67a399b1f \
-                    size    340608
+checksums           rmd160  ea189d1a42490050d591551e4396a89d4c611e23 \
+                    sha256  d618e6c257d000d974a7ebb46aaefd872f77a1efeaefe33829d7396b2ec60420 \
+                    size    384420
 
 categories          devel
 platforms           darwin freebsd
@@ -23,11 +24,14 @@ long_description \
     compilation can be satisfied from cache.  This often results in a 5 to 10 \
     times speedup in common compilations.
 
-homepage            https://ccache.samba.org/
-master_sites        https://www.samba.org/ftp/ccache/
-use_xz              yes
+homepage            https://ccache.dev
 
-depends_lib         port:zlib
+use_autoconf        yes
+autoconf.cmd        ./autogen.sh
+
+depends_lib         port:zlib \
+                    port:autoconf \
+                    port:asciidoc
 
 conflicts           ccache-devel
 


### PR DESCRIPTION
#### Description

ccache: update to 3.7.1

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.13.6 17G7020
Xcode 10.1 10B61

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?