### PR TITLE
Update version to 3.8.0-b2, hashes and filesize.

### DIFF
--- a/gnome/gtk-doc/Portfile
+++ b/gnome/gtk-doc/Portfile
@@ -78,7 +78,7 @@ variant python37 conflicts python36 description {Build using Python 3.7} {
     configure.python    ${prefix}/bin/python3.7
 }
 
-if {![variant_isset python37]} {
+if {![variant_isset python36]} {
      default_variants +python37
 }
 

--- a/lang/python38-devel/Portfile
+++ b/lang/python38-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                python38-devel
 
-version             3.8.0b1
+version             3.8.0b2
 epoch               1
 revision            0
 set major           [lindex [split $version .] 0]
@@ -25,9 +25,9 @@ master_sites        ${homepage}ftp/python/3.8.0/
 
 distname            Python-${version}
 use_xz              yes
-checksums           rmd160  b39fac594a845b31214409b3dc504124567107b4 \
-                    sha256  bd9f113242c95463fd95a5b2e9e48a00edcb9c2eb7f9a56cee864e4c5be37f10 \
-                    size    17601532
+checksums           rmd160  cbf0ee2fe22f358558d50e8dbe9c2581be951f43 \
+                    sha256  74c1609fd006409c2b69d46fb44d2ca29f4ab8745c48d30af1a6b0bacb6f09e6 \
+                    size    17638912
 
 patchfiles          patch-setup.py.diff \
                     patch-Lib-cgi.py.diff \


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
Yes, there are some test failures:
```
:info:test Ran 280 tests in 86.566s
:info:test FAILED (failures=1, errors=42, skipped=26)
:info:test 11 tests failed again:
:info:test     test_asyncio test_concurrent_futures test_grp
:info:test     test_multiprocessing_forkserver test_multiprocessing_main_handling
:info:test     test_multiprocessing_spawn test_popen test_readline test_socket
:info:test     test_socketserver test_subprocess
:info:test == Tests result: FAILURE then FAILURE ==
:info:test 392 tests OK.
:info:test 11 tests failed:
:info:test     test_asyncio test_concurrent_futures test_grp
:info:test     test_multiprocessing_forkserver test_multiprocessing_main_handling
:info:test     test_multiprocessing_spawn test_popen test_readline test_socket
:info:test     test_socketserver test_subprocess
:info:test 20 tests skipped:
:info:test     test_devpoll test_epoll test_gdb test_idle test_msilib
:info:test     test_multiprocessing_fork test_ossaudiodev test_poll test_spwd
:info:test     test_startfile test_tcl test_tix test_tk test_ttk_guionly
:info:test     test_ttk_textonly test_turtle test_winconsoleio test_winreg
:info:test     test_winsound test_zipfile64
:info:test 11 re-run tests:
:info:test     test_asyncio test_concurrent_futures test_grp
:info:test     test_multiprocessing_forkserver test_multiprocessing_main_handling
:info:test     test_multiprocessing_spawn test_popen test_readline test_socket
:info:test     test_socketserver test_subprocess
```
But a lot of these releate to path names. There are no changes other than to the metadata
- [x ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
