### PR TITLE
tor-devel: update to 0.4.1.3-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.1.2-alpha
+version             0.4.1.3-alpha
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  20d1a6443e53c881f3c8cad1bf795df4a56dc125 \
-                    sha256  f851cf49db3dd8231d682cc3025a6aa5642d5912cbca0681676cf985033bfd5b \
-                    size    7355589
+checksums           rmd160  3041302b742df15962cdb1eea09493144c9ff455 \
+                    sha256  31088eb293947a9e0ffd1a15deea75f3f290456a82f65f6738c13032f9739836 \
+                    size    7369258
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.1.3-alpha

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.13.6 17G8023
Xcode 10.1 10B61 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?