### PR TITLE
mysql8: add a log file for the MySQL service

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -13,7 +13,7 @@ homepage                https://www.mysql.com/
 
 # Set revision_client and revision_server to 0 on version bump.
 set revision_client 0
-set revision_server 0
+set revision_server 1
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -230,6 +230,8 @@ subport ${name_mysql}-server {
     }
     add_users ${mysqluser} group=${mysqluser} realname=MySQL\ Server
 
+    set log_file ${prefix}/var/log/${name}/mysql.log
+
     pre-extract {
         copy ${filespath}/org.macports.mysql-server.plist \
              ${workpath}/org.macports.${subport}.plist
@@ -246,6 +248,8 @@ subport ${name_mysql}-server {
             ${workpath}/org.macports.${subport}.plist
         reinplace "s|@GROUP@|${mysqluser}|g" \
             ${workpath}/org.macports.${subport}.plist
+        reinplace "s|@LOGFILE@|${log_file}|g" \
+            ${workpath}/org.macports.${subport}.plist
     }
 
     use_configure       no
@@ -253,6 +257,12 @@ subport ${name_mysql}-server {
     build {}
 
     destroot {
+        xinstall -d -m 755 -o ${mysqluser} -g ${mysqluser} \
+            [file dirname ${destroot}${log_file}]
+
+        touch ${destroot}${log_file}
+        file attributes ${destroot}${log_file} -o ${mysqluser} -g ${mysqluser}
+
         xinstall -d -m 755 ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${subport}
 
         xinstall -m 0644 -o root -W ${workpath} \
@@ -296,6 +306,9 @@ The first command creates the necessary files for the MySQL database service.
 (Remember to make a note of the auto-generated root password from this step.)
 The second command starts the MySQL service.
 The last command helps to improve the security of your running MySQL instance.
+
+Once enabled, the MySQL logs can be found in:
+[file dirname $log_file]
 "
 
     livecheck.type          none

--- a/databases/mysql8/files/org.macports.mysql-server.plist
+++ b/databases/mysql8/files/org.macports.mysql-server.plist
@@ -26,5 +26,9 @@
         <array>
             <string>@PREFIX@/lib/@NAMEMYSQL@/bin/mysqld</string>
         </array>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adds a standard log file for the MySQL service.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
