### PR TITLE
nodejs8-12: fix build on older systems

### DIFF
--- a/devel/nodejs10/Portfile
+++ b/devel/nodejs10/Portfile
@@ -1,6 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               compiler_blacklist_versions 1.0
+
+# on macOS nodejs only builds against libc++
+# this force is OK as node does not link against any other c++ libs
+depends_lib-append      port:libcxx
+configure.cxx_stdlib    libc++
 PortGroup               cxx11 1.1
 
 name                    nodejs10
@@ -59,6 +65,12 @@ post-patch {
         reinplace -q "s|'python'|'${configure.python}'|" ${gypfile}
     }
     reinplace "s|python|${configure.python}|" ${worksrcpath}/deps/v8/gypfiles/toolchain.gypi
+}
+
+# use the system libuv instead of the bundled version, as it is fixed for older systems
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
 
 configure.args-append   --without-npm
@@ -240,13 +252,6 @@ destroot {
         LICENSE \
         README.md \
         ${docdir}
-}
-
-if {${os.major} < 11} {
-    pre-fetch {
-        ui_error "${name} ${version} requires Mac OS X 10.7 or greater."
-        return -code error "incompatible Mac OS X version"
-    }
 }
 
 livecheck.url       ${homepage}dist/

--- a/devel/nodejs11/Portfile
+++ b/devel/nodejs11/Portfile
@@ -1,6 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               compiler_blacklist_versions 1.0
+
+# on macOS nodejs only builds against libc++
+# this force is OK as node does not link against any other c++ libs
+depends_lib-append      port:libcxx
+configure.cxx_stdlib    libc++
 PortGroup               cxx11 1.1
 
 name                    nodejs11
@@ -59,6 +65,12 @@ post-patch {
         reinplace -q "s|'python'|'${configure.python}'|" ${gypfile}
     }
     reinplace "s|python|${configure.python}|" ${worksrcpath}/deps/v8/gypfiles/toolchain.gypi
+}
+
+# use the system libuv instead of the bundled version, as it is fixed for older systems
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
 
 configure.args-append   --without-npm
@@ -242,13 +254,6 @@ destroot {
         LICENSE \
         README.md \
         ${docdir}
-}
-
-if {${os.major} < 11} {
-    pre-fetch {
-        ui_error "${name} ${version} requires Mac OS X 10.7 or greater."
-        return -code error "incompatible Mac OS X version"
-    }
 }
 
 livecheck.url       ${homepage}dist/

--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -1,6 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               compiler_blacklist_versions 1.0
+
+# on macOS nodejs only builds against libc++
+# this force is OK as node does not link against any other c++ libs
+depends_lib-append      port:libcxx
+configure.cxx_stdlib    libc++
 PortGroup               cxx11 1.1
 
 name                    nodejs12
@@ -56,6 +62,12 @@ post-patch {
     foreach gypfile [rec_glob ${worksrcpath} *.gyp*] {
         reinplace -q "s|'python'|'${configure.python}'|" ${gypfile}
     }
+}
+
+# use the system libuv instead of the bundled version, as it is fixed for older systems
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
 
 configure.args-append   --without-npm
@@ -238,13 +250,6 @@ destroot {
         LICENSE \
         README.md \
         ${docdir}
-}
-
-if {${os.major} < 11} {
-    pre-fetch {
-        ui_error "${name} ${version} requires Mac OS X 10.7 or greater."
-        return -code error "incompatible Mac OS X version"
-    }
 }
 
 livecheck.url       ${homepage}dist/

--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -3,6 +3,12 @@
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 
+# on macOS nodejs only builds against libc++
+# this force is OK as node does not link against any other c++ libs
+depends_lib-append      port:libcxx
+configure.cxx_stdlib    libc++
+PortGroup               cxx11 1.1
+
 name                    nodejs8
 version                 8.16.0
 categories              devel net
@@ -31,7 +37,7 @@ distname                node-v${version}
 
 depends_build           port:pkgconfig
 
-depends_lib             port:python27 \
+depends_lib-append      port:python27 \
                         path:lib/libssl.dylib:openssl
 
 proc rec_glob {basedir pattern} {
@@ -62,6 +68,12 @@ post-patch {
     }
     reinplace "s|/usr/bin/env node|${prefix}/bin/node|" ${worksrcpath}/tools/doc/node_modules/marked/bin/marked
     reinplace "s|python|${configure.python}|" ${worksrcpath}/deps/v8/gypfiles/toolchain.gypi
+}
+
+# use the system libuv instead of the bundled version, as it is fixed for older systems
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    depends_lib-append    path:lib/libuv.dylib:libuv
+    configure.args-append --shared-libuv
 }
 
 configure.args-append   --without-npm
@@ -198,13 +210,6 @@ destroot {
         LICENSE \
         README.md \
         ${docdir}
-}
-
-if {${os.major} < 11} {
-    pre-fetch {
-        ui_error "${name} ${version} requires Mac OS X 10.7 or greater."
-        return -code error "incompatible Mac OS X version"
-    }
 }
 
 livecheck.url       ${homepage}dist/


### PR DESCRIPTION
nodejs only builds against libc++ on macOS
the errors building against libstdc++ headers are heavy
nodejs does not link against any c++ libraries, so forcing
it to build against libc++ is acceptable on all systems

the version of libuv bundled with node could be patched to work
on systems < 10.7, but it's simpler to use the libuv port for these systems
