### PR TITLE
protobuf3-cpp: update to 3.8.0

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -591,7 +591,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebglplugin {

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       cxx11 1.1
 
-github.setup    grpc grpc 1.12.0 v
-revision        2
+github.setup    grpc grpc 1.21.4 v
+revision        0
 categories      devel
 maintainers     nomaintainer
 license         Apache-2
@@ -21,8 +21,9 @@ long_description \
     These libraries enable communication between clients and \
     servers using any combination of the supported languages.
 
-checksums       rmd160  63cf7566f66feba0b2fc443503ab29329ee5c202 \
-                sha256  02f8b368a20b67f4c57727df45d7969fb6a3ba0a1246a7c843c3a4c8e4946a64
+checksums       rmd160  1a9b6738567847bd2b426c88a16f2f8ed1bcdef6 \
+                sha256  dd76b541f0e85a87d1ccf6dfff5885002d088c75b18225de8340607c2b432076 \
+                size    15042231
 
 patchfiles patch-Makefile.diff
 

--- a/devel/libphonenumber-cpp/Portfile
+++ b/devel/libphonenumber-cpp/Portfile
@@ -6,6 +6,7 @@ PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        googlei18n libphonenumber 8.10.14 v
+revision            1
 name                libphonenumber-cpp
 license             Apache-2
 description         Google's C++ library for parsing, formatting, storing \

--- a/devel/protobuf-c/Portfile
+++ b/devel/protobuf-c/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-
 PortGroup       github 1.0
-github.setup    protobuf-c protobuf-c 1.3.1 v
+
+github.setup    protobuf-c protobuf-c 1.3.2 v
+revision        0
 categories      devel
 license         BSD
 maintainers     nomaintainer
@@ -19,14 +20,15 @@ long_description \
                 Buffer .proto files to C descriptor code, based on the \
                 original protoc.
 
-checksums       sha256  f354b2cf7ebab06025fa68dc21ba1ff1b1fbbb1f12593a907372e3f7b9783456 \
-                rmd160  b97eef304957192af8b454be74a5d754c2b8f721 \
-                size    128748
-
+checksums       sha256  6c148c2df4b7abc987810c32e3bbe679f6af71490c5ade4e721204b83f52d830 \
+                rmd160  fd3b98d09c754caa472a814d0307207d70b2f780 \
+                size    130207
 
 use_autoreconf  yes
+
+depends_build   port:pkgconfig
+
 depends_lib     port:protobuf3-cpp
-depends_build-append port:pkgconfig
 
 test.run        yes
 test.target     check

--- a/devel/protobuf3-cpp/Portfile
+++ b/devel/protobuf3-cpp/Portfile
@@ -4,7 +4,8 @@ PortSystem 1.0
 PortGroup  github 1.0
 PortGroup  cxx11 1.1
 
-github.setup    google protobuf 3.6.1 v
+github.setup    google protobuf 3.8.0 v
+revision        0
 name            protobuf3-cpp
 categories      devel
 maintainers     {blair @blair} openmaintainer
@@ -45,9 +46,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 # bundled libtool version doesn't recognise -stdlib
 use_autoreconf  yes
 
-checksums       rmd160  b8b80a6c7150ead6acde8285b4462957cf2c2cd3 \
-                sha256  b3732e471a9bb7950f090fd0457ebd2536a9ba0891b7f3785919c654fe2a2529 \
-                size    4450975
+checksums       rmd160  6fdecbb2ac2be899f97a8a94c126913071cab6e5 \
+                sha256  ddc96d83f3b7417da53bce2510b94ad2796465ef8763f7a4e82089157efe97aa \
+                size    4545607
 
 platforms       darwin
 

--- a/devel/protobuf3-java/Portfile
+++ b/devel/protobuf3-java/Portfile
@@ -3,7 +3,7 @@ PortGroup	github 1.0
 
 github.setup    google protobuf 3.4.0 v
 name            protobuf3-java
-revision        1
+revision        2
 categories      devel
 maintainers     {blair @blair}
 license         BSD

--- a/finance/bitcoin/Portfile
+++ b/finance/bitcoin/Portfile
@@ -6,6 +6,7 @@ PortGroup               cxx11 1.1
 name                    bitcoin
 categories              finance crypto
 version                 0.17.1
+revision                1
 platforms               darwin
 license                 MIT
 maintainers             {easieste @easye} yopmail.com:sami.laine openmaintainer

--- a/finance/litecoin/Portfile
+++ b/finance/litecoin/Portfile
@@ -7,6 +7,7 @@ PortGroup           github 1.0
 PortGroup           qt5 1.0
 
 github.setup        litecoin-project litecoin 0.16.3 v
+revision            1
 checksums           rmd160  aa2470a9e4f32c62953c5aae460471e0e3f1f801 \
                     sha256  0dccc577d704bd48226d11b749cca3bd7cadd23694ccbb15a87a0806704a69c3 \
                     size    6045235

--- a/games/Cockatrice/Portfile
+++ b/games/Cockatrice/Portfile
@@ -10,7 +10,7 @@ PortGroup           qt4    1.0
 github.setup        Cockatrice Cockatrice 2016-05-06-Release
 
 epoch               1
-revision            2
+revision            3
 categories          games
 maintainers         nomaintainer
 description         A board for playing trading card games like MTG online

--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
 github.setup        tumic0 QtPBFImagePlugin 1.4
+revision            1
 categories          graphics
 platforms           darwin
 license             LGPL-3

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        BVLC caffe 1de4cebfb81d50267d0d8c2595372b14e1408248
 version             20170817
-revision            10
+revision            11
 categories          math science
 maintainers         nomaintainer
 

--- a/net/et/Portfile
+++ b/net/et/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           cxx11 1.1
 
 github.setup        MisterTea EternalTerminal 5.1.9 et-v
+revision            1
 name                et
 categories          net
 license             Apache-2

--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -6,7 +6,7 @@ PortGroup               cxx11 1.1
 
 name                    mosh
 version                 1.3.2
-revision                3
+revision                4
 categories              net
 license                 {GPL-3+ OpenSSLException}
 platforms               darwin

--- a/net/ola/Portfile
+++ b/net/ola/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
 github.setup        OpenLightingProject ola 0.10.7
+revision            1
 categories          net comms
 platforms           darwin
 license             GPL-2+ LGPL-2.1+

--- a/net/ostinato/Portfile
+++ b/net/ostinato/Portfile
@@ -6,7 +6,7 @@ PortGroup           cxx11 1.1
 PortGroup           github 1.0
 
 github.setup        pstavirs ostinato 0.9 v
-revision            2
+revision            3
 maintainers         {g5pw @g5pw} openmaintainer
 license             GPL-3+
 

--- a/php/php-mysql-xdevapi/Portfile
+++ b/php/php-mysql-xdevapi/Portfile
@@ -19,7 +19,7 @@ php.pecl                yes
 
 if {[vercmp ${php.branch} 7.1] >= 0} {
     version             8.0.16
-    revision            0
+    revision            1
     checksums           rmd160  751fb2f2e33c81f6e07db4d6b32ca3a0fe41f612 \
                         sha256  5d9e835142bd0b00b1559386d4ab284bde12637a786cbaa243bf7b33410d873c \
                         size    458642

--- a/python/py-protobuf3/Portfile
+++ b/python/py-protobuf3/Portfile
@@ -7,7 +7,7 @@ PortGroup       cxx11 1.1
 
 name            py-protobuf3
 version         3.7.1
-revision        1
+revision        2
 categories-append   devel
 maintainers     nomaintainer
 license         BSD

--- a/science/gnss-sdr/Portfile
+++ b/science/gnss-sdr/Portfile
@@ -87,12 +87,12 @@ subport gnss-sdr-next {
         This port is kept up with the GNSS-SDR GIT next branch, which is typically updated daily to weekly.  This version of GNSS-SDR generally contains fixes and new features that will be incorporated in an upcoming release, and compiles against the gnuradio-next subport. This port may or not compile or function correctly, as it represents a work in progress.  If it does not work, check back in a few days.  Or try deactivating the currently active gnss-sdr and gnuradio ports, cleaning any current builds, and trying again.
 
     name                gnss-sdr-next
-    github.setup        gnss-sdr gnss-sdr 80f6cf417b4b81d2ab679781312accca3dded3ea
-    version             20190527-[string range ${github.version} 0 7]
-    checksums           rmd160 46898bc4a87d798c1a47cbfb85036d4b36827a99 \
-                        sha256 ca95a235a6dd272893389ba88b1735cbc1d112b341f7a6e118eab597abbbf33b \
-                        size   3689766
-    revision            0
+    github.setup        gnss-sdr gnss-sdr 8a6621b68c9917a247dcffbde0d41a08178cfc3a
+    version             20190625-[string range ${github.version} 0 7]
+    checksums           rmd160 bb9fa155584d2e7334c6a1a606bde1b3cdf1b032 \
+                        sha256 0eb2c4de5d5a3101fe4b232dd1ae8a09cbbe532e640fd4cf31883c5ebd7cdbe3 \
+                        size   3696941
+    revision            1
 
     conflicts           gnss-sdr gnss-sdr-devel
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58158
protobuf-c: update to 1.3.2
grpc: update to 1.21.4
revision bump other dependents of protobuf3-cpp

#### Description

Notes:

1. protobuf-c update is needed for compatibility with protobuf3-cpp 3.8. Did some cleanup of Portfile.
2. protobuf3-cpp 3.8 is needed to build grpc 1.21.4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update

###### Tested on
macOS 10.13.6 17G7024
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->