### PR TITLE
python37: update to version 3.7.4. Added size checksum

### DIFF
--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -6,7 +6,7 @@ PortGroup select 1.0
 name                python37
 
 # Remember to keep py37-tkinter and py37-gdbm's versions sync'd with this
-version             3.7.3
+version             3.7.4
 
 set major           [lindex [split $version .] 0]
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -24,9 +24,10 @@ master_sites        ${homepage}ftp/python/${version}/
 
 distname            Python-${version}
 use_xz              yes
-checksums           md5 93df27aec0cd18d6d42173e601ffbbfd \
-                    rmd160 0095f3072e17edb789656442290f8abd0ec1bc58 \
-                    sha256 da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318
+checksums           md5 d33e4aae66097051c2eca45ee3604803 \
+                    rmd160 b9ddfd1ad22b75920f37104ed2fbc0ab39c683f2 \
+                    sha256 fb799134b868199930b75f26678f18932214042639cd52b16da7fd134cd9b13f \
+                    size 17131432
 
 patchfiles          patch-setup.py.diff \
                     patch-Lib-cgi.py.diff \


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [ x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
Same test failures as with Python 3.7.3
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary filess
