### PR TITLE
chasen-base: remove old conflict handler

### DIFF
--- a/textproc/chasen-base/Portfile
+++ b/textproc/chasen-base/Portfile
@@ -68,17 +68,6 @@ post-destroot {
     close ${fh}
 }
 
-# deactivate any old chasen port.
-pre-activate {
-    if {[file exists ${prefix}/bin/chasen]
-        && ![catch {set vers [lindex [registry_active chasen] 0]}]
-        && ([vercmp [lindex $vers 1] 2.4.4] < 0 ||
-            [vercmp [lindex $vers 1] 2.4.4] == 0
-            && [vercmp [lindex $vers 2] 1] < 1)} {
-        registry_deactivate_composite chasen "" [list ports_nodepcheck 1]
-    }
-}
-
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     >chasen-(\[0-9.a-z\-\]+)<


### PR DESCRIPTION
Was present in 0717c1ed23 when port was split from `chasen` over 7 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
