### PR TITLE
deprecated-1.0 portgroup: rewording in description

### DIFF
--- a/_resources/port1.0/group/deprecated-1.0.tcl
+++ b/_resources/port1.0/group/deprecated-1.0.tcl
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 # This PortGroup is used to indicate that a port is deprecated.
-# Usage of this PortGroup does not necessarily mean that the port is about to be removed, but its usage is discouraged.
+# Ports using this PortGroup are not necessarily about to be removed, but usage of those ports is discouraged.
 # Some possible reasons for deprecation:
 #     * the port no longer builds on recent versions of macOS and/or Xcode
 #     * the project is no longer maintained upstream


### PR DESCRIPTION
Original wording may sound as if using the portgroup itself is discouraged, rather than that using ports which use this portgroup is discouraged.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
