### PR TITLE
cfiles: new port

### DIFF
--- a/sysutils/cfiles/Portfile
+++ b/sysutils/cfiles/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        mananapr cfiles 1.7.1 v
+categories          sysutils
+platforms           darwin
+license             MIT
+maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+
+description         A ncurses file manager written in C with vim like keybindings
+long_description    ${name} is a terminal file manager with vim like keybindings, \
+                    written in C using the ncurses library. It aims to provide an \
+                    interface like ranger while being lightweight, fast and minimal.
+
+checksums           rmd160  263993e1f7f9813753a208e4a86d9fb0dda65013 \
+                    sha256  10d3ca8d167c0c74c41d9213933e85519d75a302fba54614682c13381a9d93ad \
+                    size    237807
+
+patchfiles          patch-config.h.diff \
+                    patch-Makefile.diff
+
+use_configure       no
+depends_build       port:pkgconfig
+depends_lib         port:ncurses
+depends_run         port:atool \
+                    port:fzf \
+                    port:mediainfo \
+                    path:bin/pdftoppm:poppler
+
+build.args-append   CC=${configure.cc}
+
+post-patch {
+    reinplace "s#/usr/bin#${prefix}/share/cfiles/scripts#g" ${worksrcpath}/config.h
+}
+
+post-build {
+    system -W ${worksrcpath} "gzip cfiles.1"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/cfiles ${destroot}/${prefix}/bin
+    xinstall -m 444 ${worksrcpath}/cfiles.1.gz ${destroot}/${prefix}/share/man/man1
+    xinstall -d ${destroot}/${prefix}/share/cfiles/scripts
+    xinstall -m 755 ${worksrcpath}/scripts/displayimg ${destroot}/${prefix}/share/cfiles/scripts
+    xinstall -m 755 ${worksrcpath}/scripts/displayimg_uberzug ${destroot}/${prefix}/share/cfiles/scripts
+    xinstall -m 755 ${worksrcpath}/scripts/clearimg ${destroot}/${prefix}/share/cfiles/scripts
+    xinstall -m 755 ${worksrcpath}/scripts/clearimg_uberzug ${destroot}/${prefix}/share/cfiles/scripts
+}

--- a/sysutils/cfiles/files/patch-Makefile.diff
+++ b/sysutils/cfiles/files/patch-Makefile.diff
@@ -1,0 +1,8 @@
+--- Makefile.orig	2019-07-12 11:40:56.000000000 +0300
++++ Makefile	2019-07-12 11:40:59.000000000 +0300
+@@ -1,4 +1,4 @@
+-CC = gcc
++CC ?= gcc
+ 
+ NCURSES_CFLAGS = `pkg-config --cflags ncursesw`
+ NCURSES_LIBS =  `pkg-config --libs ncursesw`

--- a/sysutils/cfiles/files/patch-config.h.diff
+++ b/sysutils/cfiles/files/patch-config.h.diff
@@ -1,0 +1,11 @@
+--- config.h.orig	2019-07-10 15:52:51.000000000 +0300
++++ config.h	2019-07-10 15:52:56.000000000 +0300
+@@ -19,7 +19,7 @@
+ #define SHOW_PDF_PREVIEWS 0
+ 
+ // Program used to open non-text file (Eg: `xdg-open` or `thunar`)
+-#define FILE_OPENER "xdg-open"
++#define FILE_OPENER "open"
+ 
+ // Display Image Script
+ #define DISPLAYIMG "/usr/local/bin/displayimg_uberzug"


### PR DESCRIPTION
#### Description

[cfiles](https://github.com/mananapr/cfiles) - a ncurses file manager written in C with vim like keybindings.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
