### PR TITLE
wireguard-tools: update to 0.0.20190702

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190601
+version             0.0.20190702
 revision            0
-checksums           rmd160  6481c53f86af5eaacde46b02a08f12d85090852d \
-                    sha256  7528461824a0174bd7d4f15e68d8f0ce9a8ea318411502b80759438e8ef65568 \
-                    size    327348
+checksums           rmd160  1770c986502634e32f73755bbf991e2297226899 \
+                    sha256  1a1311bc71abd47a72c47d918be3bacc486b3de90734661858af75cc990dbaac \
+                    size    327632
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?