### PR TITLE
osxfuse: Update to 3.9.0

### DIFF
--- a/fuse/osxfuse/Portfile
+++ b/fuse/osxfuse/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                osxfuse
 epoch               1
-version             3.8.3
+version             3.9.0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          fuse devel
 platforms           macosx
@@ -97,10 +97,10 @@ checksums           osxfuse-48bc246.tar.gz \
                     rmd160  096fc6f329f626ca63d9ec5901004173357327bd \
                     sha256  1c65b389628d5a675d700330143c55c60854faafd791a0743a05cf310721fcf8 \
                     size    3391234 \
-                    osxfuse-3.8.3.dmg \
-                    rmd160  4c26f209dd60329ebe97a0f4c65b374181142584 \
-                    sha256  87e507c44c19689beefa3d47dd00ba953254d9e616cb633c1b4343407fe99700 \
-                    size    6967386
+                    osxfuse-3.9.0.dmg \
+                    rmd160  c3bfa263006f970c5edf4fe0a77243a8e3b1b0a5 \
+                    sha256  9bd40e487c18abcf94a72b96c9f3b1378b69a1a0906f05c451aa918180bcc394 \
+                    size    6976380
 
 # extract phase will just extract the dmg; post-extract will expand
 # the tarballs


### PR DESCRIPTION
#### Description

I'm running through `port livecheck installed` and trying to update things that have an open maintainer or no maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G29g
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
