### PR TITLE
helm: submission

### DIFF
--- a/sysutils/helm/Portfile
+++ b/sysutils/helm/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        helm helm 2.14.1
+categories          sysutils
+platforms           darwin
+supported_archs     x86_64
+license             Apache-2
+
+maintainers         {ogsite.net:sirn @sirn} openmaintainer
+
+description         Kubernetes Package Manager
+long_description    A tool for managing packages of pre-configured Kubernetes resources.
+
+master_sites        https://get.helm.sh/
+distname            ${name}-v${version}-darwin-amd64
+worksrcdir          darwin-amd64
+
+checksums           rmd160  b8aeae7e21eb03562bb589c036dc954e15716269 \
+                    sha256  392ec847ecc5870a48a39cb0b8d13c8aa72aaf4365e0315c4d7a2553019a451c \
+                    size    27861122
+
+use_configure       no
+
+build {
+}
+
+destroot {
+    xinstall ${worksrcpath}/helm ${destroot}${prefix}/bin/helm
+    xinstall ${worksrcpath}/tiller ${destroot}${prefix}/bin/tiller
+}


### PR DESCRIPTION
#### Description

Add Kubernetes package manager, a supplement to existing `sysutils/kubectl` port.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A471t
Xcode 11.0 11M336w

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
