### PR TITLE
libkomparediff2: remove old conflict handler

### DIFF
--- a/kde/libkomparediff2/Portfile
+++ b/kde/libkomparediff2/Portfile
@@ -27,14 +27,5 @@ license_noconflict  openssl
 
 depends_lib-append  port:kdelibs4
 
-pre-activate {
-    #Deactivate hack for when libkomparediff2 port has been separated from kompare
-    if {[file exists ${prefix}/lib/libkomparediff2.4.dylib]
-        && ![catch {set vers [lindex [registry_active kompare] 0]}] 
-        && [vercmp [lindex $vers 1] 4.12.0] < 0} {
-            registry_deactivate_composite kompare "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)


### PR DESCRIPTION
Present when port was split from `kompare` in 73b0d2f516 over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
