### PR TITLE
py-csscompressor: new port

### DIFF
--- a/python/py-csscompressor/Portfile
+++ b/python/py-csscompressor/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-csscompressor
+version             0.9.5
+revision            0
+checksums           rmd160  23c00abcceae07604b52ec1f4cf0725f217f2640 \
+                    sha256  afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05 \
+                    size    237808
+
+categories-append   www
+license             BSD
+platforms           darwin
+supported_archs     noarch
+maintainers         {isi.edu:calvin @cardi} openmaintainer
+
+description         Python implementation of the YUI CSS Compressor
+long_description    Python implementation and almost exact port of \
+                    Yahoo!'s CSS Compressor. Removes comments and \
+                    compresses whitespace from CSS files.
+homepage            http://github.com/sprymix/csscompressor
+
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+python.versions     27 37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

`py-csscompressor` is a Python implementation and almost exact port of Yahoo!'s CSS Compressor. Removes comments and compresses whitespace from CSS files.

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?