### PR TITLE
kdemultimedia4 dependencies: remove old conflict handlers

### DIFF
--- a/kde/dragon/Portfile
+++ b/kde/dragon/Portfile
@@ -28,14 +28,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.txt.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdemultimedia4 port has been fragmented into small ports
-    if {[file exists ${applications_dir}/KDE4/dragon.app/Contents/Info.plist] 
-        && ![catch {set vers [lindex [registry_active kdemultimedia4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kdemultimedia4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/ffmpegthumbs/Portfile
+++ b/kde/ffmpegthumbs/Portfile
@@ -35,15 +35,5 @@ variant ffmpeg3 description "Update code to comply with functions of ffmpeg > 2.
 
 default_variants    +ffmpeg3
 
-pre-activate {
-    #Deactivate hack for when kdemultimedia4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/ffmpegthumbs.so] 
-        && ![catch {set vers [lindex [registry_active kdemultimedia4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kdemultimedia4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/juk/Portfile
+++ b/kde/juk/Portfile
@@ -39,14 +39,5 @@ pre-configure {
         ${worksrcpath}/CMakeLists.txt
 }
 
-pre-activate {
-    #Deactivate hack for when kdemultimedia4 port has been fragmented into small ports
-    if {[file exists ${applications_dir}/KDE4/juk.app/Contents/Info.plist] 
-        && ![catch {set vers [lindex [registry_active kdemultimedia4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kdemultimedia4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/libkcddb/Portfile
+++ b/kde/libkcddb/Portfile
@@ -27,14 +27,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.txt.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdemultimedia4 port has been fragmented into small ports
-    if {[file exists ${prefix}/include/libkcddb/cdinfo.h] 
-        && ![catch {set vers [lindex [registry_active kdemultimedia4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kdemultimedia4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/libkcompactdisc/Portfile
+++ b/kde/libkcompactdisc/Portfile
@@ -23,14 +23,5 @@ license_noconflict  openssl
 
 depends_lib-append  port:kdelibs4
 
-pre-activate {
-    #Deactivate hack for when kdemultimedia4 port has been fragmented into small ports
-    if {[file exists ${prefix}/include/libkcompactdisc/kcompactdisc.h] 
-        && ![catch {set vers [lindex [registry_active kdemultimedia4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kdemultimedia4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/mplayerthumbs/Portfile
+++ b/kde/mplayerthumbs/Portfile
@@ -20,14 +20,5 @@ checksums           rmd160  9e6e28ce2ec0a67a4f0dc678413f570ffe555319 \
 
 depends_lib-append  port:kdelibs4
 
-pre-activate {
-    #Deactivate hack for when kdemultimedia4 port has been fragmented into small ports
-    if {[file exists ${applications_dir}/KDE4/mplayerthumbsconfig.app/Contents/Info.plist] 
-        && ![catch {set vers [lindex [registry_active kdemultimedia4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kdemultimedia4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)


### PR DESCRIPTION
Added when these ports were split from `kdemultimedia4` in 738fffd07b over 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
