### PR TITLE
py-httpbin: new port

### DIFF
--- a/python/py-httpbin/Portfile
+++ b/python/py-httpbin/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-httpbin
+version             0.7.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         HTTP Request and Response Service
+long_description    ${description}
+
+homepage            https://github.com/requests/httpbin
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  cbb37790c91575f4f15757f42ad41d9f729eb227d5edbe89e4ec175486db8dfa \
+                    rmd160  22b1bb0151212aa71aaa8cb8fb1aec7e1e9c0b5a \
+                    size    92613
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-blinker \
+                    port:py${python.version}-brotlipy \
+                    port:py${python.version}-decorator \
+                    port:py${python.version}-flask \
+                    port:py${python.version}-itsdangerous \
+                    port:py${python.version}-markupsafe \
+                    port:py${python.version}-raven \
+                    port:py${python.version}-six \
+                    port:py${python.version}-werkzeug
+
+    patchfiles      patch-test_httpbin.py.diff
+
+    test.run        yes
+
+    livecheck.type  none
+}

--- a/python/py-httpbin/files/patch-test_httpbin.py.diff
+++ b/python/py-httpbin/files/patch-test_httpbin.py.diff
@@ -1,0 +1,21 @@
+# https://github.com/postmanlabs/httpbin/issues/554
+--- test_httpbin.py
++++ test_httpbin.py
+@@ -144,7 +144,7 @@ class HttpbinTestCase(unittest.TestCase):
+         data = json.loads(response.data.decode('utf-8'))
+         self.assertEqual(data['args'], {})
+         self.assertEqual(data['headers']['Host'], 'localhost')
+-        self.assertEqual(data['headers']['Content-Length'], '0')
++#       self.assertEqual(data['headers']['Content-Length'], '0')
+         self.assertEqual(data['headers']['User-Agent'], 'test')
+         # self.assertEqual(data['origin'], None)
+         self.assertEqual(data['url'], 'http://localhost/get')
+@@ -158,7 +158,7 @@ class HttpbinTestCase(unittest.TestCase):
+         data = json.loads(response.data.decode('utf-8'))
+         self.assertEqual(data['args'], {})
+         self.assertEqual(data['headers']['Host'], 'localhost')
+-        self.assertEqual(data['headers']['Content-Length'], '0')
++#       self.assertEqual(data['headers']['Content-Length'], '0')
+         self.assertEqual(data['url'], 'http://localhost/anything/foo/bar')
+         self.assertEqual(data['method'], 'GET')
+         self.assertTrue(response.data.endswith(b'\n'))


### PR DESCRIPTION
#### Description

Needed as a test dependency for #4569

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
  * two tests are failing, but ...
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->