### PR TITLE
hugo: add extended variant for Sass/SCSS support.

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -44,3 +44,7 @@ variant bash_completion {
         xinstall -m 644 ${worksrcpath}/hugo.sh ${destroot}${prefix}/share/bash-completion/completions/${name}
     }
 }
+
+variant extended description {Builds Hugo Extended with Sass/SCSS support} {
+    build.args-append --tags extended
+}


### PR DESCRIPTION
#### Description

Added `extended` variant to build Hugo with `--tags extended` to enable Hugos Sass/SCSS processing (see https://gohugo.io/news/0.43-relnotes).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?