### PR TITLE
gcc9: fix build on SnowLeopard

### DIFF
--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -10,7 +10,7 @@ epoch               4
 name                gcc8
 version             8.3.0
 revision            4
-subport             libgcc8 { revision 5 }
+subport             libgcc8 { revision 6 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -40,7 +40,9 @@ checksums           rmd160  59396f7136301466d0ec15eb7307558c0da692df \
 # If it is, libgcc8 installs a full runtime, otherwise it only installs
 # what is missing from newer libgccX builds.
 # NOTE : The logic here must match that in the libgcc port.
-set isLastSupported [ expr ${os.major} < 11 ]
+# at present, libgcc8 is not the last supported libgcc for any system
+# set isLastSupported [ expr ${os.major} < 10 ]
+set isLastSupported false
 
 depends_lib         port:cctools \
                     port:gmp \

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -37,6 +37,9 @@ checksums           rmd160  b9dd53082905c4ca2f7f8291af1e4d015bc97d39 \
                     sha256  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0 \
                     size    70546856
 
+# use alternate random source on < 10.7 as arc4random_buf not available there
+patchfiles          patch-gcc9-libsanitizer-arc4randombuf-missing-less-than-1070.diff
+
 depends_lib         port:cctools \
                     port:gmp \
                     path:lib/pkgconfig/isl.pc:isl \
@@ -190,7 +193,7 @@ destroot.target     install install-info-host
 
 # Is this gcc release supported here.
 pre-fetch {
-    if { ${os.major} < 11 } {
+    if { ${os.major} < 10 } {
         ui_error "${name} ${version} is not supported on Darwin ${os.major}"
         return -code error "incompatible OS X version"
     }

--- a/lang/gcc9/files/patch-gcc9-libsanitizer-arc4randombuf-missing-less-than-1070.diff
+++ b/lang/gcc9/files/patch-gcc9-libsanitizer-arc4randombuf-missing-less-than-1070.diff
@@ -1,0 +1,25 @@
+--- libsanitizer/sanitizer_common/sanitizer_mac.cc.orig	2019-05-12 11:27:25.000000000 -0700
++++ libsanitizer/sanitizer_common/sanitizer_mac.cc	2019-05-12 13:08:51.000000000 -0700
+@@ -1077,9 +1077,22 @@
+ bool GetRandom(void *buffer, uptr length, bool blocking) {
+   if (!buffer || !length || length > 256)
+     return false;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+   // arc4random never fails.
+   arc4random_buf(buffer, length);
+   return true;
++#else
++  // Up to 256 bytes, a read off /dev/urandom will not be interrupted.
++  // blocking is moot here, O_NONBLOCK has no effect when opening /dev/urandom.
++  uptr fd = internal_open("/dev/urandom", O_RDONLY);
++  if (internal_iserror(fd))
++    return false;
++  uptr res = internal_read(fd, buffer, length);
++  if (internal_iserror(res))
++    return false;
++  internal_close(fd);
++  return true;
++#endif
+ }
+ 
+ u32 GetNumberOfCPUs() {

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -6,7 +6,7 @@ PortGroup select    1.0
 epoch               3
 name                libgcc
 version             2.0
-revision            1
+revision            2
 
 conflicts           libgcc-devel
 
@@ -32,11 +32,7 @@ homepage            https://www.macports.org/
 if { ${os.major} < 10 } {
     set gcc_version 7
 } else {
-    if { ${os.major} < 11 } {
-        set gcc_version 8
-    } else {
-        set gcc_version 9
-    }
+    set gcc_version 9
 }
 depends_lib port:libgcc${gcc_version}
 


### PR DESCRIPTION
and make libgcc9 the default libgcc for SnowLeoapard

