### PR TITLE
py-beancount, fava: fixes and cleanup

### DIFF
--- a/finance/beancount/Portfile
+++ b/finance/beancount/Portfile
@@ -1,35 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
-PortGroup           bitbucket 1.0
-
-bitbucket.setup     blais beancount bd3f97caca3d
+PortGroup           obsolete 1.0
 
 name                beancount
+replaced_by         py-beancount
 categories          finance
 license             GPL-2
 version             0.1
-platforms           darwin
-maintainers         {blair @blair} openmaintainer
-supported_archs     noarch
-
-python.versions     36
-
-description         Double-Entry Accounting from Text Files
-long_description    A double-entry bookkeeping computer language that lets \
-                    you define financial transaction records in a text file, \
-                    read them in memory, generate a variety of reports from  \
-                    them, and provides a web interface.
-
-homepage            http://furius.ca/beancount/
-fetch.type          hg
-
-depends_lib         port:py${python.version}-beautifulsoup4 \
-                    port:py${python.version}-bottle \
-                    port:py${python.version}-chardet \
-                    port:py${python.version}-dateutil \
-                    port:py${python.version}-google-api \
-                    port:py${python.version}-lxml \
-                    port:py${python.version}-magic \
-                    port:py${python.version}-ply
+revision            1

--- a/python/fava/Portfile
+++ b/python/fava/Portfile
@@ -4,7 +4,9 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    fava
+categories-append       finance
 version                 1.10
+revision                1
 checksums               rmd160  15c187e8f5a852a3850cb4a5c79e078dfc532c64 \
                         sha256  5207d0ee49f86b5f7520ea7d556e769321853bb8eaa760acc606e4f76d49a990 \
                         size    617036
@@ -12,9 +14,9 @@ checksums               rmd160  15c187e8f5a852a3850cb4a5c79e078dfc532c64 \
 license                 MIT
 platforms               darwin
 supported_archs         noarch
-maintainers             nomaintainer
+maintainers             {wholezero.org:macports @mrdomino} openmaintainer
 
-description             beancount web server
+description             Beancount web server
 long_description        Fava is a web frontend for the Beancount plain-text accounting system.
 homepage                https://beancount.github.io/fava/
 
@@ -23,8 +25,7 @@ distname                ${python.rootname}-${version}
 
 python.default_version  37
 
-depends_build-append    port:py${python.version}-setuptools \
-                        port:py${python.version}-setuptools_scm
+depends_build-append    port:py${python.version}-setuptools_scm
 
 depends_lib-append      port:py${python.version}-babel \
                         port:py${python.version}-beancount \
@@ -36,4 +37,5 @@ depends_lib-append      port:py${python.version}-babel \
                         port:py${python.version}-markdown2 \
                         port:py${python.version}-ply \
                         port:py${python.version}-rsa \
+                        port:py${python.version}-setuptools \
                         port:py${python.version}-simplejson

--- a/python/py-beancount/Portfile
+++ b/python/py-beancount/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-beancount
+categories-append   finance
 version             2.2.1
 checksums           rmd160  60650715322a8f302455f3028400281f23d850d2 \
                     sha256  ebcb59bd7c0e18a858c55d6c30eacee3fa949ee5d2c452a7aa80690e36ae2f77 \
@@ -11,11 +12,13 @@ checksums           rmd160  60650715322a8f302455f3028400281f23d850d2 \
 
 license             GPL-2
 platforms           darwin
-supported_archs     noarch
-maintainers         nomaintainer
+maintainers         {wholezero.org:macports @mrdomino} openmaintainer
 
-description         plain text accounting
-long_description    Beancount is a plain-text accounting system in Python.
+description         Double-entry plain text accounting system
+long_description    A double-entry bookkeeping computer language that lets \
+                    you define financial transaction records in a text file, \
+                    read them in memory, generate a variety of reports from  \
+                    them, and provides a basic web interface.
 homepage            http://furius.ca/beancount/
 
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}


### PR DESCRIPTION
#### Description

Context in #4423. This addresses the issues mentioned by @reneeotten (namely: remove `noarch` from beancount, move setuptools to fava's `depends_lib`) and attempts to address @yan12125's point with one possible solution.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
