### PR TITLE
multimon-ng: update to 1.1.8

### DIFF
--- a/science/multimon-ng/Portfile
+++ b/science/multimon-ng/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        EliasOenal multimon-ng 1.1.7
+github.setup        EliasOenal multimon-ng 1.1.8
 
 platforms           darwin
 categories          science comms
@@ -18,9 +18,9 @@ long_description    multimon-ng is the successor of multimon. \
     AFSK1200 AFSK2400 AFSK2400_2 AFSK2400_3 HAPN4800 FSK9600 \
     DTMF ZVEI1 ZVEI2 ZVEI3 DZVEI PZVEI EEA EIA CCIR MORSE_CW X10
 
-checksums           rmd160  c4fbc0b7bf6557e6669cf5df43b94b6fb794202f \
-                    sha256  91bbe6f39bac840fea3e64e84b9ec7461ba1e74048369532591a31dcce84d94c \
-                    size    2430248
+checksums           rmd160  89cc4931978fc6cfcb90b3b8145f046c64e513ac \
+                    sha256  3cdd157b7f38581444c994911813ef27a57aefdc4890d653fe70a84ed54eb099 \
+                    size    2430568
 
 configure.args-append \
     -DPULSE_AUDIO_SUPPORT=0 \


### PR DESCRIPTION


#### Description

- bump version to 1.1.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 11.0 11M337n

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->