### PR TITLE
muchsync: new port submission

### DIFF
--- a/mail/muchsync/Portfile
+++ b/mail/muchsync/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                muchsync
+version             5
+categories          mail
+platforms           darwin
+license             GPL-2+
+maintainers         {seichter.de:macports @rseichter} openmaintainer
+description         Synchronize mail messages and notmuch tags across machines.
+long_description    Muchsync brings Notmuch to all of your computers by \
+                    synchronizing your mail messages and Notmuch tags across \
+                    machines. The protocol is heavily pipelined to work \
+                    efficiently over high-latency networks such as mobile \
+                    broadband.
+homepage            http://www.muchsync.org/
+master_sites        http://www.muchsync.org/src/
+
+checksums           rmd160  2069ef1e6812e7cd4d7eacfb449e78d28d93c5aa \
+                    sha256  8b0afc2ce2dca636ae318659452902e26ac804d1b8b1982e74dbc4222f2155cc \
+                    size    134107
+
+depends_lib         port:notmuch


### PR DESCRIPTION
#### Description

(Copied from [this source](http://www.muchsync.org))

Notmuch is a nice mail indexer with front ends for emacs and vim. If you like the idea of fully-indexed, tag-based email like gmail, but you don’t want a cloud- or web-based solution, then notmuch may be for you. However, notmuch stores all of your mail locally on one machine. Hence, until now, if you wanted the full benefit of notmuch tags, you could only conveniently read your email on a single machine.

Muchsync brings notmuch to all of your computers by synchronizing your mail messages and notmuch tags across machines. The protocol is heavily pipelined to work efficiently over high-latency networks such as mobile broadband. [...]

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] submission

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
