### PR TITLE
Tcl/Tk ports: use tcl-lang.org instead of tcl.tk

### DIFF
--- a/devel/tklib/Portfile
+++ b/devel/tklib/Portfile
@@ -15,9 +15,9 @@ description         A companion to Tcllib, for Tk related packages.
 
 long_description    $description
 
-homepage            https://core.tcl.tk/tklib/home
+homepage            https://core.tcl-lang.org/tklib/home
 
-master_sites        https://core.tcl.tk/${name}/tarball/${distfiles}?uuid=[regsub {\.} $distname {-}]&dummy=
+master_sites        https://core.tcl-lang.org/${name}/tarball/${distfiles}?uuid=[regsub {\.} $distname {-}]&dummy=
 
 checksums           size    5308298 \
                     sha256  8f7360d702ca7255cd6a6be834305dde093cd702c02238b1b7f6c0c5df5fc00f \
@@ -36,4 +36,4 @@ post-destroot {
 
 test.run            yes
 
-livecheck.url       https://core.tcl.tk/tklib/wiki?name=Downloads
+livecheck.url       https://core.tcl-lang.org/tklib/wiki?name=Downloads

--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -18,7 +18,7 @@ long_description    \
     Open source and business-friendly, Tcl is a mature yet evolving language \
     that is truly cross platform, easily deployed and highly extensible.
 
-homepage            https://www.tcl.tk/
+homepage            https://www.tcl-lang.org/
 master_sites        sourceforge:project/tcl/Tcl/${version}
 
 checksums           rmd160  73d064888101ab3a4a832bd9b242937e5f26315c \

--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -10,7 +10,7 @@ categories          x11
 license             Tcl/Tk
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description         Tcl Tool Kit
-homepage            https://www.tcl.tk/
+homepage            https://www.tcl-lang.org/
 long_description    This is Tk version ${version}, a GUI toolkit for Tcl. The best way to get \
                     started with Tcl is to read ``Tcl and the Tk Toolkit'' by John K.         \
                     Ousterhout, Addison-Wesley, ISBN 0-201-63337-X.


### PR DESCRIPTION
tcl-lang.org is preferred to tcl.tk, as tcl.tk is sometimes unreliable.
More tcl.tk domains are now redirecting to tcl-lang.org.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
