### PR TITLE
Security update to pam-u2f

### DIFF
--- a/security/pam-u2f/Portfile
+++ b/security/pam-u2f/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                pam-u2f
-version             1.0.7
+version             1.0.8
 categories          security
 platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
@@ -20,9 +20,9 @@ homepage            https://developers.yubico.com/pam-u2f/
 master_sites        https://developers.yubico.com/pam-u2f/Releases/
 distname            pam_u2f-${version}
 
-checksums           rmd160  ca5446abdc19d9336064ede6e814e551d9c01575 \
-                    sha256  034aad8e29b159443dd6c1b7740006addc83d0659304fc4b0b4fb592f768e7cf \
-                    size    378513
+checksums           rmd160  16423970f8d802b8e4583e0f3bbc4054f24291f8 \
+                    sha256  52a203a6fab6160e06c1369ff104afed62007ca3ffbb40c297352232fa975c99 \
+                    size    384163
 
 depends_build       port:pkgconfig
 depends_lib         port:libu2f-host port:libu2f-server


### PR DESCRIPTION
o Fix debug file descriptor leak CVE-2019-12210
o Fix insecure debug file handling CVE-2019-12209

#### Description

Security update to pam-u2f

###### Type(s)

Fixes CVE-2019-12209 and CVE-2019-12210.

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 10.14.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tested basic functionality of all binary files?
