### PR TITLE
mysql56: update to 5.6.44

### DIFF
--- a/databases/mysql56/Portfile
+++ b/databases/mysql56/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mysql56
 set name_mysql      ${name}
-version             5.6.34
+version             5.6.44
 # Set revision_client and revision_server to 0 on
 # version bump.
 set revision_client 0
@@ -47,8 +47,12 @@ if {$subport eq $name} {
     patchfiles-append   patch-scripts-mysql_install_db.pl.in.diff \
                         patch-scripts-mysql_secure_installation.pl.in.diff
 
-    checksums           rmd160 4095f4276623432d235211a445b5d5f540658b2d \
-                        sha256 ee90bafec6af3abe2715ccb0b3cc9345ed8d1cce025d41e6ec2b2b7a7d820823
+    # See https://trac.macports.org/ticket/56254
+    patchfiles-append   patch_client_authentication.cc.diff
+
+    checksums           rmd160  6a6c0a18503e5f6b758e76c76d612a4ada3a8296 \
+                        sha256  c031c92c3f226856b09bf929d8a26b0cd8600036cb9db4e0fdf6b6f032ced336 \
+                        size    32531507
 
     depends_lib-append  port:zlib port:tcp_wrappers port:ncurses
     depends_run-append  port:mysql_select

--- a/databases/mysql56/files/patch_client_authentication.cc.diff
+++ b/databases/mysql56/files/patch_client_authentication.cc.diff
@@ -1,0 +1,13 @@
+Ticket: https://trac.macports.org/ticket/56254
+Upstream-Status: Backport [This change is present in recent versions of MySQL 5.7 and later.]
+--- mysql-5.6.39/sql-common/client_authentication.cc-	2018-04-08 18:42:13.000000000 -0400
++++ mysql-5.6.39/sql-common/client_authentication.cc	2018-04-08 19:19:37.000000000 -0400
+@@ -84,7 +84,7 @@
+ 
+   if (mysql->options.extension != NULL &&
+       mysql->options.extension->server_public_key_path != NULL &&
+-      mysql->options.extension->server_public_key_path != '\0')
++      mysql->options.extension->server_public_key_path[0] != '\0')
+   {
+     pub_key_file= fopen(mysql->options.extension->server_public_key_path,
+                         "r");


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/55488

Add patch for client_authentication.cc (Note: I did not observe any issue compiling without this patch)
See: https://trac.macports.org/ticket/56254


#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
