### PR TITLE
simutrans: remove old conflict handler

### DIFF
--- a/games/simutrans/Portfile
+++ b/games/simutrans/Portfile
@@ -136,16 +136,6 @@ subport simutrans-pak64 {
     destroot {
         copy ${worksrcpath}/${name} ${destroot}${data_dir}
     }
-    
-    # Deactivate old simutrans port that had an integrated pak64 that would conflict.
-    # Legacy port deactivation hack added 2012-04-22.
-    pre-activate {
-        if {[file exists ${prefix}/bin/simutrans]
-            && ![catch {set vers [lindex [registry_active simutrans] 0]}]
-            && [vercmp [lindex $vers 1] 111.2.2] < 0} {
-            registry_deactivate_composite simutrans "" [list ports_nodepcheck 1]
-        }
-    }
 }
 
 livecheck.version       ${my_version}


### PR DESCRIPTION
Originally added in f83bd7f2ee over 7 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
