### PR TITLE
py-google-api, py-oauth2client, py-uritemplate: Update to uritemplate 3.0.0, add python 3.7 support

### DIFF
--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -7,7 +7,7 @@ name                py-google-api
 set realname        google-api-python-client
 version             1.6.1
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 categories-append   www devel
 maintainers         nomaintainer

--- a/python/py-oauth2client/Portfile
+++ b/python/py-oauth2client/Portfile
@@ -7,7 +7,7 @@ name                py-oauth2client
 set realname        oauth2client
 version             4.0.0
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 categories-append   www
 maintainers         nomaintainer

--- a/python/py-uritemplate/Portfile
+++ b/python/py-uritemplate/Portfile
@@ -1,10 +1,9 @@
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
-github.setup        uri-templates uritemplate-py 0.6 uri-template-py-
 name                py-uritemplate
-python.versions     27 34 35 36
+version             3.0.0
+python.versions     27 34 35 36 37
 categories-append   textproc www
 maintainers         nomaintainer
 license             Apache-2
@@ -12,13 +11,18 @@ description         Python implementation of RFC6570, URI Template
 long_description    \
     This is a Python implementation of RFC6570, URI Template, and can expand \
     templates up to and including Level 4 in that specification.
+homepage            https://uritemplate.readthedocs.org/
+master_sites        pypi:u/uritemplate
+distname            ${python.rootname}-${version}
 
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  0272ac79d16963e322e3e7cc414e1d5ca69dcd51 \
-                    sha256  acebabf9081afc4856cda7c4b241c922b2082c25bfd19e8b8a924e959490c655
+checksums           rmd160  474382a617e79ee4e9718621d9a30e8d05a03f8e \
+                    sha256  c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d \
+                    size    30038
 
 if {${name} ne ${subport}} {
-    livecheck.type  none
+    depends_build-append port:py${python.version}-setuptools
+    livecheck.type      none
 }


### PR DESCRIPTION
#### Description

Adds "37" to the list of supported python versions for google-api and oauth2client. Also uses the latest uritemplate from pypi -- the [prior repo](https://github.com/uri-templates/uritemplate-py) instructs people to use the new one instead. AFAICT only py-google-api and py-oauth2client depend on py-uritemplate.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
