### PR TITLE
GPXSee: update to 7.9

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.8
+github.setup        tumic0 GPXSee 7.9
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  6e860fac15b5e8904a05d5ca9fa66b7762d33013 \
-                    sha256  4e60b4297651084a8bc97781d102e0a2410e7a3c1c7c8c90aae03c764ea1f2fe \
-                    size    4330878
+checksums           rmd160  2d6ac9f5198dc6eba0f13d143f5add764c06b472 \
+                    sha256  6258c67a6e2c6e47be544578dcd802ed117fb0e04406b3b6d9784b670028ceaa \
+                    size    4348716
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.9

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Removed the annoying map view re-zooming on window resize.
>   * Improved POI handling and text rendering in IMG maps.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
