### PR TITLE
gcr: remove handler for old gnome-keyring

### DIFF
--- a/gnome/gcr/Portfile
+++ b/gnome/gcr/Portfile
@@ -66,15 +66,6 @@ configure.args      --enable-vala=yes \
                     --disable-update-icon-cache \
                     --disable-silent-rules
 
-pre-activate {
-    if {![catch {set installed [lindex [registry_active gnome-keyring] 0]}]} {
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 3.0.0] < 0} {
-            registry_deactivate_composite gnome-keyring "" [list ports_nodepcheck 1]
-        }
-    }
-}
-
 post-activate {
     system "${prefix}/bin/glib-compile-schemas ${prefix}/share/glib-2.0/schemas"
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"


### PR DESCRIPTION
Handler was added 5 years ago:
 - was present when port was created in e98074fb1b
 - gnome-keyring pre-3.0.0 was removed in ae7a4339b3

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
