### PR TITLE
tomcat-native: update to version 1.2.23

### DIFF
--- a/java/tomcat-native/Portfile
+++ b/java/tomcat-native/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                tomcat-native
-version             1.2.21
+version             1.2.23
 categories          java www
 maintainers         {thebishops.org:matt @mattbishop} openmaintainer
 license             Apache-2
@@ -17,15 +17,15 @@ long_description    This port provides access to native apr and other \
 homepage            https://tomcat.apache.org/
 master_sites        apache:tomcat/tomcat-connectors/native/${version}/source/
 
-checksums           rmd160  01c9c3e44c94adf5038fb4b7698a5c18f474c8cd \
-                    sha256  05bba41671cc91c531c366a9ccd930b38a107a0212c73181961f3cda508d5007 \
-                    size    418909
+checksums           rmd160  6b40e49cfdf91045359474dd4eacde2070df41b2 \
+                    sha256  5ae5940f759cfdd68384ecf61f2c4fd9b01eb430ab0d349c0b197df0b0c0c3c7 \
+                    size    419428
 
 distname            ${name}-${version}-src
 worksrcdir          ${distname}/native
 
 depends_lib         port:apr \
-                    path:lib/libssl.dylib:openssl
+                    path:lib/libssl.dylib:openssl11
 
 # java Portgroup settings
 java.version        1.7+


### PR DESCRIPTION
#### Description

- Update tomcat-native to 1.2.23
- This version requires OpenSSL 1.1 so upgraded port dependency to opensll11

###### Type(s)

###### Tested on

- macOS 10.13.6 17G7024
- Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->