### PR TITLE
Openblas: allow use of binaries

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -14,10 +14,6 @@ description         OpenBLAS is an optimized BLAS library based on GotoBLAS2
 long_description    ${description}
 platforms           darwin
 
-# Prevent precompiled binaries to let compilation optimise the library
-# for the user processor
-archive_sites
-
 # block compilers that do not support thread-local storage. it would
 # be better to use the cxx11 1.1 PG, but it conflicts with the
 # compilers 1.0 PG & so just block compilers instead.
@@ -25,6 +21,33 @@ compiler.blacklist-append cc {*gcc-3*} {*gcc-4.[0-7]} {clang < 800.0.38}
 platform darwin i386 {
     compiler.blacklist-append {macports-clang-[3-4].*}
     compiler.fallback-append macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+}
+
+#Define target based on version of OS
+#OS 10.5 supports down to Intel Core Solo (Intel) or PowerPC G4
+if {${os.major} == 9} { 
+    if {${os.arch} eq "i386" || [variant_isset universal]} {
+        set blas_arch "YONAH"
+    } else {
+        set blas_arch "PPCG4"
+    }
+}
+#OS 10.6 supports down to Intel Core Solo architecture
+if {${os.major} == 10} { 
+    set blas_arch "YONAH"
+} 
+#OS 10.7-10.11 supports down to iMac 7,1, with Intel Core 2 Duo architecture
+#OS 10.12-13 supports down to iMac 10,1, with Intel Core 2 Duo architecture
+if {${os.major} >= 11 && ${os.major} <= 17} { 
+    set blas_arch "CORE2"
+}
+#OS 10.14 supports down to Mac Pro 5,1 that has Nehalem architecture
+if {${os.major} >= 18} { 
+    set blas_arch "NEHALEM"
+} 
+if {![info exists blas_arch]} {
+    #For older versions, we force native variant as there is no PPCG3 target in OpenBLAS
+    default_variants-append +native
 }
 
 subport OpenBLAS-devel {}
@@ -46,19 +69,29 @@ if {[string first "-devel" $subport] > 0} {
 
     github.livecheck.branch develop
 
+    #Not using precompiled binaries in -devel support
+    default_variants-append +native
+
 } else {
 
     github.setup    xianyi OpenBLAS 0.3.6 v
     checksums       rmd160 1e64aaaf26c92e8d49e3a9a61b1c43c7b99ad647 \
                     sha256 57e9fab61e1993005ab9f5d6b99929febbeddee3fda6d0e446b515ccff4f4fe4 \
                     size   11923774
-    revision        0
+    revision        1
 
     conflicts       OpenBLAS-devel
 
     patchfiles      patch-libnoarch.release.diff \
                     patch-linkLib.release.diff  \
                     patch-OpenBLAS-i386-Apple.diff
+
+    if {![variant_isset native]} {
+        notes "
+        This version is built based on a base architecture for convenience, 
+        which may not be optimized for your system. To build a version 
+        customized for your machine, use the +native variant"
+    }
 }
 
 compilers.choose    fc
@@ -66,6 +99,11 @@ compilers.setup     default_fortran
 
 variant lapack description "Add Lapack/CLapack support to the library" { }
 default_variants-append +lapack
+
+variant native description "Force compilation on machine to get fully optimized library" {
+    # Prevent precompiled binaries to let compilation optimise the library for the user processor
+    archive_sites
+}
 
 use_configure       no
 
@@ -90,6 +128,16 @@ pre-build {
 
             if {![variant_isset lapack]} {
                 puts $makeINC "NO_LAPACK = 1"
+            }
+
+            if {![variant_isset native]} { 
+                #We set a minimal target in case native variant is not set
+                if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
+                    puts $makeINC "TARGET = PPCG4"
+                }
+                else {
+                    puts $makeINC "TARGET = ${blas_arch}"
+                }
             }
 
             if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
@@ -137,6 +185,12 @@ pre-build {
             puts $makeINC "NO_LAPACK = 1"
         }
 
+        if {![variant_isset native]} { 
+            #We set a minimal target in case native variant is not set
+            puts $makeINC "TARGET = ${blas_arch}"
+        }
+
+        #Setting up build flags
         if {${build_arch} eq "ppc" || ${build_arch} eq "ppc64"} {
             # on a PPC of some sort; just disable AVX
             puts $makeINC "NO_AVX = 1"


### PR DESCRIPTION
#### Description

Changes to OpenBLAS port allow the use of binaries build by the bots.
Based on a recent discussion on the mailing list, and in particular a suggestion from Ryan, where the Mac OS version can be used to determine the minimum requirements and set up a CPU target accordingly. 
As Openblas became a dependency of several other other ports, it may become worthwhile to allow the use of binaries, even if these are built for older CPUs with lower performances. 
A native version can trigger the local build to get full customization.
https://lists.macports.org/pipermail/macports-users/2019-May/046763.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

I tested it on Mojave, but not other versions as I don't have access to them. I also added ken as a reviewer based on all the help he provided recently to get openblas to compile on older systems, in case he wants to give some input.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->