### PR TITLE
py-natsort: update to 6.0.0, add py37

### DIFF
--- a/python/py-natsort/Portfile
+++ b/python/py-natsort/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-natsort
-set realName natsort
-version             4.0.4
+version             6.0.0
+revision            0
 platforms           darwin
 supported_archs     noarch
 license             MIT
@@ -19,22 +19,30 @@ long_description    When you try to sort a list of strings that \
                     a function `natsorted` that helps sort lists \
                     'naturally', either as real numbers (i.e. \
                     signed/unsigned floats or ints), or as versions.
-homepage            https://github.com/SethMMorton/$realName
+homepage            https://github.com/SethMMorton/${python.rootname}
 
-master_sites        pypi:n/$realName
-distname            $realName-${version}
+master_sites        pypi:n/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  7f7ef1bab57862009369c1e97f8b171f8bb17f3f \
-                    sha256  c76ba3e85fba78f276ac06e4d47f2230d1070f9c19413b2a0bfe7de6af311839
+checksums           rmd160  bc57ebaf0994b8c2c5286a2442173dd9506627db \
+                    sha256  ff3effb5618232866de8d26e5af4081a4daa9bb0dfed49ac65170e28e45f2776 \
+                    size    140718
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${subport} ne ${name}} {
-    depends_build       port:py${python.version}-setuptools
-    depends_run         port:py${python.version}-pyicu
-    livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       https://pypi.python.org/pypi/$realName
-    livecheck.regex     $realName-(\\d+(?:\\.\\d+)*)${extract.suffix}
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-pyicu
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE \
+            CHANGELOG.rst ${destroot}${docdir}
+    }
+
+    livecheck.type  none
 }


### PR DESCRIPTION
#### Description
- update to latest version, add py37 subport
- fix dependency type of py-setuptools
- make use of python.rootname
- install files in post-destroot
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
