### PR TITLE
Fixed vtk +qt5 variant

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -33,7 +33,7 @@ checksums           rmd160  6e9b3d00602cb1e34483f4f68cc5f7a522516102 \
                     size    33479307
 
 cmake.out_of_source yes
-mpi.setup 
+mpi.setup
 
 depends_lib-append \
     port:expat \
@@ -45,7 +45,7 @@ depends_lib-append \
     port:lz4 \
     port:netcdf-cxx \
     port:tiff \
-    port:zlib 
+    port:zlib
 
 configure.args-delete \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
@@ -85,6 +85,10 @@ variant qt4 description {Add Qt4 support.} {
 
 variant qt5 description {Add Qt5 support.} {
     PortGroup           qt5 1.0
+    configure.args-append \
+                        -DQT_QMAKE_EXECUTABLE:PATH=${qt_qmake_cmd} \
+                        -DVTK_Group_Qt:BOOL=ON \
+                        -DVTK_BUILD_QT_DESIGNER_PLUGIN=OFF
 }
 
 variant python27 conflicts python35 python36 python37 description {Add Python 2.7 support.} {
@@ -151,7 +155,7 @@ variant python37 conflicts python27 python35 python36 description {Add Python 3.
 }
 
 variant hdf5 description {Add hdf5 readers} {
-    depends_lib-append port:boost 
+    depends_lib-append port:boost
     configure.args-append \
     -DVTK_USE_SYSTEM_HDF5:BOOL=ON \
     -DVTK_USE_SYSTEM_NETCDF:BOOL=ON \
@@ -162,8 +166,8 @@ variant hdf5 description {Add hdf5 readers} {
     -DModule_vtkIOXdmf2:BOOL=ON \
     -DModule_vtkxdmf2:BOOL=ON \
     -DModule_vtkxdmf3:BOOL=ON \
-    -DModule_vtkIOXdmf3:BOOL=ON 
-    
+    -DModule_vtkIOXdmf3:BOOL=ON
+
     mpi.enforce_variant hdf5
 }
 


### PR DESCRIPTION
#### Description

The necessary `configure.args` were completely missing.

`VTK_BUILD_QT_DESIGNER_PLUGIN=OFF` is necessary as there is no
port for Qt UiPlugin, which is required for this option.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
