### PR TITLE
submission (new Portfile): flash @2.3.0 (sysutils)

### DIFF
--- a/sysutils/flash/Portfile
+++ b/sysutils/flash/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       github 1.0
+
+github.setup    hypriot flash 2.3.0
+revision        0
+
+platforms       darwin
+supported_archs noarch
+categories      sysutils
+license         MIT
+maintainers     @jrjsmrtn openmaintainer
+
+description     Command line script to flash SD card images of any kind
+long_description    ${description}
+
+checksums       rmd160  d0f45b33da3b557cbf9253a835678310ad9ed27a \
+                sha256  7a31c2fa6a2169633c5d77b205ead4562b110e1c106b3ac4fa72ee55350e0719 \
+                size    16744
+
+depends_run     port:unzip \
+                port:curl \
+                port:pv
+
+notes           "If you want to flash directly from an AWS S3 bucket,\
+                install the py37-awscli port."
+
+use_configure   no
+build           {}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/flash ${destroot}${prefix}/bin
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} AUTHORS LICENSE README.md \
+        ${destroot}${prefix}/share/doc/${name}
+    file copy ${worksrcpath}/sample \
+        ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

submission (new Portfile): flash @2.3.0 (sysutils)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->