### PR TITLE
libcomerr: remove old conflict handlers

### DIFF
--- a/sysutils/e2fsprogs/Portfile
+++ b/sysutils/e2fsprogs/Portfile
@@ -82,22 +82,4 @@ subport libcomerr {
     post-destroot {
         ln -fs libcom_err.1.1.dylib ${destroot}${prefix}/lib/libcom_err.dylib
     }
-
-    pre-activate {
-        # both kerberos5 and e2fsprogs previously conflicted because they installed files now provided by libcomerr
-        if {![catch {set installed [lindex [registry_active kerberos5] 0]}]} {
-            set krb_version [lindex $installed 1]
-            if {[vercmp $krb_version 1.11] < 0} {
-                # kerberos5 used to install some files now provided by libcomerr in versions < 1.11
-                registry_deactivate_composite kerberos5 "" [list ports_nodepcheck 1]
-            }
-        }
-        if {![catch {set installed [lindex [registry_active e2fsprogs] 0]}]} {
-            set e2fs_version [lindex $installed 1]
-            if {[vercmp $e2fs_version 1.42.7] < 0} {
-                # e2fsprogs used to install some files now provided by libcomerr in versions < 1.42.7
-                registry_deactivate_composite e2fsprogs "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }


### PR DESCRIPTION
Were added in 58bfbe7751 and c94712551c over 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
