### PR TITLE
prometheus: update to 2.11.0

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,8 +1,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.10.0 v
+github.setup        prometheus prometheus 2.11.0 v
 github.tarball_from archive
+set promu_version   0.5.0
 
 description         The Prometheus monitoring system and time series database
 
@@ -16,15 +17,14 @@ homepage            https://prometheus.io/
 
 platforms           darwin
 categories          net
-license             apache
+license             Apache-2
 
 maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
 
-depends_build       port:curl \
-                    port:go
+depends_build       port:go
 
 build.env           GOPATH=${workpath} \
-                    PATH=$env(PATH):${workpath}/bin
+                    PATH=${workpath}/bin:$env(PATH)
 
 build.target        build
 
@@ -32,10 +32,7 @@ use_configure       no
 installs_libs       no
 use_parallel_build  no
 
-checksums \
-  rmd160    e066bbfce9ba96641f041adfa649a7a429a34856 \
-  sha256    0362f4aa2fb44cc2c572df140da742bdf99fe9f338157a83f6634694fd693000 \
-  size      11752395
+master_sites-append https://github.com/prometheus/promu/releases/download/v${promu_version}:promu
 
 set prom_user       ${name}
 set prom_conf_dir   ${prefix}/etc/${name}
@@ -46,11 +43,31 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
+set promu_distname  promu-${promu_version}.darwin-amd64
+set promu_distfile  ${promu_distname}${extract.suffix}
+
+distfiles           prometheus-${version}${extract.suffix}:main \
+                    ${promu_distfile}:promu
+
+checksums \
+  prometheus-${version}${extract.suffix} \
+    rmd160  62637ea4427d16553dd0496adaab7a4490b93620 \
+    sha256  b83f490a59292f00ab9679b008e2876ccc3a0c153916e2c141566395c7dcc7ee \
+    size    12133603 \
+  ${promu_distfile} \
+    rmd160  794fd1112584c13ae95506336578a96716377c8a \
+    sha256  17f9b9816e6a5b4304bda34d2ae025732e20837c27a431639731ebbd45eda08f \
+    size    7132062
+
 add_users           ${prom_user} \
                     group=${prom_user} \
                     realname=Prometheus
 
 post-extract {
+    # Install promu in the workpath
+    xinstall -d ${workpath}/bin
+    ln -s ${workpath}/${promu_distname}/promu ${workpath}/bin/
+
     copy  ${filespath}/org.macports.prometheus.plist \
           ${workpath}/org.macports.prometheus.plist
 
@@ -76,6 +93,9 @@ post-extract {
         ${workpath}/org.macports.prometheus.plist
 }
 
+destroot.keepdirs-append ${destroot}${prom_data_dir} \
+                         ${destroot}${prom_conf_dir}
+
 destroot {
     xinstall -m 755 ${worksrcpath}/${name}  ${destroot}${prefix}/bin/${name}
     xinstall -m 755 ${worksrcpath}/promtool ${destroot}${prefix}/bin/promtool
@@ -89,8 +109,6 @@ destroot {
 
     xinstall -m 755 -o ${prom_user} -g ${prom_user} -d \
         ${destroot}${prom_log_dir}
-
-    touch ${destroot}${prom_conf_dir}/.keep
 
     touch ${destroot}${prom_log_file}
 
@@ -113,7 +131,6 @@ destroot {
     ln -s ${prefix}/etc/LaunchDaemons/org.macports.${name}/org.macports.${name}.plist \
         ${destroot}/Library/LaunchDaemons/org.macports.${name}.plist
 
-    destroot.keepdirs-append ${destroot}${prom_data_dir}
 }
 
 post-activate {


### PR DESCRIPTION
#### Description

Upgrade Prometheus to 2.11.0
Couple of improvements to this Portfile including:
- Explicit declaration of a required dep, `promu` as a distfile; we have a PR for `promu` but that's for version `0.4.0` where this version of prometheus needs `0.5.0`
- removing `curl` as a build dep (no longer needed since MacPorts will fetch `promu` as a distfile)
- fixing license
- using destoot.keepdirs

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
