### PR TITLE
mirror_sites.tcl: remove unused xcontrib mirrors

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -892,13 +892,6 @@ set portfetch::mirror_sites::sites(tcltk) {
 set portfetch::mirror_sites::sites(tex_ctan) \
         $portfetch::mirror_sites::sites(ctan)
 
-set portfetch::mirror_sites::sites(xcontrib) {
-    http://ftp.gwdg.de/pub/x11/x.org/contrib/
-    http://ftp.x.org/contrib/
-    ftp://ftp.x.org/contrib/
-    ftp://ftp2.x.org/contrib/
-}
-
 set portfetch::mirror_sites::sites(xorg) {
     http://ftp.cica.es/mirrors/X/pub/
     ftp://ftp.cs.cuhk.edu.hk/pub/X11/


### PR DESCRIPTION
No longer used as of 17a52241d8.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
