### PR TITLE
pandoc: Update to 2.7.3 with major Portfile refactoring

### DIFF
--- a/_resources/port1.0/group/haskell-stack-1.0.tcl
+++ b/_resources/port1.0/group/haskell-stack-1.0.tcl
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# Usage:
+# PortGroup         haskell-stack 1.0
+#
+# This PortGroup configures the build to use the Haskell Stack tool. Note that
+# this PortGroup does not set defaults, but sets the values directly, i.e. you
+# should take care not to accidentally overwrite them.
+#
+# The stack root is available as the $stack_root variable after including this
+# PortGroup. The configure, build, destroot and test phases have been setup
+# (although the test phase is not enabled automatically). A dependency on
+# port:stack is also automatically added.
+
+depends_build-append  \
+                    port:stack
+
+set stack_root      ${workpath}/.stack
+
+post-extract {
+    xinstall -m 0755 -d ${stack_root}
+}
+
+configure.cmd       ${prefix}/bin/stack
+configure.pre_args
+configure.args      setup \
+                    --stack-root ${stack_root} \
+                    --with-gcc ${configure.cc} \
+                    --allow-different-user
+
+build.cmd           ${prefix}/bin/stack
+build.target        build
+build.args          --stack-root ${stack_root} \
+                    --with-gcc ${configure.cc} \
+                    --allow-different-user
+
+destroot.cmd        ${prefix}/bin/stack
+destroot.target     install
+destroot.args       --stack-root ${stack_root} \
+                    --local-bin-path ${destroot}${prefix}/bin \
+                    --with-gcc ${configure.cc} \
+                    --allow-different-user
+destroot.destdir
+
+test.cmd            ${prefix}/bin/stack
+test.target         test

--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -1,15 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           haskell 1.0
+PortGroup           github 1.0
+PortGroup           haskell-stack 1.0
 
-haskell.setup       pandoc 1.12.4.2
-name                pandoc
-revision            1
-checksums           rmd160  d3e725ff4ed36f9259c07ad3de6878e3acbd1a9b \
-                    sha256  2f47f5f36498d26aa9cda7b93bcee76afedeeca7463478b5eda076209ba27f45
+github.setup        jgm pandoc 2.7.3
 
-categories          textproc
+checksums           rmd160  cee62040091bbc861ea5f281adbc93acdc1f62d5 \
+                    sha256  efe5781f8395d338e9421f99638c35cc047f53a9d8d074b8e1ca5b64671866ef \
+                    size    11316894
+
+categories          textproc haskell
 platforms           darwin
 license             GPL-3
 maintainers         nomaintainer
@@ -24,33 +25,5 @@ long_description    \
     Textile, groff man pages, plain text, Emacs Org-Mode, AsciiDoc, EPUB (v2 \
     and v3), FictionBook2, and S5, Slidy and Slideous HTML slide shows.
 
-depends_lib-append  \
-                    port:hs-aeson \
-                    port:hs-alex \
-                    port:hs-attoparsec \
-                    port:hs-base64-bytestring \
-                    port:hs-blaze-html \
-                    port:hs-blaze-markup \
-                    port:hs-data-default \
-                    port:hs-extensible-exceptions \
-                    port:hs-happy \
-                    port:hs-highlighting-kate \
-                    port:hs-hslua \
-                    port:hs-http \
-                    port:hs-mtl \
-                    port:hs-network \
-                    port:hs-pandoc-types \
-                    port:hs-parsec \
-                    port:hs-random \
-                    port:hs-syb \
-                    port:hs-sha \
-                    port:hs-tagsoup \
-                    port:hs-temporary \
-                    port:hs-texmath \
-                    port:hs-text \
-                    port:hs-unordered-containers \
-                    port:hs-vector \
-                    port:hs-xml \
-                    port:hs-yaml \
-                    port:hs-zip-archive \
-                    port:hs-zlib
+test.run            yes
+test.args           --test-arguments='-p markdown'


### PR DESCRIPTION
pandoc: Update to 2.7.3 with major Portfile refactoring

* Use GitHub release
* Build using Haskell stack tool
* Eliminate dependencies on multiple out-of-date hs-* ports
* See https://github.com/macports/macports-ports/pull/4633

#### Description

Notes:
* This will not build until [port:stack](https://github.com/macports/macports-ports/pull/4633) is committed
* The out-of-date port dependencies `hs-*` are all deprecated and likely unnecessary
* cc @neverpanic @pmetzger @mojca 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->