### PR TITLE
hyperscan: Use `cmake.build_type  Release`

### DIFF
--- a/textproc/hyperscan/Portfile
+++ b/textproc/hyperscan/Portfile
@@ -6,7 +6,7 @@ PortGroup           github                      1.0
 PortGroup           cxx11                       1.1
 
 github.setup        intel hyperscan 5.1.1 v
-revision            0
+revision            1
 
 categories          textproc
 license             BSD
@@ -36,10 +36,9 @@ depends_lib-append \
     port:pcre \
     port:sqlite3
 
-# This flags adds -Werror, which causes compile errors with -Wshadow
+# The flag `-DCMAKE_BUILD_TYPE=MacPorts` adds -Werror, which causes compile errors with -Wshadow
 # Reference: https://github.com/intel/hyperscan/blob/master/CMakeLists.txt
-configure.pre_args-delete \
-    -DCMAKE_BUILD_TYPE=MacPorts
+cmake.build_type    Release
 
 configure.args-append \
     -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7


### PR DESCRIPTION
hyperscan: Use `cmake.build_type  Release`

* Better solution than deleting `-DCMAKE_BUILD_TYPE`
* https://github.com/macports/macports-ports/pull/4260#issuecomment-490168641

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 8.latest

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->