### PR TITLE
py-(aws-sam-translator,cfn-lint,jsonpatch,jsonpointer): new ports

### DIFF
--- a/python/py-aws-sam-translator/Portfile
+++ b/python/py-aws-sam-translator/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-aws-sam-translator
+github.setup        awslabs serverless-application-model 1.12.0 v
+github.tarball_from archive
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             Apache-2.0
+maintainers         {yan12125 @yan12125} openmaintainer
+
+description         AWS SAM Translator is a library that transform SAM templates into AWS CloudFormation templates
+long_description    ${description}
+
+checksums           sha256  6bd835557c5c08eb27ffd6e47cebcb56af8a43efb99f8ff4ceb30efa70ed7af1 \
+                    rmd160  c952a5e30ce988e51fb18930c472b58216277e3c \
+                    size    5103318
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-boto3 \
+                    port:py${python.version}-jsonschema \
+                    port:py${python.version}-six
+
+    depends_test-append \
+                    port:py${python.version}-cfn-lint \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-parameterized \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-pytest-cov \
+                    port:py${python.version}-yaml
+
+    # Note that currently tests are broken with the latest cfn-lint
+    # https://github.com/awslabs/serverless-application-model/issues/1004
+    test.run        yes
+    test.cmd        py.test-${python.branch}
+    test.target     tests
+
+    livecheck.type  none
+}

--- a/python/py-botocore/Portfile
+++ b/python/py-botocore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-botocore
-version             1.12.116
+version             1.12.176
 revision            0
 platforms           darwin
 supported_archs     noarch
@@ -20,9 +20,9 @@ homepage            https://github.com/boto/botocore
 master_sites        pypi:b/botocore
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  6315911b69ead8de43976ae8d2fbaf687470eddf \
-                    sha256  b0e79b61dda7fb5f05949a4fe319d44108e0ba6db41775d909b891e6992d5a06 \
-                    size    5472929
+checksums           rmd160  7a16870c1a247aa4629c3a4af21fe8dcf36eeb22 \
+                    sha256  bc64583e25823764da3603048bd7664e5736aea06c26d4e9e3722876689fbc6a \
+                    size    5717363
 
 python.versions     27 35 36 37
 

--- a/python/py-cfn-lint/Portfile
+++ b/python/py-cfn-lint/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                py-cfn-lint
+github.setup        aws-cloudformation cfn-python-lint 0.22.0 v
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {yan12125 @yan12125} openmaintainer
+
+description         Checks cloudformation for practices and behaviour that could potentially be improved
+long_description    ${description}
+
+checksums           sha256  de9663a8cbb69427fe9755c93fba81a4635e2e849abc1a940c7565bfb10d2af3 \
+                    rmd160  022003ed2e661b2fb95e3c861ecc766679fa375d \
+                    size    2959506
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-aws-sam-translator \
+                    port:py${python.version}-jsonpatch \
+                    port:py${python.version}-jsonschema \
+                    port:py${python.version}-yaml \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-six
+
+    depends_test-append \
+                    port:py${python.version}-mock \
+                    port:py${python.version}-pytest
+
+    test.run        yes
+    test.env-append PYTHONPATH=build/lib
+    test.cmd        py.test-${python.branch}
+    test.target     test
+
+    livecheck.type  none
+}

--- a/python/py-jsonpatch/Portfile
+++ b/python/py-jsonpatch/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jsonpatch
+version             1.23
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             unknown
+maintainers         nomaintainer
+
+description         Apply JSON-Patches (RFC 6902)
+long_description    ${description}
+
+homepage            https://github.com/stefankoegl/python-json-patch
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  49f29cab70e9068db3b1dc6b656cbe2ee4edf7dfe9bf5a0055f17a4b6804a4b9 \
+                    rmd160  4dc717550dc31026db66d035c8ff13c28b6b2b5c \
+                    size    18162
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-jsonpointer
+
+    test.run        yes
+
+    livecheck.type  none
+}

--- a/python/py-jsonpointer/Portfile
+++ b/python/py-jsonpointer/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jsonpointer
+version             2.0
+revision            0
+
+platforms           darwin
+supported_archs     noarch
+license             BSD
+maintainers         nomaintainer
+
+description         Identify specific nodes in a JSON document (RFC 6901)
+long_description    ${description}
+
+homepage            https://github.com/stefankoegl/python-json-pointer
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           sha256  c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362 \
+                    rmd160  4fe729b7eef7e220e1bf7015dcc837e330db1582 \
+                    size    8699
+
+python.versions     37
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    test.run        yes
+
+    livecheck.type  none
+}


### PR DESCRIPTION
#### Description

A bunch of recursive test dependencies for #4489.

`py-aws-sam-translator` has some issues and I had no clue how to enable tests for `py-cfn-lint`.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G6030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
  - one fails, for one I have no clue how to enable them
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->