### PR TITLE
py-pytest, py-pluggy: fix deps, update to 0.12.0

### DIFF
--- a/python/py-pluggy/Portfile
+++ b/python/py-pluggy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pluggy
-version             0.11.0
+version             0.12.0
 revision            0
 categories-append   devel
 platforms           darwin
@@ -20,9 +20,9 @@ long_description    This is the plugin manager as used by pytest but \
 master_sites        pypi:p/pluggy
 distname            pluggy-${version}
 
-checksums           rmd160  21c7fd6cb25e810dc47be9b0063ca456d3f75b50 \
-                    sha256  25a1bc1d148c9a640211872b4ff859878d422bccb59c9965e04eed468a0aa180 \
-                    size    56897
+checksums           rmd160  49727750e973c0a74ad8fc07018462790e4e050c \
+                    sha256  0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc \
+                    size    57658
 
 python.versions     27 34 35 36 37
 
@@ -31,7 +31,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-setuptools_scm
 
     depends_lib-append  port:py${python.version}-py \
-                        port:py${python.version}-setuptools
+                        port:py${python.version}-importlib-metadata
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pytest
 version             4.6.3
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -39,6 +39,7 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-attrs \
                         port:py${python.version}-more-itertools \
                         port:py${python.version}-atomicwrites \
+                        port:py${python.version}-packaging \
                         port:py${python.version}-pluggy \
                         port:py${python.version}-importlib-metadata \
                         port:py${python.version}-wcwidth


### PR DESCRIPTION
#### Description

py.test now depends on packaging, and on pluggy>=0.12.0. This isn't
caught via importing py.test, but is caught by running a package that
depends on it via pkg_resources, such as fava.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
