### PR TITLE
oksh: submission

### DIFF
--- a/shells/oksh/Portfile
+++ b/shells/oksh/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        ibara oksh 6.5 oksh-
+name                oksh
+revision            0
+checksums           rmd160  7af210fc9ca96fd55f6d337ee7600c7008f3d24f \
+                    sha256  51d3e313e52345aea105b97f3747f7b491004dcf5f13022746edef9af9725948 \
+                    size    301953
+
+homepage            https://devio.us/~bcallah/oksh/
+description         A portable OpenBSD Korn Shell
+long_description    A portable OpenBSD Korn Shell based on the Public Domain Korn Shell (pdksh)
+
+categories          shells
+platforms           darwin
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+license             BSD ISC public-domain
+
+depends_lib         port:ncurses
+
+configure.args      --mandir=${prefix}/share/man


### PR DESCRIPTION
#### Description

OpenBSD ksh is a continuation of the Public Domain Korn Shell (pdksh) by OpenBSD developers and is included as a default shell for OpenBSD system (as `ksh`). OpenBSD ksh contain features not found in pdksh, such as Bourne-style `\h \w` support in PS1 or user-definable auto-complete. This is a [portable version](https://github.com/ibara/oksh) of OpenBSD ksh. 

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A471t
Xcode 11.0 11M336w

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?