### PR TITLE
kdepimlibs4: remove old conflict handler

### DIFF
--- a/kde/kdepimlibs4/Portfile
+++ b/kde/kdepimlibs4/Portfile
@@ -46,14 +46,6 @@ patchfiles-append   patch-CMakeLists.diff \
 
 configure.args-append   -DMAILTRANSPORT_INPROCESS_SMTP=Off
 
-pre-activate {
-    if {[file exists ${applications_dir}/KDE4/akonadi2xml.app/Contents/Info.plist]
-        && ![catch {set vers [lindex [registry_active kdepim4-runtime] 0]}] 
-        && [vercmp [lindex $vers 1] 4.12.0] < 0} {
-            registry_deactivate_composite kdepim4-runtime "" [list ports_nodepcheck 1] 
-    }
-}
-
 subport kdepimlibs4-kioslaves {
 
 #kioslaves components conflict with openssl license


### PR DESCRIPTION
Was added in 1ad4068650 over 5 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
