### PR TITLE
openjfx11 @11.0.2 Initial commit of PortFile

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -21,14 +21,14 @@ subport               bazel25 { }
 if { ${name} eq ${subport} } {
     
     # Main port
-    github.setup      bazelbuild ${name} 0.27.0
+    github.setup      bazelbuild ${name} 0.27.1
     revision          0
     
     conflicts         bazel21 bazel25
 
-    checksums         rmd160  5daedd012558da22893c864f9988f70a25e5c343 \
-                      sha256  c3080d3b959ac08502ad5c84a51608c291accb1481baad88a628bbf79b30c67a \
-                      size    247946763
+    checksums         rmd160  c2c3e7115eab58b43391e02245060213422f2b6e \
+                      sha256  8051d77da4ec338acd91770f853e4c25f4407115ed86fd35a6de25921673e779 \
+                      size    247947232
 
     pre-fetch {
         # https://trac.macports.org/ticket/58518

--- a/java/openjfx11/Portfile
+++ b/java/openjfx11/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            openjfx11
+version         11.0.2
+revision        0
+
+set build       0
+set major       11
+
+categories      java devel
+maintainers     {@lhaeger} openmaintainer
+platforms       darwin
+license         GPL-2
+supported_archs x86_64
+
+description     OpenJFX ${major}
+
+long_description OpenJFX is an open source, next generation client application platform \
+                 for desktop, mobile and embedded systems built on Java.
+
+homepage        https://openjfx.io/
+
+depends_lib     port:openjdk11
+
+master_sites    https://download2.gluonhq.com/openjfx/${version}/
+distname        openjfx-${version}_osx-x64_bin-sdk
+use_zip         yes
+
+checksums       rmd160  3b74b4bd563cc46e28b886df5c9e239fb00845c2 \
+                sha256  e98158812db1a0037cdaf85824adff384e41e3edf046fda145479ce6057cb514 \
+                size    41684332
+
+worksrcdir      javafx-sdk-${version}
+
+
+use_configure   no
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/openjdk11/Contents/Home
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}/Contents/Home
+    copy ${worksrcpath}/legal ${destroot_target}/legal
+    copy ${worksrcpath}/lib   ${destroot_target}/lib
+    # src.zip is already provided by openjdk11
+    move ${destroot_target}/lib/src.zip ${destroot_target}/lib/src_javafx.zip
+}

--- a/perl/fusioninventory-agent/Portfile
+++ b/perl/fusioninventory-agent/Portfile
@@ -11,7 +11,7 @@ perl5.branches          5.26 5.28
 perl5.create_variants   ${perl5.branches}
 
 name                fusioninventory-agent
-perl5.setup         FusionInventory-Agent 2.4.1 ../../authors/id/G/GR/GROUSSE/
+perl5.setup         FusionInventory-Agent 2.5.1
 
 platforms           darwin
 maintainers         nomaintainer
@@ -25,14 +25,11 @@ long_description    Perl application that runs an agent connecting to a \
                     for inventorying purposes.
 
 homepage            http://www.fusioninventory.org/overview/
-
-# no longer released to CPAN
-# now mandatory to download releases from github
 master_sites        https://github.com/fusioninventory/fusioninventory-agent/releases/download/${version}/
 
-checksums           rmd160  86b0520638fc3c1d0caf012550275432f796a402 \
-                    sha256  aa72f0ff89178e9fff3271b15e1eceeffe1cc7cb34085a9c8fe1160262949606 \
-                    size    2566207
+checksums           rmd160  f0aa0c095b90f4ccf52f6b250181ecb910ceabb9 \
+                    sha256  c86211f8a43617f6817ee279ae90e138179a93b98116f81854d64a9207ea7020 \
+                    size    2651873
 
 depends_build-append \
                     port:p${perl5.major}-http-proxy \

--- a/perl/fusioninventory-agent/files/patch-Makefile.PL.diff
+++ b/perl/fusioninventory-agent/files/patch-Makefile.PL.diff
@@ -1,6 +1,6 @@
---- Makefile.PL.orig	2018-06-29 05:32:54.000000000 -0700
-+++ Makefile.PL	2018-09-20 14:31:16.000000000 -0700
-@@ -131,7 +131,7 @@
+--- Makefile.PL.orig	2019-07-01 08:37:06.000000000 -0700
++++ Makefile.PL	2019-07-02 14:33:22.000000000 -0700
+@@ -133,7 +133,7 @@
  # look for already existing configuration file
  my $config_file_message = -f "$MY::variables{SYSCONFDIR}/agent.cfg" ?
      "previous configuration file found, new one will be installed as agent.cfg.new" :
@@ -9,12 +9,14 @@
  
  print <<EOF;
  
-@@ -240,7 +240,7 @@
- 	if [ -f $(DESTDIR)/$(SYSCONFDIR)/agent.cfg ]; then \
- 	    install -m 644 etc/agent.cfg $(DESTDIR)$(SYSCONFDIR)/agent.cfg.new; \
- 	else \
--	    install -m 644 etc/agent.cfg $(DESTDIR)$(SYSCONFDIR)/agent.cfg; \
-+	    install -m 644 etc/agent.cfg $(DESTDIR)$(SYSCONFDIR)/agent.cfg.new; \
- 	fi
+@@ -247,8 +247,8 @@
+ 	    $(CP) etc/$$config $(DESTDIR)$(SYSCONFDIR)/$$config.new; \
+ 	    $(CHMOD) $(PERM_RW) $(DESTDIR)$(SYSCONFDIR)/$$config.new; \
+ 	  else \
+-	    $(CP) etc/$$config $(DESTDIR)$(SYSCONFDIR)/$$config; \
+-	    $(CHMOD) $(PERM_RW) $(DESTDIR)$(SYSCONFDIR)/$$config; \
++	    $(CP) etc/$$config $(DESTDIR)$(SYSCONFDIR)/$$config.new; \
++	    $(CHMOD) $(PERM_RW) $(DESTDIR)$(SYSCONFDIR)/$$config.new; \
+ 	  fi; \
+ 	done
  	$(ABSPERLRUN) -pi \
- 	    -e "s|=> undef, # SYSCONFDIR.*|=> '$(SYSCONFDIR)',|;" \

--- a/perl/p5-datetime-timezone/Portfile
+++ b/perl/p5-datetime-timezone/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 epoch               5
 perl5.branches      5.26 5.28
-perl5.setup         DateTime-TimeZone 2.35 ../../authors/id/D/DR/DROLSKY
+perl5.setup         DateTime-TimeZone 2.36 ../../authors/id/D/DR/DROLSKY
 maintainers         nomaintainer
 license             {Artistic-1 GPL}
 supported_archs     noarch
@@ -18,9 +18,9 @@ long_description    This class is the base class for all time zone \
 
 platforms           darwin
 
-checksums           rmd160  cb96b66478c3c3586d96d762cc087fb7731f70aa \
-                    sha256  79fadc0f24b6b23ffb560524544d9d200902578bf9e0943b9aa8fc5077ca8b02 \
-                    size    978789
+checksums           rmd160  165448e4d213a6845257e89ef41a48323b99f82d \
+                    sha256  7e033a3cae17a62a0a4011b9e3dd900acf8b7614e05dc6595d1f55406ec6f6a7 \
+                    size    979782
 
 if {${perl5.major} != ""} {
     depends_build-append \

--- a/perl/p5-ev/Portfile
+++ b/perl/p5-ev/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         EV 4.26 ../../authors/id/M/ML/MLEHMANN
+perl5.setup         EV 4.27 ../../authors/id/M/ML/MLEHMANN
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         EV - perl interface to libev, a high performance full-featured event loop
@@ -12,16 +12,15 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  6b05f48a56032c8f36ec7387e137b6d96d7cee1c \
-                    sha256  bfeb743e21345965ce640225cdd958422c173b98500f96664cb1bc8712234117 \
-                    size    201778
+checksums           rmd160  4dcc9dc2a96f63ecf5ea00a369e10fc16e78e2b6 \
+                    sha256  55750e5422d8cac7a2d0c89feeaca7d840ab2268f4c537655cdda0085e0d0cbc \
+                    size    205272
 
 if {${perl5.major} != ""} {
     depends_build-append \
                     port:p${perl5.major}-canary-stability
 
-#   builds using embedded copy of libev
-#   current version is libev 4.26
+#   builds using embedded libev
 
     depends_lib-append \
                     port:p${perl5.major}-common-sense

--- a/perl/p5-finance-quote/Portfile
+++ b/perl/p5-finance-quote/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Finance-Quote 1.47
+perl5.setup         Finance-Quote 1.49
 categories          perl
 maintainers         nomaintainer
 description         Perl module that allows for grabbing stock quotes.
@@ -15,13 +15,15 @@ long_description    Finance::Quote is a perl module which can be used to \
 platforms           darwin
 license             GPL-2+
 
-checksums           rmd160  b063bb00b64172ab7f87c79664c18f6ff7e9b238 \
-                    sha256  27af2df1f5eee570a8af577be3850468a869251dd212ae644ac2a1710ac2eb3f
+checksums           rmd160  cfabb132502a4d84c1d5d884036932fd897ea1e8 \
+                    sha256  95dbc4443ba656320b363c56625d04f379c943e202f60f40a2a35152b54bbf53 \
+                    size    274659
 
 if {${perl5.major} != ""} {
     depends_lib-append  \
                     port:p${perl5.major}-cgi \
                     port:p${perl5.major}-datetime \
+                    port:p${perl5.major}-datetime-format-strptime \
                     port:p${perl5.major}-encode \
                     port:p${perl5.major}-html-parser \
                     port:p${perl5.major}-html-tableextract \
@@ -29,8 +31,11 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-http-cookies \
                     port:p${perl5.major}-http-message \
                     port:p${perl5.major}-json \
+                    port:p${perl5.major}-json-parse \
                     port:p${perl5.major}-libwww-perl \
                     port:p${perl5.major}-mozilla-ca \
+                    port:p${perl5.major}-string-util \
+                    port:p${perl5.major}-text-template \
                     port:p${perl5.major}-time-piece \
                     port:p${perl5.major}-uri
 

--- a/perl/p5-mojolicious/Portfile
+++ b/perl/p5-mojolicious/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
 
-perl5.setup         Mojolicious 8.17 ../../authors/id/S/SR/SRI
+perl5.setup         Mojolicious 8.18 ../../authors/id/S/SR/SRI
 epoch               2
 categories-append   www
 platforms           darwin
@@ -16,9 +16,9 @@ homepage            https://mojolicious.org/
 description         A real-time MVC web framework emphasizing minimalism and simplicity
 long_description    ${description}
 
-checksums           rmd160  3da6e0e68e2086857dc8209d466f59a31bb8a2db \
-                    sha256  94b31f3837eecc60452bf0f4960b03354f0e58fb8ee7e51b18d52cdfaf8eb7ce \
-                    size    755684
+checksums           rmd160  3c7590dd645d4e95b2251ee8c2da18d0eb51a08c \
+                    sha256  fe76821bf8abe6c64a6abe2e327210f564a0c9cb0c5f4dc32c2dba0d43b7006e \
+                    size    761103
 
 if {${perl5.major} != ""} {
     depends_lib-append \

--- a/perl/p5-number-misc/Portfile
+++ b/perl/p5-number-misc/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28
+perl5.setup         Number-Misc 1.2
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Number::Misc - handy utilities for numbers
+long_description    ${description}
+
+platforms           darwin
+
+checksums           rmd160  1d32c470f6690cf84603468c027a19889af87cba \
+                    sha256  77b9b68c600a069cf16f4d8126ecb32151e6bcd34b0edb17b78adee689dc91d8 \
+                    size    12322
+
+if {${perl5.major} != ""} {
+    perl5.use_module_build
+    supported_archs noarch
+}

--- a/perl/p5-pdf-api2/Portfile
+++ b/perl/p5-pdf-api2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         PDF-API2 2.033 ../by-authors/id/S/SS/SSIMMS/
+perl5.setup         PDF-API2 2.034 ../../authors/id/S/SS/SSIMMS
 license             LGPL-2.1
 maintainers         nomaintainer
 description         create and manipulate PDF files
@@ -14,8 +14,9 @@ long_description    This module is 'The Next Generation' of Text::PDF::API \
 
 platforms           darwin
 
-checksums           rmd160  91860e3e819be878871f629fefceedc8c5a11415 \
-                    sha256  9c0866ec1a3053f73afaca5f5cdbe6925903b4ce606f4bf4ac317731a69d27a0
+checksums           rmd160  c2c06a0fdd64684d92172ca9ece6a4044ff4bbd2 \
+                    sha256  8aa98818fb6e4bebd6f9096e222989dcdd5fd4c5fa2ad1c7f0149053fc68f1cc \
+                    size    3510253
 
 if {${perl5.major} != ""} {
     depends_build-append \

--- a/perl/p5-string-util/Portfile
+++ b/perl/p5-string-util/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28
+perl5.setup         String-Util 1.26
+license             {Artistic-1 GPL}
+maintainers         {devans @dbevans} openmaintainer
+description         String::Util -- String processing utilities
+long_description    ${description}
+
+platforms           darwin
+
+checksums           rmd160  1e1b6fb526f3b16d16dd354c67e51d122ba8a1ea \
+                    sha256  f49a94f37c146c55211e3f87f3271b74ae4eaee416a519144e923dc0b433fa2d \
+                    size    19212
+
+if {${perl5.major} != ""} {
+    depends_build-append \
+                    port:p${perl5.major}-test-toolbox
+
+    depends_lib-append \
+                    port:p${perl5.major}-number-misc
+
+    perl5.use_module_build
+    supported_archs noarch
+}

--- a/perl/p5-test-compile/Portfile
+++ b/perl/p5-test-compile/Portfile
@@ -4,16 +4,16 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Test-Compile v2.1.1
+perl5.setup         Test-Compile v2.1.2
 maintainers         nomaintainer
 license             {Artistic-1 GPL}
 
 description         Check whether Perl files compile correctly
 long_description    ${description}
 
-checksums           rmd160  fd7b77f622c30070111f99129dceeb1b57b82421 \
-                    sha256  befaf3d6cb684bd27152f30e27ecc630bb3357f6ea25b7d5673784be3f792791 \
-                    size    16511
+checksums           rmd160  8fa208d6a10a24a8e44878d1785ee9e8b66649a0 \
+                    sha256  4fb7653e4993d38281b55b470c03580a5e59dfc40bc9215bd8a6f477106f2b26 \
+                    size    16846
 
 platforms           darwin
 

--- a/perl/p5-test-compile/Portfile
+++ b/perl/p5-test-compile/Portfile
@@ -4,19 +4,18 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Test-Compile v2.0.1
+perl5.setup         Test-Compile v2.1.1
 maintainers         nomaintainer
 license             {Artistic-1 GPL}
 
 description         Check whether Perl files compile correctly
 long_description    ${description}
 
-checksums           rmd160  33f41464dc2371963412d1f0e3f7efce831d8d1a \
-                    sha256  6935e3f71d4857104484fe21d925aa14ee7df4e61f07ebd0e0df142a877f88e5 \
-                    size    15666
+checksums           rmd160  fd7b77f622c30070111f99129dceeb1b57b82421 \
+                    sha256  befaf3d6cb684bd27152f30e27ecc630bb3357f6ea25b7d5673784be3f792791 \
+                    size    16511
 
 platforms           darwin
-supported_archs     noarch
 
 if {${perl5.major} != ""} {
     depends_build-append \
@@ -28,4 +27,5 @@ if {${perl5.major} != ""} {
                     port:p${perl5.major}-version
 
     perl5.use_module_build
+    supported_archs noarch
 }

--- a/perl/p5-test-refcount/Portfile
+++ b/perl/p5-test-refcount/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
-perl5.setup         Test-Refcount 0.09
+perl5.setup         Test-Refcount 0.10
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Test::Refcount - assert reference counts on objects
@@ -12,9 +12,9 @@ long_description    ${description}
 
 platforms           darwin
 
-checksums           rmd160  01480a92bbd7df22f0ec22ae9f870e733f8ef06f \
-                    sha256  e60d5005871332b66a197f283e35cac1e5247126057ad1ae56c0399e031c1e14 \
-                    size    17169
+checksums           rmd160  19e9eda378380d0af9ad9595675295e4ee0955ce \
+                    sha256  0457c20a4956473d157c4faaff8814154bc93f6e2b543c2812a19ff8e3370eb2 \
+                    size    17218
 
 if {${perl5.major} != ""} {
     depends_lib-append \

--- a/perl/p5-test-toolbox/Portfile
+++ b/perl/p5-test-toolbox/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.26 5.28
+perl5.setup         Test-Toolbox 0.4
+license             {Artistic-1 GPL}
+maintainers         nomaintainer
+description         Test::Toolbox - tools for testing
+long_description    ${description}
+
+platforms           darwin
+
+checksums           rmd160  79baa1a10c0e85a0f1224b26069adec60dc6b7e1 \
+                    sha256  4020b5c7f3a15ac9b187d05dfd9816b8030ec0d4a47ff8373f7633bb614ebdc3 \
+                    size    17713
+
+if {${perl5.major} != ""} {
+    perl5.use_module_build
+    supported_archs noarch
+}

--- a/python/py-tensorboard/Portfile
+++ b/python/py-tensorboard/Portfile
@@ -2,14 +2,15 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           conflicts_build 1.0
 
 name                py-tensorboard
-version             1.13.1
+version             1.14.0
 revision            0
 platforms           darwin
 supported_archs     noarch
 license             Apache-2
-maintainers         {emcrisostomo @emcrisostomo} openmaintainer
+maintainers         {emcrisostomo @emcrisostomo} {jonesc @cjones051073} openmaintainer
 
 description         TensorFlow's Visualization Toolkit
 long_description    TensorBoard is a suite of web applications for inspecting \
@@ -18,25 +19,28 @@ long_description    TensorBoard is a suite of web applications for inspecting \
 homepage            https://github.com/tensorflow/tensorboard
 
 if {${python.version} < 30} {
-    master_sites        https://files.pythonhosted.org/packages/89/ac/48dd71c2bdc8d31e367f9b72f25ccb3b89bc6b9d664fee21f9a8efa5714d/
+    master_sites        https://files.pythonhosted.org/packages/f4/37/e6a7af1c92c5b68fb427f853b06164b56ea92126bcfd87784334ec5e4d42/
     distname            tensorboard-${version}-py2-none-any
-    checksums           rmd160  06efbf9d8fe49d883f86b0889f21f13a6aec899d \
-                        sha256  53d8f40589c903dae65f39a799c2bc49defae3703754984d90613d26ebd714a4 \
-                        size    3187615
+    checksums           rmd160  f4da25dd38b8c63be0a30d6603904590738f3b58 \
+                        sha256  c35ba681a52d4922be6b225623cf77285033e7e4e68bac5c1d5490e47d129bb2 \
+                        size    3149160
 } else {
-    master_sites        https://files.pythonhosted.org/packages/0f/39/bdd75b08a6fba41f098b6cb091b9e8c7a80e1b4d679a581a0ccd17b10373/
+    master_sites        https://files.pythonhosted.org/packages/91/2d/2ed263449a078cd9c8a9ba50ebd50123adf1f8cfbea1492f9084169b89d9/
     distname            tensorboard-${version}-py3-none-any
-    checksums           rmd160  d2dd9d9a37b9677614fd06152e335110eba556ab \
-                        sha256  b664fe7772be5670d8b04200342e681af7795a12cd752709aed565c06c0cc196 \
-                        size    3187614
+    checksums           rmd160  07082183d53ff9eb641fc0f022624401b3adb51c \
+                        sha256  50e0b1bdcd488dbe39fd9416976e089b2ff4df18d9f1fab47abf4c498209c3fc \
+                        size    3149160
 }
 
 extract.suffix      .whl
 extract.only
 
-python.versions     27 35 36 37
+python.versions        27 35 36 37
+python.default_version 37
 
 if {${name} ne ${subport}} {
+
+    conflicts_build ${subport}
 
     depends_build-append \
         port:py${python.version}-pip

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -12,7 +12,7 @@ PortGroup           conflicts_build                1.0
 
 name                py-tensorflow
 version             1.14.0
-revision            1
+revision            2
 github.setup        tensorflow tensorflow ${version} v
 platforms           darwin
 supported_archs     x86_64
@@ -178,6 +178,10 @@ if {${name} ne ${subport}} {
     post-destroot {
         file delete ${destroot}${python.prefix}/bin/tensorboard
         file delete ${destroot}${prefix}/bin/tensorboard-${python.branch}
+        # https://github.com/tensorflow/tensorflow/issues/25282
+        foreach f [ exec find ${destroot}${python.prefix} -name "__init__.py" ] {
+            reinplace -q "s|from tensorflow.python.platform.googletest import mock|import mock|g" ${f}
+        }
     }
 
     livecheck.type  none

--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
+PortGroup                   legacysupport 1.0
 
 name                        lighttpd
 version                     1.4.54


### PR DESCRIPTION
#### Description

New port "openjfx11" adding javafx support to the openjdk11 port

Closes: https://trac.macports.org/ticket/58078

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

###### Notes

No idea how to "squash the commits", just trying to help... 