### PR TITLE
libkdegames: remove old conflict handler

### DIFF
--- a/kde/libkdegames/Portfile
+++ b/kde/libkdegames/Portfile
@@ -25,14 +25,5 @@ license_noconflict  openssl
 depends_lib-append  port:kdelibs4 \
                     port:libsndfile
 
-pre-activate {
-    #Deactivate hack for when kdegames4 port has been fragmented into small ports
-    if {[file exists ${prefix}/include/KDE/KExtHighscore] 
-        && ![catch {set vers [lindex [registry_active kdegames4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.10.0] < 0} {
-            registry_deactivate_composite kdegames4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)


### PR DESCRIPTION
Present when port was split from `kdegames4` in 9170d22305 over 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
