### PR TITLE
py-treq: new port

### DIFF
--- a/python/py-treq/Portfile
+++ b/python/py-treq/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-treq
+version             18.6.0
+revision            0
+
+maintainers         nomaintainer
+description         A requests-like API built on top of twisted.web's Agent
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://github.com/twisted/treq
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+license             MIT
+
+checksums           sha256  91e09ff6b524cc90aa5e934b909c8d0d1a9d36ebd618b6c38e37b17013e69f48 \
+                    rmd160  0960e004dc9769df3228915bba439acc41162294 \
+                    size    59156
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-attrs \
+                    port:py${python.version}-idna \
+                    port:py${python.version}-incremental \
+                    port:py${python.version}-openssl \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-service_identity \
+                    port:py${python.version}-six \
+                    port:py${python.version}-twisted
+
+    depends_test-append \
+                    port:py${python.version}-httpbin \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-pep8 \
+                    port:py${python.version}-pyflakes \
+                    port:py${python.version}-sphinx
+
+    test.run        yes
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+    test.cmd        trial-${python.branch}
+    test.target     treq
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?