### PR TITLE
gnetcat: specify license

### DIFF
--- a/net/gnetcat/Portfile
+++ b/net/gnetcat/Portfile
@@ -18,6 +18,7 @@ long_description \
     capabilities.
 
 categories      net
+license         GPL-2+
 platforms       darwin
 maintainers     alum.wpi.edu:arno+macports
 master_sites    sourceforge:${my_name}


### PR DESCRIPTION
#### Description

Maintainer is @fracai (adding handle to portfile is proposed in #4391)

License is `GPL-2+` as indicated by "version 2 of the License, or (at your option) any later version" appearing in source code: https://sourceforge.net/p/netcat/code/HEAD/tree/trunk/src/netcat.c#l16

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
