### PR TITLE
[volk-]gnss-sdr: Fix building and updates

### DIFF
--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                gnss-sdr
 maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
@@ -16,6 +17,19 @@ platforms           darwin
 
 dist_subdir         gnss-sdr
 
+# Requires C++14
+compiler.blacklist-append {clang < 602} \
+    gcc-4.0 \
+    apple-gcc-4.0 \
+    gcc-4.2 apple-gcc-4.2 llvm-gcc-4.2 macports-llvm-gcc-4.2 \
+    macports-gcc-4.3 \
+    macports-gcc-4.4 \
+    macports-gcc-4.5 \
+    macports-gcc-4.6 \
+    macports-gcc-4.7 \
+    macports-gcc-4.8 \
+    macports-dragonegg-*
+
 if {${subport} eq "gnss-sdr"} {
 
     long_description    ${description}: \
@@ -25,13 +39,21 @@ if {${subport} eq "gnss-sdr"} {
     checksums           rmd160 733c3211b163825be36db80d89f9fb0db0051264 \
                         sha256 d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
                         size   3575803
-    revision            1
+    revision            2
 
     conflicts           gnss-sdr-devel gnss-sdr-next
 
     depends_lib-append  port:gnuradio port:volk-gnss-sdr
 
     require_active_variants port:gnuradio uhd
+
+    # Fixes building with Boost Asio
+    patchfiles-append \
+        patch-boost-asio.diff
+
+    # Temporary patch that fixes GNU Radio version detection when it is > 3.7.14 but < 3.8
+    patchfiles-append \
+        patch-fix-gnuradio-version.diff
 
 }
 
@@ -46,7 +68,7 @@ subport gnss-sdr-devel {
     checksums           rmd160 733c3211b163825be36db80d89f9fb0db0051264 \
                         sha256 d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
                         size   3575803
-    revision            1
+    revision            2
 
     conflicts           gnss-sdr gnss-sdr-next
 
@@ -54,23 +76,27 @@ subport gnss-sdr-devel {
 
     require_active_variants port:gnuradio-devel uhd
 
+    # Fixes building with Boost Asio
+    patchfiles-append \
+        patch-boost-asio.diff
+
 }
 
 subport gnss-sdr-next {
     long_description    ${description}: \
-        This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly.  This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release, and compiles against the gnuradio-next port, which represents GNU Radio GIT next branch.  This port may or not compile or function correctly, as it represents a work in progress.  If it does not work, check back in a few days.  Or try deactivating the currently active gnss-sdr and gnuradio ports, cleaning any current builds, and trying again.
+        This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly.  This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release, and compiles against the gnuradio-next subport. This port may or not compile or function correctly, as it represents a work in progress.  If it does not work, check back in a few days.  Or try deactivating the currently active gnss-sdr and gnuradio ports, cleaning any current builds, and trying again.
 
     name                gnss-sdr-next
-    github.setup        gnss-sdr gnss-sdr 40b7377c318ceeb72983069e23a1ba4e8908b526
-    version             20190516-[string range ${github.version} 0 7]
-    checksums           rmd160 88d5e31136871a1c865f6e62377dd216669f9876 \
-                        sha256 f775db42efd2cf75f028a11de50fea05009ad7a7ed803077d7971d1bd9fbd7fb \
-                        size   3689595
+    github.setup        gnss-sdr gnss-sdr d13e00ba502462e4b498b7fcc0dc9f965df48edf
+    version             20190523-[string range ${github.version} 0 7]
+    checksums           rmd160 ee32e0d2c9666644eab648f3c37c16afc5faa8ba \
+                        sha256 4bae6b37968a726a3f9a67ca0beae7691a0f20885111559d5cd6d4dca34394ff \
+                        size   3689496
     revision            0
 
     conflicts           gnss-sdr gnss-sdr-devel
 
-    depends_lib-append  port:gnuradio-next port:volk-gnss-sdr-next port:lapack
+    depends_lib-append  port:gnuradio-next port:volk-gnss-sdr-next port:lapack port:protobuf3-cpp
 
     require_active_variants port:gnuradio-next uhd
 

--- a/science/gnss-sdr/files/patch-boost-asio.diff
+++ b/science/gnss-sdr/files/patch-boost-asio.diff
@@ -1,0 +1,25 @@
+--- CMakeLists.txt.orig 2019-05-23 09:57:03.000000000 +0200
++++ CMakeLists.txt      2019-05-25 15:42:39.000000000 +0200
+@@ -502,7 +502,21 @@
+ if(NOT Boost_FOUND)
+     message(FATAL_ERROR "Fatal error: Boost (version >=${GNSSSDR_BOOST_MIN_VERSION}) required.")
+ endif()
+-
++if(${Boost_VERSION} VERSION_LESS 107000)
++    # Check if we have std::string_view
++    include(CheckCXXSourceCompiles)
++    check_cxx_source_compiles("
++        #include <string_view>
++        int main()
++        { std::string_view sv; }"
++        has_string_view
++    )
++    if(${has_string_view})
++        add_definitions(-DBOOST_ASIO_HAS_STD_STRING_VIEW=1)
++    else()
++        add_definitions(-DBOOST_ASIO_HAS_STD_STRING_VIEW=0)
++    endif()
++endif()
+ 
+ 
+ ################################################################################

--- a/science/gnss-sdr/files/patch-fix-gnuradio-version.diff
+++ b/science/gnss-sdr/files/patch-fix-gnuradio-version.diff
@@ -1,0 +1,13 @@
+--- CMakeLists.txt.orig 2019-05-23 09:57:03.000000000 +0200
++++ CMakeLists.txt      2019-05-25 14:09:42.000000000 +0200
+@@ -1271,6 +1271,10 @@
+         find_package(Gnuradio)
+     endif()
+ endif()
++if(PC_GNURADIO_RUNTIME_VERSION VERSION_LESS "3.7.99")
++    set(PC_GNURADIO_RUNTIME_VERSION "3.7.13")
++endif()
++
+ 
+ 
+ ################################################################################

--- a/science/volk-gnss-sdr/Portfile
+++ b/science/volk-gnss-sdr/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 PortGroup           cxx11 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                volk-gnss-sdr
 maintainers         {michaelld @michaelld} {gmail.com:carles.fernandez @carlesfernandez} openmaintainer
@@ -16,6 +17,19 @@ platforms           darwin
 
 dist_subdir         gnss-sdr
 
+# Requires C++14
+compiler.blacklist-append {clang < 602} \
+    gcc-4.0 \
+    apple-gcc-4.0 \
+    gcc-4.2 apple-gcc-4.2 llvm-gcc-4.2 macports-llvm-gcc-4.2 \
+    macports-gcc-4.3 \
+    macports-gcc-4.4 \
+    macports-gcc-4.5 \
+    macports-gcc-4.6 \
+    macports-gcc-4.7 \
+    macports-gcc-4.8 \
+    macports-dragonegg-*
+
 if {${subport} eq "volk-gnss-sdr"} {
 
     long_description    ${description}: \
@@ -23,9 +37,9 @@ if {${subport} eq "volk-gnss-sdr"} {
 
     github.setup        gnss-sdr gnss-sdr 0.0.10 v
     revision            0
-    checksums           rmd160  733c3211b163825be36db80d89f9fb0db0051264 \
-                        sha256  d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
-                        size    3575803
+    checksums           rmd160 733c3211b163825be36db80d89f9fb0db0051264 \
+                        sha256 d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
+                        size   3575803
 
     conflicts           volk-gnss-sdr-devel volk-gnss-sdr-next
 
@@ -39,9 +53,9 @@ subport volk-gnss-sdr-devel {
     name                volk-gnss-sdr-devel
     github.setup        gnss-sdr gnss-sdr 31c6b6bc1da77c9589a04d52a38d2d20edacf06e
     version             20190208
-    checksums           rmd160  733c3211b163825be36db80d89f9fb0db0051264 \
-                        sha256  d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
-                        size    3575803
+    checksums           rmd160 733c3211b163825be36db80d89f9fb0db0051264 \
+                        sha256 d44b32fd2bbdc703097e2368281d77ad4e2c42ec7c76c6e7ef100b014a716e3e \
+                        size   3575803
 
     conflicts           volk-gnss-sdr volk-gnss-sdr-next
 
@@ -52,11 +66,11 @@ subport volk-gnss-sdr-next {
         This port is kept up with the VOLK-GNSS-SDR GIT next branch, which is typically updated daily to weekly.  This version of VOLK-GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release, and compiles against the gnss-sdr-next and gnuradio-next ports.  This port may or not compile or function correctly, as it represents a work in progress.  If it does not work, check back in a few days.  Or try deactivating the currently active gnss-sdr and gnuradio ports, cleaning any current builds, and trying again.
 
     name                volk-gnss-sdr-next
-    github.setup        gnss-sdr gnss-sdr dc6876e1c98f82e5bdf9d5c11033d0a8dd09071a
-    version             20190401
-    checksums           rmd160  b12df8770df43d3a870b79308a0255cce9e2c232 \
-                        sha256  24363bdf71598fa22397d76787114942c7ac7e6a5ba1ca8be690c7603234bc1a \
-                        size    3675047
+    github.setup        gnss-sdr gnss-sdr d13e00ba502462e4b498b7fcc0dc9f965df48edf
+    version             20190523
+    checksums           rmd160 ee32e0d2c9666644eab648f3c37c16afc5faa8ba \
+                        sha256 4bae6b37968a726a3f9a67ca0beae7691a0f20885111559d5cd6d4dca34394ff \
+                        size   3689496
 
     conflicts           volk-gnss-sdr volk-gnss-sdr-devel
 


### PR DESCRIPTION
#### Description

Added patches to fix problems with Boost Asio 1.66 and Gnu Radio 3.7.13.5.  Increased revision number. for gnss-sdr and gnss-sdr-devel. Update gnss-sdr-next and volk-gnss-sdr-next to newer commits.

Now gnss-sdr-next depends on gnuradio-devel instead of on gnuradio-next.

Added clang < 602 to the compiler blacklist for C++14 support.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
