### PR TITLE
texlive-bin-extra: allow dvisvgm or dvisvgm-devel

### DIFF
--- a/tex/texlive-bin-extra/Portfile
+++ b/tex/texlive-bin-extra/Portfile
@@ -35,6 +35,6 @@ depends_run         port:latexmk \
                     port:latexdiff \
                     port:pdfjam \
                     port:dvipng \
-                    port:dvisvgm
+                    path:bin/dvisvgm:dvisvgm
 
 texlive.texmfport


### PR DESCRIPTION
allow port texlive-bin-extra to use either dvisvgm or dvisvgm-devel . Simple and easy tweak, so I'm not filling out the rest of the template LOL.