### PR TITLE
Wireshark: add wireshark-chmodbpf as run dependency

### DIFF
--- a/net/wireshark2/Portfile
+++ b/net/wireshark2/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark2
 version             2.6.8
-revision            1
+revision            2
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}
@@ -139,7 +139,11 @@ variant geoip description {Build with GeoIP support} {
     depends_lib-append      port:libgeoip
 }
 
-default_variants +portaudio +zlib +libsmi +gnutls +libgcrypt +cares +geoip +kerberos5
+variant chmodbpf description {Enable Wireshark to acces macOS capture devices} {
+    depends_run             port:wireshark-chmodbpf
+}
+
+default_variants +portaudio +zlib +libsmi +gnutls +libgcrypt +cares +geoip +kerberos5 +chmodbpf
 
 if {![variant_isset qt5] && ![variant_isset no_gui]} {
     default_variants-append +qt5

--- a/net/wireshark22/Portfile
+++ b/net/wireshark22/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark22
 version             2.2.10
-revision            2
+revision            3
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         darkart.com:opendarwin.org
@@ -180,7 +180,11 @@ variant geoip description {Build with GeoIP support} {
     depends_lib-append      port:libgeoip
 }
 
-default_variants +portaudio +zlib +libsmi +gnutls +libgcrypt +cares +geoip +kerberos5
+variant chmodbpf description {Enable Wireshark to acces macOS capture devices} {
+    depends_run             port:wireshark-chmodbpf
+}
+
+default_variants +portaudio +zlib +libsmi +gnutls +libgcrypt +cares +geoip +kerberos5 +chmodbpf
 
 if {![variant_isset qt4] && ![variant_isset qt5] && ![variant_isset gtk2] && ![variant_isset gtk3] && ![variant_isset no_gui]} {
     default_variants-append +qt4

--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark3
 version             3.0.2
-revision            0
+revision            1
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}
@@ -127,6 +127,10 @@ variant geoip description {Build with GeoIP support} {
     depends_lib-append      port:libgeoip
 }
 
+variant chmodbpf description {Enable Wireshark to acces macOS capture devices} {
+    depends_run             port:wireshark-chmodbpf
+}
+
 variant python34 description {Use python34 during build} {
     depends_build-append    port:python34
 }
@@ -143,7 +147,7 @@ variant python37 description {Use python37 during build} {
     depends_build-append    port:python37
 }
 
-default_variants +zlib +libsmi +gnutls +libgcrypt +cares +geoip +kerberos5
+default_variants +zlib +libsmi +gnutls +libgcrypt +cares +geoip +kerberos5 +chmodbpf
 
 if {![variant_isset qt5] && ![variant_isset no_gui]} {
     default_variants-append +qt5
@@ -175,5 +179,3 @@ livecheck.type      regex
 livecheck.url       ${homepage}download.html
 livecheck.regex     "Stable Release \\((\\d+(?:\\.\\d+)*)"
 
-#
-##EOF


### PR DESCRIPTION
#### Description

To enhance the user experience I added wireshark-chmodbpf to `depends_run`;
in this way the user can start to "sniff" the interfaces without any other actions.

Bump revision considering that I add a new dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->