### PR TITLE
py-sure: new port, version 1.4.11

### DIFF
--- a/python/py-sure/Portfile
+++ b/python/py-sure/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sure
+version             1.4.11
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             GPL-3+
+maintainers         nomaintainer
+
+description         Utility belt for automated testing in python for python
+long_description    ${description}
+
+homepage            http://github.com/gabrielfalcao/sure
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  3c8d5271fb18e2c69e2613af1ad400d8df090f1456081635bd3171847303cdaa \
+                    rmd160  fb6c37da7c2d005c6874d266fbc8d2edcb21d833 \
+                    size    45933
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    post-extract {
+        system "find ${worksrcpath} -type d -print0 | xargs -0 chmod a+rx"
+        system "find ${worksrcpath} -type f -print0 | xargs -0 chmod a+r"
+    }
+
+    depends_run-append \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-six
+
+    depends_test-append \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-nose \
+                    port:py${python.version}-six
+
+    test.run        yes
+
+    livecheck.type  none
+}


### PR DESCRIPTION
Utility belt for automated testing in python for python

(Some recursive dependency eventually needed for #4489)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->