### PR TITLE
gitlab-runner: update to 11.11.2

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.11.1 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 11.11.2 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  c28e4c1399ad6e86b79ae810710ec2321272ef57 \
-                    sha256  0c3d1caf44d8d2e5a9c9f0a5e26d03dbbdab851080920458552e5d2f9802012d \
-                    size    27088327
+checksums           rmd160  919931be2da9abde78f906db24798ec9adbf1a23 \
+                    sha256  11416d6558e493954880e97d0e91f7ad230014f794c384d9b80b179cb0413043 \
+                    size    27084964
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 11.11.2.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?