### PR TITLE
p5-alien-base-modulebuild: remove old conflict handler

### DIFF
--- a/perl/p5-alien-base-modulebuild/Portfile
+++ b/perl/p5-alien-base-modulebuild/Portfile
@@ -37,19 +37,6 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-text-parsewords \
                     port:p${perl5.major}-uri
 
-   # p5-alien-base-modulebuild was previously part of p5-alien-base now separate
-   # deactivate old conflicting p5-alien-base before activation
-
-    pre-activate {
-        set pname p${perl5.major}-alien-base
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 0.40] < 0} {
-                registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-
     perl5.use_module_build
     supported_archs noarch
 }


### PR DESCRIPTION
Conflict was resolved over one year ago:
 - handler was present when port was created in 9d3d1f8a33
 - `p5-alien-base` was obsoleted in 41e0c82f60 and removed in 91f5ac2823

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
