### PR TITLE
py-jcc: port abandoned

### DIFF
--- a/python/py-jcc/Portfile
+++ b/python/py-jcc/Portfile
@@ -10,7 +10,7 @@ name                py-jcc
 version             3.0
 categories-append   devel
 platforms           darwin
-maintainers         gmail.com:petrus.hyvonen openmaintainer
+maintainers         nomaintainer
 license             Apache-2
 
 description         JCC is a C++ code generator for calling Java from C++/Python


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58298
See: https://trac.macports.org/ticket/57560

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
