### PR TITLE
p5-object-hashbase: remove old conflict handler

### DIFF
--- a/perl/p5-object-hashbase/Portfile
+++ b/perl/p5-object-hashbase/Portfile
@@ -16,17 +16,5 @@ checksums           rmd160  af6736f20497170c091985f5766912a24c579941 \
                     sha256  0734c671c8822bcfd34bd62adeea43c6640bd456196ab523177b7c13144df745
 
 if {${perl5.major} != ""} {
-    # p5-object-hashbase was previously part of p5-test-simple now separate
-    # deactivate old conflicting p5-test-simple before activation
-    pre-activate {
-        set pname p${perl5.major}-test-simple
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 1.302069] < 0} {
-                registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-
     supported_archs noarch
 }


### PR DESCRIPTION
Present when port was split from `p5-test-simple` in 3eb6da31fc over two years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
