### PR TITLE
qemu: update to 4.0.0 and add riscv32/64 support

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -107,7 +107,7 @@ build.args-append       V=1
 default_variants        +usb
 
 foreach t {i386 x86_64 alpha {arm aarch64} cris lm32 m68k {microblaze microblazeel} {mips mipsel mips64 mips64el} \
-           moxie or1k {ppc ppcemb ppc64} s390x {sh4 sh4eb} {sparc sparc64} tricore unicore32 {xtensa xtensaeb}} {
+           moxie or1k {ppc ppcemb ppc64} riscv32 riscv64 s390x {sh4 sh4eb} {sparc sparc64} tricore unicore32 {xtensa xtensaeb}} {
     variant target_[lindex $t 0] description "Add target support for [join $t {, }]" "append target_list \",[join $t -softmmu,]-softmmu\""
 }
 default_variants-append +target_i386 +target_x86_64

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -2,8 +2,8 @@ PortSystem 1.0
 PortGroup compiler_blacklist_versions 1.0
 
 name                    qemu
-version                 3.0.0
-revision                1
+version                 4.0.0
+revision                0
 categories              emulators
 license                 GPL-2+
 platforms               darwin
@@ -20,9 +20,9 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_bzip2               yes
 
-checksums               rmd160  2fc1cdc661929c94f704405fc4e579d5ed131e63 \
-                        sha256  933e62ad604f5f8d0a93f5e0a98fd95f9d2e23ff1dbd0c744c6c7506bba8ebe8 \
-                        size    41491935
+checksums               rmd160  7ec340477414d5faee5969532e1b0c57327292a6 \
+                        sha256  6d7f713f7400c8a636c770118957b13d6a7f72b0d2da4a925d10455d8e33af20 \
+                        size    75668251
 
 patchfiles              patch-configure.diff
 patch.pre_args          -p1


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A501i
Xcode 11.0 11M362v

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

--------

<strike>In addition to upgrading to QEMU 4.0.0, I've also add support for HVF accel with `hvf` variant. The `hvf` accelerator utilizes macOS Hypervisor.framework for native virtualization.

Once `hvf` variant is enabled, `hvf` can be enabled with `qemu-system-x86_64 -M accel=hvf` (However, I believe `hvf` only support UEFI). From my testing with Alpine Linux, I see significant speedup in CPU related operations.</strike> HVF is actually enabled by default so the variant is unnecessary.

Additionally, I've also added RISCV32 and RISCV64 to the list of target variants (enable via `target_riscv32` and `target_riscv64` respectively). 