### PR TITLE
mosh: Support building with C++20 (clang 7+ and GCC 9.1+)

### DIFF
--- a/net/mosh/Portfile
+++ b/net/mosh/Portfile
@@ -35,7 +35,12 @@ depends_lib             port:ncurses \
                         port:p${perl5.major}-getopt-long \
                         port:p${perl5.major}-io-socket-ip
 
-patchfiles              network-bind.patch
+patchfiles              network-bind.patch \
+                        patch-version-subdir.diff
+
+# Remove patch-version-subdir.diff and autoreconf when mosh > 1.3.2 is released.
+use_autoreconf          yes
+autoreconf.args         --install --verbose --force
 
 post-patch {
     reinplace "s|#!/usr/bin/env perl|#!${prefix}/bin/perl${perl5.major}|" \

--- a/net/mosh/files/patch-version-subdir.diff
+++ b/net/mosh/files/patch-version-subdir.diff
@@ -1,0 +1,103 @@
+From 599d471e1119f3606739749f151070a061c831a7 Mon Sep 17 00:00:00 2001
+From: John Hood <cgull@glup.org>
+Date: Tue, 9 Jul 2019 00:30:16 -0400
+Subject: [PATCH] Move generated includes to their own directory to avoid
+ conflicts.
+
+Fixes #1051, mosh fails to build on case-insensitive filesystems.
+
+XXX This isn't perfect because autoconf/automake drop several extra
+files in the directory anyway.
+---
+ Makefile.am             | 13 +++----------
+ configure.ac            |  3 ++-
+ src/Makefile.am         |  2 +-
+ src/include/Makefile.am | 14 ++++++++++++++
+ 4 files changed, 20 insertions(+), 12 deletions(-)
+ create mode 100644 src/include/Makefile.am
+
+diff --git Makefile.am Makefile.am
+index ac0bb8f..52726c6 100644
+--- Makefile.am
++++ Makefile.am
+@@ -1,7 +1,7 @@
+ ACLOCAL_AMFLAGS = -I m4
+ SUBDIRS = scripts src man conf
+ EXTRA_DIST = autogen.sh ocb-license.html README.md COPYING.iOS
+-BUILT_SOURCES = version.h
++BUILT_SOURCES = VERSION
+ CLANG_SCAN_BUILD = scan-build
+ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-compile-warnings=distcheck --enable-examples
+ 
+@@ -19,18 +19,11 @@ VERSION:
+ 	fi
+ 	@rm -f VERSION.dist VERSION.git
+ 
+-version.h:	VERSION
+-	@printf '#define BUILD_VERSION "%s"\n' "$$(cat VERSION)" > version.h.new
+-	@set -e; if ! diff -q version.h version.h.new > /dev/null 2>&1; then \
+-		mv -f version.h.new version.h; \
+-	fi
+-	@rm -f version.h.new
+-
+ clean-local:
+-	@rm -rf version.h VERSION cov-int mosh-coverity.txz
++	@rm -rf VERSION cov-int mosh-coverity.txz
+ 
+ cppcheck: $(BUILT_SOURCES) config.h
+-	cppcheck --enable=all --template=gcc -include config.h -I . \
++	cppcheck --enable=all --template=gcc -include src/include/config.h -I src/include \
+ 		-I src/crypto -I src/frontend -I src/network -I src/protobufs \
+ 		-I src/statesync -I src/terminal -I src/util \
+ 		-I /usr/include -I /usr/include/google/protobuf -I/usr/include/openssl \
+diff --git configure.ac configure.ac
+index 3ad983d..0304e5f 100644
+--- configure.ac
++++ configure.ac
+@@ -7,7 +7,7 @@ AM_INIT_AUTOMAKE([foreign std-options -Wall -Werror])
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+ AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])
+ AC_CONFIG_MACRO_DIR([m4])
+-AC_CONFIG_HEADERS([config.h])
++AC_CONFIG_HEADERS([src/include/config.h])
+ 
+ # Checks for programs.
+ AC_PROG_CC([cc gcc clang])
+@@ -490,6 +490,7 @@ AC_CONFIG_FILES([
+   src/Makefile
+   src/crypto/Makefile
+   src/frontend/Makefile
++  src/include/Makefile
+   src/network/Makefile
+   src/protobufs/Makefile
+   src/statesync/Makefile
+diff --git src/Makefile.am src/Makefile.am
+index 2390f7c..a714997 100644
+--- src/Makefile.am
++++ src/Makefile.am
+@@ -1 +1 @@
+-SUBDIRS = protobufs util crypto terminal network statesync frontend examples tests
++SUBDIRS = include protobufs util crypto terminal network statesync frontend examples tests
+diff --git src/include/Makefile.am src/include/Makefile.am
+new file mode 100644
+index 0000000..98d140f
+--- /dev/null
++++ src/include/Makefile.am
+@@ -0,0 +1,14 @@
++BUILT_SOURCES = version.h
++nodist_INCLUDES = version.h
++
++clean-local:
++	@rm -rf version.h
++
++version.h:	../../VERSION
++	@test -f $<
++	@printf '#define BUILD_VERSION "%s"\n' "$$(cat $<)" > version.h.new
++	@set -e; if ! diff -q $@ $@.new > /dev/null 2>&1; then \
++		mv -f $@.new $@; \
++	fi
++	@rm -f $@.new
++
+-- 
+2.20.1 (Apple Git-117)
+


### PR DESCRIPTION
mosh, like many autoconf-based packages, has a file called "VERSION"
in its workdir. C++20 now tries to include that file as the upstream
header "version".

This takes an upstream patch from
https://github.com/mobile-shell/mosh/pull/1052 which works around the
issue by moving config.h and version.h into a subdirectory.

Fixes: https://trac.macports.org/ticket/58690

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001 

Specifically tested with:
```
port -k -d -ns install mosh configure.compiler=macports-clang-8.0 build.post_args=V=
```
in order to force clang 8.0 on an OS that would normally use Xcode's older clang.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
