### PR TITLE
vlc: fix build on macOS < 10.12

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -161,6 +161,10 @@ platform darwin {
             xinstall -m 755 ${filespath}/lock.h ${worksrcpath}/include/os/lock.h
         }
     }
+    if {${os.major} < 16} {
+        patchfiles-append \
+                    patch-build-on-pre-1012.diff
+    }
     patchfiles-append \
                     patch-build-on-pre-1014.diff
 }

--- a/multimedia/VLC/files/patch-build-on-pre-1012.diff
+++ b/multimedia/VLC/files/patch-build-on-pre-1012.diff
@@ -1,0 +1,19 @@
+diff --git modules/video_output/macosx.m modules/video_output/macosx.m
+index df2f3030bb..b9f19fcba8 100644
+--- modules/video_output/macosx.m
++++ modules/video_output/macosx.m
+@@ -339,14 +339,6 @@ static void PictureDisplay (vout_display_t *vd, picture_t *pic, subpicture_t *su
+     [sys->glView setVoutFlushing:YES];
+     if (vlc_gl_MakeCurrent(sys->gl) == VLC_SUCCESS)
+     {
+-        if (@available(macOS 10.14, *)) {
+-            vout_display_place_t place;
+-            vout_display_PlacePicture(&place, &vd->source, vd->cfg, false);
+-            vout_display_opengl_Viewport(vd->sys->vgl, place.x,
+-                                         vd->cfg->display.height - (place.y + place.height),
+-                                         place.width, place.height);
+-        }
+-
+         vout_display_opengl_Display (sys->vgl, &vd->source);
+         vlc_gl_ReleaseCurrent(sys->gl);
+     }


### PR DESCRIPTION
#### Description
Upstream commit a8539f7 that was included in VLC 3.0.7 breaks build on macOS versions below 10.12. It only targets 10.14 anyway, so we can just revert it on those systems.

Fixes cbd71f2 and PR #4593

Also see the last comments in PR #4593 to see the reasoning behind this.

I think no bump of pkgrel is required because this is only supposed to fix the build on systems where building vlc 3.0.7.1 currently is not possible at all.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Not at all due to lack of access to any of the affected macOS versions.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
