### PR TITLE
shadowfox-updater: update to 2.2.0

### DIFF
--- a/www/shadowfox-updater/Portfile
+++ b/www/shadowfox-updater/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/SrKomodo/shadowfox-updater 1.7.20 v
+go.setup            github.com/SrKomodo/shadowfox-updater 2.2.0 v
 
 categories          www
 platforms           darwin linux
@@ -15,80 +15,30 @@ long_description    This is a cross-platform installer/uninstaller/updater for S
                     which is a universal dark theme for Firefox.
 
 checksums           shadowfox-updater-${version}.tar.gz \
-                    rmd160   33b787a84f4716acb9036f7d3d10aa987e27277e \
-                    sha256   6177971d90c1a0bdf1639b43726406fbc6ee219795a014f7ccd16652643fbce5 \
-                    size     10468
+                    rmd160   3ee7c93451204c67ba1189fde1eaf8d1d4a090aa \
+                    sha256   32c8d72c8b3aea8cfaea4b5237a1f46cf6fc347f73e73f0db53711814f3abf27 \
+                    size     7828
 
-go.vendors          github.com/gdamore/encoding \
-                        lock    b23993cbb6353f0e6aa98d0ee318a34728f628b9 \
-                        rmd160  27d40e6a7cd1f6c720eeffa0a6b94a8f3f82e1d4 \
-                        sha256  9400f6380819a37465c79393f25e4039d09138829f79d48c964ba2943134d421 \
-                        size    10645 \
-                    github.com/akavel/rsrc \
-                        lock    f6a15ece2cfd2560077c556499f19340ddc768e9 \
-                        rmd160  b05196b9cb157b1ce65d3692da2b264e311ff294 \
-                        sha256  e931909981f21614c1c93b9151a53ea1dc6eba08c54e23ffcdc34ac0c11b0770 \
-                        size    10817 \
-                    github.com/gdamore/tcell \
-                        lock    aaadc574a6ed8dc3abe56036ca130dcee1ee6b6e \
-                        rmd160  2355201a67476d4de9b7afd7910a7d857379d185 \
-                        sha256  1b9fe818604fe1fe8bb838081fdce799d5596e462fe1e42e2f40a2790de0c98d \
-                        size    745422 \
+go.vendors          github.com/gen2brain/dlgs \
+                        lock    342edb4c68c1aca5fab1bd443cf79ef5358f7dc5 \
+                        rmd160  cf4823fa1c8b96fce3e58375ee2cb1ab865ebfdf \
+                        sha256  07f55443db2ce77df829f40b261eef74d3838f303142165f28016b2dcb0db878 \
+                        size    13348 \
                     github.com/go-ini/ini \
-                        lock    6ed8d5f64cd79a498d1f3fab5880cc376ce41bbe \
-                        rmd160  99d3e0a39f3babdcae650d10d166a96140c90565 \
-                        sha256  38729966a1a831f3cb0ac2e538d6a471cb40eb07ad69c2f266b4f38d2ffcc5e3 \
-                        size    34927 \
-                    github.com/lucasb-eyer/go-colorful \
-                        lock    12d3b2882a08d1abc9488e34f3e1ae35165f2d07 \
-                        rmd160  00b70d87c0830afdb3604b8e7c7f6861eb515368 \
-                        sha256  d4fd4f6015c2187c6f49ff35a565c4151f60c2bf0dc791a350ba00693de5d2f6 \
-                        size    430375 \
-                    github.com/mattn/go-runewidth \
-                        lock    3ee7d812e62a0804a7d0a324e0249ca2db3476d3 \
-                        rmd160  20081e360b3a667d21a7990197740bbaf51ec259 \
-                        sha256  d3b074c23e9cebd7fe786eb4fcdb5f659a8afa7629e3ec9a142f4288067bf39b \
-                        size    19840 \
-                    github.com/gopherjs/gopherjs \
-                        lock    d547d1d9531ed93dbdebcbff7f83e7c876a1e0ee \
-                        rmd160  a353baabbae82c4a059337581db83536a7712ccb \
-                        sha256  70129d96de2f25d5a3149428d09676cfb7338bc2a244331296518b39b425fd2f \
-                        size    217267 \
-                    github.com/josephspurrier/goversioninfo \
-                        lock    2e127a11672c3803a9a71684221496594884a29b \
-                        rmd160  5f21511a9776ee79061f356e22b869973707695f \
-                        sha256  63a8013b78825b64c82e35fd688ca6471bd1dc40ae3fb5d65045e7c0fd78cda5 \
-                        size    51948 \
-                    github.com/jtolds/gls \
-                        lock    77f18212c9c7edc9bd6a33d383a7b545ce62f064 \
-                        rmd160  55e8810f0571a94687ce20e80ded711d3b6e10e8 \
-                        sha256  d50f6429c9bdfacefa2eeaba2d591907e3fc8a89d1ff1dd4cf34422d6f547b6b \
-                        size    7298 \
+                        lock    c85607071cf08ca1adaf48319cd1aa322e81d8c1 \
+                        rmd160  1df5ae9bfc4f421c93d2d3f4e89e8d8f08cdbc1a \
+                        sha256  d1299d3fa9c8989ca8b181cae4e8cf307252189f02babf721987152141cd82c2 \
+                        size    35082 \
                     github.com/mitchellh/go-homedir \
-                        lock    ae18d6b8b3205b561c79e8e5f69bff09736185f4 \
-                        rmd160  4b719f7cab0e4c79e79e4a9157bfc3a4c14f0ffb \
-                        sha256  e5a7cbabc2c28de8e3a8f3554373432b16b3e46e7e7040ca47eba3eb0efe94b1 \
-                        size    3249 \
-                    github.com/rivo/tview \
-                        lock    1ac6fbc0c2399f9acf6a801c202a6835aa99ccaf \
-                        rmd160  990785c319b2b74f9e29e4ac75a735fc73b1423c \
-                        sha256  5e99da41f93623c89447d4cc29aa9c825fb7141941be511332d3055ed2bff688 \
-                        size    2865633 \
-                    github.com/smartystreets/assertions \
-                        lock    b6c0e53d73045618965505ac26ff7864fe3ab2b2 \
-                        rmd160  b3883a0fa0ac2f83be367b97fca63e1ba9954abd \
-                        sha256  ac94d923b2ee78c277e5ad00a1c76641cb558893f7a72f0e91e38146e5fcd37e \
-                        size    52140 \
-                    github.com/smartystreets/goconvey \
-                        lock    044398e4856c3a83fb98f9de0a8ed1c6495e2843 \
-                        rmd160  366083374678d26af55fbce7ed3b2edbf3accc30 \
-                        sha256  de25f88d08e3723c51c3d33290407c6077f175419a849f4e7f49bf37adba2f00 \
-                        size    1477203 \
-                    golang.org/x/text \
-                        lock    f21a4dfb5e38f5895301dc265a8def02365cc3d0 \
-                        rmd160  fecb60b88ea1fdd2ff097059183c1a4d555059a6 \
-                        sha256  ec51c6c0bbc46fc17c603aac5eb887c517f9a75529789517ccc8bd5fd7e03d94 \
-                        size    6102629 \
+                        lock    af06845cf3004701891bf4fdb884bfe4920b3727 \
+                        rmd160  44b3985e40e5bbb22d11f8622c340f9ed727ea91 \
+                        sha256  024c8a57316c7fbc0eb23cdbfd57f72a74b51beb83d714034d67ee9aba48100c \
+                        size    3366 \
+                    github.com/skratchdot/open-golang \
+                        lock    79abb63cd66e41cb1473e26d11ebdcd68b04c8e5 \
+                        rmd160  cc18c81d90b1515f8b8c8bae709a15f819675453 \
+                        sha256  1334fd442554dc8b8507cf7db3409f14a6a91321e84d70f1d73a4ff21598d134 \
+                        size    7075 \
 
 destroot {
     xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Updates `shadowfox-updater` to [2.2.0.](https://github.com/SrKomodo/shadowfox-updater/releases/tag/v2.2.0)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
