### PR TITLE
tin-devel: mark obsolete, replace with tin

### DIFF
--- a/news/tin-devel/Portfile
+++ b/news/tin-devel/Portfile
@@ -1,101 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           obsolete 1.0
+
+# Remove after 2020-05-20
 
 name                tin-devel
-conflicts           tin
+replaced_by         tin
 version             2.3.4
-revision            4
+revision            5
 categories          news
 license             BSD
-platforms           darwin
-maintainers         nomaintainer
-
-homepage            http://www.tin.org/
-description         A threaded NNTP and spool based UseNet newsreader
-
-long_description    tin is a full-screen easy to use Usenet reader. It can read news \
-            locally or remotely via a NNTP (Network News Transport Protocol) \
-            server. It will automatically utilize NOV (News OVerview) style \
-            index files if available locally or via the NNTP XOVER command.
-
-master_sites        ftp://ftp.tin.org/pub/news/clients/tin/unstable
-
-checksums           rmd160  440be790c40794bc33c0e21696c3e76af9d0fdf7 \
-                    sha256  1751ab4807648798063340058f0262cd2fe05cb2f9a65b359a2878119df1f55a
-
-depends_lib         port:icu \
-                    port:libiconv \
-                    port:libidn \
-                    port:ncurses \
-                    port:pcre
-
-distname            tin-${version}
-
-configure.args      --enable-break-long-lines \
-                    --enable-nntp \
-                    --enable-mh-mail-handling \
-                    --enable-included-msgs \
-                    --enable-ipv6 \
-                    --with-coffee \
-                    --mandir=${prefix}/share/man \
-                    --infodir=${prefix}/share/info \
-                    --datadir=${prefix}/share \
-                    --sysconfdir=${prefix}/etc \
-                    --with-defaults-dir=${prefix}/etc/${name} \
-                    --disable-pgp-gpg \
-                    --without-ispell \
-                    --with-screen=ncursesw
-
-build.dir           "${worksrcpath}/src"
-
-pre-destroot {
-    xinstall -d "${destroot}${prefix}/share/doc/${name}"
-    xinstall -d "${destroot}${prefix}/etc/${name}"
-    xinstall -m 644 -v -W "${worksrcpath}/doc" \
-        auth.txt CHANGES config-anomalies \
-        filtering good-netkeeping-seal iso2asc.txt \
-        keymap.sample mailcap.sample pgp.txt \
-        reading-mail.txt TODO umlaute.txt umlauts.txt \
-        WHATSNEW \
-        "${destroot}${prefix}/share/doc/${name}"
-    file copy "${worksrcpath}/doc/tin.defaults" \
-        "${destroot}${prefix}/etc/${name}/tin.defaults-${version}"
-}
-
-post-destroot {
-    xinstall -m 755 -v -W "${worksrcpath}/tools" \
-        expiretover tinews.pl tinlock \
-        "${destroot}${prefix}/bin"
-
-    # mutt-devel also installs these man pages, so removing here (since they
-    # describe mail formats, makes a little more sense to be in the mail app)
-    # ticket #11475
-    delete ${destroot}${prefix}/share/man/man5/mbox.5
-    delete ${destroot}${prefix}/share/man/man5/mmdf.5
-}
-
-post-activate {
-    set f "${prefix}/etc/${name}/tin.defaults"
-    if {![file exists ${f}]} {
-        file copy ${f}-${version} ${f}
-    }
-}
-
-variant gpg description {GnuPG support} {
-    depends_run             path:bin/gpg:gnupg2
-    configure.args-delete   --disable-pgp-gpg
-    configure.args-append   --with-gpg=${prefix}/bin/gpg \
-                            --without-pgp \
-                            --without-pgpk
-}
-
-variant ispell description {Ispell/Aspell support} {
-    depends_run             bin:ispell:aspell
-    configure.args-delete   --without-ispell
-    configure.args-append   --with-ispell=${prefix}/bin/ispell
-}
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     {unstable/tin-([0-9.]+).tar.gz}

--- a/news/tin/Portfile
+++ b/news/tin/Portfile
@@ -3,7 +3,6 @@
 PortSystem          1.0
 
 name                tin
-conflicts           tin-devel
 version             2.4.2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          news


### PR DESCRIPTION
`tin` is more up to date than `tin-devel`.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
