### PR TITLE
dovecot2-sieve: Upgrade to v0.5.6, dovecot v2.3.6, Portfile overhaul

### DIFF
--- a/mail/dovecot2-sieve/Portfile
+++ b/mail/dovecot2-sieve/Portfile
@@ -1,74 +1,50 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github                      1.0
+PortGroup           cxx11                       1.1
+
+github.setup        dovecot pigeonhole 0.5.6
 
 name                dovecot2-sieve
-version             0.5.0.1
-# set hg.tag to tag or rev.
-hg.tag              ${version}
-#hg.tag              2027
 
 # Maintainers: Please revbump port:dovecot2-sieve and port:dovecot2-antispam
 # on port:dovecot2 version changes.
-# Maintainers: Please revbump port:dovecot2-sieve when hg.tag changes or reset to 0 on version
-# changes.
-revision            1
+revision            0
 
 # Please keep port:dovecot2 major.minor version in sync.
 # On port:dovecot2 major.minor version change please find the new version
 # of port:dovecot2-sieve.
-set dovecot2        2.3
+set dovecot2        2.3.6
 
 categories          mail
 maintainers         nomaintainer
 platforms           darwin
 license             LGPL
+homepage            http://pigeonhole.dovecot.org/
 
 description         Pigeonhole sieve and managesieve plugins for dovecot
 long_description    ${description}
 
-homepage            http://pigeonhole.dovecot.org/
-master_sites        http://pigeonhole.dovecot.org/releases/${dovecot2}
-
 distname            dovecot-${dovecot2}-pigeonhole-${version}
 
-checksums           rmd160  8149f94a0dc3421b025d43180d6a4c5e9b1b3eff \
-                    sha256  56356d14b10c45aa472074e85bfc582c2f08a15a43ecf24f481df39b206efad2
+checksums           rmd160  9d131dfd2b5a6d7d07d5f10f94f8f755d75f21b3 \
+                    sha256  0745d0106996d4d3a28efb0f2f09c00f2ec9bf6d712fa79b5eb687a9ee1b8543 \
+                    size 1025316 
 
-depends_build       port:libtool port:autoconf port:automake
-depends_lib         port:dovecot2
+depends_lib         port:dovecot2 \
+                    port:gettext \
+                    port:mercurial
 
-if {${hg.tag} ne ${version}} {
-
-    master_sites        http://hg.rename-it.nl/dovecot-${dovecot2}-pigeonhole/archive
-    distname            ${hg.tag}
-    use_bzip2           yes
-    worksrcdir          dovecot-[join [split ${dovecot2} .] -]-pigeonhole-${hg.tag}
-    depends_lib-append  port:gettext port:mercurial
-}
-
-pre-configure {
-    if {![file exists "${worksrcpath}/configure"]} {
-
-        system "cd ${worksrcpath} && ./autogen.sh"
-    }
-}
+# Note: https://trac.macports.org/ticket/58544#comment:11 for this build logic
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
 
 configure.ldflags-append \
                     -L${prefix}/lib/dovecot
 configure.args      --with-managesieve=yes \
                     --disable-dependency-tracking
-
-livecheck.type      regex
-livecheck.version   ${hg.tag}
-
-if {${hg.tag} != ${version}} {
-
-    version             ${version}-${hg.tag}
-    livecheck.url       http://hg.rename-it.nl/dovecot-${dovecot2}-pigeonhole/log
-    livecheck.regex     "\\] rev (\[0-9\]+)</i>"
-} else {
-
-    livecheck.url       http://hg.rename-it.nl/dovecot-${dovecot2}-pigeonhole/tags
-    livecheck.regex     "<b>(\[0-9\.\]+)</b>"
-}


### PR DESCRIPTION
dovecot2-sieve: Upgrade to v0.5.6, dovecot v2.3.6, Portfile overhaul

* Version upgrades
* Migrate Portfile to GitHub releases
* Deprecate no-longer-available source pages

Related:
* https://github.com/macports/macports-ports/pull/4480

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->