### PR TITLE
tcl: Don't let TCL_CC contain ccache

### DIFF
--- a/lang/tcl/Portfile
+++ b/lang/tcl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tcl
 version             8.6.9
-revision            1
+revision            2
 # Tk (x11/tk) port depends on this version
 categories          lang
 license             Tcl/Tk
@@ -51,6 +51,10 @@ destroot.destdir    INSTALL_ROOT=${destroot}
 post-destroot {
     ln -s tclsh8.6 ${destroot}${prefix}/bin/tclsh
     ln -s libtcl8.6.dylib ${destroot}${prefix}/lib/libtcl.dylib
+
+    if {${configure.ccache}} {
+        reinplace {/TCL_CC/s/ccache //} ${destroot}${prefix}/lib/tclConfig.sh
+    }
 }
 
 variant threads description {add multithreading support} {


### PR DESCRIPTION
#### Description

`TCL_CC` in tclConfig.sh contains the compiler that was used to compile Tcl. If ccache was used when compiling Tcl, then `TCL_CC` will have "ccache " before the compiler path. If you later use tclConfig.sh to compile something else, but you no longer have ccache installed, the build will fail.

This PR fixes that by deleting the "ccache " prefix from `TCL_CC` if ccache was used.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
