### PR TITLE
py-mock: update to 3.0.5

### DIFF
--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -7,7 +7,7 @@ name                py-mock
 set real_name       mock
 version             2.0.0
 revision            2
-python.versions     27 34 35 36 37
+
 categories-append   devel
 platforms           darwin
 supported_archs     noarch
@@ -30,13 +30,18 @@ checksums           rmd160  10f4cb9343d99620e298cc0ffea143ee321e4ec2 \
                     sha256  b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba \
                     size    73684
 
-if {${name} eq ${subport}} {
-    livecheck.type  pypi
-} else {
-    depends_build-append  port:py${python.version}-setuptools
-    depends_lib-append  port:py${python.version}-funcsigs \
-                        port:py${python.version}-pbr \
-                        port:py${python.version}-six
+python.versions     27 34 35 36 37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_lib-append \
+                     port:py${python.version}-funcsigs \
+                     port:py${python.version}-pbr \
+                     port:py${python.version}-six
 
     livecheck.type  none
+} else {
+    livecheck.type  pypi
 }

--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-mock
-set real_name       mock
-version             2.0.0
-revision            2
+version             3.0.5
+revision            0
 
 categories-append   devel
 platforms           darwin
@@ -14,21 +13,16 @@ supported_archs     noarch
 license             BSD
 maintainers         nomaintainer
 
-description         A Python Mocking and Patching Library for Testing
-long_description  \
-    mock is a Python module that provides a core Mock class. It removes the \
-    need to create a host of stubs throughout your test suite. After \
-    performing an action, you can make assertions about which methods / \
-    attributes were used and arguments they were called with. You can also \
-    specify return values and set needed attributes in the normal way.
+description         Rolling backport of unittest.mock for all Pythons
+long_description    ${description}
 
-homepage            http://www.voidspace.org.uk/python/mock/
-master_sites        pypi:m/${real_name}
-distname            ${real_name}-${version}
+homepage            https://mock.readthedocs.org/en/latest/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-checksums           rmd160  10f4cb9343d99620e298cc0ffea143ee321e4ec2 \
-                    sha256  b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba \
-                    size    73684
+checksums           sha256  83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3 \
+                    rmd160  45ba6e6c2b53e92b62bcf54be579ddb9f9087177 \
+                    size    28126
 
 python.versions     27 34 35 36 37
 
@@ -37,11 +31,19 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     depends_lib-append \
-                     port:py${python.version}-funcsigs \
-                     port:py${python.version}-pbr \
                      port:py${python.version}-six
 
+    if {${python.version} eq 27} {
+        depends_lib-append \
+                     port:py${python.version}-funcsigs
+    }
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE.txt \
+            CHANGELOG.rst ${destroot}${docdir}
+    }
+
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- whitespace changes / rearrange Portfile
- update to latest version
- install files in post-destroot
- update homepage, description
- use default PyPI livecheck

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
