### PR TITLE
tktable: update to 2.11

### DIFF
--- a/x11/tktable/Portfile
+++ b/x11/tktable/Portfile
@@ -4,19 +4,24 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                tktable
-version             2.10
-revision            2
+version             2.11
+revision            0
 categories          x11
+license             Tcl/Tk
 maintainers         nomaintainer
 description         A table/matrix widget extension to Tk/Tcl
 long_description    ${description}
 homepage            http://tktable.sourceforge.net/
 platforms           darwin
-master_sites        sourceforge
-distname            Tktable${version}
-checksums           rmd160  b326a472584a6965328f3f27dc98f69ddbdd45f9 \
-                    sha256  c335117fa1be45fe4d3032e96fd4b4641fff6a4f8467878608dabed11198a4cb \
-                    size    284135
+
+# TkTable 2.11 was never posted to SourceForge.
+# A copy of the TkTable repository, owned by a Tcl/Tk developer,
+# is available for users to obtain 2.11 from.
+master_sites        https://chiselapp.com/user/pooryorick/repository/tktable/tarball/4018de567f/
+distname            unnamed-4018de567f
+checksums           rmd160  2332e79467b15c5b9855dd12ad6f21328017fa2b \
+                    sha256  7c9c06338c2cb7e414f23650e4122093b540c60c672dc4f440a12588e1b3a1d5 \
+                    size    292797
 
 # ensure correct libraries are found during testing
 # see https://trac.macports.org/ticket/38238
@@ -47,4 +52,4 @@ if {![variant_isset quartz]} {
 test.run            yes
 test.target         test
 
-livecheck.regex     "/tktable(\\d+(?:\\.\\d+)*)${extract.suffix}"
+livecheck.type      none


### PR DESCRIPTION
 - Use repo snapshot (release was never posted to SourceForge)
 - Specify license
 - Disable livecheck (project has been dormant since ~2013)

#### Description

(The repository is an unofficial backup, but is owned by one of the Tcl/Tk developers. I asked if users could obtain the 2.11 release from there, and the owner responded that their repo was probably the best place to do so.)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F131a
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
