### PR TITLE
android: update to version 28

### DIFF
--- a/java/android/Portfile
+++ b/java/android/Portfile
@@ -3,9 +3,9 @@
 PortSystem 1.0
 
 name                android
-version             23
+version             28.0.3
 categories          java devel emulators
-maintainers         nomaintainer
+maintainers         openmaintainer krischik
 license             Apache-2
 platforms           darwin
 description         Android SDK
@@ -13,36 +13,49 @@ long_description                                                        \
     The Android SDK allows development for the Android mobile platform.
 supported_archs     noarch
 
+set platformversion 28
+set addonversion    24
+set lldbversion     3.1
+set cmakeversion    3.10.2.4988404
 set patchversion    121820
+set internalversion 4333796
 set appbundles      ${name}-appbundles-r${patchversion}.tar.gz
-set tools           ${name}-tools-r${patchversion}.tar.gz
-set prog            ${name}-sdk_r${version}-macosx.zip
+set swt             swt-4.7.1a-cocoa-macosx-x86_64.zip
+set prog            sdk-tools-darwin-${internalversion}.zip
 
-homepage            https://developer.${name}.com/
-master_sites        https://dl.google.com/${name}:prog                  \
+homepage            https://developer.${name}.com
+master_sites        https://dl.google.com/android/repository:prog                                                           \
+                    https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.7.1a-201710090410:swt \
                     macports:${name}:appbundles
-distfiles           ${prog}:prog                                        \
-                    ${appbundles}:appbundles                            \
-                    ${tools}:appbundles
+distfiles           ${prog}:prog            \
+                    ${swt}:swt              \
+                    ${appbundles}:appbundles
 distname            ${name}-sdk-macosx
 worksrcdir          ${name}-sdk-macosx
-extract.only        ${appbundles} ${tools}
+default_variants    +platform_${platformversion}
 
-checksums           ${prog}                                             \
-                    md5     fe64ec74a943572da9cfa4a90243461d            \
-                    sha1    7119841e5fcadd8ef2b75c1fe419c4cbc9a97336    \
-                    rmd160  801b01eb49c04ca43507b2c5f2f7baac598db50f    \
-                    ${appbundles}                                       \
-                    md5     d363cae627e4922da942a1c115965eca            \
-                    sha1    54468931ffa347540d8627a0addb54c844e2c9de    \
-                    rmd160  623f21017f6d04c2a425f9e691fa138ad5ad2b7a    \
-                    ${tools}                                            \
-                    md5     46e2caebec7ca9e25f97a924d09fb982            \
-                    sha1    2c9c56246ed15ae82c90ff5da1f1a9c531b6189a    \
-                    rmd160  2dfbe666c93d701dab56728ad4eeaff0654ce608
+checksums           ${prog}                                                                     \
+                    md5     d912ced50eea9f9a842aef9892c956f1                                    \
+                    sha1    ed85ea7b59bc3483ce0af4c198523ba044e083ad                            \
+                    rmd160  b99bcbc28c11c17f676c7d79f8caa7a3fcb03168                            \
+                    sha256  ecb29358bc0f13d7c2fa0f9290135a5b608e38434aad9bf7067d0252c160853e    \
+                    size    103022432                                                           \
+                    ${swt}                                                                      \
+                    rmd160  583dc2b63ede56daf62b427f92230aadfbac07bd                            \
+                    sha256  d79bb527b7a27f166bf145370c00d0040271f7affb1fdd0c0a5c2254c5464007    \
+                    size    5666940                                                             \
+                    ${appbundles}                                                               \
+                    md5     d363cae627e4922da942a1c115965eca                                    \
+                    sha1    54468931ffa347540d8627a0addb54c844e2c9de                            \
+                    rmd160  623f21017f6d04c2a425f9e691fa138ad5ad2b7a                            \
+                    sha256  62fe92fc858bf1931823915af5c4f0edd83218c862809634300f0c3ea19bae1c    \
+                    size    930653
 
 use_configure       no
 build.cmd           true
+build.asroot        yes
+extract.asroot      yes
+extract.only        ${appbundles}
 
 # This port installs binaries linked with this C++ library.
 configure.cxx_stdlib libstdc++
@@ -55,7 +68,58 @@ destroot.keepdirs                                               \
     ${destroot}${prefix}/share/java/${worksrcdir}/temp
 
 post-extract {
-        system "unzip -q ${distpath}/${prog} -d ${workpath}"
+    system "
+        mkdir -v -p ${workpath}/swt
+        mkdir -v -p ${workpath}/android-sdk-macosx
+
+        unzip -q ${distpath}/${prog} -d ${workpath}
+        unzip -q ${distpath}/${swt}  -d ${workpath}/swt
+
+        mv -v ${workpath}/tools ${workpath}/android-sdk-macosx
+    "
+}
+
+pre-build {
+    system "
+        export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+        pushd ${workpath}/android-sdk-macosx/tools/bin
+            echo '---> sdkmanager: Update'
+
+            ./sdkmanager --update
+
+            echo '---> sdkmanager: Licenses'
+
+            # just using yes won't work. You need to provide
+            # a limited amount of 'Y'
+
+            printf 'Y\nY\nY\nY\nY\nY\nY'            |   \
+                ./sdkmanager --licenses >'/dev/null'
+
+            echo '---> sdkmanager: Build Tool'
+
+            ./sdkmanager                                \
+                'build-tools;'${version}                \
+                'cmake;'${cmakeversion}                 \
+                'docs'                                  \
+                'emulator'                              \
+                'lldb;'${lldbversion}                   \
+                'platform-tools'                        \
+                'tools'
+
+            echo '---> sdkmanager: Platforms Addon'
+
+            ./sdkmanager                                \
+                'add-ons;addon-google_apis-google-'${addonversion}
+
+            echo '---> sdkmanager: Extras'
+
+            ./sdkmanager                                \
+                'extras;android;m2repository'           \
+                'extras;google;m2repository'            \
+                'extras;google;google_play_services'
+        popd
+    "
 }
 
 destroot {
@@ -63,42 +127,52 @@ destroot {
 
     # file copy can not copy with rename and directory tree.
     #
-    system "cp -r ${worksrcpath}/. ${destroot}${prefix}/share/java/${distname}/."
-
-    xinstall -m 770 -d ${destroot}${prefix}/share/java/${distname}/docs
-    xinstall -m 770 -d ${destroot}${prefix}/share/java/${distname}/samples
-    xinstall -m 770 -d ${destroot}${prefix}/share/java/${distname}/temp
-
     system "
-        chgrp -R _developer ${destroot}${prefix}/share/java/${distname};
-        chmod -R g+w ${destroot}${prefix}/share/java/${distname};
+        cp -r ${worksrcpath}/. ${destroot}${prefix}/share/java/${distname}/.
+
+        if test -e ${destroot}${prefix}/share/java/android-sdk-macosx/build-tools/28.0.3/zipalign; then
+            cp                                                                                  \
+                ${destroot}${prefix}/share/java/android-sdk-macosx/build-tools/28.0.3/zipalign  \
+                ${destroot}${prefix}/share/java/android-sdk-macosx/tools/zipalign
+        fi
     "
 
-    ui_info "####################################################################"
-    ui_info "# add-ons, docs, platforms, samples and temp have been made        #"
-    ui_info "# group _developer writable. You need to be member of the          #"
-    ui_info "# _developer group to use the android tools. If you are not use:   #"
-    ui_info "#                                                                  #"
-    ui_info "# sudo dscl . append /Groups/_developer GroupMembership <username> #"
-    ui_info "####################################################################"
-    ui_info "# you need to download the actual SDKs. Because of the licence     #"
-    ui_info "# querys this can not be done automaticaly. Use:                   #"
-    ui_info "#                                                                  #"
-    ui_info "# @PREFIX@/share/java/android-sdk-macosx/tools/android update sdk  #"
-    ui_info "####################################################################"
+    xinstall -m 770 -d ${destroot}${prefix}/share/java/${distname}/samples
+    xinstall -m 770 -d ${destroot}${prefix}/share/java/${distname}/temp
 }
 
 platform macosx {
     post-destroot {
         xinstall -m 755 -d ${destroot}${applications_dir}/Developer
 
-        system "touch ${destroot}${applications_dir}/Developer/.localized"
+        system "
+            touch ${destroot}${applications_dir}/Developer/.localized
+        "
 
-        copy                                                                            \
-            ${workpath}/tools-r${patchversion}/zipalign                                 \
-            ${destroot}${prefix}/share/java/android-sdk-macosx/tools/zipalign
+        # file copy won't overwrite a file. But this is precisely what
+        # we want: override an old outdate java library.
 
-        foreach comp { Android-DDMS Android-Draw9Patch Android-Emulator Android-Hierarchyviewer Android-Manager Android-Monitor} {
+        system "
+            cp -v                       \
+                ${workpath}/swt/swt.jar \
+                ${destroot}${prefix}/share/java/android-sdk-macosx/tools/lib/monitor-x86_64/plugins/org.eclipse.swt.cocoa.macosx.x86_64_3.100.1.v4236b.jar
+        "
+
+        system "
+            chgrp -R _developer ${destroot}${prefix}/share/java/${distname}
+            chmod -R g+w        ${destroot}${prefix}/share/java/${distname}
+            chmod -R g+X        ${destroot}${prefix}/share/java/${distname}
+        "
+
+        ui_info "####################################################################"
+        ui_info "# add-ons, docs, platforms, samples and temp have been made        #"
+        ui_info "# group _developer writable. You need to be member of the          #"
+        ui_info "# _developer group to use the android tools. If you are not use:   #"
+        ui_info "#                                                                  #"
+        ui_info "# sudo dscl . append /Groups/_developer GroupMembership <username> #"
+        ui_info "####################################################################"
+
+        foreach comp {Android-Monitor} {
             copy                                                                                \
                 ${workpath}/appbundles-r${patchversion}/${comp}.app                             \
                 ${destroot}${applications_dir}/Developer
@@ -107,10 +181,102 @@ platform macosx {
         }
     }
 }
-#
-#    post-install {
-#       system "( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | }${prefix}/share/java/android-sdk-macosx/tools/android update sdk --no-ui"
-#    }
+
+variant platform_23 description "Install Android API 23 Version 6.0" {
+    build {
+        system "
+            export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+            echo '---> sdkmanager: Platforms 23'
+
+            pushd ${workpath}/android-sdk-macosx/tools/bin
+                ./sdkmanager                \
+                    'platforms;android-23'  \
+                    'sources;android-23'
+            popd
+        "
+    }
+}
+
+variant platform_24 description "Install Android API 24 Version 7.0" {
+    build {
+        system "
+            export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+            echo '---> sdkmanager: Platforms 24'
+
+            pushd ${workpath}/android-sdk-macosx/tools/bin
+                ./sdkmanager                \
+                    'platforms;android-24'  \
+                    'sources;android-24'
+            popd
+        "
+    }
+}
+
+variant platform_25 description "Install Android API 25 Version 7.1.2" {
+    build {
+        system "
+            export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+            echo '---> sdkmanager: Platforms 25'
+
+            pushd ${workpath}/android-sdk-macosx/tools/bin
+                ./sdkmanager                \
+                    'platforms;android-25'  \
+                    'sources;android-25'
+            popd
+        "
+    }
+}
+
+variant platform_26 description "Install Android API 26 Version 8.0" {
+    build {
+        system "
+            export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+            echo '---> sdkmanager: Platforms 26'
+
+            pushd ${workpath}/android-sdk-macosx/tools/bin
+                ./sdkmanager                \
+                    'platforms;android-26'  \
+                    'sources;android-26'
+            popd
+        "
+    }
+}
+
+variant platform_27 description "Install Android API 27 Version 8.1" {
+    build {
+        system "
+            export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+            echo '---> sdkmanager: Platforms 27'
+
+            pushd ${workpath}/android-sdk-macosx/tools/bin
+                ./sdkmanager                \
+                    'platforms;android-27'  \
+                    'sources;android-27'
+            popd
+        "
+    }
+}
+
+variant platform_28 description "Install Android API 28 Version 9.0" {
+    build {
+        system "
+            export JAVA_HOME=\$(/usr/libexec/java_home --version 1.8)
+
+            echo '---> sdkmanager: Platforms 28'
+
+            pushd ${workpath}/android-sdk-macosx/tools/bin
+                ./sdkmanager                \
+                    'platforms;android-28'  \
+                    'sources;android-28'
+            popd
+        "
+    }
+}
 
 livecheck.type      regex
 livecheck.url       ${homepage}studio/index.html


### PR DESCRIPTION
#### Description

Update to Android SDK 28 and new SDK tools. Most GUI tools are gone but it's now possible to install the SDK from the command line.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ x ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [ x ] followed our [Commit Message Guidelines]
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ x ] checked your Portfile with `port lint`?
--->  Verifying Portfile for android
--->  0 errors and 0 warnings found.
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ x ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
