### PR TITLE
GPXSee: update to 7.8

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.7
+github.setup        tumic0 GPXSee 7.8
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  fc410d5d4f46816a0755f14e8deb965b18c159fc \
-                    sha256  12b31f86cba73a259e737e876a1b9ac17d82204ed84ece56876eb734853c1509 \
-                    size    4329477
+checksums           rmd160  6e860fac15b5e8904a05d5ca9fa66b7762d33013 \
+                    sha256  4e60b4297651084a8bc97781d102e0a2410e7a3c1c7c8c90aae03c764ea1f2fe \
+                    size    4330878
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.8

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for QuadTiles maps.
>   * Added (optional) km/mi path markers.
>   * Fixed broken IMG maps after print/PDF export.
>   * Fixed broken zoom fit on IMG maps.
>   * Fixed broken WMS scale denominators to zoom levels transition.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
