### PR TITLE
cogl: remove old conflict handler

### DIFF
--- a/graphics/cogl/Portfile
+++ b/graphics/cogl/Portfile
@@ -48,22 +48,6 @@ configure.args      --enable-cogl-pango=yes \
 
 use_parallel_build  no
 
-#
-# if clutter is installed and version is less than 1.12.0
-# deactivate clutter before activating cogl to avoid conflict
-#
-# previous versions included cogl in port clutter
-#
-
-pre-activate {
-    if { [file exists ${prefix}/lib/pkgconfig/clutter-1.0.pc]
-        && ![catch {set vers [lindex [registry_active clutter] 0]}]
-        && [vercmp [lindex $vers 1] 1.12.0] < 0} {
-        
-        registry_deactivate clutter "" "" "" [list ports_nodepcheck 1]
-    }
-}
-
 variant x11 conflicts quartz {
     patchfiles-append     patch-disable-quartz.diff
     depends_lib-append    port:gdk-pixbuf2 \


### PR DESCRIPTION
Present when port was split from clutter in 77825414bc over 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
