### PR TITLE
libstemmer: Use absolute prefix path in `libstemmer.dylib`

### DIFF
--- a/textproc/libstemmer/Portfile
+++ b/textproc/libstemmer/Portfile
@@ -4,6 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        snowballstem snowball d29510a
+revision            1
+
 name                libstemmer
 version             0.1-20181121
 categories          textproc
@@ -38,6 +40,7 @@ post-build {
     copy ${worksrcpath}/libstemmer.o ${worksrcpath}/libstemmer.a
     system -W ${worksrcpath} "ranlib libstemmer.a"
     system -W ${worksrcpath} "${configure.cc} -fpic -shared -Wl,-all_load libstemmer.a -o libstemmer.dylib"
+    system -W ${worksrcpath} "install_name_tool -id ${prefix}/lib/libstemmer.dylib libstemmer.dylib"
 }
 
 destroot {


### PR DESCRIPTION
libstemmer: Use absolute prefix path in `libstemmer.dylib`

* Relative object paths will break packages whose libraries are not in the same directory as `libstemmer.dylib`

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->