### PR TITLE
LaTeXML: update to upstream version 0.8.4

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                LaTeXML
-version             0.8.3
-checksums           rmd160  27cd0fa18dbb99daf524a57128183c4df7cf3f01 \
-                    sha256  28a57369b65b85d09c1a2516e69d26bbbe102ab790cae5e2fc9709b26185f62f \
-                    size    10704659
+version             0.8.4
+checksums           rmd160  902a574fbd1439017cec3117fefbecac50745ed4 \
+                    sha256  92599b45fb587ac14b2ba9cc84b85d9ddc2deaf1cbdc2e89e7a6559e1fbb34cc \
+                    size    11502627
 
 license             public-domain
 maintainers         {nist.gov:bruce.miller @brucemiller}


### PR DESCRIPTION
#### Description
Update LaTeXML to version 0.8.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F203
Xcode 10.2.1 10E1001
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
