### PR TITLE
gwyddion: update to 2.53

### DIFF
--- a/science/gwyddion/Portfile
+++ b/science/gwyddion/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                gwyddion
 version             2.53
-# revision            1
+revision            0
 categories          science x11
 platforms           darwin
 license             gpl-2

--- a/science/gwyddion/Portfile
+++ b/science/gwyddion/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                gwyddion
-version             2.50
-revision            1
+version             2.53
+# revision            1
 categories          science x11
 platforms           darwin
 license             gpl-2
@@ -20,8 +20,9 @@ master_sites        sourceforge:project/gwyddion/gwyddion/${version}
 use_xz              yes
 use_parallel_build  yes
 
-checksums           sha256  a511b528bfc0fbd53d0d867ece37ce4bf84c0989f75e535631ce60cff77b48ad \
-                    rmd160  4f4e53e625aff385ee226ac392c420e614236657
+checksums           sha256  bc7fdea79b180a5c3f4ac18abea103e72ee99eb4d77d7d7f66ee8b72a68b8b80 \
+                    rmd160  8fd592f338ca15107a438b944b9a010f8ba3933c \
+                    size    4452716
 
 depends_build       port:pkgconfig
 
@@ -38,6 +39,8 @@ configure.args      --disable-desktop-file-update \
                     --with-x \
                     --x-includes=${prefix}/include \
                     --x-libraries=${prefix}/lib
+
+patchfiles          patch-libgwyddion-gwyutils-c.diff
 
 variant quartz description { Build gwyddion with quartz gl support } {
     depends_lib-append    port:gtk-osx-application-gtk2

--- a/science/gwyddion/files/patch-libgwyddion-gwyutils-c.diff
+++ b/science/gwyddion/files/patch-libgwyddion-gwyutils-c.diff
@@ -1,0 +1,12 @@
+--- libgwyddion/gwyutils.c
++++ libgwyddion/gwyutils.c
+@@ -587,7 +587,7 @@ ensure_osx_basedir(G_GNUC_UNUSED gpointer arg)
+ {
+     int len, maxlen = 256;
+     char *res_url_path;
+-    gchar *basedir;
++    gchar *basedir = NULL;
+
+     CFBundleRef bundle_ref = NULL;
+     CFStringRef bid_str_ref = NULL;^
+


### PR DESCRIPTION
#### Description

Update gwyddion to 2.53

*  update to version 2.53

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
