### PR TITLE
nepomuk-core: remove old conflict handler

### DIFF
--- a/kde/nepomuk-core/Portfile
+++ b/kde/nepomuk-core/Portfile
@@ -36,15 +36,6 @@ patchfiles-append   patch-cmake-baloo.diff \
                     patch-CMakeLists-visibility.diff \
                     patch-CMakelists.diff
 
-pre-activate {
-    #Deactivate hack for when nepomuk-core was splitted from kde4-runtime
-    if {[file exists ${applications_dir}/KDE4/nepomukbackup.app/Contents/Info.plist] 
-        && ![catch {set vers [lindex [registry_active kde4-runtime] 0]}] 
-        && [vercmp [lindex $vers 1] 4.9.3] < 0} {
-            registry_deactivate_composite kde4-runtime "" [list ports_nodepcheck 1] 
-    } 
-}
-
 variant baloo description "Add support for baloo indexing" {
     depends_lib-append  port:baloo
     patchfiles-delete   patch-cmake-baloo.diff


### PR DESCRIPTION
Was added in f747977627 over 6 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
