### PR TITLE
hs-c2hs: remove old handler for c2hs

### DIFF
--- a/devel/hs-c2hs/Portfile
+++ b/devel/hs-c2hs/Portfile
@@ -21,11 +21,3 @@ long_description    \
     correct Haskell types.
 
 depends_lib-append  port:hs-language-c
-
-pre-activate {
-    # deactivate hack added 2013-06-09
-    if {![catch {set installed [lindex [registry_active c2hs] 0]}]} {
-        # this port used to be called c2hs
-        registry_deactivate_composite c2hs "" [list ports_nodepcheck 1]
-    }
-}


### PR DESCRIPTION
Was added when port was renamed from `c2hs` in 7977eb69a1 almost 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
