### PR TITLE
go: update to version 1.12.6

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                go
 epoch               2
-version             1.12.5
+version             1.12.6
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
@@ -30,9 +30,9 @@ master_sites        https://storage.googleapis.com/golang/
 distfiles           ${name}${version}.src.tar.gz
 worksrcdir          ${name}
 
-checksums           rmd160  729742d403f03468bc3c744d802cb1c3260ff8c5 \
-                    sha256  2aa5f088cbb332e73fc3def546800616b38d3bfe6b8713b8a6404060f22503e8 \
-                    size    21971348
+checksums           rmd160  cbb7fb2ca3215dfae36a077f2be5fb1268cdee51 \
+                    sha256  c96c5ccc7455638ae1a8b7498a030fe653731c8391c5f8e79590bce72f92b4ca \
+                    size    21975398
 
 depends_build       port:go-1.4
 
@@ -114,10 +114,10 @@ destroot {
 
     set grfdir ${destroot}${GOROOT_FINAL}
     set docdir ${destroot}${prefix}/share/doc/${name}
-    
+
     xinstall -d ${grfdir}
     xinstall -d ${docdir}
-    
+
     foreach f {api bin lib misc pkg src test} {
         copy ${worksrcpath}/${f} ${grfdir}
     }


### PR DESCRIPTION
#### Description

Updates go to latest release version 1.12.6.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F203
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->