### PR TITLE
Submission: scdoc @1.9.4

### DIFF
--- a/textproc/scdoc/Portfile
+++ b/textproc/scdoc/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                scdoc
+version             1.9.4
+categories          textproc
+license             MIT
+maintainers         {@herrbischoff herrbischoff.com:marcel} \
+                    openmaintainer
+description         Simple man page generator.
+long_description    scdoc is a simple man page generator for POSIX systems written in C99.
+platforms           darwin
+homepage            https://git.sr.ht/~sircmpwn/scdoc/
+master_sites        https://git.sr.ht/~sircmpwn/scdoc/archive/
+distname            ${version}
+worksrcdir          ${name}-${distname}
+
+checksums           rmd160  01fa4a1284d647afa60ea83c38865bab18a0df00 \
+                    sha256  a10e200bcbc7d6faf9678444636886fee2fd99c754b630fc62fa9d247f1eec03 \
+                    size    11527
+
+use_configure       no
+
+patchfiles          patch-makefile.diff
+
+post-patch {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile
+}
+
+build.target

--- a/textproc/scdoc/files/patch-makefile.diff
+++ b/textproc/scdoc/files/patch-makefile.diff
@@ -1,0 +1,10 @@
+--- Makefile.orig       2019-03-04 16:43:31.000000000 +0100
++++ Makefile    2019-06-05 16:54:49.000000000 +0200
+@@ -1,6 +1,5 @@
+ VERSION=1.9.4
+ CFLAGS+=-g -DVERSION='"$(VERSION)"' -Wall -Wextra -Werror -Wno-unused-parameter
+-LDFLAGS+=-static
+ INCLUDE+=-Iinclude
+ PREFIX?=/usr/local
+ _INSTDIR=$(DESTDIR)$(PREFIX)
+ 


### PR DESCRIPTION
#### Description

scdoc is a simple man page generator for POSIX systems written in C99. It is required by [aerc](https://github.com/macports/macports-ports/pull/4527), another submission.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->