### PR TITLE
xsane: update homepage, master_sites, livecheck

### DIFF
--- a/graphics/xsane/Portfile
+++ b/graphics/xsane/Portfile
@@ -9,16 +9,21 @@ license         GPL-2
 categories      graphics x11
 maintainers     {puffin.lb.shuttle.de:michael.klein @mklein-de} openmaintainer
 description     X11 frontend for SANE
-homepage        http://www.xsane.org/
+# http://www.xsane.org/ has been gone since June 2018
+# no sign of further upstream development activity 
+# switch homepage to archive.org snapshot for now
+#homepage        http://www.xsane.org/
+homepage        https://web.archive.org/web/20180521010640/http://xsane.org:80/
 platforms       darwin
 
 long_description This is an X11 frontend for the Scanner Access Now Easy \
                  Project.
 
-master_sites    ${homepage}download/ \
-                ftp://ftp2.sane-project.org/pub/sane/xsane/ \
-                ftp://ftp3.sane-project.org/pub/sane/xsane/ \
-                ftp://sunsite.uio.no/pub/sane/xsane/
+# all previous master_sites are gone as well but source is available from Ubuntu
+master_sites    http://archive.ubuntu.com/ubuntu/pool/universe/x/xsane/
+
+distname        ${name}_${version}.orig
+worksrcdir      ${name}-${version}
 
 checksums       md5     936f1cc76b37caa8f285e1e15ac7e0aa \
                 sha1    59e238b310979f71a8e15b692eab3c5b2ce6fc32 \
@@ -61,5 +66,5 @@ variant disable_gimp description {Disable building of GIMP plugin} {
 }
 
 livecheck.type  regex
-livecheck.url   ftp://ftp2.sane-project.org/pub/sane/xsane/
-livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+livecheck.url   ${master_sites}
+livecheck.regex "${name}_(\\d+(?:\\.\\d+)*)\\.orig${extract.suffix}"


### PR DESCRIPTION
Upstream website has been gone since June 2018 with no sign of
further upstream development. All previous master_sites are
gone as well but source is available from Ubuntu archive. No
change in installed content so no rebuild is necessary.

Note: xsane development history has been archived at
https://gitlab.com/sane-project/frontend/xsane

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G48f
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
