### PR TITLE
mysql8: compile against cyrus-sasl2 for SASL dependency

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -12,8 +12,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} openmaintainer
 homepage                https://www.mysql.com/
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client 0
-set revision_server 1
+set revision_client 1
+set revision_server 2
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -50,6 +50,7 @@ if {$subport eq $name} {
                         size    111710205
 
     depends_lib-append  path:lib/libssl.dylib:openssl \
+                        port:cyrus-sasl2 \
                         port:icu \
                         port:zlib
 
@@ -104,6 +105,7 @@ if {$subport eq $name} {
         -DWITH_BOOST:PATH="${worksrcpath}/../${boost_distname}" \
         -DWITH_ICU:PATH="${prefix}" \
         -DWITH_INNODB_MEMCACHED=1 \
+        -DWITH_SASL:PATH="${prefix}" \
         -DWITH_SSL:PATH="${prefix}" \
         -DWITH_ZLIB:PATH="${prefix}"
 


### PR DESCRIPTION
MySQL 8's InnoDB has a SASL requirement; this change looks to satisfy it using the macOS system libsasl2.

**Trac Tickets:**
* https://trac.macports.org/ticket/58555

Mayhaps there is a cleaner or more recommended way to do this?

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
