### PR TITLE
pdfjam: remove old conflict handler

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -51,17 +51,6 @@ destroot {
        ${destroot}${prefix}/share/doc/${name}
 }
 
-pre-activate {
-    # texlive-bin-extra used to contain pdfjam, but doesn't
-    # anymore. If the old version is installed, deactivate it to avoid
-    # a conflict.
-    if {[file exists ${prefix}/bin/pdfjam]
-        && ![catch {set vers [lindex [registry_active texlive-bin-extra] 0]}]
-        && [vercmp [lindex $vers 1] 19536] < 0} {
-        registry_deactivate_composite texlive-bin-extra "" [list ports_nodepcheck 1]
-    }
-}
-
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     "<strong>(\[0-9.\]+)</strong>:"


### PR DESCRIPTION
Conflict was addressed over 8 years ago:
 - conflict in `texlive-bin-extra` was removed in bf9af6378c
 - conflict handler was added in f2bf6657920

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
