### PR TITLE
youtube-dl: update to version 2019.06.27

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                youtube-dl
-version             2019.06.08
+version             2019.06.27
 revision            0
-checksums           rmd160  bccdfbfeccbd820dbc6af9157dd3558a0c4faa38 \
-                    sha256  275a8506ecd6c72589bfc66b749cd80847e7393df1d6e1becd1d11ba90980837 \
-                    size    3169571
+checksums           rmd160  1074db38af1769bd13ca5eee61d0998bb946b40b \
+                    sha256  feb0e1a7f162c683e10d18a16992095a366e62896a0ac0644116ec07a18fb8cf \
+                    size    3170966
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
youtube-dl: update to version 2019.06.27
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
