### PR TITLE
mail/notmuch: configure phase bugfix V2

### DIFF
--- a/mail/notmuch/files/notmuch-0.29-configure.patch
+++ b/mail/notmuch/files/notmuch-0.29-configure.patch
@@ -5,7 +5,7 @@
  }
  EOF
 -    if ! TEMP_GPG=$(mktemp -d); then
-+    if ! TEMP_GPG=$(mktemp -d -t /tmp); then
++    if ! TEMP_GPG=$(mktemp -d /tmp/notmuch.XXXXXXXX); then
          printf 'No.\nCould not make tempdir for testing session-key support.\n'
          errors=$((errors + 1))
      elif ${CC} ${CFLAGS} ${gmime_cflags} _check_session_keys.c ${gmime_ldflags} -o _check_session_keys \


### PR DESCRIPTION
Amendment to #4573

The configure phase fails on OS X 10.10 and older due to a length limitation for GNUPGHOME. I changed the relevant mktemp statement again, to create a temporary home within in the build directory.

I don't have any old OS X installation to test on, so I am relying on the MacPorts CI process for this pull request.