### PR TITLE
assimp: fix livecheck regex

### DIFF
--- a/graphics/assimp/Portfile
+++ b/graphics/assimp/Portfile
@@ -47,3 +47,5 @@ subport assimp_tools {
         xinstall -m 0755 ${configure.dir}/tools/assimp_qt_viewer/assimp_qt_viewer ${destroot}${prefix}/bin
     }
 }
+
+github.livecheck.regex {(\d\.\d\.\d)}


### PR DESCRIPTION
Filter out release candidates and a very bizzare extra period at the
start of the most recent release candidate's version number.

#### Description


###### Type(s)

- [x] enhancement

###### Tested on
macOS 10.13.6 17G7024
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
