### PR TITLE
py-agate-excel: update to 0.2.3

### DIFF
--- a/python/py-agate-excel/Portfile
+++ b/python/py-agate-excel/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 set base_name       agate-excel
 name                py-agate-excel
-version             0.2.2
+version             0.2.3
 python.versions     27 35 36 37
 platforms           darwin
 maintainers         {gmail.com:esafak @esafak} openmaintainer
@@ -17,9 +17,9 @@ long_description    ${description}
 homepage            https://pypi.python.org/pypi/$base_name
 master_sites        pypi:a/$base_name
 
-checksums           rmd160  0739b15171e050ec17cea13ca63ebca9f46b1790 \
-                    sha256  8923f71ee2b5b7b21e52fb314a769b28fb902f647534f5cbbb41991d8710f4c7 \
-                    size    4562
+checksums           rmd160  1e8bc5c720e70f1d7246a2bf358e8fb734e08c00 \
+                    sha256  8f255ef2c87c436b7132049e1dd86c8e08bf82d8c773aea86f3069b461a17d52 \
+                    size    153880
 
 distname            $base_name-${version}
 


### PR DESCRIPTION
#### Description
This updates ```py-agate-excel``` to version ```0.2.3```. In particular, updating this library fixes an issue where the ```in2csv``` command fails when parsing excel files. For more information, see wireservice/agate-excel#27.

@esafak is the maintainer of this package, but I figured I'd try submitting an update. It's my first time submitting a port file for upgrade, so let me know if I've done anything wrong.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
 - There do not appear to be any tests
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

I tested that the ```in2csv``` binary worked for ```2.7``` and ```3.7```. `py37-agate-excel` is also a dependent of `p37-csvkit` - is there a good way to test the entire package?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
