### PR TITLE
Revert "py-google-api: update to 1.7.9"

### DIFF
--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-google-api
 set realname        google-api-python-client
-version             1.7.9
+version             1.6.7
 
 python.versions     27 34 35 36 37
 
@@ -23,9 +23,9 @@ homepage            https://pypi.python.org/pypi/${realname}
 master_sites        pypi:g/${realname}/
 distname            ${realname}-${version}
 
-checksums           rmd160  873bf2f66b15993daac708926c12c25e75792ac0 \
-                    sha256  048da0d68564380ee23b449e5a67d4666af1b3b536d2fb0a02cee1ad540fa5ec \
-                    size    142053
+checksums           rmd160  d50870fbecb85b293d85cea4952f51b3195bad06 \
+                    sha256  05583a386e323f428552419253765314a4b29828c3cee15be735f9ebfa5aebf2 \
+                    size    51899
 
 if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

The upgrade to 1.7.9 breaks the fava port with the following error
message:

```
pkg_resources.DistributionNotFound: The 'google-auth-httplib2>=0.0.3'
distribution was not found and is required by google-api-python-client
```

This reverts commit 805399c27c217d34dbb65a050eb63ad4fbe8a392.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
