### PR TITLE
petsc-devel: mark obsolete, replace with petsc

### DIFF
--- a/math/petsc/Portfile
+++ b/math/petsc/Portfile
@@ -120,15 +120,14 @@ if {[variant_isset universal]} {
     }
 }
 
+# Remove after 2020-05-21
 subport petsc-devel {
-    bitbucket.setup     petsc petsc d745d2547b89
-    bitbucket.livecheck master
-    name                petsc-devel
-    version             3.7.99
-    revision            7
+    PortGroup           obsolete 1.0
 
-    checksums           rmd160  d67afbc8fd5ec371cd1debfff4b9c0bb41f04a78 \
-                        sha256  88beb37f34b5f997d47ff0950bc1b89a41035de05b292873d215e7fd78824f56
+    name                petsc-devel
+    replaced_by         petsc
+    version             3.7.99
+    revision            8
 }
 
 notes               "Add the following line to your .bash_profile if you plan to use\


### PR DESCRIPTION
It was suggested that `petsc-devel` be obsoleted in favor of `petsc` which is less outdated.
See: https://trac.macports.org/ticket/58028#comment:3

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
