### PR TITLE
PothosWidgets: fix qt5 components

### DIFF
--- a/science/PothosWidgets/Portfile
+++ b/science/PothosWidgets/Portfile
@@ -18,8 +18,10 @@ github.setup        pothosware PothosWidgets 0.5.0 pothos-widgets-
 checksums           rmd160  187474f5078694ab61a00932954b575d84025463 \
                     sha256  38d5565035b92486852359eb2aac995d100bb9964079c9220236b7b98ea9394c \
                     size    18996
-revision            0
+revision            1
 
 depends_lib-append \
     port:PothosCore
 
+qt5.depends_component \
+    qtsvg


### PR DESCRIPTION
#### Description

fix qt5 components

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->