### PR TITLE
nonpareil: fix whitespace, license and scons build

### DIFF
--- a/emulators/nonpareil/Portfile
+++ b/emulators/nonpareil/Portfile
@@ -1,153 +1,153 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 # vim: set fileencoding=utf-8 tabstop=4 shiftwidth=4 softtabstop=4 noexpandtab filetype=tcl :
 
-PortSystem			1.0
+PortSystem          1.0
 
-name				nonpareil
-version				0.79
-revision			5
-platforms			darwin
-categories			emulators
-maintainers			nomaintainer
-description			a high-fidelity simulator for calculators.
-long_description	Nonpareil is a high-fidelity simulator for calculators. \
-					It currently supports many HP calculators models		\
-					introduced between 1972 and 1982. Simulation fidelity	\
-					is achieved through the use of the actual microcode of	\
-					the calculators, thus in most cases the simulation		\
-					behavior exactly matches that of the real calculator.	\
-					In particular, numerical results will be identical,		\
-					because the simulator is using the BCD arithmetic		\
-					algorithms from the calculator.
+name                nonpareil
+version             0.79
+revision            5
+platforms           darwin
+categories          emulators
+maintainers         nomaintainer
+description         a high-fidelity simulator for calculators.
+long_description    Nonpareil is a high-fidelity simulator for calculators. \
+                    It currently supports many HP calculators models        \
+                    introduced between 1972 and 1982. Simulation fidelity   \
+                    is achieved through the use of the actual microcode of  \
+                    the calculators, thus in most cases the simulation      \
+                    behavior exactly matches that of the real calculator.   \
+                    In particular, numerical results will be identical,	    \
+                    because the simulator is using the BCD arithmetic       \
+                    algorithms from the calculator.
 
-homepage			http://nonpareil.brouhaha.com/
-master_sites		http://nonpareil.brouhaha.com/download:prog	\
-					macports:nonpareil:appbundles				\
-					macports:nonpareil:voyager
+homepage            http://nonpareil.brouhaha.com/
+master_sites        http://nonpareil.brouhaha.com/download:prog	\
+                    macports:nonpareil:appbundles				\
+                    macports:nonpareil:voyager
 
-set patchversion	47826
-set prog			nonpareil-${version}.tar.gz
-set appbundles		nonpareil-appbundles-r${patchversion}.tar.gz
+set patchversion    47826
+set prog            nonpareil-${version}.tar.gz
+set appbundles      nonpareil-appbundles-r${patchversion}.tar.gz
 
-distfiles			${prog}:prog				\
-					${appbundles}:appbundles
+distfiles           ${prog}:prog            \
+                    ${appbundles}:appbundles
 
-checksums			${prog} \
-					md5		4274dee70d9633304194a904b2573489 \
-					sha1	83bc2f57e6ece9ce19e3449cce075ef246a9f4c2 \
-					rmd160	0bbf88e7c4614ac757bebbc1089804bea088d181 \
-					${appbundles} \
-					md5		b71f77851f4204b984b80e57c4ad7e65 \
-					sha1	4798b1ae8a56275a4c2eb4df54f352c457f1ff0a \
-					rmd160	f0aa0eea748297f652f08c239fe1922b9f61e31d
+checksums           ${prog} \
+                    md5		4274dee70d9633304194a904b2573489 \
+                    sha1	83bc2f57e6ece9ce19e3449cce075ef246a9f4c2 \
+                    rmd160	0bbf88e7c4614ac757bebbc1089804bea088d181 \
+                    ${appbundles} \
+                    md5		b71f77851f4204b984b80e57c4ad7e65 \
+                    sha1	4798b1ae8a56275a4c2eb4df54f352c457f1ff0a \
+                    rmd160	f0aa0eea748297f652f08c239fe1922b9f61e31d
 
-extract.only		${prog}									\
-					${appbundles}							
+extract.only        ${prog}                                 \
+                    ${appbundles}
 
-depends_lib			path:lib/pkgconfig/glib-2.0.pc:glib2	\
-					port:gtk2								\
-					port:libpng								\
-					port:libxml2							\
-					port:libsdl_sound						\
-					port:netpbm
+depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2    \
+                    port:gtk2                               \
+                    port:libpng                             \
+                    port:libxml2                            \
+                    port:libsdl_sound                       \
+                    port:netpbm
 
-depends_build		port:bison								\
-					port:flex								\
-					port:pkgconfig							\
-					port:scons
+depends_build       port:bison                              \
+                    port:flex                               \
+                    port:pkgconfig                          \
+                    port:scons
 
-patchfiles			osx.patch								\
-					patch-src-printer.c.diff				\
-					patch-src-util.diff
+patchfiles          osx.patch                               \
+                    patch-src-printer.c.diff                \
+                    patch-src-util.diff
 
-use_parallel_build	yes
-use_configure		no
-build.cmd			scons
-build.args			prefix=${prefix}
+use_parallel_build  yes
+use_configure       no
+build.cmd           scons
+build.args          prefix=${prefix}
 build.target
 
-destroot.args		prefix=${prefix} destdir=${destroot}
+destroot.args       prefix=${prefix} destdir=${destroot}
 
 
 post-patch {
-	reinplace s|@PREFIX@|${prefix}|g ${worksrcpath}/src/SConscript
+    reinplace s|@PREFIX@|${prefix}|g ${worksrcpath}/src/SConscript
 }
 
 platform macosx {
-	post-destroot {
-		xinstall -d ${destroot}${applications_dir}/Nonpareil
-		foreach calc {HP-21 HP-25 HP-32E HP-33C HP-34C HP-37E HP-38C HP-38E HP-41CV HP-41CX HP-45 HP-55 HP-80} {
-			copy														\
-				${workpath}/appbundles-r${patchversion}/${calc}.app	\
-				${destroot}${applications_dir}/Nonpareil
-			reinplace s|@PREFIX@|${prefix}|g \
-				${destroot}${applications_dir}/Nonpareil/${calc}.app/Contents/MacOS/${calc}.command
-		}
-	}
+    post-destroot {
+        xinstall -d ${destroot}${applications_dir}/Nonpareil
+        foreach calc {HP-21 HP-25 HP-32E HP-33C HP-34C HP-37E HP-38C HP-38E HP-41CV HP-41CX HP-45 HP-55 HP-80} {
+            copy                                                    \
+                ${workpath}/appbundles-r${patchversion}/${calc}.app \
+                ${destroot}${applications_dir}/Nonpareil
+            reinplace s|@PREFIX@|${prefix}|g \
+                ${destroot}${applications_dir}/Nonpareil/${calc}.app/Contents/MacOS/${calc}.command
+        }
+    }
 }
 
-variant voyager														\
-	description "Include Voyager Models (Not GPL licensed)!"		{
+variant voyager	                                                    \
+    description "Include Voyager Models (Not GPL licensed)!"        {
 
-	set voyager				nonpareil-voyager-r${patchversion}.tar.gz
+    set voyager     nonpareil-voyager-r${patchversion}.tar.gz
 
-	distfiles-append		${voyager}:voyager
+    distfiles-append        ${voyager}:voyager
 
-	checksums-append		${voyager} \
-							md5		fbb227a28045c0bf8165bba86f199ec9 \
-							sha1	8a51f656a523c5739d82a35ad933f8c448be58e6 \
-							rmd160	4f7fec5af3b387fd6a7df44ce0a7b019eeb4a253
+    checksums-append        ${voyager} \
+                            md5		fbb227a28045c0bf8165bba86f199ec9 \
+                            sha1	8a51f656a523c5739d82a35ad933f8c448be58e6 \
+                            rmd160	4f7fec5af3b387fd6a7df44ce0a7b019eeb4a253
 
-	extract.only-append		${voyager}
+    extract.only-append     ${voyager}
 
-	depends_build-append	port:p7zip	\
-							port:netpbm
+    depends_build-append    port:p7zip  \
+                            port:netpbm
 
-	patchfiles-append		patch-image-voyager.diff	\
-							patch-kml-voyager.diff		\
-							patch-rom-voyager.diff		\
-							patch-src-voyager.diff
+    patchfiles-append       patch-image-voyager.diff    \
+                            patch-kml-voyager.diff      \
+                            patch-rom-voyager.diff      \
+                            patch-src-voyager.diff
 
-	post-patch {
-		system -W ${worksrcpath} "
-			cp -R -v ../voyager-r${patchversion}/* .
-		"
-	}
-	post-destroot {
-		foreach calc {HP-11C HP-12C HP-15C HP-16C} {
-			copy													\
-				${workpath}/appbundles-r${patchversion}/${calc}.app	\
-				${destroot}${applications_dir}/Nonpareil
-			reinplace s|@PREFIX@|${prefix}|g \
-				${destroot}${applications_dir}/Nonpareil/${calc}.app/Contents/MacOS/${calc}.command
-		}
-	}
+    post-patch {
+        system -W ${worksrcpath} "
+            cp -R -v ../voyager-r${patchversion}/* .
+        "
+    }
+    post-destroot {
+        foreach calc {HP-11C HP-12C HP-15C HP-16C} {
+            copy                                                    \
+                ${workpath}/appbundles-r${patchversion}/${calc}.app	\
+                ${destroot}${applications_dir}/Nonpareil
+            reinplace s|@PREFIX@|${prefix}|g \
+                ${destroot}${applications_dir}/Nonpareil/${calc}.app/Contents/MacOS/${calc}.command
+        }
+    }
 }
 
-variant debugger						\
-	description "Include Debugger!"		{
-	build.args-append			debug=yes has_debugger_gui=yes
-	destroot.args-append		debug=yes has_debugger_gui=yes
+variant debugger                        \
+    description "Include Debugger!"     {
+    build.args-append           debug=yes has_debugger_gui=yes
+    destroot.args-append        debug=yes has_debugger_gui=yes
 }
 
-variant hpil												\
-	description "Include HP-Interface-Loop emulation (experimental) See http://pagesperso-orange.fr/kdntl/hp41/nonpareil-patch-doc.html"	{
+variant hpil                                                \
+    description "Include HP-Interface-Loop emulation (experimental) See http://pagesperso-orange.fr/kdntl/hp41/nonpareil-patch-doc.html" {
 
     global hpil
-	set hpil nonpareil-wholepatch-20090714.diff.bz2
+    set hpil nonpareil-wholepatch-20090714.diff.bz2
 
     # can't just add to patchfiles because this one needs -p1 but the rest -p0
-	distfiles-append		${hpil}:hpil
-	master_sites-append     http://pagesperso-orange.fr/kdntl/hp41:hpil
+    distfiles-append        ${hpil}:hpil
+    master_sites-append     http://pagesperso-orange.fr/kdntl/hp41:hpil
 
-	checksums-append		${hpil} \
-	                md5     2bc700c9cb49ec4e0fe0240ab5653688 \
+    checksums-append        ${hpil} \
+                    md5     2bc700c9cb49ec4e0fe0240ab5653688 \
                     sha1    e77648269e6e8cb04f6b4b275077ed8493b451ae \
                     rmd160  ec3bea3f6eda7d29a480a880a7875d4e9fc6c8cf
-	
-	patchfiles-delete		patch-src-util.diff
+
+    patchfiles-delete       patch-src-util.diff
 
 	post-patch {
-		system -W ${worksrcpath} "bzcat ${distpath}/${hpil} | patch -p1"
-	}
+        system -W ${worksrcpath} "bzcat ${distpath}/${hpil} | patch -p1"
+    }
 }

--- a/emulators/nonpareil/Portfile
+++ b/emulators/nonpareil/Portfile
@@ -5,9 +5,10 @@ PortSystem          1.0
 
 name                nonpareil
 version             0.79
-revision            5
+revision            6
 platforms           darwin
 categories          emulators
+license             GPL-2
 maintainers         nomaintainer
 description         a high-fidelity simulator for calculators.
 long_description    Nonpareil is a high-fidelity simulator for calculators. \
@@ -58,7 +59,8 @@ depends_build       port:bison                              \
 
 patchfiles          osx.patch                               \
                     patch-src-printer.c.diff                \
-                    patch-src-util.diff
+                    patch-src-util.diff                     \
+                    patch-sconstruct.diff
 
 use_parallel_build  yes
 use_configure       no

--- a/emulators/nonpareil/files/patch-sconstruct.diff
+++ b/emulators/nonpareil/files/patch-sconstruct.diff
@@ -1,0 +1,82 @@
+--- SConstruct	2008-08-23 19:37:34.000000000 -0500
++++ SConstruct	2019-07-04 09:06:34.000000000 -0500
+@@ -27,57 +27,57 @@
+ # Options
+ #-----------------------------------------------------------------------------
+ 
+-opts = Options (conf_file)
++opts = Variables (conf_file)
+ 
+-opts.AddOptions (EnumOption ('host',
++opts.Add (EnumVariable ('host',
+ 			     help = 'host build platform',
+ 			     allowed_values = ('posix', 'win32'),
+ 			     default = 'posix',
+-			     ignorecase = 1),
++			     ignorecase = 1))
+ 
+-		 EnumOption ('target',
++opts.Add (EnumVariable ('target',
+ 			     help = 'execution target platform',
+ 			     allowed_values = ('posix', 'win32'),
+ 			     default = 'posix',
+-			     ignorecase = 1),
++			     ignorecase = 1))
+ 
+-		 PathOption ('prefix',
++opts.Add (PathVariable ('prefix',
+ 			     'installation path prefix',
+-			     '/usr/local'),
++			     '/usr/local'))
+ 
+ 		 # Don't use PathOption for other paths, because we don't
+ 		 # require the directories to preexist.
+-		 ('bindir',
++opts.Add ('bindir',
+ 		  'path for executable files (default is $prefix/bin)',
+-		  ''),
++		  '')
+ 
+-		 ('libdir',
++opts.Add ('libdir',
+ 		  'path for library files (default is $prefix/lib/nonpareil)',
+-		  ''),
++		  '')
+ 
+-		 ('destdir',
++opts.Add ('destdir',
+ 		  'installation virtual root directory (for packaging)',
+-		  ''),
++		  '')
+ 
+-		 BoolOption ('debug',
++opts.Add (BoolVariable ('debug',
+ 			     help = 'compile for debugging',
+-			     default = 1),
++			     default = 1))
+ 
+ 		 # Feature switches:
+ 
+-		 BoolOption ('has_debugger_gui',
++opts.Add (BoolVariable ('has_debugger_gui',
+ 			     help = 'enable debugger GUI interface',
+-			     default = 0),
++			     default = 0))
+ 
+-		 BoolOption ('has_debugger_cli',
++opts.Add (BoolVariable ('has_debugger_cli',
+ 			     help = 'enable debugger command-line interface',
+-			     default = 0),
++			     default = 0))
+ 
+-		 BoolOption ('use_tcl',
++opts.Add (BoolVariable ('use_tcl',
+ 			     help = 'use Tcl as debug command interpreter (only when debugger CLI is enabled)',
+-			     default = 1),  # only if has_debugger_cli
++			     default = 1))  # only if has_debugger_cli
+ 
+-		 BoolOption ('use_readline',
++opts.Add (BoolVariable ('use_readline',
+ 			     help = 'use Readline library for command editing and history (only when debugger CLI is enabled)',
+ 			     default = 1))  # only if has_debugger_cli
+ 


### PR DESCRIPTION
#### Description
Fix SConstruct to build on SCons > 0.98.1. Ticket [#21150](https://trac.macports.org/ticket/21150) is still unresolved for calculators built with the voyager variant.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
