### PR TITLE
micronaut: update to 1.1.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.1.1 v
+github.setup    micronaut-projects micronaut-core 1.1.2 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  2485c815b29d7fc2db7f3fbeebba820f5192a942 \
-                sha256  7cf3dafa792f0786f70fb0e0120ed945e72be03b639261729c1aff19310430bd \
-                size    12804252
+checksums       rmd160  0b8e5b902a7ca3990c48b046a7cd093d5429fbc5 \
+                sha256  07b9712e98ceb1b884306cf0903e46317f3f9ab6583154e47c36b40977098a6d \
+                size    12807913
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.1.2.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?