### PR TITLE
notmuch: update to 0.28.4, dependency fix

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           conflicts_build 1.0
 
 name                notmuch
-version             0.28.3
+version             0.28.4
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -19,13 +19,19 @@ long_description    \"Not much mail\" is what Notmuch thinks about your email \
 homepage            https://notmuchmail.org
 master_sites        ${homepage}/releases/
 
-checksums           rmd160  17d98c379b9cf26606280709a6a3af940d0b97ef \
-                    sha256  4e212d8b4ae30da04edb05d836dcdb569488ff6760706cecb882488eb1710eec \
-                    size    921920
+checksums           rmd160  7b15b0ba3d1cda8f90b9b1083e14fd39b7040aae \
+                    sha256  bab1cabb0542ce2bd4b41a15b84a8d81c8dc3332162705ded6f311dd898656ca \
+                    size    922364
 
 depends_build       port:pkgconfig \
                     port:python37 \
-                    port:py37-sphinx
+                    port:py37-sphinx \
+                    port:py37-sphinxcontrib-applehelp \
+                    port:py37-sphinxcontrib-devhelp \
+                    port:py37-sphinxcontrib-htmlhelp \
+                    port:py37-sphinxcontrib-jsmath \
+                    port:py37-sphinxcontrib-qthelp \
+                    port:py37-sphinxcontrib-serializinghtml
 
 depends_lib         port:gmime \
                     port:talloc \


### PR DESCRIPTION
Update to upstream release 0.28.4. Added several sphinxcontrib ports as dependencies.

Closes: https://trac.macports.org/ticket/58444
