### PR TITLE
groovy: update to 2.5.7

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.6
+version         2.5.7
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,9 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  442cb35d37270675bb6f9d57b7cbbc919e564842 \
-                sha256  b64d0807d85857cb9d7a2137c6d5d828890598597ad0fd149faac20198ed8e92 \
-                size    29977599
+checksums       rmd160  fd3b3ba43b53e67b3aa86286633cf8f455295dc0 \
+                sha256  3d905dfe4f739c8c0d9dd181e6687ac816e451bf327a9ec0740da473cfebc9e0 \
+                size    30058416
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.7.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?