### PR TITLE
py-pyqt5-webengine: fix livecheck

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -21,6 +21,10 @@ checksums               rmd160  9215967ed17e4b897d482a3d45c33e4ca900a596 \
                         sha256  c565829e77dc9c281aa1a0cdf2eddaead4e0f844cbaf7a4408441967f03f5f0f \
                         size    3147205
 
+livecheck.type          regex
+livecheck.url           https://www.riverbankcomputing.com/software/pyqt/download5
+livecheck.regex         >PyQt5_gpl-(\[0-9.\]*).tar.gz<
+
 python.versions 27 34 35 36 37
 subport "${name}-common" {}
 
@@ -57,6 +61,10 @@ if {${subport} eq "${name}-common"} {
     checksums           rmd160  5e0c3cd69448b8dee042ba6565c823e266c22a14 \
                         sha256  860704672ea1b616e1347be1f347bc1c749e64ed378370863fe209e84e9bd473 \
                         size    42474
+
+    livecheck.type      regex
+    livecheck.url       https://www.riverbankcomputing.com/software/pyqtwebengine/download
+    livecheck.regex     >PyQtWebEngine_gpl-(\[0-9.\]*).tar.gz<
 
     depends_lib-append  port:py${python.version}-pyqt5
     qt5.depends_component \
@@ -161,7 +169,3 @@ if {${subport} eq "${name}-common"} {
     }
 
 }
-
-livecheck.type     regex
-livecheck.url      https://www.riverbankcomputing.com/software/pyqt/download5
-livecheck.regex    >PyQt5_gpl-(\[0-9.\]*).tar.gz<


### PR DESCRIPTION
#### Description

Since the patch versions of `py-pyqt5` and `py-pyqt5-webengine` no longer appear to be synchronized, their livechecks need to be separated.

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
