### PR TITLE
griffon-devel: mark obsolete, replace with griffon

### DIFF
--- a/devel/griffon-devel/Portfile
+++ b/devel/griffon-devel/Portfile
@@ -1,73 +1,10 @@
 PortSystem 1.0
+PortGroup           obsolete 1.0
+
+# Remove after 2020-05-20
 
 name                griffon-devel
+replaced_by         griffon
 version             0.9.5-rc2
-revision			2
-set branch          [join [lrange [split ${version} .] 0 1] .]
+revision			3
 categories          devel java
-maintainers         nomaintainer
-platforms           darwin
-
-description         Griffon is a Grails like application framework for developing desktop applications in Groovy.
-long_description    Griffon aims to bring the "coding by convention" paradigm to Groovy. \
-                    It is an open-source application framework that leverages the Groovy \
-                    language and complements Java desktop development. \
-                    You can use Griffon as a standalone development environment that hides all \
-                    configuration details or integrate your Java business logic. \
-                    Griffon aims to make development as simple as possible and hence \
-                    should appeal to a wide range of developers not just those from the Java community.
-
-homepage            http://griffon.codehaus.org/
-conflicts			griffon
-
-distname            griffon-${version}-bin
-master_sites        http://dist.codehaus.org/griffon/griffon/${branch}.x/
-extract.suffix      .tgz
-
-checksums           md5     63d375d43d4205fead67ac62156f0c6a \
-                    sha1    d3fbf2579ec568fe4e73602bb0b297b5f97378c0 \
-                    rmd160  64683017fba794aadc9bdc171182a13bec3a1c83
-
-worksrcdir          .
-set workTarget      ""
-use_configure       no
-
-build.cmd           true
-
-pre-destroot {
-    # Remove extraneous bat files
-    foreach f [glob -directory ${worksrcpath}${workTarget}/griffon-${version}/bin *.bat] {
-        file delete $f
-    }
-}
-
-destroot    {
-    # Create the target java directory
-    xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}
-
-    # Copy over the needed elements of our directory tree
-    file copy ${worksrcpath}/griffon-${version}/bash					\
-              ${worksrcpath}/griffon-${version}/conf					\
-              ${worksrcpath}/griffon-${version}/dist					\
-              ${worksrcpath}/griffon-${version}/INSTALL					\
-              ${worksrcpath}/griffon-${version}/lib						\
-              ${worksrcpath}/griffon-${version}/LICENSE					\
-              ${worksrcpath}/griffon-${version}/media					\
-              ${worksrcpath}/griffon-${version}/src						\
-              ${worksrcpath}/griffon-${version}/scripts					\
-              ${destroot}${prefix}/share/java/${name}/
-
-	xinstall -m 755 -d ${destroot}${prefix}/share/java/${name}/bin
-	xinstall -m 755 {*}[glob ${worksrcpath}/griffon-${version}/bin/*] ${destroot}${prefix}/share/java/${name}/bin
-   	
-   	# Symlink programs into the bin directory
-    ln -s ${prefix}/share/java/${name}/bin/griffon ${destroot}${prefix}/bin
-    ln -s ${prefix}/share/java/${name}/bin/startGriffon ${destroot}${prefix}/bin
-}
-
-post-activate {
-    ui_msg "****************************************************************************"
-    ui_msg "* Remember to set the environment variable GRIFFON_HOME to the path to"
-    ui_msg "* the griffon distribution: ${prefix}/share/java/${name}"
-    ui_msg "****************************************************************************"
- }


### PR DESCRIPTION
The `griffon` port uses a more recent version than `griffon-devel`.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
