### PR TITLE
Update Percona

### DIFF
--- a/databases/percona/Portfile
+++ b/databases/percona/Portfile
@@ -5,11 +5,12 @@ PortSystem          1.0
 name                percona
 set name_mysql      ${name}
 set name_package    ${name}-server
-set version_mysql   5.6.32
-set release         78.1
+set version_mysql   8.0.15
+set release         6
 # Please set revision_client and revision_server to 0 if you bump version_mysql or release.
-set revision_client 2
-set revision_server 2
+set revision_client 0
+set revision_server 0
+set boost_version   1.68.0
 version             ${version_mysql}-${release}
 categories          databases
 platforms           darwin
@@ -19,31 +20,54 @@ homepage            http://www.percona.com/
 
 if {$subport eq $name} {
 
-    PortGroup           cmake 1.0
+    PortGroup           cmake 1.1
     PortGroup           select 1.0
+    PortGroup           compiler_blacklist_versions 1.0
+    PortGroup           legacysupport 1.0
 
     set version_branch  [join [lrange [split ${version} .] 0 1] .]
+    set boost_distver   [join [split ${boost_version} .] _]
+    set boost_distname  boost_${boost_distver}
 
     revision            ${revision_client}
     license             GPL-2
     description         Multithreaded SQL database server
     long_description    Percona is a fork of the MySQL server, a multi-threaded SQL database.
 
-    master_sites \
-    http://www.percona.com/redir/downloads/Percona-Server-${version_branch}/Percona-Server-${version}/source/tarball
+    master_sites        https://www.percona.com/redir/downloads/Percona-Server-${version_branch}/Percona-Server-${version}/source/tarball:percona \
+                        sourceforge:project/boost/boost/${boost_version}:boost
 
     distname            ${name_package}-${version}
-    cmake.out_of_source yes
-    distfiles           ${distname}${extract.suffix}:src
+    distfiles           ${distname}${extract.suffix}:percona \
+                        ${boost_distname}${extract.suffix}:boost
     use_parallel_build  yes
 
-    patch.pre_args      -p1
-    patchfiles          patch-cmake-install_layout.cmake.diff
+    # Requires c++14
+    compiler.blacklist-append *gcc* {clang < 900} macports-clang-3.* \
+                              macports-clang-4.0 macports-clang-5.0 macports-clang-6.0
+    compiler.whitelist clang macports-clang-7.0 macports-clang-8.0
 
-    checksums           rmd160  f8470414a56cd59b6b846f65cde43d68a62814d2 \
-                        sha256  d94d73bf12459c57fcc8fa8018d7a08775d45ba718999a4ef0a09f543c654778
+    patchfiles          patch-cmake-install_layout.cmake.diff \
+                        patch-cmake-lzma.cmake.diff \
+                        patch-libmysql-CMakeLists.txt.diff
 
-    depends_lib-append  port:zlib port:tcp_wrappers
+    checksums           ${distname}${extract.suffix} \
+                        rmd160  904197ca867504d947eeaa7a5b1a896aa26e6471 \
+                        sha256  25d946763aabc51bd18a547fba6be109ad083700318844e80675ae567057358b \
+                        size    160116772 \
+                        ${boost_distname}${extract.suffix} \
+                        rmd160  2995fce4cb6d2741f47e3566626f965b7047934e \
+                        sha256  da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf \
+                        size    108771741
+
+    depends_lib-append  port:cyrus-sasl2 \
+                        port:icu \
+                        port:libevent \
+                        port:lz4 \
+                        port:protobuf-cpp \
+                        port:re2 \
+                        port:zlib \
+                        port:tcp_wrappers
     depends_run-append  port:mysql_select
 
     select.group        mysql
@@ -67,6 +91,17 @@ if {$subport eq $name} {
             ${cmake.build_dir}/macports/my.cnf
     }
 
+    # the default `cmake.build_type MacPorts` confuses Percona
+    cmake.build_type    Release
+
+    if {[variant_isset debug]} {
+        # storage/innobase/btr/btr0cur.cc:2960:18: error: use of undeclared identifier 'debug_sync_set_action'
+        # See also https://jira.mariadb.org/browse/MDEV-11148
+        pre-fetch {
+            return -code error "Building Percona with debugging enabled is currently broken"
+        }
+    }
+
     if { (![variant_isset universal] && ${build_arch} eq "i386") || ([variant_isset universal] && [lsearch ${universal_archs} i386] != -1) } {
         # switch to /usr/bin/gcc and /usr/bin/g++
         # closest to SET(CMAKE_CXX_COMPILER g++) removed in the patchfile
@@ -83,24 +118,26 @@ if {$subport eq $name} {
                         -DMYSQL_DATADIR:PATH=${prefix}/var/db/${name_mysql} \
                         -DDEFAULT_CHARSET:STRING=utf8 \
                         -DDEFAULT_COLLATION:STRING=utf8_general_ci \
+                        -DWITH_ICU:STRING=system \
+                        -DWITH_LIBEVENT:STRING=system \
+                        -DWITH_LZ4:STRING=system \
+                        -DWITH_LZMA:STRING=system \
+                        -DWITH_PROTOBUF:STRING=system \
+                        -DWITH_RE2:STRING=system \
+                        -DWITH_SASL:STRING=system \
                         -DWITH_ZLIB:STRING=system \
-                        -DWITH_UNIT_TESTS:BOOL=ON \
+                        -DWITH_UNIT_TESTS:BOOL=OFF \
                         -DENABLE_GCOV:BOOL=OFF \
                         -DENABLE_DTRACE:BOOL=OFF \
                         -DWITH_EDITLINE:STRING=bundled \
                         -DWITH_LIBWRAP:BOOL=ON \
                         -DWITH_SSL:STRING=bundled \
                         -DWITH_EMBEDDED_SERVER:BOOL=ON \
-                        -DWITHOUT_TOKUDB=ON
-
-    post-build {
-        set dirs ${cmake.build_dir}
-        foreach dir ${dirs} {
-            reinplace -E {s|-arch [a-z0-9_]+||g} \
-                ${dir}/scripts/mysql_config \
-                ${dir}/scripts/mysqlbug
-        }
-    }
+                        -DWITHOUT_TOKUDB=ON \
+                        -DWITHOUT_ROCKSDB=ON \
+                        -DDOWNLOAD_BOOST=0 \
+                        -DWITH_BOOST:PATH="${worksrcpath}/../${boost_distname}" \
+                        -DINSTALL_MYSQLTESTDIR=
 
     post-destroot {
         # proc portdestroot::destroot_finish fails to find and compress our man pages
@@ -112,10 +149,6 @@ if {$subport eq $name} {
             reinplace -q "s|/etc/|${prefix}/etc/${name_mysql}/|g" ${manpage}
             # Compress all manpages with gzip
             system "$gzip -9vf ${manpage}"
-        }
-        foreach samp_conffile [glob -type f ${destroot}${prefix}/share/${name_mysql}/support-files/my-*.cnf] {
-            # Fix paths in sample configuration files
-            reinplace -q "s|/etc/my.cnf|${prefix}/etc/${name_mysql}/my.cnf|g" ${samp_conffile}
         }
         set link_dir ${destroot}${prefix}/lib/${name_mysql}/mysql
         foreach link_target [glob -directory ${link_dir} -type f -nocomplain -tails libperconaserver*.*] {

--- a/databases/percona/files/patch-cmake-install_layout.cmake.diff
+++ b/databases/percona/files/patch-cmake-install_layout.cmake.diff
@@ -1,11 +1,11 @@
---- a/cmake/install_layout.cmake	2013-06-23 08:41:38.000000000 -0700
-+++ b/cmake/install_layout.cmake	2013-06-23 08:44:25.000000000 -0700
+--- cmake/install_layout.cmake	2013-06-23 08:41:38.000000000 -0700
++++ cmake/install_layout.cmake	2013-06-23 08:44:25.000000000 -0700
 @@ -69,7 +69,7 @@
  ENDIF()
  
  SET(INSTALL_LAYOUT "${DEFAULT_INSTALL_LAYOUT}"
--CACHE STRING "Installation directory layout. Options are: STANDALONE (as in zip or tar.gz installer), RPM, DEB, SVR4")
-+CACHE STRING "Installation directory layout. Options are: STANDALONE (as in zip or tar.gz installer), RPM, DEB, SVR4, MACPORTS")
+-CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), WIN (as in zip installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX, SLES")
++CACHE STRING "Installation directory layout. Options are: TARGZ (as in tar.gz installer), WIN (as in zip installer), STANDALONE, RPM, DEB, SVR4, FREEBSD, GLIBC, OSX, SLES, MACPORTS")
  
  IF(UNIX)
    IF(INSTALL_LAYOUT MATCHES "RPM")
@@ -13,8 +13,8 @@
      SET(CMAKE_INSTALL_PREFIX ${default_prefix}
        CACHE PATH "install prefix" FORCE)
    ENDIF()
--  SET(VALID_INSTALL_LAYOUTS "RPM" "STANDALONE" "DEB" "SVR4")
-+  SET(VALID_INSTALL_LAYOUTS "RPM" "STANDALONE" "DEB" "SVR4" "MACPORTS")
+-  SET(VALID_INSTALL_LAYOUTS "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "SLES" "STANDALONE")
++  SET(VALID_INSTALL_LAYOUTS "RPM" "DEB" "SVR4" "FREEBSD" "GLIBC" "OSX" "TARGZ" "SLES" "STANDALONE" "MACPORTS")
    LIST(FIND VALID_INSTALL_LAYOUTS "${INSTALL_LAYOUT}" ind)
    IF(ind EQUAL -1)
      MESSAGE(FATAL_ERROR "Invalid INSTALL_LAYOUT parameter:${INSTALL_LAYOUT}."

--- a/databases/percona/files/patch-cmake-lzma.cmake.diff
+++ b/databases/percona/files/patch-cmake-lzma.cmake.diff
@@ -1,0 +1,11 @@
+--- cmake/lzma.cmake.orig	2019-06-22 00:17:53.000000000 +0800
++++ cmake/lzma.cmake	2019-06-22 00:18:00.000000000 +0800
+@@ -24,7 +24,7 @@
+ # bundled is the default
+ 
+ MACRO (FIND_SYSTEM_LZMA)
+-  FIND_PATH(PATH_TO_LZMA NAMES lzma/lzma.h)
++  FIND_PATH(PATH_TO_LZMA NAMES lzma/lzma.h lzma.h)
+   FIND_LIBRARY(LZMA_SYSTEM_LIBRARY NAMES lzma)
+   IF (PATH_TO_LZMA AND LZMA_SYSTEM_LIBRARY)
+     SET(SYSTEM_LZMA_FOUND 1)

--- a/databases/percona/files/patch-libmysql-CMakeLists.txt.diff
+++ b/databases/percona/files/patch-libmysql-CMakeLists.txt.diff
@@ -1,0 +1,12 @@
+--- libmysql/CMakeLists.txt.orig	2019-06-22 00:40:07.000000000 +0800
++++ libmysql/CMakeLists.txt	2019-06-22 00:40:12.000000000 +0800
+@@ -372,9 +372,3 @@
+ ELSE()
+   TARGET_LINK_LIBRARIES(libmysql_api_test libmysql)
+ ENDIF()
+-
+-# Verify that libmysql_api_test runs OK
+-ADD_CUSTOM_COMMAND(TARGET libmysql_api_test POST_BUILD
+-  COMMAND $<TARGET_FILE:libmysql_api_test>
+-  > ${CMAKE_CURRENT_BINARY_DIR}/libmysql_api_test.out
+-  )

--- a/net/tcp_wrappers/Portfile
+++ b/net/tcp_wrappers/Portfile
@@ -1,7 +1,7 @@
 PortSystem              1.0
 name                    tcp_wrappers
 version                 20
-revision                2
+revision                3
 categories              net
 license                 Permissive
 maintainers             {jeremyhu @jeremyhu} openmaintainer
@@ -25,8 +25,8 @@ checksums           sha1    6b197780e11633013bc6026e9f5d1b008c9e8e64 \
 
 platforms               darwin
 
-patchfiles              clang.patch
-patch.pre_args          -p2
+patchfiles              clang.patch \
+                        fix-prototypes.patch
 
 post-patch {
     reinplace "s:/usr/lib/:${prefix}/lib/:g" ${worksrcpath}/Makefile

--- a/net/tcp_wrappers/files/clang.patch
+++ b/net/tcp_wrappers/files/clang.patch
@@ -1,6 +1,6 @@
 diff -Naurp tcp_wrappers-20.orig/tcp_wrappers/fix_options.c tcp_wrappers-20/tcp_wrappers/fix_options.c
---- tcp_wrappers-20.orig/tcp_wrappers/fix_options.c	1999-04-22 18:57:28.000000000 -0700
-+++ tcp_wrappers-20/tcp_wrappers/fix_options.c	2012-02-14 00:46:53.000000000 -0800
+--- fix_options.c.orig	1999-04-22 18:57:28.000000000 -0700
++++ fix_options.c	2012-02-14 00:46:53.000000000 -0800
 @@ -28,7 +28,7 @@ static char sccsid[] = "@(#) fix_options
  #define BUFFER_SIZE	512		/* Was: BUFSIZ */
  

--- a/net/tcp_wrappers/files/fix-prototypes.patch
+++ b/net/tcp_wrappers/files/fix-prototypes.patch
@@ -1,0 +1,131 @@
+--- tcpd.h
++++ tcpd.h
+@@ -4,6 +4,11 @@
+   * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
+   */
+ 
++/* Need FILE. */
++#include <stdio.h>
++
++__BEGIN_DECLS
++
+ /* Structure to describe one communications endpoint. */
+ 
+ #define STRING_LENGTH	128		/* hosts, users, processes */
+@@ -29,10 +38,10 @@ struct request_info {
+     char    pid[10];			/* access via eval_pid(request) */
+     struct host_info client[1];		/* client endpoint info */
+     struct host_info server[1];		/* server endpoint info */
+-    void  (*sink) ();			/* datagram sink function or 0 */
+-    void  (*hostname) ();		/* address to printable hostname */
+-    void  (*hostaddr) ();		/* address to printable address */
+-    void  (*cleanup) ();		/* cleanup function or 0 */
++    void  (*sink) (int);		/* datagram sink function or 0 */
++    void  (*hostname) (struct host_info *); /* address to printable hostname */
++    void  (*hostaddr) (struct host_info *); /* address to printable address */
++    void  (*cleanup) (struct request_info *); /* cleanup function or 0 */
+     struct netconfig *config;		/* netdir handle */
+ };
+ 
+@@ -70,20 +79,22 @@ extern void fromhost();			/* get/validat
+ #define fromhost sock_host		/* no TLI support needed */
+ #endif
+ 
+-extern int hosts_access();		/* access control */
+-extern void shell_cmd();		/* execute shell command */
+-extern char *percent_x();		/* do %<char> expansion */
+-extern void rfc931();			/* client name from RFC 931 daemon */
+-extern void clean_exit();		/* clean up and exit */
+-extern void refuse();			/* clean up and exit */
+-extern char *xgets();			/* fgets() on steroids */
+-extern char *split_at();		/* strchr() and split */
+-extern unsigned long dot_quad_addr();	/* restricted inet_addr() */
+-extern int numeric_addr();		/* IP4/IP6 inet_addr (restricted) */
+-extern struct hostent *tcpd_gethostbyname();
++extern int hosts_access(struct request_info *request);	/* access control */
++extern void shell_cmd(char *);		/* execute shell command */
++extern char *percent_x(char *, int, char *, struct request_info *);
++					/* do %<char> expansion */
++extern void rfc931(struct sockaddr_gen *, struct sockaddr_gen *, char *);
++					/* client name from RFC 931 daemon */
++extern void clean_exit(struct request_info *);	/* clean up and exit */
++extern void refuse(struct request_info *);	/* clean up and exit */
++extern char *xgets(char *, int, FILE *);	/* fgets() on steroids */
++extern char *split_at(char *, int);		/* strchr() and split */
++extern unsigned long dot_quad_addr(char *);	/* restricted inet_addr() */
++extern int numeric_addr(char *str, union gen_addr *addr, int *af, int *len);		/* IP4/IP6 inet_addr (restricted) */
++extern struct hostent *tcpd_gethostbyname(char *host, int af);
+					/* IP4/IP6 gethostbyname */
+ #ifdef HAVE_IPV6
+-extern char *skip_ipv6_addrs();		/* skip over colons in IPv6 addrs */
++extern char *skip_ipv6_addrs(char *str);		/* skip over colons in IPv6 addrs */
+ #else
+ #define skip_ipv6_addrs(x)	x
+ #endif
+@@ -121,20 +139,23 @@ extern struct request_info *request_set(
+   * host_info structures serve as caches for the lookup results.
+   */
+ 
+-extern char *eval_user();		/* client user */
+-extern char *eval_hostname();		/* printable hostname */
+-extern char *eval_hostaddr();		/* printable host address */
+-extern char *eval_hostinfo();		/* host name or address */
+-extern char *eval_client();		/* whatever is available */
+-extern char *eval_server();		/* whatever is available */
++extern char *eval_user(struct request_info *);	/* client user */
++extern char *eval_hostname(struct host_info *);	/* printable hostname */
++extern char *eval_hostaddr(struct host_info *);	/* printable host address */
++extern char *eval_hostinfo(struct host_info *);	/* host name or address */
++extern char *eval_client(struct request_info *);/* whatever is available */
++extern char *eval_server(struct request_info *);/* whatever is available */
+ #define eval_daemon(r)	((r)->daemon)	/* daemon process name */
+ #define eval_pid(r)	((r)->pid)	/* process id */
+ 
+ /* Socket-specific methods, including DNS hostname lookups. */
+ 
+-extern void sock_host();		/* look up endpoint addresses */
+-extern void sock_hostname();		/* translate address to hostname */
+-extern void sock_hostaddr();		/* address to printable address */
++/* look up endpoint addresses */
++extern void sock_host(struct request_info *);
++/* translate address to hostname */
++extern void sock_hostname(struct host_info *);
++/* address to printable address */
++extern void sock_hostaddr(struct host_info *);
+ #define sock_methods(r) \
+ 	{ (r)->hostname = sock_hostname; (r)->hostaddr = sock_hostaddr; }
+ 
+@@ -182,7 +203,7 @@ extern struct tcpd_context tcpd_context;
+   * behavior.
+   */
+ 
+-extern void process_options();		/* execute options */
++extern void process_options(char *, struct request_info *);/* execute options */
+ extern int dry_run;			/* verification flag */
+ 
+ /* Bug workarounds. */
+@@ -221,3 +242,6 @@ extern char *fix_strtok();
+ #define strtok	my_strtok
+ extern char *my_strtok();
+ #endif
++
++__END_DECLS
++
+--- scaffold.c	2005-03-09 18:22:04.000000000 +0100
++++ scaffold.c	2005-03-09 18:20:47.000000000 +0100
+@@ -237,10 +237,12 @@ struct request_info *request;
+ 
+ /* ARGSUSED */
+ 
+-void    rfc931(request)
+-struct request_info *request;
++void    rfc931(rmt_sin, our_sin, dest)
++struct sockaddr_gen *rmt_sin;
++struct sockaddr_gen *our_sin;
++char   *dest;
+ {
+-    strcpy(request->user, unknown);
++    strcpy(dest, unknown);
+ }
+ 
+ /* check_path - examine accessibility */


### PR DESCRIPTION
#### Description

Update Percona to the latest version, which should be compatible with OpenSSL 1.1. See commit messages for details.

@jeremyhu: changes to tcp_wrappers are needed to compile percona.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Not actaully tested locally. It builds fine on 10.13 & 10.14 and there are no build errors before the timeout on 10.11 & 10.12 as indicated by Travis CI and Azure PIpelines.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
