### PR TITLE
mpv: fix build with swift 5

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -7,7 +7,7 @@ PortGroup               legacysupport 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.29.1 v
-revision                5
+revision                6
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic}
@@ -206,8 +206,10 @@ platform darwin {
     # https://github.com/mpv-player/mpv/pull/6214
     patchfiles-append   patch-fix-swift-detection.diff
 
-    # swift build tools test fails on 10.10 now
-    if {${os.major} < 15} {
+    # cocoa-cb backend requires Swift 3 support, which is only available
+    # in Xcode 8.0 to Xcode 10.1. Xcode 10.2 ship with Swift 5 which
+    # dropped Swift 3 compatibility.
+    if {[vercmp ${xcodeversion} 8.0] < 0 || {[vercmp ${xcodeversion} 10.2]} >= 0} {
         configure.args-replace  --enable-swift \
                                 --disable-swift
     }


### PR DESCRIPTION
#### Description

Fix `mpv` building with Swift 5 that will be the default version in future macOS release. There is a patch from upstream (https://github.com/mpv-player/mpv/pull/6612, https://github.com/mpv-player/mpv/pull/6703) for Swift 5 that hasn't been merged yet.

Disabling swift effectively disables the newer `cocoa-cb` (swift) backend and instead use the older `cocoa` (objc) backend.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A501i
Xcode 11.0 11M362v

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->