### PR TITLE
kdesdk4 deps: remove old conflict handlers

### DIFF
--- a/kde/cervisia/Portfile
+++ b/kde/cervisia/Portfile
@@ -28,14 +28,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/dolphin-plugins/Portfile
+++ b/kde/dolphin-plugins/Portfile
@@ -28,14 +28,5 @@ depends_lib-append  port:kdelibs4 \
 # kde4-baseapps is not universal
 universal_variant   no
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kapptemplate/Portfile
+++ b/kde/kapptemplate/Portfile
@@ -28,14 +28,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kcachegrind4/Portfile
+++ b/kde/kcachegrind4/Portfile
@@ -33,14 +33,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kde-dev-scripts/Portfile
+++ b/kde/kde-dev-scripts/Portfile
@@ -28,14 +28,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kde-dev-utils/Portfile
+++ b/kde/kde-dev-utils/Portfile
@@ -21,14 +21,5 @@ checksums           rmd160  71b0e7b02fac2bb93504e695c249a2c07f132581 \
 
 depends_lib-append  port:kdelibs4
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kdesdk-kioslaves/Portfile
+++ b/kde/kdesdk-kioslaves/Portfile
@@ -30,14 +30,5 @@ depends_lib-append  port:kdelibs4 \
 #with svn 1.9 with 1.8 headers
 patchfiles-append   patch-CMakeLists-nosvn.diff
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kdesdk-strigi-analyzers/Portfile
+++ b/kde/kdesdk-strigi-analyzers/Portfile
@@ -25,14 +25,5 @@ license_noconflict  openssl
 depends_lib-append  port:kdelibs4 \
                     port:strigi
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kdesdk-thumbnailers/Portfile
+++ b/kde/kdesdk-thumbnailers/Portfile
@@ -25,14 +25,5 @@ license_noconflict  openssl
 depends_lib-append  port:kdelibs4 \
                     port:gettext
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kompare/Portfile
+++ b/kde/kompare/Portfile
@@ -31,14 +31,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/lokalize/Portfile
+++ b/kde/lokalize/Portfile
@@ -29,14 +29,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/okteta/Portfile
+++ b/kde/okteta/Portfile
@@ -29,14 +29,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/poxml/Portfile
+++ b/kde/poxml/Portfile
@@ -32,14 +32,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/umbrello/Portfile
+++ b/kde/umbrello/Portfile
@@ -33,14 +33,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdesdk4 port has been fragmented into small ports
-    if {[file exists ${prefix}/bin/kdedoc]
-        && ![catch {set vers [lindex [registry_active kdesdk4] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdesdk4 "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)


### PR DESCRIPTION
Present when ports were split from `kdesdk4` in b0fc438ffc over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
