### PR TITLE
py-upt-macports: update

### DIFF
--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set git_hash        bb4e67ed3779359cbf5213f3e48b023b010dff07
+set git_hash        e9e40f0946d2393982f42fbd6c2dfb26b35786ed
 github.setup        macports upt-macports ${git_hash}
-version             0.1-20190512
+version             0.1-20190601
 name                py-${github.project}
 revision            0
 
@@ -18,9 +18,9 @@ platforms           darwin
 supported_archs     noarch
 
 license             BSD
-checksums           sha256  9974332e0c7382f6bfca75471ac0afb7e3246b68fe655c78854441aea2689ebd \
-                    rmd160  e04956bf7872e572e8bfcf7b22bf1ad368271d61 \
-                    size    5582
+checksums           sha256  6688092c129be5c238b2d15dea7ca352eb805adf2b1ce1b019b90edbae723d8f \
+                    rmd160  b1ba08abf7583c88897bb075c21107e2ad0d492e \
+                    size    6557
 
 python.versions     37
 


### PR DESCRIPTION
#### Description

py-upt-macports: update to e9e40f (20190601)

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->