### PR TITLE
node_exporter: new port for the Prometheus Node Exporter, v0.18.0

### DIFF
--- a/net/node_exporter/Portfile
+++ b/net/node_exporter/Portfile
@@ -1,0 +1,108 @@
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        prometheus node_exporter 0.18.0 v
+github.tarball_from archive
+
+description         Machine-metric exporter for the Prometheus monitoring \
+                    system.
+
+long_description    The Prometheus Node Exporter can expose metrics that \
+                    Prometheus can scrape, including a wide variety of \
+                    system, hardware- and kernel-related metrics.
+
+homepage            https://prometheus.io/docs/guides/node-exporter
+
+platforms           darwin
+categories          net
+license             apache
+
+maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
+
+depends_build       port:curl \
+                    port:go
+
+build.env           GOPATH=${workpath} \
+                    PATH=$env(PATH):${workpath}/bin
+
+build.target        build
+
+use_configure       no
+installs_libs       no
+use_parallel_build  no
+
+checksums \
+  rmd160    329f461588f42e450d085be02393ff7613baa71a \
+  sha256    2f71a4a11fa1388e4a459865520365396f8b6ebbad9d45df476fe60ee0de0415 \
+  size      2104908
+
+set svc_name        prometheus-node-exporter
+set prom_user       prometheus
+set ne_doc_dir      ${prefix}/share/doc/${svc_name}
+set ne_share_dir    ${prefix}/share/${svc_name}
+set ne_log_dir      ${prefix}/var/log/${svc_name}
+set ne_log_file     ${ne_log_dir}/${name}.log
+
+add_users           ${prom_user} \
+                    group=${prom_user} \
+                    realname=Prometheus
+
+post-extract {
+    copy  ${filespath}/org.macports.${name}.plist \
+          ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@NAME@|${name}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@USER@|${prom_user}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@GROUP@|${prom_user}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@LOGFILE@|${ne_log_file}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+
+    xinstall -d 755 ${destroot}${ne_doc_dir}
+    xinstall -d 755 ${destroot}${ne_share_dir}
+    xinstall -d 755 -o ${prom_user} -g ${prom_user} ${destroot}${ne_log_dir}
+
+    touch ${destroot}${ne_log_file}
+
+    file attributes ${destroot}${ne_log_file} \
+        -owner ${prom_user} -group ${prom_user}
+
+    foreach _dir {examples text_collector_examples} {
+        copy ${worksrcpath}/${_dir} ${destroot}${ne_share_dir}/
+    }
+
+    copy {*}[glob ${worksrcpath}/docs/*] ${destroot}${ne_doc_dir}/
+
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
+        ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
+}
+
+notes "
+To enable the Prometheus Node Exporter service, use `port load`, as follows:
+
+\$ sudo port load ${name}
+
+When enabled, the service will log to:
+${prefix}${ne_log_file}
+"

--- a/net/node_exporter/files/org.macports.node_exporter.plist
+++ b/net/node_exporter/files/org.macports.node_exporter.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.@NAME@</string>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/@NAME@</string>
+        </array>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>WorkingDirectory</key>
+    <string>@PREFIX@</string>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
+    <key>HardResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>4096</integer>
+    </dict>
+    <key>SoftResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>4096</integer>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
New port for the [Prometheus Node Exporter](https://prometheus.io/docs/guides/node-exporter/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
