### PR TITLE
yarn: update to 1.16.0

### DIFF
--- a/devel/yarn/Portfile
+++ b/devel/yarn/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        yarnpkg yarn 1.15.2 v
-revision            1
+github.setup        yarnpkg yarn 1.16.0 v
+revision            0
 
 categories          devel
 
@@ -27,9 +27,9 @@ homepage            https://yarnpkg.com/
 
 github.tarball_from releases
 distname            ${name}-${git.branch}
-checksums           rmd160  53d9f9d4d6dcc2214915f05a498c78535f6b59ef \
-                    sha256  c4feca9ba5d6bf1e820e8828609d3de733edf0e4722d17ed7ce493ed39f61abd \
-                    size    1169927
+checksums           rmd160  46cd51881cddc91fadadc0951f57d12e4994637e \
+                    sha256  df202627d9a70cf09ef2fb11cb298cb619db1b958590959d6f6e571b50656029 \
+                    size    1172930
 
 depends_run         path:bin/node:nodejs10
 


### PR DESCRIPTION
#### Description

Update yarn to version 1.16.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?