### PR TITLE
py-upt: update to version 0.7 and py-upt-macports: update

### DIFF
--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set git_hash        20b55dcc6a06f48da8a22c415bc74315dda5cb2e
+set git_hash        bb4e67ed3779359cbf5213f3e48b023b010dff07
 github.setup        macports upt-macports ${git_hash}
-version             0.1-20190425
+version             0.1-20190512
 name                py-${github.project}
 revision            0
 
@@ -18,9 +18,9 @@ platforms           darwin
 supported_archs     noarch
 
 license             BSD
-checksums           sha256  0ca86ece08418bec373d7c8de89dab17426ed23916bfc0bddae6265f8af917b0 \
-                    rmd160  ac5ba54d37bb8b907ea930cdc13f449e036e10e2 \
-                    size    4608
+checksums           sha256  9974332e0c7382f6bfca75471ac0afb7e3246b68fe655c78854441aea2689ebd \
+                    rmd160  e04956bf7872e572e8bfcf7b22bf1ad368271d61 \
+                    size    5582
 
 python.versions     37
 

--- a/python/py-upt/Portfile
+++ b/python/py-upt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-upt
-version             0.6
+version             0.7
 revision            0
 
 maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
@@ -19,9 +19,9 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
 license             BSD
-checksums           sha256  707b79dd699f5bdd68ef2eeb66bacfe2f86e0c93f99ad3a5c48b1b6a799b222b \
-                    rmd160  3b7b367dde8fe48315708de8cbbcf02034286fd5 \
-                    size    23609
+checksums           sha256  7de9a0cc9d55c175b611ed748ee7ea572ec308411934769e2e647d1d26ba2eea \
+                    rmd160  6dc1b42ac5760f8225c81b1cd9539332b33b1b7c \
+                    size    24223
 
 python.versions     37
 


### PR DESCRIPTION
#### Description

py-upt: update to version 0.7
py-upt-macports: update to bb4e67e (20190512)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->