### PR TITLE
php-sqlsrv: New port, versions 5.6.1 and 5.3.0

### DIFF
--- a/php/php-sqlsrv/Portfile
+++ b/php/php-sqlsrv/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               php 1.1
+
+name                    php-sqlsrv
+categories-append       databases
+platforms               darwin
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 MIT
+
+php.branches            7.0 7.1 7.2
+php.pecl                yes
+
+description             Microsoft sqlsrv drivers for PHP
+
+long_description        ${description}
+
+if {[vercmp ${php.branch} 7.0] >= 0} {
+    version             5.3.0
+    revision            0
+    checksums           rmd160  ab9e9d47f6385fb0a57f489933859def1b6761fc \
+                        sha256  dfcacbaf5ea505d11a057c673544ff923e74c78f16cc95ee57808a44ee20967a \
+                        size    173492
+}
+
+if {${subport} ne ${name}} {
+    depends_lib-append  port:msodbcsql
+
+    # msodbcsql is x86_64-only
+    supported_archs     x86_64
+}

--- a/php/php-sqlsrv/Portfile
+++ b/php/php-sqlsrv/Portfile
@@ -9,14 +9,20 @@ platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 MIT
 
-php.branches            7.0 7.1 7.2
+php.branches            7.0 7.1 7.2 7.3
 php.pecl                yes
 
 description             Microsoft sqlsrv drivers for PHP
 
 long_description        ${description}
 
-if {[vercmp ${php.branch} 7.0] >= 0} {
+if {[vercmp ${php.branch} 7.1] >= 0} {
+    version             5.6.1
+    revision            1
+    checksums           rmd160  2ef591fa12fc8829ef7c2736adba10c45c6f9b78 \
+                        sha256  0ab48ae7a9957586f5ec3ea1c19c528951517529078679a0dc3fd9fe83305445 \
+                        size    183396
+} elseif {[vercmp ${php.branch} 7.0] >= 0} {
     version             5.3.0
     revision            0
     checksums           rmd160  ab9e9d47f6385fb0a57f489933859def1b6761fc \


### PR DESCRIPTION
#### Description

php-sqlsrv: New port, versions 5.6.1 and 5.3.0

Based on a port submitted by @stronk7. Thanks!

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
