### PR TITLE
ports abandoned by googlemail.com:usx303

### DIFF
--- a/net/argus-clients/Portfile
+++ b/net/argus-clients/Portfile
@@ -7,8 +7,7 @@ version         3.0.8
 revision        2
 categories      net
 license         GPL-2+ BSD-old
-maintainers     googlemail.com:usx303 \
-                openmaintainer
+maintainers     nomaintainer
 
 homepage        http://www.qosient.com/argus/
 description     Network Audit Record Generation and Utilization System

--- a/security/libprelude/Portfile
+++ b/security/libprelude/Portfile
@@ -8,8 +8,7 @@ set download_id 241
 revision        5
 categories      security
 license         GPL-2+
-maintainers     googlemail.com:usx303 \
-                openmaintainer
+maintainers     nomaintainer
 
 description     Prelude Universal SIM - framework library
 

--- a/security/libpreludedb/Portfile
+++ b/security/libpreludedb/Portfile
@@ -7,8 +7,7 @@ version         0.9.15.1
 revision        1
 categories      security
 license         GPL-2+
-maintainers     googlemail.com:usx303 \
-                openmaintainer
+maintainers     nomaintainer
 
 description     Prelude Universal SIM - database wrapper
 

--- a/security/nbtscan/Portfile
+++ b/security/nbtscan/Portfile
@@ -6,7 +6,7 @@ name            nbtscan
 version         1.5.1
 revision        1
 categories      security
-maintainers     googlemail.com:usx303
+maintainers     nomaintainer
 
 description     NBTscan
 

--- a/security/prelude-lml/Portfile
+++ b/security/prelude-lml/Portfile
@@ -7,8 +7,7 @@ version         0.9.12.2
 revision        1
 categories      security
 license         GPL-3+
-maintainers     googlemail.com:usx303 \
-                openmaintainer
+maintainers     nomaintainer
 
 description     Prelude Network Intrusion Detection System Log Monitoring Lackey
 

--- a/security/prelude-manager/Portfile
+++ b/security/prelude-manager/Portfile
@@ -7,8 +7,7 @@ version         0.9.14
 revision        3
 categories      security
 license         GPL-3+
-maintainers     googlemail.com:usx303 \
-                openmaintainer
+maintainers     nomaintainer
 
 description     Prelude Universal SIM - manager
 


### PR DESCRIPTION
argus-clients libprelude libpreludedb nbtscan prelude-ml prelude-manager

Closes: https://trac.macports.org/ticket/58400
See: https://trac.macports.org/ticket/55133

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
Any better suggestions for commit message with this many abandoned ports?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
