### PR TITLE
py-parameterized: new port, version 0.7.0

### DIFF
--- a/python/py-parameterized/Portfile
+++ b/python/py-parameterized/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-parameterized
+version             0.7.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             FreeBSD
+maintainers         nomaintainer
+
+description         Parameterized testing with any Python test framework
+long_description    ${description}
+
+homepage            https://github.com/wolever/parameterized
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  d8c8837fb677ed2d5a93b9e2308ce0da3aeb58cf513120d501e0b7af14da78d5 \
+                    rmd160  03f016fca3efcaa1d556625dab260fc3754d759a \
+                    size    20751
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_test-append \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-nose
+
+    # there are five different ways of running tests, see tox.ini
+    # this runs just one
+    test.run        yes
+    test.cmd        ${python.bin} -m unittest
+    test.target     parameterized.test
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

Parameterized testing with any Python test framework

(Some recursive dependency eventually needed for #4489.)

###### Tested on

macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->