### PR TITLE
openjdk8: update to 8u212-b04

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -4,27 +4,27 @@ PortSystem       1.0
 
 name             openjdk8
 version          8u212
-revision         0
+revision         1
 
-set build        03
+set build        04
 set major        8
 
 subport openjdk8-openj9 {
     version      8u212
-    revision     0
+    revision     1
 
-    set build    03
+    set build    04
     set major    8
-    set openj9_version 0.14.0
+    set openj9_version 0.14.2
 }
 
 subport openjdk8-openj9-large-heap {
     version      8u212
-    revision     0
+    revision     1
 
-    set build    03
+    set build    04
     set major    8
-    set openj9_version 0.14.0
+    set openj9_version 0.14.2
 }
 
 subport openjdk10 {
@@ -114,9 +114,9 @@ if {${subport} eq "openjdk8"} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  d3f4816a3ae147fc605db9e9c1ee222275b53241 \
-                 sha256  3d80857e1bb44bf4abe6d70ba3bb2aae412794d335abe46b26eb904ab6226fe0 \
-                 size    102150875
+    checksums    rmd160  05e4da37f972cc986c6d555740e02d8d7e6fb217 \
+                 sha256  6f16c4c09e66a422db8a420e180f8a10e3009e330822fd03a2586847bc1bee49 \
+                 size    102150841
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -126,9 +126,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  b58a4fe668fc41c74b0f240178dc970426fa4aa4 \
-                 sha256  c213a707ac19c80c563da2e2134766764895f0670c572baaa178b453c36f2f0b \
-                 size    113303200
+    checksums    rmd160  75c03713518b6dbee1be1add220a07e6a2058124 \
+                 sha256  7bb6e7b8e2c29efc1fc1de2802d7e4cb002e178d1fb01f9ad1e4110da714aca7 \
+                 size    113300023
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -143,9 +143,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  920c2f7520504e3bf151e53fbec014e72846daab \
-                 sha256  98d0586b977e581ed84569d66477817b324f309ecf6b70fbe8bead7d5827d0ae \
-                 size    113292700
+    checksums    rmd160  a64dea8a6d0cb7d6b51771f6285d7643792a8e08 \
+                 sha256  827a783e10842a053642659cd06bddaf0788a7b37bdfd02e26d5d00ca1c7073f \
+                 size    113293115
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u212-b04.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?