### PR TITLE
LaTeXML: update required perl to 5.28; post-configure to update shebang line …

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -17,7 +17,7 @@ long_description \
 
 # Written in Perl, but it is an application, not just modules
 PortGroup           perl5 1.0
-perl5.branches      5.26
+perl5.branches      5.28
 perl5.setup         ${name} ${version}
 perl5.link_binaries_suffix
 
@@ -47,6 +47,17 @@ depends_lib-append \
 # Also requires: DB_File, Pod::Parser, Test::More & version
 # but those should be in any non-obsolete Perl's core modules.
 
+#============================================================
+# The #! line normally uses env perl for flexibility,
+# but this doesn't work w/multiple perls on MacPorts
+post-configure {
+    fs-traverse file ${workpath}/${worksrcdir}/bin {
+        if {[file isfile ${file}]} {
+            ui_info "Fixing path in ${file}"
+            reinplace "s|#!/usr/bin/env perl|#!${prefix}/bin/perl${perl5.major}|g" ${file}
+        }
+    }
+}
 #============================================================
 # LaTeXML works MUCH better if there is a TeX installed.
 # - it uses some latex style files from texlive within bindings


### PR DESCRIPTION
…to specific perl version

#### Description

Updated required perl for LaTeXML to 5.28;
Added a post-configure to replace "env perl" in shebang (#!) lines with the specific requested perl.

See https://trac.macports.org/ticket/58361#comment:1

##### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

##### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
