### PR TITLE
openjfx11: Initial commit of portfile

### DIFF
--- a/java/openjfx11/Portfile
+++ b/java/openjfx11/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            openjfx11
+version         11.0.2
+revision        0
+
+set build       0
+set major       11
+
+categories      java devel
+maintainers     {@lhaeger} openmaintainer
+platforms       darwin
+license         GPL-2
+supported_archs x86_64
+
+description     OpenJFX ${major}
+
+long_description OpenJFX is an open source, next generation client application platform \
+                 for desktop, mobile and embedded systems built on Java.
+
+homepage        https://openjfx.io/
+
+depends_lib     port:openjdk11
+
+master_sites    https://download2.gluonhq.com/openjfx/${version}/
+distname        openjfx-${version}_osx-x64_bin-sdk
+use_zip         yes
+
+checksums       rmd160  3b74b4bd563cc46e28b886df5c9e239fb00845c2 \
+                sha256  e98158812db1a0037cdaf85824adff384e41e3edf046fda145479ce6057cb514 \
+                size    41684332
+
+worksrcdir      javafx-sdk-${version}
+
+use_configure   no
+
+build {}
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/openjdk11/Contents/Home
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}/Contents/Home
+    copy ${worksrcpath}/legal ${destroot_target}/legal
+    copy ${worksrcpath}/lib   ${destroot_target}/lib
+    # src.zip is already provided by openjdk11
+    move ${destroot_target}/lib/src.zip ${destroot_target}/lib/src_javafx.zip
+}


### PR DESCRIPTION
openjfx11: Initial commit of portfile

Closes: https://trac.macports.org/ticket/58078

#### Description

New port openjfx11 to support javafx with openjdk11

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
