### PR TITLE
QtCurve-extra: remove old conflict handler

### DIFF
--- a/kde/qtcurve/Portfile
+++ b/kde/qtcurve/Portfile
@@ -113,16 +113,6 @@ subport ${name}-extra {
         xinstall -m 644 ${filespath}/QtCurveOSX.colors ${destroot}/${prefix}/share/apps/color-schemes/
         xinstall -m 644 ${filespath}/OxygenOSXGraphite.colors ${destroot}/${prefix}/share/apps/color-schemes/
     }
-    pre-activate {
-        # QtCurve-extra installs files that previously belonged to QtCurve
-        if {![catch {set installed [lindex [registry_active qtcurve] 0]}]} {
-            set _epoch [lindex $installed 5]
-            if {${_epoch} < 2} {
-                ui_debug "Deactivating conflicting version of port:qtcurve"
-                registry_deactivate_composite qtcurve "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }
 
 if {${subport} ne "${name}-extra"} {


### PR DESCRIPTION
Was added in 16e4129c34 over 2 years ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
