### PR TITLE
py-qdarkstyle: update to 2.7, py-helpdev: new port

### DIFF
--- a/python/py-helpdev/Portfile
+++ b/python/py-helpdev/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-helpdev
+version             0.6.10
+revision            0
+
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         nomaintainer
+
+description         HelpDev - Extracts information about the Python environment easily.
+long_description    ${description}
+
+homepage            https://gitlab.com/dpizetta/helpdev
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  9e61d24458b7506809670222ca656b139e67d46c530cd227a899780152d7b44e \
+                    rmd160  b80d5a0368aaf5e9e2623902a257fa0b72c5d459 \
+                    size    12864
+
+python.versions     27 34 35 36 37
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-importlib-metadata \
+                    port:py${python.version}-psutil \
+                    port:py${python.version}-setuptools
+
+    livecheck.type  none
+}

--- a/python/py-qdarkstyle/Portfile
+++ b/python/py-qdarkstyle/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-qdarkstyle
 python.rootname     QDarkStyle
-version             2.6.8
+version             2.7
 revision            0
 categories-append   devel
 platforms           darwin
@@ -24,20 +24,23 @@ homepage            https://github.com/ColinDuquesnoy/QDarkStyleSheet
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  c00a12a8f353d37c23043c0fd51cd88aea427b58 \
-                    sha256  037a54bf0aa5153f8055b65b8b36ac0d0f7648f2fd906c011a4da22eb0f582a2 \
-                    size    222172
+checksums           sha256  de7aba62119a839556afd7b3b962588410b6249cbcfcbd56e51e6e827264c38f \
+                    rmd160  3ccddb5ad4c2c7b656cfc8352c5520a5069e3ff2 \
+                    size    1245786
 
 python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools
 
+    depends_lib-append \
+                    port:py${python.version}-helpdev
+
     post-destroot {
         set dest_doc ${destroot}${prefix}/share/doc/${subport}
         xinstall -d ${dest_doc}
         xinstall -m 0644 -W ${worksrcpath} AUTHORS.md CHANGES.md \
-            LICENSE.md PRODUCTION.md README.md ${dest_doc}
+            LICENSE.md CONTRIBUTING.md README.md ${dest_doc}
     }
 
     livecheck.type  none


### PR DESCRIPTION
#### Description
- update py-qdarkstyle to latest version
- add py-helpdev, new port, as dependency
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
