### PR TITLE
alertmanager: upgrade to 0.18.0

### DIFF
--- a/net/alertmanager/Portfile
+++ b/net/alertmanager/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus alertmanager 0.17.0 v
+github.setup        prometheus alertmanager 0.18.0 v
 github.tarball_from archive
-set promu_version   0.4.0
+set promu_version   0.5.0
 
 description         The Alertmanager handles alerts sent by client \
                     applications such as the Prometheus server.
@@ -44,13 +44,13 @@ distfiles           alertmanager-${version}${extract.suffix}:main \
 
 checksums \
   ${promu_distfile} \
-    rmd160  c9936951a23f7cc8fec7df7d37248fff489f5d23 \
-    sha256  2b95dd9f198cf2143b55edc6c855b34e59a95319785e0393224e881103748d61 \
-    size    7130688 \
+    rmd160  794fd1112584c13ae95506336578a96716377c8a \
+    sha256  17f9b9816e6a5b4304bda34d2ae025732e20837c27a431639731ebbd45eda08f \
+    size    7132062 \
   alertmanager-${version}${extract.suffix} \
-    rmd160  626e2f17560ef2ca70edb9fe57b0fc8506936c09 \
-    sha256  8254591e058338b31a023f0eb3ab69de9d1547e0a446d28cab4664609793e4a2 \
-    size    5118311
+    rmd160  1e8c16b606ca8f4e8cbeda2699a2c2993df022c1 \
+    sha256  aa9536f001c4c46ceb5aa1767c81922777b3a2740529d25d86c9f27554cbd466 \
+    size    5181819
 
 set svc_name        prometheus-alertmanager
 set prom_user       prometheus


### PR DESCRIPTION
Upgrade to `alertmanager`.

NOTE: this is a `promu` project, which builds everywhere but not in the `buildbot` environments for some reason.  So this will build in Travis & Azure, but fail in `buildbot`.  We have a PR for a `promu` port that attempts to build `promu` in Ports to see if that makes a difference, but we don't know why yet.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
