### PR TITLE
Update openssl

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                openssl
 epoch               1
-version             1.0.2r
+version             1.0.2s
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -40,10 +40,10 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           sha1    b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d \
-                    rmd160  f268c8f87ee6b8ca1523761b064de575f6851ae0 \
-                    sha256  ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6 \
-                    size    5348369
+checksums           sha1    cf43d57a21e4baf420b3628677ebf1723ed53bc1 \
+                    rmd160  6067f88e5f1ac797e189648386adb12ca4aba85d \
+                    sha256  cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96 \
+                    size    5349149
 
 patchfiles          install-headers-HFS+.patch \
                     parallel-building.patch \

--- a/devel/openssl10/Portfile
+++ b/devel/openssl10/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                openssl10
-version             1.0.2r
+version             1.0.2s
 
 categories          devel security
 platforms           darwin
@@ -34,10 +34,10 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           sha1    b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d \
-                    rmd160  f268c8f87ee6b8ca1523761b064de575f6851ae0 \
-                    sha256  ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6 \
-                    size    5348369
+checksums           sha1    cf43d57a21e4baf420b3628677ebf1723ed53bc1 \
+                    rmd160  6067f88e5f1ac797e189648386adb12ca4aba85d \
+                    sha256  cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96 \
+                    size    5349149
 
 patchfiles          install-headers-HFS+.patch \
                     parallel-building.patch \

--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                openssl11
-version             1.1.1b
+version             1.1.1c
 
 # Please revbump these ports when updating OpenSSL.
 #  - freeradius (#43461)
@@ -40,10 +40,10 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           sha1    e9710abf5e95c48ebf47991b10cbb48c09dae102 \
-                    rmd160  2f6ab1216c04d089cf930f128f142d9e4a531535 \
-                    sha256  5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b \
-                    size    8213737
+checksums           sha1    71b830a077276cbeccc994369538617a21bee808 \
+                    rmd160  6e31a6191e954b3a960cc996833ae275de6c0f2f \
+                    sha256  f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90 \
+                    size    8864262
 
 # patchfiles
 


### PR DESCRIPTION
#### Description

Update OpenSSL 1.0 and 1.1 branches to the latest version. It might be kind of confusing for two openssl 1.0 ports. See https://github.com/macports/macports-ports/pull/3822 for the background.

1.1.1c fixes CVE-2019-1543 [1]. The 1.0.2 branch is not affected by this CVE.

I will rebase the branch in https://github.com/macports/macports-ports/pull/3822 soon. May not be done until tomorrow due to its complexity.

[1] https://www.openssl.org/news/vulnerabilities.html

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? - tested `openssl s_client -connect httpbin.org:443`.