### PR TITLE
new port: golangci-lint v1.17.1

### DIFF
--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/golangci/golangci-lint 1.17.1 v
+
+platforms           darwin
+categories          devel
+license             GPL-3
+installs_libs       no
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         Linters Runner for Go.
+
+long_description    GolangCI-Lint is a linters aggregator. It's fast: on \
+                    average 5 times faster than gometalinter. It's easy to \
+                    integrate and use, has nice output and has a minimum \
+                    number of false positives. It supports go modules.
+
+checksums           rmd160  2abb836c0258e23f21d2b5f6b837c4142ebba1f7 \
+                    sha256  610a199d74a1feb0f17c9331b7ab5f9454cdf594a419437fa672240c0a360d58 \
+                    size    3929522
+
+build.args          ./cmd/golangci-lint
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
New port for [GoLangCI-Lint](https://github.com/golangci/golangci-lint), meant as a prerequisite for #4666 

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
