### PR TITLE
libmagic: remove old conflict handler

### DIFF
--- a/sysutils/file/Portfile
+++ b/sysutils/file/Portfile
@@ -63,15 +63,4 @@ subport libmagic {
     post-destroot {
         delete ${destroot}${prefix}/bin/file ${destroot}${prefix}/share/man/man1/file.1
     }
-    
-    pre-activate {
-        # file @5.14_0 and earlier installed some files now provided by libmagic
-        if {![catch {set installed [lindex [registry_active file] 0]}]} {
-            set file_version [lindex ${installed} 1]
-            set file_revision [lindex ${installed} 2]
-            if {[vercmp ${file_version} 5.14] < 0 || ([vercmp ${file_version} 5.14] == 0 && ${file_revision} < 1)} {
-                registry_deactivate_composite file "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }


### PR DESCRIPTION
Present when made a subport of `file` in 0ef83065b4 over 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
