### PR TITLE
Google cloud SDK bug fix / update

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             252.0.0
+version             253.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  7ad60c8fdbbb68f23ce19bfe1c340ce36bed76c1 \
-                    sha256  4fe60f4cbcccdabac5dc9a882c6e9df8d8892553717e3aeb330469357bdcaab8 \
-                    size    19918025
+checksums           rmd160  7bd428fcc034ac3e591444ca7bb40ecbf66ad6bc \
+                    sha256  f068ff59f6391adb8f1557d451f17c9733e3caaf52fd4e3369ffbdc81acb5385 \
+                    size    20060497
 
 python.default_version 27
 

--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -37,7 +37,12 @@ destroot {
     system -W ${worksrcpath} "CLOUDSDK_CONFIG=${worksrcpath}/.config ./install.sh --usage-reporting false --command-completion false --path-update false --quiet"
     set libexecdir ${destroot}${prefix}/libexec/${name}
     xinstall -d ${libexecdir}
-    copy ${worksrcpath}/bin ${worksrcpath}/lib ${worksrcpath}/platform ${libexecdir}
+    copy \
+        ${worksrcpath}/.install \
+        ${worksrcpath}/bin \
+        ${worksrcpath}/lib \
+        ${worksrcpath}/platform \
+        ${libexecdir}
     foreach f { bq docker-credential-gcloud gcloud gsutil } {
         ln -s ../libexec/${name}/bin/${f} ${destroot}${prefix}/bin/${f}
     }


### PR DESCRIPTION
#### Description

I encountered a problem when running the Google SDK. Some commands such as `gcloud container clusters get-credentials ...` fail with the following error:

```
Fetching cluster endpoint and auth data.
ERROR: Path to sdk installation not found. Please switch to application default
credentials using one of

$ gcloud config set container/use_application_default_credentials true
$ export CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
ERROR: (gcloud.container.clusters.get-credentials) Path to sdk installation not found. Please switch to application default
credentials using one of

$ gcloud config set container/use_application_default_credentials true
$ export CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
```
I inspected the SDK source code and the reason for this error is the failure of the SDK to find its own installation path. The reason why it fails to do so is because it's looking for the location of a `.install` directory, which was not copied by the port in the `destroot` phase. I have fixed this and the problem went away.

I also took the liberty of updating the port to the latest version, in this way we don't need a revbump.

###### Type(s)
- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
