### PR TITLE
gpsd-devel: Update to 20190619-48d3833c

### DIFF
--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -19,7 +19,7 @@ long_description        GPSD is a service daemon that handles GPSes and other \
                         includes a number of clients which can be run against \
                         a local GPSD or a GPSD on another machine.
 
-homepage                http://www.catb.org/${name}/
+homepage                https://gpsd.io
 
 subport gpsd-devel {}
 

--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -57,19 +57,20 @@ if {${subport} eq ${name}} {
     conflicts           gpsd
 
     revision            0
-    set commit          c0a78c2d2819cb9dca0ad3011d4ad4d3e22e0f18
-    version             20190525-[string range ${commit} 0 7]
-    checksums           rmd160 a915a08c8fd0f341936a0688b37969936f8da965 \
-                        sha256 df59b1d6f1ed5df26729aed181b46ed4946964f8168ac179bf082e1a9461be79 \
-                        size   11328510
+    git.branch          48d3833c514e6faf9a5b3af08d71559d553be65b
+    version             20190619-[string range ${git.branch} 0 7]
+    checksums           rmd160  7e845b5e1fc982d50a6d6a9c363cfd96531dc2cd \
+                        sha256  dffd82203604a1b862f72a8e425ed74ca05025e9dcf08108bd3032783858e5ee \
+                        size    8645874
 
-    master_sites        http://git.savannah.gnu.org/cgit/gpsd.git/snapshot
-    distname            ${name}-${commit}
+    master_sites        https://gitlab.com/gpsd/gpsd/-/archive/${git.branch}/
+    distname            ${name}-${git.branch}
+    use_bzip2           yes
 
-    livecheck.type          regex
-    livecheck.version       ${commit}
-    livecheck.url           http://git.savannah.gnu.org/cgit/gpsd.git
-    livecheck.regex         "id=(\[0-9a-f\]*)'>HEAD"
+    livecheck.type      regexm
+    livecheck.version   ${git.branch}
+    livecheck.url       https://gitlab.com/gpsd/gpsd/commits/master?format=atom
+    livecheck.regex     {gpsd/gpsd/commit/([0-9a-f]{40}).*}
 }
 
 # GPSD requires Python 2.6, 2.7, or 3.2+; don't use 2.6, 3.2, or


### PR DESCRIPTION
#### Description

gpsd-devel: Update to 20190619-48d3833c

Also update homepage

Project has moved to GitLab

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
