### PR TITLE
py-sqlalchemy-migrate: add py37 subport

### DIFF
--- a/python/py-sqlalchemy-migrate/Portfile
+++ b/python/py-sqlalchemy-migrate/Portfile
@@ -11,7 +11,7 @@ platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-tempita/Portfile
+++ b/python/py-tempita/Portfile
@@ -14,7 +14,7 @@ long_description    ${description}
 license             MIT
 homepage            https://pypi.python.org/pypi/Tempita/
 
-python.versions     27 35 36
+python.versions     27 35 36 37
 
 distname            Tempita-${version}
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
