### PR TITLE
mirror_sites.tcl: Fetch distfiles via HTTP on 10.8 or older

### DIFF
--- a/_resources/port1.0/fetch/mirror_sites.tcl
+++ b/_resources/port1.0/fetch/mirror_sites.tcl
@@ -501,7 +501,7 @@ set portfetch::mirror_sites::sites(macports) {
 }
 
 global os.platform os.major
-set distfiles_scheme [expr {${os.platform} eq "darwin" && ${os.major} < 10 ? "http" : "https"}]
+set distfiles_scheme [expr {${os.platform} eq "darwin" && ${os.major} < 13 ? "http" : "https"}]
 
 set portfetch::mirror_sites::sites(macports_distfiles) "
     ${distfiles_scheme}://distfiles.macports.org/:mirror


### PR DESCRIPTION
#### Description

For some reason(s), https://distfiles.macports.org no longer works
on Mac OS X <= 10.8.

Closes: https://trac.macports.org/ticket/58688

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
