### PR TITLE
cracklib: update to 2.9.7

### DIFF
--- a/security/cracklib/Portfile
+++ b/security/cracklib/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        cracklib cracklib 2.9.6 v
+github.setup        cracklib cracklib 2.9.7 v
 
 categories          security
 license             LGPL-2.1
@@ -27,8 +27,9 @@ depends_lib         port:gettext \
                     port:libiconv \
                     port:zlib
 
-checksums           rmd160  d8657a70a2068dbb275ef4487cdbe798884f8618 \
-                    sha256  7b253ce2c2307d9383aa88e0199b67d2e0eed6baf8b651a7bd8eb265f79ca3ce
+checksums           rmd160  1f03d3f7203aad5e7f239e4fd170dd56b1a84af5 \
+                    sha256  11cdb4cb8fcdac7dd4b75b87142e3fee07fd42a709a0d9a69e07094d9a601ba3 \
+                    size    8665338
 
 worksrcdir          ${distname}/src
 

--- a/security/cracklib/files/autogen.sh.patch
+++ b/security/cracklib/files/autogen.sh.patch
@@ -1,13 +1,13 @@
---- autogen.sh.orig	2017-03-13 12:03:45.000000000 -0700
-+++ autogen.sh	2017-03-13 12:04:30.000000000 -0700
-@@ -5,8 +5,8 @@
- cd ..
+--- autogen.sh.orig	2019-03-03 11:39:00.000000000 -0600
++++ autogen.sh	2019-05-16 13:20:00.000000000 -0500
+@@ -6,8 +6,8 @@
  autoreconf -f -i
  
--curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
--curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
-+#curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
-+#curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
+ # Grab latest versions instead of what is bundled with autoconf
+-curl --silent "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
+-curl --silent "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
++#curl --silent "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
++#curl --silent "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
  
  #for f in "lt~obsolete.m4" "ltversion.m4" "ltsugar.m4" "ltoptions.m4" "libtool.m4"; do
  	#curl "http://git.savannah.gnu.org/cgit/libtool.git/plain/m4/${f}?id=v2.4.2.418" > m4/${f}


### PR DESCRIPTION
#### Description

Note that `cracklib @2.9.6` currently has a checksum mismatch issue (see https://github.com/macports/macports-ports/pull/4343#issuecomment-493106460), likely as described in https://trac.macports.org/ticket/54839; updating should resolve that issue.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
