### PR TITLE
dovecot2: Add missing build dependency port:automake

### DIFF
--- a/mail/dovecot2/Portfile
+++ b/mail/dovecot2/Portfile
@@ -23,7 +23,6 @@ long_description    Dovecot is an IMAP and POP3 server for Linux/UNIX-like \
                     avoid most of the common pitfalls.
 
 depends_build-append \
-                    port:autoconf \
                     port:gettext \
                     port:pandoc \
                     port:pkgconfig \
@@ -55,11 +54,18 @@ post-patch {
         ${worksrcpath}/doc/example-config/conf.d/10-master.conf
 }
 
+# Note: https://trac.macports.org/ticket/58544#comment:11 for this build logic
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
 pre-configure {
     # the line `dummy < /dev/tty` breaks this; just copy the necessary file
     # system -W ${worksrcpath} "gettextize -f"
     xinstall -W ${worksrcpath} ${prefix}/share/gettext/config.rpath .
-    system -W ${worksrcpath} "./autogen.sh"
 }
 
 configure.args      --sysconfdir=${prefix}/etc \


### PR DESCRIPTION
dovecot2: Add missing build dependency port:automake

* https://trac.macports.org/ticket/58544

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->