### PR TITLE
wpa_passphrase: new port

### DIFF
--- a/net/wpa_passphrase/Portfile
+++ b/net/wpa_passphrase/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            wpa_passphrase
+version         2.8
+revision        0
+
+platforms       darwin
+categories      net
+license         BSD
+maintainers     @jrjsmrtn openmaintainer
+
+description     Generate a WPA PSK from an ASCII passphrase for a SSID
+long_description    wpa_passphrase pre-computes PSK entries for network \
+                    configuration blocks of a wpa_supplicant.conf file. \
+                    An ASCII passphrase and SSID are used to generate a \
+                    256-bit PSK.
+homepage        https://w1.fi/wpa_supplicant/
+
+depends_lib     port:openssl
+
+master_sites    https://w1.fi/releases/
+distname        wpa_supplicant-${version}
+
+checksums       rmd160  aad7b11821396dda36641a04aa51e20f006953d1 \
+                sha256  a689336a12a99151b9de5e25bfccadb88438f4f4438eb8db331cd94346fd3d96 \
+                size    3155904
+
+patchfiles      patch-Makefile.diff
+
+use_configure   no
+
+build.dir       ${worksrcpath}/wpa_supplicant
+pre-build {
+    delete "${build.dir}/.config"
+    copy "${build.dir}/defconfig" "${build.dir}/.config"
+    reinplace "s|^CONFIG_|#CONFIG_|g" "${build.dir}/.config"
+    reinplace -E "s|^#CONFIG_OSX.+$|CONFIG_OSX=y|" "${build.dir}/.config"
+}
+
+destroot {
+    xinstall -m 755 ${build.dir}/wpa_passphrase \
+        ${destroot}${prefix}/bin
+
+    file copy ${build.dir}/doc/docbook/wpa_passphrase.8 \
+        ${destroot}${prefix}/share/man/man8
+}

--- a/net/wpa_passphrase/files/patch-Makefile.diff
+++ b/net/wpa_passphrase/files/patch-Makefile.diff
@@ -1,0 +1,26 @@
+--- wpa_supplicant/Makefile.orig	2019-07-12 11:14:27.000000000 +0200
++++ wpa_supplicant/Makefile	2019-07-12 11:15:17.000000000 +0200
+@@ -44,22 +44,8 @@
+ CONFIG_TDLS_TESTING=y
+ endif
+ 
+-BINALL=wpa_supplicant wpa_cli
+-
+-ifndef CONFIG_NO_WPA_PASSPHRASE
+-BINALL += wpa_passphrase
+-endif
+-
++BINALL=wpa_passphrase
+ ALL = $(BINALL)
+-ALL += systemd/wpa_supplicant.service
+-ALL += systemd/wpa_supplicant@.service
+-ALL += systemd/wpa_supplicant-nl80211@.service
+-ALL += systemd/wpa_supplicant-wired@.service
+-ALL += dbus/fi.w1.wpa_supplicant1.service
+-ifdef CONFIG_BUILD_WPA_CLIENT_SO
+-ALL += libwpa_client.so
+-endif
+-
+ 
+ all: verify_config $(ALL) dynamic_eap_methods
+ 


### PR DESCRIPTION
#### Description

wpa_passphrase - Generate a WPA PSK from an ASCII passphrase for a SSID

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->