### PR TITLE
dart-sdk: Update to version 2.4.0

### DIFF
--- a/lang/dart-sdk/Portfile
+++ b/lang/dart-sdk/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dart-sdk
-version             2.3.0
+version             2.4.0
 categories          lang
 license             BSD
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ use_zip             yes
 dist_subdir         ${name}/${version}
 worksrcdir          ${name}
 
-checksums           rmd160  5bfe4ff636aae30c3e4779ca75fe6b0a0dd0fe83 \
-                    sha256  d94259c928d97b0b89fea3f6ab0f7d0f7e15d9761cc719db9c4c731181bd1d58 \
-                    size    152083780
+checksums           rmd160  eb4713d24e060eb960e2bbdda0c2d1baa16e06ec \
+                    sha256  5af4c52660a082a791d7b808b738432d5b86bdbba9292bf9e1c11398d3804b0e \
+                    size    127926000
 
 use_configure       no
 build               {}


### PR DESCRIPTION
#### Description

Dart SDK version 2.4.0 has been released.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->