### PR TITLE
nonpareil: resolve conflict with nss

### DIFF
--- a/emulators/nonpareil/Portfile
+++ b/emulators/nonpareil/Portfile
@@ -75,6 +75,12 @@ post-patch {
     reinplace s|@PREFIX@|${prefix}|g ${worksrcpath}/src/SConscript
 }
 
+post-destroot {
+    # avoids conflict with nss
+    # ref: https://trac.macports.org/ticket/58683
+    file rename ${destroot}${prefix}/bin/modutil ${destroot}${prefix}/bin/modutil-${name}
+}
+
 platform macosx {
     post-destroot {
         xinstall -d ${destroot}${applications_dir}/Nonpareil


### PR DESCRIPTION
renames `bin/modutil` to `bin/modutil-nonpareil` in order to avoid conflict with nss

closes: https://trac.macports.org/ticket/58683

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
