### PR TITLE
Update QtCreator ports; preparing for botan2 update

### DIFF
--- a/devel/qt4-creator-mac/Portfile
+++ b/devel/qt4-creator-mac/Portfile
@@ -12,22 +12,23 @@ description         Cross-platform integrated development environment (IDE) tail
 long_description    Qt Creator is a cross-platform integrated development environment (IDE) tailored to the needs of Qt developers.
 
 version             2.8.1
-revision            2
+revision            3
 checksums           rmd160 9348896ff468a90e2c36260621c615c1ee89e82c \
-                    sha256 d5ae007a297a4288d0e95fd605edbfb8aee80f6788c7a6cfb9cb297f50c364b9
+                    sha256 d5ae007a297a4288d0e95fd605edbfb8aee80f6788c7a6cfb9cb297f50c364b9 \
+                    size   24381282
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 homepage            https://www.qt.io/qt-features-libraries-apis-tools-and-ide/
 distname            qt-creator-${version}-src
 master_sites        https://download.qt.io/official_releases/qtcreator/${branch}/${version}/
 
-depends_lib-append  port:botan \
-                    port:qt4-mac-sqlite3-plugin
+depends_lib-append  port:qt4-mac-sqlite3-plugin
 
 # fix up QMake build files to remove debug and release building;
 # specify that here instead.
 patchfiles          patch-remove_build_types.diff \
-                    patch-macports-paths.diff
+                    patch-macports-paths.diff \
+                    patch-no-pointer-comparison.diff
 
 post-patch {
     # remove arch from QMake build scripts
@@ -48,8 +49,6 @@ pre-configure {
     # always build just the release, no debug
     configure.pre_args-append CONFIG+="release"
 }
-
-configure.args      "USE_SYSTEM_BOTAN=1"
 
 build.target-append docs
 

--- a/devel/qt4-creator-mac/files/patch-no-pointer-comparison.diff
+++ b/devel/qt4-creator-mac/files/patch-no-pointer-comparison.diff
@@ -1,0 +1,11 @@
+--- src/plugins/debugger/debuggerplugin.cpp.orig	2019-05-31 21:06:24.000000000 +0800
++++ src/plugins/debugger/debuggerplugin.cpp	2019-05-31 21:06:03.000000000 +0800
+@@ -1091,7 +1091,7 @@
+         const QAction *act = qobject_cast<QAction *>(sender());
+         QTC_ASSERT(act, return);
+         const BreakpointModelId id = act->data().value<BreakpointModelId>();
+-        QTC_ASSERT(id > 0, return);
++        QTC_ASSERT(id, return);
+         BreakTreeView::editBreakpoint(id, mainWindow());
+     }
+ 

--- a/devel/qt5-qtcreator/Portfile
+++ b/devel/qt5-qtcreator/Portfile
@@ -7,6 +7,7 @@ PortGroup           cxx11  1.1
 name                qt5-qtcreator
 
 version             4.9.0
+revision            1
 categories          devel aqua
 platforms           darwin
 # from https://blog.qt.io/blog/2016/01/13/new-agreement-with-the-kde-free-qt-foundation/
@@ -43,9 +44,6 @@ use_parallel_build  no
 if { ${subport} eq ${name}  } {
 
     qt5.depends_component  qtscript qtdeclarative qttools qtmacextras qtquickcontrols qtsvg
-
-    depends_lib-append     port:botan
-    configure.args-append  "USE_SYSTEM_BOTAN=1"
 
     depends_lib-append     port:qbs
     configure.args-append  "QBS_INSTALL_DIR=${prefix}"


### PR DESCRIPTION
#### Description

See individual commit messages and https://trac.macports.org/ticket/58513.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 I think; just updated to xcode 11 beta and I didn't re-test these two ports

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
There's a warning, which seems unrelated to this PR.
```
Warning: Variant qtwebengine conflicts with non-existing variant universal
```
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? Both runs. I didn't test coding with that.
