### PR TITLE
prometheus: new port for Prometheus 2.10.0

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,0 +1,136 @@
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        prometheus prometheus 2.10.0 v
+github.tarball_from archive
+
+description         The Prometheus monitoring system and time series database
+
+long_description    Prometheus is an open-source systems monitoring and \
+                    alerting toolkit originally built at SoundCloud. Since \
+                    its inception in 2012, many companies and organizations \
+                    have adopted Prometheus, and the project has a very \
+                    active developer and user community.
+
+homepage            https://prometheus.io/
+
+platforms           darwin
+categories          net
+license             apache
+
+maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
+
+depends_build       port:curl \
+                    port:go
+
+build.env           GOPATH=${workpath} \
+                    PATH=$env(PATH):${workpath}/bin
+
+build.target        build
+
+use_configure       no
+installs_libs       no
+use_parallel_build  no
+
+checksums \
+  rmd160    e066bbfce9ba96641f041adfa649a7a429a34856 \
+  sha256    0362f4aa2fb44cc2c572df140da742bdf99fe9f338157a83f6634694fd693000 \
+  size      11752395
+
+set prom_user       ${name}
+set prom_conf_dir   ${prefix}/etc/${name}
+set prom_conf_file  ${prom_conf_dir}/prometheus.yml
+set prom_data_dir   ${prefix}/var/db/${name}
+set prom_doc_dir    ${prefix}/share/doc/${name}
+set prom_share_dir  ${prefix}/share/${name}
+set prom_log_dir    ${prefix}/var/log/${name}
+set prom_log_file   ${prom_log_dir}/${name}.log
+
+add_users           ${prom_user} \
+                    group=${prom_user} \
+                    realname=Prometheus
+
+post-extract {
+    copy  ${filespath}/org.macports.prometheus.plist \
+          ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@NAME@|${name}|g" \
+        ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@USER@|${prom_user}|g" \
+        ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@GROUP@|${prom_user}|g" \
+        ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@CONF_FILE@|${prom_conf_file}|g" \
+        ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@DATA_DIR@|${prom_data_dir}|g" \
+        ${workpath}/org.macports.prometheus.plist
+
+    reinplace "s|@LOGFILE@|${prom_log_file}|g" \
+        ${workpath}/org.macports.prometheus.plist
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name}  ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 ${worksrcpath}/promtool ${destroot}${prefix}/bin/promtool
+
+    xinstall -d 755 ${destroot}${prom_conf_dir}
+    xinstall -d 755 ${destroot}${prom_doc_dir}
+    xinstall -d 755 ${destroot}${prom_share_dir}
+
+    xinstall -m 755 -o ${prom_user} -g ${prom_user} -d \
+        ${destroot}${prom_data_dir}
+
+    xinstall -m 755 -o ${prom_user} -g ${prom_user} -d \
+        ${destroot}${prom_log_dir}
+
+    touch ${destroot}${prom_conf_dir}/.keep
+
+    touch ${destroot}${prom_log_file}
+
+    file attributes ${destroot}${prom_log_file} \
+        -owner ${prom_user} -group ${prom_user}
+
+    copy ${filespath}/example-prometheus-config.yml \
+        ${destroot}${prom_share_dir}/
+
+    copy {*}[glob ${worksrcpath}/docs/*] ${destroot}${prom_doc_dir}/
+
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
+        ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
+
+    destroot.keepdirs-append ${destroot}${prom_data_dir}
+}
+
+post-activate {
+    if {![file exists ${prom_conf_file}]} {
+        copy  ${prom_share_dir}/example-prometheus-config.yml ${prom_conf_file}
+    }
+}
+
+notes "
+To change Prometheus configuration, you can make edits to:
+
+ ${prom_conf_file}
+
+To enable the Prometheus service, use `port load`, as follows:
+
+\$ sudo port load ${name}
+
+Once enabled, the service will log to:
+ ${prom_log_file}
+"

--- a/net/prometheus/files/example-prometheus-config.yml
+++ b/net/prometheus/files/example-prometheus-config.yml
@@ -1,0 +1,29 @@
+# my global config
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+    - targets: ['localhost:9090']

--- a/net/prometheus/files/org.macports.prometheus.plist
+++ b/net/prometheus/files/org.macports.prometheus.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.@NAME@</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>Disabled</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>SessionCreate</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <false/>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>ExitTimeOut</key>
+    <integer>600</integer>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/prometheus</string>
+            <string>--storage.tsdb.path=@DATA_DIR@</string>
+            <string>--config.file=@CONF_FILE@</string>
+        </array>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
+</dict>
+</plist>


### PR DESCRIPTION
#### Description

New port for the [Prometheus](https://prometheus.io/) monitoring system.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
