### PR TITLE
mysql8: disable CMake Xcode check and use the compiler-blacklist PG

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -26,6 +26,7 @@ if {$subport eq $name} {
     PortGroup           cmake 1.1
     PortGroup           select 1.0
     PortGroup           compiler_blacklist_versions 1.0
+    PortGroup           legacysupport 1.0
 
     description         Multithreaded SQL database server
     long_description    MySQL is an open-source, multi-threaded SQL database.

--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -12,8 +12,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} openmaintainer
 homepage                https://www.mysql.com/
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client 2
-set revision_server 3
+set revision_client 3
+set revision_server 4
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -25,6 +25,7 @@ if {$subport eq $name} {
     PortGroup           muniversal 1.0
     PortGroup           cmake 1.1
     PortGroup           select 1.0
+    PortGroup           compiler_blacklist_versions 1.0
 
     description         Multithreaded SQL database server
     long_description    MySQL is an open-source, multi-threaded SQL database.
@@ -60,6 +61,8 @@ if {$subport eq $name} {
     select.file         ${filespath}/${name_mysql}
 
     use_parallel_build  yes
+
+    compiler.blacklist-append {clang < 800}
 
     # Use default CMake build_types
     if {[variant_isset debug]} {
@@ -118,7 +121,8 @@ if {$subport eq $name} {
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
                     patch-router-cmake-set_rpath.diff \
-                    patch-sql-local-boost.diff
+                    patch-sql-local-boost.diff \
+                    patch-disable-xcode-check.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports

--- a/databases/mysql8/files/patch-disable-xcode-check.diff
+++ b/databases/mysql8/files/patch-disable-xcode-check.diff
@@ -1,0 +1,42 @@
+--- ./cmake/os/Darwin.cmake.orig	2019-06-10 02:21:49.000000000 -0400
++++ ./cmake/os/Darwin.cmake	2019-06-10 02:46:18.000000000 -0400
+@@ -24,21 +24,24 @@
+ 
+ INCLUDE(CheckCSourceRuns)
+ 
+-# We require at least XCode 9.0
+-IF(NOT FORCE_UNSUPPORTED_COMPILER)
+-  IF(CMAKE_C_COMPILER_ID MATCHES "Clang")
+-    CHECK_C_SOURCE_RUNS("
+-      int main()
+-      {
+-        return (__clang_major__ < 9);
+-      }" HAVE_SUPPORTED_CLANG_VERSION)
+-    IF(NOT HAVE_SUPPORTED_CLANG_VERSION)
+-      MESSAGE(FATAL_ERROR "XCode 9.0 or newer is required!")
+-    ENDIF()
+-  ELSE()
+-    MESSAGE(FATAL_ERROR "Unsupported compiler!")
+-  ENDIF()
+-ENDIF()
++# MACPORTS: XCode version check disabled to rely instead on compiler 
++#           blacklisting in the ports build process.
++# 
++# # We require at least XCode 9.0
++# IF(NOT FORCE_UNSUPPORTED_COMPILER)
++#   IF(CMAKE_C_COMPILER_ID MATCHES "Clang")
++#     CHECK_C_SOURCE_RUNS("
++#       int main()
++#       {
++#         return (__clang_major__ <= 9);
++#       }" HAVE_SUPPORTED_CLANG_VERSION)
++#     IF(NOT HAVE_SUPPORTED_CLANG_VERSION)
++#       MESSAGE(FATAL_ERROR "XCode 9.0 or newer is required!")
++#     ENDIF()
++#   ELSE()
++#     MESSAGE(FATAL_ERROR "Unsupported compiler!")
++#   ENDIF()
++# ENDIF()
+ 
+ # This is used for the version_compile_machine variable.
+ IF(CMAKE_SIZEOF_VOID_P MATCHES 8)


### PR DESCRIPTION

#### Description
This change stops MySQL's CMake build process from checking the XCode version as it's possible that it's not indicative of whether or not MySQL can still build.  We are using the 'compiler-blacklist` portgroup instead.  I don't have access to older platforms and XCode/Clang versions, so I can't comprehensively test this one.

#### Related Trac ticket:
- https://trac.macports.org/ticket/58579


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
