### PR TITLE
gtest: blacklist ineffective compilers

### DIFF
--- a/devel/gtest/Portfile
+++ b/devel/gtest/Portfile
@@ -3,6 +3,9 @@
 PortSystem      1.0
 PortGroup       cmake 1.1
 PortGroup       github 1.0
+PortGroup       compiler_blacklist_versions 1.0
+
+compiler.blacklist-append {clang < 500} *gcc-3.* *gcc-4.*
 
 github.setup    google googletest 1.8.1 release-
 revision        0


### PR DESCRIPTION
fixes built on older systems
tested on 10.7

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

[ci-skip]