### PR TITLE
gcc5: libgcj compatibility with libgcc9

### DIFF
--- a/lang/gcc5/Portfile
+++ b/lang/gcc5/Portfile
@@ -9,7 +9,7 @@ PortGroup conflicts_build 1.0
 name                gcc5
 epoch               2
 version             5.5.0
-revision            4
+revision            5
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -78,6 +78,8 @@ patchfiles-append   patch-libisl.diff
 post-extract {
     ln -s ${prefix}/libexec/isl18/include/isl ${worksrcpath}/gcc
 }
+
+patchfiles-append   patch-gcj-unwind.diff
 
 if {[vercmp ${xcodeversion} 10.2] >= 0} {
     # https://trac.macports.org/ticket/58260

--- a/lang/gcc5/files/patch-gcj-unwind.diff
+++ b/lang/gcc5/files/patch-gcj-unwind.diff
@@ -1,0 +1,78 @@
+https://trac.macports.org/ticket/58469
+
+--- libjava/posix.cc	2007-02-22 11:04:55.000000000 -0500
++++ libjava/posix.cc	2019-05-13 23:21:13.000000000 -0400
+@@ -10,6 +10,15 @@
+ 
+ #include <config.h>
+ 
++#if defined(__APPLE__) && defined(__MACH__)
++/* libgcj doesn't normally provide this symbol. Declare it as "hidden" to make
++ * sure that it's only available for libgcj's own use. The declaration must come
++ * before any other in order to ensure that the desired hidden visibility is
++ * applied. */
++extern "C" __attribute__ ((visibility ("hidden")))
++void * _darwin10_Unwind_FindEnclosingFunction (void *);
++#endif
++
+ #include "posix.h"
+ 
+ #include <stdlib.h>
+@@ -27,6 +36,10 @@
+ #include <java/io/InterruptedIOException.h>
+ #include <java/util/Properties.h>
+ 
++#if defined(__APPLE__) && defined(__MACH__)
++#include "unwind-dw2-fde.h"
++#endif
++
+ #if defined (ECOS)
+ extern "C" unsigned long long _clock (void);
+ #endif
+@@ -248,3 +261,15 @@
+ 
+   return ret_val;
+ }
++
++#if defined(__APPLE__) && defined(__MACH__)
++void *
++_darwin10_Unwind_FindEnclosingFunction (void *pc)
++{
++  struct dwarf_eh_bases bases;
++  const struct dwarf_fde *fde = _Unwind_Find_FDE ((void*)(((uintptr_t)pc)-1), &bases);
++  if (fde)
++    return bases.func;
++  return NULL;
++}
++#endif
+--- libgcc/unwind-dw2-fde.h	2015-01-22 11:22:31.000000000 -0500
++++ libgcc/unwind-dw2-fde.h	2019-05-13 21:08:51.000000000 -0400
+@@ -26,6 +26,10 @@
+ #ifndef GCC_UNWIND_DW2_FDE_H
+ #define GCC_UNWIND_DW2_FDE_H
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ #ifndef HIDE_EXPORTS
+ #pragma GCC visibility push(default)
+ #endif
+@@ -154,7 +158,7 @@
+ static inline const struct dwarf_cie *
+ get_cie (const struct dwarf_fde *f)
+ {
+-  return (const void *)&f->CIE_delta - f->CIE_delta;
++  return (const struct dwarf_cie *)((const void *)&f->CIE_delta - f->CIE_delta);
+ }
+ 
+ static inline const fde *
+@@ -179,4 +183,8 @@
+ #pragma GCC visibility pop
+ #endif
+ 
++#ifdef __cplusplus
++}
++#endif
++
+ #endif /* unwind-dw2-fde.h */


### PR DESCRIPTION
#### Description

`libgcc_s.1.dylib` formerly provided `__darwin10_Unwind_FindEnclosingFunction`, but this is no longer true as of GCC 9.1.0. This symbol is used by libgcj, and its absence causes the compiler `gcj-mp-5` and ports that are built by `gcj` to abort on any attempted call. Provide a hidden definition in gcc5's `libgcj.16.dylib` for libgcj's own use.

gcc5 is the most recent MacPorts GCC port to provide gcj.

Closes: https://trac.macports.org/ticket/58469

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2 10E125 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->