### PR TITLE
p5-tk: build with FreeType/Fontconfig support

### DIFF
--- a/perl/p5-tk/Portfile
+++ b/perl/p5-tk/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
 perl5.setup         Tk 804.034
-revision            1
+revision            2
 license             {Artistic-1 GPL} MIT
 maintainers         {@chrstphrchvz gmx.us:chrischavez} openmaintainer
 description         p5-tk is a Perl interface to Tk
@@ -14,15 +14,24 @@ long_description    ${description}
 platforms           darwin
 
 checksums           rmd160  899afc1936811a318110430b5250303cb61ed5c3 \
-                    sha256  fea6b144c723528a2206c8cd9175844032ee9c14ee37791f0f151e5e5b293fe2
+                    sha256  fea6b144c723528a2206c8cd9175844032ee9c14ee37791f0f151e5e5b293fe2 \
+                    size    6937691
 
 if {${perl5.major} != ""} {
     depends_lib-append \
                     port:p${perl5.major}-term-readkey \
+                    port:fontconfig \
+                    port:freetype \
                     port:jpeg \
                     port:libpng \
+                    port:Xft2 \
                     port:xorg-libX11
 
+# Must specify X11INC to find freetype.h
+# (can't just use X11=${prefix})
+# See https://rt.cpan.org/Ticket/Display.html?id=129923
     configure.args-append \
-                    X11=${prefix}
+                    XFT=1 \
+                    X11INC=${prefix}/include \
+                    X11LIB=${prefix}/lib
 }


### PR DESCRIPTION
Add size to checksums

#### Description

This is how Perl/Tk seems to be built by default on other OSes (e.g. Linux). However FreeBSD makes this an option (though enabled by default); should I instead add this as a variant so it can be disabled?


Before:

![Screen Shot 2019-06-27 at 7 39 45 AM](https://user-images.githubusercontent.com/7941193/60267115-13c6b880-98af-11e9-9d02-1da2d0a9129f.png)

After:

![Screen Shot 2019-06-27 at 7 39 04 AM](https://user-images.githubusercontent.com/7941193/60267120-1c1ef380-98af-11e9-8b97-57059d1eeafc.png)


<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 
Perl 5.28.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
