### PR TITLE
adblock2privoxy: Submission of AdBlock/EasyList to Privoxy format converter

### DIFF
--- a/_resources/port1.0/group/haskell-stack-1.0.tcl
+++ b/_resources/port1.0/group/haskell-stack-1.0.tcl
@@ -21,6 +21,13 @@ post-extract {
     xinstall -m 0755 -d ${stack_root}
 }
 
+# libHSbase shipped with GHC links against system libiconv, which provides the
+# 'iconv' symbol, but not the 'libiconv' symbol. Because the compilation
+# process statically links libHSbase.a, we must have /usr/lib in the library
+# search path first :/
+compiler.library_path
+compiler.cpath
+
 configure.cmd       ${prefix}/bin/stack
 configure.pre_args
 configure.args      setup \

--- a/www/adblock2privoxy/Portfile
+++ b/www/adblock2privoxy/Portfile
@@ -1,0 +1,129 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell-stack 1.0
+
+name                adblock2privoxy
+version             2.0.1
+categories          www haskell
+maintainers         @essandess
+license             GPL-3
+platforms           macosx
+homepage            https://github.com/essandess/adblock2privoxy
+
+description         Convert adblock config files to privoxy format
+long_description    ${description}. \
+            AdBlock Plus browser plugin has great block list files \
+            provided by big community, but it is client software and \
+            cannot work on a server as proxy.  Privoxy proxy has good \
+            potential to block ads at server side, but it experiences \
+            acute shortage of updated block lists.  This software \
+            converts adblock lists to privoxy config files format. \
+            Almost all adblock features are supported including \
+            block/unblock requests (on privoxy) all syntax features \
+            are supported except for regex templates matching host \
+            name hide/unhide page elements (via CSS) all syntax \
+            features are supported all block request options except \
+            for outdated ones: Supported: script, image, stylesheet, \
+            object, xmlhttprequest, object-subrequest, subdocument, \
+            document, elemhide, other, popup, third-party, domain=..., \
+            match-case, donottrack.
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+checksums           rmd160  301ba12cb3c624eaca766400972818b79b52adce \
+                    sha256  064f501995eef83146ed49ccf83856faee8ab7e6e1fd70013d8bb1e12a3a1411 \
+                    size    42119
+
+depends_run-append \
+                    port:nginx \
+                    port:privoxy
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/etc/${name} \
+        ${destroot}${prefix}/etc/${name}/privoxy \
+        ${destroot}${prefix}/etc/${name}/css
+    xinstall -m 0644 -W ${filespath} \
+        nginx.conf \
+        ${destroot}${prefix}/etc/${name}
+    xinstall -m 0644 -W ${filespath} \
+        default.html \
+        ${destroot}${prefix}/etc/${name}/css
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${destroot}${prefix}/etc/${name}/nginx.conf
+}
+
+startupitem.create  yes
+startupitems \
+    name            ${name} \
+    start           "( /bin/test -f \"\${prefix}/etc/adblock2privoxy/privoxy/ab2p.task\" \\
+\t&& \"\${prefix}/bin/adblock2privoxy\" -t \"\${prefix}/etc/adblock2privoxy/privoxy/ab2p.task\" \\
+\t|| \"\${prefix}/bin/adblock2privoxy\" -p \"\${prefix}/etc/adblock2privoxy/privoxy\" \\
+\t\t-w \"\${prefix}/etc/adblock2privoxy/css\" \\
+\t\t-d 127.0.0.1:8119 \\
+\t\thttps://easylist.to/easylist/easyprivacy.txt \\
+\t\thttps://easylist.to/easylist/easylist.txt \\
+\t\thttps://easylist.to/easylist/fanboy-annoyance.txt \\
+\t\thttps://easylist.to/easylist/fanboy-social.txt \\
+\t\thttps://easylist-downloads.adblockplus.org/antiadblockfilters.txt \\
+\t\thttps://easylist-downloads.adblockplus.org/malwaredomains_full.txt \\
+\t\thttps://raw.githubusercontent.com/ryanbr/fanboy-adblock/master/fanboy-antifacebook.txt \\
+\t\thttps://raw.githubusercontent.com/Dawsey21/Lists/master/adblock-list.txt \\
+\t) && \"\${prefix}/bin/port\" reload privoxy" \
+    stop            "/usr/bin/kill -SIGUSR1 `/usr/bin/pgrep -u root ${name}` 2>/dev/null" \
+    pidfile         none
+
+startupitems-append \
+    name            ${name}-nginx \
+    init            "pidfile=\"\${prefix}/var/run/nginx/nginx-adblock2privoxy.pid\"" \
+    start           "\"\${prefix}/sbin/nginx\" \\
+\t\t-c \\
+\t\t\"\${prefix}/etc/${name}/nginx.conf\" \\
+\t\t-g \\
+\t\t\"daemon off;\"" \
+    stop            "if \[ -f \${pidfile} \]; then
+\t\t/usr/bin/kill `cat \${pidfile}` \\
+\t\t\t&& /bin/rm -f \${pidfile} ;
+\telse
+\t\t/usr/bin/kill -SIGUSR1 `/usr/bin/pgrep -u root nginx` 2>/dev/null ;
+\tfi"
+
+post-activate {
+    # org.macports.adblock2privoxy
+    reinplace \
+        "s|^<key>ProgramArguments</key>|<key>StartCalendarInterval</key>\\
+	<array>\\
+		<dict>\\
+			<key>Weekday</key>\\
+			<integer>7</integer>\\
+			<key>Hour</key>\\
+			<integer>1</integer>\\
+			<key>Minute</key>\\
+			<integer>30</integer>\\
+		</dict>\\
+	</array>\\
+&|" \
+        ${prefix}/etc/${startupitem.location}/org.macports.${name}/org.macports.${name}.plist
+}
+
+notes "
+Example production run:
+
+adblock2privoxy -p ${prefix}/etc/adblock2privoxy/privoxy -w ${prefix}/etc/adblock2privoxy/css -d 10.0.1.3:8119 \\
+  https://easylist.to/easylist/easyprivacy.txt  \\
+  https://easylist.to/easylist/easylist.txt  \\
+  https://easylist.to/easylist/fanboy-annoyance.txt  \\
+  https://easylist.to/easylist/fanboy-social.txt  \\
+  https://easylist-downloads.adblockplus.org/antiadblockfilters.txt  \\
+  https://easylist-downloads.adblockplus.org/malwaredomains_full.txt  \\
+  https://raw.githubusercontent.com/ryanbr/fanboy-adblock/master/fanboy-antifacebook.txt \\
+  https://raw.githubusercontent.com/Dawsey21/Lists/master/adblock-list.txt
+
+Update run:
+
+adblock2privoxy -t ${prefix}/etc/adblock2privoxy/privoxy/ab2p.task
+"
+
+livecheck.type      regex
+livecheck.url       https://hackage.haskell.org/package/${name}
+livecheck.regex     "/package/[quotemeta ${name}]-\[^/\]+/[quotemeta ${name}]-(\[^\"\]+)[quotemeta ${extract.suffix}]"

--- a/www/adblock2privoxy/files/default.html
+++ b/www/adblock2privoxy/files/default.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+ <meta charset='utf-8'>
+</head>
+<body>
+<p><a href="https://github.com/essandess/adblock2privoxy">adblock2privoxy</a> blackhole 🕳</p>
+</body>
+</html>

--- a/www/adblock2privoxy/files/nginx.conf
+++ b/www/adblock2privoxy/files/nginx.conf
@@ -1,0 +1,52 @@
+worker_processes  auto;
+
+events {
+    worker_connections  64;
+}
+
+# this must be consistent with daemondo's --pidfile specification
+pid @PREFIX@/var/run/nginx/nginx-adblock2privoxy.pid;
+
+# error_log @PREFIX@/var/log/nginx/error_adblock2privoxy.log warn;
+error_log off;
+
+http {
+  # access_log @PREFIX@/var/log/nginx/access_adblock2privoxy.log;
+  access_log off;
+
+  # avoid error 413 Request Entity Too Large
+  # client_max_body_size 64M;
+  keepalive_timeout 65;
+
+  server {
+    listen 127.0.0.1:8119;
+    #ab2p css domain name (optional, should be equal to --domainCSS parameter)
+    server_name localhost;
+
+    #root = --webDir parameter value
+    root @PREFIX@/etc/adblock2privoxy/css;
+
+    # Ensure that http://localhost:8119/ is a legitimate (200 return code)
+    # default page; use as iOS proxy.pac blackhole
+    # Test with curl -I --proxy http://127.0.0.1:8119 http://www.foo.com/bar?q=snafoo
+    location / {
+        rewrite ^ /default.html break;
+    }
+
+    location ~ ^/+(ab2p(?:\.common)?\.css) {
+        # ab2p.css in top-level directory
+        try_files $uri $1;
+    }
+
+    location ~ ^/[^/.]+\..+/ab2p\.css$ {
+        # first reverse domain names order
+    rewrite ^/([^/]*?)\.([^/.]+)(?:\.([^/.]+))?(?:\.([^/.]+))?(?:\.([^/.]+))?(?:\.([^/.]+))?(?:\.([^/.]+))?(?:\.([^/.]+))?(?:\.([^/.]+))?/ab2p.css$ /$9/$8/$7/$6/$5/$4/$3/$2/$1/ab2p.css last;
+    }
+
+    location ~ (^.*/+)[^/]+/+ab2p\.css {
+        # then try to get CSS for current domain
+        # if it is unavailable - get CSS for parent domain
+        try_files $uri $1ab2p.css;
+    }
+  }
+}


### PR DESCRIPTION
adblock2privoxy: Submission of AdBlock/EasyList to Privoxy format converter

* Build of the adblock2privoxy binary using Haskell stack
* Launchdaemon for initialization and regular updates
* Launchdaemon for dedicated nginx web server and blackhole for CSS hiding

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->