### PR TITLE
qt5-phonon-backend-gstreamer: remove obsolete port

### DIFF
--- a/audio/phonon-backend-gstreamer/Portfile
+++ b/audio/phonon-backend-gstreamer/Portfile
@@ -24,11 +24,6 @@ patchfiles-append   patch-gstreamer_CMakeLists.txt.diff
 
 depends_lib-append  port:gstreamer1-gst-plugins-good
 
-subport qt5-${name} {
-    replaced_by     ${name}-qt5
-    PortGroup       obsolete 1.0
-}
-
 subport ${name}-qt5 {
     PortGroup       qt5 1.0
     PortGroup       cmake 1.0


### PR DESCRIPTION
Obsoleted by 414fbb185c over two years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
