### PR TITLE
mg: update to version 6.5

### DIFF
--- a/editors/mg/Portfile
+++ b/editors/mg/Portfile
@@ -1,10 +1,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup	    ibara mg 20180927 mg-
+github.setup	    ibara mg 6.5 mg-
+github.tarball_from releases
 
-name                mg
-version             20180927
+# change version from date to OpenBSD version
+epoch               1
+
 categories          editors
 platforms           darwin
 license             ISC/BSD
@@ -13,9 +15,9 @@ description         small Emacs-like editor
 long_description    Micro GNU/Emacs: a small, fast, lightweight, emacs-like editor.\
                     No extension language, just a basic editor for text & code.
 
-checksums           rmd160  a335cf28dfb2bb5a5cafbb8475889452031ba938 \
-                    sha256  e2065ddedc186c93f882f4ec5cf3cda194ead68b81b5225de4764401c2880f1b \
-                    size    157198
+checksums           rmd160  3a28ec30e6a2f8ec49f968abdf21caa8135c86c7 \
+                    sha256  3e4bb4582c8d1a72fb798bc320a9eede04f41e7e72a1421193174b1a6fc43cd8 \
+                    size    159278
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description

- bump version to 6.5
- use epoch because version changed from date (20180927) to OpenBSD
  version number

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->