### PR TITLE
cctools: Allow multiple MacPorts clang versions to satisfy 'as', decouple from llvm variant version.

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -6,7 +6,7 @@ name                    cctools
 # Xcode 10.0
 version                 921
 set ld64_version        409.12
-revision                1
+revision                2
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} openmaintainer
@@ -140,8 +140,28 @@ post-patch {
             reinplace "s:\"llvm-objdump\":\"llvm-objdump-mp-${llvm_version}\":" ${worksrcpath}/otool/main.c
             reinplace "s:\"llvm-mc\":\"llvm-mc-mp-${llvm_version}\":" ${worksrcpath}/as/driver.c
             reinplace "s:@@LLVM_LIBDIR@@:${prefix}/libexec/llvm-${llvm_version}/lib:" ${worksrcpath}/libstuff/lto.c
-            reinplace "s:__MP_CLANG_NAME__:clang-mp-${llvm_version}:" ${worksrcpath}/as/driver.c
         }
+
+        # List of clang versions to search for at runtime internally by 'as'
+        # Build list from llvm variants, excluding clang < 5 and devel version
+        # (unless devel variant is used in which case it is included first)
+        set as_comps ""
+        foreach variantname ${all_llvm_variants} {
+            set ver $llvm_variant_version($variantname)
+            # Use all non-devel and clang > 4 versions
+            if { ${ver} ne "devel" && ${ver} > 4.999 } {
+                if { ${as_comps} ne "" } {
+                    set as_comps ",${as_comps}"
+                }
+                set as_comps "\"clang-mp-${ver}\"${as_comps}"
+            }
+        }
+        # If llvmdev variant is active, include at start of list
+        if {[variant_isset llvmdev]} {
+            set as_comps "\"clang-mp-devel\",${as_comps}"
+        }
+        ui_debug "as compiler list ${as_comps}"
+        reinplace "s:__MP_CLANG_NAMES__:${as_comps}:" ${worksrcpath}/as/driver.c
 
         if {${os.major} >= 11} {
             set try_system_clang 1

--- a/devel/cctools/files/as-try-clang.patch
+++ b/devel/cctools/files/as-try-clang.patch
@@ -1,6 +1,6 @@
---- as/driver.c.orig	2018-09-19 08:01:56.000000000 +1000
-+++ as/driver.c	2019-01-25 01:35:21.000000000 +1100
-@@ -295,11 +295,18 @@ char **envp)
+--- as/driver.c.orig	2019-05-25 16:26:59.000000000 +0100
++++ as/driver.c	2019-05-25 16:49:42.000000000 +0100
+@@ -295,11 +295,26 @@
  	    arch_flag.cputype == CPU_TYPE_ARM64 ||
  	    arch_flag.cputype == CPU_TYPE_ARM64_32 ||
  	    arch_flag.cputype == CPU_TYPE_ARM)){
@@ -9,22 +9,30 @@
 -		printf("%s: assembler (%s) not installed\n", progname, as);
 -		exit(1);
 -	    }
-+        as = makestr(prefix, "__MP_CLANG_NAME__", NULL);
-+        if(access(as, F_OK) != 0){
++          const char * mp_comps[] = { __MP_CLANG_NAMES__ };
++          const size_t n_comps = sizeof(mp_comps) / sizeof(mp_comps[0]);
++          for ( size_t i = 0; i < n_comps; ++i ) {
++            as = makestr(prefix, mp_comps[i], NULL);
++            if(access(as, F_OK) == 0){
++              // found working compiler so break
++              break;
++            } else {
++              as = NULL;
++            }
++          }
 +#if __TRY_SYSTEM_CLANG__
++          if ( as == NULL ) {
 +            as = "/usr/bin/clang";
 +            if(access(as, F_OK) != 0){
-+                as = NULL;
++              as = NULL;
 +            }
-+#else
-+            as = NULL;
++          }
 +#endif
-+        }
-+        if (as != NULL) {
++          if (as != NULL) {
  	    new_argv = allocate((argc + 8) * sizeof(char *));
  	    new_argv[0] = as;
  	    j = 1;
-@@ -360,6 +367,7 @@ char **envp)
+@@ -360,6 +375,7 @@
  		exit(0);
  	    else
  		exit(1);

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -8,7 +8,7 @@ PortGroup           conflicts_build             1.0
 
 epoch               3
 name                gcc10
-version             10-20190505
+version             10-20190519
 revision            0
 subport             libgcc-devel { revision 0 }
 platforms           darwin
@@ -29,9 +29,9 @@ master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/sn
 distname            gcc-${version}
 use_xz              yes
 
-checksums           rmd160  08c507e6d6b888a47f0e998f35c3a43269630c67 \
-                    sha256  5ef4500a9e440fd9469dabd0a7d2ece133932c199573a70eae38af09b0940a3e \
-                    size    68789736
+checksums           rmd160  0e9acd4efa4687cb15b98335aa9bd33c9072a93b \
+                    sha256  7615e16b43b5ce0320912e055a82273d8311baee657a1e099c7fe5cb6cdad949 \
+                    size    68850804
 
 depends_lib         port:cctools \
                     port:gmp \
@@ -97,50 +97,6 @@ configure.env-append \
                     OTOOL=${prefix}/bin/otool \
                     OTOOL64=${prefix}/bin/otool
 
-# Make sure the MP clang version used by cctool's 'as' is available at build time and used.
-if { ${os.major} > 10 } {
-    if {![catch {set installed [lindex [registry_active cctools] 0]}]} {
-        # cctools already installed, so figure out from registry what variant to use
-        # First, is xcode variant in use ?
-        if {[active_variants cctools xcode ""]} {
-            # xcode variant is in use. Warn (as no longer the default) but accept as should still work.
-            ui_warn "cctools has (non default) xcode variant active. Consider reinstalling cctools using default variants."
-        } else {
-            # llvm variant list here must have all possible variants from cctools in it
-            set llvm_variant_found "no"
-            foreach {llvm_v llvm_v_nodot} {3.4 34 3.7 37 3.9 39 4.0 40 5.0 50 6.0 60 7.0 70 8.0 80 devel dev} {
-                if {[active_variants cctools llvm${llvm_v_nodot} ""]} {
-                    depends_build-append port:clang-${llvm_v}
-                    configure.compiler macports-clang-${llvm_v}
-                    set llvm_variant_found "yes"
-                    break
-                }
-            }
-            # If we failed to find the active variant, error out as it could mean
-            # above variant list is out of date.
-            if { ${llvm_variant_found} eq "no" } {
-                ui_error "Failed to determine active llvm variant for cctools. Please check variant list."
-                return -code error "configuration error"
-            } else {
-                ui_debug "${subport}: cctools has llvm variant ${llvm_v} active"
-            }
-        }
-    } else {
-        # cctools is not yet installed, so have to play 'guess the default variant' :(
-        # Logic here needs to match that used in cctools port.
-        if { ${os.major} <= 11 } {
-            set llvm_v 3.4
-        } elseif { ${os.major} <= 13 } {
-            set llvm_v 3.7
-        } else {
-            set llvm_v 7.0
-        }
-        depends_build-append port:clang-${llvm_v}
-        configure.compiler macports-clang-${llvm_v}
-        ui_debug "${subport}: cctools not active. Will assume default llvm variant is ${llvm_v}"
-    }
-}
-
 pre-configure {
 
     # Set package info
@@ -174,6 +130,10 @@ compiler.blacklist-append {llvm-gcc-4.2 < 2336.1}
 
 # https://trac.macports.org/ticket/47996
 compiler.blacklist-append {clang < 300}
+
+# https://trac.macports.org/ticket/58493
+compiler.blacklist-append {clang < 800}
+compiler.whitelist clang macports-clang-7.0
 
 # "-stdlib" would be passed on to the bootstrap compiler if present
 configure.cxx_stdlib

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -1,16 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem                                      1.0
-PortGroup           select                      1.0
-PortGroup           compiler_blacklist_versions 1.0
-PortGroup           active_variants             1.1
-PortGroup           conflicts_build             1.0
+PortSystem                                       1.0
+PortGroup           select                       1.0
+PortGroup           compiler_blacklist_versions  1.0
+PortGroup           active_variants              1.1
+PortGroup           conflicts_build              1.0
 
 epoch               2
 name                gcc9
 version             9.1.0
-revision            1
-subport             libgcc9 { revision 1 }
+revision            2
+subport             libgcc9 { revision 2 }
 platforms           darwin
 categories          lang
 maintainers         nomaintainer
@@ -101,50 +101,6 @@ configure.env-append \
                     OTOOL=${prefix}/bin/otool \
                     OTOOL64=${prefix}/bin/otool
 
-# Make sure the MP clang version used by cctool's 'as' is available at build time and used.
-if { ${os.major} > 10 } {
-    if {![catch {set installed [lindex [registry_active cctools] 0]}]} {
-        # cctools already installed, so figure out from registry what variant to use
-        # First, is xcode variant in use ?
-        if {[active_variants cctools xcode ""]} {
-            # xcode variant is in use. Warn (as no longer the default) but accept as should still work.
-            ui_warn "cctools has (non default) xcode variant active. Consider reinstalling cctools using default variants."
-        } else {
-            # llvm variant list here must have all possible variants from cctools in it
-            set llvm_variant_found "no"
-            foreach {llvm_v llvm_v_nodot} {3.4 34 3.7 37 3.9 39 4.0 40 5.0 50 6.0 60 7.0 70 8.0 80 devel dev} {
-                if {[active_variants cctools llvm${llvm_v_nodot} ""]} {
-                    depends_build-append port:clang-${llvm_v}
-                    configure.compiler macports-clang-${llvm_v}
-                    set llvm_variant_found "yes"
-                    break
-                }
-            }
-            # If we failed to find the active variant, error out as it could mean
-            # above variant list is out of date.
-            if { ${llvm_variant_found} eq "no" } {
-                ui_error "Failed to determine active llvm variant for cctools. Please check variant list."
-                return -code error "configuration error"
-            } else {
-                ui_debug "${subport}: cctools has llvm variant ${llvm_v} active"
-            }
-        }
-    } else {
-        # cctools is not yet installed, so have to play 'guess the default variant' :(
-        # Logic here needs to match that used in cctools port.
-        if { ${os.major} <= 11 } {
-            set llvm_v 3.4
-        } elseif { ${os.major} <= 13 } {
-            set llvm_v 3.7
-        } else {
-            set llvm_v 7.0
-        }
-        depends_build-append port:clang-${llvm_v}
-        configure.compiler macports-clang-${llvm_v}
-        ui_debug "${subport}: cctools not active. Will assume default llvm variant is ${llvm_v}"
-    }
-}
-
 pre-configure {
 
     # Set package info
@@ -178,6 +134,10 @@ compiler.blacklist-append {llvm-gcc-4.2 < 2336.1}
 
 # https://trac.macports.org/ticket/47996
 compiler.blacklist-append {clang < 300}
+
+# https://trac.macports.org/ticket/58493
+compiler.blacklist-append {clang < 800}
+compiler.whitelist clang macports-clang-7.0
 
 # "-stdlib" would be passed on to the bootstrap compiler if present
 configure.cxx_stdlib


### PR DESCRIPTION
#### Description

cctools : Update logic to select macports clang to be used by 'as' at runtime, to be a list of possible clang versions, independent of the llvm variant cctools is built with. cctools/as will at runtime search these in order and use the first it finds. If none is found, /usr/bin/clang is then used.

gcc9/gcc10: Remove logic used to determine cctools variant used, as no longer needed given above.

Closes: https://trac.macports.org/ticket/58493

###### Type(s)

- [x] enhancement

###### Tested on

Multiple macOS version (10.14, 10.11, 10.9).

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->