### PR TITLE
botan: minor changes for botan2 and simplification/cleanup

### DIFF
--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -12,15 +12,13 @@ subport ${name}-qt5     {}
 if {[string match "${name}-qt5*" ${subport}]} {
     PortGroup           qt5 1.0
     set Qt_Major        5
-    if {[vercmp ${qt5.version} 5.7]>=0} {
-        PortGroup       cxx11 1.1
-    }
 } else {
     PortGroup           qt4 1.0
     set Qt_Major        4
 }
 # best included after the required Qt PG
 PortGroup               cmake 1.1
+PortGroup               cxx11 1.1
 
 categories              devel crypto security
 maintainers             {gmail.com:rjvbertin @RJVB} openmaintainer
@@ -38,10 +36,6 @@ use_xz                  yes
 checksums               rmd160  dddc3cf240dc5424b9df13fc1bf41c8e04f3b814 \
                         sha256  d716d2d8e3ed8d95bbdb061f03081d7d032206f746a30a4d29d72196f50e7b02 \
                         size    691676
-
-depends_lib-append      port:botan \
-                        port:libgcrypt \
-                        port:nss
 
 patch.pre_args          -Np1
 patchfiles-append       patch-qca-ossl.diff \
@@ -62,8 +56,11 @@ configure.args          -DCMAKE_INSTALL_PREFIX:PATH=${qt_dir} \
                         -DQCA_DOC_INSTALL_DIR:PATH=${qt_docs_dir} \
                         -DQCA_MAN_INSTALL_DIR:PATH=${prefix}/share/man \
                         -DPKGCONFIG_INSTALL_PREFIX:PATH=${qt_pkg_config_dir} \
-                        -DOSX_FRAMEWORK:BOOL=OFF \
-                        -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+                        -DOSX_FRAMEWORK:BOOL=OFF
+
+# botan requires C++11
+configure.cxxflags-append \
+                        -std=c++11
 
 if {${Qt_Major} eq "4"} {
     configure.args-append \
@@ -106,58 +103,52 @@ variant examples description {Include examples in install} {
 ### Plugin subports:
 ### The ossl, cyrus-sasl and gnupg plugins used to be standalone ports
 ### are now implemented as subports. The other plugins are built together with
-### the main port; I don't see a reason to introduce new subports for components
-### that used to be built along with the main ports, only to impose new dependencies
-### on the ports that require qca.
-### 
+### the main ports.
+###
 # Qt4 receives no suffix:
 set qt.versions     {"" "-qt5"}
 foreach qv ${qt.versions} {
+    # the main ports
+    if {${subport} eq "${name}${qv}"} {
+        # revbump for botan2
+        revision                1
+        depends_lib-append      port:botan \
+                                port:libgcrypt \
+                                port:nss
+        configure.args-append   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+    }
+
+    # plugins depend on the corresponding main port and the libraries of which they expose the Functionality
     subport ${name}${qv}-ossl {
         license                 LGPL-2.1+
-        depends_lib-append      port:${name}${qv} port:openssl
-        configure.args-delete   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+        depends_lib             port:${name}${qv} port:openssl
         configure.args-append   -DBUILD_PLUGINS:STRING="ossl"
         build.dir               ${workpath}/build/plugins/qca-ossl
     }
     subport ${name}${qv}-cyrus-sasl {
         license                 LGPL-2.1+
-        depends_lib-append      port:${name}${qv} port:cyrus-sasl2
-        configure.args-delete   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+        depends_lib             port:${name}${qv} port:cyrus-sasl2
         configure.args-append   -DBUILD_PLUGINS:STRING="cyrus-sasl"
         build.dir               ${workpath}/build/plugins/qca-cyrus-sasl
     }
     subport ${name}${qv}-gnupg {
         license                 LGPL-2.1+
-        depends_lib-append      port:${name}${qv}
-        configure.args-delete   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+        depends_lib             port:${name}${qv}
         configure.args-append   -DBUILD_PLUGINS:STRING="gnupg"
         build.dir               ${workpath}/build/plugins/qca-gnupg
     }
     subport ${name}${qv}-pkcs11 {
         license                 LGPL-2.1+
-        depends_lib-append      port:${name}${qv} port:openssl port:pkcs11-helper
-        configure.args-delete   -DBUILD_PLUGINS:STRING="botan\;gcrypt\;logger\;nss\;softstore"
+        depends_lib             port:${name}${qv} port:openssl port:nss port:pkcs11-helper
         configure.args-append   -DBUILD_PLUGINS:STRING="pkcs11"
         build.dir               ${workpath}/build/plugins/qca-pkcs11
     }
 }
-### Provide stub subports for those plugins that have been available through
-### a subport for a while.
+
 foreach virtual {"botan" "gcrypt" "logger" "nss" "softstore"} {
     subport ${name}-${virtual} {
-        archive_sites
-        distfiles
-        depends_lib         port:${name}
-        use_configure       no
-        supported_archs     noarch
-        patchfiles
-        build {}
-        destroot {
-            set stubdir ${destroot}${prefix}/share/doc/${subport}
-            xinstall -d -m 755 ${stubdir}
-            system "touch ${stubdir}/.this.is.a.stubport"
-        }
+        replaced_by         qca
+        PortGroup           obsolete 1.0
     }
 }
 


### PR DESCRIPTION
    Makes plugin subports depend only on the corresponding main port
    and whatever additional libraries they need. Botan in particular is
    a dependency only for the qca-botan plugin that is included in the main
    port.
    Also, the stub subports are now obsolete and can be retired at the next
    release.

This supercedes the corresponding change to port:qca in #4571 
Depends on #4571 (the port:botan change)