### PR TITLE
perl5.30: new port

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -30,6 +30,7 @@ set perl5.versions_info {
     5.24 4 2 8d6b67fc6d58334b2fdbfa9d6d7456265dca1f4e  e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10  14125130
     5.26 3 2 84ed404407c198ca2b8194c374c7914d941b6f49  9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477  14539342
     5.28 2 0 8ec4c3a3fa2df12c47cf3e9613dc215333f3d042  0b0189bfa4b2da20e899b4bdd746ac402e8f746a58e4fcf5516484157f2aab07  12374448
+    5.30 0 0 64ff4c65823122c337e18278585d71def1de9c5d  ac501cad4af904d33370a9ea39dbb7a8ad4cb19bc7bc8a9c17d8dc3e81ef6306  12419868
 }
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5.size} ${perl5.versions_info} {
@@ -110,7 +111,7 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
             patchfiles-append \
                             ${perl5.major}/adjust-dependency-paths-PR126706.patch
         }
-        if {${perl5.major} >= 5.26} {
+        if {${perl5.major} >= 5.26 && ${perl5.major} < 5.30} {
             # enable syscall() on Sierra for compatibility with earlier OS versions and perl5.24
             # Apple has deprecated syscall() on Sierra but it is still available
             patchfiles-append \

--- a/lang/perl5/files/5.30/avoid-no-cpp-precomp-PR38913.patch
+++ b/lang/perl5/files/5.30/avoid-no-cpp-precomp-PR38913.patch
@@ -1,0 +1,11 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -130,7 +130,7 @@ esac
+ 
+ # Avoid Apple's cpp precompiler, better for extensions
+ if [ "X`echo | ${cc} -no-cpp-precomp -E - 2>&1 >/dev/null`" = "X" ]; then
+-    cppflags="${cppflags} -no-cpp-precomp"
++
+ 
+     # This is necessary because perl's build system doesn't
+     # apply cppflags to cc compile lines as it should.

--- a/lang/perl5/files/5.30/clean-up-paths.patch
+++ b/lang/perl5/files/5.30/clean-up-paths.patch
@@ -1,0 +1,37 @@
+--- Configure.orig
++++ Configure
+@@ -108,8 +108,8 @@ if test -d c:/. || ( uname -a | grep -i 
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
++paths='/bin /usr/bin /usr/ucb /usr/lbin'
++paths="$paths /opt/bin __PREFIX__/bin __PREFIX__ /opt/lbin"
+ paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+ paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+ paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+@@ -1431,7 +1431,7 @@ archobjs=''
+ i_whoami=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
++locincpth="__PREFIX__/include /usr/gnu/include"
+ locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
+ :
+ : no include file wanted by default
+@@ -1448,12 +1448,12 @@ libnames=''
+ : change the next line if compiling for Xenix/286 on Xenix/386
+ xlibpth='/usr/lib/386 /lib/386'
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
++loclibpth="__PREFIX__/lib /usr/gnu/lib"
+ loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
+ 
+ : general looking path for locating libraries
+ glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
++glibpth="$glibpth /usr/ccs/lib /usr/ucblib"
+ test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+ test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+ test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"

--- a/lang/perl5/files/5.30/config.h.ed
+++ b/lang/perl5/files/5.30/config.h.ed
@@ -1,0 +1,157 @@
+/define[ 	]PRINTF_FORMAT_NULL_OK/c
+#ifdef __LP64__
+/*#define PRINTF_FORMAT_NULL_OK	/ **/
+#else /* !__LP64__ */
+#define PRINTF_FORMAT_NULL_OK	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]LONGSIZE/c
+#ifdef __LP64__
+#define LONGSIZE 8		/**/
+#else /* !__LP64__ */
+#define LONGSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]CASTI32/c
+#ifdef __ppc__
+#define CASTI32		/**/
+#else /* !__ppc__ */
+/*#define CASTI32		/ **/
+#endif /* __ppc__ */
+.
+/define[ 	]CASTNEGFLOAT/a
+.
+.,.+1c
+#ifdef __i386__
+/*#define CASTNEGFLOAT		/ **/
+#define CASTFLAGS 1		/**/
+#else
+#define CASTNEGFLOAT		/**/
+#define CASTFLAGS 0		/**/
+#endif
+.
+/define[ 	]Quad_t/a
+.
+.,.+2c
+#ifdef __LP64__
+#   define Quad_t long	/**/
+#   define Uquad_t unsigned long	/**/
+#   define QUADKIND 2	/**/
+#else /* !__LP64__ */
+#   define Quad_t long long	/**/
+#   define Uquad_t unsigned long long	/**/
+#   define QUADKIND 3	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]PTRSIZE/c
+#ifdef __LP64__
+#define PTRSIZE 8		/**/
+#else /* !__LP64__ */
+#define PTRSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_BSD_SETPGRP/c
+#if __DARWIN_UNIX03
+/*#define USE_BSD_SETPGRP	/ **/
+#else /* !__DARWIN_UNIX03 */
+#define USE_BSD_SETPGRP	/**/
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]I32TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I32TYPE		int	/**/
+#define	U32TYPE		unsigned int	/**/
+#else /* !__LP64__ */
+#define	I32TYPE		long	/**/
+#define	U32TYPE		unsigned long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]I64TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I64TYPE		long	/**/
+#define	U64TYPE		unsigned long	/**/
+#else /* !__LP64__ */
+#define	I64TYPE		long long	/**/
+#define	U64TYPE		unsigned long long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]IVSIZE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	IVSIZE		8		/**/
+#define	UVSIZE		8		/**/
+#else /* !__LP64__ */
+#define	IVSIZE		4		/**/
+#define	UVSIZE		4		/**/
+#endif /* __LP64__ */
+.
+/NV_PRESERVES_UV$/a
+.
+.,.+1c
+#ifdef __LP64__
+#undef	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	53
+#else /* !__LP64__ */
+#define	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	32
+#endif /* __LP64__ */
+.
+/define[ 	]HAS_STDIO_STREAM_ARRAY/a
+.
+.,.+3c
+#if __DARWIN_UNIX03
+/*#define	HAS_STDIO_STREAM_ARRAY	/ **/
+#define STDIO_STREAM_ARRAY	
+#else /* !__DARWIN_UNIX03 */
+#define	HAS_STDIO_STREAM_ARRAY	/**/
+#define STDIO_STREAM_ARRAY	__sF
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]USE_64_BIT_INT/c
+#ifdef __LP64__
+#define	USE_64_BIT_INT		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_INT		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_64_BIT_ALL/c
+#ifdef __LP64__
+#define	USE_64_BIT_ALL		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_ALL		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]Gid_t_f/c
+#ifdef __LP64__
+#define	Gid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Gid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]Size_t_size/c
+#ifdef __LP64__
+#define Size_t_size 8		/* */
+#else /* !__LP64__ */
+#define Size_t_size 4		/* */
+#endif /* __LP64__ */
+.
+/define[ 	]Uid_t_f/c
+#ifdef __LP64__
+#define	Uid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Uid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]NEED_VA_COPY/c
+#ifdef __LP64__
+#define	NEED_VA_COPY		/**/
+#else /* !__LP64__ */
+/*#define	NEED_VA_COPY		/ **/
+#endif /* __LP64__ */
+.
+w

--- a/lang/perl5/files/5.30/enable-syscall-on-sierra.patch
+++ b/lang/perl5/files/5.30/enable-syscall-on-sierra.patch
@@ -1,0 +1,34 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -346,17 +346,20 @@ EOM
+     prodvers_minor=$(echo $prodvers|awk -F. '{print $2}')
+ 
+     # macOS (10.12) deprecated syscall().
+-    if [ "$prodvers_minor" -ge 12 ]; then
+-        d_syscall='undef'
+-        # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
+-        case "$MACOSX_DEPLOYMENT_TARGET" in
+-          10.[6-9]|10.10|10.11)
+-          ccflags="$ccflags -Werror=partial-availability -D_DARWIN_FEATURE_CLOCK_GETTIME=0"
+-          ;;
+-        *)
+-          ;;
+-        esac
+-    fi
++    # but it's still available on both macOS 10.12 and 10.13
++    # for compatibility with perl5.24 allow syscall() configuration on Sierra and later
++    # will auto-configure without syscall() if and when it's actually removed
++    # if [ "$prodvers_minor" -ge 12 ]; then
++    #     d_syscall='undef'
++    #     # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
++    #     case "$MACOSX_DEPLOYMENT_TARGET" in
++    #       10.[6-9]|10.10|10.11)
++    #       ccflags="$ccflags -Werror=partial-availability -D_DARWIN_FEATURE_CLOCK_GETTIME=0"
++    #       ;;
++    #     *)
++    #       ;;
++    #     esac
++    # fi
+ 
+    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+    ;;

--- a/lang/perl5/files/5.30/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.30/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.30/fix-miniperl-linking-PR36438.patch
+++ b/lang/perl5/files/5.30/fix-miniperl-linking-PR36438.patch
@@ -1,0 +1,11 @@
+--- Makefile.SH.orig
++++ Makefile.SH
+@@ -1015,7 +1015,7 @@ NAMESPACEFLAGS = -force_flat_namespace
+ 		$spitshell >>$Makefile <<'!NO!SUBS!'
+ lib/buildcustomize.pl: $& $(miniperl_objs) write_buildcustomize.pl
+ 	-@rm -f miniperl.xok
+-	$(CC) $(CLDFLAGS) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
++	unset LIBRARY_PATH && $(CC) $(subst -L__PREFIX__/lib,,$(CLDFLAGS)) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
+ 	    $(miniperl_objs) $(libs)
+ 	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
+ 	$(MINIPERL) -f write_buildcustomize.pl

--- a/lang/perl5/files/5.30/install-under-short-version-PR43480.patch
+++ b/lang/perl5/files/5.30/install-under-short-version-PR43480.patch
@@ -1,0 +1,39 @@
+https://trac.macports.org/ticket/43480
+--- Configure.orig
++++ Configure
+@@ -4370,6 +4370,8 @@ dos|vms)
+ *)
+ 	version=`echo $revision $patchlevel $subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
++	version_short=`echo $revision $patchlevel | \
++		 $awk '{ printf "%d.%d\n", $1, $2 }'`
+ 	api_versionstring=`echo $api_revision $api_version $api_subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
+ 	;;
+@@ -7343,7 +7345,7 @@ esac
+ : /opt/perl/lib/perl5... would be redundant.
+ : The default "style" setting is made in installstyle.U
+ case "$installstyle" in
+-*lib/perl5*) set dflt privlib lib/$package/$version ;;
++*lib/perl5*) set dflt privlib lib/$package/$version_short ;;
+ *)	 set dflt privlib lib/$version ;;
+ esac
+ eval $prefixit
+@@ -7591,7 +7593,7 @@ siteprefixexp="$ansexp"
+ prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ case "$sitelib" in
+ '') case "$installstyle" in
+-	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version ;;
++	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version_short ;;
+ 	*)	 dflt=$siteprefix/lib/site_$prog/$version ;;
+ 	esac
+ 	;;
+@@ -8008,7 +8010,7 @@ case "$vendorprefix" in
+ 	'')
+ 		prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ 		case "$installstyle" in
+-		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version ;;
++		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version_short ;;
+ 		*)	     dflt=$vendorprefix/lib/vendor_$prog/$version ;;
+ 		esac
+ 		;;

--- a/lang/perl5/files/5.30/patch-Configure-remove-libs.diff
+++ b/lang/perl5/files/5.30/patch-Configure-remove-libs.diff
@@ -1,0 +1,14 @@
+* Prevent build from picking up the bind9 port's static libbind
+* Don't link against cryptlib
+  https://trac.macports.org/ticket/53446
+--- Configure.orig
++++ Configure
+@@ -1487,7 +1487,7 @@ archname=''
+ usereentrant='undef'
+ : List of libraries we want.
+ : If anyone needs extra -lxxx, put those in a hint file.
+-libswanted="cl pthread socket bind inet nsl ndbm gdbm dbm db malloc dl ld"
++libswanted="pthread socket inet nsl ndbm gdbm dbm db malloc dl ld"
+ libswanted="$libswanted sun m crypt sec util c cposix posix ucb bsd BSD"
+ : We probably want to search /usr/shlib before most other libraries.
+ : This is only used by the lib/ExtUtils/MakeMaker.pm routine extliblist.


### PR DESCRIPTION
Note that I disabled `enable-syscall-on-sierra.patch`. I'm not sure if we need that one or not (maybe we do, I probably just wanted to check whether stock perl works as expected).

I can add the modules as well, but it would be cool if I could remove 5.26 at the same time as adding 5.30.

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->