### PR TITLE
libiconv: remove cp932fix variant

### DIFF
--- a/textproc/libiconv/Portfile
+++ b/textproc/libiconv/Portfile
@@ -5,8 +5,6 @@ PortGroup               muniversal 1.0
 
 name                    libiconv
 version                 1.16
-set cp932fix_version    1.13
-set cp932fix_patchfile  ${name}-${cp932fix_version}-cp932-devel.patch.gz
 categories              textproc
 license                 {LGPL-2+ GPL-3+}
 maintainers             ryandesign
@@ -24,13 +22,9 @@ long_description \
     iconv() API for dealing with unicode and other types of \
     conversion.
 
-checksums               ${distname}${extract.suffix} \
-                        rmd160  770adf60b3099e5dcae434c1b6301d8c58330a49 \
+checksums               rmd160  770adf60b3099e5dcae434c1b6301d8c58330a49 \
                         sha256  e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04 \
                         size    5166734 \
-                        ${cp932fix_patchfile} \
-                        rmd160  62852bd1cd22f0be0280c4f64bd6d256b4b00917 \
-                        sha256  7ac7133de0549316a98504ec1b50c751de69f8df91f99a92465a9eeb187f0147
 
 depends_build           port:gperf
 
@@ -70,10 +64,6 @@ post-destroot {
     if {[file exists ${destroot}${prefix}/lib/charset.alias]} {
         delete ${destroot}${prefix}/lib/charset.alias
     }
-}
-
-variant cp932fix description {Apply a patch to fix the conversion problem between Shift-JIS and Unicode (See Microsoft KB Q170559)} {
-    patchfiles-append ${cp932fix_patchfile}
 }
 
 if { [variant_isset universal] } {


### PR DESCRIPTION
The cp932fix patch is quite old and no longer applies.
Fixes https://trac.macports.org/ticket/58523

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
