### PR TITLE
py-beancount-import: new port

### DIFF
--- a/python/py-beancount-import/Portfile
+++ b/python/py-beancount-import/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-beancount-import
+categories-append   finance
+version             1.3.0
+checksums           rmd160  2c574b08a3c2083678f3b42997892fbb38e4e5e0 \
+                    sha256  b4f8020d68e249933633365c620859079bcacef0b4e7a2b3c3c20eefbdf8cac5 \
+                    size    321899
+
+license             GPL-2
+supported_archs     noarch
+platforms           darwin
+maintainers         {wholezero.org:macports @mrdomino} openmaintainer
+
+description         Semi-automatic imports of financial data into Beancount
+long_description    Beancount-import is a tool for semi-automatically importing \
+                    financial data from external data sources into the \
+                    Beancount bookkeeping system, as well as merging and \
+                    reconciling imported transactions with each other and with \
+                    existing transactions.
+homepage            https://github.com/jbms/beancount-import
+
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+use_zip             yes
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-atomicwrites \
+                    port:py${python.version}-beancount \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-jsonschema \
+                    port:py${python.version}-nltk \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-scikit-learn \
+                    port:py${python.version}-scipy \
+                    port:py${python.version}-tornado
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Adds beancount_import from pypi.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
