### PR TITLE
p5-xml-sax-base: remove old conflict handler

### DIFF
--- a/perl/p5-xml-sax-base/Portfile
+++ b/perl/p5-xml-sax-base/Portfile
@@ -12,14 +12,3 @@ platforms           darwin
 
 checksums           rmd160  db0deffe2536d7e96b00010a8bb87f2d56eac36b \
                     sha256  66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0
-
-if {${perl5.major} != ""} {
-    pre-activate {
-        # XML::SAX::Exception moved to this port from p5-xml-sax
-        if {![catch {set vers [lindex [registry_active p${perl5.major}-xml-sax] 0]}]
-            && [vercmp [lindex $vers 1] 0.990] < 0} {
-            registry_deactivate_composite p${perl5.major}-xml-sax "" [list ports_nodepcheck 1]
-        }
-    }
-}
-                    


### PR DESCRIPTION
Added in a19452f9bc over 7 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
