### PR TITLE
Add GitHub handle decibel to maintainers

### DIFF
--- a/java/postgresql-jdbc/Portfile
+++ b/java/postgresql-jdbc/Portfile
@@ -4,7 +4,7 @@ name			postgresql-jdbc
 version			9.1-901
 categories		java databases
 license			BSD
-maintainers		decibel.org:decibel
+maintainers		{decibel.org:decibel @decibel}
 description		PostgreSQL JDBC driver
 long_description	Pure Java JDBC driver for connecting to PostgreSQL databases.
 homepage		http://jdbc.postgresql.org/

--- a/textproc/docbook-dsssl/Portfile
+++ b/textproc/docbook-dsssl/Portfile
@@ -11,7 +11,7 @@ license         MIT
 description     The docbook DSSSL stylesheets
 long_description ${description}
 platforms       darwin
-maintainers     decibel.org:decibel
+maintainers     {decibel.org:decibel @decibel}
 supported_archs noarch
 master_sites    sourceforge:docbook
 homepage        http://docbook.sf.net/


### PR DESCRIPTION
Hi @decibel, I would like to confirm if you are still interested in maintaining `postgresql-jdbc` and `docbook-dssl` in MacPorts. If so, please confirm that the email address `decibel.org:decibel` is correct, or if it should be updated; and whether we may add your GitHub handle (which will allow you to be notified of any proposed changes to your ports on GitHub).

Alternatively, please let us know if you are no longer interested in maintaining either of these ports, or if you believe either port should be removed from MacPorts.

Thanks!

See: https://trac.macports.org/ticket/56050
See: https://trac.macports.org/ticket/58266

#### Description


<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
