### PR TITLE
graalvm: new port submission

### DIFF
--- a/java/graalvm/Portfile
+++ b/java/graalvm/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             graalvm
+version          19.0.2
+revision         0
+
+categories       java devel
+maintainers      {breun.nl:nils @breun} {@hcarvalhoalves gmail.com:hcarvalhoalves} openmaintainer
+platforms        darwin
+license          GPL-2
+supported_archs  x86_64
+
+description      GraalVM Community Edition
+
+long_description GraalVM is a universal virtual machine for running applications written in \
+                 JavaScript, Python, Ruby, R, JVM-based languages like Java, Scala, Clojure, \
+                 Kotlin, and LLVM-based languages such as C and C++.
+homepage         https://www.graalvm.org/
+
+master_sites     https://github.com/oracle/graal/releases/download/vm-${version}/
+    
+checksums        rmd160  04bcdd5f6709a24fd5015cb050b5a5556fae1857 \
+                 sha256  1364c582fa0d308c7f676ae2b799cd60549b40f5ebd5fcfc3c89533d613971f8 \
+                 size    333205458
+
+distname         ${name}-ce-darwin-amd64-${version}
+worksrcdir       ${name}-ce-${version}
+
+use_configure    no
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+configure.cxx_stdlib libstdc++
+
+set target /Library/Java/JavaVirtualMachines/${name}
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make GraalVM the default
+by adding the following line to your Bash shell profile (~/.bash_profile):
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New Portfile for GraalVM Community Edition.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?