### PR TITLE
jemalloc: update to version 5.2.0

### DIFF
--- a/devel/jemalloc/Portfile
+++ b/devel/jemalloc/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jemalloc jemalloc 5.1.0
+github.setup        jemalloc jemalloc 5.2.0
 license             BSD
 platforms           darwin
 categories          devel
@@ -17,9 +17,9 @@ homepage            http://jemalloc.net
 
 use_bzip2           yes
 
-checksums           rmd160  52b1340ca8cafd7414aa5e3a7a028cb1feba0b80 \
-                    sha256  5396e61cc6103ac393136c309fae09e44d74743c86f90e266948c50f3dbb7268 \
-                    size    515622
+checksums           rmd160  a805e8c2ad3e7a2f7960bc1407baeaca797bd77e \
+                    sha256  74be9f44a60d2a99398e706baa921e4efde82bf8fd16e5c0643c375c5851e3b4 \
+                    size    543892
 
 github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update jemalloc port to latest release (5.2.0 – was 5.1.0).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.3 16D30
Xcode 8.3.3 8E3004b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
