### PR TITLE
tex: remove/reorder dead/not-updated master_sites

### DIFF
--- a/_resources/port1.0/group/texlive-1.0.tcl
+++ b/_resources/port1.0/group/texlive-1.0.tcl
@@ -133,9 +133,8 @@ proc texlive.texmfport {} {
     supported_archs noarch
     installs_libs   no
 
-    master_sites    https://giraffe.cs.washington.edu/texlive/ \
-                    https://alpaca.cs.washington.edu/texlive/ \
-                    https://www.ambulatoryclam.net/texlive/
+    master_sites    https://www.ambulatoryclam.net/texlive/ \
+                    https://alpaca.cs.washington.edu/texlive/
     use_xz          yes
 
     global name master_sites distname extract.suffix

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -39,9 +39,8 @@ license         Copyleft Permissive LGPL-2.1+ BSD
 # download time, it omits a number of libraries and utilities that we
 # don't build. However, the port should still work with an unmodified
 # texlive distfile.
-master_sites    https://giraffe.cs.washington.edu/texlive/ \
-                https://alpaca.cs.washington.edu/texlive/ \
-                https://www.ambulatoryclam.net/texlive/
+master_sites    https://www.ambulatoryclam.net/texlive/ \
+                https://alpaca.cs.washington.edu/texlive/
 use_xz          yes
 distname        texlive-source-${version}-stripped
 worksrcdir      ${distname}

--- a/tex/texlive-common/Portfile
+++ b/tex/texlive-common/Portfile
@@ -19,9 +19,8 @@ platforms           darwin
 supported_archs     noarch
 license             Permissive
 
-master_sites        https://giraffe.cs.washington.edu/texlive/ \
-                    https://alpaca.cs.washington.edu/texlive/ \
-                    https://www.ambulatoryclam.net/texlive/
+master_sites        https://www.ambulatoryclam.net/texlive/ \
+                    https://alpaca.cs.washington.edu/texlive/ 
 worksrcdir          ${distname}
 use_xz              yes
 


### PR DESCRIPTION

Removes https://giraffe.cs.washington.edu/texlive/ which appears dead (and has been for sometime).

Places https://alpaca.cs.washington.edu/texlive/ last in list as whilst still alive, does not appear to be fully up to date.

I would add others to replace those removed/out-of date, but I am not sure where to find an up to date mirror list ?