### PR TITLE
packer: update to v1.4.1

### DIFF
--- a/sysutils/packer/Portfile
+++ b/sysutils/packer/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        hashicorp packer 1.4.0 v
+github.setup        hashicorp packer 1.4.1 v
 
 # NOTE: github.fetch is used as packer's Makefile has several lines that
 #       expect to be run from a git repo.
@@ -33,12 +33,7 @@ installs_libs       no
 
 worksrcdir          ${distname}/src/github.com/hashicorp/packer
 
-pre-build {
-    reinplace "/go get.*govendor/d" ${worksrcpath}/Makefile
-}
-
 depends_build       port:go \
-                    port:govendor \
                     port:realpath
 
 build.env           GOPATH=${workpath}/${distname} \


### PR DESCRIPTION
#### Description

Update to v1.4.1.
Also, remove govendor dependency since it is no longer required.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4
Xcode 10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->