### PR TITLE
libsdl2 support libs: require immintrin.h

### DIFF
--- a/devel/libsdl2_image/Portfile
+++ b/devel/libsdl2_image/Portfile
@@ -22,6 +22,9 @@ distname        ${my_name}-${version}
 checksums       rmd160 38f41a706fd9e6cce11f7e5c13fc58c02d6878cc \
                 sha256 e74ec49c2402eb242fbfa16f2f43a19582a74c2eabfbfb873f00d4250038ceac
 
+# error: immintrin.h: No such file or directory
+compiler.blacklist-append *gcc3.* *gcc-4.*
+
 depends_build   port:pkgconfig
 depends_lib     port:libsdl2 \
                 port:jpeg \

--- a/devel/libsdl2_net/Portfile
+++ b/devel/libsdl2_net/Portfile
@@ -22,6 +22,9 @@ distname        ${my_name}-${version}
 checksums       rmd160 58d27e62ddf40068243e68148fdd98cad0f89832 \
                 sha256 15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21
 
+# error: immintrin.h: No such file or directory
+compiler.blacklist-append *gcc3.* *gcc-4.*
+
 depends_build   port:pkgconfig
 depends_lib     port:libsdl2
 

--- a/devel/libsdl2_ttf/Portfile
+++ b/devel/libsdl2_ttf/Portfile
@@ -20,6 +20,9 @@ distname        ${my_name}-${version}
 checksums       rmd160 a651ca843f4fee0b439f76ba308f047e52d699c1 \
                 sha256 a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33
 
+# error: immintrin.h: No such file or directory
+compiler.blacklist-append *gcc3.* *gcc-4.*
+
 depends_build   port:pkgconfig
 depends_lib     port:libsdl2 \
                 port:freetype


### PR DESCRIPTION
not found with gcc-3.* or gcc-4.*

fixes build on 10.6 where clang is not the default