### PR TITLE
py-josepy: remove old conflict handler

### DIFF
--- a/python/py-josepy/Portfile
+++ b/python/py-josepy/Portfile
@@ -20,16 +20,5 @@ checksums           rmd160  c297a66f6f9f50c30c82292ed0e0a5c2c87e8d3c \
                     size    52130
 
 if {${name} ne ${subport}} {
-    pre-activate {
-        # both py-acme and py-josepy previously conflicted because they installed files now provided by py-josepy
-        if {![catch {set installed [lindex [registry_active py${python.version}-acme] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 0.21.0] < 0} {
-                # py-acme used to install some files now provided by py-josepy in versions < 0.21.0
-                registry_deactivate_composite py${python.version}-acme "" [list ports_nodepcheck 1]
-            }
-        }
-    }
-
     depends_lib-append  port:py${python.version}-setuptools
 }


### PR DESCRIPTION
Was added in 9cb1cb05bd over one year ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
