### PR TITLE
snort: Add interface variants, remove unused/deprecated mysql variants

### DIFF
--- a/net/snort/Portfile
+++ b/net/snort/Portfile
@@ -2,13 +2,13 @@
 
 PortSystem 1.0
 
-name             snort
-version          2.9.13
-revision         0
-categories       net
-maintainers      nomaintainer
-license          GPL-2
-description      Open Source Network Intrusion Detection System
+name            snort
+version         2.9.13
+revision        1
+categories      net
+maintainers     nomaintainer
+license         GPL-2
+description     Open Source Network Intrusion Detection System
 long_description \
     Snort is an open source network intrusion detection system, capable \
     of performing real-time traffic analysis and packet logging on IP \
@@ -16,47 +16,67 @@ long_description \
     searching/matching and can be used to detect a variety of attacks \
     and probes, such as buffer overflows, stealth port scans, CGI \
     attacks, SMB probes, OS fingerprinting attempts, and much more.
-homepage         https://www.snort.org/
-platforms        darwin freebsd
-master_sites     ${homepage}downloads/snort/
+homepage        https://www.snort.org/
+platforms       darwin freebsd
+master_sites    ${homepage}downloads/snort/
 
-checksums           rmd160  fd6e48daa14622209871ddeecb0edcb7457ceddb \
-                    sha256  31447393d15286b848810dd78ab2cb3ad231fcd1f1663f959587690eeea75413 \
-                    size    6553425
+checksums       rmd160  fd6e48daa14622209871ddeecb0edcb7457ceddb \
+                sha256  31447393d15286b848810dd78ab2cb3ad231fcd1f1663f959587690eeea75413 \
+                size    6553425
 
-depends_build    port:pkgconfig
+depends_build   port:pkgconfig
 
-depends_lib      port:daq \
-                 port:luajit \
-                 port:nghttp2 \
-                 path:lib/libssl.dylib:openssl
-
-#patchfiles       patch-src-strlcatu.h.diff patch-src-strlcpyu.h.diff
+depends_lib     port:daq \
+                port:luajit \
+                port:nghttp2 \
+                path:lib/libssl.dylib:openssl
 
 add_users snort group=snort home=${prefix}/var/snort shell=/sbin/nologin realname=Snort\ user
 
+# snort interface, defined outside variants below so that `port lint` succeeds
+set interface en0
 
-set if en1
+# provide snort interface as port variants
+variant if_en0 \
+    conflicts if_en1 \
+    description "Snort launch daemon interface en0" {
+        set interface en0
+}
+
+variant if_en1 \
+    conflicts if_en0 \
+    description "Snort launch daemon interface en1" {
+        set interface en1
+}
+
+if { ![variant_isset if_en0] && ![variant_isset if_en1] } {
+    default_variants +if_en0
+}
+
 startupitem.create  yes
-startupitem.executable ${prefix}/bin/${name} -i ${if} -c ${prefix}/etc/snort/snort.conf -l ${prefix}/var/log/snort -u snort -g snort --pid-path ${prefix}/var/run
-startupitem.pidfile "${prefix}/var/run/snort_${if}.pid"
+startupitem.executable \
+    ${prefix}/bin/${name} \
+        -u snort -g snort \
+        -d \
+        -e \
+        -l ${prefix}/var/log/snort \
+        --pid-path ${prefix}/var/run \
+        -i ${interface} \
+        -c ${prefix}/etc/snort/snort.conf
+startupitem.pidfile "${prefix}/var/run/snort_${interface}.pid"
 #startupitem.start   "${prefix}/share/${name}/snort.sh"
 #startupitem.stop    "/bin/kill \$(cat ${prefix}/var/run/snort_*.pid)"
 
-destroot.asroot     yes
+destroot.asroot yes
 post-destroot {
-# Copy the Snort database schemas
-#    xinstall -d -m 755 ${destroot}${prefix}/share/${name}/schemas
-#    xinstall -m 755 {*}[glob ${worksrcpath}/schemas/create*] ${destroot}${prefix}/share/${name}/schemas
-
-# Copy Snort's etc/ files
+    # Copy Snort's etc/ files
     xinstall -d -m 755 ${destroot}${prefix}/etc/${name}
     xinstall {*}[glob ${worksrcpath}/etc/*.map] ${destroot}${prefix}/etc/${name}
     xinstall {*}[glob ${worksrcpath}/etc/*.conf*] ${destroot}${prefix}/etc/${name}
     xinstall -d -m 755 ${destroot}${prefix}/share/examples/${name}
     file rename ${destroot}${prefix}/etc/${name}/snort.conf ${destroot}${prefix}/share/examples/${name}/snort.conf.dist
 
-# fix snort.conf.dist
+    # fix snort.conf.dist
     reinplace "s|dynamicpreprocessor directory /usr/local/lib/snort_dynamicpreprocessor/|dynamicpreprocessor directory ${prefix}/lib/snort_dynamicpreprocessor/|g" ${destroot}${prefix}/share/examples/${name}/snort.conf.dist
     reinplace "s|dynamicengine /usr/local/lib/snort_dynamicengine/libsf_engine.so|dynamicengine ${prefix}/lib/snort_dynamicengine/libsf_engine.dylib|g" ${destroot}${prefix}/share/examples/${name}/snort.conf.dist
     reinplace "s|dynamicdetection directory /usr/local/lib/snort_dynamicrule/|dynamicdetection directory ${prefix}/lib/snort_dynamicrule/|g" ${destroot}${prefix}/share/examples/${name}/snort.conf.dist
@@ -107,7 +127,7 @@ Oinkmaster is the recommended way with regular updates.
 Change at least your HOME_NET in snort.conf and Validate your config with
     $ snort -T -c ${prefix}/etc/snort/snort.conf
 
-By default ${prefix}/share/${name}/snort.sh is configured to listen only on ${if} interface.
+By default ${prefix}/share/${name}/snort.sh is configured to listen only on ${interface} interface.
 If you want to listen multiple interface, you need to start one snort instance per interface (or bond them)
 
     $ grep 'Snort rules read' /var/log/system.log
@@ -128,75 +148,6 @@ http://systemnoise.com/wordpress/?p=89
 http://labs.snort.org/iplists/
 
 "
-
-if {![variant_isset mysql51] && ![variant_isset mysql55] && ![variant_isset mysql56] && ![variant_isset mariadb] && ![variant_isset percona] } {
-    default_variants +mysql57
-}
-
-variant mysql51 \
-    conflicts mysql55 mysql56  mysql57mariadb percona \
-    description "Enable MySQL 5.1 support" {
-
-    depends_lib-append          port:mysql51
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql51/bin/mysql_config
-    configure.args-append   --with-mysql-includes=${prefix}/include/mysql51/mysql \
-                            --with-mysql-libraries=${prefix}/lib/mysql51/mysql
-    configure.env               CFLAGS=-L${prefix}/lib/mysql51/mysql
-}
-
-variant mysql55 \
-    conflicts mysql51 mysql56 mysql57 mariadb percona \
-    description "Enable MySQL 5.5 support" {
-
-    depends_lib-append          port:mysql55
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql55/bin/mysql_config
-    configure.args-append   --with-mysql-includes=${prefix}/include/mysql55/mysql \
-                            --with-mysql-libraries=${prefix}/lib/mysql55/mysql
-    configure.env               CFLAGS=-L${prefix}/lib/mysql55/mysql
-}
-
-variant mysql56 \
-    conflicts mysql51 mysql55 mysql57 mariadb percona \
-    description "Enable MySQL 5.6 support" {
-
-    depends_lib-append          port:mysql56
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql56/bin/mysql_config
-    configure.args-append   --with-mysql-includes=${prefix}/include/mysql56/mysql \
-                            --with-mysql-libraries=${prefix}/lib/mysql56/mysql
-    configure.env               CFLAGS=-L${prefix}/lib/mysql56/mysql
-}
-
-variant mysql57 \
-    conflicts mysql51 mysql55 mysql56 mariadb percona \
-    description "Enable MySQL 5.7 support" {
-
-    depends_lib-append          port:mysql57
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql57/bin/mysql_config
-    configure.args-append   --with-mysql-includes=${prefix}/include/mysql57/mysql \
-                            --with-mysql-libraries=${prefix}/lib/mysql57/mysql
-    configure.env               CFLAGS=-L${prefix}/lib/mysql57/mysql
-}
-
-variant mariadb \
-    conflicts mysql51 mysql55 mysql56 mysql57 percona \
-    description "Enable MariaDB (MySQL) support" {
-
-    depends_lib-append          port:mariadb
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mariadb/bin/mysql_config
-    configure.args-append   --with-mysql-includes=${prefix}/include/mariadb/mysql \
-                            --with-mysql-libraries=${prefix}/lib/mariadb/mysql
-    configure.env               CFLAGS=-L${prefix}/lib/mariadb/mysql
-}
-
-variant percona \
-    conflicts mysql51 mysql55 mysql56 mysql57 mariadb \
-    description "Enable Percona (MySQL) support" {
-    depends_lib-append          port:percona
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/percona/bin/mysql_config
-    configure.args-append   --with-mysql-includes=${prefix}/include/percona/mysql \
-                            --with-mysql-libraries=${prefix}/lib/percona/mysql
-    configure.env               CFLAGS=-L${prefix}/lib/percona/mysql
-}
 
 livecheck.type      regex
 livecheck.url       ${homepage}downloads


### PR DESCRIPTION
snort: Add interface variants, remove unused/deprecated mysql variants

* Add variants if_en0, if_en1, […] for the snort launch daemon
* Snort no longer supports SQL variants, remove these unused dependencies

#### Description

Snort itself no longer supports SQL output because it's too slow. This port should not default to installing MySQL, especially when it is not used for building or at runtime.

Therefore, I've removed the unused MySQL dependencies from this `Portfile`.

In addition, I've added variants to support different interfaces, with the default interface `en0`, corresponding to the variant `if_en0`.

The unused MySQL part of the build may be confirmed by examining the output of the `configure` command during build:
```
clang: warning: argument unused during compilation: '-L/opt/local/lib/mysql57/mysql' [-Wunused-command-line-argument]
clang: warning: clang: warning: argument unused during compilation: '-L/opt/local/lib/mysql57/mysql' [-Wunused-command-line-argument]argument unused during compilation: '-L/opt/local/lib/mysql57/mysql' [-Wunused-command-line-argument]
```

Any the dynamic library dependencies in the final binary:
```
otool -L `which snort` | grep -i sql
# nothing there
```

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Notes on this PR:
* It would be good if @Schamschula could weigh in
* Is there some programmatic way within the `Portfile` to specify arbitrary interface names? This would avoid a possible zoo of interfaces you'd want to have snort watch. What if we wanted, say, a variant like `if_pflog0` to watch interface `pflog0`?
* After snort 3 comes out of alpha/beta, we'll want to add [intel/hyperscan](../../../../intel/hyperscan) support to snort 3, https://github.com/macports/macports-ports/pull/4260. Because hyperscan is [already used](https://blog.github.com/2018-10-17-behind-the-scenes-of-github-token-scanning/) every single time we type or commit anything into GitHub, I'd suggest that's it's rock solid and should be the default.