### PR TITLE
goffice08: revise comment

### DIFF
--- a/gnome/goffice/Portfile
+++ b/gnome/goffice/Portfile
@@ -72,9 +72,9 @@ if {${name} eq ${subport}} {
     livecheck.type      none
 }
 
-# Snapshot of goffice @0.8.17 for gnucash.
-# Can be removed once gnucash no longer needs this version.
-# No longer required in gnucash unstable 2.7.1 leading to 2.8 series
+# Snapshot of goffice @0.8.17
+# Still used by nip2 (needed until it moves to gtk3):
+# see https://trac.macports.org/ticket/58494#comment:1
 
 subport goffice08 {
     epoch               1


### PR DESCRIPTION
The existing comment suggests removing `goffice08` since it is no longer used by `gnucash`. However `nip2` still requires it for the time being.

See: https://trac.macports.org/ticket/58494#comment:1

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
