### PR TITLE
Add old_openssl port group

### DIFF
--- a/_resources/port1.0/group/old_openssl-1.0.tcl
+++ b/_resources/port1.0/group/old_openssl-1.0.tcl
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4; truncate-lines: t -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+#
+# Usage:
+# PortGroup     old_openssl 1.0
+#
+# This port group is for ports that are incompatible with the latest OpenSSL.
+# It's not needed for most ports.
+#
+# options:
+# openssl.branch: the OpenSSL branch to use (e.g. 1.0 for the latest OpenSSL on the 1.0.x branch).
+#   Currently only 1.0 is available.
+
+options openssl.branch
+option_proc openssl.branch openssl_set_branch
+options openssl.includedir
+default openssl.includedir      {${prefix}/include/openssl-${openssl.branch}}
+options openssl.libdir
+default openssl.libdir          {${prefix}/lib/openssl-${openssl.branch}}
+
+proc openssl_set_branch {option action args} {
+    if {$action ne "set"} {
+        return
+    }
+
+    global openssl.branch
+
+    set branch_no_dot [string map {. ""} ${openssl.branch}]
+
+    depends_lib-delete      path:lib/libssl.dylib:openssl
+    depends_lib-append      port:openssl${branch_no_dot}
+}
+
+proc openssl.configure {method} {
+    global prefix openssl.branch openssl.includedir openssl.libdir
+
+    switch ${method} {
+        pkgconfig {
+            configure.env-append PKG_CONFIG_PATH=${prefix}/lib/openssl-${openssl.branch}/pkgconfig
+            depends_build-append port:pkgconfig
+        }
+        build_flags {
+            configure.cppflags-prepend -I${openssl.includedir}
+            configure.ldflags-prepend -L${openssl.libdir}
+        }
+        default {
+            return -code error "invalid method \"${method}\" for openssl.configure"
+        }
+    } 
+}

--- a/lang/php/Portfile
+++ b/lang/php/Portfile
@@ -3,6 +3,7 @@
 PortSystem              1.0
 PortGroup               php 1.1
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               old_openssl 1.0
 
 name                    php
 platforms               darwin freebsd
@@ -1327,11 +1328,11 @@ if {[vercmp ${branch} 5.5] >= 0} {
 
 subport ${php}-openssl {
     switch -- ${version} {
-        5.2.17              {revision 0}
-        5.3.29              {revision 0}
-        5.4.45              {revision 0}
-        5.5.38              {revision 0}
-        5.6.40              {revision 0}
+        5.2.17              {revision 1}
+        5.3.29              {revision 1}
+        5.4.45              {revision 1}
+        5.5.38              {revision 1}
+        5.6.40              {revision 1}
         7.0.33              {revision 0}
         7.1.29              {revision 0}
         7.2.18              {revision 0}
@@ -1356,6 +1357,21 @@ subport ${php}-openssl {
     
     configure.args-append   --with-kerberos=${prefix} \
                             --with-openssl=${prefix}
+
+    if {[vercmp ${branch} 5.6] <= 0} {
+        openssl.branch 1.0
+        openssl.configure pkgconfig
+
+        # This patch is for reordering -I and -L flags during the build to make
+        # openssl-1.0 directories appear before others
+        patchfiles-append       patch-${php}-ext-openssl-config.m4.diff
+
+        post-patch {
+            reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/ext/openssl/config.m4
+        }
+
+        configure.args-replace  --with-openssl=${prefix} --with-openssl=shared
+    }
 }
 
 subport ${php}-oracle {

--- a/lang/php/files/patch-php52-ext-openssl-config.m4.diff
+++ b/lang/php/files/patch-php52-ext-openssl-config.m4.diff
@@ -1,0 +1,13 @@
+--- ext/openssl/config.m4.orig	2019-01-09 17:54:13.000000000 +0800
++++ ext/openssl/config.m4	2019-05-11 16:52:27.000000000 +0800
+@@ -32,4 +32,10 @@
+   ], [
+     AC_MSG_ERROR([OpenSSL check failed. Please check config.log for more information.])
+   ])
++
++  INCLUDES=`echo "$INCLUDES" | sed "s|-I@PREFIX@/include ||g"`
++  INCLUDES="$INCLUDES -I@PREFIX@/include"
++
++  LDFLAGS=`echo "$LDFLAGS" | sed "s|-L@PREFIX@/lib ||g"`
++  OPENSSL_SHARED_LIBADD="$OPENSSL_SHARED_LIBADD -L@PREFIX@/lib"
+ fi

--- a/lang/php/files/patch-php53-ext-openssl-config.m4.diff
+++ b/lang/php/files/patch-php53-ext-openssl-config.m4.diff
@@ -1,0 +1,13 @@
+--- ext/openssl/config.m4.orig	2019-01-09 17:54:13.000000000 +0800
++++ ext/openssl/config.m4	2019-05-11 16:52:27.000000000 +0800
+@@ -32,4 +32,10 @@
+   ], [
+     AC_MSG_ERROR([OpenSSL check failed. Please check config.log for more information.])
+   ])
++
++  INCLUDES=`echo "$INCLUDES" | sed "s|-I@PREFIX@/include ||g"`
++  INCLUDES="$INCLUDES -I@PREFIX@/include"
++
++  LDFLAGS=`echo "$LDFLAGS" | sed "s|-L@PREFIX@/lib ||g"`
++  OPENSSL_SHARED_LIBADD="$OPENSSL_SHARED_LIBADD -L@PREFIX@/lib"
+ fi

--- a/lang/php/files/patch-php54-ext-openssl-config.m4.diff
+++ b/lang/php/files/patch-php54-ext-openssl-config.m4.diff
@@ -1,0 +1,13 @@
+--- ext/openssl/config.m4.orig	2019-01-09 17:54:13.000000000 +0800
++++ ext/openssl/config.m4	2019-05-11 16:52:27.000000000 +0800
+@@ -32,4 +32,10 @@
+   ], [
+     AC_MSG_ERROR([OpenSSL check failed. Please check config.log for more information.])
+   ])
++
++  INCLUDES=`echo "$INCLUDES" | sed "s|-I@PREFIX@/include ||g"`
++  INCLUDES="$INCLUDES -I@PREFIX@/include"
++
++  LDFLAGS=`echo "$LDFLAGS" | sed "s|-L@PREFIX@/lib ||g"`
++  OPENSSL_SHARED_LIBADD="$OPENSSL_SHARED_LIBADD -L@PREFIX@/lib"
+ fi

--- a/lang/php/files/patch-php55-ext-openssl-config.m4.diff
+++ b/lang/php/files/patch-php55-ext-openssl-config.m4.diff
@@ -1,0 +1,13 @@
+--- ext/openssl/config.m4.orig	2019-01-09 17:54:13.000000000 +0800
++++ ext/openssl/config.m4	2019-05-11 16:52:27.000000000 +0800
+@@ -32,4 +32,10 @@
+   ], [
+     AC_MSG_ERROR([OpenSSL check failed. Please check config.log for more information.])
+   ])
++
++  INCLUDES=`echo "$INCLUDES" | sed "s|-I@PREFIX@/include ||g"`
++  INCLUDES="$INCLUDES -I@PREFIX@/include"
++
++  LDFLAGS=`echo "$LDFLAGS" | sed "s|-L@PREFIX@/lib ||g"`
++  OPENSSL_SHARED_LIBADD="$OPENSSL_SHARED_LIBADD -L@PREFIX@/lib"
+ fi

--- a/lang/php/files/patch-php56-ext-openssl-config.m4.diff
+++ b/lang/php/files/patch-php56-ext-openssl-config.m4.diff
@@ -1,0 +1,13 @@
+--- ext/openssl/config.m4.orig	2019-01-09 17:54:13.000000000 +0800
++++ ext/openssl/config.m4	2019-05-11 16:52:27.000000000 +0800
+@@ -32,4 +32,10 @@
+   if test "$PHP_SYSTEM_CIPHERS" != "no"; then
+     AC_DEFINE(USE_OPENSSL_SYSTEM_CIPHERS,1,[ Use system default cipher list instead of hardcoded value ])
+   fi
++
++  INCLUDES=`echo "$INCLUDES" | sed "s|-I@PREFIX@/include ||g"`
++  INCLUDES="$INCLUDES -I@PREFIX@/include"
++
++  LDFLAGS=`echo "$LDFLAGS" | sed "s|-L@PREFIX@/lib ||g"`
++  OPENSSL_SHARED_LIBADD="$OPENSSL_SHARED_LIBADD -L@PREFIX@/lib"
+ fi

--- a/lang/python26/Portfile
+++ b/lang/python26/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup old_openssl 1.0
 
 name                    python26
 # Remember to keep py26-tkinter and py26-gdbm's versions sync'd with this
@@ -48,7 +49,7 @@ patchfiles              patch-Makefile.pre.in.diff \
                         yosemite.patch \
                         improve-QuickTime.h-check.patch
 
-depends_lib             port:gettext port:zlib port:openssl10 \
+depends_lib             port:gettext port:zlib \
                         port:sqlite3 port:db46 port:ncurses \
                         port:bzip2 port:libedit
 depends_run             port:python_select \
@@ -61,8 +62,8 @@ configure.ccache        no
 # signed integer overflow is normally undefined as per the C spec, but python
 # needs it to be defined as twos-complement
 configure.cflags-append -fwrapv
-configure.cppflags-prepend -I${prefix}/include/openssl-1.0
-configure.ldflags-prepend -L${prefix}/lib/openssl-1.0
+openssl.branch 1.0
+openssl.configure build_flags
 
 post-patch {
    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/Lib/cgi.py \

--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -4,6 +4,7 @@ PortSystem		1.0
 PortGroup		muniversal 1.0
 PortGroup		compiler_blacklist_versions 1.0
 PortGroup		select 1.0
+PortGroup		old_openssl 1.0
 
 name			ruby
 version			1.8.7-p374
@@ -34,11 +35,12 @@ platforms		darwin
 
 depends_lib		port:libiconv \
 				port:readline \
-                port:openssl10 \
 				port:zlib \
 				port:ncurses \
 				port:gdbm
 depends_run		port:ruby_select
+
+openssl.branch  1.0
 
 select.group	ruby
 select.file		${filespath}/ruby18
@@ -97,8 +99,8 @@ configure.args	--enable-shared \
 				--without-tk \
 				--with-vendordir=${prefix}/lib/ruby/vendor_ruby \
 				--with-opt-dir=${prefix} \
-                --with-openssl-include=${prefix}/include/openssl-1.0 \
-                --with-openssl-lib=${prefix}/lib/openssl-1.0 \
+                --with-openssl-include=${openssl.includedir} \
+                --with-openssl-lib=${openssl.libdir} \
 				--program-suffix=1.8
 # ignore minor version for archdir, like i686-darwin9
 configure.env	UNAME_RELEASE=${os.major}


### PR DESCRIPTION
#### Description

They are not compatible with OpenSSL 1.1. For example, php56-openssl
fails with:
```
/opt/local/var/macports/build/_Users_yen_var_syncthing_Projects_macports-ports_lang_php/php56-openssl/work/php-5.6.40/ext/openssl/openssl.c:1904:15: error: incomplete definition of type 'struct X509_extension_st'
        p = extension->value->data;
            ~~~~~~~~~^
```
All ports tested with the following PHP script:

<?php
echo file_get_contents('https://httpbin.org/ip');
?>

Closes: https://trac.macports.org/ticket/58464

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? _only php*-openssl ports_
- [x] tested basic functionality of all binary files?
