### PR TITLE
sf-pwgen: Submission of macOS command line password generator

### DIFF
--- a/security/sf-pwgen/Portfile
+++ b/security/sf-pwgen/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github                      1.0
+PortGroup           cxx11                       1.1
+
+github.setup        anders pwgen 1.5
+
+name                sf-pwgen
+categories          security
+maintainers         nomaintainer
+platforms           darwin
+license             BSD
+
+description         macOS command line password generator.
+
+long_description    ${description} \
+                    A command line tool that generates passwords using \
+                    macOS's SecurityFoundation framework.
+
+checksums           rmd160  b1a7c50fb49dd75e694e951203c93360edf4caff \
+                    sha256  65633b914fe61725dfe9da5ff29b8cca769ff59a382a3c8fa56bb9f71ee97e7f \
+                    size 8668
+
+use_configure       no
+build.target        ""
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} \
+        sf-pwgen \
+        ${destroot}${prefix}/bin
+}
+
+notes "
+Example correct-horse-battery-staple usage:
+
+    sf-pwgen --algorithm memorable --count 2 --length 24 | paste -s -d -- '-'
+"


### PR DESCRIPTION
sf-pwgen: Submission of macOS command line password generator

* Generate macOS password suggestions as in Keychain Access.app
* Port of https://github.com/anders/pwgen

Example usage:

`sf-pwgen --algorithm memorable --count 2 --length 24 | paste -s -d -- '-'`<br/>
> `faad3478!metamorphosis-dodoes3:reaccreditation`

![correct-horse-battery-staple](https://imgs.xkcd.com/comics/password_strength.png)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->