### PR TITLE
recode-devel: mark obsolete, replace with recode

### DIFF
--- a/textproc/recode-devel/Portfile
+++ b/textproc/recode-devel/Portfile
@@ -1,52 +1,10 @@
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           obsolete 1.0
 
-github.setup        pinard Recode 3.7-beta2 v
+# Remove after 2020-05-22
+
 name                recode-devel
-conflicts           recode
+replaced_by         recode
+version             3.7-beta2
+revision            1
 categories          textproc
-maintainers         nomaintainer
-platforms           darwin
-description         charset conversion program
-
-long_description \
-	This recode program has the purpose of converting files between \
-	various character sets and usages. When exact transliterations \
-	are not possible, as it is often the case, the program may get \
-	rid of the offending characters or fall back on approximations.
-
-homepage            http://recode.progiciels-bpi.ca/
-distname            recode-${version}
-dist_subdir         recode
-
-checksums           rmd160  9d6c8d9eaf5262d5b35e7bef3fbaba223cd4f871 \
-                    sha256  ba3eec3e6a223b84c7f0d3e177ef62d12c65e90323e8691b45a41e350017e528
-
-depends_lib         port:libtool port:gettext port:libiconv
-
-# src/libiconv.c patch from Debian,
-# http://packages.debian.org/stable/text/recode
-# patchfiles          patch-lib_Makefile.in.diff patch-src_libiconv.c.diff
-patchfiles          patch-src-recodext.h.diff
-
-pre-configure {
-    xinstall -m 644 -W ${prefix}/share/libtool/build-aux config.guess config.sub ${worksrcpath}
-}
-
-configure.ldflags-append \
-                    -lintl -liconv
-
-configure.args      --infodir=${prefix}/share/info \
-                    --mandir=${prefix}/share/man \
-                    --with-libiconv-prefix=${prefix} \
-                    --with-libintl-prefix=${prefix}
-
-post-destroot {
-    set docdir ${prefix}/share/doc/${name}-${version}
-    xinstall -d ${destroot}${docdir}
-    xinstall -m 0644 -W ${worksrcpath} AUTHORS COPYING ChangeLog README THANKS \
-        TODO ${destroot}${docdir}
-}
-
-test.run        yes
-test.target     check


### PR DESCRIPTION
The `recode` port is up to date; `recode-devel` has never been updated.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
