### PR TITLE
atkmm: remove old conflict handler

### DIFF
--- a/gnome/atkmm/Portfile
+++ b/gnome/atkmm/Portfile
@@ -38,13 +38,4 @@ autoreconf.args     -fvi
 
 configure.args      --disable-silent-rules
 
-pre-activate {
-    if { [file exists ${prefix}/lib/pkgconfig/atkmm-1.6.pc]
-        && ![catch {set vers [lindex [registry_active gtkmm] 0]}]
-        && [vercmp [lindex $vers 1] 2.22.0] < 0} {
-
-        registry_deactivate_composite gtkmm "" [list ports_nodepcheck 1]
-    }
-}
-
 livecheck.type      gnome


### PR DESCRIPTION
Present when `atkmm` was split from `gtkmm` in b062b75c72 over 8 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
