### PR TITLE
girara, zathura: demote intltool to a build dependency

### DIFF
--- a/devel/girara/Portfile
+++ b/devel/girara/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                girara
 version             0.2.7
-revision            1
+revision            2
 categories          devel gnome
 platforms           darwin
 license             zlib
@@ -29,11 +29,11 @@ master_sites        ${homepage}download/
 checksums           rmd160  24ac2ce791459c879353e58edc047f903b2c12c0 \
                     sha256  98e6a343298ae46869c990bc6e0732555e19af2e386cdc1a911f109b1c5c32e5
 
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:intltool
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gtk3 \
-                    port:intltool \
                     port:libnotify \
                     port:json-c
 

--- a/office/zathura/Portfile
+++ b/office/zathura/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                zathura
 version             0.3.7
+revision            1
 categories          office
 platforms           darwin
 license             zlib
@@ -28,12 +29,12 @@ master_sites        ${homepage}download/
 checksums           rmd160  94b1ddf760883b3a8edb02bc57963537815aaccd \
                     sha256  22afff89f4093f22fb82188417ff9bfa9695b19a4fe894dca05b7c821b390ff0
 
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:intltool
 
 depends_lib         port:desktop-file-utils \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:gtk3 \
-                    port:intltool \
                     port:sqlite3 \
                     port:libmagic \
                     path:lib/libgirara-gtk3.dylib:girara


### PR DESCRIPTION
intltool is a perl script that is only used at build time for
generating i18n files. libintl is provided by gettext.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
