### PR TITLE
hs-cpphs: remove old conflict handler

### DIFF
--- a/devel/hs-cpphs/Portfile
+++ b/devel/hs-cpphs/Portfile
@@ -17,11 +17,3 @@ long_description    \
     Cpphs is a re-implementation of the C pre-processor that is both more \
     compatible with Haskell, and itself written in Haskell so that it can be \
     distributed with compilers.
-
-pre-activate {
-    # deactivate hack added 2013-06-09
-    if {![catch {set installed [lindex [registry_active cpphs] 0]}]} {
-        # this port used to be named cpphs
-        registry_deactivate_composite cpphs "" [list ports_nodepcheck 1]
-    }
-}


### PR DESCRIPTION
Added when renamed from `cpphs` in 8c53a5d773 almost 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
