### PR TITLE
py-requests-mock: update to 1.6.0, add noarch

### DIFF
--- a/python/py-requests-mock/Portfile
+++ b/python/py-requests-mock/Portfile
@@ -3,31 +3,26 @@
 PortSystem          1.0
 PortGroup           python 1.0
 
-set _name           requests-mock
-set _n              [string index ${_name} 0]
+name                py-requests-mock
+version             1.6.0
+revision            0
 
-name                py-${_name}
-version             1.5.2
 platforms           darwin
+supported_archs     noarch
 license             Apache-2
-
 maintainers         {petr @petrrr} openmaintainer
 
 description         Mock out responses from the requests package
-
-long_description    \
-    ${_name}provides a building block to stub out the HTTP requests portions \
-    of your testing code. 
-
+long_description    ${python.rootname} provides a building block to stub out the \
+                    HTTP requests portions of your testing code.
 
 homepage            https://requests-mock.readthedocs.io/
+master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
+distname            ${python.rootname}-${version}
 
-distname            ${_name}-${version}
-master_sites        pypi:${_n}/${_name}/
-
-checksums           rmd160  d94c35439b7804dc3379c10cb0bddeda9107c2ea \
-                    sha256  7a5fa99db5e3a2a961b6f20ed40ee6baeff73503cf0a553cc4d679409e6170fb \
-                    size    47581
+checksums           sha256  12e17c7ad1397fd1df5ead7727eb3f1bdc9fe1c18293b0492e0e01b57997e38d \
+                    rmd160  e9b99dca4c6b223a7f6249b412ef782cb63ab693 \
+                    size    50766
 
 python.versions     27 36 37
 
@@ -40,8 +35,4 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-six
 
     livecheck.type      none
-} else {
-    livecheck.type  regex
-    livecheck.url   https://pypi.python.org/pypi/${_name}/json
-    livecheck.regex "\"${_name}-(\[.\\d\]+)\\${extract.suffix}\""
 }


### PR DESCRIPTION
#### Description
- update to latest version
- use python.rootname
- use default PyPI livecheck

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? N/A
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
