### PR TITLE
kuser, kcron: remove old conflict handlers

### DIFF
--- a/kde/kcron/Portfile
+++ b/kde/kcron/Portfile
@@ -28,14 +28,5 @@ if {![variant_isset docs]} {
     patchfiles      patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdeadmin port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/kcm_cron.so]
-        && ![catch {set vers [lindex [registry_active kdeadmin] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdeadmin "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)

--- a/kde/kuser/Portfile
+++ b/kde/kuser/Portfile
@@ -32,14 +32,5 @@ if {![variant_isset docs]} {
     patchfiles-append   patch-CMakeLists.diff
 }
 
-pre-activate {
-    #Deactivate hack for when kdeadmin port has been fragmented into small ports
-    if {[file exists ${prefix}/lib/kde4/kcm_cron.so]
-        && ![catch {set vers [lindex [registry_active kdeadmin] 0]}] 
-        && [vercmp [lindex $vers 1] 4.11.0] < 0} {
-            registry_deactivate_composite kdeadmin "" [list ports_nodepcheck 1] 
-    } 
-}
-
 livecheck.url       ${kde4.mirror}
 livecheck.regex     (\\d+(\\.\\d+)+)


### PR DESCRIPTION
Present when ports were split from `kdeadmin` in a80fc5fae1 over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
