### PR TITLE
z: update - add subport z-devel pointing to git master, add homepage

### DIFF
--- a/sysutils/z/Portfile
+++ b/sysutils/z/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rupa z 1.11 v
+name                z
+homepage            https://github.com/rupa/z
 categories          sysutils
 maintainers         nomaintainer
 description         Tracks most-used directories to make cd smarter
@@ -13,8 +14,27 @@ platforms           darwin
 license             WTFPL-2
 supported_archs     noarch
 
-checksums           rmd160  64173ef1b8e77f1db4ee53486f55159ed8b43d83 \
-                    sha256  a06d8d56bd8373229b1f11690ac5d9f13753215ce57488efa1c5a6efc6f735bb
+if {${name} eq ${subport}} {
+   github.setup       rupa z 1.11 v
+   revision           0
+
+   checksums          rmd160  64173ef1b8e77f1db4ee53486f55159ed8b43d83 \
+                      sha256  a06d8d56bd8373229b1f11690ac5d9f13753215ce57488efa1c5a6efc6f735bb
+
+   conflicts          z-devel
+}
+
+subport z-devel {
+   github.setup       rupa z 9d5a3fe0407101e2443499e4b95bca33f7a9a9ca
+   version            20180810
+   revision           0
+
+   checksums          rmd160  bcf75ba6af08a3883f9a70c9a433ae456cfce427 \
+                      sha256  fc82ffe3bbf6535cad08cb7b77481c1e6b1eec974f3c3dd4dbc7a69187e50e36 \
+                      size    5940
+
+   conflicts          z
+}
 
 use_configure       no
 

--- a/sysutils/z/Portfile
+++ b/sysutils/z/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 name                z
-homepage            https://github.com/rupa/z
 categories          sysutils
 maintainers         nomaintainer
 description         Tracks most-used directories to make cd smarter
@@ -19,7 +18,8 @@ if {${name} eq ${subport}} {
    revision           0
 
    checksums          rmd160  64173ef1b8e77f1db4ee53486f55159ed8b43d83 \
-                      sha256  a06d8d56bd8373229b1f11690ac5d9f13753215ce57488efa1c5a6efc6f735bb
+                      sha256  a06d8d56bd8373229b1f11690ac5d9f13753215ce57488efa1c5a6efc6f735bb \
+                      size    6003
 
    conflicts          z-devel
 }


### PR DESCRIPTION
#### Description

- add subport z-devel pointing to git master (20180810)
  note: this version allows ~/.z to be a symbolic link and therefore to share ~/.z between different hosts

- add homepage entry at portfile global section

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
