### PR TITLE
dovecot2: Upgrade to v2.3.6 and major Portfile overhaul

### DIFF
--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -1,23 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github                      1.0
+PortGroup           cxx11                       1.1
 
-PortGroup           legacysupport 1.0
-legacysupport.newest_darwin_requires_legacy 10
+github.setup        dovecot core 2.3.6
 
 name                dovecot2
 set base_name       dovecot
 # Please revbump port:dovecot2-sieve and port:dovecot2-antispam
 # on port:dovecot2 version changes.
-version             2.3.0.1
-# set hg.tag to tag or rev.
-hg.tag              ${version}
-#hg.tag              69630e6048fd
-set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          mail
 maintainers         nomaintainer
 platforms           darwin
 license             LGPL-2.1
+homepage            https://www.dovecot.org
 
 description         Secure, fast imap and pop3 server
 long_description    Dovecot is an IMAP and POP3 server for Linux/UNIX-like \
@@ -25,28 +22,14 @@ long_description    Dovecot is an IMAP and POP3 server for Linux/UNIX-like \
                     it is written in C, it uses several coding techniques to \
                     avoid most of the common pitfalls.
 
-homepage            http://dovecot.org/
-master_sites        http://dovecot.org/releases/${branch}
-
-distname            ${base_name}-${version}
-
-use_parallel_build  no
-
-depends_build       port:pkgconfig
+depends_build       port:gettext \
+                    port:pandoc \
+                    port:pkgconfig
 depends_lib         port:libiconv \
                     port:zlib \
                     port:xz \
                     port:bzip2 \
                     path:lib/libssl.dylib:openssl
-
-if {${hg.tag} ne ${version}} {
-
-    master_sites        http://hg.dovecot.org/dovecot-${branch}/archive
-    distname            ${hg.tag}
-    use_bzip2           yes
-    worksrcdir          dovecot-[join [split ${branch} .] -]-${hg.tag}
-    depends_lib-append  port:gettext port:mercurial
-}
 
 set default_internal_user   _dovecot
 set default_login_user      _dovenull
@@ -54,10 +37,12 @@ add_users ${default_internal_user} group=${default_internal_user} realname=Dovec
 add_users ${default_login_user}    group=${default_login_user}    realname=Dovenull
 
 patch.pre_args      -p1
-patchfiles          patch-doc-example-config-conf.d-10-master.conf.diff
+patchfiles          patch-doc-example-config-conf.d-10-master.conf.diff \
+                    patch-src-master-master-settings.c.diff
 
-checksums           rmd160  6745d03a4b8d860476e2e7aacf91dd757b906037 \
-                    sha256  ab772b3e214683aba347203c9391295552255c4d69afb324c7b8c8fc5ad6f153
+checksums           rmd160  acef61b86b6de091ba8dfaffee5d5e5dfa43e0d1 \
+                    sha256  3e2347edfafcb26ae05c3402c6a84d4ec8893e24f5488f9789c0714f67940539 \
+                    size 3599231
 
 post-patch {
     reinplace "s|@@default_internal_user@@|${default_internal_user}|g" \
@@ -67,11 +52,10 @@ post-patch {
 }
 
 pre-configure {
-    if {${hg.tag} ne ${version}} {
-
-        system -W ${worksrcpath} "gettextize -f"
-        system -W ${worksrcpath} "./autogen.sh"
-    }
+    # the line `dummy < /dev/tty` breaks this; just copy the necessary file
+    # system -W ${worksrcpath} "gettextize -f"
+    xinstall -W ${worksrcpath} ${prefix}/share/gettext/config.rpath .
+    system -W ${worksrcpath} "./autogen.sh"
 }
 
 configure.args      --sysconfdir=${prefix}/etc \
@@ -79,16 +63,10 @@ configure.args      --sysconfdir=${prefix}/etc \
                     --with-ssl=openssl \
                     --with-zlib \
                     --with-bzlib \
-                    --with-ssldir=${prefix}/etc/ssl \
-                    --enable-shared \
-                    --enable-static \
-                    --with-shared-libs
+                    --with-ssldir=${prefix}/etc/openssl \
+                    --with-shared-libs \
+                    --with-pam
 
-# Do not build with kqueue or poll support prior to Darwin 10.7.0 (Mac OS X 10.6)
-if {${os.platform} eq "darwin" && [vercmp ${os.version} 10.7.0] < 0} {
-    configure.args-append \
-                    --with-ioloop=select
-}
 configure.cppflags  -I${prefix}/include/openssl
 
 variant gssapi \
@@ -96,103 +74,121 @@ variant gssapi \
     configure.args-append       --with-gssapi=yes
 }
 
-variant postgresql82  \
-    conflicts postgresql83 postgresql84 postgresql90 postgresql91 postgresql92 \
-    description "Enable PostgreSQL 8.2 support" {
+variant ldap description {Enable LDAP support} {
+    depends_lib-append          port:openldap
+    configure.args-append       --with-ldap=yes
+}
 
-    depends_lib-append          port:postgresql82
-    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql82/bin/pg_config
+variant solr description {Enable apache-solr support} {
+    depends_lib-append          port:clucene port:curl port:expat
+    depends_run-append          port:apache-solr8
+    configure.args-append       --with-solr --with-lucene
+}
+
+variant lucene description {Enable lucene support} {
+    depends_lib-append          port:clucene
+    configure.args-append       --with-lucene
+}
+
+variant libstemmer description {Use libstemmer for full-text search} {
+    depends_lib-append          port:libstemmer
+    configure.args-append       --with-libstemmer
+}
+
+variant postgresql96 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
+        postgresql95 \
+    description "Enable PostgreSQL 9.6 support" {
+    depends_lib-append          port:postgresql96
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql96/bin/pg_config
     configure.args-append       --with-pgsql
 }
 
-variant postgresql83 \
-    conflicts postgresql82 postgresql84 postgresql90 postgresql91 postgresql92 \
-    description "Enable PostgreSQL 8.3 support" {
-
-    depends_lib-append          port:postgresql83
-    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql83/bin/pg_config
+variant postgresql95 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql90 postgresql91 postgresql92 postgresql93 postgresql94 \
+        postgresql96 \
+    description "Enable PostgreSQL 9.5 support" {
+    depends_lib-append          port:postgresql95
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql95/bin/pg_config
     configure.args-append       --with-pgsql
 }
 
-variant postgresql84 \
-    conflicts postgresql82 postgresql83 postgresql90 postgresql91 postgresql92 \
-    description "Enable PostgreSQL 8.4 support" {
-
-    depends_lib-append          port:postgresql84
-    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql84/bin/pg_config
+variant postgresql94 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql90 postgresql91 postgresql92 postgresql93 \
+        postgresql95 postgresql96 \
+    description "Enable PostgreSQL 9.4 support" {
+    depends_lib-append          port:postgresql94
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql94/bin/pg_config
     configure.args-append       --with-pgsql
 }
 
-variant postgresql90 \
-    conflicts postgresql82 postgresql83 postgresql84 postgresql91 postgresql92 \
-    description "Enable PostgreSQL 9.0 support" {
-
-    depends_lib-append          port:postgresql90
-    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql90/bin/pg_config
-    configure.args-append       --with-pgsql
-}
-
-variant postgresql91 \
-    conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql92 \
-    description "Enable PostgreSQL 9.1 support" {
-
-    depends_lib-append          port:postgresql91
-    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql91/bin/pg_config
+variant postgresql93 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql90 postgresql91 postgresql92 \
+        postgresql94 postgresql95 postgresql96 \
+    description "Enable PostgreSQL 9.3 support" {
+    depends_lib-append          port:postgresql93
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql93/bin/pg_config
     configure.args-append       --with-pgsql
 }
 
 variant postgresql92 \
-    conflicts postgresql82 postgresql83 postgresql84 postgresql90 postgresql91 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql90 postgresql91 \
+        postgresql93 postgresql94 postgresql95 postgresql96 \
     description "Enable PostgreSQL 9.2 support" {
-
     depends_lib-append          port:postgresql92
     configure.env-append        PG_CONFIG=${prefix}/lib/postgresql92/bin/pg_config
     configure.args-append       --with-pgsql
 }
 
-variant mysql5 \
-    conflicts mysql51 mysql55 mysql56 mariadb percona \
-    description "Enable MySQL 5.1 support" {
-
-    depends_lib-append          port:mysql5
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql5/bin/mysql_config
-    configure.args-append       --with-mysql
+variant postgresql91 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql90 \
+        postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+    description "Enable PostgreSQL 9.1 support" {
+    depends_lib-append          port:postgresql91
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql91/bin/pg_config
+    configure.args-append       --with-pgsql
 }
 
-variant mysql51 \
-    conflicts mysql5 mysql55 mysql56 mariadb percona \
-    description "Enable MySQL 5.1 support" {
-
-    depends_lib-append          port:mysql51
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql51/bin/mysql_config
-    configure.args-append       --with-mysql
+variant postgresql90 \
+    conflicts postgresql82 postgresql83 postgresql84 \
+        postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+    description "Enable PostgreSQL 9.0 support" {
+    depends_lib-append          port:postgresql90
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql90/bin/pg_config
+    configure.args-append       --with-pgsql
 }
 
-variant mysql55 \
-    conflicts mysql5 mysql51 mysql56 mariadb percona \
-    description "Enable MySQL 5.5 support" {
-
-    depends_lib-append          port:mysql55
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql55/bin/mysql_config
-    configure.args-append       --with-mysql
+variant postgresql84 \
+    conflicts postgresql82 postgresql83 \
+        postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+    description "Enable PostgreSQL 8.4 support" {
+    depends_lib-append          port:postgresql84
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql84/bin/pg_config
+    configure.args-append       --with-pgsql
 }
 
-variant mysql56 \
-    conflicts mysql5 mysql51 mysql55 mariadb percona \
-    description "Enable MySQL 5.6 support" {
-
-    depends_lib-append          port:mysql56
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql56/bin/mysql_config
-    configure.args-append       --with-mysql
+variant postgresql83 \
+    conflicts postgresql82 postgresql84 \
+        postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+    description "Enable PostgreSQL 8.3 support" {
+    depends_lib-append          port:postgresql83
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql83/bin/pg_config
+    configure.args-append       --with-pgsql
 }
 
-variant mariadb \
-    conflicts mysql5 mysql51 mysql55 mysql56 percona \
-    description "Enable MariaDB (MySQL) support" {
-
-    depends_lib-append          port:mariadb
-    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mariadb/bin/mysql_config
-    configure.args-append       --with-mysql
+variant postgresql82  \
+    conflicts postgresql83 postgresql84 \
+        postgresql91 postgresql92 postgresql93 postgresql94 postgresql95 postgresql96 \
+    description "Enable PostgreSQL 8.2 support" {
+    depends_lib-append          port:postgresql82
+    configure.env-append        PG_CONFIG=${prefix}/lib/postgresql82/bin/pg_config
+    configure.args-append       --with-pgsql
 }
 
 variant percona \
@@ -203,27 +199,44 @@ variant percona \
         configure.args-append       --with-mysql
 }
 
-variant ldap description {Enable LDAP support} {
-
-    depends_lib-append          port:openldap
-    configure.args-append       --with-ldap
+variant mariadb \
+    conflicts mysql5 mysql51 mysql55 mysql56 percona \
+    description "Enable MariaDB (MySQL) support" {
+    depends_lib-append          port:mariadb
+    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mariadb/bin/mysql_config
+    configure.args-append       --with-mysql
 }
 
-variant lucene description {Enable lucene support} {
-
-    depends_lib-append          port:clucene
-    configure.args-append       --with-lucene
+variant mysql56 \
+    conflicts mysql5 mysql51 mysql55 mariadb percona \
+    description "Enable MySQL 5.6 support" {
+    depends_lib-append          port:mysql56
+    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql56/bin/mysql_config
+    configure.args-append       --with-mysql
 }
 
-variant libstemmer description {Use libstemmer for full-text search} {
-    depends_lib-append          port:libstemmer
-    configure.args-append       --with-libstemmer
+variant mysql55 \
+    conflicts mysql5 mysql51 mysql56 mariadb percona \
+    description "Enable MySQL 5.5 support" {
+    depends_lib-append          port:mysql55
+    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql55/bin/mysql_config
+    configure.args-append       --with-mysql
 }
 
-variant solr description {Enable apache-solr support} {
+variant mysql51 \
+    conflicts mysql5 mysql55 mysql56 mariadb percona \
+    description "Enable MySQL 5.1 support" {
+    depends_lib-append          port:mysql51
+    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql51/bin/mysql_config
+    configure.args-append       --with-mysql
+}
 
-    depends_lib-append          port:expat port:curl
-    configure.args-append       --with-solr
+variant mysql5 \
+    conflicts mysql51 mysql55 mysql56 mariadb percona \
+    description "Enable MySQL 5.1 support" {
+    depends_lib-append          port:mysql5
+    configure.env-append        MYSQL_CONFIG=${prefix}/lib/mysql5/bin/mysql_config
+    configure.args-append       --with-mysql
 }
 
 variant no_startupitem description {Do not install a launchd plist} {}
@@ -234,6 +247,5 @@ if {![variant_isset "no_startupitem"]} {
     startupitem.pidfile     auto ${prefix}/var/run/${base_name}/master.pid
 }
 
-livecheck.url       [lindex ${master_sites} 0]
-livecheck.type      regex
-livecheck.regex     "${base_name}-(\\d+\\.\\d+(\[0-9rc.\]+)?).tar.gz"
+destroot.keepdirs \
+    ${destroot}${prefix}/etc/${base_name}

--- a/mail/dovecot2/files/patch-src-master-master-settings.c.diff
+++ b/mail/dovecot2/files/patch-src-master-master-settings.c.diff
@@ -1,0 +1,27 @@
+--- ./src/master/master-settings.c
++++ ./src/master/master-settings.c	2019-05-26 23:25:08.000000000 -0400
+@@ -209,9 +209,9 @@
+ 	.protocols = "imap pop3 lmtp",
+ 	.listen = "*, ::",
+ 	.ssl = "yes:no:required",
+-	.default_internal_user = "dovecot",
+-	.default_internal_group = "dovecot",
+-	.default_login_user = "dovenull",
++	.default_internal_user = "_dovecot",
++	.default_internal_group = "_dovenull",
++	.default_login_user = "_dovenull",
+ 	.default_process_limit = 100,
+ 	.default_client_limit = 1000,
+ 	.default_idle_kill = 60,
+@@ -222,7 +222,10 @@
+ 	.first_valid_uid = 500,
+ 	.last_valid_uid = 0,
+ 	.first_valid_gid = 1,
+-	.last_valid_gid = 0,
++	/* macOS: `last_valid_gid = 100` to avoid the error */
++	/* imap: Fatal: setgroups(501) failed: Too many extra groups */
++	/* https://www.systemcodegeeks.com/mac-os/macos-dovecot-setgroups-failed/ */
++	.last_valid_gid = 100,
+ 
+ #ifndef CONFIG_BINARY
+ 	.services = ARRAY_INIT


### PR DESCRIPTION
dovecot2: Upgrade to v2.3.6 and major Portfile overhaul

* Upgrade to dovecot 2.3.6
* Overhaul Portfile to use GitHub releases
* Remove deprecated source links
* Hardcode _dovecot:_dovenull default user and group
* Hardcode `last_valid_gid = 100` to avoid macOS [issue](https://www.systemcodegeeks.com/mac-os/macos-dovecot-setgroups-failed/)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->