### PR TITLE
mosh: include a patch for bind function

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -6,7 +6,7 @@ PortGroup               cxx11 1.1
 
 name                    mosh
 version                 1.3.2
-revision                2
+revision                3
 categories              net
 license                 {GPL-3+ OpenSSLException}
 platforms               darwin
@@ -34,6 +34,8 @@ depends_lib             port:ncurses \
                         port:zlib \
                         port:p${perl5.major}-getopt-long \
                         port:p${perl5.major}-io-socket-ip
+
+patchfiles              network-bind.patch
 
 post-patch {
     reinplace "s|#!/usr/bin/env perl|#!${prefix}/bin/perl${perl5.major}|" \

--- a/net/mosh/files/network-bind.patch
+++ b/net/mosh/files/network-bind.patch
@@ -1,0 +1,11 @@
+--- src/network/network.cc.orig	2017-07-22 21:14:53 UTC
++++ src/network/network.cc
+@@ -335,7 +335,7 @@ bool Connection::try_bind( const char *a
+       }
+     }
+ 
+-    if ( bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
++    if ( ::bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
+       set_MTU( local_addr.sa.sa_family );
+       return true;
+     } else if ( i == search_high ) { /* last port to search */


### PR DESCRIPTION
#### Description

This PR includes a patch from [FreeBSD](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230624) to fix an issue where `std::bind()` (a partial function) conflict with `bind()` (the socket bind) function in newer libc++. This issue has been fixed [upstream](https://github.com/mobile-shell/mosh/pull/996) but has not made into a release yet.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A471t
Xcode 11.0 11M336w

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?