### PR TITLE
tor: update to 0.4.0.5

### DIFF
--- a/security/tor/Portfile
+++ b/security/tor/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                tor
 conflicts           tor-devel
-version             0.3.5.8
-revision            1
+version             0.4.0.5
+revision            0
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ long_description    Tor provides a distributed network of servers \
 homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 
-checksums           rmd160  f94869f6f11277a7c786f8355c528912ab55733b \
-                    sha256  d5c56603942a8927670f50a4a469fb909e29d3571fdd013389d567e57abc0b47 \
-                    size    6994335
+checksums           rmd160  cc0bead52c77d0cb7f65c7c083c48d3810514287 \
+                    sha256  b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e \
+                    size    7203877
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor: update to 0.4.0.5

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [X] security fix

###### Tested on

macOS 10.13.6 17G8018
Xcode 10.1 10B61 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?