### PR TITLE
rtaudio: update version to 5.1.0

### DIFF
--- a/audio/rtaudio/Portfile
+++ b/audio/rtaudio/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
 platforms           darwin macosx
 categories          audio
@@ -17,20 +18,17 @@ long_description    RtAudio is a set of C++ classes that provides a \
     with computer audio hardware.
 homepage            http://www.music.mcgill.ca/~gary/rtaudio/
 
-github.setup        thestk rtaudio 5.0.0
-checksums           rmd160  a9f5f7e602f9c7de6fa94e164706df32d33905ab \
-                    sha256  6929fb7b396de8e20333ba7169a270c31b541a0fb04eaa8bea7d1c4231afba20 \
-                    size    211315
+github.setup        thestk rtaudio 5.1.0
+checksums           rmd160  daee9e400bbc169f038979d6886598406c8424f5 \
+                    sha256  75d96e613ca1294da4c80eb0cd45a49cd854faf02197233aed296604b8438315 \
+                    size    226775
 revision            0
 
 depends_build-append \
     port:pkgconfig
 
-# future versions will use cmake
-use_autoreconf      yes
-configure.args      --with-core
-
-build.args-append   \
-    CC=${configure.cc} \
-    CXX=${configure.cxx} \
-    CPP=${configure.cpp}
+# use only macOS CoreAudio
+configure.args-append \
+    -DRTAUDIO_API_OSS=OFF \
+    -DRTAUDIO_API_PULSE=OFF \
+    -DRTAUDIO_API_JACK=OFF


### PR DESCRIPTION
#### Description

- bump version to 5.1.0
- move to cmake configuration tool, see discussion at
  https://github.com/macports/macports-ports/commit/c88a970fb47cda7f44db236af0e4bb8df2f8e40a
- disable all audio backends except macOS CoreAudio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->