### PR TITLE
Updating repository URLs to new location.

### DIFF
--- a/science/esorepo/Portfile
+++ b/science/esorepo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                esorepo
 version             1.1
-revision            1
+revision            2
 categories          science
 license             GPL-2+
 platforms           darwin
@@ -38,17 +38,17 @@ pre-activate {
     set config_data [read ${config_file}]
     close ${config_file}
     set already_in_sources 0
-    if {[regexp -line {^ftp://ftp\.eso\.org/pub/dfs/pipelines/repositories/macports/ports\.tar$} ${config_data}]} {
+    if {[regexp -line {^ftp://ftp\.eso\.org/pub/dfs/pipelines/repositories/stable/macports/ports\.tar$} ${config_data}]} {
         set already_in_sources 1
-        ui_error "${prefix}/etc/macports/sources.conf already contains a reference to ftp://ftp.eso.org/pub/dfs/pipelines/repositories/macports/ports.tar."
+        ui_error "${prefix}/etc/macports/sources.conf already contains a reference to ftp://ftp.eso.org/pub/dfs/pipelines/repositories/stable/macports/ports.tar."
     }
     set config_file [open ${prefix}/etc/macports/archive_sites.conf r]
     set config_data [read ${config_file}]
     close ${config_file}
     set already_in_archive_sites 0
-    if {[regexp -line {^urls\s+ftp://ftp\.eso\.org/pub/dfs/pipelines/repositories/macports/packages$} ${config_data}]} {
+    if {[regexp -line {^urls\s+ftp://ftp\.eso\.org/pub/dfs/pipelines/repositories/stable/macports/packages$} ${config_data}]} {
         set already_in_archive_sites 1
-        ui_error "${prefix}/etc/macports/archive_sites.conf already contains a reference to ftp://ftp.eso.org/pub/dfs/pipelines/repositories/macports/packages."
+        ui_error "${prefix}/etc/macports/archive_sites.conf already contains a reference to ftp://ftp.eso.org/pub/dfs/pipelines/repositories/stable/macports/packages."
     }
     set config_file [open ${prefix}/etc/macports/pubkeys.conf r]
     set config_data [read ${config_file}]
@@ -72,7 +72,7 @@ pre-activate {
     }
     set config_file [open ${prefix}/etc/macports/sources.conf a]
     puts ${config_file} "# ESO MacPorts Portfile source repository (automatically added by ${name})."
-    puts ${config_file} "ftp://ftp.eso.org/pub/dfs/pipelines/repositories/macports/ports.tar"
+    puts ${config_file} "ftp://ftp.eso.org/pub/dfs/pipelines/repositories/stable/macports/ports.tar"
     close ${config_file}
     set config_file [open ${prefix}/etc/macports/archive_sites.conf a]
     puts ${config_file} "# ESO MacPorts binary package repository (automatically added by ${name})."
@@ -81,7 +81,7 @@ pre-activate {
     puts ${config_file} "prefix           /opt/local"
     puts ${config_file} "applications_dir /Applications/MacPorts"
     puts ${config_file} "frameworks_dir   /opt/local/Library/Frameworks"
-    puts ${config_file} "urls             ftp://ftp.eso.org/pub/dfs/pipelines/repositories/macports/packages"
+    puts ${config_file} "urls             ftp://ftp.eso.org/pub/dfs/pipelines/repositories/stable/macports/packages"
     close ${config_file}
     set config_file [open ${prefix}/etc/macports/pubkeys.conf a]
     puts ${config_file} "# ESO RSA public signature key (automatically added by ${name})."
@@ -91,10 +91,10 @@ pre-activate {
 
 post-deactivate {
     reinplace -E "/^# ESO MacPorts Portfile source repository \\(automatically added by ${name}\\)\\.\[\[:space:]]*$/{ \
-        N;/\\nftp:\\/\\/ftp\\.eso\\.org\\/pub\\/dfs\\/pipelines\\/repositories\\/macports\\/ports\\.tar\[\[:space:]]*$/d;}" \
+        N;/\\nftp:\\/\\/ftp\\.eso\\.org\\/pub\\/dfs\\/pipelines\\/repositories\\/stable\\/macports\\/ports\\.tar\[\[:space:]]*$/d;}" \
         ${prefix}/etc/macports/sources.conf
     reinplace -E "/^# ESO MacPorts binary package repository \\(automatically added by ${name}\\)\\.\[\[:space:]]*$/{ \
-        N;N;N;N;N;N;/\\nurls \[\[:space:]]*ftp:\\/\\/ftp\\.eso\\.org\\/pub\\/dfs\\/pipelines\\/repositories\\/macports\\/packages\[\[:space:]]*$/d;}" \
+        N;N;N;N;N;N;/\\nurls \[\[:space:]]*ftp:\\/\\/ftp\\.eso\\.org\\/pub\\/dfs\\/pipelines\\/repositories\\/stable\\/macports\\/packages\[\[:space:]]*$/d;}" \
         ${prefix}/etc/macports/archive_sites.conf
     reinplace -E "/^# ESO RSA public signature key \\(automatically added by ${name}\\)\\.\[\[:space:]]*$/{ \
         N;/\\n\[^#]*\\/share\\/${name}\\/eso-pubkey\\.pem\[\[:space:]]*$/d;}" \


### PR DESCRIPTION
#### Description

Updating the esorepo Portfile to use current repository URLs. i.e. changing from:
  ftp://ftp.eso.org/pub/dfs/pipelines/repositories/macports/
to the following:
  ftp://ftp.eso.org/pub/dfs/pipelines/repositories/stable/macports/
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->

macOS 10.14.4 18E2034
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
