### PR TITLE
py-sphinx: reverse depends_run to required packages

### DIFF
--- a/python/py-sphinx/Portfile
+++ b/python/py-sphinx/Portfile
@@ -6,6 +6,7 @@ PortGroup           select 1.0
 
 name                py-sphinx
 version             2.0.1
+revision            1
 categories-append   textproc devel
 license             BSD
 maintainers         {jmr @jmroot} openmaintainer
@@ -49,6 +50,14 @@ if {$subport ne $name} {
         depends_run-append  port:py${python.version}-six \
                             port:py${python.version}-sphinxcontrib-websupport \
                             port:py${python.version}-typing
+    } else {
+        depends_run-append  port:py${python.version}-sphinxcontrib-applehelp \
+                            port:py${python.version}-sphinxcontrib-devhelp \
+                            port:py${python.version}-sphinxcontrib-htmlhelp \
+                            port:py${python.version}-sphinxcontrib-jsmath \
+                            port:py${python.version}-sphinxcontrib-serializinghtml \
+                            port:py${python.version}-sphinxcontrib-qthelp
+
     }
 
     distname        Sphinx-${version}

--- a/python/py-sphinxcontrib-applehelp/Portfile
+++ b/python/py-sphinxcontrib-applehelp/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-sphinxcontrib-applehelp
 version             1.0.1
+revision            1
 categories-append   textproc devel
 platforms           darwin
 license             BSD
@@ -26,8 +27,6 @@ python.versions     34 35 36 37
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
-    depends_run-append \
-                        port:py${python.version}-sphinx
     livecheck.type      none
 } else {
     livecheck.type      pypi

--- a/python/py-sphinxcontrib-devhelp/Portfile
+++ b/python/py-sphinxcontrib-devhelp/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-sphinxcontrib-devhelp
 version             1.0.1
+revision            1
 categories-append   textproc devel
 platforms           darwin
 license             BSD
@@ -27,7 +28,6 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_run-append \
-                        port:py${python.version}-sphinx \
                         port:py${python.version}-docutils
     livecheck.type      none
 } else {

--- a/python/py-sphinxcontrib-htmlhelp/Portfile
+++ b/python/py-sphinxcontrib-htmlhelp/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-sphinxcontrib-htmlhelp
 version             1.0.2
+revision            1
 categories-append   textproc devel
 platforms           darwin
 license             BSD
@@ -28,7 +29,6 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_run-append \
-                        port:py${python.version}-sphinx \
                         port:py${python.version}-docutils
     livecheck.type      none
 } else {

--- a/python/py-sphinxcontrib-jsmath/Portfile
+++ b/python/py-sphinxcontrib-jsmath/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-sphinxcontrib-jsmath
 version             1.0.1
+revision            1
 categories-append   textproc devel
 platforms           darwin
 license             BSD
@@ -27,7 +28,6 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_run-append \
-                        port:py${python.version}-sphinx \
                         port:py${python.version}-docutils
     livecheck.type      none
 } else {

--- a/python/py-sphinxcontrib-qthelp/Portfile
+++ b/python/py-sphinxcontrib-qthelp/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-sphinxcontrib-qthelp
 version             1.0.2
+revision            1
 categories-append   textproc devel
 platforms           darwin
 license             BSD
@@ -27,7 +28,6 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
     depends_run-append \
-                        port:py${python.version}-sphinx \
                         port:py${python.version}-docutils
     livecheck.type      none
 } else {

--- a/python/py-sphinxcontrib-serializinghtml/Portfile
+++ b/python/py-sphinxcontrib-serializinghtml/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-sphinxcontrib-serializinghtml
 version             1.1.3
+revision            1
 categories-append   textproc devel
 platforms           darwin
 license             BSD
@@ -26,8 +27,6 @@ python.versions     34 35 36 37
 if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools
-    depends_run-append \
-                        port:py${python.version}-sphinx
     livecheck.type      none
 } else {
     livecheck.type      pypi


### PR DESCRIPTION
I wanted to use `sphinx-build` for building another package, but it didn't work due to missing `sphinxcontrib` packages. This fixes it.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
