### PR TITLE
xercesc3, xml-security-c: use HTTPS sites

### DIFF
--- a/security/xml-security-c/Portfile
+++ b/security/xml-security-c/Portfile
@@ -39,5 +39,5 @@ post-configure {
 }
 
 livecheck.type      regex
-livecheck.url       http://archive.apache.org/dist/santuario/c-library/
+livecheck.url       https://archive.apache.org/dist/santuario/c-library/
 livecheck.regex     ${name}-(\\d+(\\.\\d+)+)${extract.suffix}

--- a/textproc/xercesc3/Portfile
+++ b/textproc/xercesc3/Portfile
@@ -15,7 +15,7 @@ long_description    Xerces-C++ is a validating XML parser written in \
                     and write XML data.  A shared library is provided \
                     for parsing, generating, manipulating, and \
                     validating XML documents.
-homepage            http://xerces.apache.org/xerces-c/
+homepage            https://xerces.apache.org/xerces-c/
 master_sites        apache:xerces/c/3/sources/
 distname            xerces-c-${version}
 use_bzip2           yes
@@ -42,5 +42,5 @@ post-destroot {
 }
 
 livecheck.type      regex
-livecheck.url       http://www.apache.org/dist/xerces/c/3/sources/
+livecheck.url       https://www.apache.org/dist/xerces/c/3/sources/
 livecheck.regex     xerces-c-(\\d+\\.\\d+\\.\\d+)


### PR DESCRIPTION
(Skipping HTTPS for [`xml-security-c` homepage](http://santuario.apache.org/) since modern browsers may not load some of its resources by default.)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
