### PR TITLE
py*-beancount, fava: new ports

### DIFF
--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    fava
+version                 1.10
+checksums               rmd160  15c187e8f5a852a3850cb4a5c79e078dfc532c64 \
+                        sha256  5207d0ee49f86b5f7520ea7d556e769321853bb8eaa760acc606e4f76d49a990 \
+                        size    617036
+
+license                 MIT
+platforms               darwin
+supported_archs         noarch
+maintainers             nomaintainer
+
+description             beancount web server
+long_description        Fava is a web frontend for the Beancount plain-text accounting system.
+homepage                https://beancount.github.io/fava/
+
+master_sites            pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname                ${python.rootname}-${version}
+
+python.default_version  37
+
+depends_build-append    port:py${python.version}-setuptools \
+                        port:py${python.version}-setuptools_scm
+
+depends_lib-append      port:py${python.version}-babel \
+                        port:py${python.version}-beancount \
+                        port:py${python.version}-cheroot \
+                        port:py${python.version}-click \
+                        port:py${python.version}-flask \
+                        port:py${python.version}-flask-babel \
+                        port:py${python.version}-jinja2 \
+                        port:py${python.version}-markdown2 \
+                        port:py${python.version}-ply \
+                        port:py${python.version}-rsa \
+                        port:py${python.version}-simplejson

--- a/python/py-beancount/Portfile
+++ b/python/py-beancount/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-beancount
+version             2.2.1
+checksums           rmd160  60650715322a8f302455f3028400281f23d850d2 \
+                    sha256  ebcb59bd7c0e18a858c55d6c30eacee3fa949ee5d2c452a7aa80690e36ae2f77 \
+                    size    597196
+
+license             GPL-2
+platforms           darwin
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         plain text accounting
+long_description    Beancount is a plain-text accounting system in Python.
+homepage            http://furius.ca/beancount/
+
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-beautifulsoup4 \
+                    port:py${python.version}-bottle \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-google-api \
+                    port:py${python.version}-httplib2 \
+                    port:py${python.version}-lxml \
+                    port:py${python.version}-magic \
+                    port:py${python.version}-ply \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-requests
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

This adds ports for [beancount](https://github.com/beancount/beancount) and [fava](https://github.com/beancount/fava). (N.B. beancount depends on Python >=3.5, so it seems like it should only be available for 3.7 if I understand correctly.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
