### PR TITLE
ihaskell: Submission of a Haskell kernel for Jupyter

### DIFF
--- a/devel/ihaskell/Portfile
+++ b/devel/ihaskell/Portfile
@@ -1,0 +1,184 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           haskell_stack 1.0
+
+github.setup        gibiansky IHaskell ac0882d
+git.branch          master
+name                ihaskell
+# set the version to be the date of the last commit
+version             2019.08.30
+
+categories          devel haskell
+platforms           darwin
+license             MIT
+maintainers         nomaintainer
+
+description         A Haskell kernel for IPython, with hlint.
+long_description    \
+    IHaskell is a kernel for the Jupyter project, which allows you to \
+    use Haskell inside Jupyter frontends (including the console and \
+    notebook). For a tour of some IHaskell features, check out the \
+    demo Notebook at \
+    http://nbviewer.ipython.org/github/gibiansky/IHaskell/blob/master/notebooks/IHaskell.ipynb. More \
+    example notebooks are available on the wiki at \
+    https://github.com/gibiansky/IHaskell/wiki. The wiki also has more \
+    extensive documentation of IHaskell features. \
+    Additionaly, the auxiallary tools hlint, HsColor, aeson, cpphs, \
+    and happy are installed.
+
+conflicts           hs-happy
+
+checksums           rmd160  47cf8fed7674b0e2421019ff4c813ee4eea93882 \
+                    sha256  c6e6c9a7d71ba6349027f1fb818608f8355acafe6fa7cbe57265ec9951a5ddb4 \
+                    size    753553
+
+# use these to specify python versions, python3 required 
+set python3_version 3.7
+set python3_version_nickname \
+    [join [lrange [split ${python3_version} .] 0 1] {}]
+
+# See https://github.com/gibiansky/IHaskell#mac,
+# https://github.com/gibiansky/IHaskell/blob/master/requirements.txt
+depends_lib-append  \
+                    path:lib/pkgconfig/pango.pc:pango \
+                    port:python${python3_version_nickname} \
+                    port:py${python3_version_nickname}-cairo \
+                    port:py${python3_version_nickname}-ipykernel \
+                    port:py${python3_version_nickname}-ipywidgets \
+                    port:py${python3_version_nickname}-jupyter \
+                    port:py${python3_version_nickname}-jupyter_client \
+                    port:py${python3_version_nickname}-jupyter_core \
+                    port:py${python3_version_nickname}-magic \
+                    port:py${python3_version_nickname}-nbformat \
+                    port:py${python3_version_nickname}-pkgconfig \
+                    port:py${python3_version_nickname}-widgetsnbextension \
+                    port:zmq
+
+haskell_stack.system_ghc \
+                    yes
+
+# relative paths to ${prefix}
+set ihaskell_datadir \
+                    share/${name}
+set jupyter_dir     share/jupyter
+set hlint_datadir \
+                    share/hlint/datadir
+
+post-extract {
+    xinstall -o macports -m 0755 -d \
+        "[option haskell_stack.stack_root]" \
+        ${destroot}${prefix}/${ihaskell_datadir}/html \
+        ${destroot}${prefix}/${jupyter_dir} \
+        ${destroot}${prefix}/${hlint_datadir}
+
+    # append configure-options to stack.yaml
+    reinplace "\$ a\\
+\\
+# Avoid MacPorts iconv link error\\
+# See https://github.com/commercialhaskell/stack/issues/825\\
+extra-lib-dirs:\\
+\\ \\ - /usr/lib\\
+" \
+        stack.yaml
+
+    # Fix for cabal data-files hardcoded path in binary
+    # See:
+    # https://github.com/commercialhaskell/stack/issues/848
+    # https://github.com/commercialhaskell/stack/issues/4857
+    # https://github.com/haskell/cabal/issues/462
+    # https://github.com/haskell/cabal/issues/3586
+    xinstall -m 0644 -W ${worksrcpath} \
+        ${filespath}/Paths_${name}.hs ./src
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+}
+
+# no jupyter_select yet, so hack PATH to find `which jupyter`: 
+# https://trac.macports.org/ticket/50608
+# note: this command does not change the destroot PATH environment, so export
+# PATH explicitly in the necessary system command below
+destroot.env-append \
+    PATH=$env(PATH):${prefix}/Library/Frameworks/Python.framework/Versions/${python3_version}/bin \
+    ${name}_datadir=${destroot}${prefix}/${ihaskell_datadir}
+
+post-destroot {
+    # install the data-files into destroot (see ${name}.cabal)
+    fs-traverse f ${worksrcpath}/.stack-work {
+        if { [file isfile ${f}] } {
+            foreach datafile {
+                html/kernel.js
+                html/logo-64x64.svg
+                } {
+                if { [string match "*/${datafile}" ${f}] } {
+                    xinstall -m 0644 ${f} \
+                        ${destroot}${prefix}/${ihaskell_datadir}/${datafile}
+                }
+            }
+        }
+    }
+    
+    # run ihaskell to install the IPython files into destroot
+    system -W ${worksrcpath} "\
+        export \
+            PATH=$env(PATH):${prefix}/Library/Frameworks/Python.framework/Versions/${python3_version}/bin \
+            ${name}_datadir=${destroot}${prefix}/${ihaskell_datadir} \
+            ; \
+        ${destroot}${prefix}/bin/ihaskell install \
+            --prefix=${destroot}${prefix} \
+        "
+
+    # install auxilliary binaries and data-files
+    fs-traverse f "[option haskell_stack.stack_root]" {
+        if { [file isfile ${f}] } {
+            foreach binary {
+                bin/HsColour
+                bin/aeson-pretty
+                bin/cpphs
+                bin/happy
+                bin/hlint
+                } {
+                if { [string match "*/${binary}" ${f}] } {
+                    xinstall -m 0755 ${f} \
+                        ${destroot}${prefix}/${binary}
+                }
+            }
+        }
+    }
+    fs-traverse f "[option haskell_stack.stack_root]" {
+        if { [file isfile ${f}] 
+            && [string match "hlint.yaml" [file tail ${f}]] } {
+            set stack_hlint_datadir [file dirname ${f}]
+            break
+        }
+    }
+    xinstall -m 0644 {*}[glob ${stack_hlint_datadir}/*] \
+        ${destroot}${prefix}/${hlint_datadir}
+
+    # install the hlint manpage
+    xinstall -m 0755 -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 ${destroot}${prefix}/${hlint_datadir}/hlint.1 \
+        ${destroot}${prefix}/share/man/man1
+
+    # delete any destroot path appearing in text files
+    fs-traverse f ${destroot}${prefix} {
+        if {[file isfile ${f}]} {
+            if {[string match "text/*" [lindex [exec /usr/bin/file --mime-type ${f}] end]]} {
+                reinplace -q "s|${destroot}||g" ${f}
+            }
+        }
+    }
+}
+
+# Remove hlint_datadir instructions after this cabal issue is fixed:
+# https://github.com/haskell/cabal/issues/6234
+notes "
+
+The environment variable `hlint_datadir` must be set before running the
+Jupyter notebook (due to a Cabal path issue):
+
+        export hlint_datadir=${prefix}/${hlint_datadir}
+        jupyter-${python3_version} notebook-${python3_version}
+"

--- a/devel/ihaskell/files/Paths_ihaskell.hs
+++ b/devel/ihaskell/files/Paths_ihaskell.hs
@@ -1,0 +1,62 @@
+{- Cabal data-files hardcoded path in binary fix.
+
+This file replaces the Paths_*.hs automatically created by cabal.
+
+See:
+* https://github.com/commercialhaskell/stack/issues/848
+* https://github.com/commercialhaskell/stack/issues/4857
+* https://github.com/haskell/cabal/issues/462
+* https://github.com/haskell/cabal/issues/3586
+
+-}
+        
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoRebindableSyntax #-}
+{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
+module Paths_ihaskell (
+    version,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
+    getDataFileName, getSysconfDir
+  ) where
+
+import qualified Control.Exception as Exception
+import Data.Version (Version(..))
+import System.Environment (getEnv)
+import Prelude
+
+#if defined(VERSION_base)
+
+#if MIN_VERSION_base(4,0,0)
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#else
+catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
+#endif
+
+#else
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#endif
+catchIO = Exception.catch
+
+version :: Version
+version = Version [2,0,1] []
+bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
+
+bindir     = "@PREFIX@/bin"
+libdir     = "@PREFIX@/lib/ihaskell"
+dynlibdir  = "@PREFIX@/lib/ihaskell"
+datadir    = "@PREFIX@/share/ihaskell"
+libexecdir = "@PREFIX@/lib/ihaskell"
+sysconfdir = "@PREFIX@/etc"
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+getBinDir = catchIO (getEnv "ihaskell_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "ihaskell_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "ihaskell_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "ihaskell_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "ihaskell_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "ihaskell_sysconfdir") (\_ -> return sysconfdir)
+
+getDataFileName :: FilePath -> IO FilePath
+getDataFileName name = do
+  dir <- getDataDir
+  return (dir ++ "/" ++ name)


### PR DESCRIPTION
ihaskell: Submission of a Haskell kernel for Jupyter

* Uses port:stack for build
* Uses Paths_ihaskell.hs for correct `${prefix}` of Cabal data-files path

Related: haskell/cabal#6234
Related: commercialhaskell/stack#5026
Related: https://trac.macports.org/ticket/50608

#### Description

Notes:
* This will not build until [port:stack](https://github.com/macports/macports-ports/pull/4633) is committed
* This will not build until upstream issue is addressed, https://github.com/gibiansky/IHaskell/issues/1058

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->