### PR TITLE
buku: new port

### DIFF
--- a/www/buku/Portfile
+++ b/www/buku/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        jarun Buku 4.2.2 v
+name                buku
+revision            0
+checksums           rmd160  fac1af78f8910b2df5ec3bcf6868b3c6cf156dad \
+                    sha256  baa80075369f74bbb0f5f6248159be4f8d682094cf6d62ad8e1e869c36779b37 \
+                    size    480214
+
+description         A command-line bookmark manager
+
+categories          www
+platforms           darwin
+supported_archs     noarch
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+license             GPL-3
+
+python.default_version  37
+
+depends_lib-append  port:py${python.version}-beautifulsoup4 \
+                    port:py${python.version}-certifi \
+                    port:py${python.version}-cryptography \
+                    port:py${python.version}-html5lib \
+                    port:py${python.version}-urllib3
+
+# remove patch in the next release
+patchfiles          patch-prompt-colors-fix.diff
+
+post-extract {
+    # build only buku by default
+    reinplace "s|exclude=\\\['tests'\\\]|include=\\\['buku'\\\]|" ${worksrcpath}/setup.py
+    reinplace "s|, 'bukuserver=bukuserver.server:cli'||" ${worksrcpath}/setup.py
+}
+
+pre-destroot {}
+
+post-destroot {
+    # install documentation
+    xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} CHANGELOG LICENSE README.md ${destroot}${prefix}/share/doc/${name}
+
+    # install man pages
+    xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 -W ${worksrcpath} buku.1 ${destroot}${prefix}/share/man/man1/
+
+    # install shell completions (bash, fish, zsh)
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions/
+    xinstall -m 644 ${worksrcpath}/auto-completion/bash/buku-completion.bash ${destroot}${prefix}/share/bash-completion/completions/${name}
+    xinstall -d ${destroot}${prefix}/share/fish/completions/
+    xinstall -m 644 ${worksrcpath}/auto-completion/fish/buku.fish ${destroot}${prefix}/share/fish/completions/
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions/
+    xinstall -m 644 ${worksrcpath}/auto-completion/zsh/_buku ${destroot}${prefix}/share/zsh/site-functions/
+}

--- a/www/buku/files/patch-prompt-colors-fix.diff
+++ b/www/buku/files/patch-prompt-colors-fix.diff
@@ -1,0 +1,11 @@
+--- buku.orig	2019-05-13 22:45:52.000000000 -0700
++++ buku	2019-05-13 22:46:13.000000000 -0700
+@@ -4915,7 +4915,7 @@
+         setup_logger(LOGGER)
+ 
+         # Enable prompt with reverse video
+-        PROMPTMSG = '\x1b[7mbuku (? for help)\x1b[0m '
++        PROMPTMSG = '\001\x1b[7\002mbuku (? for help)\001\x1b[0m\002 '
+ 
+     # Enable browser output in case of a text based browser
+     if os.getenv('BROWSER') in TEXT_BROWSERS:


### PR DESCRIPTION
#### Description

`buku` is a command-line bookmark manager.

###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?