### PR TITLE
mosml, mosml-dynlibs: port abandoned, adjust formatting

### DIFF
--- a/lang/mosml-dynlibs/Portfile
+++ b/lang/mosml-dynlibs/Portfile
@@ -1,42 +1,42 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem        1.0
+PortSystem          1.0
 
-name              mosml-dynlibs
-version           2.01_0
-revision          4
-categories        lang devel ml
-platforms         darwin
-license           GPL-2+
-maintainers       nomaintainer
+name                mosml-dynlibs
+version             2.01_0
+revision            4
+categories          lang devel ml
+platforms           darwin
+license             GPL-2+
+maintainers         nomaintainer
 
-description       Moscow ML dynamic libraries
-long_description  Dynamic libraries for Moscow ML includes:\
-                  intinf, crypt, munix, mregex, msocket, mgdbm, mgd
+description         Moscow ML dynamic libraries
+long_description    Dynamic libraries for Moscow ML includes: \
+                    intinf, crypt, munix, mregex, msocket, mgdbm, mgd
 
-homepage          http://www.dina.dk/~sestoft/mosml.html
-master_sites      http://www.dina.kvl.dk/~sestoft/mosml
-distfiles         mos201src.tar.gz
+homepage            http://www.dina.dk/~sestoft/mosml.html
+master_sites        http://www.dina.kvl.dk/~sestoft/mosml
+distfiles           mos201src.tar.gz
 
 checksums           rmd160  b2a9582d8c0bfdad2b8a74740e54ab33d3856637 \
                     sha256  9ec5695358a4aa4702d856c026f3cf0bce77275e8d1318fd90d455a44c46edff
 
-patchfiles        patch-configure.diff\
-                  patch-src-Makefile.diff\
-                  patch-src-Makefile-inc.diff\
-                  patch-src-launch-Makefile.diff\
-                  patch-src-dynlibs.diff
+patchfiles          patch-configure.diff \
+                    patch-src-Makefile.diff \
+                    patch-src-Makefile-inc.diff \
+                    patch-src-launch-Makefile.diff \
+                    patch-src-dynlibs.diff
 
 post-patch {
-  file attributes ${worksrcpath}/configure -permissions +x
+    file attributes ${worksrcpath}/configure -permissions +x
 }
 
-worksrcdir        mosml
-build.target      world-dyn
-build.pre_args    -Csrc DESTROOT=${prefix} ${build.target}
-destroot.target   install-world-dyn
-destroot.pre_args -Csrc DESTROOT=${destroot}${prefix} ${destroot.target}
+worksrcdir          mosml
+build.target        world-dyn
+build.pre_args      -Csrc DESTROOT=${prefix} ${build.target}
+destroot.target     install-world-dyn
+destroot.pre_args   -Csrc DESTROOT=${destroot}${prefix} ${destroot.target}
 
-depends_lib       port:gmp \
-                  port:gdbm \
-                  port:gd2
+depends_lib         port:gmp \
+                    port:gdbm \
+                    port:gd2

--- a/lang/mosml/Portfile
+++ b/lang/mosml/Portfile
@@ -1,45 +1,49 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name              mosml
-version           2.01
-revision          2
-categories        lang devel ml
-platforms         darwin
-license           GPL-2+
-maintainers       rift.dk:cso
-description       Moscow ML is an implementation of Standard ML (SML)
-long_description  Moscow ML is a light-weight implementation of Standard ML\
-                  (SML), a strict functional language widely used in teaching\
-                  and research. Version 2.01 implements the full SML language,\
-                  including SML Modules, and much of the SML Basis Library.
-homepage          http://www.dina.dk/~sestoft/mosml.html
-master_sites      http://www.dina.kvl.dk/~sestoft/mosml
-distfiles         mos201src.tar.gz
-checksums         md5 74aaaf988201fe92a9dbfbcb1e646f70
-patchfiles        patch-src-Makefile.diff\
-                  patch-src-Makefile-inc.diff\
-                  patch-src-launch-Makefile.diff\
-                  patch-src-dynlibs.diff \
-                  patch-src-runtime-mosml.c.diff \
-                  patch-src-runtime-sys.c.diff
+PortSystem          1.0
 
-worksrcdir        mosml
+name                mosml
+version             2.01
+revision            2
+categories          lang devel ml
+platforms           darwin
+license             GPL-2+
+maintainers         rift.dk:cso
+description         Moscow ML is an implementation of Standard ML (SML)
+long_description    Moscow ML is a light-weight implementation of Standard ML \
+                    (SML), a strict functional language widely used in teaching \
+                    and research. Version 2.01 implements the full SML language, \
+                    including SML Modules, and much of the SML Basis Library.
+
+homepage            http://www.dina.dk/~sestoft/mosml.html
+master_sites        http://www.dina.kvl.dk/~sestoft/mosml
+distfiles           mos201src.tar.gz
+
+checksums           md5 74aaaf988201fe92a9dbfbcb1e646f70
+
+patchfiles          patch-src-Makefile.diff \
+                    patch-src-Makefile-inc.diff \
+                    patch-src-launch-Makefile.diff \
+                    patch-src-dynlibs.diff \
+                    patch-src-runtime-mosml.c.diff \
+                    patch-src-runtime-sys.c.diff
+
+worksrcdir          mosml
 
 post-patch {
-   reinplace  "s|LD=gcc|LD=${configure.cc}|"      ${worksrcpath}/src/Makefile.inc
-   reinplace  "s|CC=gcc|CC=${configure.cc}|"      ${worksrcpath}/src/Makefile.inc
-   reinplace  "s|CCP=|CPP=${configure.cpp}|"      ${worksrcpath}/src/Makefile.inc
+    reinplace "s|LD=gcc|LD=${configure.cc}|" ${worksrcpath}/src/Makefile.inc
+    reinplace "s|CC=gcc|CC=${configure.cc}|" ${worksrcpath}/src/Makefile.inc
+    reinplace "s|CCP=|CPP=${configure.cpp}|" ${worksrcpath}/src/Makefile.inc
 }
 
-configure.dir     ${worksrcpath}/src/config
-configure.cmd     ./autoconf
-configure.pre_args ${configure.cc}
+configure.dir       ${worksrcpath}/src/config
+configure.cmd       ./autoconf
+configure.pre_args  ${configure.cc}
 
-build.target      world
-build.pre_args    -Csrc DESTROOT=${prefix} ${build.target}
+build.target        world
+build.pre_args      -Csrc DESTROOT=${prefix} ${build.target}
 
-destroot.pre_args -Csrc DESTROOT=${destroot}${prefix} ${destroot.target}
+destroot.pre_args   -Csrc DESTROOT=${destroot}${prefix} ${destroot.target}
 post-destroot {
-   system "ln -sf ${prefix}/bin/camlrunm ${destroot}${prefix}/lib/mosml/camlrunm"
+    system "ln -sf ${prefix}/bin/camlrunm ${destroot}${prefix}/lib/mosml/camlrunm"
 }
-

--- a/lang/mosml/Portfile
+++ b/lang/mosml/Portfile
@@ -8,7 +8,7 @@ revision            2
 categories          lang devel ml
 platforms           darwin
 license             GPL-2+
-maintainers         rift.dk:cso
+maintainers         nomaintainer
 description         Moscow ML is an implementation of Standard ML (SML)
 long_description    Moscow ML is a light-weight implementation of Standard ML \
                     (SML), a strict functional language widely used in teaching \


### PR DESCRIPTION
Adjust whitespace
`mosml`: add modeline
Closes: https://trac.macports.org/ticket/39663

`mosml`: port abandoned
Closes: https://trac.macports.org/ticket/58268

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
