### PR TITLE
py-google-api: fix deps

### DIFF
--- a/python/py-cachetools/Portfile
+++ b/python/py-cachetools/Portfile
@@ -22,7 +22,7 @@ homepage            https://github.com/tkem/cachetools
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-python.versions     27 37
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 name                py-google-api
 set realname        google-api-python-client
 version             1.7.9
+revision            1
 
 python.versions     27 34 35 36 37
 
@@ -30,13 +31,13 @@ checksums           rmd160  873bf2f66b15993daac708926c12c25e75792ac0 \
 if {${name} ne ${subport}} {
     depends_build           port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-httplib2 \
+                            port:py${python.version}-google-auth \
+                            port:py${python.version}-google-auth-httplib2 \
                             port:py${python.version}-six \
-                            port:py${python.version}-uritemplate \
-                            port:py${python.version}-oauth2client
+                            port:py${python.version}-uritemplate
 
     post-destroot {
         delete ${destroot}${python.pkgd}/uritemplate
-        delete ${destroot}${python.pkgd}/oauth2client
 
         set egg-info ${destroot}${python.pkgd}/google_api_python_client-${version}-py${python.branch}.egg-info
         foreach d [glob -dir ${egg-info} *] {

--- a/python/py-google-auth-httplib2/Portfile
+++ b/python/py-google-auth-httplib2/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-google-auth-httplib2
+version             0.0.3
+
+python.versions     27 34 35 36 37
+
+categories-append   www devel
+maintainers         {wholezero.org:macports @mrdomino} openmaintainer
+license             Apache-2
+description         provides an httplib2 transport for google-auth
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://pypi.python.org/pypi/${python.rootname}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  2a244e22de54eac2042adb13b87dc39001b77084 \
+                    sha256  098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445 \
+                    size    9957
+
+if {${name} ne ${subport}} {
+    depends_build       port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-google-auth \
+                        port:py${python.version}-httplib2
+
+    livecheck.type      none
+}

--- a/python/py-google-auth/Portfile
+++ b/python/py-google-auth/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-google-auth
+version             1.6.3
+
+python.versions     27 34 35 36 37
+
+categories-append   www devel
+maintainers         {wholezero.org:macports @mrdomino} openmaintainer
+license             Apache-2
+description         simplifies using Google's various server-to-server \
+                    authentication mechanisms
+long_description    ${description}
+
+platforms           darwin
+supported_archs     noarch
+
+homepage            https://pypi.python.org/pypi/${python.rootname}
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
+
+checksums           rmd160  45de1837e270a4200d3f843c192fb95c1378ad9e \
+                    sha256  0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4 \
+                    size    80899
+
+if {${name} ne ${subport}} {
+    depends_build       port:py${python.version}-setuptools
+    depends_lib-append  port:py${python.version}-cachetools \
+                        port:py${python.version}-asn1-modules \
+                        port:py${python.version}-rsa \
+                        port:py${python.version}-six
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description

This packages the current dependencies for py-google-api, transitioning from oauth2client to google-auth and google-auth-httplib2. This also fixes the fava port.

Closes #4624.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
