### PR TITLE
poppler: really fix self-build conflict

### DIFF
--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -47,6 +47,11 @@ depends_lib-append  port:bzip2 \
                     port:tiff \
                     port:zlib
 
+# remove top-level paths, such that internal headers and
+# libraries are used instead of any already-installed ones.
+configure.ldflags-delete -L${prefix}/lib
+configure.cppflags-delete -I${prefix}/include
+
 configure.ldflags-append -liconv
 gobject_introspection yes
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58574

#### Description

Instead of adding the build conflict removed by https://trac.macports.org/changeset/18c09e26c90050596ad6c20e7c181de06c03e917/macports-ports , let's just fixup the Portfile so that this issue no longer exists.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
