### PR TITLE
wireguard-tools: update to 0.0.20190531

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190406
+version             0.0.20190531
 revision            0
-checksums           rmd160  37074b9f42044c23ff2ecec5ff8626b665d6f944 \
-                    sha256  2f06f3adf70b95e74a7736a22dcf6e9ef623b311a15b7d55b5474e57c3d0415b \
-                    size    324112
+checksums           rmd160  9d6bc40ec9cfdda120e4f63b1ab584de0b149d1b \
+                    sha256  8b0280322ec4c46fd1a786af4db0c4d0c600053542c4563582baac478e4127b1 \
+                    size    326832
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?