### PR TITLE
apache-ant: update to 1.10.6

### DIFF
--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup               java 1.0
 
 name                    apache-ant
-version                 1.10.5
+version                 1.10.6
 categories              devel java
 license                 Apache-2 W3C
 maintainers             openmaintainer {blair @blair}
@@ -24,9 +24,9 @@ distname                ${name}-${version}-bin
 master_sites            apache:ant/
 master_sites.mirror_subdir        binaries
 # Remember also to update the checksums in the source variant below.
-checksums               rmd160  bc2823d7ce5a83ff3078f6997c147efe33872643 \
-                        sha256  3f762e16c4b5446e64869d146efe76be865a1d83062eede2d0a8fc11d1e20b2d \
-                        size    4730768
+checksums               rmd160  f240de850ef42c4ddf857b405c4f38f01d1eadcf \
+                        sha256  45c93201dcb0b90622d7c712aa828fc2eeea5819f6aad2b52d6850abcd60636a \
+                        size    5375076
 
 worksrcdir              ${name}-${version}
 set workTarget          ""
@@ -45,9 +45,9 @@ variant source description "build from source; not recommended" {
         java.version                    1.8+
         distname                        ${name}-${version}-src
         master_sites.mirror_subdir      source
-        checksums                       rmd160  3f03bfeed5c95136b2aa5a5df87680c9803fe002 \
-                                        sha256  71a5cdd45a54901b6321d5a140d882f7580c38f766a4e4959bcc36555da9f3ac \
-                                        size    4465063
+        checksums                       rmd160  3adb7a2657ce3eb486f23887b50b867a3a29b7c6 \
+                                        sha256  628be0efd81719231c89df68911cfa15a03868039b70d706ef3a0900b4106cd7 \
+                                        size    4525119
         set workTarget                  /${name}
 
         build.cmd                       ./build.sh

--- a/devel/apache-ant/Portfile
+++ b/devel/apache-ant/Portfile
@@ -42,6 +42,7 @@ build.cmd               true
 # dependent support isn't available when ant is built, due to circular
 # dependencies back to ant.
 variant source description "build from source; not recommended" {
+        java.version                    1.8+
         distname                        ${name}-${version}-src
         master_sites.mirror_subdir      source
         checksums                       rmd160  3f03bfeed5c95136b2aa5a5df87680c9803fe002 \
@@ -52,6 +53,11 @@ variant source description "build from source; not recommended" {
         build.cmd                       ./build.sh
         build.args                      -Dchmod.fail=false -Ddist.name=${name}
         build.target                    dist
+
+        post-patch {
+            # Don't fail on Javadoc errors
+            reinplace "s|failonerror=\"true\"||g" ${worksrcpath}/build.xml
+        }
 }
 
 pre-destroot {


### PR DESCRIPTION
Update apache-ant to 1.10.6, and fix source build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->