### PR TITLE
p5-future: update to version 0.40, dependencies

### DIFF
--- a/perl/p5-future/Portfile
+++ b/perl/p5-future/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Future 0.39 ../../authors/id/P/PE/PEVANS
+perl5.setup         Future 0.40 ../../authors/id/P/PE/PEVANS
 
 platforms           darwin
 maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
@@ -16,21 +16,19 @@ description         Future - represent an operation awaiting completion
 
 long_description    ${description}
 
-checksums           rmd160  71e4b0f8d20bbe35fe9cd9e791acc357228a9025 \
-                    sha256  1fdd988fabf477ad57156c8f9c1948c8037d7851830e8f37ae74e5a0ee4b6b45 \
-                    size    88840
+checksums           rmd160  e65c2c6556e46ff72c693bbb6a20d3cea8c12fbb \
+                    sha256  6eafed7c0351643358cd8bc56a0f6217fe84580dbd5d42e1b9663cdad5bc1d6c \
+                    size    91250
 
 if {${perl5.major} != ""} {
     depends_build-append \
                     port:p${perl5.major}-test-fatal \
                     port:p${perl5.major}-test-identity \
-                    port:p${perl5.major}-test-pod \
                     port:p${perl5.major}-test-refcount
 
     depends_lib-append \
                     port:p${perl5.major}-test-simple \
-                    port:p${perl5.major}-test-refcount \
                     port:p${perl5.major}-time-hires
-}
 
-perl5.use_module_build
+    perl5.use_module_build
+}


### PR DESCRIPTION
#### Description

* perl5.use_module_build only makes sense in versioned subports
* p5-test-refcount is not required at runtime (see META.json)
* p5-test-pod is an optional dep for author/release testing

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
