### PR TITLE
xcrysden: change getline test to os version

### DIFF
--- a/science/xcrysden/Portfile
+++ b/science/xcrysden/Portfile
@@ -79,7 +79,7 @@ patchfiles          patch-Makefile.diff \
 configure {
     configure.optflags -O3
     configure.cflags-append -DUSE_INTERP_RESULT
-    if {[string match "*gcc-4.2" ${configure.compiler}]} {
+    if {${os.major} < 11 } {
         configure.cflags-append -DXC_HAVE_NO_GETLINE
     }
     system -W ${worksrcpath} "echo '


### PR DESCRIPTION
fixes build on < 10.7 by testing for os.version
rather than gcc-4.2.
adding PG legacysupport did not fix this port

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
