### PR TITLE
rust: update to 1.34.2

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           active_variants 1.1
 
 name                rust
-version             1.34.0
+version             1.34.2
 categories          lang devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -67,10 +67,9 @@ foreach arch ${architectures} {
 }
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  561f3bcddefafadc2ddf2a467472d4ffd7c5c2af \
-                    sha256  7ac85acffd79dd3a7c44305d9eaabd1f1e7116e2e6e11e770e4bf5f92c0f1f59 \
-                    size    149930034 \
-
+                    rmd160  5b8903967ae7689b12f57a6278b2a0abd8fde5a4 \
+                    sha256  c69a4a85a1c464368597df8878cb9e1121aae93e215616d45ad7d23af3052f56 \
+                    size    149925014
 
 checksums-append \
                     rust-std-${ruststd_version}-i686-apple-${os.platform}${extract.suffix} \


### PR DESCRIPTION
#### Description
Destabilize The Error::type_id method, CVE-2019-12083

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
