### PR TITLE
py-tox: update to 3.12.1; add subports to dependencies

### DIFF
--- a/python/py-filelock/Portfile
+++ b/python/py-filelock/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-filelock
-version             3.0.4
+version             3.0.12
+revision            0
 maintainers         {@funasoul gmail.com:funasoul} openmaintainer
 platforms           darwin
 supported_archs     noarch
@@ -19,17 +20,13 @@ homepage            http://pypi.python.org/pypi/filelock/
 distname            filelock-${version}
 master_sites        pypi:f/filelock/
 
-checksums           rmd160  51423a7699221b2d24b0fbe4fa4fd117b546a2fe \
-                    sha256  011327d4ed939693a5b28c0fdf2fd9bda1f68614c1d6d0643a89382ce9843a71 \
-                    size    6496
+checksums           rmd160  f4045fa508760a35480bef08ea89f2a102dc249a \
+                    sha256  18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59 \
+                    size    8549
 
-python.versions     27 36 37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
     livecheck.type  none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/filelock/
-    livecheck.regex filelock (\\d(\\.\\d+)*)
 }

--- a/python/py-toml/Portfile
+++ b/python/py-toml/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160 8f619d6251935a9b17370ec8e0b71050d2937451 \
                     sha256 229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
                     size 16719
 
-python.versions     37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools

--- a/python/py-tox/Portfile
+++ b/python/py-tox/Portfile
@@ -5,7 +5,9 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-tox
-version             3.2.1
+version             3.12.1
+revision            0
+
 categories-append   devel
 maintainers         {gmail.com:pedro.salgado @steenzout} openmaintainer
 platforms           darwin
@@ -20,9 +22,9 @@ master_sites        pypi:t/tox/
 
 distname            tox-${version}
 
-checksums           rmd160  e1f1b9ad6c8b39da6f45022a3e826f8689633314 \
-                    sha256  eb61aa5bcce65325538686f09848f04ef679b5cd9b83cc491272099b28739600 \
-                    size    268827
+checksums           rmd160  3aabd3591fe183cf44e806ff7c2c5b86f535eef7 \
+                    sha256  f87fd33892a2df0950e5e034def9468988b8d008c7e9416be665fcc0dd45b14f \
+                    size    287477
 
 python.versions     27 34 35 36 37
 
@@ -31,10 +33,12 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools_scm
 
     depends_lib-append \
+                    port:py${python.version}-filelock \
                     port:py${python.version}-pluggy \
                     port:py${python.version}-py \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-six \
+                    port:py${python.version}-toml \
                     port:py${python.version}-virtualenv \
                     port:tox_select
 
@@ -47,6 +51,4 @@ when you execute the commands without a version suffix, e.g. 'tox', run:
 port select --set ${select.group} [file tail ${select.file}]
 "
     livecheck.type  none
-} else {
-    livecheck.type  pypi
 }


### PR DESCRIPTION
#### Description
- update py-tox to latest version
- update py-filelock to latest version; add py34/py35 subports, needed for py-tox
- py-toml: add py27/py34/py35/py36 subports, needed vor py-tox
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
