### PR TITLE
py-uncertainties: update to 3.1.1, add noarch

### DIFF
--- a/python/py-uncertainties/Portfile
+++ b/python/py-uncertainties/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 PortGroup               github 1.0
 
-github.setup            lebigot uncertainties 3.1
+github.setup            lebigot uncertainties 3.1.1
 revision                0
 
 name                    py-uncertainties
@@ -15,10 +15,11 @@ description             The python uncertainties package.
 long_description        The uncertainties package transparently handles\
                         calculations for numbers with uncertainties.
 platforms               darwin
+supported_archs         noarch
 
-checksums               rmd160  f09f08c1cc5ee33b83790a063af5928804c1f972 \
-                        sha256  5c7258da19fa611d15295d64995be82e6eeea9da70a7bc64eccfcbfec933df66 \
-                        size    147879
+checksums               rmd160  d615a1e89fc708dbe133b392ef0d993f64c3fe55 \
+                        sha256  ce6cde393948e011023104d8b01fcae1dcaeadb70ab00f5fbcc9e31100358714 \
+                        size    148169
 
 python.versions         27 34 35 36 37
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
