### PR TITLE
geoexpress-sdk: fix failure to parse on < 10.11

### DIFF
--- a/gis/geoexpress-sdk/Portfile
+++ b/gis/geoexpress-sdk/Portfile
@@ -29,8 +29,10 @@ if { ${os.major} >= 16 } {
                     sha256  b5a067659451a9178cab165640071a004f03a8dd90f8a73bf3e3934528951079 \
                     size    56759213
 } else {
+  pre-fetch {
     ui_error "${name} ${version} requires Mac OS X 10.11 or greater."
     return -code error "incompatible Mac OS X version"
+  }
 }
 
 fetch {


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/58465

