### PR TITLE
rspamd: Add hyperscan regex processing

### DIFF
--- a/mail/rspamd/Portfile
+++ b/mail/rspamd/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cxx11                       1.1
 
 github.setup        rspamd rspamd 1.9.2
-revision            2
+revision            3
 
 categories          mail
 license             BSD
@@ -37,6 +37,7 @@ depends_lib-append  \
                     port:gd2 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gmime \
+                    port:hyperscan \
                     port:libevent \
                     port:libmagic \
                     port:libstemmer \
@@ -80,6 +81,7 @@ configure.args-append \
     -DDBDIR=${prefix}/var/lib/${name} \
     -DENABLE_FANN=ON \
     -DENABLE_GD=ON \
+    -DENABLE_HYPERSCAN=ON \
     -DENABLE_LIBUNWIND=ON \
     -DENABLE_LUAJIT=ON \
     -DENABLE_SNOWBALL=ON \
@@ -101,10 +103,6 @@ configure.args-append \
 # Do not use -DENABLE_PCRE2=ON without pcre jit debugging
 # # configure.args-append \
 # #     -DENABLE_PCRE2=ON
-
-# This option will need its own macport, see https://github.com/intel/hyperscan
-# configure.args-append \
-#     -DENABLE_HYPERSCAN=ON
 
 # Build with -DENABLE_FULL_DEBUG=ON
 # configure.args-append \


### PR DESCRIPTION
* Add hyperscan regex processing to the rspamd build
* https://github.com/macports/macports-ports/pull/4260
* Best regex option, also addresses current issues with ort:pcre, port:pcre2

see: https://trac.macports.org/ticket/58437

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->