### PR TITLE
clamav-server: Bug fixes for MacPorts default launchd.plist keys

### DIFF
--- a/sysutils/clamav-server/Portfile
+++ b/sysutils/clamav-server/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 
 name                    clamav-server
 version                 0.101.2
+revision                1
 homepage                https://www.clamav.net/
 categories              sysutils
 platforms               darwin
@@ -241,6 +242,7 @@ post-activate {
 <key>StartInterval</key><integer>21600</integer>\\
 &|" \
         ${prefix}/etc/${startupitem.location}/org.macports.freshclam/org.macports.freshclam.plist
+    system -W ${prefix}/etc/${startupitem.location}/org.macports.freshclam "/usr/bin/plutil -remove KeepAlive org.macports.freshclam.plist"
 
     if {[variant_isset "scan_schedule_access"]} {
         # org.macports.ClamavScanSchedule
@@ -262,6 +264,8 @@ post-activate {
 </array>\\
 &|" \
             ${prefix}/etc/${startupitem.location}/org.macports.ClamavScanSchedule/org.macports.ClamavScanSchedule.plist
+        system -W ${prefix}/etc/${startupitem.location}/org.macports.ClamavScanSchedule "/usr/bin/plutil -remove KeepAlive org.macports.ClamavScanSchedule.plist"
+        system -W ${prefix}/etc/${startupitem.location}/org.macports.ClamavScanSchedule "/usr/bin/plutil -insert RunAtLoad -bool NO org.macports.ClamavScanSchedule.plist"
 
         # org.macports.ClamavScanOnAccess
         reinplace \
@@ -269,6 +273,7 @@ post-activate {
 <key>GroupName</key><string>${clamavuser}</string>\\
 &|" \
             ${prefix}/etc/${startupitem.location}/org.macports.ClamavScanOnAccess/org.macports.ClamavScanOnAccess.plist
+        system -W ${prefix}/etc/${startupitem.location}/org.macports.ClamavScanOnAccess "/usr/bin/plutil -insert ProcessType -string Background org.macports.ClamavScanOnAccess.plist"
     }
 
     # Quarantine directory one level up from MacPorts prefix location


### PR DESCRIPTION
clamav-server: Bug fixes for MacPorts default launchd.plist keys

* `KeepAlive`, `RunAtLoad` fixes

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->