### PR TITLE
gstlal-calibration: remove old conflict handler

### DIFF
--- a/science/gstlal-calibration/Portfile
+++ b/science/gstlal-calibration/Portfile
@@ -55,17 +55,6 @@ destroot.args-append \
               pkgpythondir="${pythondir}/${name}" \
               pkgpyexecdir="${pythondir}/${name}"
 
-pre-activate {
-  # gstlal-calibration now contains files that used to be provided by gstlal-ugly
-  if {![catch {set installed [lindex [registry_active gstlal-ugly] 0]}]} {
-    set _version [lindex $installed 1]
-    if {[vercmp $_version 0.6.0] < 0} {
-      # gstlal-ugly used to install some files now provided by gstlal-calibration in versions < 0.6.0
-      registry_deactivate_composite gstlal-ugly "" [list ports_nodepcheck 1]
-    }
-  }
-}
-
 livecheck.type   none
 #livecheck.type   regex
 #livecheck.url    ${master_sites}


### PR DESCRIPTION
Present when port was created in cbaf50936b over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
