### PR TITLE
hub: update version to 2.12.1  - build/install manpages

### DIFF
--- a/devel/hub/Portfile
+++ b/devel/hub/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        github hub 2.11.2 v
+github.setup        github hub 2.12.1 v
 categories          devel
 platforms           darwin
 license             MIT
@@ -16,16 +16,16 @@ long_description    \
 
 homepage            https://hub.github.com/
 
-checksums           rmd160  87dd92df86a426e8340c3688663ccd1d22b8926f \
-                    sha256  dcc46aeed9d6b2fcc4159509d752bcb3149095b78a099d0bbc612c258bc4da4b \
-                    size    1044142
+checksums           rmd160  64dee50bea74d090359ae43c22eee5e5a30a988a \
+                    sha256  8070fc65e0eb05e89b3715a72ba6956c1288e57e9a42b45b775e6f9fae372112 \
+                    size    1623943
 
 worksrcdir          src/github.com/${github.author}/${name}
 
 depends_build-append \
                     port:go port:bash
-build.target
-build.cmd           ./script/build
+build.target        man-pages
+build.cmd           make
 build.env-append    GOPATH=${workpath}
 
 use_configure       no
@@ -40,6 +40,11 @@ post-extract {
 
 destroot {
     xinstall -W ${worksrcpath} bin/hub ${destroot}${prefix}/bin
+    set man-pages ${destroot}${prefix}/share/man/man1
+    xinstall -d ${man-pages}
+    foreach m [glob -directory ${worksrcpath}/share/man/man1 *.1] {
+        xinstall -W ${worksrcpath} ${m} ${man-pages}/
+    }
     set bash-completions ${destroot}${prefix}/share/bash-completion/completions
     xinstall -d ${bash-completions}
     xinstall -W ${worksrcpath} etc/hub.bash_completion.sh ${bash-completions}/hub


### PR DESCRIPTION
#### Description

up

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
