### PR TITLE
WIP ShellCheck: update to 0.6.0

### DIFF
--- a/devel/hs-aeson-devel/Portfile
+++ b/devel/hs-aeson-devel/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       aeson 1.4.3.0
+name                hs-aeson-devel
+revision            0
+checksums           rmd160  27986996c031040f85b975faf1e9c173a69df463 \
+                    sha256  6564ac0fb429cd4bcafc706fa4b905dab94f57f765ebd96a65c9ba4b9e520c19 \
+                    size    272210
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/bos/aeson
+
+description         Fast JSON parsing and encoding
+long_description    \
+    A JSON parsing and encoding library optimized for ease of use and high performance.
+
+depends_lib-append  \
+                    port:hs-attoparsec-devel \
+                    port:hs-base-compat \
+                    port:hs-contravariant \
+                    port:hs-dlist \
+                    port:hs-hashable-devel \
+                    port:hs-nats-devel \
+                    port:hs-primitive-devel \
+                    port:hs-scientific \
+                    port:hs-semigroups \
+                    port:hs-tagged \
+                    port:hs-text-devel \
+                    port:hs-th-abstraction \
+                    port:hs-time-locale-compat \
+                    port:hs-transformers-compat \
+                    port:hs-unordered-containers-devel \
+                    port:hs-uuid-types \
+                    port:hs-vector-devel \
+                    port:hs-void-devel

--- a/devel/hs-attoparsec-devel/Portfile
+++ b/devel/hs-attoparsec-devel/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       attoparsec 0.13.2.2
+name                hs-attoparsec-devel
+revision            0
+checksums           rmd160  e85cd747d37b5a456a32ac379cbef84cc3948b93 \
+                    sha256  dd93471eb969172cc4408222a3842d867adda3dd7fb39ad8a4df1b121a67d848 \
+                    size    159729
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/bos/attoparsec
+
+description         A fast parser combinator library
+
+long_description    \
+    A fast parser combinator library, aimed particularly at dealing \
+    efficiently with network protocols and complicated text/binary file \
+    formats.
+
+depends_lib-append  \
+                    port:hs-fail \
+                    port:hs-scientific-devel \
+                    port:hs-semigroups-devel \
+                    port:hs-text-devel

--- a/devel/hs-base-compat/Portfile
+++ b/devel/hs-base-compat/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       base-compat 0.10.5
+name                hs-base-compat
+revision            0
+checksums           rmd160  459e98340b34eda19ad9e10807f7abda160fa632 \
+                    sha256  990aea21568956d44ab018c5dbfbaea014b9a0d5295d29ca7550149419a6fb41 \
+                    size    33158
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             MIT
+homepage            https://github.com/haskell-compat/base-compat
+
+description         A compatibility layer for base
+
+long_description    \
+    Provides functions available in later versions of base to a wider range of compilers, \
+    without requiring you to use CPP pragmas in your code.

--- a/devel/hs-contravariant/Portfile
+++ b/devel/hs-contravariant/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       contravariant 1.5.2
+revision            0
+checksums           rmd160  142d8aa32515fe8db59c3ecde43b337c72343e75 \
+                    sha256  c4262c24e3dcc2ba8ca221ed52a6390818a715301e4f13135d8d732e0c7dc60c \
+                    size    16006
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/ekmett/contravariant/
+
+description         Contravariant functors
+
+long_description    \
+    This package provides: \
+    \n - Data.Functor.Contravariant.Compose \
+    \n - Data.Functor.Contravariant.Divisible \
+    \n - Data.Functor.Contravariant.Generic
+
+depends_lib-append  \
+                    port:hs-statevar \
+                    port:hs-tagged \
+                    port:hs-transformers-compat \
+                    port:hs-void-devel

--- a/devel/hs-dlist/Portfile
+++ b/devel/hs-dlist/Portfile
@@ -3,16 +3,19 @@
 PortSystem          1.0
 PortGroup           haskell 1.0
 
-haskell.setup       dlist 0.6.0.1
-revision            2
-checksums           rmd160  83eecf68ef17b8897a69f06b3b09366c645b5dfa \
-                    sha256  85c485d7b2d347847f4b8f49d9ec054d57703ef666623b62042a15f8996e0823
+haskell.setup       dlist 0.8.0.6
+revision            0
+checksums           rmd160  c5f4e238508449c5b6758ed8dde734d1e308e393 \
+                    sha256  780b4ac91d6e88e77ebf1629568bddd45959b8e0cd295b17c7d55d835c03c73f \
+                    size    9057
 
 maintainers         {cal @neverpanic} openmaintainer
 platforms           darwin
 license             BSD
+homepage            https://github.com/spl/dlist
 
 description         Differences lists
+
 long_description    \
     Differences lists: a list-like type supporting O(1) append. This is \
     particularly useful for efficient logging and pretty printing, (e.g. with \

--- a/devel/hs-fail/Portfile
+++ b/devel/hs-fail/Portfile
@@ -1,0 +1,20 @@
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       fail 4.9.0.0
+revision            0
+checksums           rmd160  5f362dad5753c8293a0a08da8956b732271e98ae \
+                    sha256  6d5cdb1a5c539425a9665f740e364722e1d9d6ae37fbc55f30fe3dbbbb91d4a2 \
+                    size    2416
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail
+
+description         Forward-compatible MonadFail class
+
+long_description    \
+    This package contains the Control.Monad.Fail module providing the \
+    MonadFail class that became available in base-4.9.0.0 for older base \
+    package versions.

--- a/devel/hs-generic-deriving/Portfile
+++ b/devel/hs-generic-deriving/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       generic-deriving 1.12.4
+revision            0
+checksums           rmd160  4d586154ee88e2b903fccd1f4e18b8a28c7c8df5 \
+                    sha256  4401c13d38938338fb152bbc1049c5e1f880199afc2015421d5496811b4eaf6d \
+                    size    67688
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/dreixel/generic-deriving
+
+description         Generic programming library for generalised deriving
+
+long_description    \
+    This package provides functionality for generalising the deriving mechanism \
+    in Haskell to arbitrary classes. It was first described in the paper: \
+    A generic deriving mechanism for Haskell. Jose Pedro Magalhaes, \
+    Atze Dijkstra, Johan Jeuring, and Andres Loeh. Haskell'10.
+
+depends_lib-append  port:hs-th-abstraction

--- a/devel/hs-hashable-devel/Portfile
+++ b/devel/hs-hashable-devel/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       hashable 1.2.7.0
+name                hs-hashable-devel
+revision            0
+checksums           rmd160  cff9cff44a2bc6a3cc3defd63cb02c72b5e12a04 \
+                    sha256  ecb5efc0586023f5a0dc861100621c1dbb4cbb2f0516829a16ebac39f0432abf \
+                    size    30182
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            http://github.com/tibbe/hashable
+
+description         A class for types that can be converted to a hash value
+
+long_description    \
+    This package defines a class, Hashable, for types that can be converted \
+    to a hash value. This class exists for the benefit of hashing-based \
+    data structures. The package provides instances for basic types and a way \
+    to combine hash values.
+
+depends_lib-append  port:hs-text-devel

--- a/devel/hs-integer-logarithms/Portfile
+++ b/devel/hs-integer-logarithms/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       integer-logarithms 1.0.3
+revision            0
+checksums           rmd160  ac15eb20926ddbe7e8fb66c1d3239ced8dcae16b \
+                    sha256  5ae262018698af35bb74916fad170d96d3eb44669c72ed36db9a19a3392cec16 \
+                    size    8840
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             MIT
+homepage            https://github.com/Bodigrim/integer-logarithms
+
+description         Integer logarithms
+
+long_description    Integer logarithms, originally split from arithmoi package
+
+depends_lib-append  port:hs-nats-devel

--- a/devel/hs-mtl-devel/Portfile
+++ b/devel/hs-mtl-devel/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       mtl 2.2.2
+name                hs-mtl-devel
+revision            0
+checksums           rmd160  dc0359ce7de9018c4d68370e9b7af830c53009a4 \
+                    sha256  8803f48a8ed33296c3a3272f448198737a287ec31baa901af09e2118c829bef6 \
+                    size    16966
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/haskell/mtl
+
+description         Monad classes, using functional dependencies
+
+long_description    \
+        Monad classes using functional dependencies, with instances for various \
+        monad transformers, inspired by the paper Functional Programming with \
+        Overloading and Higher-Order Polymorphism, by Mark P Jones, in Advanced \
+        School of Functional Programming, 1995
+
+# needs hs-transformers >= 0.4
+depends_lib-append  port:hs-transformers-devel

--- a/devel/hs-nats-devel/Portfile
+++ b/devel/hs-nats-devel/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       nats 1.1.2
+name                hs-nats-devel
+revision            0
+checksums           rmd160  22fd69f162b4a7dc87b2755ad89a88ee12ee35c6 \
+                    sha256  b9d2d85d8612f9b06f8c9bfd1acecd848e03ab82cfb53afe1d93f5086b6e80ec \
+                    size    7776
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/ekmett/nats/
+
+description         Haskell 98 natural numbers
+long_description    ${description}
+
+depends_lib-append  port:hs-hashable-devel

--- a/devel/hs-primitive-devel/Portfile
+++ b/devel/hs-primitive-devel/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       primitive 0.6.4.0
+name                hs-primitive-devel
+revision            0
+checksums           rmd160  f8d0bec3981b9c24db73eaadeff79b3a9511638c \
+                    sha256  4cbeaf7924dd79221f327ea101a29bf35c4976dc3319df157ff46ea68e6a0c64 \
+                    size    45937
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/haskell/primitive
+
+description         Primitive memory-related operations
+long_description    ${description}

--- a/devel/hs-scientific-devel/Portfile
+++ b/devel/hs-scientific-devel/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       scientific 0.3.6.2
+name                hs-scientific-devel
+revision            0
+checksums           rmd160  8dd3b320db88ed7a239197ec212e221c584ecfa3 \
+                    sha256  278d0afc87450254f8a76eab21b5583af63954efc9b74844a17a21a68013140f \
+                    size    23510
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/basvandijk/scientific
+
+description         Numbers represented using scientific notation
+
+long_description    \
+    Data.Scientific provides a space efficient and arbitrary precision \
+    scientific number type.
+
+depends_lib-append  \
+                    port:hs-hashable-devel \
+                    port:hs-text-devel \
+                    port:hs-integer-logarithms \
+                    port:hs-primitive-devel

--- a/devel/hs-semigroups-devel/Portfile
+++ b/devel/hs-semigroups-devel/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       semigroups 0.18.5
+name                hs-semigroups-devel
+revision            0
+checksums           rmd160  9aee2d58d99363ddc9848498c734e85262130e5d \
+                    sha256  ab2a96af6e81e31b909c37ba65f436f1493dbf387cfe0de10b6586270c4ce29d \
+                    size    20162
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/ekmett/semigroups/
+
+description         Haskell 98 semigroups
+
+long_description    \
+    In mathematics, a semigroup is an algebraic structure consisting of a set \
+    together with an associative binary operation. A semigroup generalizes \
+    a monoid in that there might not exist an identity element. It also \
+    (originally) generalized a group (a monoid with all inverses) to a type \
+    where every element did not have to have an inverse, thus the name \
+    semigroup.
+
+depends_lib-append  \
+                    port:hs-hashable-devel \
+                    port:hs-nats-devel \
+                    port:hs-tagged \
+                    port:hs-transformers-compat \
+                    port:hs-text-devel \
+                    port:hs-unordered-containers-devel

--- a/devel/hs-statevar/Portfile
+++ b/devel/hs-statevar/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       StateVar 1.2
+name                hs-statevar
+revision            0
+checksums           rmd160  f45b0d43284b3af13071809973716fcfbdc6824c \
+                    sha256  afc036021fcd38f15fcc4af392a3e57017d5ddcc926e99391dbfc8c4e6375f8b \
+                    size    4770
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/haskell-opengl/StateVar
+
+description         State variables
+
+long_description    \
+    This package contains state variables, which are references in the IO monad, \
+    like IORefs or parts of the OpenGL state.
+
+depends_lib-append  port:hs-stm

--- a/devel/hs-tagged/Portfile
+++ b/devel/hs-tagged/Portfile
@@ -3,14 +3,18 @@
 PortSystem          1.0
 PortGroup           haskell 1.0
 
-haskell.setup       tagged 0.7
-revision            3
-checksums           rmd160  7716bd84272ced0ab8d86d07ccb3b601b64a8082 \
-                    sha256  f51b0ff097dadfa0508d4fff889f96e274743876c33f13c08335aca80d85e8bc
+haskell.setup       tagged 0.8.6
+revision            0
+checksums           rmd160  050cdac17ff3c87ace3e7df011fa9516ca686bfc \
+                    sha256  ad16def0884cf6f05ae1ae8e90192cf9d8d9673fa264b249499bd9e4fac791dd \
+                    size    11759
 
 license             BSD
 maintainers         {cal @neverpanic} openmaintainer
 platforms           darwin
+homepage            https://github.com/ekmett/tagged
 
 description         Haskell 98 phantom types to avoid unsafely passing dummy arguments
 long_description    ${description}
+
+depends_lib-append  port:hs-transformers-compat

--- a/devel/hs-text-devel/Portfile
+++ b/devel/hs-text-devel/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       text 1.2.3.1
+name                hs-text-devel
+revision            0
+checksums           rmd160  91d24a5de8b3b15655ffe46123ddb7256952f1f8 \
+                    sha256  8360624d5d01f278da320eebd16fd5d6f366b7f876d0ad424041d58e5e1147a6 \
+                    size    157382
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/haskell/text
+
+description         An efficient packed Unicode text type
+
+long_description    \
+    An efficient packed, immutable Unicode text type (both strict and lazy), \
+    with a powerful loop fusion optimization framework. The Text type represents \
+    Unicode character strings, in a time and space-efficient manner. \
+    This package provides text processing capabilities that are optimized for \
+    performance critical use, both in terms of large data quantities and high speed.

--- a/devel/hs-th-abstraction/Portfile
+++ b/devel/hs-th-abstraction/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       th-abstraction 0.3.1.0
+revision            0
+checksums           rmd160  93e265849febb38175121d22c2443e4225bceb6d \
+                    sha256  4b9e1bcc6ec3d897fb09c3d7fa2f37f0672d5370e0e3e49809886da81fe001b9 \
+                    size    34248
+
+license             ISC
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/glguy/th-abstraction
+
+description         Nicer interface for reified information about data types
+
+long_description    \
+    This package normalizes variations in the interface for inspecting datatype \
+    information via Template Haskell so that packages and support a single, easier \
+    to use informational datatype while supporting many versions of Template Haskell.

--- a/devel/hs-time-locale-compat/Portfile
+++ b/devel/hs-time-locale-compat/Portfile
@@ -1,0 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       time-locale-compat 0.1.1.5
+revision            0
+checksums           rmd160  f1144e9d37022b6065f47d2d71b35f1dcccfb7b2 \
+                    sha256  07ff1566de7d851423a843b2de385442319348c621d4f779b3d365ce91ac502c \
+                    size    1956
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/khibino/haskell-time-locale-compat
+
+description         Wrapped name module for time-format locale between old-locale and time-1.5.
+long_description    ${description}

--- a/devel/hs-transformers-compat/Portfile
+++ b/devel/hs-transformers-compat/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       transformers-compat 0.6.5
+revision            0
+checksums           rmd160  c0af2e8d2fdc91618e48deb573791b0aac778e74 \
+                    sha256  da67cf11515da751b32a8ce6e96549f7268f7c435769ad19dc9766b69774620b \
+                    size    40421
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/ekmett/transformers-compat/
+
+description         Compatibility shim for the transformers library
+
+long_description    \
+    This package includes backported versions of types that were \
+    added to transformers in transformers 0.3, 0.4, and 0.5 for users \
+    who need strict transformers 0.2 or 0.3 compatibility to run on \
+    old versions of the platform, but also need those types.
+
+depends_lib-append  \
+                    port:hs-fail \
+                    port:hs-generic-deriving \
+                    port:hs-mtl-devel

--- a/devel/hs-transformers-devel/Portfile
+++ b/devel/hs-transformers-devel/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       transformers 0.5.6.2
+name                hs-transformers-devel
+revision            0
+checksums           rmd160  458eb178d1139f5ea9a35412b9c693c66bfc517d \
+                    sha256  b668795d600297e4c8a7fd55a107b9827b2c52c0bc14c5ea0d65e20e6691c66c \
+                    size    42370
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://hub.darcs.net/ross/transformers
+
+description         Concrete functor and monad transformers
+
+long_description    \
+    A portable library of functor and monad transformers, containing: \
+    \n - the monad transformer class (in Control.Monad.Trans.Class) \
+    \n - concrete functor and monad transformers, each with associated \
+    operations and functions to lift operations associated with other \
+    transformers.

--- a/devel/hs-unordered-containers-devel/Portfile
+++ b/devel/hs-unordered-containers-devel/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       unordered-containers 0.2.10.0
+name                hs-unordered-containers-devel
+revision            0
+checksums           rmd160  b0a825c7c5fde3d5cb4136790f59c677e03eef41 \
+                    sha256  65f117bdbdea9efc75fb9fd539873de7687e005d8898bb21821020a4b383c573 \
+                    size    44733
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/tibbe/unordered-containers
+
+description         Efficient hashing-based container types
+
+long_description    \
+    Efficient hashing-based container types. The containers have been optimized for \
+    performance critical use, both in terms of large data quantities and high speed.
+
+depends_lib-append  port:hs-hashable-devel

--- a/devel/hs-uuid-types/Portfile
+++ b/devel/hs-uuid-types/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       uuid-types 1.0.3
+revision            0
+checksums           rmd160  c308fb6772f4dff0a6a7f561610c5a739b636a12 \
+                    sha256  9276517ab24a9b06f39d6e3c33c6c2b4ace1fc2126dbc1cd9806866a6551b3fd \
+                    size    11999
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/aslatter/uuid
+
+description         Type definitions for Universally Unique Identifiers
+long_description    ${description}
+
+depends_lib-append  \
+                    port:hs-hashable-devel \
+                    port:hs-random \
+                    port:hs-text-devel

--- a/devel/hs-vector-devel/Portfile
+++ b/devel/hs-vector-devel/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       vector 0.12.0.3
+name                hs-vector-devel
+revision            0
+checksums           rmd160  c030f62c6116e7701ec727b18a9c630a77f70281 \
+                    sha256  b8a2bfbf9d22d34a28cde9b9e92bfb054e46797754154dd5883295c38936e5a8 \
+                    size    124899
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             BSD
+homepage            https://github.com/haskell/vector
+
+description         Efficient arrays
+
+long_description    An efficient implementation of Int-indexed arrays (both mutable \
+                    and immutable), with a powerful loop optimisation framework.
+
+depends_lib-append  \
+                    port:hs-fail \
+                    port:hs-primitive-devel \
+                    port:hs-semigroups-devel

--- a/devel/hs-void-devel/Portfile
+++ b/devel/hs-void-devel/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell 1.0
+
+haskell.setup       void 0.7.3
+name                hs-void-devel
+revision            0
+checksums           rmd160  a0a57f9add4ace1b263572676f510c61f47dcbb7 \
+                    sha256  53af758ddc37dc63981671e503438d02c6f64a2d8744e9bec557a894431f7317 \
+                    size    6741
+
+license             BSD
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+homepage            https://github.com/ekmett/void
+
+description         A Haskell 98 logically uninhabited data type
+
+long_description    \
+    A Haskell 98 logically uninhabited data type, used to indicate that a given \
+    term should not exist.
+
+depends_lib-append  port:hs-hashable-devel \
+                    port:hs-semigroups-devel

--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -1,24 +1,29 @@
 PortSystem          1.0
 PortGroup           haskell 1.0
 
-haskell.setup       ShellCheck 0.3.8
+haskell.setup       ShellCheck 0.6.0
 name                shellcheck
-checksums           rmd160  18780082aa13e56f84fdd3bd0ddbcb98ccefb117 \
-                    sha256  c185b77166724c06531b3e07b7a8353c0451809a1f60e9f6756d29247853651a
+revision            0
+checksums           rmd160  72f643df053b295a3c603a0bee5150c2702a57b1 \
+                    sha256  f6e79fb34d076504176761cc8b7c3f996f8d31bed23250fb1570e32283cd7df6 \
+                    size    140211
 
 license             GPL-3+
 maintainers         {cal @neverpanic} openmaintainer
 platforms           darwin
 homepage            https://github.com/koalaman/shellcheck
 
-# needs hs-quickcheck >= 2.7.4
-depends_lib-append  port:hs-json \
-                    port:hs-mtl \
+# needs hs-quickcheck >= 2.7.4, hs-mtl >= 2.2
+depends_lib-append  \
+                    port:hs-aeson-devel \
+                    port:hs-mtl-devel \
                     port:hs-parsec \
                     port:hs-quickcheck-devel \
-                    port:hs-regex-tdfa
+                    port:hs-regex-tdfa \
+                    port:hs-semigroups-devel
 
 description         ShellCheck, a static analysis tool for shell scripts
+
 long_description    \
     The goals of ShellCheck are: \
     \n - To point out and clarify typical beginner's syntax issues, that causes a shell to give cryptic error messages. \


### PR DESCRIPTION
#### Description

This PR update ShellCheck to 0.6.0 and upgrade/introduce a new port of all dependencies required to get it running. ShellCheck has since switched from `hs-json` to `hs-aeson`, and even though [ShellCheck dependencies](https://hackage.haskell.org/package/ShellCheck-0.6.0/dependencies) says any version of `aeson` is fine, it actually requires a newer version of `aeson` (thus existing `hs-aeson` does not work). 

So instead of updating `hs-aeson`, which may break other packages in process, I decided to create `hs-aeson-devel` and add new port for its dependencies, using `-devel` suffix in its name (if the package already exists). Some `-devel` package can be link against the existing `hs-hashable` in MacPorts, but `hs-aeson-devel` require `hashable >=1.2.7.0`, so I have to link its dependencies with `hs-hashable-devel` because otherwise `hs-aeson` will fail to build (due to deriving error with `Hashable Text`).

I tried to keep the dependencies tree clean by following few rules:

* Any dependencies of `hs-aeson-devel` are linked against `hs-hashable-devel`
* Any `-devel` packages are linked against `-devel` packages instead of haskell-platform
* Any non-`-devel` packages are linked against packages in haskell-platforms if possible

Please consider this PR as a **WIP**, as I believe it require a lot more work to be done before it can be merged, but I need feedback from existing maintainers, so I'm sorry for opening a WIP PR.

Thanks!

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A471t
Xcode 11.0 11M336w

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

I used `sudo port -vs install` to install because I cannot enable tracing on GHC possibly because I'm running a beta software (sorry about this); the process simply hangs and require kill -9 to exit.