### PR TITLE
restic: update to 0.9.5 and add docs variant

### DIFF
--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -18,7 +18,25 @@ checksums           rmd160  7297c7dc01980c0ece228ad492bbc7d06fae6d37 \
                     sha256  f818778b135d3b0ca9710992e13b7e06458fcde3aa914b60907aeca7ac84bb5e \
                     size    26934307
 
+set pyver           3.7
+
+variant             docs description {Build the documentation} {
+    set pyver_nodot [string map {. {}} ${pyver}]
+
+    depends_build-append \
+                    port:python${pyver_nodot} \
+                    port:py${pyver_nodot}-sphinx \
+                    port:py${pyver_nodot}-sphinx_rtd_theme
+}
+
 build.cmd           go run build.go
+
+post-build {
+    if {[variant_isset docs]} {
+        reinplace -W ${worksrcpath}/doc "s|sphinx-build|sphinx-build-${pyver}|g" Makefile
+        system -W ${worksrcpath}/doc "make html"
+    }
+}
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
@@ -26,4 +44,8 @@ destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -m 755 -d ${destroot}${docdir}
     xinstall -m 644 -W ${worksrcpath} LICENSE README.rst ${destroot}${docdir}
+
+    if {[variant_isset docs]} {
+        file copy ${worksrcpath}/doc/_build/html ${destroot}${docdir}
+    }
 }

--- a/sysutils/restic/Portfile
+++ b/sysutils/restic/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/restic/restic 0.9.4 v
+go.setup            github.com/restic/restic 0.9.5 v
 categories          sysutils
 
 license             BSD
@@ -14,9 +14,9 @@ long_description    Restic is a program that does backups right. Its design goal
 
 homepage            https://restic.net/
 
-checksums           rmd160  05dde2739f3c2ed9109f1ece2e96008cec36ac2a \
-                    sha256  9198c43abd08b3a09ea59226282447316e13da579713dda2d81a28c37902d2c8 \
-                    size    26211387
+checksums           rmd160  7297c7dc01980c0ece228ad492bbc7d06fae6d37 \
+                    sha256  f818778b135d3b0ca9710992e13b7e06458fcde3aa914b60907aeca7ac84bb5e \
+                    size    26934307
 
 build.cmd           go run build.go
 


### PR DESCRIPTION
#### Description
The `docs` variant builds the HTML documentation with sphinx. Let me know if there is a better way to do this (e.g. user selectable output format).
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->