### PR TITLE
p5-inc-latest: remove old conflict handler

### DIFF
--- a/perl/p5-inc-latest/Portfile
+++ b/perl/p5-inc-latest/Portfile
@@ -16,19 +16,5 @@ checksums           rmd160  4f2fd5553853d987674e79069726370f465bb9a2 \
                     sha256  daa905f363c6a748deb7c408473870563fcac79b9e3e95b26e130a4a8dc3c611
 
 if {${perl5.major} != ""} {
-
-   # p5-inc-latest was previously part of p5-module-build now separate
-   # deactivate old conflicting p5-module-build before activation
-
-    pre-activate {
-        set pname p${perl5.major}-module-build
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 0.421.1] < 0} {
-                registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-
     supported_archs noarch
 }


### PR DESCRIPTION
Was added in 76c61f152f over 4 years ago.

#### Description


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
