### PR TITLE
ld64-136: remove obsolete port

### DIFF
--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -102,14 +102,6 @@ subport ld64-127 {
         ld64-ppc-9610466.patch
 }
 
-subport ld64-136 {
-    # Xcode 4.6
-    version             136
-    revision            10
-    replaced_by         ld64-236
-    PortGroup           obsolete 1.0
-}
-
 subport ld64-236 {
     # Xcode 5.1
     version             236.3
@@ -245,7 +237,7 @@ if {${subport} eq ${name}} {
         xinstall -m 755 ${filespath}/ld-xcode ${destroot}${prefix}/libexec/ld64/ld-xcode
         ln -s ../libexec/ld64/ld-xcode ${destroot}${prefix}/bin/ld-xcode
     }
-} elseif {${subport} ne "${name}-136"} {
+} else {
     distfiles           dyld-${dyld_version}.tar.gz ${name}-${version}.tar.gz
 
     depends_build       path:include/mach-o/arm/reloc.h:libmacho-headers


### PR DESCRIPTION
Obsoleted by 87e7b2fc0c over two years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
