### PR TITLE
mpstats: add subport mpstats-gsoc and stop submission of inactive ports

### DIFF
--- a/sysutils/mpstats/Portfile
+++ b/sysutils/mpstats/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                mpstats
 version             0.1.8
+revision            1
 categories          sysutils macports
 license             BSD
 platforms           darwin
@@ -16,6 +17,7 @@ long_description \
    support and test more and which ports are most commonly used.
 
 homepage            https://www.macports.org/
+subport             mpstats-gsoc {}
 distfiles
 
 set launchd_dir     ${prefix}/etc/${startupitem.location}/${startupitem.uniquename}/
@@ -24,6 +26,14 @@ startupitem.create   no
 startupitem.type     launchd
 startupitem.autostart \
                     yes
+
+if {${subport} eq "mpstats-gsoc"} {
+    set fname mpstats-gsoc
+    set confname stats-gsoc
+} else {
+    set fname mpstats
+    set confname stats-gsoc
+}
 
 extract.mkdir       yes
 extract {
@@ -36,6 +46,10 @@ configure {
         ${worksrcpath}/mpstats.plist.default
     reinplace "s|@LABEL@|${startupitem.uniquename}|g" \
         ${worksrcpath}/mpstats.plist.default
+    reinplace "s|@CONFNAME@|${confname}|g" \
+        ${worksrcpath}/mpstats.tcl
+    reinplace "s|@PORTNAME@|${fname}|g" \
+        ${worksrcpath}/mpstats.plist.default
 }
 
 build {}
@@ -43,7 +57,7 @@ build {}
 destroot {
     xinstall -m 755 \
         ${worksrcpath}/mpstats.tcl \
-        ${destroot}${prefix}/libexec/mpstats
+        ${destroot}${prefix}/libexec/${fname}
 
     xinstall -m 755 -d \
         ${destroot}${launchd_dir}
@@ -54,8 +68,8 @@ destroot {
     xinstall -m 755 -d \
         ${destroot}${prefix}/etc/macports
     xinstall -m 444 \
-        ${filespath}/stats.conf \
-        ${destroot}${prefix}/etc/macports/stats.conf
+        ${filespath}/${confname}.conf \
+        ${destroot}${prefix}/etc/macports/${confname}.conf
 
     # install the plist, if startupitem.install is set
     if {[getuid] == 0 && ${startupitem.install}} {

--- a/sysutils/mpstats/files/mpstats.plist.default
+++ b/sysutils/mpstats/files/mpstats.plist.default
@@ -13,7 +13,7 @@
 		</dict>
 		<key>ProgramArguments</key>
 		<array>
-			<string>@PREFIX@/libexec/mpstats</string>
+			<string>@PREFIX@/libexec/@PORTNAME@</string>
 			<string>submit</string>
 		</array>
 		<key>StartCalendarInterval</key>

--- a/sysutils/mpstats/files/mpstats.tcl
+++ b/sysutils/mpstats/files/mpstats.tcl
@@ -49,7 +49,7 @@ proc usage {} {
 # Prints an error message (but doesn't abort) if the UUID is empty.
 proc read_config {} {
     global prefix stats_url stats_id
-    set conf_path "${prefix}/etc/macports/stats.conf"
+    set conf_path "${prefix}/etc/macports/@CONFNAME@.conf"
     if {[file isfile $conf_path]} {
         set fd [open $conf_path r]
         while {[gets $fd line] >= 0} {
@@ -273,13 +273,11 @@ proc json_encode_stats {id os_dict ports_dict} {
 
     set os_json [json_encode_dict os]
     set active_ports_json [json_encode_portlist [dict get $ports "active"]]
-    set inactive_ports_json [json_encode_portlist [dict get $ports "inactive"]]
 
     set json "\{"
     append json "\n  \"id\": \"$id\","
     append json "\n  \"os\": [json_encode_dict os "  "],"
-    append json "\n  \"active_ports\": [json_encode_portlist [dict get $ports "active"] "  "],"
-    append json "\n  \"inactive_ports\": [json_encode_portlist [dict get $ports "inactive"] "  "]"
+    append json "\n  \"active_ports\": [json_encode_portlist [dict get $ports "active"] "  "]"
     append json "\n\}"
 
     return $json
@@ -377,7 +375,6 @@ proc action_stats {subcommands} {
 
     # Build dictionary of port information
     dict set ports active   [get_installed_ports yes]
-    dict set ports inactive [get_installed_ports no]
 
     # Make sure there aren't too many subcommands
     if {[llength $subcommands] > 1} {

--- a/sysutils/mpstats/files/stats-gsoc.conf
+++ b/sysutils/mpstats/files/stats-gsoc.conf
@@ -1,0 +1,4 @@
+# configuration for mpstats-gsoc
+
+# Where to submit usage data
+stats_url       http://frozen-falls-98471.herokuapp.com/statistics/submit/


### PR DESCRIPTION
#### Description

Submission of inactive ports is purposeless and only increases the size of data submitted- it can be removed.

mpstats-gsoc shall temporarily make submissions to [https://frozen-falls-98471.herokuapp.com](https://frozen-falls-98471.herokuapp.com) which is required to collect some initial data for development of [macports-webapp](https://github.com/macports/macports-webapp).

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->