### PR TITLE
ssh-copy-id: remove old conflict handler

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -255,17 +255,6 @@ subport ssh-copy-id {
         xinstall -m 755 ${worksrcpath}/contrib/ssh-copy-id ${destroot}${prefix}/bin
         xinstall -m 644 ${worksrcpath}/contrib/ssh-copy-id.1 ${destroot}${prefix}/share/man/man1
     }
-
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active openssh] 0]}]} {
-            set _version [lindex $installed 1]
-            set _revision [lindex $installed 2]
-            if {[vercmp $_version 7.3p1] < 0 || ([vercmp $_version 7.3p1] == 0 && $_revision < 1)} {
-                # openssh @7.3p1 and earlier used to install some files now provided by ssh-copy-id
-                registry_deactivate_composite openssh "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }
 
 livecheck.type      regex


### PR DESCRIPTION
Was added in cd1cc0653a over one year ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
