### PR TITLE
auto-multiple-choice: Update get language codes from CPAN

### DIFF
--- a/python/py-sphinx-gallery/Portfile
+++ b/python/py-sphinx-gallery/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        sphinx-gallery sphinx-gallery 0.3.1 v
+github.setup        sphinx-gallery sphinx-gallery 0.4.0 v
+revision            0
 name                py-sphinx-gallery
 platforms           darwin
 supported_archs     noarch
@@ -14,22 +15,23 @@ maintainers         nomaintainer
 description         Extension for automatic generation of an example gallery
 long_description    ${description}
 
-checksums \
-    rmd160  e1171e7d9d86f8c3c104574edcde8bbdfeef1cb8 \
-    sha256  bd8dea86dacf48091229c2d7737bbf6efa5a9dd5b49060f232d0c232cfbcc563 \
-    size    383518
+checksums           rmd160  dfc05aaa3695cadaf45c4592374256ef152e03f5 \
+                    sha256  56a370df236defee839f6e37e0d8d1553e412bf1f8d844dcba51a14f802f4fe6 \
+                    size    392841
 
 python.versions     27 36 37
 
 if {${subport} ne ${name}} {
-    depends_build       port:py${python.version}-setuptools \
-                        port:py${python.version}-pytest-runner
-    livecheck.type      none
+    depends_build-append \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-pytest-runner
 
     post-destroot {
-        set DOCDIR "${destroot}${prefix}/share/doc/${subport}"
-        xinstall -d ${DOCDIR}
-        xinstall -m 0644 -W ${worksrcpath} LICENSE ${DOCDIR}
+        set DOCDIR ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${DOCDIR}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE README.rst \
+            CHANGES.rst ${destroot}${DOCDIR}
     }
-}
 
+    livecheck.type      none
+}

--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -75,6 +75,7 @@ depends_run             \
                         port:p${perl5.major}-file-mimeinfo \
                         port:p${perl5.major}-glib-object-introspection \
                         port:p${perl5.major}-gtk3 \
+                        port:p${perl5.major}-locale-codes \
                         port:p${perl5.major}-locale-gettext \
                         port:p${perl5.major}-module-load-conditional \
                         port:p${perl5.major}-openoffice-oodoc \


### PR DESCRIPTION
auto-multiple-choice: Update get language codes from CPAN

Get rid of info message:
Locale::Language will be removed from the Perl core distribution in the next major release. Please install it from CPAN.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
Use CPAN Locale::Codes to suppress info message about Locale::Language removed in future version of Perl core.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->