### PR TITLE
py-upt-rubygems: New Port (Submission)

### DIFF
--- a/python/py-semver/Portfile
+++ b/python/py-semver/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-semver
+version             2.8.1
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
+
+description         Python helper for Semantic Versioning (http://semver.org/)
+long_description    ${description}
+
+homepage            https://github.com/k-bx/python-semver
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8 \
+                    rmd160  5f9956b60803890a026c3307e3ced20a9b61139d \
+                    size    5576
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}

--- a/python/py-upt-cpan/Portfile
+++ b/python/py-upt-cpan/Portfile
@@ -4,24 +4,24 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-upt-cpan
-version             0.4
+version             0.5
 revision            0
-
-maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
-description         CPAN frontend for upt
-long_description    ${description}
 
 platforms           darwin
 supported_archs     noarch
+license             BSD
+maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
+
+description         CPAN frontend for upt
+long_description    ${description}
 
 homepage            https://framagit.org/upt/upt-cpan
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-license             BSD
-checksums           sha256  47ebc37bf4510867858eec52e2d23221bc5a0f061a057b41892cb96b8e3def14 \
-                    rmd160  418532c5abb388d4ddcb050610944266ba1f456c \
-                    size    5091
+checksums           sha256  182cd011053a9d496069e99b0d1750be849b434bf5be3bd88d578b2caa162bc7 \
+                    rmd160  46b5b3696c04510f21cc04bd9bff478785c17c38 \
+                    size    5108
 
 python.versions     37
 

--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set git_hash        e9e40f0946d2393982f42fbd6c2dfb26b35786ed
+set git_hash        4186851e388d7fc819b74fa2f330a1d100596da6
 github.setup        macports upt-macports ${git_hash}
-version             0.1-20190601
+version             0.1-20190616
 name                py-${github.project}
 revision            0
 
@@ -18,9 +18,9 @@ platforms           darwin
 supported_archs     noarch
 
 license             BSD
-checksums           sha256  6688092c129be5c238b2d15dea7ca352eb805adf2b1ce1b019b90edbae723d8f \
-                    rmd160  b1ba08abf7583c88897bb075c21107e2ad0d492e \
-                    size    6557
+checksums           sha256  9b4bac2a13b8346da5725c2746bf53bfe54669758849dd81df546e32d60dc1fc \
+                    rmd160  14a840f71979b889b5ccf0df4d784183e8f62962 \
+                    size    8249
 
 python.versions     37
 

--- a/python/py-upt-rubygems/Portfile
+++ b/python/py-upt-rubygems/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-upt-rubygems
+version             0.2
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
+
+description         RubyGems frontend for upt
+long_description    ${description}
+
+homepage            https://framagit.org/upt/upt-rubygems
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  5e71e20a43d0a6b263dc703a080df77e89ffd1cf3ce1a984f261958041c93406 \
+                    rmd160  1c3eaf3080ade1e5d4225aecd39c3b0eedbd1e64 \
+                    size    5180
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-semver
+
+    depends_test-append \
+                    port:py${python.version}-requests-mock
+
+    test.run        yes
+    test.cmd        ${python.bin} -m unittest
+    test.target
+    test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.md LICENSE CHANGELOG \
+            ${destroot}${docdir}
+    }
+
+    livecheck.type  none
+}

--- a/python/py-upt/Portfile
+++ b/python/py-upt/Portfile
@@ -2,50 +2,13 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
 name                py-upt
+replaced_by         upt
 version             0.7
-revision            0
-
-maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
-description         Package software from any package manager to any distribution
-long_description    ${description}
-
-platforms           darwin
-supported_archs     noarch
-
-homepage            https://framagit.org/upt/upt
-master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
-distname            ${python.rootname}-${version}
-
+revision            1
 license             BSD
-checksums           sha256  7de9a0cc9d55c175b611ed748ee7ea572ec308411934769e2e647d1d26ba2eea \
-                    rmd160  6dc1b42ac5760f8225c81b1cd9539332b33b1b7c \
-                    size    24223
 
-python.versions     37
-
-if {${name} ne ${subport}} {
-    depends_lib-append \
-                    port:py${python.version}-spdx-lookup \
-                    port:py${python.version}-setuptools
-
-    depends_run-append \
-                    port:py${python.version}-upt-macports \
-                    port:py${python.version}-upt-cpan \
-                    port:py${python.version}-upt-pypi
-
-    test.run        yes
-    test.cmd        ${python.bin} -m unittest
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    post-destroot {
-        set docdir ${prefix}/share/doc/${subport}
-        xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} README.md LICENSE CHANGELOG \
-            ${destroot}${docdir}
-    }
-
-    livecheck.type  none
-}
+subport py37-upt "replaced_by upt"
+# remove after June 17, 2020

--- a/sysutils/upt/Portfile
+++ b/sysutils/upt/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                upt
+version             0.8
+revision            0
+
+categories-prepend  sysutils
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
+
+description         Package software from any package manager to any distribution
+long_description    ${description}
+
+homepage            https://framagit.org/upt/upt
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  ecb4b8da0e2e6a5f6926dc41cc45fd3923e8dfb6a9a8aafaa9149b5144d8898c \
+                    rmd160  3d3aade4ec513943b4fc8f12042a3f4328f60102 \
+                    size    25792
+
+python.default_version  37
+
+depends_lib-append \
+                port:py${python.version}-spdx-lookup \
+                port:py${python.version}-setuptools
+
+depends_run-append \
+                port:py${python.version}-upt-cpan \
+                port:py${python.version}-upt-macports \
+                port:py${python.version}-upt-pypi \
+                port:py${python.version}-upt-rubygems
+
+test.run        yes
+test.cmd        ${python.bin} -m unittest
+test.target
+test.env        PYTHONPATH=${worksrcpath}/build/lib
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} README.md LICENSE CHANGELOG \
+        ${destroot}${docdir}
+}


### PR DESCRIPTION
#### Description

py-upt-rubygems: New Port
py-upt : update to version 0.7
py-upt-cpan: update to version 0.5


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13
Xcode 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
