### PR TITLE
qtkeychain-qt5: remove old conflict handler

### DIFF
--- a/security/qtkeychain/Portfile
+++ b/security/qtkeychain/Portfile
@@ -65,16 +65,3 @@ if {${subport} eq ${name}} {
     }
     default_variants +qt5
 }
-
-# see https://trac.macports.org/wiki/PortfileRecipes#deactivatehack
-if {${subport} eq "${name}-qt5"} {
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active ${name}] 0]}]} {
-            set _version  [lindex $installed 1]
-            set _revision [lindex $installed 2]
-            if {[vercmp $_version 0.8.0] < 0 || ([vercmp $_version 0.8.0] == 0 && $_revision < 2)} {
-                registry_deactivate_composite ${name} "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-}


### PR DESCRIPTION
Was added in 4f51117bbd over one year ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
