### PR TITLE
qore-devel: mark obsolete, replace with qore

### DIFF
--- a/lang/qore-devel/Portfile
+++ b/lang/qore-devel/Portfile
@@ -1,51 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           obsolete 1.0
 
 name                qore-devel
+replaced_by         qore
 version             0.8.12.0.99
-revision            1
+revision            2
 categories          lang
 license             {LGPL-2.1 MIT}
-maintainers         {davidnichols @davidnich}
-
-description         dynamically-typed programming language - development version from git master
-long_description    Qore is a multithreaded, embeddabble programming language designed for SMP scalability. \
-                    This package uses git master. Use the qore package for the latest stable release.
-homepage            http://qore.org
-platforms           darwin
-master_sites        sourceforge
-
-conflicts           qore
-livecheck.type      none
-worksrcdir          trunk
-
-# git fetches are not working for me with SSL errors from github,
-# but only from macports; see https://trac.macports.org/ticket/42063
-fetch.type          svn
-svn.url             https://github.com/qorelanguage/qore/trunk/
-
-depends_build       port:flex \
-                    port:bison \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool
-
-depends_lib         path:lib/libssl.dylib:openssl \
-                    port:pcre \
-                    port:zlib \
-                    port:bzip2 \
-                    port:gmp \
-                    port:mpfr
-
-pre-configure {
-    # reconf.sh is mandatory for git builds. git-revision.h is not created when in an exported directory.
-    system -W ${worksrcpath} "./reconf.sh && echo \"#define BUILD \\\"git_master\\\"\" > ${worksrcpath}/include/qore/intern/git-revision.h"
-}
-
-# --disable-dependency-tracking is safe here. The build is always done in one run.
-#                               It's required to prevent autotools from using -M* options for multiple -arch options
-configure.args      --disable-debug --disable-static --disable-dependency-tracking
-
-# the autoconf check for iconv() in libiconv fails with GNU iconv, but we need it, so we turn it on anyway
-configure.ldflags   -liconv

--- a/lang/qore/Portfile
+++ b/lang/qore/Portfile
@@ -13,7 +13,6 @@ long_description    Qore is a scripting language designed for multi-threading an
 homepage            http://qore.org
 platforms           darwin
 master_sites        https://github.com/qorelanguage/qore/releases/download/release-${version}
-conflicts           qore-devel
 
 checksums           rmd160 11d27b816c44fb6cdc52ab4238baa61dd0b711bf \
                     sha256 9984dee0005056c6eb32736779d2d6e57f895537cf52932fc8276ee66735807a \


### PR DESCRIPTION
The `qore` port is up to date, while `qore-devel` hasn't been updated for nearly 3 years.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
