### PR TITLE
SoapyAudio: update version to 0.1.1

### DIFF
--- a/science/SoapyAudio/Portfile
+++ b/science/SoapyAudio/Portfile
@@ -13,10 +13,10 @@ maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintai
 description         Soapy SDR plugin for Audio devices
 long_description    ${description}
 
-github.setup        pothosware SoapyAudio 0.1.0 soapy-audio-
-checksums           rmd160  d63f01e8ba4b7961642972a86e7c0c814996c3ed \
-                    sha256  6ee256f3c7595e1d1e09e6ced45f5871de7b8ef9c615951562667516bd9a2968 \
-                    size    90312
+github.setup        pothosware SoapyAudio 0.1.1 soapy-audio-
+checksums           rmd160  33abfd40e489471fcec1da2363bda51e0c900b87 \
+                    sha256  0782c8a865e22cc253f534293782e48c5b23d6b79bf003fc0be4d3053f701902 \
+                    size    93936
 revision            0
 
 depends_build-append \


### PR DESCRIPTION
#### Description

- bump version to 0.1.1
- now support rtaudio from macports

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->