### PR TITLE
mail/notmuch: configure script bugfix, dependency update

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -5,6 +5,7 @@ PortGroup           conflicts_build 1.0
 
 name                notmuch
 version             0.29
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -34,11 +35,13 @@ depends_build       port:pkgconfig \
                     port:py37-sphinxcontrib-serializinghtml
 
 depends_lib         port:gmime3 \
+                    port:gpgme \
                     port:talloc \
                     port:xapian-core \
                     port:zlib
 
-patchfiles          ${distname}-doc-makefile.patch \
+patchfiles          ${distname}-configure.patch \
+                    ${distname}-doc-makefile.patch \
                     patch-bindings-python-notmuch-globals.py.diff
 
 post-patch {

--- a/mail/notmuch/files/notmuch-0.29-configure.patch
+++ b/mail/notmuch/files/notmuch-0.29-configure.patch
@@ -1,0 +1,11 @@
+--- configure
++++ configure
+@@ -529,7 +529,7 @@ int main () {
+     return 0;
+ }
+ EOF
+-    if ! TEMP_GPG=$(mktemp -d); then
++    if ! TEMP_GPG=$(mktemp -d -t /tmp); then
+         printf 'No.\nCould not make tempdir for testing session-key support.\n'
+         errors=$((errors + 1))
+     elif ${CC} ${CFLAGS} ${gmime_cflags} _check_session_keys.c ${gmime_ldflags} -o _check_session_keys \


### PR DESCRIPTION
Amendment to #4556
- Added a patch for the configure script to deal with Apple's ancient mktemp binary.
- Added dependency to gpgme.
