### PR TITLE
grails-devel: mark obsolete, replace with grails

### DIFF
--- a/devel/grails-devel/Portfile
+++ b/devel/grails-devel/Portfile
@@ -1,69 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup           obsolete 1.0
+
+# Remove after 2020-05-21
 
 name				grails-devel
+replaced_by         grails
 version				2.2.0.RC2
+revision            1
 categories			devel java
-maintainers			nomaintainer
-description			An open-source web application framework that leverages the Groovy language
-long_description	Grails aims to bring the "coding by convention" paradigm to Groovy. \
-					It's an open-source web application framework that leverages the Groovy \
-					language and complements Java Web development. \
-					You can use Grails as a standalone development environment that hides all \
-					configuration details or integrate your Java business logic. \
-					Grails aims to make development as simple as possible and hence \
-					should appeal to a wide range of developers not just those from the Java community.
-homepage			http://www.grails.org/
 license				Apache-2
-platforms			darwin
-conflicts			grails
-distname			grails-${version}
-master_sites		http://dist.springframework.org.s3.amazonaws.com/release/GRAILS/
-checksums           md5     db6be38e3b233d0903e44d1b1c66ac00 \
-                    sha1    190d5a508916e4eacaf43101363fc6c2f731ff9b
-
-worksrcdir			grails-${version}
-set workTarget		""
-
-extract.suffix	   	.zip
-extract.cmd       	unzip
-extract.pre_args  	"-q -o"
-extract.post_args 	"-d ${workpath}"
-
-use_configure 		no
-
-build.cmd 			true
-
-pre-destroot {
-	# Remove extraneous bat files
-	foreach f [glob -directory ${worksrcpath}${workTarget}/bin *.bat] {
-		file delete $f
-	}
-}
-
-destroot	{
-	# Create the target java directory
-	xinstall -m 755 -d ${destroot}${prefix}/share/java/grails
-
-	# Copy over the needed elements of our directory tree
-	file copy ${worksrcpath}/bin     						\
-			  ${worksrcpath}/dist 							\
-			  ${worksrcpath}/conf 							\
-			  ${worksrcpath}/lib 							\
-			  ${worksrcpath}/media 							\
-			  ${worksrcpath}/plugins						\
-			  ${worksrcpath}/scripts						\
-			  ${worksrcpath}/src						    \
-			  ${worksrcpath}/build.properties 				\
-			  ${destroot}${prefix}/share/java/grails
-
-	# Symlink grails into the bin directory
-	system "cd ${destroot}${prefix}/bin && ln -s ${prefix}/share/java/grails/bin/grails"
-	system "cd ${destroot}${prefix}/bin && ln -s ${prefix}/share/java/grails/bin/startGrails"
-}
-
-notes "
-Remember to set the environment variable GRAILS_HOME to the path to\
-the grails distribution: ${prefix}/share/java/grails
-"

--- a/devel/grails/Portfile
+++ b/devel/grails/Portfile
@@ -15,7 +15,6 @@ long_description	Grails aims to bring the "coding by convention" paradigm to Gro
 homepage			http://www.grails.org/
 license				Apache-2
 platforms			darwin
-conflicts			grails-devel
 distname			${name}-${version}
 master_sites		http://dist.springframework.org.s3.amazonaws.com/release/GRAILS/
 checksums           md5	9edbfe19b50a59872653d5322e424fa5 \


### PR DESCRIPTION
The `grails` port is slightly less outdated than `grails-devel`; neither port has been updated in over 6 years.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
