### PR TITLE
mirror_sites.tcl: removed unused xfree mirrors

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -909,17 +909,6 @@ set portfetch::mirror_sites::sites(xcontrib) {
     ftp://ftp2.x.org/contrib/
 }
 
-set portfetch::mirror_sites::sites(xfree) {
-    https://mirror.aarnet.edu.au/pub/xfree86/
-    ftp://ftp.esat.net/pub/X11/XFree86/
-    http://ftp-stud.fht-esslingen.de/pub/Mirrors/ftp.xfree86.org/XFree86/
-    http://www.gtlib.gatech.edu/pub/XFree86/
-    http://ftp.gwdg.de/pub/xfree86/XFree86/
-    ftp://ftp.physics.uvt.ro/pub/XFree86/
-    ftp://ftp.fit.vutbr.cz/pub/XFree86/
-    ftp://ftp.xfree86.org/pub/XFree86/
-}
-
 set portfetch::mirror_sites::sites(xorg) {
     http://ftp.cica.es/mirrors/X/pub/
     ftp://ftp.cs.cuhk.edu.hk/pub/X11/


### PR DESCRIPTION
Last port to use these was removed in 050fffe670.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
