### PR TITLE
atom: update to 1.37.0

### DIFF
--- a/editors/atom/Portfile
+++ b/editors/atom/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        atom atom 1.34.0 v
+github.setup        atom atom 1.37.0 v
 categories          editors
 platforms           darwin
 license             MIT
@@ -14,9 +14,9 @@ long_description    ${description}
 
 homepage            https://atom.io
 
-checksums           rmd160  a7613762351ddff29724bbaf609ba28814ee6051 \
-                    sha256  13e83b5caa12eb35e836dd75cc1d00a9f7e044e6e24e4446ed15cdcff80d874b \
-                    size    11761241
+checksums           rmd160  ddb3f9c7f4aa13f7e00fd5b3bf293eaac7dd860f \
+                    sha256  4cdcfc98329f2bdb32ed1321fdf296d9f2d74b74e0e024390558cbaf3e22e5ad \
+                    size    11838203
 
 patchfiles          patch-install-prefix.diff
 


### PR DESCRIPTION
#### Description

Straightforward update of atom to 1.37.0. Builds and runs fine here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
