### PR TITLE
lighttpd: add legacysupport PG

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   legacysupport 1.0
 
 name                        lighttpd
 version                     1.4.54


### PR DESCRIPTION
for *at functions now used in version 1.4.54

