### PR TITLE
gstreamer1 ports: remove old conflict handlers

### DIFF
--- a/gnome/gstreamer1-gst-plugins-base/Portfile
+++ b/gnome/gstreamer1-gst-plugins-base/Portfile
@@ -174,17 +174,6 @@ if {[variant_isset universal]} {
     }
 }
 
-# in version 1.14.0 some functionality moved here from bad
-# deactivate the old port before activating the new one
-pre-activate {
-    if {![catch {set installed [lindex [registry_active gstreamer1-gst-plugins-bad] 0]}]} {
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 1.14.0] < 0} {
-            registry_deactivate_composite gstreamer1-gst-plugins-bad "" [list ports_nodepcheck 1]
-        }
-    }
-}
-
 test.run            yes
 test.target         check
 

--- a/gnome/gstreamer1-gst-plugins-good/Portfile
+++ b/gnome/gstreamer1-gst-plugins-good/Portfile
@@ -170,24 +170,6 @@ if {[variant_isset universal]} {
 # gstflvmux.h:73: error: redefinition of typedef ‘GstFlvMuxPadClass’
 compiler.blacklist  *gcc-3.* *gcc-4.* {clang < 300}
 
-# in version 1.14.0 some functionality moved here from bad and ugly
-# deactivate the old ports before activating the new one
-pre-activate {
-    if {![catch {set installed [lindex [registry_active gstreamer1-gst-plugins-bad] 0]}]} {
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 1.14.0] < 0} {
-            registry_deactivate_composite gstreamer1-gst-plugins-bad "" [list ports_nodepcheck 1]
-        }
-    }
-
-    if {![catch {set installed [lindex [registry_active gstreamer1-gst-plugins-ugly] 0]}]} {
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 1.14.0] < 0} {
-            registry_deactivate_composite gstreamer1-gst-plugins-ugly "" [list ports_nodepcheck 1]
-        }
-    }
-}
-
 livecheck.type      regex
 livecheck.url       ${master_sites}
 livecheck.regex     "${my_name}-(\\d+\\\.\\d*\[02468\](?:\\.\\d+)*)${extract.suffix}"

--- a/gnome/gstreamer1/Portfile
+++ b/gnome/gstreamer1/Portfile
@@ -83,17 +83,6 @@ if {[variant_isset universal]} {
     }
 }
 
-# in version 1.14.0 some functionality moved here from bad
-# deactivate the old port before activating the new one
-pre-activate {
-    if {![catch {set installed [lindex [registry_active gstreamer1-gst-plugins-bad] 0]}]} {
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 1.14.0] < 0} {
-            registry_deactivate_composite gstreamer1-gst-plugins-bad "" [list ports_nodepcheck 1]
-        }
-    }
-}
-
 test.run            yes
 test.target         check
 


### PR DESCRIPTION
Were added in 4f4518c8f8, ab0574731f, and adbc145f6e one year ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
