### PR TITLE
Library needed by SDRangel

### DIFF
--- a/audio/codec2/Portfile
+++ b/audio/codec2/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+platforms           darwin macosx
+categories          audio
+license             LGPL-2.1
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         Codec 2 is an open source speech codec designed for \
+    communications quality speech between 700 and 3200 bit/s.
+long_description    Codec 2 is an open source speech codec designed for \
+    communications quality speech between 700 and 3200 bit/s. The main \
+    application is low bandwidth HF/VHF digital radio. It fills a gap in \
+    open source voice codecs beneath 5000 bit/s and is released under the \
+    GNU Lesser General Public License (LGPL). Informal listening tests \
+    indicate that Codec 2 at 700 bits/s has better speech quality than \
+    MELP and is comparable to TWELP at 600 bit/s.  The Codec 2 project \
+    also contains several modems (OFDM, FDMDV, COHPSK and mFSK) carefully \
+    designed for digital voice over HF radio.
+homepage            http://www.rowetel.com/codec2.html
+
+# migrated from https://svn.code.sf.net/p/freetel/code/codec2/tags/${version}
+github.setup        drowe67 codec2 ff5841a18bfd9df0e8a250dc57fb7388cabccda1
+version             0.8.1
+checksums           rmd160  0e4c0d91e893b4e20e609be77fca037c246999c5 \
+                    sha256  2aa2db1abb7ef4878341e4858deb02a795fb136e3692eb35a5bd677f2aedecc9 \
+                    size    12272696
+revision            0
+
+depends_lib-append \
+    port:libsamplerate \
+    port:speex
+
+configure.args-append \
+    -DCMAKE_BUILD_TYPE=Release

--- a/audio/dsdcc/Portfile
+++ b/audio/dsdcc/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          audio
+license             GPL-3+
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         Digital Speech Decoder (DSD) rewritten as a C++ library
+long_description    ${description}
+
+github.setup        f4exb dsdcc 5dd8d1eeddb5df53c9e46f53b50781864cf5f6fe
+version             1.8.5
+checksums           rmd160  e6011b353ae560dca34566076b04b18c6b54c498 \
+                    sha256  689afa355b2fcb9f02f5ee6789a3844489e14fe8797146f94e2594fa0db308a7 \
+                    size    12745955
+revision            0
+
+configure.args-append \
+    -DBUILD_TYPE=RELEASE \
+    -DUSE_MBELIB=OFF
+
+variant mbelib description {Enable mbelib support} {
+    depends_lib-append      port:mbelib
+    configure.args-replace  -DUSE_MBELIB=OFF -DUSE_MBELIB=ON
+}
+
+test.run            yes
+test.cmd            ./dsdccx

--- a/audio/mbelib/Portfile
+++ b/audio/mbelib/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+
+platforms           darwin macosx
+categories          audio
+license             ISC
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         P25 Phase 1 and ProVoice vocoder
+long_description    ${description}
+
+github.setup        szechyjs mbelib 1.3.0 debian/
+checksums           rmd160  d14359c99e8191d25654f792b36590e7372a3990 \
+                    sha256  b7f2e48722028939841606e5292e55844e2112e3a27a2646e674d7ff6055d15d \
+                    size    400249
+revision            0
+
+notes {
+    This source code is provided for educational purposes only.
+    It is a written description of how certain voice encoding/decoding
+    algorithms could be implemented.  Executable objects compiled or
+    derived from this package may be covered by one or more patents.
+    Readers are strongly advised to check for any patent restrictions or
+    licencing requirements before compiling or using this source code.
+}

--- a/science/cm256cc/Portfile
+++ b/science/cm256cc/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+platforms           darwin macosx
+categories          science
+license             BSD
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         Fast GF(256) Cauchy MDS Block Erasure Codec in C++
+long_description    ${description}
+
+github.setup        f4exb cm256cc 62dfc8b4cfc8ce86b5006e3358f6d9664a406f77
+version             1.0.5
+checksums           rmd160  cca7ab9e354317d5c7bcac41a0dde82ba4dc2403 \
+                    sha256  d65184951cc52fc2a0dd164e8e3c0a887ff36c46594f8f8eb21d93f1e8999524 \
+                    size    45095
+revision            0
+
+supported_archs     x86_64 i386
+
+depends_lib-append \
+    port:boost
+
+test.run            yes
+test.cmd            ./cm256_test

--- a/science/freedv-gui/Portfile
+++ b/science/freedv-gui/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           cxx11 1.1
+PortGroup           github 1.0
+PortGroup           wxWidgets 1.0
+
+categories          science comms
+platforms           darwin macosx
+license             LGPL-2.1
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+description         GUI Application for FreeDV – an open source digital \
+    voice protocol that integrates the modems, codecs, and FEC
+long_description    ${description}
+
+github.setup        drowe67 freedv-gui 9b66784d31102d7d63cc5f67208e24fff95beb66
+version             1.3.1
+checksums           rmd160  222b7b15f4fe8b7c427506a48a20e82fe1c17be4 \
+                    sha256  e8da1d5843cebd9b4c9e53a604eec7c26ce00d2f70c5ebb049bfb893199003af \
+                    size    618399
+revision            0
+
+depends_build-append \
+    port:pkgconfig
+
+wxWidgets.use       wxWidgets-3.2
+depends_lib-append \
+    port:${wxWidgets.port} \
+    port:portaudio \
+    port:hamlib \
+    port:libsndfile \
+    port:libsamplerate \
+    port:libao \
+    port:codec2 \
+    port:speexDSP
+
+configure.args-append \
+    -DUSE_STATIC_CODEC2=FALSE \
+    -DWXCONFIG=${wxWidgets.wxconfig} \
+    -DWXRC=${wxWidgets.wxrc}
+
+# avoid dmg
+patchfiles          patch-src_cmakelists.txt.diff
+
+variant bundle description {Enable the optional macOS bundle of FreeDV} {
+    post-destroot {
+        xinstall -d -m 0755 ${destroot}${applications_dir}
+        copy ${cmake.build_dir}/src/FreeDV.app ${destroot}${applications_dir}
+    }
+}
+
+default_variants-append +bundle

--- a/science/freedv-gui/files/patch-src_cmakelists.txt.diff
+++ b/science/freedv-gui/files/patch-src_cmakelists.txt.diff
@@ -1,0 +1,13 @@
+--- src/CMakeLists.txt.old	2019-04-10 21:29:07.000000000 +0200
++++ src/CMakeLists.txt	2019-04-10 21:29:37.000000000 +0200
+@@ -70,10 +70,5 @@
+         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/freedv.icns FreeDV.app/Contents/Resources
+         COMMAND echo ARGS -n "APPL????" > FreeDV.app/Contents/PkgInfo
+         COMMAND cp ARGS freedv FreeDV.app/Contents/MacOS/FreeDV
+-        COMMAND dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @executable_path/../libs/
+-        COMMAND mkdir dist_tmp
+-        COMMAND cp -r FreeDV.app dist_tmp
+-        COMMAND hdiutil create -srcfolder dist_tmp/ -volname FreeDV -format UDZO ./FreeDV.dmg
+-        COMMAND rm -rf dist_tmp
+     )
+ endif(APPLE)

--- a/science/perseus-sdr/Portfile
+++ b/science/perseus-sdr/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+platforms           darwin macosx
+categories          science
+license             LGPL-3.0
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+name                perseus-sdr
+description         Perseus Software Defined Radio Control Library
+long_description    ${description}
+homepage            http://microtelecom.it/perseus/
+
+github.setup        Microtelecom libperseus-sdr 0.8.1 v
+distname            libperseus_sdr-${version}
+checksums           rmd160  a9e27ec11b5533a30ff3ef1fb67bb6e04885f552 \
+                    sha256  4400d845120178b7d323b49d045c5edbcb203e800606808093918d6037c9239c \
+                    size    550633
+revision            0
+
+use_autoconf        yes
+autoconf.cmd        ./bootstrap.sh
+
+# need for autoconf
+depends_build-append \
+    port:autoconf    \
+    port:automake    \
+    port:libtool
+
+depends_lib-append \
+    path:lib/libusb.dylib:libusb
+
+post-extract {
+    # remove ssse3 on ppc
+    if {$build_arch eq "ppc" || $build_arch eq "ppc64"} {
+        patchfiles-append \
+            patch-makefile.am.diff
+    }
+}
+
+post-destroot {
+    # install only the dynamic version
+    delete ${destroot}/${prefix}/bin/perseustest
+    move ${destroot}/${prefix}/bin/perseustest_dyn ${destroot}${prefix}/bin/perseustest
+}
+
+test.run            yes
+test.cmd            ./examples/perseustest

--- a/science/perseus-sdr/files/patch-makefile.am.diff
+++ b/science/perseus-sdr/files/patch-makefile.am.diff
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 60d33a3..fcf9df8 100644
+--- Makefile.am
++++ Makefile.am
+@@ -19,7 +19,7 @@ AM_LIBS    = -ldl
+ endif
+ 
+ if OS_MACOS
+-AM_CFLAGS  =  -Wall -O3 -mssse3 -DGIT_REVISION=\"@VERSION@\"
++AM_CFLAGS  =  -Wall -O3 -DGIT_REVISION=\"@VERSION@\"
+ AM_LDFLAGS =
+ AM_LIBS    = -ldl
+ endif


### PR DESCRIPTION
#### Description

This PR is a collection of ports needed by SDRangel (and maybe others HAM software). The latter will be sent in the future (I am rewriting all cmake files).

- cm256cc: Fast GF(256) Cauchy MDS Block Erasure Codec in C++
- mbelib: P25 Phase 1 and ProVoice vocoder
- dsdcc: Digital Speech Decoder (DSD) rewritten as a C++ library
- codec2: Codec 2 is an open source speech codec designed for communications quality speech between 700 and 3200 bit/s.
- freedv-gui: (not strictly needed by SDRangel) GUI Application for FreeDV – an open source digital voice protocol that integrates the modems, codecs, and FEC.
- perseus-sdr: Perseus Software Defined Radio Control Library

Template used in accordance with michaelld.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->