### PR TITLE
tor-devel: update to 0.4.1.1

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.0.5
+version             0.4.1.1-alpha
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  cc0bead52c77d0cb7f65c7c083c48d3810514287 \
-                    sha256  b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e \
-                    size    7203877
+checksums           rmd160  04c61763be4befaa689a084bed7569f82fc1b5c2 \
+                    sha256  60100c5cbed22a3e474452bb1b8ee941b98f4a268d7bbaa3ad04c7390ccb3e01 \
+                    size    7350019
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.1.1

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.13.6 17G8011
Xcode 10.1 10B61 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?