### PR TITLE
buildbot: new ports

### DIFF
--- a/devel/buildbot-2/Portfile
+++ b/devel/buildbot-2/Portfile
@@ -1,0 +1,79 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                buildbot-2
+version             2.3.1
+revision            0
+
+categories          devel python
+platforms           darwin
+supported_archs     noarch
+license             GPL-2
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+
+description         buildmaster for buildbot continuous integration system
+
+long_description    Buildbot is a system to automate the compile/test \
+                    cycle of most software projects to validate code \
+                    changes. This port provides version ${version} of the \
+                    master part of the system. \
+                    Legacy version is available under buildbot-0.8. \
+                    This version will soon be renamed to just 'buildbot'.
+
+homepage            http://buildbot.net
+master_sites        pypi:b/buildbot/
+distname            buildbot-${version}
+dist_subdir         buildbot
+
+checksums           sha256  cf35d2a87b11aba29c59e47e843deba1be9649114e792e830252ed8f7c35f963 \
+                    rmd160  f6136aa647589b40520db1383d05ff477324e2b9 \
+                    size    3138465
+
+python.default_version \
+                    37
+depends_run-append  port:py${python.version}-buildbot \
+                    port:py${python.version}-buildbot-www \
+                    port:py${python.version}-buildbot-console-view \
+                    port:py${python.version}-buildbot-grid-view \
+                    port:py${python.version}-buildbot-waterfall-view
+
+set sharedir        ${prefix}/share/${name}
+set docdir          ${prefix}/share/doc/${name}
+set plistfile       org.macports.buildmaster.template.plist
+
+post-extract {
+    file mkdir ${worksrcpath}/macports
+    copy ${filespath}/${plistfile} ${worksrcpath}/macports/${plistfile}
+}
+
+post-patch {
+    reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/macports/${plistfile}
+    reinplace -locale C "s|@PYTHONVER@|${python.branch}|g" ${worksrcpath}/macports/${plistfile}
+}
+
+build {}
+destroot {}
+
+post-destroot {
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} README.rst COPYING CREDITS NEWS UPGRADING \
+        ${destroot}${docdir}
+    xinstall -d ${destroot}${sharedir}
+    xinstall -m 0755 ${worksrcpath}/macports/${plistfile} \
+        ${destroot}${sharedir}
+    ln -s ${prefix}/bin/buildbot-${python.branch} ${destroot}${prefix}/bin/buildbot
+}
+
+livecheck.type      regex
+livecheck.url       https://pypi.python.org/pypi/buildbot/
+
+notes "
+An example launchd plist file is available in ${sharedir}. After you have\
+created your build master, copy the plist to /Library/LaunchDaemons (as root)\
+and edit the UserName and WorkingDirectory fields as needed. Then instruct\
+launchd to run it with:
+
+sudo launchctl load -w /Library/LaunchDaemons/your.plist.name
+"

--- a/devel/buildbot-2/files/org.macports.buildmaster.template.plist
+++ b/devel/buildbot-2/files/org.macports.buildmaster.template.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Disabled</key>
+	<true/>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>@PREFIX@/bin:/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>org.macports.buildmaster</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@PREFIX@/bin/twistd-@PYTHONVER@</string>
+		<string>--nodaemon</string>
+		<string>--no_save</string>
+		<string>--python=buildbot.tac</string>
+		<string>--pidfile=buildmaster.pid</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>UserName</key>
+	<string>aUserName</string>
+	<key>WorkingDirectory</key>
+	<string>/Users/pathToSlave</string>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+</dict>
+</plist>

--- a/devel/buildbot-worker/Portfile
+++ b/devel/buildbot-worker/Portfile
@@ -1,0 +1,80 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                buildbot-worker
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         Buildbot Worker Daemon
+long_description    ${description}
+
+categories-prepend  devel
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://buildbot.net/
+master_sites        pypi:[string index ${name} 0]/${name}
+
+license             GPL-2
+
+checksums           sha256  a26c68debb70f15abee307aff7b225e91a2eedca9c8d571212c391e615c36f53 \
+                    rmd160  02688cb6233c80e46038a528f5e0b938353ef325 \
+                    size    110554
+
+python.default_version \
+                    37
+
+depends_build-append \
+                    port:py${python.version}-setuptools
+
+depends_run-append  port:py${python.version}-future \
+                    port:py${python.version}-twisted
+
+depends_test-append port:py${python.version}-mock
+
+build.env           NO_INSTALL_REQS=1
+
+set sharedir        ${prefix}/share/${name}
+set docdir          ${prefix}/share/doc/${name}
+set plistfile       org.macports.${name}.template.plist
+
+# Add a user that can be used to run the buildbot slave
+add_users           buildbot group=buildbot
+
+pre-extract {
+    file mkdir ${worksrcpath}/macports
+    copy ${filespath}/${plistfile} ${worksrcpath}/macports/${plistfile}
+}
+
+post-patch {
+    reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/macports/${plistfile}
+    reinplace -locale C "s|@PYTHONVER@|${python.branch}|g" ${worksrcpath}/macports/${plistfile}
+}
+
+post-destroot {
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} COPYING NEWS README UPGRADING \
+        ${destroot}${docdir}
+    xinstall -m 0644 ${worksrcpath}/docs/${name}.1 \
+        ${destroot}${prefix}/share/man/man1
+    xinstall -d ${destroot}${sharedir}
+    xinstall -m 0755 ${worksrcpath}/macports/${plistfile} \
+        ${destroot}${sharedir}
+}
+                    
+test.run            yes
+test.env            PYTHONPATH=.
+test.cmd            ${prefix}/bin/trial-${python.branch}
+test.target         buildbot_worker.test
+
+notes "
+An example launchd plist file is available in ${sharedir}. After you have\
+created your build slave, copy the plist to /Library/LaunchDaemons (as root)\
+and edit the WorkingDirectory field as needed. Then instruct launchd to run\
+it with:
+
+sudo launchctl load -w /Library/LaunchDaemons/your.plist.name
+"

--- a/devel/buildbot-worker/files/org.macports.buildbot-worker.template.plist
+++ b/devel/buildbot-worker/files/org.macports.buildbot-worker.template.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Disabled</key>
+	<true/>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>@PREFIX@/bin:/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>org.macports.buildworker</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@PREFIX@/bin/twistd-@PYTHONVER@</string>
+		<string>--nodaemon</string>
+		<string>--no_save</string>
+		<string>--python=buildbot.tac</string>
+		<string>--pidfile=buildslave.pid</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>UserName</key>
+	<string>buildbot</string>
+	<key>WorkingDirectory</key>
+	<string>/Users/pathToWorker</string>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+</dict>
+</plist>

--- a/python/py-buildbot-console-view/Portfile
+++ b/python/py-buildbot-console-view/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-buildbot-console-view
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         Buildbot Console View plugin
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://buildbot.net/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             GPL-2
+
+checksums           sha256  2a6370db2141aebd7466fee390824fb7190d1e7122d6ebb844690cde141ca2f8 \
+                    rmd160  238e90a9f48f3f1420b535303e022095205f1b25 \
+                    size    607024
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-buildbot-pkg
+
+    livecheck.type  none
+}

--- a/python/py-buildbot-grid-view/Portfile
+++ b/python/py-buildbot-grid-view/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-buildbot-grid-view
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         Buildbot Grid View plugin
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://buildbot.net/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             GPL-2
+
+checksums           sha256  b25317adb7b526a4582d495e3f55db67a16cd7fe3f0d01b4d0d6df2b3b8f78f6 \
+                    rmd160  a9bd72d550624e8c4e8c9583977439955bbcae69 \
+                    size    605141
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-buildbot-pkg
+
+    livecheck.type  none
+}

--- a/python/py-buildbot-pkg/Portfile
+++ b/python/py-buildbot-pkg/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-buildbot-pkg
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         Buildbot packaging tools
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            http://buildbot.net/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             GPL-2
+
+checksums           sha256  25968ace0c62cb773ed85d4ddbe07fd5aee68f4455909243ffb3ac12608cf82e \
+                    rmd160  b917b5d58d24874068eede4bc7312cb3c58185e1 \
+                    size    4754
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}

--- a/python/py-buildbot-waterfall-view/Portfile
+++ b/python/py-buildbot-waterfall-view/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-buildbot-waterfall-view
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         Buildbot Waterfall View plugin
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://buildbot.net/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             GPL-2
+
+checksums           sha256  949ae00cadb50f280709353feeccdc267c6ea68119e2be9b7faab21707c82edf \
+                    rmd160  6d8a037995c6e081b29c801eaf84e4638479550f \
+                    size    683181
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-buildbot-pkg
+
+    livecheck.type  none
+}

--- a/python/py-buildbot-www/Portfile
+++ b/python/py-buildbot-www/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-buildbot-www
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         Buildbot UI
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://buildbot.net/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             GPL-2
+
+checksums           sha256  ff8546b7769f156f06e418cdd5621c78086924dbc81d48fbe35f4c98c7e1eb79 \
+                    rmd160  6a31272a9446a57b65b793c329e6d46fb48e1022 \
+                    size    721159
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-buildbot \
+                    port:py${python.version}-buildbot-pkg \
+                    port:py${python.version}-mock
+
+    livecheck.type  none
+}

--- a/python/py-buildbot/Portfile
+++ b/python/py-buildbot/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-buildbot
+version             2.3.1
+revision            0
+
+maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
+description         The Continuous Integration Framework
+long_description    The BuildBot is a system to automate the compile/test \
+                    cycle required by most software projects to validate \
+                    code changes.
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://buildbot.net/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             GPL-2
+
+checksums           sha256  cf35d2a87b11aba29c59e47e843deba1be9649114e792e830252ed8f7c35f963 \
+                    rmd160  f6136aa647589b40520db1383d05ff477324e2b9 \
+                    size    3138465
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-autobahn \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-jinja2 \
+                    port:py${python.version}-jwt \
+                    port:py${python.version}-sqlalchemy \
+                    port:py${python.version}-sqlalchemy-migrate \
+                    port:py${python.version}-treq \
+                    port:py${python.version}-twisted \
+                    port:py${python.version}-txaio \
+                    port:py${python.version}-yaml \
+                    port:py${python.version}-zopeinterface
+
+    depends_test-append \
+                    port:py${python.version}-boto3 \
+                    port:py${python.version}-enchant \
+                    port:py${python.version}-flake8 \
+                    port:py${python.version}-isort \
+                    port:py${python.version}-lz4 \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-pylint \
+                    port:py${python.version}-treq
+    #               port:py${python.version}-moto \
+    #               port:py${python.version}-pyjade \
+    #               port:py${python.version}-setuptools-trial \
+    #               port:py${python.version}-txrequests
+
+    # currently defunct due to missing dependencies
+    test.run        yes
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/53006

###### Type(s)
submission (new Portfiles)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
