### PR TITLE
libpurple: remove old conflict handler

### DIFF
--- a/net/pidgin/Portfile
+++ b/net/pidgin/Portfile
@@ -107,15 +107,6 @@ subport libpurple {
                             --enable-tk \
                             --with-tclconfig=${prefix}/lib \
                             --with-tkconfig=${prefix}/lib
-
-    pre-activate {
-        if {![catch {set installed [lindex [registry_active pidgin] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 2.10.9] < 0} {
-                registry_deactivate_composite pidgin "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }
 
 subport finch {


### PR DESCRIPTION
Present when port was split from `pidgin` in 84a5226670 over 4 years ago

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
