### PR TITLE
py-cachetools: new port

### DIFF
--- a/python/py-cachetools/Portfile
+++ b/python/py-cachetools/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-cachetools
+version             3.1.0
+checksums           rmd160  ba8042f518899a8a6fe0b1506741290cbf720812 \
+                    sha256  9efcc9fab3b49ab833475702b55edd5ae07af1af7a4c627678980b45e459c460 \
+                    size    20664
+
+license             MIT
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         memoizing collections and decorators
+long_description    This module provides various ${description}, including variants of the \
+                    Python 3 Standard Library @lru_cache function decorator.
+homepage            https://github.com/tkem/cachetools
+
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+python.versions     27 37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

cachetools is a dependency of [beancount](https://github.com/beancount/beancount/); I'm not sure what it does, except that with it packaged as such, beancount is working on my system (and cachetools imports successfully in python 2.7 and 3.7.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
