### PR TITLE
p5-mail-message: remove old conflict handler

### DIFF
--- a/perl/p5-mail-message/Portfile
+++ b/perl/p5-mail-message/Portfile
@@ -32,17 +32,4 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-user-identity
 
     supported_archs noarch
-
-    # p5-mail-message was previously part of p5-mail-box now separate
-    # deactivate conflicting p5-mail-box < 3.000 before activation
-
-    pre-activate {
-        set pname p${perl5.major}-mail-box
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 3.000] < 0} {
-                registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }


### PR DESCRIPTION
Was present when split from `p5-mail-box` in da4459f00c over two years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
