### PR TITLE
py-uncertainties: update to 3.1

### DIFF
--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -4,7 +4,8 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            lebigot uncertainties 3.0.3
+github.setup            lebigot uncertainties 3.1
+revision                0
 
 name                    py-uncertainties
 categories-append       math
@@ -15,15 +16,29 @@ long_description        The uncertainties package transparently handles\
                         calculations for numbers with uncertainties.
 platforms               darwin
 
-checksums               rmd160  e8580d87d559459d2ce45b98ca5d76e172949086 \
-                        sha256  f3d5a14f1479680338f01221e7eab69b39f6358374bf8a42d3d2a0e481afa5d0 \
-                        size    147055
+checksums               rmd160  f09f08c1cc5ee33b83790a063af5928804c1f972 \
+                        sha256  5c7258da19fa611d15295d64995be82e6eeea9da70a7bc64eccfcbfec933df66 \
+                        size    147879
 
 python.versions         27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append  \
                         port:py${python.version}-setuptools
+
+    depends_test-append port:py${python.version}-nose \
+                        port:py${python.version}-numpy
+    test.run            yes
+    test.cmd            ${python.bin} setup.py
+    test.target         nosetests
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE.txt \
+            INSTALL.txt ${destroot}${docdir}
+    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to latest version
- install files in post-destroot
- enable tests
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001
Python 2.7 and 3.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
