### PR TITLE
p5-cpan-meta: remove old conflict handler

### DIFF
--- a/perl/p5-cpan-meta/Portfile
+++ b/perl/p5-cpan-meta/Portfile
@@ -18,16 +18,6 @@ checksums           rmd160  6f85c17dba70983ed6d7e0179675e2e9ed0f6d01 \
 supported_archs     noarch
 
 if {${perl5.major} != ""} {
-   # Parse::CPAN::Meta, now part of this module, was previously provided by separate port p5-parse-cpan-meta
-   # deactivate old conflicting p5-parse-cpan-meta before activation
-
-    pre-activate {
-        set pname p${perl5.major}-parse-cpan-meta
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-        }
-    }
-
     depends_lib-append \
                     port:p${perl5.major}-cpan-meta-requirements \
                     port:p${perl5.major}-cpan-meta-yaml \


### PR DESCRIPTION
Was added in 9ee6a50716 over two years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
