### PR TITLE
webkit2-gtk: fix bad_optional_access build error

### DIFF
--- a/www/webkit2-gtk/Portfile
+++ b/www/webkit2-gtk/Portfile
@@ -13,6 +13,7 @@ PortGroup           cxx11 1.1
 name                webkit2-gtk
 conflicts           webkit2-gtk-devel
 version             2.20.5
+revision            1
 description         Apple's WebKit2 HTML rendering library for GTK+3 (with optional support for GTK+2 plugins)
 long_description    ${description}
 maintainers         {devans @dbevans}
@@ -80,7 +81,8 @@ patchfiles-append \
     PR-157574.patch \
     patch-bundle-link-webcore.diff \
     patch-enable-plugin-architecture-unix.diff \
-    patch-name-conflicts.diff
+    patch-name-conflicts.diff \
+    patch_bad_optional_access.diff
     
 # Source/WTF/wtf/RAMSize.cpp has changed, and the Darwin parts were
 # stripped out. Replace it with the previous version

--- a/www/webkit2-gtk/files/patch_bad_optional_access.diff
+++ b/www/webkit2-gtk/files/patch_bad_optional_access.diff
@@ -1,0 +1,15 @@
+--- Source/WTF/wtf/Optional.h	(revision 235660)
++++ Source/WTF/wtf/Optional.h	(revision 235661)
+@@ -278,12 +278,4 @@
+ 
+ 
+-// 20.5.8, class bad_optional_access
+-class bad_optional_access : public std::logic_error {
+-public:
+-  explicit bad_optional_access(const std::string& what_arg) : std::logic_error{what_arg} {}
+-  explicit bad_optional_access(const char* what_arg) : std::logic_error{what_arg} {}
+-};
+-
+-
+ template <class T>
+ union storage_t


### PR DESCRIPTION
* apply upstream patch

#### Description

I experienced a build error with webkit2-gtk+quartz. I am not so sure it is specific to +quartz or the clang version used for building. Applying the upstream patch fixed it.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
