### PR TITLE
wireshark-chmodbpf: fix group creation if installed from binary

### DIFF
--- a/net/wireshark-chmodbpf/Portfile
+++ b/net/wireshark-chmodbpf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                wireshark-chmodbpf
 version             1.0
-revision            1
+revision            2
 platforms           darwin macosx
 categories          net
 license             {GPL-2 GPL-3}
@@ -35,6 +35,12 @@ pre-destroot {
 destroot {
     reinplace s|@BPF_GROUP@|${bpf_group}|g ${worksrcpath}/sbin/${name}
     xinstall -m 0755 -o root -g wheel ${worksrcpath}/sbin/${name} ${destroot}${prefix}/sbin/${name}
+}
+
+# fix group creation if installed from the binary package
+post-install {
+    # create the group to access capture devices
+    addgroup ${bpf_group}
 }
 
 # create startup that run ${name} script


### PR DESCRIPTION
#### Description

wireshark-chmodbpf: fix group creation if installed from the binary package

Closes: https://trac.macports.org/ticket/58537

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->