### PR TITLE
VLC : address remaining (?) build issues on 10.11

### DIFF
--- a/multimedia/VLC/files/patch-build-on-pre-1012.diff
+++ b/multimedia/VLC/files/patch-build-on-pre-1012.diff
@@ -90,3 +90,254 @@ index 20aedfc63e440cbb16ec3d0078d7d433434b8131..26ca20e4b449a52b7650a3ef7f2c1337
  
          vout_display_opengl_Display (sys->vgl, &vd->source);
          vlc_gl_ReleaseCurrent(sys->gl);
+diff --git modules/gui/macosx/VLCBottomBarView.m modules/gui/macosx/VLCBottomBarView.m
+index 26e9dd3da5ecd6d2b8ffbbb8fb59ff49f2d16ed2..3691486d253854aa971f5a798e91310527273350 100644
+--- modules/gui/macosx/VLCBottomBarView.m
++++ modules/gui/macosx/VLCBottomBarView.m
+@@ -84,9 +84,11 @@
+         _darkStroke = [NSColor blackColor];
+     }
+ 
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10.14, *)) {
+         [self viewDidChangeEffectiveAppearance];
+     }
++#endif
+ }
+ 
+ - (void)calculatePaths
+@@ -144,6 +146,7 @@
+ 
+ - (void)viewDidChangeEffectiveAppearance
+ {
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10_14, *)) {
+         if ([self.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua])
+             [self setDark:YES];
+@@ -152,6 +155,7 @@
+ 
+         [self setNeedsDisplay:YES];
+     }
++#endif
+ }
+ 
+ @end
+diff --git modules/gui/macosx/VLCControlsBarCommon.m modules/gui/macosx/VLCControlsBarCommon.m
+index 85aeaf1371f6e0cac6b4e83a3737c25efc901315..ee9ef9d31f4efe72f42ae0c010385e4b41500376 100644
+--- modules/gui/macosx/VLCControlsBarCommon.m
++++ modules/gui/macosx/VLCControlsBarCommon.m
+@@ -55,9 +55,11 @@
+ 
+ - (void)dealloc
+ {
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10_14, *)) {
+         [[NSApplication sharedApplication] removeObserver:self forKeyPath:@"effectiveAppearance"];
+     }
++#endif
+ }
+ 
+ - (void)awakeFromNib
+@@ -65,6 +67,7 @@
+     [super awakeFromNib];
+     
+     _darkInterface = var_InheritBool(getIntf(), "macosx-interfacestyle");
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10_14, *)) {
+         NSApplication *app = [NSApplication sharedApplication];
+         _darkInterface = [app.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua];
+@@ -74,6 +77,7 @@
+                  options:0
+                  context:nil];
+     }
++#endif
+     _nativeFullscreenMode = var_InheritBool(getIntf(), "macosx-nativefullscreenmode");
+ 
+     [self.dropView setDrawBorder: NO];
+@@ -439,6 +443,7 @@
+         [self.fullscreenButton setState:b_fullscreen];
+ }
+ 
++#ifdef MAC_OS_X_VERSION_10_13
+ // This is used for both VLCControlsBarCommon, as well as VLCMainWindowControlsBar instances
+ - (void)observeValueForKeyPath:(NSString *)keyPath
+                       ofObject:(id)object
+@@ -455,5 +460,13 @@
+         }
+     }
+ }
++#else
++- (void)observeValueForKeyPath:(NSString *)keyPath
++                      ofObject:(id)object
++                        change:(NSDictionary *)change
++                       context:(void *)context
++{
++}
++#endif
+ 
+ @end
+diff --git modules/gui/macosx/VLCMain.m modules/gui/macosx/VLCMain.m
+index 883fad846ecf167de60c428e891b73296a8c4072..6ececa433b5f9fef4115c7552514732d2af7948d 100644
+--- modules/gui/macosx/VLCMain.m
++++ modules/gui/macosx/VLCMain.m
+@@ -95,6 +95,7 @@ int OpenIntf (vlc_object_t *p_this)
+             [VLCApplication sharedApplication];
+             [VLCMain sharedInstance];
+ 
++#ifdef MAC_OS_X_VERSION_10_13
+             if (@available(macOS 10.14, *)) {
+                 if (var_InheritBool(getIntf(), "macosx-interfacestyle")) {
+ 
+@@ -104,6 +105,7 @@ int OpenIntf (vlc_object_t *p_this)
+                     app.appearance = [NSAppearance appearanceNamed: NSAppearanceNameDarkAqua];
+                 }
+             }
++#endif
+ 
+             [NSBundle loadNibNamed:@"MainMenu" owner:[[VLCMain sharedInstance] mainMenu]];
+             [[[VLCMain sharedInstance] mainWindow] makeKeyAndOrderFront:nil];
+diff --git modules/gui/macosx/VLCMainWindow.m modules/gui/macosx/VLCMainWindow.m
+index 66d9a6b0570f468ceadae22177cc1f57dcd606c2..30bc49b106e24cf1b096360afc4f6f56ff5b7119 100644
+--- modules/gui/macosx/VLCMainWindow.m
++++ modules/gui/macosx/VLCMainWindow.m
+@@ -135,9 +135,11 @@ static const float f_min_window_height = 307.;
+ - (void)dealloc
+ {
+     [[NSNotificationCenter defaultCenter] removeObserver: self];
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10_14, *)) {
+         [[NSApplication sharedApplication] removeObserver:self forKeyPath:@"effectiveAppearance"];
+     }
++#endif
+ }
+ 
+ - (void)awakeFromNib
+@@ -192,6 +194,7 @@ static const float f_min_window_height = 307.;
+ 
+     // Dropzone
+     [_dropzoneLabel setStringValue:_NS("Drop media here")];
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10.14, *)) {
+         NSApplication *app = [NSApplication sharedApplication];
+         if ([app.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua]) {
+@@ -204,7 +207,9 @@ static const float f_min_window_height = 307.;
+                  options:0
+                  context:nil];
+         self.dropzoneBackgroundImageView.hidden = YES;
+-    } else {
++    } else
++#endif
++    {
+         [_dropzoneImageView setImage:imageFromRes(@"dropzone")];
+     }
+     [_dropzoneButton setTitle:_NS("Open media...")];
+@@ -307,12 +312,14 @@ static const float f_min_window_height = 307.;
+         isAReload = YES;
+ 
+     BOOL darkMode = NO;
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10.14, *)) {
+         NSApplication *app = [NSApplication sharedApplication];
+         if ([app.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua]) {
+             darkMode = YES;
+         }
+     }
++#endif
+ 
+     o_sidebaritems = [[NSMutableArray alloc] init];
+     SideBarItem *libraryItem = [SideBarItem itemWithTitle:_NS("LIBRARY") identifier:@"library"];
+@@ -755,6 +762,7 @@ static const float f_min_window_height = 307.;
+     [self.fspanel setVolumeLevel:[[VLCCoreInteraction sharedInstance] volume]];
+ }
+ 
++#ifdef MAC_OS_X_VERSION_10_13
+ - (void)observeValueForKeyPath:(NSString *)keyPath
+                       ofObject:(id)object
+                         change:(NSDictionary<NSKeyValueChangeKey,id> *)change
+@@ -769,6 +777,15 @@ static const float f_min_window_height = 307.;
+         [self reloadSidebar];
+     }
+ }
++#else
++- (void)observeValueForKeyPath:(NSString *)keyPath
++                      ofObject:(id)object
++                        change:(NSDictionary *)change
++                       context:(void *)context
++{
++}
++#endif
++
+ 
+ #pragma mark -
+ #pragma mark Video Output handling
+@@ -1299,9 +1316,12 @@ static const float f_min_window_height = 307.;
+     [super awakeFromNib];
+     [self setAcceptsMouseMovedEvents: YES];
+ 
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10.14, *)) {
+         [self setContentMinSize: NSMakeSize(363., f_min_video_height + [[self controlsBar] height])];
+-    } else {
++    } else
++#endif
++    {
+         BOOL darkInterface = config_GetInt(getIntf(), "macosx-interfacestyle");
+ 
+         if (darkInterface) {
+diff --git modules/gui/macosx/VLCSlider.m modules/gui/macosx/VLCSlider.m
+index 816dcdac31fb1d5b74409f4e665343ce5fa05c9f..200c532a9d314fd528ab2d50027d8a60c15c0c83 100644
+--- modules/gui/macosx/VLCSlider.m
++++ modules/gui/macosx/VLCSlider.m
+@@ -35,9 +35,12 @@
+         NSAssert([self.cell isKindOfClass:[VLCSliderCell class]],
+                  @"VLCSlider cell is not VLCSliderCell");
+         _isScrollable = YES;
++#ifdef MAC_OS_X_VERSION_10_13
+         if (@available(macOS 10.14, *)) {
+             [self viewDidChangeEffectiveAppearance];
+-        } else {
++        } else
++#endif
++        {
+             [self setSliderStyleLight];
+         }
+     }
+diff --git modules/gui/macosx/VLCVolumeSlider.m modules/gui/macosx/VLCVolumeSlider.m
+index bc30e4a86e737634f33e0a8830ff32010d99fb94..02c50a438a8f0592667b5e482882ccef17ffbb1d 100644
+--- modules/gui/macosx/VLCVolumeSlider.m
++++ modules/gui/macosx/VLCVolumeSlider.m
+@@ -56,6 +56,7 @@
+ 
+ - (void)viewDidChangeEffectiveAppearance
+ {
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10_14, *)) {
+         if ([self.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua]) {
+             [(VLCVolumeSliderCell*)self.cell setSliderStyleDark];
+@@ -65,6 +66,7 @@
+ 
+         [self setNeedsDisplay:YES];
+     }
++#endif
+ }
+ 
+ - (void)setUsesBrightArtwork:(BOOL)brightArtwork
+diff --git modules/gui/macosx/Windows.m modules/gui/macosx/Windows.m
+index 9e459dda2477a712e34b6021241073d40465c149..a2accf389a3bde219f73a3259aac5f0ce64766e3 100644
+--- modules/gui/macosx/Windows.m
++++ modules/gui/macosx/Windows.m
+@@ -231,10 +231,13 @@
+ - (id)initWithContentRect:(NSRect)contentRect styleMask:(NSWindowStyleMask)styleMask
+                   backing:(NSBackingStoreType)backingType defer:(BOOL)flag
+ {
++#ifdef MAC_OS_X_VERSION_10_13
+     if (@available(macOS 10.14, *)) {
+         self = [super initWithContentRect:contentRect styleMask:styleMask
+                                   backing:backingType defer:flag];
+-    } else {
++    } else
++#endif
++    {
+         _darkInterface = config_GetInt(getIntf(), "macosx-interfacestyle");
+ 
+         if (_darkInterface) {


### PR DESCRIPTION
This fixes the (hopefully all) remaining build issues on 10.11 as signalled by the build bot.

The new fixes are all analogous to the existing fixes: they wrap `@available(... 10.14 ...)` runtime checks in #ifdefs that enable them only on 10.13 and up.