### PR TITLE
GPXSee: update to 7.6

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.5
+github.setup        tumic0 GPXSee 7.6
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  fe8f83307e9ad2804b458e5d151ff7d6d6ca6db6 \
-                    sha256  dbe4cd975fa63125f9a4f681347ab9727aa48a1f2f0b26e980dcdd998067e751 \
-                    size    4303676
+checksums           rmd160  16b6244443039137899486fa1f6fe8e575d0dfd6 \
+                    sha256  c91eba71771309d9ab86b35df64ba04842f7d7450fb55b92a8e7aa17cb9eb168 \
+                    size    4328807
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.6

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for Garmin IMG maps.
>   * Fixed coordinates info display issues.
>   * Fixed rendering of large areas using OpenGL.
>   * Fixed broken speed type switch.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
