### PR TITLE
wireguard-go: update to 0.0.20190517

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20190409
-revision            1
-checksums           rmd160  3f3ead66c45dd636d03143fc5b2373a50de91f4b \
-                    sha256  bd7305d69435438ece56df62695197c38469fd0be8c9b6fe56484b6347bf05d6 \
-                    size    66364
+version             0.0.20190517
+revision            0
+checksums           rmd160  cfd41f0dd863e6cc5ed89e55d9ebede8390119ed \
+                    sha256  6877d431847df0afd514e753eed8571bc7e85069b837bc8472b5186fbb004e78 \
+                    size    69496
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?