### PR TITLE
Submission: aerc @0.1.2

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aerc
+version             0.1.2
+categories          mail
+license             MIT
+maintainers         {@herrbischoff herrbischoff.com:marcel} \
+                    openmaintainer
+description         Terminal-based email client.
+long_description    aerc is an email client that runs in your terminal, \
+                    featuring editing emails in an embedded terminal tmux-style \
+                    and first-class support for working with Git & email.
+platforms           darwin
+homepage            https://aerc-mail.org
+master_sites        https://git.sr.ht/~sircmpwn/aerc/archive/
+distname            ${version}
+worksrcdir          ${name}-${distname}
+
+checksums           rmd160  ad55bb47eef82368a2959e5ff56c5437e91149cc \
+                    sha256  37b58c32dbaa4395deb12974b92ed0725cb248e348b7f45bdc4354f548cbf4be \
+                    size    60190
+
+use_configure       no
+
+pre-build {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile
+}
+
+depends_build       port:go \
+                    port:scdoc
+
+build.target


### PR DESCRIPTION
#### Description

aerc is an email client for your terminal.

The test will fail for now because it relies on another submission, [scdoc](https://github.com/macports/macports-ports/pull/4526) to build properly.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->