### PR TITLE
abiword-x11: deactivate champlain due to crashes

### DIFF
--- a/editors/abiword-x11/Portfile
+++ b/editors/abiword-x11/Portfile
@@ -9,7 +9,7 @@ PortGroup           gobject_introspection 1.0
 name                abiword-x11
 set dname           abiword
 version             3.0.2
-revision            1
+revision            2
 license             GPL-2+
 description         A word processor with gnome support.
 long_description    ${description}
@@ -38,7 +38,6 @@ depends_lib         port:desktop-file-utils \
                     port:goffice \
                     port:gtk3 \
                     port:jpeg \
-                    port:libchamplain \
                     port:libgcrypt \
                     port:libgsf \
                     port:libical \
@@ -56,9 +55,10 @@ depends_run         port:adwaita-icon-theme
 
 gobject_introspection   yes
 
+# champlain seems to cause crashes on startup
 configure.args      --disable-default-plugins \
                     --disable-silent-rules \
-                    --with-champlain=yes \
+                    --with-champlain=no \
                     --enable-clipart=yes \
                     --enable-templates=yes
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.2 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
