### PR TITLE
healpix, healpix-c, healpix-cxx: remove old conflict handlers

### DIFF
--- a/science/healpix-c/Portfile
+++ b/science/healpix-c/Portfile
@@ -23,11 +23,3 @@ checksums           rmd160  66afdda4488570c43c446c5c2f28f84a39d54396 \
 
 depends_build       port:pkgconfig
 depends_lib         port:cfitsio
-
-pre-activate {
-    if {[file exists ${prefix}/lib/libchealpix.a]
-        && ![catch {set vers [lindex [registry_active healpix] 0]}]
-        && [vercmp [lindex $vers 1] 3.00] < 0} {
-        registry_deactivate_composite healpix "" [list ports_nodepcheck 1]
-    }
-}

--- a/science/healpix-cxx/Portfile
+++ b/science/healpix-cxx/Portfile
@@ -37,11 +37,3 @@ variant openmp description "enable OpenMP parallel acceleration" {
     compiler.whitelist macports-clang-6.0 macports-clang-5.0 macports-clang-4.0 macports-clang-3.9 macports-clang-3.7 macports-gcc-7 macports-gcc-6 macports-gcc-5 macports-gcc-4.8 macports-gcc-4.7 macports-gcc-4.6 macports-gcc-4.5 macports-gcc-4.4 macports-gcc-4.3
     compiler.fallback macports-clang-6.0
 }
-
-pre-activate {
-    if {[file exists ${prefix}/lib/libchealpix.a]
-        && ![catch {set vers [lindex [registry_active healpix] 0]}]
-        && [vercmp [lindex $vers 1] 3.00] < 0} {
-        registry_deactivate_composite healpix "" [list ports_nodepcheck 1]
-    }
-}

--- a/science/healpix/Portfile
+++ b/science/healpix/Portfile
@@ -42,15 +42,6 @@ if {${name} eq ${subport}} {
 
     livecheck.regex {healpix/files/Healpix_([0-9]+\.[0-9]+[a-z]?)}
 } else {
-
-    pre-activate {
-        if {[file exists ${prefix}/lib/libchealpix.a]
-            && ![catch {set vers [lindex [registry_active healpix] 0]}]
-            && [vercmp [lindex $vers 1] 3.00] < 0} {
-            registry_deactivate_composite healpix "" [list ports_nodepcheck 1]
-        }
-    }
-
     livecheck.type  none
 }
 


### PR DESCRIPTION
Were added to `healpix` in 1177510ebf over 6 years ago, and to `healpix-c` and `healpix-cxx` in 79c1f3f57e over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
