### PR TITLE
thrift-devel: mark obsolete, replace with thrift

### DIFF
--- a/devel/thrift-devel/Portfile
+++ b/devel/thrift-devel/Portfile
@@ -1,116 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       obsolete 1.0
 
+# Remove after 2020-05-18
 name            thrift-devel
-conflicts       thrift
+replaced_by     thrift
 version         1372257
-revision        3
+revision        4
 categories      devel
 license         Apache-2
-maintainers     {blair @blair} openmaintainer
-platforms       darwin
-
-description     framework for scalable cross-language services development
-long_description \
-    Thrift is a software framework for scalable cross-language \
-    services development. It combines a software stack with a code \
-    generation engine to build services that work efficiently and \
-    seamlessly between C++, Java, Python, PHP, Ruby, Erlang, Perl, \
-    Haskell, C#, Cocoa, Smalltalk, and OCaml.
-
-homepage        http://thrift.apache.org/
-fetch.type      svn
-svn.url         https://svn.apache.org/repos/asf/thrift/trunk
-svn.revision    ${version}
-
-worksrcdir      [file tail ${svn.url}]
-
-use_parallel_build  no
-
-depends_build       port:autoconf \
-                    port:automake \
-                    port:boost \
-                    port:libtool \
-                    port:pkgconfig
-depends_lib-append  path:lib/libssl.dylib:openssl
-
-pre-configure {
-    system "cd ${worksrcpath} && ./bootstrap.sh"
-
-    # Remove when https://issues.apache.org/jira/browse/THRIFT-1614 is
-    # fixed.
-    reinplace "s|thrifty\.h|thrifty.hh|g" \
-        ${worksrcpath}/compiler/cpp/src/thriftl.ll
-}
-
-configure.args  --with-c_glib=no \
-                --with-csharp=no \
-                --with-d=no \
-                --with-erlang=no \
-                --with-go=no \
-                --with-haskell=no \
-                --with-java=no \
-                --with-perl=no \
-                --with-php=no \
-                --with-php_extension=no \
-                --with-python=no \
-                --with-qt4=no \
-                --with-ruby=no
-
-variant java description "enable the Java library" {
-    depends_build-append    bin:ant:apache-ant
-    configure.env-append    JAVA_PREFIX=${prefix}/share/java
-    configure.args-delete   --with-java=no
-    configure.args-append   --with-java=yes
-}
-
-variant csharp description "enable the C# library" {
-    configure.args-delete   --with-csharp=no
-    configure.args-append   --with-csharp=yes
-    depends_lib-append      port:mono
-}
-
-variant glib2 description "enable the C (GLib) library" {
-    configure.args-delete   --with-c_glib=no
-    configure.args-append   --with-c_glib=yes
-    depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2
-}
-
-# doesn't install into destroot
-#variant ruby description "enable the Ruby library" {
-#    configure.args-delete   --with-ruby=no
-#    configure.args-append   --with-ruby=yes
-#    depends_lib-append      port:ruby
-#}
-
-variant haskell description "enable the Haskell library" {
-    configure.args-delete   --with-haskell=no
-    configure.args-append   --with-haskell=yes
-    depends_lib-append      port:ghc \
-                            port:hs-http \
-}
-
-variant php description "enable the PHP library" {
-    configure.env-append    PHP_PREFIX=${prefix}/lib/php
-    configure.args-delete   --with-php=no
-    configure.args-append   --with-php=yes
-    depends_lib-append      path:bin/php:php5
-}
-
-variant erlang description "enable the Erlang library" {
-    configure.args-delete   --with-erlang=no
-    configure.args-append   --with-erlang=yes
-    depends_lib-append      port:erlang
-}
-
-# See https://issues.apache.org/jira/browse/THRIFT-1348.
-variant qt4 description "enable non-blocking thrift server for use within Qt" {
-    configure.args-delete   --with-qt4=no
-    configure.args-append   --with-qt4=yes
-    depends_lib-append      port:qt4-mac
-}
-
-livecheck.type  regex
-livecheck.url   http://www.apache.org/dist/thrift/
-livecheck.regex {(\d+(?:\.\d+)*)/}

--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -4,7 +4,6 @@ PortSystem      1.0
 PortGroup       conflicts_build 1.0
 
 name            thrift
-conflicts       thrift-devel
 version         0.10.0
 revision        2
 categories      devel


### PR DESCRIPTION
Port has not been updated since 2012; efforts to update it were never incorporated. The version used by the `thrift` port is newer.

Closes: https://trac.macports.org/ticket/42695
Closes: https://trac.macports.org/ticket/56579

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
