### PR TITLE
nodejsX: Use glob to find includes to install instead of hardcoded lists

### DIFF
--- a/devel/nodejs10/Portfile
+++ b/devel/nodejs10/Portfile
@@ -11,6 +11,7 @@ PortGroup               cxx11 1.1
 
 name                    nodejs10
 version                 10.15.3
+revision                1
 
 categories              devel net
 platforms               darwin
@@ -127,122 +128,28 @@ destroot {
     xinstall -d ${incdir}
     xinstall -d ${docdir}
 
-# install binaries
+    # install binaries
     xinstall -m 755 -W ${worksrcpath} \
         out/Release/node \
         ${bindir}
 
-# install headers
-    xinstall -m 644 -W ${worksrcpath} \
-        src/aliased_buffer.h \
-        src/async_wrap-inl.h \
-        src/async_wrap.h \
-        src/base64.h \
-        src/base_object-inl.h \
-        src/base_object.h \
-        src/connect_wrap.h \
-        src/connection_wrap.h \
-        src/debug_utils.h \
-        src/env-inl.h \
-        src/env.h \
-        src/handle_wrap.h \
-        src/inspector_agent.h \
-        src/inspector_io.h \
-        src/inspector_socket.h \
-        src/inspector_socket_server.h \
-        src/js_stream.h \
-        src/memory_tracker-inl.h \
-        src/memory_tracker.h \
-        src/module_wrap.h \
-        src/node.h \
-        src/node_api.h \
-        src/node_api_types.h \
-        src/node_buffer.h \
-        src/node_code_cache.h \
-        src/node_constants.h \
-        src/node_context_data.h \
-        src/node_contextify.h \
-        src/node_counters.h \
-        src/node_crypto.h \
-        src/node_crypto_bio.h \
-        src/node_crypto_clienthello-inl.h \
-        src/node_crypto_clienthello.h \
-        src/node_crypto_groups.h \
-        src/node_dtrace.h \
-        src/node_errors.h \
-        src/node_file.h \
-        src/node_http2.h \
-        src/node_http2_state.h \
-        src/node_i18n.h \
-        src/node_internals.h \
-        src/node_javascript.h \
-        src/node_messaging.h \
-        src/node_mutex.h \
-        src/node_object_wrap.h \
-        src/node_perf.h \
-        src/node_perf_common.h \
-        src/node_persistent.h \
-        src/node_platform.h \
-        src/node_revert.h \
-        src/node_root_certs.h \
-        src/node_stat_watcher.h \
-        src/node_url.h \
-        src/node_version.h \
-        src/node_watchdog.h \
-        src/node_win32_etw_provider-inl.h \
-        src/node_win32_etw_provider.h \
-        src/node_win32_perfctr_provider.h \
-        src/node_worker.h \
-        src/pipe_wrap.h \
-        src/req_wrap-inl.h \
-        src/req_wrap.h \
-        src/sharedarraybuffer_metadata.h \
-        src/spawn_sync.h \
-        src/stream_base-inl.h \
-        src/stream_base.h \
-        src/stream_pipe.h \
-        src/stream_wrap.h \
-        src/string_bytes.h \
-        src/string_decoder-inl.h \
-        src/string_decoder.h \
-        src/string_search.h \
-        src/tcp_wrap.h \
-        src/tls_wrap.h \
-        src/tty_wrap.h \
-        src/udp_wrap.h \
-        src/util-inl.h \
-        src/util.h \
-        src/v8abbr.h \
-        deps/v8/include/v8-inspector-protocol.h \
-        deps/v8/include/v8-inspector.h \
-        deps/v8/include/v8-platform.h \
-        deps/v8/include/v8-profiler.h \
-        deps/v8/include/v8-testing.h \
-        deps/v8/include/v8-util.h \
-        deps/v8/include/v8-value-serializer-version.h \
-        deps/v8/include/v8-version-string.h \
-        deps/v8/include/v8-version.h \
-        deps/v8/include/v8.h \
-        deps/v8/include/v8config.h \
-        deps/uv/include/uv.h \
-        deps/cares/include/ares.h \
-        deps/cares/include/ares_build.h \
-        deps/cares/include/ares_rules.h \
-        deps/cares/include/ares_version.h \
-        deps/cares/include/nameser.h \
-        ${incdir}
+    # install headers
+    xinstall -m 644 {*}[glob ${worksrcpath}/src/*.h]                ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/v8/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/cares/include/*.h] ${incdir}
 
-# install dtrace script
+    # install dtrace script
     xinstall -m 644 -W ${worksrcpath} \
         src/node.d \
         ${libddir}
 
-# install manpage
+    # install manpage
     xinstall -m 644 -W ${worksrcpath} \
         doc/node.1 \
         ${destroot}${prefix}/share/man/man1
 
-# install docs
+    # install docs
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS \
         CHANGELOG.md \

--- a/devel/nodejs11/Portfile
+++ b/devel/nodejs11/Portfile
@@ -11,7 +11,8 @@ PortGroup               cxx11 1.1
 
 name                    nodejs11
 version                 11.15.0
-revision                0
+revision                1
+
 categories              devel net
 platforms               darwin
 license                 {MIT BSD}
@@ -127,124 +128,28 @@ destroot {
     xinstall -d ${incdir}
     xinstall -d ${docdir}
 
-# install binaries
+    # install binaries
     xinstall -m 755 -W ${worksrcpath} \
         out/Release/node \
         ${bindir}
 
-# install headers
-    xinstall -m 644 -W ${worksrcpath} \
-        src/aliased_buffer.h \
-        src/async_wrap-inl.h \
-        src/async_wrap.h \
-        src/base64.h \
-        src/base_object-inl.h \
-        src/base_object.h \
-        src/connect_wrap.h \
-        src/connection_wrap.h \
-        src/debug_utils.h \
-        src/env-inl.h \
-        src/env.h \
-        src/handle_wrap.h \
-        src/inspector_agent.h \
-        src/inspector_io.h \
-        src/inspector_socket.h \
-        src/inspector_socket_server.h \
-        src/js_stream.h \
-        src/memory_tracker-inl.h \
-        src/memory_tracker.h \
-        src/module_wrap.h \
-        src/node.h \
-        src/node_api.h \
-        src/node_api_types.h \
-        src/node_buffer.h \
-        src/node_constants.h \
-        src/node_context_data.h \
-        src/node_contextify.h \
-        src/node_crypto.h \
-        src/node_crypto_bio.h \
-        src/node_crypto_clienthello-inl.h \
-        src/node_crypto_clienthello.h \
-        src/node_crypto_groups.h \
-        src/node_dtrace.h \
-        src/node_errors.h \
-        src/node_file.h \
-        src/node_http2.h \
-        src/node_http2_state.h \
-        src/node_http_parser_impl.h \
-        src/node_i18n.h \
-        src/node_internals.h \
-        src/node_messaging.h \
-        src/node_metadata.h \
-        src/node_mutex.h \
-        src/node_native_module.h \
-        src/node_object_wrap.h \
-        src/node_options-inl.h \
-        src/node_options.h \
-        src/node_perf.h \
-        src/node_perf_common.h \
-        src/node_persistent.h \
-        src/node_platform.h \
-        src/node_revert.h \
-        src/node_root_certs.h \
-        src/node_stat_watcher.h \
-        src/node_union_bytes.h \
-        src/node_url.h \
-        src/node_version.h \
-        src/node_watchdog.h \
-        src/node_win32_etw_provider-inl.h \
-        src/node_win32_etw_provider.h \
-        src/node_worker.h \
-        src/pipe_wrap.h \
-        src/req_wrap-inl.h \
-        src/req_wrap.h \
-        src/sharedarraybuffer_metadata.h \
-        src/spawn_sync.h \
-        src/stream_base-inl.h \
-        src/stream_base.h \
-        src/stream_pipe.h \
-        src/stream_wrap.h \
-        src/string_bytes.h \
-        src/string_decoder-inl.h \
-        src/string_decoder.h \
-        src/string_search.h \
-        src/tcp_wrap.h \
-        src/tls_wrap.h \
-        src/tty_wrap.h \
-        src/udp_wrap.h \
-        src/util-inl.h \
-        src/util.h \
-        src/v8abbr.h \
-        deps/v8/include/v8-inspector-protocol.h \
-        deps/v8/include/v8-inspector.h \
-        deps/v8/include/v8-platform.h \
-        deps/v8/include/v8-profiler.h \
-        deps/v8/include/v8-testing.h \
-        deps/v8/include/v8-util.h \
-        deps/v8/include/v8-value-serializer-version.h \
-        deps/v8/include/v8-version-string.h \
-        deps/v8/include/v8-version.h \
-        deps/v8/include/v8.h \
-        deps/v8/include/v8config.h \
-        deps/uv/include/uv.h \
-        deps/cares/include/ares.h \
-        deps/cares/include/ares_build.h \
-        deps/cares/include/ares_rules.h \
-        deps/cares/include/ares_version.h \
-        deps/cares/include/nameser.h \
-        ${incdir}
+   # install headers
+    xinstall -m 644 {*}[glob ${worksrcpath}/src/*.h]                ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/v8/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/cares/include/*.h] ${incdir}
 
-# install dtrace script
+    # install dtrace script
     xinstall -m 644 -W ${worksrcpath} \
         src/node.d \
         ${libddir}
 
-# install manpage
+    # install manpage
     xinstall -m 644 -W ${worksrcpath} \
         doc/node.1 \
         ${destroot}${prefix}/share/man/man1
 
-# install docs
+    # install docs
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS \
         CHANGELOG.md \

--- a/devel/nodejs12/Portfile
+++ b/devel/nodejs12/Portfile
@@ -11,6 +11,8 @@ PortGroup               cxx11 1.1
 
 name                    nodejs12
 version                 12.2.0
+revision                1
+
 categories              devel net
 platforms               darwin
 license                 {MIT BSD}
@@ -124,123 +126,28 @@ destroot {
     xinstall -d ${incdir}
     xinstall -d ${docdir}
 
-# install binaries
+    # install binaries
     xinstall -m 755 -W ${worksrcpath} \
         out/Release/node \
         ${bindir}
 
-# install headers
-    xinstall -m 644 -W ${worksrcpath} \
-        src/aliased_buffer.h \
-        src/async_wrap-inl.h \
-        src/async_wrap.h \
-        src/base64.h \
-        src/base_object-inl.h \
-        src/base_object.h \
-        src/connect_wrap.h \
-        src/connection_wrap.h \
-        src/debug_utils.h \
-        src/env-inl.h \
-        src/env.h \
-        src/handle_wrap.h \
-        src/inspector_agent.h \
-        src/inspector_io.h \
-        src/inspector_socket.h \
-        src/inspector_socket_server.h \
-        src/js_stream.h \
-        src/memory_tracker-inl.h \
-        src/memory_tracker.h \
-        src/module_wrap.h \
-        src/node.h \
-        src/node_api.h \
-        src/node_api_types.h \
-        src/node_buffer.h \
-        src/node_constants.h \
-        src/node_context_data.h \
-        src/node_contextify.h \
-        src/node_crypto.h \
-        src/node_crypto_bio.h \
-        src/node_crypto_clienthello-inl.h \
-        src/node_crypto_clienthello.h \
-        src/node_crypto_groups.h \
-        src/node_dtrace.h \
-        src/node_errors.h \
-        src/node_file.h \
-        src/node_http2.h \
-        src/node_http2_state.h \
-        src/node_http_parser_impl.h \
-        src/node_i18n.h \
-        src/node_internals.h \
-        src/node_messaging.h \
-        src/node_metadata.h \
-        src/node_mutex.h \
-        src/node_native_module.h \
-        src/node_object_wrap.h \
-        src/node_options-inl.h \
-        src/node_options.h \
-        src/node_perf.h \
-        src/node_perf_common.h \
-        src/node_platform.h \
-        src/node_revert.h \
-        src/node_root_certs.h \
-        src/node_stat_watcher.h \
-        src/node_union_bytes.h \
-        src/node_url.h \
-        src/node_version.h \
-        src/node_watchdog.h \
-        src/node_win32_etw_provider-inl.h \
-        src/node_win32_etw_provider.h \
-        src/node_worker.h \
-        src/pipe_wrap.h \
-        src/req_wrap-inl.h \
-        src/req_wrap.h \
-        src/sharedarraybuffer_metadata.h \
-        src/spawn_sync.h \
-        src/stream_base-inl.h \
-        src/stream_base.h \
-        src/stream_pipe.h \
-        src/stream_wrap.h \
-        src/string_bytes.h \
-        src/string_decoder-inl.h \
-        src/string_decoder.h \
-        src/string_search.h \
-        src/tcp_wrap.h \
-        src/tls_wrap.h \
-        src/tty_wrap.h \
-        src/udp_wrap.h \
-        src/util-inl.h \
-        src/util.h \
-        src/v8abbr.h \
-        deps/v8/include/v8-inspector-protocol.h \
-        deps/v8/include/v8-inspector.h \
-        deps/v8/include/v8-platform.h \
-        deps/v8/include/v8-profiler.h \
-        deps/v8/include/v8-testing.h \
-        deps/v8/include/v8-util.h \
-        deps/v8/include/v8-value-serializer-version.h \
-        deps/v8/include/v8-version-string.h \
-        deps/v8/include/v8-version.h \
-        deps/v8/include/v8.h \
-        deps/v8/include/v8config.h \
-        deps/uv/include/uv.h \
-        deps/cares/include/ares.h \
-        deps/cares/include/ares_build.h \
-        deps/cares/include/ares_rules.h \
-        deps/cares/include/ares_version.h \
-        deps/cares/include/nameser.h \
-        ${incdir}
+    # install headers
+    xinstall -m 644 {*}[glob ${worksrcpath}/src/*.h]                ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/v8/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/cares/include/*.h] ${incdir}
 
-# install dtrace script
+    # install dtrace script
     xinstall -m 644 -W ${worksrcpath} \
         src/node.d \
         ${libddir}
 
-# install manpage
+    # install manpage
     xinstall -m 644 -W ${worksrcpath} \
         doc/node.1 \
         ${destroot}${prefix}/share/man/man1
 
-# install docs
+    # install docs
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS \
         CHANGELOG.md \

--- a/devel/nodejs6/Portfile
+++ b/devel/nodejs6/Portfile
@@ -5,7 +5,7 @@ PortGroup               compiler_blacklist_versions 1.0
 
 name                    nodejs6
 version                 6.17.1
-revision                1
+revision                2
 
 categories              devel net
 platforms               darwin
@@ -127,81 +127,28 @@ destroot {
     xinstall -d ${incdir}
     xinstall -d ${docdir}
 
-# install binaries
+    # install binaries
     xinstall -m 755 -W ${worksrcpath} \
         out/Release/node \
         ${bindir}
 
-# install headers
-    xinstall -m 644 -W ${worksrcpath} \
-        src/async-wrap-inl.h \
-        src/async-wrap.h \
-        src/base-object-inl.h \
-        src/base-object.h \
-        src/env-inl.h \
-        src/env.h \
-        src/handle_wrap.h \
-        src/node.h \
-        src/node_buffer.h \
-        src/node_constants.h \
-        src/node_counters.h \
-        src/node_crypto.h \
-        src/node_crypto_bio.h \
-        src/node_crypto_clienthello-inl.h \
-        src/node_crypto_clienthello.h \
-        src/node_crypto_groups.h \
-        src/node_dtrace.h \
-        src/node_file.h \
-        src/node_http_parser.h \
-        src/node_i18n.h \
-        src/node_internals.h \
-        src/node_javascript.h \
-        src/node_object_wrap.h \
-        src/node_root_certs.h \
-        src/node_stat_watcher.h \
-        src/node_version.h \
-        src/node_watchdog.h \
-        src/node_wrap.h \
-        src/pipe_wrap.h \
-        src/spawn_sync.h \
-        src/stream_wrap.h \
-        src/string_bytes.h \
-        src/tcp_wrap.h \
-        src/tls_wrap.h \
-        src/tree.h \
-        src/tty_wrap.h \
-        src/udp_wrap.h \
-        src/util-inl.h \
-        src/util.h \
-        src/v8abbr.h \
-        deps/v8/include/v8-debug.h \
-        deps/v8/include/v8-profiler.h \
-        deps/v8/include/v8-testing.h \
-        deps/v8/include/v8.h \
-        deps/v8/include/v8-platform.h \
-        deps/v8/include/v8-util.h \
-        deps/v8/include/v8config.h \
-        deps/uv/include/uv.h \
-        deps/uv/include/uv-unix.h \
-        deps/uv/include/uv-darwin.h \
-        deps/uv/include/tree.h \
-        deps/uv/include/uv-threadpool.h \
-        deps/cares/include/ares.h \
-        deps/cares/include/ares_version.h \
-        deps/cares/include/nameser.h \
-        ${incdir}
+    # install headers
+    xinstall -m 644 {*}[glob ${worksrcpath}/src/*.h]                ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/v8/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/cares/include/*.h] ${incdir}
 
-# install dtrace script
+    # install dtrace script
     xinstall -m 644 -W ${worksrcpath} \
         src/node.d \
         ${libddir}
 
-# install manpage
+    # install manpage
     xinstall -m 644 -W ${worksrcpath} \
         doc/node.1 \
         ${destroot}${prefix}/share/man/man1
 
-# install docs
+    # install docs
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS \
         CHANGELOG.md \

--- a/devel/nodejs8/Portfile
+++ b/devel/nodejs8/Portfile
@@ -11,6 +11,8 @@ PortGroup               cxx11 1.1
 
 name                    nodejs8
 version                 8.16.0
+revision                1
+
 categories              devel net
 platforms               darwin
 license                 {MIT BSD}
@@ -130,77 +132,28 @@ destroot {
     xinstall -d ${incdir}
     xinstall -d ${docdir}
 
-# install binaries
+    # install binaries
     xinstall -m 755 -W ${worksrcpath} \
         out/Release/node \
         ${bindir}
-
-# install headers
-    xinstall -m 644 -W ${worksrcpath} \
-        src/env-inl.h \
-        src/env.h \
-        src/handle_wrap.h \
-        src/node.h \
-        src/node_buffer.h \
-        src/node_constants.h \
-        src/node_counters.h \
-        src/node_crypto.h \
-        src/node_crypto_bio.h \
-        src/node_crypto_clienthello-inl.h \
-        src/node_crypto_clienthello.h \
-        src/node_crypto_groups.h \
-        src/node_dtrace.h \
-        src/node_i18n.h \
-        src/node_internals.h \
-        src/node_javascript.h \
-        src/node_object_wrap.h \
-        src/node_root_certs.h \
-        src/node_stat_watcher.h \
-        src/node_version.h \
-        src/node_watchdog.h \
-        src/node_wrap.h \
-        src/pipe_wrap.h \
-        src/spawn_sync.h \
-        src/stream_wrap.h \
-        src/string_bytes.h \
-        src/tcp_wrap.h \
-        src/tls_wrap.h \
-        src/tty_wrap.h \
-        src/udp_wrap.h \
-        src/util-inl.h \
-        src/util.h \
-        src/v8abbr.h \
-        deps/v8/include/v8-debug.h \
-        deps/v8/include/v8-profiler.h \
-        deps/v8/include/v8-testing.h \
-        deps/v8/include/v8.h \
-        deps/v8/include/v8-platform.h \
-        deps/v8/include/v8-util.h \
-        deps/v8/include/v8config.h \
-        deps/uv/include/uv.h \
-        deps/uv/include/uv/darwin.h \
-        deps/uv/include/uv/errno.h \
-        deps/uv/include/uv/posix.h \
-        deps/uv/include/uv/threadpool.h \
-        deps/uv/include/uv/tree.h \
-        deps/uv/include/uv/unix.h \
-        deps/uv/include/uv/version.h \
-        deps/cares/include/ares.h \
-        deps/cares/include/ares_version.h \
-        deps/cares/include/nameser.h \
-        ${incdir}
-
-# install dtrace script
+    
+    # install headers
+    xinstall -m 644 {*}[glob ${worksrcpath}/src/*.h]                ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/v8/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/uv/include/*.h]    ${incdir}
+    xinstall -m 644 {*}[glob ${worksrcpath}/deps/cares/include/*.h] ${incdir}
+    
+    # install dtrace script
     xinstall -m 644 -W ${worksrcpath} \
         src/node.d \
         ${libddir}
 
-# install manpage
+    # install manpage
     xinstall -m 644 -W ${worksrcpath} \
         doc/node.1 \
         ${destroot}${prefix}/share/man/man1
 
-# install docs
+    # install docs
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS \
         CHANGELOG.md \


### PR DESCRIPTION
#### Description

Replace long hardcoded lists of headers to install with cleaner glob.

Note, the glob finds all the headers previously listed, plus in some cases some additional ones currently missing. e.g.

```
Oberon ~/Downloads > ls
nodejs12.contents.1.log	nodejs12.contents.2.log
Oberon ~/Downloads > diff nodejs12.contents.*
18a19,21
>   /opt/local/include/node/histogram-inl.h
>   /opt/local/include/node/histogram.h
>   /opt/local/include/node/http_parser_adaptor.h
20a24
>   /opt/local/include/node/inspector_profiler.h
22a27,30
>   /opt/local/include/node/js_native_api.h
>   /opt/local/include/node/js_native_api_types.h
>   /opt/local/include/node/js_native_api_v8.h
>   /opt/local/include/node/js_native_api_v8_internals.h
30a39
>   /opt/local/include/node/node_binding.h
47a57
>   /opt/local/include/node/node_main_instance.h
51a62
>   /opt/local/include/node/node_native_module_env.h
57a69,70
>   /opt/local/include/node/node_process.h
>   /opt/local/include/node/node_report.h
62a76
>   /opt/local/include/node/node_v8_platform-inl.h
89a104
>   /opt/local/include/node/v8-internal.h
96a112,113
>   /opt/local/include/node/v8-wasm-trap-handler-posix.h
>   /opt/local/include/node/v8-wasm-trap-handler-win.h
```

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->