### PR TITLE
py-google-api: update to 1.7.9

### DIFF
--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-google-api
 set realname        google-api-python-client
-version             1.6.7
+version             1.7.9
 
 python.versions     27 34 35 36 37
 
@@ -23,9 +23,9 @@ homepage            https://pypi.python.org/pypi/${realname}
 master_sites        pypi:g/${realname}/
 distname            ${realname}-${version}
 
-checksums           rmd160  d50870fbecb85b293d85cea4952f51b3195bad06 \
-                    sha256  05583a386e323f428552419253765314a4b29828c3cee15be735f9ebfa5aebf2 \
-                    size    51899
+checksums           rmd160  873bf2f66b15993daac708926c12c25e75792ac0 \
+                    sha256  048da0d68564380ee23b449e5a67d4666af1b3b536d2fb0a02cee1ad540fa5ec \
+                    size    142053
 
 if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Update py-google-api from 1.6.7 to 1.7.9.

1.7.x can use either oauth2client (as in 1.6.x) or google-auth.
google-auth is not currently packaged for MacPorts, so this package
continues to depend on oauth2client for now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2016
Xcode 9.2 9C40b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
