### PR TITLE
doctl: new port

### DIFF
--- a/www/doctl/Portfile
+++ b/www/doctl/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/digitalocean/doctl 1.18.0 v
+revision            0
+
+checksums           rmd160  7d454c8812222227a28f8e4b1c27c9b37d9ef589 \
+                    sha256  5f681494c3a9750e0cf944a140da2e23c117c8b8b06e474c96c73552a7162e5c \
+                    size    15651051
+
+categories          www devel
+platforms           darwin
+license             Apache-2
+maintainers         {@kritr gmail.com:krdevmail} openmaintainer
+description         A command line interface for the DigitalOcean API
+long_description    ${description}
+
+depends_build-append port:git
+
+build.env-append    GO111MODULE=on
+build.target        ${worksrcpath}/cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin
+}
+
+variant bash_completion {
+    depends_run-append path:etc/bash_completion:bash-completion
+    post-destroot {
+        set completions_path ${destroot}${prefix}/share/bash-completion/completions
+        xinstall -d ${completions_path}
+        set completion-file [open ${completions_path}/${name} "w"]
+        puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion bash]
+        close ${completion-file}
+    }
+}
+
+variant zsh_completion description {Install zsh completion} {
+    depends_run-append path:${prefix}/bin/zsh:zsh
+    post-destroot {
+        set site-functions ${destroot}${prefix}/share/zsh/site-functions
+        xinstall -d ${site-functions}
+        set completion-file [open ${site-functions}/_${name} "w"]
+        puts ${completion-file} [exec ${destroot}${prefix}/bin/${name} completion zsh]
+        close ${completion-file}
+    }
+}


### PR DESCRIPTION
#### Description

doctl is a command line interface for the DigitalOcean API.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
