### PR TITLE
spring-boot-cli: update to 2.1.6

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.1.5
+version         2.1.6
 
 categories      java
 platforms       darwin
@@ -28,9 +28,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  2df28f01ee0b1d691e6963b33abe5e35549b073b \
-                sha256  c4d07caaae149059e70a0096d61be3c46f73f0c4590277dd8006fd3decbba50e \
-                size    11143365
+checksums       rmd160  8a8d1f527398d1552d5f1294eba1b6f041fb4fbb \
+                sha256  42bea1642d0bbac760944a6dd5848f440a40e1999ef493a20f0d7bc45cf3e37c \
+                size    11144964
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.1.6.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?