### PR TITLE
lcdf-typetools: remove old conflict handler

### DIFF
--- a/print/lcdf-typetools/Portfile
+++ b/print/lcdf-typetools/Portfile
@@ -44,15 +44,6 @@ variant texlive description {Link against TeXLive's libkpathsea} {
     depends_lib-append      port:texlive-bin
     configure.args-replace  --without-kpathsea \
                             --with-kpathsea=${prefix}
-
-    pre-activate {
-        # texlive-fontutils used to provide its own copy of
-        # lcdf-typetools, but now (as of TL2012) depends on this port
-        if {![catch {set vers [lindex [registry_active texlive-fontutils] 0]}]
-            && [vercmp [lindex $vers 1] 26926] < 0} {
-            registry_deactivate_composite texlive-fontutils "" [list ports_nodepcheck 1]
-        }
-    }
 }
 
 default_variants    +texlive


### PR DESCRIPTION
Was added in 39d162a475 almost 7 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
