### PR TITLE
web-ext: update to 3.1.0

### DIFF
--- a/devel/web-ext/Portfile
+++ b/devel/web-ext/Portfile
@@ -3,15 +3,16 @@
 PortSystem              1.0
 
 name                    web-ext
-version                 3.0.0
-checksums               rmd160  37b498f90d371ae5dccff7fc334d2a3a4d838981 \
-                        sha256  f8c651fd812fee68ea9030c17a269ce5c9989ffa640b368f69dbc5f071c6b0af \
-                        size    212552
+version                 3.1.0
+revision                0
+checksums               rmd160  fc472f846a52da6c047b0537a6e6e8b9520670ad \
+                        sha256  3b444cb0369d59873aab7113a85bb0a01d2f108a20d8083b4d92fd9616323a83 \
+                        size    194790
 
 categories              devel
 maintainers             nomaintainer
 license                 MPL-2
-description             A command line tool to help build, run, and test web extensions 
+description             A command line tool to help build, run, and test web extensions
 
 long_description        ${description}
 


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G4015
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?