### PR TITLE
ipfs: submission

### DIFF
--- a/net/ipfs/Portfile
+++ b/net/ipfs/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/ipfs/go-ipfs 0.4.21 v
+name                ipfs
+categories          net
+checksums           rmd160  449fff53125df076d113d7501bd3f192a8904dab \
+                    sha256  cfcd121f26939df24172a25501616d51792d26f1a36bfdfbfde8e9e2f28296b5 \
+                    size    736479
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+platforms           darwin
+license             MIT
+homepage            https://ipfs.io
+
+description         Global, versioned, peer-to-peer filesystem
+long_description    IPFS is a global, versioned, peer-to-peer filesystem. \
+                    It combines good ideas from Git, BitTorrent, Kademlia, \
+                    SFS, and the Web. It is like a single bittorrent swarm, \
+                    exchanging git objects. IPFS provides an interface as \
+                    simple as the HTTP web, but with permanence built in.
+
+depends_build       port:go
+
+build.cmd           make
+build.target        build
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/cmd/ipfs/ipfs ${destroot}${prefix}/bin
+    xinstall -d ${destroot}${prefix}/share/examples/${name}
+    xinstall -W ${worksrcpath}/misc/launchd io.ipfs.ipfs-daemon.plist ${destroot}${prefix}/share/examples/${name}/ipfs.plist
+    reinplace "s|{{IPFS_BIN}}|${prefix}/bin/ipfs|g" ${destroot}${prefix}/share/examples/${name}/ipfs.plist
+    reinplace "s|{{IPFS_PATH}}|/Users/USERNAME/.ipfs|g" ${destroot}${prefix}/share/examples/${name}/ipfs.plist
+}
+
+notes-append \
+    "IPFS provides an example launchd plist. To use it:" \
+    "1. Copy ${prefix}/share/examples/${name}/ipfs.plist to ~/Library/LaunchAgents" \
+    "2. Edit ipfs.plist by replacing USERNAME with your actual username" \
+    "3. Log out and in again, or run: launchctl load ~/Library/LaunchAgents/ipfs.plist"
+
+github.livecheck.regex  {([0-9.-]+)}


### PR DESCRIPTION
#### Description

This port installs [ipfs](https://github.com/ipfs/go-ipfs/), a global, versioned, peer-to-peer filesystem. 

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A471t
Xcode 11.0 11M336w

###### Verification 

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?