### PR TITLE
kdenetwork4 dependencies: remove old conflict handlers

### DIFF
--- a/kde/kdenetwork-filesharing/Portfile
+++ b/kde/kdenetwork-filesharing/Portfile
@@ -24,14 +24,5 @@ license_noconflict  openssl
 
 depends_lib-append  port:kdelibs4
 
-pre-activate {
-    #Deactivate hack for when kdenetwork4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/sambausershareplugin.so]
-        && ![catch {set vers [lindex [registry_active kdenetwork4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdenetwork4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kdenetwork-strigi-analyzers/Portfile
+++ b/kde/kdenetwork-strigi-analyzers/Portfile
@@ -26,14 +26,5 @@ depends_lib-append  port:kdelibs4 \
                     port:strigi \
                     port:boost
 
-pre-activate {
-    #Deactivate hack for when kdenetwork4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/sambausershareplugin.so]
-        && ![catch {set vers [lindex [registry_active kdenetwork4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdenetwork4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kdnssd/Portfile
+++ b/kde/kdnssd/Portfile
@@ -24,13 +24,4 @@ license_noconflict  openssl
 
 depends_lib-append  port:kdelibs4
 
-pre-activate {
-    #Deactivate hack for when kdenetwork4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/sambausershareplugin.so]
-        && ![catch {set vers [lindex [registry_active kdenetwork4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdenetwork4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.type      none

--- a/kde/kget/Portfile
+++ b/kde/kget/Portfile
@@ -49,14 +49,5 @@ pre-configure {
     reinplace "s|%PREFIX%|${prefix}|g" ${worksrcpath}/CMakeLists.txt
 }
 
-pre-activate {
-    #Deactivate hack for when kdenetwork4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/sambausershareplugin.so]
-        && ![catch {set vers [lindex [registry_active kdenetwork4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdenetwork4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kopete/Portfile
+++ b/kde/kopete/Portfile
@@ -52,14 +52,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdenetwork4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/sambausershareplugin.so]
-        && ![catch {set vers [lindex [registry_active kdenetwork4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdenetwork4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/krdc/Portfile
+++ b/kde/krdc/Portfile
@@ -35,14 +35,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdenetwork4 port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/sambausershareplugin.so]
-        && ![catch {set vers [lindex [registry_active kdenetwork4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdenetwork4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)


### PR DESCRIPTION
Added when ports were split from `kdenetwork4` in 9335e767c8 over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
