### PR TITLE
jack: remove old conflict handler

### DIFF
--- a/audio/jack/Portfile
+++ b/audio/jack/Portfile
@@ -56,23 +56,3 @@ platform darwin {
         configure.ldflags-append -stdlib=${configure.cxx_stdlib}
     }
 }
-
-# deactivate hack added 2018-04-06
-pre-configure {
-    # When upgrading from jack1 to jack2, the build can fail outside of trace
-    # mode because waf puts the CPPFLAGS at the beginning of the compiler
-    # command line. This was fixed in waf 1.9.0, but jack2 ships waf 1.8.17.
-    #
-    # Instead of using the conflicts-build portgroup, use a deactivate hack to
-    # force-deactive the old version before building, which should solve the
-    # issue.
-    if {![catch {set installed [lindex [registry_active jack] 0]}]} {
-        elevateToRoot "deactivate jack1"
-        set _version [lindex $installed 1]
-        if {[vercmp $_version 1.9.12] < 0} {
-            # 1.9.12 is the first version of jack2 packaged in MacPorts
-            registry_deactivate_composite jack "" [list ports_nodepcheck 1]
-        }
-        dropPrivileges
-    }
-}


### PR DESCRIPTION
Was added in a4e16dbb04 over one year ago.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
