### PR TITLE
dcmtk: avoid conflicts

### DIFF
--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -9,7 +9,7 @@ PortGroup               github 1.0
 
 github.setup            DCMTK dcmtk 3.6.4 DCMTK-
 
-revision                3
+revision                4
 set unpatched_version   [lindex [split ${version} _] 0]
 set stripped_version    [string map {. ""} ${unpatched_version}]
 categories              graphics
@@ -129,6 +129,13 @@ if {[variant_isset doc]} {
 }
 
 destroot.args           docdir=${prefix}/share/doc/${name}
+
+post-destroot {
+    # avoid conflict with other MacPorts libraries
+    foreach lib {charls} {
+        delete ${destroot}${prefix}/lib/lib${lib}.dylib
+    }
+}
 
 test.run                yes
 test.cmd                env DYLD_LIBRARY_PATH=${cmake.build_dir}/lib make

--- a/graphics/dcmtk/Portfile
+++ b/graphics/dcmtk/Portfile
@@ -39,8 +39,9 @@ checksums \
 
 compiler.blacklist      *gcc* {clang < 137}
 
-# Still puts ${prefix}/include at the head of the -I list...
-conflicts_build         ${name}
+# avoid self-conflict
+configure.cppflags-replace -I${prefix}/include -isystem${prefix}/include
+
 
 depends_lib             port:zlib \
                         port:libiconv \


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5
Xcode 10.2.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
