### PR TITLE
qemu fixes

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -107,7 +107,7 @@ build.args-append       V=1
 default_variants        +usb
 
 foreach t {i386 x86_64 alpha {arm aarch64} cris lm32 m68k {microblaze microblazeel} {mips mipsel mips64 mips64el} \
-           moxie or1k {ppc ppcemb ppc64} riscv32 riscv64 s390x {sh4 sh4eb} {sparc sparc64} tricore unicore32 {xtensa xtensaeb}} {
+           moxie or1k {ppc ppc64} riscv32 riscv64 s390x {sh4 sh4eb} {sparc sparc64} tricore unicore32 {xtensa xtensaeb}} {
     variant target_[lindex $t 0] description "Add target support for [join $t {, }]" "append target_list \",[join $t -softmmu,]-softmmu\""
 }
 default_variants-append +target_i386 +target_x86_64

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -1,6 +1,9 @@
 PortSystem 1.0
 PortGroup compiler_blacklist_versions 1.0
 
+# https://trac.macports.org/ticket/58700
+PortGroup legacysupport 1.0
+
 name                    qemu
 version                 4.0.0
 revision                0

--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -47,8 +47,8 @@ depends_lib             port:curl \
 compiler.blacklist      {clang < 500} *gcc-4.2 *gcc-4.0 gcc-3.3
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Emulated TLS needed, which was added in LLVM 3.8
-    compiler.blacklist-append   macports-clang-3.4 macports-clang-3.3
-    compiler.fallback-append    macports-clang-8.0
+    compiler.blacklist-append   macports-clang-3.4 macports-clang-3.3 macports-clang-3.7
+    compiler.fallback-append    macports-clang-8.0 macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
     configure.cflags-append     -femulated-tls
 }
 


### PR DESCRIPTION
a series of three commits that fix qemu for older systems and remove a deleted ppc target.

checked on 10.6.8 / x86_64 / libc++ / built with clang-5.0