### PR TITLE
flrig: update version to 1.3.45

### DIFF
--- a/science/flrig/Portfile
+++ b/science/flrig/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                flrig
-version             1.3.44
+version             1.3.45
 categories          science
 platforms           darwin macosx
 license             GPL-3
@@ -18,9 +18,9 @@ long_description    FLRIG is a transceiver control program designed to be \
 homepage            http://www.w1hkj.com
 master_sites        http://www.w1hkj.com/files/${name}/
 
-checksums           rmd160  ba26991b501871c9a6947fac4c2477f6a0a347e1 \
-                    sha256  d21f606454647144ea982207eb16cabf43c6a69484ac1b3305b0795c25c40578 \
-                    size    792305
+checksums           rmd160  ef456ff188f994ebf93ee8bff2468f853dc6b795 \
+                    sha256  5b68785114e8ac3128e85b6fc20518479e6d5e741d1e7a0410b28c4939f63693 \
+                    size    799650
 
 depends_build-append \
     port:pkgconfig


### PR DESCRIPTION

#### Description

- bump version to 1.3.45

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->