### PR TITLE
openmpi: Limit availability of various clang/gcc versions to platforms where they are supported

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -16,11 +16,11 @@ license             BSD
 maintainers         nomaintainer
 description         A High Performance Message Passing Library
 long_description    Open MPI is a project combining technologies and resources \
-            from several other projects (FT-MPI, LA-MPI, LAM/MPI, and \
-            PACX-MPI) in order to build the best MPI library available. A \
-            completely new MPI-2 compliant implementation, Open MPI offers \
-            advantages for system and software vendors, application developers \
-            and computer science researchers.
+                    from several other projects (FT-MPI, LA-MPI, LAM/MPI, and \
+                    PACX-MPI) in order to build the best MPI library available. A \
+                    completely new MPI-2 compliant implementation, Open MPI offers \
+                    advantages for system and software vendors, application developers \
+                    and computer science researchers.
 
 homepage            https://www.open-mpi.org/
 set subdir          ompi/v${branch}/downloads/
@@ -62,27 +62,29 @@ if {[string first "-devel" $subport] > 0} {
 # Sup-ports names and corresponding configure.compiler value
 array set clist {
     clang   {clang}
-    clang33 {macports-clang-3.3}
-    clang34 {macports-clang-3.4}
-    clang37 {macports-clang-3.7}
-    clang39 {macports-clang-3.9}
     clang40 {macports-clang-4.0}
     clang50 {macports-clang-5.0}
     clang60 {macports-clang-6.0}
     clang70 {macports-clang-7.0}
     clang80 {macports-clang-8.0}
-    gcc43   {macports-gcc-4.3}
-    gcc44   {macports-gcc-4.4}
-    gcc45   {macports-gcc-4.5}
-    gcc46   {macports-gcc-4.6}
-    gcc47   {macports-gcc-4.7}
-    gcc48   {macports-gcc-4.8}
-    gcc49   {macports-gcc-4.9}
     gcc5    {macports-gcc-5}
     gcc6    {macports-gcc-6}
     gcc7    {macports-gcc-7}
     gcc8    {macports-gcc-8}
     gcc9    {macports-gcc-9}
+}
+# gcc   4.x     not supported on mac OS 10.12 (darwin16) or newer
+# clang 3.{3,4} not supported on mac OS 10.12 (darwin16) or newer
+if { ${os.major} < 16 } {
+    set clist(clang33) {macports-clang-3.3}
+    set clist(clang34) {macports-clang-3.4}
+    # Only provide gcc 4.9, as older versions do not build.
+    set clist(gcc49)   {macports-gcc-4.9}
+}
+# clang 3.{7,9} not supported on mac OS 10.14 (darwin18) or newer
+if { ${os.major} < 18 } {
+    set clist(clang37) {macports-clang-3.7}
+    set clist(clang39) {macports-clang-3.9}
 }
 
 foreach key [array name clist] {


### PR DESCRIPTION
Removes the openmpi subports for gcc 4.{3-8} compilers. These compilers are not available for macOS 10.12+, and on older systems the `openmpi-gcc4x`  subports anyway fail to build since the openmpi 4.0.x update. Given we have gcc{5,6,7,8,9} variants available I don't think we loose much just removing these options. gcc 4.9 sub-port still appears to build, so this is kept on darwin < 16 as the last 4.x version.

Limit the availability of clang 3.x versions to OS versions where these compilers are still supported.