### PR TITLE
github portgroup: deprecate "tags", rename to "tarball" instead

### DIFF
--- a/_resources/port1.0/group/github-1.0.tcl
+++ b/_resources/port1.0/group/github-1.0.tcl
@@ -23,7 +23,7 @@ default github.master_sites {${github.homepage}/tarball/${git.branch}}
 default master_sites {${github.master_sites}}
 
 options github.tarball_from
-default github.tarball_from tags
+default github.tarball_from tarball
 option_proc github.tarball_from handle_tarball_from
 proc handle_tarball_from {option action args} {
     global github.author github.project github.master_sites git.branch github.homepage
@@ -40,8 +40,11 @@ proc handle_tarball_from {option action args} {
             archive {
                 github.master_sites ${github.homepage}/archive/${git.branch}
             }
-            tags {
+            tarball {
                 github.master_sites ${github.homepage}/tarball/${git.branch}
+            }
+            tags {
+                return -code error "the value \"tags\" is deprecated for github.tarball_from. Please use \"tarball\" instead."
             }
             default {
                 return -code error "invalid value \"${args}\" for github.tarball_from"

--- a/audio/midi_patchbay/Portfile
+++ b/audio/midi_patchbay/Portfile
@@ -5,7 +5,6 @@ PortGroup           xcode 1.0
 PortGroup           github 1.0
 
 github.setup        notahat midi_patchbay 1.0.3 release-
-github.tarball_from tags
 categories          audio
 license             MIT
 platforms           darwin

--- a/net/dnscrypt-proxy/Portfile
+++ b/net/dnscrypt-proxy/Portfile
@@ -16,8 +16,6 @@ platforms           darwin
 
 depends_build       port:go
 
-github.tarball_from tags
-
 checksums           rmd160  052bb7866c4de0de638597a2d93009b273ea2c5b\
                     sha256  f1148db6fa86fb147931c5f5dbfb38fa7d11c213954b791525302b69f5e495eb\
                     size    2553310

--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -27,8 +27,6 @@ if {${subport} eq "gnss-sdr"} {
                         size   3575803
     revision            1
 
-    github.tarball_from tags
-
     conflicts           gnss-sdr-devel gnss-sdr-next
 
     depends_lib-append  port:gnuradio port:volk-gnss-sdr

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -26,7 +26,6 @@ if {${subport} eq "volk-gnss-sdr"} {
     checksums           rmd160  733c3211b163825be36db80d89f9fb0db0051264 \
                         sha256  d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
                         size    3575803
-    github.tarball_from tags
 
     conflicts           volk-gnss-sdr-devel volk-gnss-sdr-next
 

--- a/shells/xonsh/Portfile
+++ b/shells/xonsh/Portfile
@@ -6,7 +6,6 @@ PortGroup           python 1.0
 
 github.setup        xonsh xonsh 0.9.3
 revision            0
-github.tarball_from tags
 categories          shells
 platforms           darwin
 maintainers         {mps @Schamschula} openmaintainer


### PR DESCRIPTION
#### Description

As per @ryandesign's suggestion in #2587, we are deprecating the `tags` option for `github.tarball_from`, and renaming it to `tarball`.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
