### PR TITLE
update Mednafen to 1.22.2

### DIFF
--- a/emulators/mednafen/Portfile
+++ b/emulators/mednafen/Portfile
@@ -3,63 +3,51 @@
 PortSystem          1.0
 
 name                mednafen
-version             0.9.48
+version             1.22.2
 epoch               1
 platforms           darwin
 categories          emulators games
 license             GPL-2
-maintainers         nomaintainer
+maintainers         @gnubeest \
+                    openmaintainer
 
-description         Super-fast and super-compatible emulator for many video game systems
-long_description    Medfafen is a portable (utilizing OpenGL and SDL) \
-    argument-driven multi-system emulator with many \
-    advanced features. The Atari Lynx, GameBoy, GameBoy \
-    Colour, GameBoy Advance, NES, PC Engine (TurboGrafx 16) \
-    and SuperGrafx are emulated. Mednafen has the ability \
-    to remap hotkey functions and virtual system inputs \
-    to a keyboard, a joystick, or both simultaneously. \
-    Save states are supported, as is real-time game \
-    rewinding.
+description         Portable argument-driven multi-system emulator
+
+long_description    Mednafen is a portable, utilizing OpenGL and SDL, \
+                    argument(command-line)-driven multi-system emulator. \
+                    Mednafen has the ability to remap hotkey functions \
+                    and virtual system inputs to a keyboard, a joystick, \
+                    or both simultaneously. Save states are supported, \
+                    as is real-time game rewinding. Screen snapshots may \
+                    be taken, in the PNG file format, at the press of a \
+                    button. Mednafen can record audiovisual movies in \
+                    the QuickTime file format, with several different \
+                    lossless codecs supported.
 
 homepage            https://mednafen.github.io
 master_sites        ${homepage}/releases/files/
 use_xz              yes
 
-checksums           rmd160  2ab57de60be19f592be69eea88e6372a8d0b27d4 \
-                    sha256  d3cc0c838f496511946d6ea18fda5965d2b71577c610acc811835cc87d152102
+checksums           rmd160   7dbec84f5802ac43a21646337de70ae21ca702be \
+                    sha256   fad433ac694696d69ea38f6f4be1d0a6c1aa3609ec7f46ce75412be2f2df2f95 \
+                    size     3270004
 
 depends_build       port:pkgconfig
 
 depends_lib         \
                     port:gettext \
-                    port:jack \
-                    port:libcdio \
-                    port:libiconv \
-                    port:libsdl \
-                    port:libsdl_net \
+                    port:libsdl2 \
                     port:libsndfile \
                     port:zlib
 
 worksrcdir          ${name}
 
 post-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 755 ${worksrcpath}/README ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 755 ${worksrcpath}/ChangeLog ${destroot}${prefix}/share/doc/${name}
-    xinstall {*}[glob ${worksrcpath}/Documentation/*] ${destroot}${prefix}/share/doc/${name}
+                    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+                    xinstall -m 755 ${worksrcpath}/README ${destroot}${prefix}/share/doc/${name}
+                    xinstall -m 755 ${worksrcpath}/ChangeLog ${destroot}${prefix}/share/doc/${name}
+                    xinstall {*}[glob ${worksrcpath}/Documentation/*] ${destroot}${prefix}/share/doc/${name}
 }
-
-notes "
-Mednafen works by executing the ROM file of a game console you'd like to\
-emulate. Note that no ROM files are included with Mednafen, so first you must\
-obtain the game console ROM file of your choice, by legal means of course.
-
-Supported ROM file formats are listed in section 'File Formats/Expansion\
-Hardware' in the Mednafen documenation at ${prefix}/share/doc/${name}. Once\
-you've obtained a supported type of game console ROM file, start the Mednafen\
-command-line executable and use the ROM filename (including path) as an\
-argument. See the documentation for more options.
-"
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
Update Mednafen to 1.22.2

Tested on:
macOS 10.13.6 17G7024
Xcode 10.1 10B61