### PR TITLE
kdelibs4: remove old conflict handler

### DIFF
--- a/kde/kdelibs4/Portfile
+++ b/kde/kdelibs4/Portfile
@@ -107,13 +107,6 @@ pre-configure {
     delete file ${worksrcpath}/cmake/modules/FindFlex.cmake
 }
 
-pre-activate {
-    if {![catch {set vers [lindex [registry_active kde4-runtime] 0]}]
-        && [vercmp [lindex $vers 1] 4.8.1] < 0} {
-        registry_deactivate_composite kde4-runtime "" [list ports_nodepcheck 1]
-    }
-}
-
 post-destroot {
     xinstall -d ${destroot}${prefix}/include/nepomuk
     xinstall -m 0644 {*}[glob ${worksrcpath}/nepomuk/core/*.h] \


### PR DESCRIPTION
Was last needed 7 years ago in daccb8001d

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
