### PR TITLE
new port: alertmanager

### DIFF
--- a/net/alertmanager/Portfile
+++ b/net/alertmanager/Portfile
@@ -1,0 +1,150 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        prometheus alertmanager 0.17.0 v
+github.tarball_from archive
+set promu_version   0.4.0
+
+description         The Alertmanager handles alerts sent by client \
+                    applications such as the Prometheus server.
+
+long_description    AlertManager takes care of deduplicating, grouping, and \
+                    routing them to the correct receiver integration such as \
+                    email, PagerDuty, or OpsGenie. It also takes care of \
+                    silencing and inhibition of alerts.
+
+homepage            https://prometheus.io/docs/alerting/alertmanager/
+
+platforms           darwin
+categories          net
+license             Apache-2
+
+maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
+
+depends_build       port:go
+
+build.env           GOPATH=${workpath} \
+                    PATH=${workpath}/bin:$env(PATH)
+
+build.target        build
+
+use_configure       no
+installs_libs       no
+use_parallel_build  no
+
+set promu_distname  promu-${promu_version}.darwin-amd64
+set promu_distfile  ${promu_distname}${extract.suffix}
+
+master_sites-append https://github.com/prometheus/promu/releases/download/v${promu_version}:promu
+
+distfiles           alertmanager-${version}${extract.suffix}:main \
+                    ${promu_distfile}:promu
+
+checksums \
+  ${promu_distfile} \
+    rmd160  c9936951a23f7cc8fec7df7d37248fff489f5d23 \
+    sha256  2b95dd9f198cf2143b55edc6c855b34e59a95319785e0393224e881103748d61 \
+    size    7130688 \
+  alertmanager-${version}${extract.suffix} \
+    rmd160  626e2f17560ef2ca70edb9fe57b0fc8506936c09 \
+    sha256  8254591e058338b31a023f0eb3ab69de9d1547e0a446d28cab4664609793e4a2 \
+    size    5118311
+
+set svc_name        prometheus-alertmanager
+set prom_user       prometheus
+set am_config_dir   ${prefix}/etc/${svc_name}
+set am_config_file  ${am_config_dir}/config.yml
+set am_data_dir     ${prefix}/var/db/${svc_name}
+set am_share_dir    ${prefix}/share/${svc_name}
+set am_log_dir      ${prefix}/var/log/${svc_name}
+set am_log_file     ${am_log_dir}/${name}.log
+
+add_users           ${prom_user} \
+                    group=${prom_user} \
+                    realname=Prometheus
+
+post-extract {
+    # Install promu
+    xinstall -d ${workpath}/bin
+    ln -s ${workpath}/${promu_distname}/promu ${workpath}/bin/
+
+    copy  ${filespath}/org.macports.${name}.plist \
+          ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@NAME@|${name}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@USER@|${prom_user}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@GROUP@|${prom_user}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@LOGFILE@|${am_log_file}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@DATADIR@|${am_data_dir}|g" \
+        ${workpath}/org.macports.${name}.plist
+
+    reinplace "s|@CONFIGFILE@|${am_config_file}|g" \
+        ${workpath}/org.macports.${name}.plist
+}
+
+destroot.keepdirs   ${destroot}${am_config_dir} \
+                    ${destroot}${am_data_dir}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/amtool
+
+    xinstall -d 755 ${destroot}${am_config_dir}
+    xinstall -d 755 ${destroot}${am_share_dir}
+    xinstall -d 755 -o ${prom_user} -g ${prom_user} ${destroot}${am_log_dir}
+    xinstall -d 755 -o ${prom_user} -g ${prom_user} ${destroot}${am_data_dir}
+
+    touch ${destroot}${am_log_file}
+
+    file attributes ${destroot}${am_log_file} \
+        -owner ${prom_user} -group ${prom_user}
+
+    copy ${worksrcpath}/doc ${destroot}${am_share_dir}/
+    copy ${worksrcpath}/examples ${destroot}${am_share_dir}/
+
+    xinstall -d -m 755 \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -m 0644 -o root -W ${workpath} org.macports.${name}.plist \
+        ${destroot}${prefix}/etc/LaunchDaemons/org.macports.${name}
+
+    xinstall -d -m 755 ${destroot}/Library/LaunchDaemons
+
+    ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
+        ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
+}
+
+post-activate {
+    if {![file exists ${am_config_file}]} {
+        copy  ${am_share_dir}/doc/examples/simple.yml ${am_config_file}
+    }
+}
+
+
+notes "
+To enable the Prometheus AlertManager service, use `port load`, as follows:
+
+\$ sudo port load ${name}
+
+When enabled, the service will log to:
+
+  ${am_log_file}
+
+Configuration for AlertManager can be found at:
+
+  ${am_config_file}
+
+"

--- a/net/alertmanager/files/org.macports.alertmanager.plist
+++ b/net/alertmanager/files/org.macports.alertmanager.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.macports.@NAME@</string>
+    <key>ProgramArguments</key>
+        <array>
+            <string>@PREFIX@/bin/@NAME@</string>
+            <string>--config.file=@CONFIGFILE@</string>
+            <string>--storage.path=@DATADIR@</string>
+        </array>
+    <key>UserName</key>
+    <string>@USER@</string>
+    <key>GroupName</key>
+    <string>@GROUP@</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>WorkingDirectory</key>
+    <string>@PREFIX@</string>
+    <key>StandardErrorPath</key>
+    <string>@LOGFILE@</string>
+    <key>StandardOutPath</key>
+    <string>@LOGFILE@</string>
+    <key>HardResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>4096</integer>
+    </dict>
+    <key>SoftResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>4096</integer>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
New port for the Prometheus AlertManager (https://prometheus.io/docs/alerting/alertmanager/)

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
