### PR TITLE
gitlab-runner: update to 12.0.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 11.11.2 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.0.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  919931be2da9abde78f906db24798ec9adbf1a23 \
-                    sha256  11416d6558e493954880e97d0e91f7ad230014f794c384d9b80b179cb0413043 \
-                    size    27084964
+checksums           rmd160  72e22bd9a4b97c68a2c9dd66a8505ab744d8bf21 \
+                    sha256  6cb84e076d191ff0116c976af735240f90cd1e3e13e79b4c33682b4a0cedec01 \
+                    size    27123646
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.0.0.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?