### PR TITLE
py-pyqt5: update to 5.12.2

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 PortGroup               cxx11  1.1
 
 name                    py-pyqt5
-version                 5.12.1
+version                 5.12.2
 revision                0
 categories-append       devel
 platforms               darwin
@@ -15,11 +15,11 @@ long_description        ${description}. The bindings \
                         are implemented as a set of Python modules and contain over 620 classes.
 homepage                https://www.riverbankcomputing.com/software/pyqt/intro
 license                 GPL-3
-master_sites            https://www.riverbankcomputing.com/static/Downloads/PyQt5/
+master_sites            https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/
 distname                PyQt5_gpl-${version}
-checksums               rmd160  bfe5376baf97bde0ebad0fd7f109e23ff3242975 \
-                        sha256  3718ce847d824090fd5f95ff3f13847ee75c2507368d4cbaeb48338f506e59bf \
-                        size    3147086
+checksums               rmd160  9215967ed17e4b897d482a3d45c33e4ca900a596 \
+                        sha256  c565829e77dc9c281aa1a0cdf2eddaead4e0f844cbaf7a4408441967f03f5f0f \
+                        size    3147205
 
 python.versions 27 34 35 36 37
 subport "${name}-common" {}
@@ -48,6 +48,8 @@ if {${subport} eq "${name}-common"} {
 } elseif {[string first "webengine" ${subport}] != -1} {
     PortGroup           qmake5 1.0
 
+    version             5.12.1
+    revision            0
     description         PyQt5 Webengine bindings
     long_description    ${description}
     master_sites        https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}


### PR DESCRIPTION
#### Description

https://www.riverbankcomputing.com/news/pyqt-5122: includes support for Qt 5.12.3

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001
Python 3.7.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
```
--->  Verifying Portfile for py-pyqt5
Error: Line 81 repeats inclusion of PortGroup qmake5
--->  1 errors and 0 warnings found.
```
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
