### PR TITLE
py-pip: add `sudo` to notes

### DIFF
--- a/python/py-pip/Portfile
+++ b/python/py-pip/Portfile
@@ -85,7 +85,7 @@ if {${name} ne ${subport}} {
     "
 
     foreach entry ${select.entries} {
-        notes-append "port select --set $entry"
+        notes-append "sudo port select --set $entry"
     }
 
     livecheck.type      none


### PR DESCRIPTION
#### Description

Add `sudo` to the notes for `py-pip` as elevated privileges are
required for `port select`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G7024
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?