### PR TITLE
new port: promu 0.5.0

### DIFF
--- a/devel/promu/Portfile
+++ b/devel/promu/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        prometheus promu 0.5.0 v
+
+platforms           darwin
+categories          devel
+license             Apache-2
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         The Prometheus Utility Tool
+
+long_description    A utility tool for building and releasing Prometheus \
+                    projects.
+
+fetch.type          git
+
+depends_build       port:golangci-lint \
+                    port:go
+
+use_configure       no
+use_parallel_build  no
+
+switch ${build_arch} {
+    i386    { set goarch 386 }
+    x86_64  { set goarch amd64 }
+    default { set goarch {} }
+}
+
+build.env           GOPATH=${workpath} GOOS=${os.platform} GOARCH=${goarch}
+build.target        build
+
+post-extract {
+    file mkdir ${workpath}/bin
+    ln -s ${prefix}/bin/golangci-lint ${workpath}/bin/
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
This submission is for `promu`, a build tool used for building projects related to [Prometheus](https://www.prometheus.io)

There are 3 ports currently using `promu` as part of their build process:
* `alertmanager`
* `node_exporter` 
* `prometheus`

These 3 ports currently fetch the `promu` binary directly on their own during the build process, but this submission moves `promu` into ports proper.  We will also be able to test whether this port changes the situation we see where `promu`, when fetched as a binary, fails to run in the MacPorts buildbot environment as seen in the following cases:

* https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/31977/steps/install-port/logs/stdio
* https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/32363/steps/install-port/logs/stdio
* https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/33178/steps/install-port/logs/stdio

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
