### PR TITLE
cctools: use clang as assembler only if new enough

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               xcodeversion 1.0
 
 name                    cctools
 # Xcode 10.0
 version                 921
 set ld64_version        409.12
-revision                1
+revision                2
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} openmaintainer
@@ -140,14 +141,22 @@ post-patch {
             reinplace "s:\"llvm-objdump\":\"llvm-objdump-mp-${llvm_version}\":" ${worksrcpath}/otool/main.c
             reinplace "s:\"llvm-mc\":\"llvm-mc-mp-${llvm_version}\":" ${worksrcpath}/as/driver.c
             reinplace "s:@@LLVM_LIBDIR@@:${prefix}/libexec/llvm-${llvm_version}/lib:" ${worksrcpath}/libstuff/lto.c
-            reinplace "s:__MP_CLANG_NAME__:clang-mp-${llvm_version}:" ${worksrcpath}/as/driver.c
+
+            # use mp-clang-${llvm_version} as assember if it is new enough; clang's integrated assembler had bugs prior to clang-5.0
+            # https://trac.macports.org/ticket/58493
+            if {${llvm_version} ne "3.4" && ${llvm_version} ne "3.7" && ${llvm_version} ne "3.9" && ${llvm_version} ne "4.0"} {
+                reinplace "s:__MP_CLANG_NAME__:clang-mp-${llvm_version}:" ${worksrcpath}/as/driver.c
+            } else {
+                # the clang corresponding to the llvm version is too old, restore original default behaviour
+                reinplace "s:__MP_CLANG_NAME__:CLANG:" ${worksrcpath}/as/driver.c
+            }
         }
 
-        if {${os.major} >= 11} {
+        # clang's integrated assembler had bugs prior to Xcode 7.3.1
+        # https://trac.macports.org/ticket/58493
+        if {[vercmp $xcodeversion 7.3.1] >= 0} {
             set try_system_clang 1
         } else {
-            # clang's integrated assembler may not work well on 10.6 and doesn't
-            # exist on older OS versions.
             set try_system_clang 0
         }
         reinplace "s:__TRY_SYSTEM_CLANG__:${try_system_clang}:" ${worksrcpath}/as/driver.c


### PR DESCRIPTION
prior to Xcode 7.3.1 / clang-5.0 clang's assember had at least one bug
closes: https://trac.macports.org/ticket/58493
