### PR TITLE
Fix cheroot backports, update to google-api 1.6.7 and oauth2client 4.1.3

### DIFF
--- a/python/py-cheroot/Portfile
+++ b/python/py-cheroot/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-cheroot
 version             6.5.5
-revision            1
+revision            2
 categories-append   www
 platforms           darwin
 supported_archs     noarch
@@ -24,6 +24,7 @@ master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 checksums           rmd160  ccfebbc1e5cb37d3ad7526f0dbcbf6fdd441f27e \
                     sha256  f6a85e005adb5bc5f3a92b998ff0e48795d4d98a0fbb7edde47a7513d4100601 \
                     size    83794
+patchfiles          patch-cheroot-setup_cfg.diff
 
 python.versions     27 34 35 36 37
 

--- a/python/py-cheroot/files/patch-cheroot-setup_cfg.diff
+++ b/python/py-cheroot/files/patch-cheroot-setup_cfg.diff
@@ -1,0 +1,11 @@
+--- setup.cfg.orig	2019-05-19 09:28:28.000000000 -0700
++++ setup.cfg	2019-05-19 09:28:46.000000000 -0700
+@@ -57,7 +57,7 @@
+ 	setuptools_scm>=1.15.0
+ 	setuptools_scm_git_archive>=1.0
+ install_requires = 
+-	backports.functools_lru_cache
++	backports.functools_lru_cache;python_version=="2.7"
+ 	six>=1.11.0
+ 	more_itertools>=2.6
+ 

--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-google-api
 set realname        google-api-python-client
-version             1.6.1
+version             1.6.7
 
 python.versions     27 34 35 36 37
 
@@ -23,8 +23,9 @@ homepage            https://pypi.python.org/pypi/${realname}
 master_sites        pypi:g/${realname}/
 distname            ${realname}-${version}
 
-checksums           rmd160 97b7feea292b17ea603d8bcc73d3c8323674ea00 \
-                    sha256 1b161de2de3900e5faef55c4ed73a9f7c3303b229d2dc9c55b6caea1f09e9fb4
+checksums           rmd160  d50870fbecb85b293d85cea4952f51b3195bad06 \
+                    sha256  05583a386e323f428552419253765314a4b29828c3cee15be735f9ebfa5aebf2 \
+                    size    51899
 
 if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools

--- a/python/py-oauth2client/Portfile
+++ b/python/py-oauth2client/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oauth2client
 set realname        oauth2client
-version             4.0.0
+version             4.1.3
 
 python.versions     27 34 35 36 37
 
@@ -22,13 +22,16 @@ homepage            https://pypi.python.org/pypi/${realname}
 master_sites        pypi:o/${realname}
 distname            ${realname}-${version}
 
-checksums           rmd160 97a433b6dfb7dcf6a2a9bbd2bb1aa5d00711961d \
-                    sha256 80be5420889694634b8517b4acd3292ace881d9d1aa9d590d37ec52faec238c7
+checksums           rmd160  bfa0e65e574bdaaad29928a66962bdeb284f28be \
+                    sha256  d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6 \
+                    size    155910
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools
     depends_lib-append   port:py${python.version}-httplib2 \
-                         port:py${python.version}-uritemplate
+                         port:py${python.version}-asn1-modules \
+                         port:py${python.version}-rsa \
+                         port:py${python.version}-six
     livecheck.type      none
 } else {
     livecheck.type      pypi

--- a/python/py-setuptools_scm_git_archive/Portfile
+++ b/python/py-setuptools_scm_git_archive/Portfile
@@ -13,7 +13,7 @@ supported_archs     noarch
 master_sites        pypi:s/setuptools_scm_git_archive
 distname            setuptools_scm_git_archive-${version}
 
-python.versions     27 36 37
+python.versions     27 34 35 36 37
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 


### PR DESCRIPTION
#### Description

This is a few separate minor changes. The biggest change here is a patch to make cheroot only depend on py-backports-functools_lru_cache for Python 2.7. Seemingly upstream's preferred approach is to include backports on all versions; see cherrypy/cheroot#181 for discussion.

While I was at it I bumped a couple version numbers and brought the dependencies for oauth2client in line with its setup.py (which also fixes the package; it broke [fava](https://github.com/beancount/fava) for me prior to this change.)

Note that oauth2client is deprecated, and google-api now depends on google-auth instead (which has yet to be ported.) I don't have time to make the switch currently, so I just updated google-api to the most recent version that still depended on oauth2client.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
