### PR TITLE
dvipng: remove old conflict handler

### DIFF
--- a/tex/dvipng/Portfile
+++ b/tex/dvipng/Portfile
@@ -32,14 +32,3 @@ depends_lib     port:gd2 \
                 port:libpng \
                 port:bzip2
 depends_run     port:ghostscript
-
-# texlive-bin-extra used to contain dvipng before it was split off
-# into this port; deactivate old version to prevent conflict
-pre-activate {
-    if { ![catch {set vers [lindex [registry_active texlive-bin-extra] 0]}]
-         && ([vercmp [lindex $vers 1] 23089] < 0
-             || [vercmp [lindex $vers 1] 23089] == 0
-             && [lindex $vers 2] < 1)} {
-        registry_deactivate_composite texlive-bin-extra "" [list ports_nodepcheck 1]
-    }
-}


### PR DESCRIPTION
Was added in 5d53277238 over 7 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
