### PR TITLE
sshuttle: requires setuptools to run

### DIFF
--- a/net/sshuttle/Portfile
+++ b/net/sshuttle/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 
 github.setup        sshuttle sshuttle 0.78.5 v
 fetch.type          git
+revision            1
 
 maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 categories          net
@@ -23,3 +24,5 @@ python.versions     27 35 36 37
 
 depends_build-append port:py${python.version}-setuptools \
                      port:py${python.version}-setuptools_scm
+
+depends_run-append  port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Add explicit run dependency on `setuptools` as sshuttle also requires it at runtime.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
