### PR TITLE
pgf-devel: mark obsolete, replace with pgf

### DIFF
--- a/tex/pgf-devel/Portfile
+++ b/tex/pgf-devel/Portfile
@@ -1,49 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       obsolete 1.0
 
+# Remove after 2020-05-18
 name            pgf-devel
-conflicts       pgf
+replaced_by     pgf
 version         2010-09-28
+revision        1
 categories      tex textproc
-platforms       darwin
-maintainers     alum.wpi.edu:arno+macports openmaintainer
-supported_archs noarch
-
-description     PGF and TikZ -- Graphic systems for TeX (development version)
-
-long_description \
-    PGF is a TeX macro package for generating graphics. It is platform- and \
-    format-independent and works together with the most important TeX backend \
-    drivers, including pdftex and dvips. It comes with a user-friedly syntax \
-    layer called TikZ. This development build provides the latest features \
-    and bug-fixes.
-
-homepage        http://www.texample.net/tikz/builds/
-master_sites    http://www.texample.net/media/pgf/builds/
-distfiles       pgfCVS${version}_TDS.zip
-use_zip         yes
-extract.mkdir   yes
-
-checksums       rmd160  0064c6768e8a6bfb06bdf20e27f333d8f771bea8 \
-                sha256  2460196db3fd4e9a3dd159e4a8a2dd6b4cdb2872879be6212b4b600a7385a118
-
-livecheck.type  regex
-livecheck.url   ${homepage}
-livecheck.regex Build date (.*)</a></dt>
-
-depends_lib     bin:texhash:texlive
-
-use_configure   no
-build { }
-
-destroot {
-    set latex_local "${destroot}${prefix}/share/texmf-local"
-    xinstall -d ${latex_local}
-    copy ${worksrcpath}/tex ${latex_local}
-    copy ${worksrcpath}/doc ${latex_local}
-}
-
-post-activate {
-    system "texhash"
-}


### PR DESCRIPTION
Port has not been updated since 2012, whereas the `pgf` port was last updated this year.

Maintainer is @fracai

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
