### PR TITLE
p5-alien-build: remove old conflict handlers

### DIFF
--- a/perl/p5-alien-build/Portfile
+++ b/perl/p5-alien-build/Portfile
@@ -31,38 +31,5 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-test-simple \
                     port:p${perl5.major}-text-parsewords
 
-   # Test::Alien, now part of this module, was previously provided by separate port p5-test-alien
-   # deactivate old conflicting p5-test-alien before activation
-
-    pre-activate {
-        set pname p${perl5.major}-test-alien
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-        }
-    }
-
-   # Alien::Base, now part of this module, was previously provided by separate port p5-alien-base
-   # deactivate old conflicting p5-alien-base before activation
-
-    pre-activate {
-        set pname p${perl5.major}-alien-base
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-        }
-    }
-
-   # Alien::Base::PkgConfig, previously part of p5-alien-base-modulebuild, moved to this port as of ABMB version 1.00
-   # deactivate old conflicting p5-alien-base-modulebuild before activation
-
-    pre-activate {
-        set pname p${perl5.major}-alien-base-modulebuild
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 1.0.0] < 0} {
-                registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-
     supported_archs noarch
 }


### PR DESCRIPTION
Were added in df5c88c6eb, d5ee5f5c41, and 5110a2d59c over one year ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
