### PR TITLE
gitlab-runner: update to 11.11.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.10.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 11.11.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  1c2882ae63a8c5a4d8b736ad44c7c2aeb304c434 \
-                    sha256  b5588fc945bceff8a51f251261102bf4cc167c12674bef4064780386eb25696a \
-                    size    27068191
+checksums           rmd160  a66ae825dc4cefd3ef5188946bf2de13adf58f18 \
+                    sha256  f0c17fc46a45e9a5b8fcf5ea5fe8227de79cb9c19ac135469cfb4926ef6e1e4c \
+                    size    27083441
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 11.11.0.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?