### PR TITLE
wireguard-tools: update to 0.0.20190601

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190531
+version             0.0.20190601
 revision            0
-checksums           rmd160  9d6bc40ec9cfdda120e4f63b1ab584de0b149d1b \
-                    sha256  8b0280322ec4c46fd1a786af4db0c4d0c600053542c4563582baac478e4127b1 \
-                    size    326832
+checksums           rmd160  6481c53f86af5eaacde46b02a08f12d85090852d \
+                    sha256  7528461824a0174bd7d4f15e68d8f0ce9a8ea318411502b80759438e8ef65568 \
+                    size    327348
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?