### PR TITLE
py-nclib: Update to 0.8.3 and enable support for Python 3.7

### DIFF
--- a/python/py-nclib/Portfile
+++ b/python/py-nclib/Portfile
@@ -4,7 +4,7 @@ PortSystem           1.0
 PortGroup            python 1.0
 
 name                 py-nclib
-version              0.8.2
+version              0.8.3
 
 description          A Python socket library that wants to be your friend
 long_description     nclib provides easy-to-use interfaces for connecting to \
@@ -25,8 +25,9 @@ python.versions      27 34 35 36
 
 master_sites         pypi:n/nclib
 distname             nclib-${version}
-checksums            rmd160  978d85bc2520a6836674b5deaaca5c93caf45eea \
-                     sha256  a4435b0e5fe5302326b1c1a6be430c45ae9d5c3e9de2103381780121651e101e
+checksums            rmd160  a1044012c12cba1ced18bc493f732ab6fc18b056 \
+                     sha256  7ee56ca74ade02796c01923b117d7192b7a2381ab06464b4168b0f4e0e0deb1d \
+                     size    13445
 
 if {${name} ne ${subport}}  {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-nclib/Portfile
+++ b/python/py-nclib/Portfile
@@ -21,7 +21,7 @@ categories-append    net
 platforms            darwin
 maintainers          {@F30 f30.me:f30} openmaintainer
 
-python.versions      27 34 35 36
+python.versions      27 34 35 36 37
 
 master_sites         pypi:n/nclib
 distname             nclib-${version}


### PR DESCRIPTION
#### Description
Update py-nclib to 0.8.3 and enable support for Python 3.7.

###### Tested on
macOS 10.14.5 18F132
Command Line Tools for Xcode 10.2

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?