### PR TITLE
new port: sshuttle

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        sshuttle sshuttle 0.78.5 v
+fetch.type          git
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+categories          net
+description         Transparent proxy server that works as a poor man's VPN.
+long_description    Transparent proxy server that works as a poor man's VPN. \
+                    Forwards over ssh. Doesn't require admin. Works with \
+                    Linux and MacOS. Supports DNS tunneling. 
+
+platforms           darwin
+license             LGPL-2
+homepage            https://sshuttle.readthedocs.io/en/stable/
+
+python.default_version      37
+python.versions     27 35 35 37
+
+depends_build-append port:py${python.version}-setuptools \
+                     port:py${python.version}-setuptools_scm


### PR DESCRIPTION
#### Description

New port for sshuttle ( https://github.com/sshuttle/sshuttle )

#### Related Trac tickets:
- https://trac.macports.org/ticket/48460
- https://trac.macports.org/ticket/52198

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
