### PR TITLE
tor-devel: update to 0.4.0.5

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.0.4-rc
+version             0.4.0.5
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  cbef1f0b5ce7737d305525a1fcaad48d83003a7f \
-                    sha256  9ebac95bc9eed602d439ca3232e7ee74df338e643f1568fac798945de64ae963 \
-                    size    7193480
+checksums           rmd160  cc0bead52c77d0cb7f65c7c083c48d3810514287 \
+                    sha256  b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e \
+                    size    7203877
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.0.5

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.13.6 17G7023
Xcode 10.1 10B61 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?