### PR TITLE
mysql8: prevent using external boost libs

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -12,8 +12,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} openmaintainer
 homepage                https://www.mysql.com/
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client 1
-set revision_server 2
+set revision_client 2
+set revision_server 3
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -117,7 +117,8 @@ if {$subport eq $name} {
 
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
-                    patch-router-cmake-set_rpath.diff
+                    patch-router-cmake-set_rpath.diff \
+                    patch-sql-local-boost.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports

--- a/databases/mysql8/files/patch-sql-local-boost.diff
+++ b/databases/mysql8/files/patch-sql-local-boost.diff
@@ -1,0 +1,19 @@
+--- a/sql/CMakeLists.txt.orig	2019-04-13 07:46:31.000000000 -0400
++++ b/sql/CMakeLists.txt	2019-06-09 04:02:17.000000000 -0400
+@@ -24,7 +24,15 @@
+ INCLUDE_DIRECTORIES(
+   ${CMAKE_SOURCE_DIR}/libbinlogevents/include
+ )
+-INCLUDE_DIRECTORIES(SYSTEM ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})
++
++# Prevent Boost from including external precompiled Boost libraries
++IF(USING_LOCAL_BOOST)
++  ADD_DEFINITIONS(
++    -DBOOST_ALL_NO_LIB
++)
++ENDIF()
++
++INCLUDE_DIRECTORIES(${BOOST_INCLUDE_DIR} ${BOOST_PATCHES_DIR} SYSTEM)
+ 
+ MY_INCLUDE_SYSTEM_DIRECTORIES(ICU)
+ 


### PR DESCRIPTION
#### Description

This port is configured to acquire and build against its own version of `boost`, since the version of `boost` in MacPorts is not recent enough.  However there is a bug where if MacPorts already has `boost` installed, a part of the build process tries to compile against that instead of its own local `boost`.  This causes the build process to fail.  This patch adds CMake configuration to help ensure that we are only building against the local `boost` lib, and not the one installed and managed by MacPorts.

Related Trac tickets:
- https://trac.macports.org/ticket/58563

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
