### PR TITLE
tor: Add startupitem and basic working configuration

### DIFF
--- a/security/tor/Portfile
+++ b/security/tor/Portfile
@@ -5,6 +5,7 @@ PortSystem          1.0
 name                tor
 conflicts           tor-devel
 version             0.3.5.8
+revision            1
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -30,6 +31,10 @@ depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \
                     port:zlib
 
+set torUser         _tor
+set torGroup        _tor
+add_users           ${torUser} group=${torGroup} home=${prefix}/var/lib/tor
+
 configure.args      --disable-silent-rules
 
 # https://gitweb.torproject.org/torspec.git/tree/proposals/278-directory-compression-scheme-negotiation.txt
@@ -38,8 +43,56 @@ configure.args-append \
                     --disable-lzma \
                     --disable-zstd
 
+post-destroot {
+    # Create a working torrc file with basic, locked-down permissions
+    xinstall -o ${torUser} -g ${torGroup} -m 0640 ${destroot}${prefix}/etc/tor/torrc.sample ${destroot}${prefix}/etc/tor/torrc
+    system -W ${destroot}${prefix}/etc/tor "cat >> torrc <<LOCAL_TOR_CONFIGURATION
+
+# Local Tor configuration
+SocksPolicy accept 127.0.0.1  # accept only localhost connections
+SocksPolicy reject *
+ExitPolicy reject *:*  # no exits allowed
+DataDirectory ${prefix}/var/lib/tor
+PidFile ${prefix}/var/run/tor/tor.pid
+# tor process uid
+User ${torUser}
+LOCAL_TOR_CONFIGURATION"
+    # save the existing config if it exists
+    if [file exists ${prefix}/etc/tor/torrc] {
+        file rename ${prefix}/etc/tor/torrc \
+                    ${prefix}/etc/tor/torrc.previous
+    }
+}
+
+post-activate {
+    # DataDirectory and PID file Ddirectory permissions
+    system "chown ${torUser}:${torGroup} ${prefix}/var/lib/tor"
+    system "chmod 0750 ${prefix}/var/lib/tor"
+    system "chown ${torUser}:${torGroup} ${prefix}/var/run/tor"
+    system "chmod 0750 ${prefix}/var/run/tor"
+}
+
 test.run            yes
 test.target         check
+
+platform darwin {
+    startupitem.create          yes
+    startupitem.name            Tor
+    startupitem.start           "\[ -f \"${prefix}/etc/tor/torrc\" \] \\"
+    startupitem.start-append    "\t&& ${prefix}/bin/tor \\"
+    startupitem.start-append    "\t\t-f ${prefix}/etc/tor/torrc 2>/dev/null"
+    startupitem.stop            "if \[ -f \"${prefix}/var/run/tor/tor.pid\" \]; then"
+    startupitem.stop-append     "\tkill `cat ${prefix}/var/run/tor/tor.pid` \\"
+    startupitem.stop-append     "\t\t&& rm -f ${prefix}/var/run/tor/tor.pid"
+    startupitem.stop-append     "else"
+    startupitem.stop-append     "\t/usr/bin/killall -SIGUSR1 tor 2>/dev/null"
+    startupitem.stop-append     "fi"
+    startupitem.pidfile         none ${prefix}/var/run/tor/tor.pid
+}
+
+destroot.keepdirs   ${destroot}${prefix}/var/lib/tor \
+                    ${destroot}${prefix}/var/run/tor \
+                    ${destroot}${prefix}/var/log/tor
 
 livecheck.type      regex
 livecheck.url       ${master_sites}?C=M\;O=D


### PR DESCRIPTION
tor: Add startupitem and basic working configuration

* Create startupitem
* Create Tor user/group _tor:_tor
* Create basic torrc with localhost access only, no exits
* Create DataDirectory, PidFile

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->