### PR TITLE
p5-graveyard: restore missing '}'

### DIFF
--- a/perl/p5-graveyard/Portfile
+++ b/perl/p5-graveyard/Portfile
@@ -1705,6 +1705,7 @@ foreach branch $defaultBranches {
         revision 2
         replaced_by subversion-perlbindings-$replacements($branch)
     }
+}
 
 if {${subport} ne ${name}} {
     PortGroup obsolete 1.0


### PR DESCRIPTION
Erroneously deleted in 980c517f4e

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
