### PR TITLE
swfdec-devel: mark obsolete, replace with swfdec

### DIFF
--- a/multimedia/swfdec-devel/Portfile
+++ b/multimedia/swfdec-devel/Portfile
@@ -1,28 +1,10 @@
 PortSystem 1.0
+PortGroup       obsolete 1.0
+
+# Remove after 2020-05-20
 
 name            swfdec-devel
+replaced_by     swfdec
 version         0.7.2
-revision	1
+revision	    2
 categories      multimedia
-platforms       darwin
-
-maintainers     nomaintainer
-
-description     Decoder/renderer for Flash animations.
-long_description ${description}
-homepage        https://swfdec.freedesktop.org/
-
-distname	swfdec-${version}
-master_sites	${homepage}download/swfdec/0.7/
-checksums	md5 7624b5642c947fb054273f091a1d970c
-
-depends_build   port:pkgconfig
-depends_lib     port:gstreamer010-gst-plugins-good \
-                port:libsoup \
-                path:lib/pkgconfig/cairo.pc:cairo
-
-pre-configure {
-    reinplace "s|-Wl,-Bsymbolic||g" ${worksrcpath}/configure
-}
-
-configure.args  --with-audio=none


### PR DESCRIPTION
The `swfdec` port uses a more recent version than `swfdec-devel`.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
