### PR TITLE
taglib-devel: mark obsolete, replace with taglib

### DIFF
--- a/audio/taglib-devel/Portfile
+++ b/audio/taglib-devel/Portfile
@@ -1,23 +1,10 @@
 PortSystem      1.0
-PortGroup       kde4   1.1
+PortGroup       obsolete 1.0
  
+# Remove after 2020-05-20
+
 name            taglib-devel
+replaced_by     taglib
 version         1.5-svn
+revision        1
 categories      audio
-maintainers     nomaintainer
-description     TagLib Audio Meta-Data Library
-long_description \
-    TagLib is a library for reading and editing the meta-data of \
-    several popular audio formats. Currently it supports both ID3v1 \
-    and ID3v2 for MP3 files, Ogg Vorbis comments and ID3 tags and \
-    Vorbis comments in FLAC files.
-homepage        http://developer.kde.org/~wheeler/taglib.html
-platforms       darwin
-master_sites    http://developer.kde.org/~wheeler/files/src/
-distname        taglib
-
-fetch.type      svn
-svn.url         svn://anonsvn.kde.org/home/kde/trunk/kdesupport/${distname}
-svn.revision    1010859
-
-configure.args-append  ../${distname}


### PR DESCRIPTION
`taglib` is up to date, while `taglib-devel` is still the same version as when created 10 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
