### PR TITLE
ntpsec: update to 1.1.6

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,7 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.5
+version             1.1.6
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -18,9 +18,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  01cab05c677b01cc03c7fb9af3d76c4189170b54 \
-                    sha256  e97211a2f33d4d1ace4b2239556e0c2547ed6fc1eec6e3aab765b24151e5b756 \
-                    size    2597462
+checksums           rmd160  b539282b5d15c7541994c65ef24af1d890b25f9f \
+                    sha256  8d7c4e41206f7e23727b8b76e06ea0d7d5b13f0afe6ac4c52181c8522e38f79c \
+                    size    2600632
 
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}

--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,7 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.4
+version             1.1.5
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -18,9 +18,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  9d4f0363f383ffe9efd3470635d5960eae5399f1 \
-                    sha256  76f1b993f9853b68b6b1724e1906e5c076470082d8ba11b3b849a94ae56465ef \
-                    size    2536268
+checksums           rmd160  01cab05c677b01cc03c7fb9af3d76c4189170b54 \
+                    sha256  e97211a2f33d4d1ace4b2239556e0c2547ed6fc1eec6e3aab765b24151e5b756 \
+                    size    2597462
 
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}

--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,7 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.3
+version             1.1.4
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -18,9 +18,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  cdaae8f682cd4cc97a37d86aca1d3196cfea0437 \
-                    sha256  226b4b29d5166ea3d241a24f7bfc2567f289cf6ed826d8aeb9f2f261c1836bde \
-                    size    2462330
+checksums           rmd160  9d4f0363f383ffe9efd3470635d5960eae5399f1 \
+                    sha256  76f1b993f9853b68b6b1724e1906e5c076470082d8ba11b3b849a94ae56465ef \
+                    size    2536268
 
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}
@@ -45,6 +45,11 @@ configure.args      --alltests \
 destroot.cmd        ${build.cmd}
 
 default_variants    +doc
+
+# ntpsec has issues with universal builds:
+# 1) It expects endianness to be single-valued at configure time.
+# 2) There are problems with Python compiled extensions and universality.
+universal_variant   no
 
 variant classic description {Enable classic mode} {
     configure.args-append   --enable-classic-mode

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,5 @@
 --- ./attic/backwards.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/backwards.c	2019-07-02 11:55:05.000000000 -0700
++++ ./attic/backwards.c	2019-07-11 17:37:25.000000000 -0700
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -10,7 +10,7 @@
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
 --- ./attic/clocks.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/clocks.c	2019-07-02 11:55:05.000000000 -0700
++++ ./attic/clocks.c	2019-07-11 17:37:25.000000000 -0700
 @@ -5,6 +5,8 @@
  #include <stdio.h>
  #include <time.h>
@@ -21,7 +21,7 @@
    const int type;
    const char* name;
 --- ./attic/digest-timing.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/digest-timing.c	2019-07-02 11:55:05.000000000 -0700
++++ ./attic/digest-timing.c	2019-07-11 17:37:25.000000000 -0700
 @@ -34,6 +34,8 @@
  #include <openssl/rand.h>
  #include <openssl/objects.h>
@@ -32,7 +32,7 @@
  
  #ifndef EVP_MD_CTX_reset
 --- ./include/ntp_machine.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_machine.h	2019-07-02 11:55:05.000000000 -0700
++++ ./include/ntp_machine.h	2019-07-11 17:37:25.000000000 -0700
 @@ -13,14 +13,135 @@
  
  #ifndef CLOCK_REALTIME
@@ -176,7 +176,7 @@
  int ntp_set_tod (struct timespec *tvs);
  
 --- ./include/ntp_stdlib.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_stdlib.h	2019-07-02 11:55:05.000000000 -0700
++++ ./include/ntp_stdlib.h	2019-07-11 17:37:25.000000000 -0700
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -188,7 +188,7 @@
  extern	sockaddr_u * netof6	(sockaddr_u *);
  extern	const char * socktoa	(const sockaddr_u *);
 --- ./include/ntp_syscall.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_syscall.h	2019-07-02 11:55:05.000000000 -0700
++++ ./include/ntp_syscall.h	2019-07-11 17:37:25.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -202,7 +202,7 @@
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
 --- ./libntp/clockwork.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./libntp/clockwork.c	2019-07-02 11:55:05.000000000 -0700
++++ ./libntp/clockwork.c	2019-07-11 17:37:25.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -217,7 +217,7 @@
  #include "ntp.h"
  #include "ntp_machine.h"
 --- ./libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./libntp/statestr.c	2019-07-02 11:55:05.000000000 -0700
++++ ./libntp/statestr.c	2019-07-11 17:37:25.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -318,8 +318,8 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpd/ntp_control.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_control.c	2019-07-02 11:55:05.000000000 -0700
+--- ./ntpd/ntp_control.c.orig	2019-06-30 00:21:32.000000000 -0700
++++ ./ntpd/ntp_control.c	2019-07-11 17:37:25.000000000 -0700
 @@ -1357,6 +1357,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
@@ -443,7 +443,7 @@
  
  	case CS_K_PPS_FREQ:
 --- ./ntpd/ntp_loopfilter.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2019-07-02 11:55:05.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2019-07-11 17:37:25.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -680,7 +680,7 @@
 -#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL && SIGSYS */
 --- ./ntpd/ntp_timer.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2019-07-02 11:55:05.000000000 -0700
++++ ./ntpd/ntp_timer.c	2019-07-11 17:37:25.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -704,7 +704,7 @@
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
 --- ./ntpd/refclock_local.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/refclock_local.c	2019-07-02 11:55:05.000000000 -0700
++++ ./ntpd/refclock_local.c	2019-07-11 17:37:25.000000000 -0700
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -728,7 +728,7 @@
  	refclock_receive(peer);
  }
 --- ./ntpfrob/precision.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpfrob/precision.c	2019-07-02 11:55:05.000000000 -0700
++++ ./ntpfrob/precision.c	2019-07-11 17:37:25.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -738,7 +738,7 @@
  #define	DEFAULT_SYS_PRECISION	-99
  
 --- ./tests/libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./tests/libntp/statestr.c	2019-07-02 11:55:05.000000000 -0700
++++ ./tests/libntp/statestr.c	2019-07-11 17:37:25.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -760,7 +760,7 @@
  
  // statustoa
 --- ./wafhelpers/bin_test.py.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2019-07-02 11:55:05.000000000 -0700
++++ ./wafhelpers/bin_test.py	2019-07-11 17:37:25.000000000 -0700
 @@ -91,6 +91,12 @@ def cmd_bin_test(ctx, config):
          for cmd in cmd_map3:
              cmd_map2[cmd] = cmd_map3[cmd]
@@ -775,7 +775,7 @@
          if not run(cmd, cmd_map[cmd], False):
              fails += 1
 --- ./wafhelpers/options.py.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wafhelpers/options.py	2019-07-02 11:55:05.000000000 -0700
++++ ./wafhelpers/options.py	2019-07-11 17:37:25.000000000 -0700
 @@ -19,6 +19,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -786,7 +786,7 @@
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
 --- ./wscript.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wscript	2019-07-02 11:55:05.000000000 -0700
++++ ./wscript	2019-07-11 17:37:25.000000000 -0700
 @@ -593,7 +593,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,5 @@
 --- ./attic/backwards.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/backwards.c	2019-07-11 17:37:25.000000000 -0700
++++ ./attic/backwards.c	2019-07-11 17:54:24.000000000 -0700
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -10,7 +10,7 @@
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
 --- ./attic/clocks.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/clocks.c	2019-07-11 17:37:25.000000000 -0700
++++ ./attic/clocks.c	2019-07-11 17:54:24.000000000 -0700
 @@ -5,6 +5,8 @@
  #include <stdio.h>
  #include <time.h>
@@ -21,7 +21,7 @@
    const int type;
    const char* name;
 --- ./attic/digest-timing.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/digest-timing.c	2019-07-11 17:37:25.000000000 -0700
++++ ./attic/digest-timing.c	2019-07-11 17:54:24.000000000 -0700
 @@ -34,6 +34,8 @@
  #include <openssl/rand.h>
  #include <openssl/objects.h>
@@ -32,7 +32,7 @@
  
  #ifndef EVP_MD_CTX_reset
 --- ./include/ntp_machine.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_machine.h	2019-07-11 17:37:25.000000000 -0700
++++ ./include/ntp_machine.h	2019-07-11 17:54:24.000000000 -0700
 @@ -13,14 +13,135 @@
  
  #ifndef CLOCK_REALTIME
@@ -176,7 +176,7 @@
  int ntp_set_tod (struct timespec *tvs);
  
 --- ./include/ntp_stdlib.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_stdlib.h	2019-07-11 17:37:25.000000000 -0700
++++ ./include/ntp_stdlib.h	2019-07-11 17:54:24.000000000 -0700
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -188,7 +188,7 @@
  extern	sockaddr_u * netof6	(sockaddr_u *);
  extern	const char * socktoa	(const sockaddr_u *);
 --- ./include/ntp_syscall.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_syscall.h	2019-07-11 17:37:25.000000000 -0700
++++ ./include/ntp_syscall.h	2019-07-11 17:54:24.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -202,7 +202,7 @@
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
 --- ./libntp/clockwork.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./libntp/clockwork.c	2019-07-11 17:37:25.000000000 -0700
++++ ./libntp/clockwork.c	2019-07-11 17:54:24.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -217,7 +217,7 @@
  #include "ntp.h"
  #include "ntp_machine.h"
 --- ./libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./libntp/statestr.c	2019-07-11 17:37:25.000000000 -0700
++++ ./libntp/statestr.c	2019-07-11 17:54:24.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -319,7 +319,7 @@
  /*
   * statustoa - return a descriptive string for a peer status
 --- ./ntpd/ntp_control.c.orig	2019-06-30 00:21:32.000000000 -0700
-+++ ./ntpd/ntp_control.c	2019-07-11 17:37:25.000000000 -0700
++++ ./ntpd/ntp_control.c	2019-07-11 17:54:24.000000000 -0700
 @@ -1357,6 +1357,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
@@ -443,7 +443,7 @@
  
  	case CS_K_PPS_FREQ:
 --- ./ntpd/ntp_loopfilter.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2019-07-11 17:37:25.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2019-07-11 17:54:24.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -680,7 +680,7 @@
 -#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL && SIGSYS */
 --- ./ntpd/ntp_timer.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2019-07-11 17:37:25.000000000 -0700
++++ ./ntpd/ntp_timer.c	2019-07-11 17:54:24.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -704,7 +704,7 @@
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
 --- ./ntpd/refclock_local.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/refclock_local.c	2019-07-11 17:37:25.000000000 -0700
++++ ./ntpd/refclock_local.c	2019-07-11 17:54:24.000000000 -0700
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -728,7 +728,7 @@
  	refclock_receive(peer);
  }
 --- ./ntpfrob/precision.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpfrob/precision.c	2019-07-11 17:37:25.000000000 -0700
++++ ./ntpfrob/precision.c	2019-07-11 17:54:24.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -738,7 +738,7 @@
  #define	DEFAULT_SYS_PRECISION	-99
  
 --- ./tests/libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./tests/libntp/statestr.c	2019-07-11 17:37:25.000000000 -0700
++++ ./tests/libntp/statestr.c	2019-07-11 17:54:24.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -760,7 +760,7 @@
  
  // statustoa
 --- ./wafhelpers/bin_test.py.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2019-07-11 17:37:25.000000000 -0700
++++ ./wafhelpers/bin_test.py	2019-07-11 17:54:24.000000000 -0700
 @@ -91,6 +91,12 @@ def cmd_bin_test(ctx, config):
          for cmd in cmd_map3:
              cmd_map2[cmd] = cmd_map3[cmd]
@@ -775,7 +775,7 @@
          if not run(cmd, cmd_map[cmd], False):
              fails += 1
 --- ./wafhelpers/options.py.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wafhelpers/options.py	2019-07-11 17:37:25.000000000 -0700
++++ ./wafhelpers/options.py	2019-07-11 17:54:24.000000000 -0700
 @@ -19,6 +19,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -786,7 +786,7 @@
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
 --- ./wscript.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wscript	2019-07-11 17:37:25.000000000 -0700
++++ ./wscript	2019-07-11 17:54:24.000000000 -0700
 @@ -593,7 +593,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,16 @@
---- ./attic/clocks.c.orig	2019-01-13 21:40:59.000000000 -0800
-+++ ./attic/clocks.c	2019-01-15 12:40:57.000000000 -0800
+--- ./attic/backwards.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./attic/backwards.c	2019-07-02 11:55:05.000000000 -0700
+@@ -7,6 +7,8 @@
+ #include <stdlib.h>
+ #include <time.h>
+ 
++#include "ntp_machine.h"	/* For clock_gettime fallback */
++
+ #define UNUSED_ARG(arg)         ((void)(arg))
+ 
+ static void ts_print(struct timespec *ts0, struct timespec *ts1);
+--- ./attic/clocks.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./attic/clocks.c	2019-07-02 11:55:05.000000000 -0700
 @@ -5,6 +5,8 @@
  #include <stdio.h>
  #include <time.h>
@@ -9,8 +20,8 @@
  struct table {
    const int type;
    const char* name;
---- ./attic/digest-timing.c.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./attic/digest-timing.c	2019-01-15 12:40:57.000000000 -0800
+--- ./attic/digest-timing.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./attic/digest-timing.c	2019-07-02 11:55:05.000000000 -0700
 @@ -34,6 +34,8 @@
  #include <openssl/rand.h>
  #include <openssl/objects.h>
@@ -20,8 +31,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- ./include/ntp_machine.h.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./include/ntp_machine.h	2019-01-15 12:40:57.000000000 -0800
+--- ./include/ntp_machine.h.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./include/ntp_machine.h	2019-07-02 11:55:05.000000000 -0700
 @@ -13,14 +13,135 @@
  
  #ifndef CLOCK_REALTIME
@@ -164,9 +175,9 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- ./include/ntp_stdlib.h.orig	2018-09-25 23:08:35.000000000 -0700
-+++ ./include/ntp_stdlib.h	2019-01-15 12:40:57.000000000 -0800
-@@ -102,7 +102,9 @@ extern	const char * eventstr	(int);
+--- ./include/ntp_stdlib.h.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./include/ntp_stdlib.h	2019-07-02 11:55:05.000000000 -0700
+@@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
  extern	const char * res_access_flags(unsigned short);
@@ -176,8 +187,8 @@
  extern	char *	statustoa	(int, int);
  extern	sockaddr_u * netof6	(sockaddr_u *);
  extern	const char * socktoa	(const sockaddr_u *);
---- ./include/ntp_syscall.h.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./include/ntp_syscall.h	2019-01-15 12:40:57.000000000 -0800
+--- ./include/ntp_syscall.h.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./include/ntp_syscall.h	2019-07-02 11:55:05.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -190,8 +201,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- ./libntp/clockwork.c.orig	2019-01-13 21:40:59.000000000 -0800
-+++ ./libntp/clockwork.c	2019-01-15 12:40:57.000000000 -0800
+--- ./libntp/clockwork.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./libntp/clockwork.c	2019-07-02 11:55:05.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -205,8 +216,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- ./libntp/statestr.c.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./libntp/statestr.c	2019-01-15 12:40:57.000000000 -0800
+--- ./libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./libntp/statestr.c	2019-07-02 11:55:05.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -307,9 +318,9 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpd/ntp_control.c.orig	2019-01-13 21:40:59.000000000 -0800
-+++ ./ntpd/ntp_control.c	2019-01-15 12:40:57.000000000 -0800
-@@ -1478,6 +1478,7 @@ ctl_putsys(
+--- ./ntpd/ntp_control.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./ntpd/ntp_control.c	2019-07-02 11:55:05.000000000 -0700
+@@ -1357,6 +1357,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
  	const char *ss;
@@ -317,15 +328,15 @@
  	static struct timex ntx;
  	static unsigned long ntp_adjtime_time;
  
-@@ -1492,6 +1493,7 @@ ctl_putsys(
+@@ -1372,6 +1373,7 @@ ctl_putsys(
  		else
- 			ntp_adjtime_time = current_time;
+                     ntp_adjtime_time = current_time;
  	}
 +#endif	/* HAVE_KERNEL_PLL */
  
  	switch (varid) {
  
-@@ -1880,50 +1882,93 @@ ctl_putsys(
+@@ -1767,50 +1769,93 @@ ctl_putsys(
  		break;
  
  		/*
@@ -423,7 +434,7 @@
  		break;
  
  	case CS_K_FREQTOL:
--	    ctl_putsfp(sys_var[varid].text, ntx.tolerance);
+-	        ctl_putsfp(sys_var[varid].text, ntx.tolerance);
 +		CTL_IF_KERNLOOP(
 +			ctl_putsfp,
 +			(sys_var[varid].text, ntx.tolerance)
@@ -431,8 +442,8 @@
  		break;
  
  	case CS_K_PPS_FREQ:
---- ./ntpd/ntp_loopfilter.c.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2019-01-15 12:40:57.000000000 -0800
+--- ./ntpd/ntp_loopfilter.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2019-07-02 11:55:05.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -440,37 +451,27 @@
 +#ifdef HAVE_KERNEL_PLL
  # define FREQTOD(x)	((x) / 65536e6)            /* NTP to double */
  # define DTOFREQ(x)	((int32_t)((x) * 65536e6)) /* double to NTP */
-+#endif
++#endif /* HAVE_KERNEL_PLL */
  
  /*
   * This is an implementation of the clock discipline algorithm described
-@@ -122,13 +124,16 @@ double	drift_comp;		/* frequency (s/s) *
- static double init_drift_comp; /* initial frequency (PPM) */
- double	clock_stability;	/* frequency stability (wander) (s/s) */
- unsigned int	sys_tai;		/* TAI offset from UTC */
--#ifndef ENABLE_LOCKCLOCK
-+#if !defined(ENABLE_LOCKCLOCK) && defined(HAVE_KERNEL_PLL)
- static bool loop_started;	/* true after LOOP_DRIFTINIT */
-+#endif /* !ENABLE_LOCKCLOCK && HAVE_KERNEL_PLL */
-+#ifndef ENABLE_LOCKCLOCK
- static void rstclock (int, double); /* transition function */
+@@ -127,6 +129,7 @@ static void rstclock (int, double); /* t
  static double direct_freq(double); /* direct set frequency */
  static void set_freq(double);	/* set frequency */
- #endif /* ENABLE_LOCKCLOCK */
  
 +#ifdef HAVE_KERNEL_PLL
  #ifndef PATH_MAX
  # define PATH_MAX MAX_PATH
  #endif
-@@ -144,6 +149,7 @@ static unsigned int loop_tai;		/* last T
- #endif /* ENABLE_LOCKCLOCK */
+@@ -140,6 +143,7 @@ static unsigned int loop_tai;	/* last TA
+ #endif /* STA_NANO */
  static	void	start_kern_loop(void);
  static	void	stop_kern_loop(void);
 +#endif /* HAVE_KERNEL_PLL */
  
  /*
   * Clock state machine control flags
-@@ -160,7 +166,9 @@ struct clock_control_flags clock_ctl = {
+@@ -156,7 +160,9 @@ struct clock_control_flags clock_ctl = {
  int	freq_cnt;		/* initial frequency clamp */
  
  static int freq_set;		/* initial set frequency switch */
@@ -480,7 +481,7 @@
  
  /*
   * Clock state machine variables
-@@ -180,6 +188,7 @@ static int sys_hufflen;		/* huff-n'-puff
+@@ -174,6 +180,7 @@ static int sys_hufflen;		/* huff-n'-puff
  static int sys_huffptr;		/* huff-n'-puff filter pointer */
  static double sys_mindly;	/* huff-n'-puff filter min delay */
  
@@ -488,17 +489,17 @@
  /* Emacs cc-mode goes nuts if we split the next line... */
  #define MOD_BITS (MOD_OFFSET | MOD_MAXERROR | MOD_ESTERROR | \
      MOD_STATUS | MOD_TIMECONST)
-@@ -189,7 +198,9 @@ static struct sigaction sigsys;	/* curre
+@@ -183,7 +190,9 @@ static struct sigaction sigsys;	/* curre
  static struct sigaction newsigsys; /* new sigaction status */
  static sigjmp_buf env;		/* environment var. for pll_trap() */
  #endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL */
  
 +#ifdef HAVE_KERNEL_PLL
- #ifndef ENABLE_LOCKCLOCK
  static void
  sync_status(const char *what, int ostatus, int nstatus)
-@@ -215,6 +226,7 @@ static char *file_name(void)
+ {
+@@ -208,6 +217,7 @@ static char *file_name(void)
  	}
  	return this_file;
  }
@@ -506,7 +507,7 @@
  
  /*
   * init_loopfilter - initialize loop filter data
-@@ -230,6 +242,7 @@ init_loopfilter(void)
+@@ -223,6 +233,7 @@ init_loopfilter(void)
  	freq_cnt = (int)clock_minstep;
  }
  
@@ -514,16 +515,16 @@
  /*
   * ntp_adjtime_error_handler - process errors from ntp_adjtime
   */
-@@ -428,6 +441,7 @@ or, from ntp_adjtime():
+@@ -421,6 +432,7 @@ or, from ntp_adjtime():
  	}
  	return;
  }
-+#endif
++#endif /* HAVE_KERNEL_PLL */
  
  /*
   * local_clock - the NTP logical clock loop filter.
-@@ -453,7 +467,9 @@ local_clock(
- #else
+@@ -453,7 +465,9 @@ local_clock(
+ 
  	int	rval;		/* return code */
  	int	osys_poll;	/* old system poll */
 +#ifdef HAVE_KERNEL_PLL
@@ -532,7 +533,7 @@
  	double	mu;		/* interval since last update */
  	double	clock_frequency; /* clock frequency */
  	double	dtemp, etemp;	/* double temps */
-@@ -722,6 +738,7 @@ local_clock(
+@@ -705,6 +719,7 @@ local_clock(
  		}
  	}
  
@@ -540,7 +541,7 @@
  	/*
  	 * This code segment works when clock adjustments are made using
  	 * precision time kernel support and the ntp_adjtime() system
-@@ -837,6 +854,7 @@ local_clock(
+@@ -820,6 +835,7 @@ local_clock(
  		}
  #endif /* STA_NANO */
  	}
@@ -548,7 +549,7 @@
  
  	/*
  	 * Clamp the frequency within the tolerance range and calculate
-@@ -950,8 +968,10 @@ adj_host_clock(
+@@ -929,8 +945,10 @@ adj_host_clock(
  	} else if (freq_cnt > 0) {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(1));
  		freq_cnt--;
@@ -559,7 +560,7 @@
  	} else {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(sys_poll));
  	}
-@@ -962,9 +982,11 @@ adj_host_clock(
+@@ -941,9 +959,11 @@ adj_host_clock(
  	 * set_freq().  Otherwise it is a component of the adj_systime()
  	 * offset.
  	 */
@@ -571,7 +572,7 @@
  		freq_adj = drift_comp;
  
  	/* Bound absolute value of total adjustment to NTP_MAXFREQ. */
-@@ -1056,6 +1078,7 @@ set_freq(
+@@ -1031,6 +1051,7 @@ set_freq(
  
  	drift_comp = freq;
  	loop_desc = "ntpd";
@@ -579,7 +580,7 @@
  	if (clock_ctl.pll_control) {
  		int ntp_adj_ret;
  		ZERO(ntv);
-@@ -1068,11 +1091,13 @@ set_freq(
+@@ -1043,10 +1064,12 @@ set_freq(
  		    ntp_adjtime_error_handler(__func__, &ntv, ntp_adj_ret, errno, false, false, __LINE__ - 1);
  		}
  	}
@@ -587,13 +588,12 @@
  	mprintf_event(EVNT_FSET, NULL, "%s %.6f PPM", loop_desc,
  	    drift_comp * US_PER_S);
  }
- #endif /* HAVE_LOCKCLOCK */
  
 +#ifdef HAVE_KERNEL_PLL
  static void
  start_kern_loop(void)
  {
-@@ -1133,8 +1158,10 @@ start_kern_loop(void)
+@@ -1107,8 +1130,10 @@ start_kern_loop(void)
  	  	    "kernel time sync enabled");
  	}
  }
@@ -604,7 +604,7 @@
  static void
  stop_kern_loop(void)
  {
-@@ -1142,6 +1169,7 @@ stop_kern_loop(void)
+@@ -1116,6 +1141,7 @@ stop_kern_loop(void)
  		report_event(EVNT_KERN, NULL,
  		    "kernel time sync disabled");
  }
@@ -612,35 +612,28 @@
  
  
  /*
-@@ -1154,17 +1182,21 @@ select_loop(
+@@ -1128,11 +1154,15 @@ select_loop(
  {
  	if (clock_ctl.kern_enable == use_kern_loop)
  		return;
 +#ifdef HAVE_KERNEL_PLL
  	if (clock_ctl.pll_control && !use_kern_loop)
  		stop_kern_loop();
-+#endif
++#endif /* HAVE_KERNEL_PLL */
  	clock_ctl.kern_enable = use_kern_loop;
 +#ifdef HAVE_KERNEL_PLL
  	if (clock_ctl.pll_control && use_kern_loop)
  		start_kern_loop();
-+#endif
++#endif /* HAVE_KERNEL_PLL */
  	/*
  	 * If this loop selection change occurs after initial startup,
  	 * call set_freq() to switch the frequency compensation to or
- 	 * from the kernel loop.
- 	 */
--#if !defined(ENABLE_LOCKCLOCK)
-+#if defined(HAVE_KERNEL_PLL) && !defined(ENABLE_LOCKCLOCK)
- 	if (clock_ctl.pll_control && loop_started)
- 		set_freq(drift_comp);
- #endif
-@@ -1215,10 +1247,12 @@ loop_config(
+@@ -1186,10 +1216,12 @@ loop_config(
+ 	 * variables. Otherwise, continue leaving no harm behind.
  	 */
  	case LOOP_DRIFTINIT:
- #ifndef ENABLE_LOCKCLOCK
 +#ifdef HAVE_KERNEL_PLL
- 		if (clock_ctl.mode_ntpdate)
+ 		if (lockclock || clock_ctl.mode_ntpdate)
  			break;
  
  		start_kern_loop();
@@ -648,32 +641,30 @@
  
  		/*
  		 * Initialize frequency if given; otherwise, begin frequency
-@@ -1236,13 +1270,16 @@ loop_config(
+@@ -1207,11 +1239,14 @@ loop_config(
  			rstclock(EVNT_FSET, 0);
  		else
  			rstclock(EVNT_NSET, 0);
 +#ifdef HAVE_KERNEL_PLL
  		loop_started = true;
 +#endif /* HAVE_KERNEL_PLL */
- #endif /* !ENABLE_LOCKCLOCK */
  		break;
  
  	case LOOP_KERN_CLEAR:
  #if 0		/* XXX: needs more review, and how can we get here? */
- #ifndef ENABLE_LOCKCLOCK
 +# ifdef HAVE_KERNEL_PLL
- 		if (clock_ctl.pll_control && clock_ctl.kern_enable) {
+ 		if (!lockclock && (clock_ctl.pll_control && clock_ctl.kern_enable)) {
  			memset((char *)&ntv, 0, sizeof(ntv));
  			ntv.modes = MOD_STATUS;
-@@ -1252,6 +1289,7 @@ loop_config(
+@@ -1221,6 +1256,7 @@ loop_config(
  				pll_status,
  				ntv.status);
  		   }
 +# endif /* HAVE_KERNEL_PLL */
- #endif /* ENABLE_LOCKCLOCK */
  #endif
  		break;
-@@ -1331,7 +1369,7 @@ loop_config(
+ 
+@@ -1299,7 +1335,7 @@ loop_config(
  }
  
  
@@ -682,14 +673,14 @@
  /*
   * _trap - trap processor for undefined syscalls
   *
-@@ -1349,4 +1387,4 @@ pll_trap(
+@@ -1317,4 +1353,4 @@ pll_trap(
  	clock_ctl.pll_control = false;
  	siglongjmp(env, 1);
  }
 -#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL && SIGSYS */
---- ./ntpd/ntp_timer.c.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2019-01-15 12:40:57.000000000 -0800
+--- ./ntpd/ntp_timer.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./ntpd/ntp_timer.c	2019-07-02 11:55:05.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -700,7 +691,7 @@
  
  #ifdef HAVE_TIMER_CREATE
  /* TC_ERR represents the timer_create() error return value. */
-@@ -373,7 +375,11 @@ check_leapsec(
+@@ -381,7 +383,11 @@ check_leapsec(
  
  	leap_result_t lsdata;
  	uint32_t       lsprox;
@@ -712,44 +703,32 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ./ntpd/refclock_local.c.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./ntpd/refclock_local.c	2019-01-15 12:40:57.000000000 -0800
-@@ -131,6 +131,9 @@ local_poll(
- 	struct peer *peer
- 	)
- {
-+#if defined(HAVE_KERNEL_PLL) && defined(ENABLE_LOCKCLOCK)
-+	struct timex ntv;
-+#endif /* HAVE_KERNEL_PLL ENABLE_LOCKCLOCK */
- 	struct refclockproc *pp;
- 
- 	UNUSED_ARG(unit);
-@@ -156,8 +159,7 @@ local_poll(
+--- ./ntpd/refclock_local.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./ntpd/refclock_local.c	2019-07-02 11:55:05.000000000 -0700
+@@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
  	 */
--#if defined(ENABLE_LOCKCLOCK)
--	struct timex ntv;
-+#if defined(HAVE_KERNEL_PLL) && defined(ENABLE_LOCKCLOCK)
- 	memset(&ntv,  0, sizeof ntv);
- 	switch (ntp_adjtime(&ntv)) {
- 	case TIME_OK:
-@@ -181,11 +183,11 @@ local_poll(
++#ifdef HAVE_KERNEL_PLL
+ 	if (lockclock) {
+ 		struct timex ntv;
+ 		memset(&ntv,  0, sizeof ntv);
+@@ -188,6 +189,13 @@ local_poll(
+ 		pp->disp = DISPERSION;
+ 		pp->jitter = 0;
  	}
- 	pp->disp = 0;
- 	pp->jitter = 0;
--#else /* ENABLE_LOCKCLOCK */
-+#else /* HAVE_KERNEL_PLL && ENABLE_LOCKCLOCK */
- 	pp->leap = LEAP_NOWARNING;
- 	pp->disp = DISPERSION;
- 	pp->jitter = 0;
--#endif /* ENABLE_LOCKCLOCK */
-+#endif /* HAVE_KERNEL_PLL && ENABLE_LOCKCLOCK */
++	pp->disp = 0;
++	pp->jitter = 0;
++#else /* !HAVE_KERNEL_PLL */
++	pp->leap = LEAP_NOWARNING;
++	pp->disp = DISPERSION;
++	pp->jitter = 0;
++#endif /* !HAVE_KERNEL_PLL */
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ./ntpfrob/precision.c.orig	2019-01-13 21:40:59.000000000 -0800
-+++ ./ntpfrob/precision.c	2019-01-15 12:40:57.000000000 -0800
+--- ./ntpfrob/precision.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./ntpfrob/precision.c	2019-07-02 11:55:05.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -758,8 +737,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- ./tests/libntp/statestr.c.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./tests/libntp/statestr.c	2019-01-15 12:40:57.000000000 -0800
+--- ./tests/libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./tests/libntp/statestr.c	2019-07-02 11:55:05.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -780,11 +759,11 @@
  }
  
  // statustoa
---- ./wafhelpers/bin_test.py.orig	2019-01-13 21:40:59.000000000 -0800
-+++ ./wafhelpers/bin_test.py	2019-01-15 12:40:57.000000000 -0800
-@@ -88,6 +88,12 @@ def cmd_bin_test(ctx, config):
-       for cmd in cmd_map3:
-         cmd_map2[cmd] = cmd_map3[cmd]
+--- ./wafhelpers/bin_test.py.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./wafhelpers/bin_test.py	2019-07-02 11:55:05.000000000 -0700
+@@ -91,6 +91,12 @@ def cmd_bin_test(ctx, config):
+         for cmd in cmd_map3:
+             cmd_map2[cmd] = cmd_map3[cmd]
  
 +    # Kludge to remove ntptime if it didn't get built
 +    if not ctx.env.HEADER_SYS_TIMEX_H:
@@ -795,40 +774,29 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd], False):
              fails += 1
---- ./wafhelpers/options.py.orig	2018-08-28 22:18:48.000000000 -0700
-+++ ./wafhelpers/options.py	2019-01-15 12:40:57.000000000 -0800
-@@ -21,6 +21,8 @@ def options_cmd(ctx, config):
+--- ./wafhelpers/options.py.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./wafhelpers/options.py	2019-07-02 11:55:05.000000000 -0700
+@@ -19,6 +19,8 @@ def options_cmd(ctx, config):
+                    help="Droproot earlier (breaks SHM and NetBSD).")
+     grp.add_option('--enable-seccomp', action='store_true',
                     default=False, help="Enable seccomp (restricts syscalls).")
-     grp.add_option('--disable-dns-lookup', action='store_true',
-                    default=False, help="Disable DNS lookups.")
 +    grp.add_option('--disable-kernel-pll', action='store_true',
 +                   default=False, help="Disable kernel PLL.")
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- ./wscript.orig	2019-01-13 21:40:59.000000000 -0800
-+++ ./wscript	2019-01-15 12:40:57.000000000 -0800
-@@ -559,13 +559,13 @@ int main(int argc, char **argv) {
-         ctx.define("__EXTENSIONS__", "1", quote=False)
- 
+--- ./wscript.orig	2019-06-21 19:41:51.000000000 -0700
++++ ./wscript	2019-07-02 11:55:05.000000000 -0700
+@@ -593,7 +593,7 @@ int main(int argc, char **argv) {
      structures = (
--        ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
--        ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
+         ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
+         ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
 -        ("struct timex", ["sys/time.h", "sys/timex.h"], True),
--        ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
-+        ("struct if_laddrconf", ["sys/types.h", "net/if6.h"]),
-+        ("struct if_laddrreq", ["sys/types.h", "net/if6.h"]),
-+        ("struct timex", ["sys/time.h", "sys/timex.h"]),
-+        ("struct ntptimeval", ["sys/time.h", "sys/timex.h"]),
++        ("struct timex", ["sys/time.h", "sys/timex.h"], False),
+         ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
--    for (s, h, r) in structures:
--        ctx.check_cc(type_name=s, header_name=h, mandatory=r)
-+    for (s, h) in structures:
-+        ctx.check_cc(type_name=s, header_name=h, mandatory=False)
- 
-     # waf's SNIP_FIELD should likely include this header itself
-     # This is needed on some systems to get size_t for following checks
-@@ -765,6 +765,21 @@ int main(int argc, char **argv) {
+     for (s, h, r) in structures:
+@@ -795,6 +795,21 @@ int main(int argc, char **argv) {
      ctx.define("HAVE_WORKING_FORK", 1,
                 comment="Whether a working fork() exists")
  


### PR DESCRIPTION
This includes the patches for compatibility with macOS<10.13,
which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_1_4

TESTED:
Built and ran on MacPro 10.9, MacPro 10.14, MacBookPro 10.9,
PowerBook 10.5, and VMs for 10.5-10.13.  Built with default
variants, all single non-default variants, and all non-default
variants.

NOTE:
Does not address ticket 57272 (s/b low priority).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
