### PR TITLE
bochs: fix build: strrchr() const overload produces an error.

### DIFF
--- a/emulators/bochs/Portfile
+++ b/emulators/bochs/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                bochs
 version             2.6.8
-revision            1
+revision            2
 categories          emulators
 license             LGPL-2.1+
 platforms           darwin
@@ -21,7 +21,8 @@ master_sites        sourceforge
 checksums           sha256  79700ef0914a0973f62d9908ff700ef7def62d4a28ed5de418ef61f3576585ce \
                     rmd160  cf6f9a427559c79e18c208a89e7146b6e9798ea5
 
-patchfiles          patch-.bochsrc.diff
+patchfiles          patch-.bochsrc.diff \
+                    patch-cdrom_osx.cc.diff
 
 depends_lib         port:gettext \
                     port:readline

--- a/emulators/bochs/files/patch-cdrom_osx.cc.diff
+++ b/emulators/bochs/files/patch-cdrom_osx.cc.diff
@@ -1,0 +1,11 @@
+--- iodev/hdimage/cdrom_osx.cc.orig	2019-06-28 17:01:30.000000000 +0700
++++ iodev/hdimage/cdrom_osx.cc	2019-06-28 17:06:39.000000000 +0700
+@@ -191,7 +191,7 @@
+   mach_port_t port = 0;
+   char *devname;
+ 
+-  if ((devname = strrchr(devpath, '/')) != NULL) {
++  if ((devname = (char *) strrchr(devpath, '/')) != NULL) {
+     ++devname;
+   }
+   else {


### PR DESCRIPTION
#### Description

Fix build: strrchr() const overload produces an error.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->