### PR TITLE
websocat: update to 1.5.0

### DIFF
--- a/net/websocat/Portfile
+++ b/net/websocat/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        vi websocat 1.4.0 v
+github.setup        vi websocat 1.5.0 v
 
 categories          net
 license             MIT
@@ -22,123 +22,129 @@ destroot {
 }
 
 cargo.crates \
-	MacTypes-sys		2.1.0 eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f \
-	arc-swap		0.3.7 1025aeae2b664ca0ea726a89d574fe8f4e77dd712d443236ad1de00379450cf6 \
-	arrayvec		0.4.10 92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71 \
-	autocfg		0.1.2 a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799 \
+	arc-swap		0.3.11 bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841 \
+	arrayvec		0.4.11 b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba \
+	autocfg		0.1.4 0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf \
 	base64		0.10.1 0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e \
 	base64		0.9.3 489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643 \
-	bitflags		1.0.4 228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12 \
-	byteorder		1.3.1 a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb \
+	bitflags		1.1.0 3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd \
+	byteorder		1.3.2 a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5 \
 	bytes		0.4.12 206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c \
-	cc		1.0.31 c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d \
-	cfg-if		0.1.7 11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4 \
-	clap		2.32.0 b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e \
+	c2-chacha		0.2.2 7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101 \
+	cc		1.0.37 39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d \
+	cfg-if		0.1.9 b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33 \
+	clap		2.33.0 5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9 \
 	cloudabi		0.0.3 ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f \
-	core-foundation		0.5.1 286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980 \
-	core-foundation-sys		0.5.1 716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa \
+	core-foundation		0.6.4 25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d \
+	core-foundation-sys		0.6.2 e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b \
 	crossbeam-deque		0.7.1 b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71 \
 	crossbeam-epoch		0.7.1 04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4 \
 	crossbeam-queue		0.1.2 7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b \
 	crossbeam-utils		0.6.5 f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c \
 	derivative		1.0.2 6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898 \
-	env_logger		0.6.1 b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a \
+	env_logger		0.6.2 aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3 \
 	fnv		1.0.6 2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3 \
 	foreign-types		0.3.2 f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
 	foreign-types-shared		0.1.1 00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
 	fuchsia-cprng		0.1.1 a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
 	fuchsia-zircon		0.3.3 2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82 \
 	fuchsia-zircon-sys		0.3.3 3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7 \
-	futures		0.1.25 49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b \
+	futures		0.1.28 45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869 \
+	getrandom		0.1.6 e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55 \
 	heck		0.3.1 20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205 \
-	httparse		1.3.3 e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83 \
-	hyper		0.10.15 df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c \
+	httparse		1.3.4 cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
+	hyper		0.10.16 0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273 \
 	idna		0.1.5 38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e \
 	iovec		0.1.2 dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08 \
 	kernel32-sys		0.2.2 7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d \
 	language-tags		0.2.2 a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a \
 	lazy_static		1.3.0 bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14 \
-	lazycell		1.2.1 b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f \
-	libc		0.2.50 aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1 \
+	libc		0.2.59 3262021842bf00fe07dbd6cf34ff25c99d7a7ebef8deea84db72be3ea3bb0aff \
 	lock_api		0.1.5 62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c \
 	log		0.3.9 e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b \
-	log		0.4.6 c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6 \
+	log		0.4.7 c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3 \
 	matches		0.1.8 7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
 	memoffset		0.2.1 0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3 \
 	mime		0.2.6 ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0 \
-	mio		0.6.16 71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432 \
+	mio		0.6.19 83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23 \
 	mio-named-pipes		0.1.6 f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3 \
 	mio-uds		0.6.7 966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125 \
 	miow		0.2.1 8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919 \
 	miow		0.3.3 396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226 \
-	native-tls		0.2.2 ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2 \
+	native-tls		0.2.3 4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e \
 	net2		0.2.33 42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88 \
 	nodrop		0.1.13 2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945 \
-	num_cpus		1.10.0 1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba \
-	openssl		0.10.20 5a0d6b781aac4ac1bd6cafe2a2f0ad8c16ae8e1dd5184822a16c50139f8838d9 \
+	num_cpus		1.10.1 bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273 \
+	openssl		0.10.23 97c140cbb82f3b3468193dd14c1b88def39f341f68257f8a7fe8ed9ed3f628a5 \
 	openssl-probe		0.1.2 77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
-	openssl-sys		0.9.43 33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d \
+	openssl-sys		0.9.47 75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc \
 	owning_ref		0.4.0 49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13 \
 	parking_lot		0.7.1 ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337 \
 	parking_lot_core		0.4.0 94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9 \
 	percent-encoding		1.0.1 31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831 \
 	pkg-config		0.3.14 676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c \
-	proc-macro2		0.4.27 4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915 \
-	quote		0.6.11 cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1 \
+	ppv-lite86		0.2.5 e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b \
+	proc-macro2		0.4.30 cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759 \
+	quote		0.6.13 6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1 \
 	rand		0.6.5 6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca \
+	rand		0.7.0 d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c \
 	rand_chacha		0.1.1 556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef \
+	rand_chacha		0.2.0 e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d \
 	rand_core		0.3.1 7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
 	rand_core		0.4.0 d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0 \
+	rand_core		0.5.0 615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca \
 	rand_hc		0.1.0 7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4 \
+	rand_hc		0.2.0 ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
 	rand_isaac		0.1.1 ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08 \
-	rand_jitter		0.1.3 7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832 \
+	rand_jitter		0.1.4 1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b \
 	rand_os		0.1.3 7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071 \
 	rand_pcg		0.1.2 abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44 \
 	rand_xorshift		0.1.1 cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c \
 	rdrand		0.4.0 678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
 	readwrite		0.1.1 5718c4700d9a67aa8a73b2c088dc03e6685a722a7b1b6eed973eb81fdf2f7f1a \
-	redox_syscall		0.1.51 423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85 \
-	remove_dir_all		0.5.1 3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5 \
+	redox_syscall		0.1.56 2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84 \
+	remove_dir_all		0.5.2 4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e \
 	rustc_version		0.2.3 138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
 	safemem		0.3.0 8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9 \
 	schannel		0.1.15 f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339 \
 	scopeguard		0.3.3 94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27 \
-	security-framework		0.2.2 bfab8dda0e7a327c696d893df9ffa19cadc4bd195797997f5223cf5831beaf05 \
-	security-framework-sys		0.2.3 3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc \
+	security-framework		0.3.1 eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2 \
+	security-framework-sys		0.3.1 9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56 \
 	semver		0.9.0 1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403 \
 	semver-parser		0.7.0 388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3 \
 	sha1		0.6.0 2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d \
-	signal-hook		0.1.8 97a47ae722318beceb0294e6f3d601205a1e6abaa4437d9d33e3a212233e3021 \
+	signal-hook		0.1.10 4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68 \
+	signal-hook-registry		1.0.1 cded4ffa32146722ec54ab1f16320568465aa922aa9ab4708129599740da85d7 \
 	slab		0.4.2 c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8 \
 	slab_typesafe		0.1.3 56e1a2062526abda41283046a3149dc589cb760c8c6672dd88e209f7fba0c0c1 \
-	smallvec		0.6.9 c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be \
+	smallvec		0.6.10 ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7 \
 	smart-default		0.3.0 70e5c02ddada494809d36623d38050f3bd63446750abd21e7e13c01aa3a79b69 \
-	socket2		0.3.8 c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7 \
+	socket2		0.3.9 4e626972d3593207547f14bf5fc9efa4d0e7283deb73fef1dff313dae9ab8878 \
+	spin		0.5.0 44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55 \
 	stable_deref_trait		1.1.1 dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8 \
-	structopt		0.2.15 3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1 \
-	structopt-derive		0.2.15 528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6 \
-	syn		0.15.29 1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2 \
-	tempfile		3.0.7 b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a \
-	textwrap		0.10.0 307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6 \
+	structopt		0.2.16 fa19a5a708e22bb5be31c1b6108a2a902f909c4b9ba85cba44c06632386bc0ff \
+	structopt-derive		0.2.16 c6d59d0ae8ef8de16e49e3ca7afa16024a3e0dfd974a75ef93fdc5464e34523f \
+	syn		0.15.39 b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c \
+	tempfile		3.1.0 7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+	textwrap		0.11.0 d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
 	time		0.1.42 db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f \
 	tk-listen		0.2.1 5462b0f968c0457efe38fcd2df7e487096b992419e4f5337b06775a614bbda4b \
-	tokio		0.1.17 1021bb1f4150435ab8f222eb7ed37c60b2d57037def63ba43085a79f387512d7 \
+	tokio		0.1.22 5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6 \
 	tokio-codec		0.1.1 5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f \
-	tokio-current-thread		0.1.5 c756b04680eea21902a46fca4e9f410a2332c04995af590e07ff262e2193a9a3 \
-	tokio-executor		0.1.6 30c6dbf2d1ad1de300b393910e8a3aa272b724a400b6531da03eed99e329fbf0 \
+	tokio-current-thread		0.1.6 d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443 \
+	tokio-executor		0.1.8 0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac \
 	tokio-file-unix		0.5.1 7742e2a421379472607d46e2641e66ee2d135f5274d12ad0aba1c1fbbcea2e8c \
 	tokio-fs		0.1.6 3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af \
 	tokio-io		0.1.12 5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926 \
-	tokio-process		0.2.3 88e1281e412013f1ff5787def044a9577a0bed059f451e835f1643201f8b777d \
+	tokio-process		0.2.4 afbd6ef1b8cc2bd2c2b580d882774d443ebb1c6ceefe35ba9ea4ab586c89dbe8 \
 	tokio-reactor		0.1.9 6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce \
 	tokio-signal		0.2.7 dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296 \
 	tokio-stdin-stdout		0.1.5 1fc480d205310fa52f8ea65e7f9443568b6b342f326e86431d2aeb176d720c17 \
-	tokio-sync		0.1.4 fda385df506bf7546e70872767f71e81640f1f251bdf2fd8eb81a0eaec5fe022 \
+	tokio-sync		0.1.6 2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7 \
 	tokio-tcp		0.1.3 1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119 \
-	tokio-threadpool		0.1.12 742e511f6ce2298aeb86fc9ea0d8df81c2388c6ebae3dc8a7316e8c9df0df801 \
-	tokio-timer		0.2.10 2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6 \
+	tokio-threadpool		0.1.15 90ca01319dea1e376a001e8dc192d42ebde6dd532532a5bad988ac37db365b19 \
+	tokio-timer		0.2.11 f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e \
 	tokio-tls		0.2.1 354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c \
-	tokio-trace-core		0.1.0 350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3 \
 	tokio-udp		0.1.3 66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92 \
 	tokio-uds		0.2.5 037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445 \
 	traitobject		0.1.0 efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079 \
@@ -146,434 +152,452 @@ cargo.crates \
 	unicase		1.4.2 7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33 \
 	unicode-bidi		0.3.4 49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5 \
 	unicode-normalization		0.1.8 141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426 \
-	unicode-segmentation		1.2.1 aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1 \
+	unicode-segmentation		1.3.0 1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9 \
 	unicode-width		0.1.5 882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526 \
 	unicode-xid		0.1.0 fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc \
 	url		1.7.2 dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a \
-	vcpkg		0.2.6 def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d \
+	vcpkg		0.2.7 33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95 \
 	version_check		0.1.5 914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd \
-	websocket		0.22.3 7cc2d74d89f9df981ab41ae624e33cf302fdf456b93455c6a31911a99c9f0bb8 \
+	websocket		0.23.0 b255b190f412e45000c35be7fe9b48b39a2ac5eb90d093d421694e5dae8b335c \
 	winapi		0.2.8 167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a \
-	winapi		0.3.6 92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0 \
+	winapi		0.3.7 f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770 \
 	winapi-build		0.1.1 2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc \
 	winapi-i686-pc-windows-gnu		0.4.0 ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
 	winapi-x86_64-pc-windows-gnu		0.4.0 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
 	ws2_32-sys		0.2.1 d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e
 
 
-checksums-append  	\
-  websocat-1.4.0.tar.gz \
-	rmd160  13a0ccaab385ce97cd16e7e53897110df9975185 \
-	sha256  263a25f69c7d25bc9998f13079c5d1b5bd3791d607b2a3c5af493f4ac7b2de03 \
-	size    90169 \
-  MacTypes-sys-2.1.0.crate \
-	rmd160  8cb05e17fc2370cbd0838668c6b01a02bd5c0994 \
-	size    9274 \
-  arc-swap-0.3.7.crate \
-	rmd160  000942dff52eec2ee7dbaada3523e8b00d529ae6 \
-	size    41557 \
-  arrayvec-0.4.10.crate \
-	rmd160  c9053ff76d759abd696ec0c3c0439da4f00bc7f4 \
-	size    26133 \
-  autocfg-0.1.2.crate \
-	rmd160  ddd19921861ba2352e90956cd03a684a131eccdc \
-	size    10444 \
+checksums-append \
+  websocat-1.5.0.tar.gz \
+       rmd160  02ed0af35d86dbe04d39ea66f89cf8c6292e8b25 \
+       sha256  c7db39379048582b90198d42960efb2f66c3f46dc61fda98ad7dd82298291ce5 \
+       size    90979 \
+  arc-swap-0.3.11.crate \
+       rmd160  1ef431874bdbb51bef5e55848b3d84331bcc30d3 \
+       size    46282 \
+  arrayvec-0.4.11.crate \
+       rmd160  73df390cd1779f395b1f5485f161eb4b20a44cbe \
+       size    26439 \
+  autocfg-0.1.4.crate \
+       rmd160  e52e99774e26b36d8e8eea851aa7c575ed13916a \
+       size    10937 \
   base64-0.10.1.crate \
-	rmd160  d026e10544f0490980d7007105ac5e4d6da1f6f9 \
-	size    41988 \
+       rmd160  d026e10544f0490980d7007105ac5e4d6da1f6f9 \
+       size    41988 \
   base64-0.9.3.crate \
-	rmd160  bcad6aa30bbf392479517b341b41909fbc969f40 \
-	size    37993 \
-  bitflags-1.0.4.crate \
-	rmd160  fd720dba692f079a1c6662e43677533bb68654de \
-	size    15282 \
-  byteorder-1.3.1.crate \
-	rmd160  2fc0e248e42fa36629bcb84c6b34f5b9e071076f \
-	size    20959 \
+       rmd160  bcad6aa30bbf392479517b341b41909fbc969f40 \
+       size    37993 \
+  bitflags-1.1.0.crate \
+       rmd160  f7c30bcec212f74d7b040f6bf8340f14c061308d \
+       size    16322 \
+  byteorder-1.3.2.crate \
+       rmd160  6855f165b244fee60983125516fa4f1688fe64ea \
+       size    21596 \
   bytes-0.4.12.crate \
-	rmd160  e70f56debe13fecdec4d236459b493295062099e \
-	size    46361 \
-  cc-1.0.31.crate \
-	rmd160  44cf8ef9236c9b07e6b625aa01b5c7aa4069ebed \
-	size    42956 \
-  cfg-if-0.1.7.crate \
-	rmd160  41e96e680f9467e1e7dde73e7ad88a60e3dc76cd \
-	size    7360 \
-  clap-2.32.0.crate \
-	rmd160  069963d76d9d566b3ec52976b30c798d564e198d \
-	size    196073 \
+       rmd160  e70f56debe13fecdec4d236459b493295062099e \
+       size    46361 \
+  c2-chacha-0.2.2.crate \
+       rmd160  ddb8d97c93fe4579faafe222f72d68cac1c8f315 \
+       size    13766 \
+  cc-1.0.37.crate \
+       rmd160  1c3749ed0fbcfc86d97e0a87961719a05cd448ff \
+       size    44499 \
+  cfg-if-0.1.9.crate \
+       rmd160  1f1502ee926498c9c5d97afd88b8fbad71b5db4e \
+       size    7353 \
+  clap-2.33.0.crate \
+       rmd160  348604c8483c354b6577ace03dc4ed9f115397cd \
+       size    196458 \
   cloudabi-0.0.3.crate \
-	rmd160  4da7ab080c1d18e5881dbcb419d250d0c38387eb \
-	size    22156 \
-  core-foundation-0.5.1.crate \
-	rmd160  fa15db28e2ad013125c308c21145abd5f86d6580 \
-	size    22519 \
-  core-foundation-sys-0.5.1.crate \
-	rmd160  7cc63d488ef7510a2569b9c84fc09bac320c263e \
-	size    15974 \
+       rmd160  4da7ab080c1d18e5881dbcb419d250d0c38387eb \
+       size    22156 \
+  core-foundation-0.6.4.crate \
+       rmd160  8d948e1bbf57cc31664c698199afc617e4a17665 \
+       size    25233 \
+  core-foundation-sys-0.6.2.crate \
+       rmd160  5a664bb615d9bd3a8d91f6ffc9757fb3b3bfc8ca \
+       size    16204 \
   crossbeam-deque-0.7.1.crate \
-	rmd160  961f874f702846f1bc6c0a6008ce49c0a0d69749 \
-	size    19407 \
+       rmd160  961f874f702846f1bc6c0a6008ce49c0a0d69749 \
+       size    19407 \
   crossbeam-epoch-0.7.1.crate \
-	rmd160  dc7e0d75bfcf8c90b40b22133d847ca1d538aed4 \
-	size    35215 \
+       rmd160  dc7e0d75bfcf8c90b40b22133d847ca1d538aed4 \
+       size    35215 \
   crossbeam-queue-0.1.2.crate \
-	rmd160  e76e05bc5888d2d2a8337811323108f1095aec6c \
-	size    14104 \
+       rmd160  e76e05bc5888d2d2a8337811323108f1095aec6c \
+       size    14104 \
   crossbeam-utils-0.6.5.crate \
-	rmd160  8808ebe05797dde4a01a4ff580a8775c9891beeb \
-	size    31735 \
+       rmd160  8808ebe05797dde4a01a4ff580a8775c9891beeb \
+       size    31735 \
   derivative-1.0.2.crate \
-	rmd160  e62196d8ba37e612f9454be3e68759602e6bdebe \
-	size    39388 \
-  env_logger-0.6.1.crate \
-	rmd160  9b753e7dcfc688df9790c33c1274d809d6b4a1c9 \
-	size    28567 \
+       rmd160  e62196d8ba37e612f9454be3e68759602e6bdebe \
+       size    39388 \
+  env_logger-0.6.2.crate \
+       rmd160  06aeaae6aa1d53b550a5c958e4384e99d72145d2 \
+       size    31078 \
   fnv-1.0.6.crate \
-	rmd160  2dd59fa1942e8e496ea4e2e01dc98279a95b5dcf \
-	size    11131 \
+       rmd160  2dd59fa1942e8e496ea4e2e01dc98279a95b5dcf \
+       size    11131 \
   foreign-types-0.3.2.crate \
-	rmd160  a99c7ff186c330c0a433e24c0ed522b1825541f7 \
-	size    7504 \
+       rmd160  a99c7ff186c330c0a433e24c0ed522b1825541f7 \
+       size    7504 \
   foreign-types-shared-0.1.1.crate \
-	rmd160  6b4724c5b5329e657a05dafbac7325d471612211 \
-	size    5672 \
+       rmd160  6b4724c5b5329e657a05dafbac7325d471612211 \
+       size    5672 \
   fuchsia-cprng-0.1.1.crate \
-	rmd160  fcb487cceb0781d879fd05d4e4ad74f3a5ff5411 \
-	size    2950 \
+       rmd160  fcb487cceb0781d879fd05d4e4ad74f3a5ff5411 \
+       size    2950 \
   fuchsia-zircon-0.3.3.crate \
-	rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
-	size    22565 \
+       rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
+       size    22565 \
   fuchsia-zircon-sys-0.3.3.crate \
-	rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
-	size    7191 \
-  futures-0.1.25.crate \
-	rmd160  89f1b4a79d325158a8007584c5f6849ed2b192f2 \
-	size    158626 \
+       rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
+       size    7191 \
+  futures-0.1.28.crate \
+       rmd160  a2777672132427e37ab5d96d1eb49ba51b7092ae \
+       size    158343 \
+  getrandom-0.1.6.crate \
+       rmd160  6b5ab4378a793d98489d126d65d0519d738dc6b2 \
+       size    18529 \
   heck-0.3.1.crate \
-	rmd160  e1df454f4fb46feab9f869917f22e1ebcd3c3579 \
-	size    54666 \
-  httparse-1.3.3.crate \
-	rmd160  beb43d80099d3d01c91f5ed0d112a19b11e26438 \
-	size    23689 \
-  hyper-0.10.15.crate \
-	rmd160  9835b122c3a8df774a976d1fc3aaeeedec33fc58 \
-	size    113334 \
+       rmd160  e1df454f4fb46feab9f869917f22e1ebcd3c3579 \
+       size    54666 \
+  httparse-1.3.4.crate \
+       rmd160  549fe0984407396d47ef72eac967cc743cbb4af3 \
+       size    23739 \
+  hyper-0.10.16.crate \
+       rmd160  8d64d2e7da04f09d4aed1f9d8a05a58fb82baaaf \
+       size    113115 \
   idna-0.1.5.crate \
-	rmd160  e4049ab9ac2f8338e23c55d1f948c55a7f265d02 \
-	size    258735 \
+       rmd160  e4049ab9ac2f8338e23c55d1f948c55a7f265d02 \
+       size    258735 \
   iovec-0.1.2.crate \
-	rmd160  eb35790d17a2d6dab4353f57e6b1875b0e41ad4b \
-	size    8565 \
+       rmd160  eb35790d17a2d6dab4353f57e6b1875b0e41ad4b \
+       size    8565 \
   kernel32-sys-0.2.2.crate \
-	rmd160  c25a6cce8b38dad557b1c21e41e688d43406389f \
-	size    24537 \
+       rmd160  c25a6cce8b38dad557b1c21e41e688d43406389f \
+       size    24537 \
   language-tags-0.2.2.crate \
-	rmd160  7e3789f65f62c9c16bf98c0ddc9fb99b7a5a5a98 \
-	size    12754 \
+       rmd160  7e3789f65f62c9c16bf98c0ddc9fb99b7a5a5a98 \
+       size    12754 \
   lazy_static-1.3.0.crate \
-	rmd160  2c6a061cf2efd4e192d0984704bfc2443460507f \
-	size    10616 \
-  lazycell-1.2.1.crate \
-	rmd160  aa0807dc6f3190c61f6525b601ade584e5f55cfa \
-	size    11691 \
-  libc-0.2.50.crate \
-	rmd160  c270dfd41f364739e2156e480087fbad06806b82 \
-	size    392277 \
+       rmd160  2c6a061cf2efd4e192d0984704bfc2443460507f \
+       size    10616 \
+  libc-0.2.59.crate \
+       rmd160  96ea1ade26552308eb4462f1d6509eb348bdf5a3 \
+       size    408668 \
   lock_api-0.1.5.crate \
-	rmd160  ba1a2e7fc818e0cdef3386da54a0041444173327 \
-	size    16967 \
+       rmd160  ba1a2e7fc818e0cdef3386da54a0041444173327 \
+       size    16967 \
   log-0.3.9.crate \
-	rmd160  c9386d3be326986a40a13636f6ea5c76a1362b7c \
-	size    16686 \
-  log-0.4.6.crate \
-	rmd160  af66860f529673c05c3a4b161d0290c2bbfb462c \
-	size    22303 \
+       rmd160  c9386d3be326986a40a13636f6ea5c76a1362b7c \
+       size    16686 \
+  log-0.4.7.crate \
+       rmd160  8bb103f9439b4bdb20ce024c0b2cd81a7e3d84aa \
+       size    30733 \
   matches-0.1.8.crate \
-	rmd160  dc8239e015b64fbc488e1ea9ff74aad38f872a72 \
-	size    2216 \
+       rmd160  dc8239e015b64fbc488e1ea9ff74aad38f872a72 \
+       size    2216 \
   memoffset-0.2.1.crate \
-	rmd160  5920a7d0cbebb035c2e91fb056f54a48fd8ac2ee \
-	size    4618 \
+       rmd160  5920a7d0cbebb035c2e91fb056f54a48fd8ac2ee \
+       size    4618 \
   mime-0.2.6.crate \
-	rmd160  d0a1d95a42251831eb1185fe4a65399574f5cf3a \
-	size    6719 \
-  mio-0.6.16.crate \
-	rmd160  6aa3bd58ab209388827c60b39373fe124c270f10 \
-	size    126174 \
+       rmd160  d0a1d95a42251831eb1185fe4a65399574f5cf3a \
+       size    6719 \
+  mio-0.6.19.crate \
+       rmd160  0c186f8f91a53e72688448bc1e143dd92fbc3a0e \
+       size    128192 \
   mio-named-pipes-0.1.6.crate \
-	rmd160  bab8582f85aef6cb61305890467a8e2bf0e48688 \
-	size    14766 \
+       rmd160  bab8582f85aef6cb61305890467a8e2bf0e48688 \
+       size    14766 \
   mio-uds-0.6.7.crate \
-	rmd160  3f4b14a55229a89af6113ed9cb6279399ba66156 \
-	size    14389 \
+       rmd160  3f4b14a55229a89af6113ed9cb6279399ba66156 \
+       size    14389 \
   miow-0.2.1.crate \
-	rmd160  cb287b2c09dcd951fb798144902df7b503dbed2b \
-	size    21133 \
+       rmd160  cb287b2c09dcd951fb798144902df7b503dbed2b \
+       size    21133 \
   miow-0.3.3.crate \
-	rmd160  706cc44a06694b16f78425ec89ef39677ee458a4 \
-	size    22850 \
-  native-tls-0.2.2.crate \
-	rmd160  c23ad69ae2043b08d9fd8016c904721cfeb6438f \
-	size    29238 \
+       rmd160  706cc44a06694b16f78425ec89ef39677ee458a4 \
+       size    22850 \
+  native-tls-0.2.3.crate \
+       rmd160  b6b9f41b001b0c6160fa53c3ded471450a39840d \
+       size    29087 \
   net2-0.2.33.crate \
-	rmd160  d88b2fc1b694904e6dc6e13a829f659ef17452b7 \
-	size    20936 \
+       rmd160  d88b2fc1b694904e6dc6e13a829f659ef17452b7 \
+       size    20936 \
   nodrop-0.1.13.crate \
-	rmd160  6478a3dead0c72da1d32615205d0c2f4ab17734a \
-	size    7508 \
-  num_cpus-1.10.0.crate \
-	rmd160  169ecd5e5105fe52094fa7298a427d854e1eb19c \
-	size    10669 \
-  openssl-0.10.20.crate \
-	rmd160  806490ac4e31fd2d1f601564f267879262249704 \
-	size    178977 \
+       rmd160  6478a3dead0c72da1d32615205d0c2f4ab17734a \
+       size    7508 \
+  num_cpus-1.10.1.crate \
+       rmd160  1802e890170e9d79802badd2ad6e1a4ddfe4a5b1 \
+       size    11151 \
+  openssl-0.10.23.crate \
+       rmd160  24aea5348ef98820505de7b2239a6ab82bf30740 \
+       size    179328 \
   openssl-probe-0.1.2.crate \
-	rmd160  1c34c57af386e16d9fedf37664faad661753c595 \
-	size    6427 \
-  openssl-sys-0.9.43.crate \
-	rmd160  5eb34521740f731a09c7f84f98f485838a2e4804 \
-	size    43849 \
+       rmd160  1c34c57af386e16d9fedf37664faad661753c595 \
+       size    6427 \
+  openssl-sys-0.9.47.crate \
+       rmd160  c94b8a5c6ede68cf8fef89937c0f8f66a5ad8446 \
+       size    44276 \
   owning_ref-0.4.0.crate \
-	rmd160  b3718973496355ca2de77e567f3cb2388ff203ba \
-	size    12233 \
+       rmd160  b3718973496355ca2de77e567f3cb2388ff203ba \
+       size    12233 \
   parking_lot-0.7.1.crate \
-	rmd160  34a24353720b1c0c088b34e54c8ae1df2f29ea22 \
-	size    32670 \
+       rmd160  34a24353720b1c0c088b34e54c8ae1df2f29ea22 \
+       size    32670 \
   parking_lot_core-0.4.0.crate \
-	rmd160  fa8a0e4fbb236dfb080c3baf5deb2af2c98ee4a9 \
-	size    26817 \
+       rmd160  fa8a0e4fbb236dfb080c3baf5deb2af2c98ee4a9 \
+       size    26817 \
   percent-encoding-1.0.1.crate \
-	rmd160  68898d3983e831ac02ae8d440a5c6f5a8e395695 \
-	size    10057 \
+       rmd160  68898d3983e831ac02ae8d440a5c6f5a8e395695 \
+       size    10057 \
   pkg-config-0.3.14.crate \
-	rmd160  71db4ba8eb80a327f21fc2d689233fd4cf825ae0 \
-	size    13565 \
-  proc-macro2-0.4.27.crate \
-	rmd160  fc4c569a1c2d2dc804c9b56a65656ec49d02ce92 \
-	size    34098 \
-  quote-0.6.11.crate \
-	rmd160  fe563ac113aa2e383dc20d6a65f5a496a0afc9bf \
-	size    17283 \
+       rmd160  71db4ba8eb80a327f21fc2d689233fd4cf825ae0 \
+       size    13565 \
+  ppv-lite86-0.2.5.crate \
+       rmd160  a473697895928f1fcfd5cc4ef6547755b5490a2a \
+       size    20606 \
+  proc-macro2-0.4.30.crate \
+       rmd160  43879e7551a9f3ccf5f7c99d93f1c06201690ac8 \
+       size    34731 \
+  quote-0.6.13.crate \
+       rmd160  a6e3a2ae56e97c6947e0bd2e39a9570296d7dd34 \
+       size    17475 \
   rand-0.6.5.crate \
-	rmd160  427c0ab83f05d822421e780e8ec040b68ec770c9 \
-	size    104814 \
+       rmd160  427c0ab83f05d822421e780e8ec040b68ec770c9 \
+       size    104814 \
+  rand-0.7.0.crate \
+       rmd160  5f362eb35700aca52e8a4e55886830282543d81f \
+       size    104208 \
   rand_chacha-0.1.1.crate \
-	rmd160  1859cc8038a4f6bfca8ba9265607088485b64648 \
-	size    11703 \
+       rmd160  1859cc8038a4f6bfca8ba9265607088485b64648 \
+       size    11703 \
+  rand_chacha-0.2.0.crate \
+       rmd160  995d634de6ecf67e4675680e6f735dafdfc8e495 \
+       size    11539 \
   rand_core-0.3.1.crate \
-	rmd160  151b865da8c059c878b5f248c53d0cc434af2536 \
-	size    15483 \
+       rmd160  151b865da8c059c878b5f248c53d0cc434af2536 \
+       size    15483 \
   rand_core-0.4.0.crate \
-	rmd160  b7e2fc8530d7153ffa54ae73280950ce4ff7263d \
-	size    20326 \
+       rmd160  b7e2fc8530d7153ffa54ae73280950ce4ff7263d \
+       size    20326 \
+  rand_core-0.5.0.crate \
+       rmd160  1d43cea130631eade4f249aa0726a79a9fdf1902 \
+       size    19736 \
   rand_hc-0.1.0.crate \
-	rmd160  067ca62839fb5cde9dc018dc0c95db5b6eb3387b \
-	size    11644 \
+       rmd160  067ca62839fb5cde9dc018dc0c95db5b6eb3387b \
+       size    11644 \
+  rand_hc-0.2.0.crate \
+       rmd160  efa420ab36323d31e86851bc62a3563407011dc3 \
+       size    11670 \
   rand_isaac-0.1.1.crate \
-	rmd160  5d0f0a1a2b0385cd7901ceeda695d31cfacd0cac \
-	size    16020 \
-  rand_jitter-0.1.3.crate \
-	rmd160  12e1144a23bc45e402c45f71c87719b1e060759d \
-	size    18341 \
+       rmd160  5d0f0a1a2b0385cd7901ceeda695d31cfacd0cac \
+       size    16020 \
+  rand_jitter-0.1.4.crate \
+       rmd160  e5c1e68eb77d3b49f45df42b5c968ace138ae3c8 \
+       size    18409 \
   rand_os-0.1.3.crate \
-	rmd160  31464c2c79c6feef74efeeddd5e7c1bcd23e925b \
-	size    18965 \
+       rmd160  31464c2c79c6feef74efeeddd5e7c1bcd23e925b \
+       size    18965 \
   rand_pcg-0.1.2.crate \
-	rmd160  c961a4b07e33d52df877640e517e6bde5439e485 \
-	size    10844 \
+       rmd160  c961a4b07e33d52df877640e517e6bde5439e485 \
+       size    10844 \
   rand_xorshift-0.1.1.crate \
-	rmd160  510849fe396efa98d27b272f6c7884d69b9151c8 \
-	size    8997 \
+       rmd160  510849fe396efa98d27b272f6c7884d69b9151c8 \
+       size    8997 \
   rdrand-0.4.0.crate \
-	rmd160  7417f0430f8348d5aae1706d954092a01b2cbd27 \
-	size    6456 \
+       rmd160  7417f0430f8348d5aae1706d954092a01b2cbd27 \
+       size    6456 \
   readwrite-0.1.1.crate \
-	rmd160  4fb70cd2b08a641c3de441afe44b265cc1ee6ce1 \
-	size    2307 \
-  redox_syscall-0.1.51.crate \
-	rmd160  05366191fef3454ac8c0d51781f7e6c7f87b28f0 \
-	size    15646 \
-  remove_dir_all-0.5.1.crate \
-	rmd160  13b7dcf0ae8c4100d53134d45c32539b7a4debfb \
-	size    8726 \
+       rmd160  4fb70cd2b08a641c3de441afe44b265cc1ee6ce1 \
+       size    2307 \
+  redox_syscall-0.1.56.crate \
+       rmd160  ebecde11789346c25d2c830581e4f9d5e88a7baa \
+       size    17117 \
+  remove_dir_all-0.5.2.crate \
+       rmd160  8bf4b2c9c859c1ba10fe9b0b48508594a7713d15 \
+       size    8907 \
   rustc_version-0.2.3.crate \
-	rmd160  6ca6aa5c736a1f88dd7579eb78d097ec40663173 \
-	size    10210 \
+       rmd160  6ca6aa5c736a1f88dd7579eb78d097ec40663173 \
+       size    10210 \
   safemem-0.3.0.crate \
-	rmd160  7a6ebe4c105f7a6ce43ed5e6710b586c3cf04802 \
-	size    6947 \
+       rmd160  7a6ebe4c105f7a6ce43ed5e6710b586c3cf04802 \
+       size    6947 \
   schannel-0.1.15.crate \
-	rmd160  0f984c2135a49d3947a6532ae1e6313f42fe42cb \
-	size    38901 \
+       rmd160  0f984c2135a49d3947a6532ae1e6313f42fe42cb \
+       size    38901 \
   scopeguard-0.3.3.crate \
-	rmd160  e77508e3d64bc39c22ac5c87f8937906d160019e \
-	size    9605 \
-  security-framework-0.2.2.crate \
-	rmd160  6ed217c952bcc6470b8fc4bffc63b80554368a2c \
-	size    44080 \
-  security-framework-sys-0.2.3.crate \
-	rmd160  fa3b0252085b65be364fee048441638eb630c00e \
-	size    9478 \
+       rmd160  e77508e3d64bc39c22ac5c87f8937906d160019e \
+       size    9605 \
+  security-framework-0.3.1.crate \
+       rmd160  76612f72e40c972c1fb18081dd80b79f6c5f83ae \
+       size    46179 \
+  security-framework-sys-0.3.1.crate \
+       rmd160  38f4f937bf50486cf2a5a55d162305aa3c3668b0 \
+       size    9283 \
   semver-0.9.0.crate \
-	rmd160  f3ba6d2359a3690d316a22586db785538b0e09ac \
-	size    17344 \
+       rmd160  f3ba6d2359a3690d316a22586db785538b0e09ac \
+       size    17344 \
   semver-parser-0.7.0.crate \
-	rmd160  63f826b792b17493186d587b9887efd93121294b \
-	size    10268 \
+       rmd160  63f826b792b17493186d587b9887efd93121294b \
+       size    10268 \
   sha1-0.6.0.crate \
-	rmd160  1910100f3679d39457f376d7758484f9a16596e6 \
-	size    9244 \
-  signal-hook-0.1.8.crate \
-	rmd160  08453cf11fa79d6d4c7fe0eccdd6d799531f0433 \
-	size    24492 \
+       rmd160  1910100f3679d39457f376d7758484f9a16596e6 \
+       size    9244 \
+  signal-hook-0.1.10.crate \
+       rmd160  5d4fea3bb2f9d11bce040cf9b268fd965acb50e7 \
+       size    20840 \
+  signal-hook-registry-1.0.1.crate \
+       rmd160  fe36ca1f112a5e8681d05cce3f46c0d28e98dbb3 \
+       size    12520 \
   slab-0.4.2.crate \
-	rmd160  cd54b2a9d76748b6c98daabc31ed1e2e3a5d94cc \
-	size    10136 \
+       rmd160  cd54b2a9d76748b6c98daabc31ed1e2e3a5d94cc \
+       size    10136 \
   slab_typesafe-0.1.3.crate \
-	rmd160  959f23a7c29a6668ebe4e25239afea7ab8697624 \
-	size    5980 \
-  smallvec-0.6.9.crate \
-	rmd160  0ee1b52e09fe799339f600687807c31ec2fed3ec \
-	size    21548 \
+       rmd160  959f23a7c29a6668ebe4e25239afea7ab8697624 \
+       size    5980 \
+  smallvec-0.6.10.crate \
+       rmd160  5044d4b2e17297c0af2740e4e2d293123f11cdac \
+       size    22064 \
   smart-default-0.3.0.crate \
-	rmd160  467e1f24e6e1f8d3b59a47d46f4ee13f350f83f1 \
-	size    6297 \
-  socket2-0.3.8.crate \
-	rmd160  68636e4247ca2b226901cd7305de28157d7d0943 \
-	size    30379 \
+       rmd160  467e1f24e6e1f8d3b59a47d46f4ee13f350f83f1 \
+       size    6297 \
+  socket2-0.3.9.crate \
+       rmd160  0ac14dd70bff160aecef4f17581701d40b5dddb6 \
+       size    29791 \
+  spin-0.5.0.crate \
+       rmd160  be7748b2372eb2e83821065368e888b9400927b0 \
+       size    10493 \
   stable_deref_trait-1.1.1.crate \
-	rmd160  2864679bbc382223ef85944502118c744a22e703 \
-	size    8007 \
-  structopt-0.2.15.crate \
-	rmd160  0170ac7f614847f7324d0451a2b677388035ac8e \
-	size    25564 \
-  structopt-derive-0.2.15.crate \
-	rmd160  e51949a6a5b890e76d8bdfe842d4136de4bf08e3 \
-	size    12486 \
-  syn-0.15.29.crate \
-	rmd160  132f683d772d4291186ee6233adc14dc3e802776 \
-	size    146203 \
-  tempfile-3.0.7.crate \
-	rmd160  71e2a2526670a6d70d6467c2eb3797ca51628d14 \
-	size    23922 \
-  textwrap-0.10.0.crate \
-	rmd160  93e9595c1e99d77cfa8f5111f40b52d6292e617b \
-	size    15986 \
+       rmd160  2864679bbc382223ef85944502118c744a22e703 \
+       size    8007 \
+  structopt-0.2.16.crate \
+       rmd160  ec7d60e0545c490493b4d095f3027181a1721066 \
+       size    26165 \
+  structopt-derive-0.2.16.crate \
+       rmd160  42feb0d6df6b31f29818912d6a9aa19428fa0c52 \
+       size    12951 \
+  syn-0.15.39.crate \
+       rmd160  cb913c35bb624e7931c141cfea009f23af729364 \
+       size    185194 \
+  tempfile-3.1.0.crate \
+       rmd160  27c7a980d9e3f38162841dbbcadfabc63ec0af94 \
+       size    25823 \
+  textwrap-0.11.0.crate \
+       rmd160  3a9a334e7c0c6cbb9f54e51ad991304da31caf2c \
+       size    17322 \
   time-0.1.42.crate \
-	rmd160  f4a8c4e0f8f7aa638b92d04a5ebcec90cafb1a52 \
-	size    30005 \
+       rmd160  f4a8c4e0f8f7aa638b92d04a5ebcec90cafb1a52 \
+       size    30005 \
   tk-listen-0.2.1.crate \
-	rmd160  eb1ce849024fced57e2147ab89fba3131de8a51d \
-	size    14268 \
-  tokio-0.1.17.crate \
-	rmd160  61b071bab06ce6ca0b023a30b7cdf60569bc823b \
-	size    83529 \
+       rmd160  eb1ce849024fced57e2147ab89fba3131de8a51d \
+       size    14268 \
+  tokio-0.1.22.crate \
+       rmd160  55e71bc5256922f94ea6bd9791bc1ee7e3a65e36 \
+       size    70031 \
   tokio-codec-0.1.1.crate \
-	rmd160  5b62e89cbf3e2ffedd292463fe1699d888245a54 \
-	size    7617 \
-  tokio-current-thread-0.1.5.crate \
-	rmd160  446ff6de40637e9d57261e3502ede0ac98ded9e8 \
-	size    19371 \
-  tokio-executor-0.1.6.crate \
-	rmd160  43c9bcb0feddb9440015ab6b09bf3c248e58a060 \
-	size    10059 \
+       rmd160  5b62e89cbf3e2ffedd292463fe1699d888245a54 \
+       size    7617 \
+  tokio-current-thread-0.1.6.crate \
+       rmd160  09193c4ae334739445819025d4175037262a1f33 \
+       size    19339 \
+  tokio-executor-0.1.8.crate \
+       rmd160  66e91969374b9d26bf81d12effb759e41bc2de72 \
+       size    11775 \
   tokio-file-unix-0.5.1.crate \
-	rmd160  0c4a433c6815d6bc924d3a347c8d3575bbe3e7bb \
-	size    11181 \
+       rmd160  0c4a433c6815d6bc924d3a347c8d3575bbe3e7bb \
+       size    11181 \
   tokio-fs-0.1.6.crate \
-	rmd160  fb7b584e3c1d86529a30463413f8e4ba90d8f7d4 \
-	size    16102 \
+       rmd160  fb7b584e3c1d86529a30463413f8e4ba90d8f7d4 \
+       size    16102 \
   tokio-io-0.1.12.crate \
-	rmd160  14f554b4af6bc19cdf33449b007d26db27bc4488 \
-	size    33555 \
-  tokio-process-0.2.3.crate \
-	rmd160  65a0008a024ff9cff2805a6e3dcab723eadca12d \
-	size    19886 \
+       rmd160  14f554b4af6bc19cdf33449b007d26db27bc4488 \
+       size    33555 \
+  tokio-process-0.2.4.crate \
+       rmd160  6c851751f6ae9d239c2d25fb6488e008623fa70a \
+       size    24856 \
   tokio-reactor-0.1.9.crate \
-	rmd160  fb0519383730b9397eaa64df32770436a0790532 \
-	size    20657 \
+       rmd160  fb0519383730b9397eaa64df32770436a0790532 \
+       size    20657 \
   tokio-signal-0.2.7.crate \
-	rmd160  1bb78c85b8134a2981905ae2c82d6a8188952af8 \
-	size    15122 \
+       rmd160  1bb78c85b8134a2981905ae2c82d6a8188952af8 \
+       size    15122 \
   tokio-stdin-stdout-0.1.5.crate \
-	rmd160  f59a315d87ece595843c27494f4d9c23e45e6aa8 \
-	size    6661 \
-  tokio-sync-0.1.4.crate \
-	rmd160  431c69f81b1f9314b800f5cfcf0de99efd242605 \
-	size    39715 \
+       rmd160  f59a315d87ece595843c27494f4d9c23e45e6aa8 \
+       size    6661 \
+  tokio-sync-0.1.6.crate \
+       rmd160  ca03bb5bce86ece40724900db22e2d1a91baf299 \
+       size    41598 \
   tokio-tcp-0.1.3.crate \
-	rmd160  6ca216b10267b0bfc2b3c1cc89124f0a6a523dfc \
-	size    12629 \
-  tokio-threadpool-0.1.12.crate \
-	rmd160  fbd1b05b080c72dff184488eeba1e12776cc321d \
-	size    49338 \
-  tokio-timer-0.2.10.crate \
-	rmd160  2447cf8286983bb22181a18b4754b43f1aa0d7e7 \
-	size    37593 \
+       rmd160  6ca216b10267b0bfc2b3c1cc89124f0a6a523dfc \
+       size    12629 \
+  tokio-threadpool-0.1.15.crate \
+       rmd160  bb548d8df2a41919ed939619b1cf0d06027b9aba \
+       size    50047 \
+  tokio-timer-0.2.11.crate \
+       rmd160  48fcbeccfdd7be43a79c7ec484d1e2d89d4f30cd \
+       size    37578 \
   tokio-tls-0.2.1.crate \
-	rmd160  200f76f85f59e1ed3c8440a3bea61caa260eb81c \
-	size    16354 \
-  tokio-trace-core-0.1.0.crate \
-	rmd160  41ca28ce741ceb399ad5568ac40201518d9bb374 \
-	size    20087 \
+       rmd160  200f76f85f59e1ed3c8440a3bea61caa260eb81c \
+       size    16354 \
   tokio-udp-0.1.3.crate \
-	rmd160  dcbb925a5a925e793752144f677c6fafd497e566 \
-	size    10227 \
+       rmd160  dcbb925a5a925e793752144f677c6fafd497e566 \
+       size    10227 \
   tokio-uds-0.2.5.crate \
-	rmd160  db4ccc9f346f282902e0d97224b3e5cb92550e75 \
-	size    11808 \
+       rmd160  db4ccc9f346f282902e0d97224b3e5cb92550e75 \
+       size    11808 \
   traitobject-0.1.0.crate \
-	rmd160  6e8e0afd100a977645278f67004401fc02876d7e \
-	size    1957 \
+       rmd160  6e8e0afd100a977645278f67004401fc02876d7e \
+       size    1957 \
   typeable-0.1.2.crate \
-	rmd160  4e318e8d5cba5bd38d26ce463bd90ac24019dd77 \
-	size    901 \
+       rmd160  4e318e8d5cba5bd38d26ce463bd90ac24019dd77 \
+       size    901 \
   unicase-1.4.2.crate \
-	rmd160  0b0793bceea1ff1c9e29f83a7f4a60aefeca9499 \
-	size    3907 \
+       rmd160  0b0793bceea1ff1c9e29f83a7f4a60aefeca9499 \
+       size    3907 \
   unicode-bidi-0.3.4.crate \
-	rmd160  7c16a80cb62bef8cc6d73eb6126d496b46dbad1d \
-	size    32228 \
+       rmd160  7c16a80cb62bef8cc6d73eb6126d496b46dbad1d \
+       size    32228 \
   unicode-normalization-0.1.8.crate \
-	rmd160  1d29be540d48523e5923337e7d6ece56f7b15919 \
-	size    71158 \
-  unicode-segmentation-1.2.1.crate \
-	rmd160  5695c194d6f49bbb4a4e7a452fcbc5b03b8d80ce \
-	size    68223 \
+       rmd160  1d29be540d48523e5923337e7d6ece56f7b15919 \
+       size    71158 \
+  unicode-segmentation-1.3.0.crate \
+       rmd160  5fc9badbc435ea03dbb0a32aac9fd36788d666ba \
+       size    90567 \
   unicode-width-0.1.5.crate \
-	rmd160  360df9e831a6e20931c240d13747f3711dc568d9 \
-	size    15761 \
+       rmd160  360df9e831a6e20931c240d13747f3711dc568d9 \
+       size    15761 \
   unicode-xid-0.1.0.crate \
-	rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
-	size    16000 \
+       rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
+       size    16000 \
   url-1.7.2.crate \
-	rmd160  c46442b7903a874b0556861845d5121bfc3b5397 \
-	size    68597 \
-  vcpkg-0.2.6.crate \
-	rmd160  6bf4e1d4423173717dfb8ebc5cfde722331a8b85 \
-	size    9866 \
+       rmd160  c46442b7903a874b0556861845d5121bfc3b5397 \
+       size    68597 \
+  vcpkg-0.2.7.crate \
+       rmd160  230b0fdb1a38b0fbe17ff584e21b0205b1b87273 \
+       size    11012 \
   version_check-0.1.5.crate \
-	rmd160  0806190559062dc843ecf13393f6c1319367eac1 \
-	size    8173 \
-  websocket-0.22.3.crate \
-	rmd160  0fe9117fbd0fd1d215e493e62211f8e94a794bbf \
-	size    66977 \
+       rmd160  0806190559062dc843ecf13393f6c1319367eac1 \
+       size    8173 \
+  websocket-0.23.0.crate \
+       rmd160  221a8cc84a0233a1e549d82b0dc2ff5618761a61 \
+       size    67888 \
   winapi-0.2.8.crate \
-	rmd160  a30e4a3792706281d7940240df05d7ef60c53ef9 \
-	size    455145 \
-  winapi-0.3.6.crate \
-	rmd160  549ef0ff7cd1a0f2aabf915ae603ed2c3c920ab6 \
-	size    1029391 \
+       rmd160  a30e4a3792706281d7940240df05d7ef60c53ef9 \
+       size    455145 \
+  winapi-0.3.7.crate \
+       rmd160  23a1008eda3a544f6dfe1cd63241a456d7c3de19 \
+       size    1075776 \
   winapi-build-0.1.1.crate \
-	rmd160  f1b6c5812fd6613c6e67e22c5f961963ae3ac5f2 \
-	size    669 \
+       rmd160  f1b6c5812fd6613c6e67e22c5f961963ae3ac5f2 \
+       size    669 \
   winapi-i686-pc-windows-gnu-0.4.0.crate \
-	rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
-	size    2918815 \
+       rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
+       size    2918815 \
   winapi-x86_64-pc-windows-gnu-0.4.0.crate \
-	rmd160  300417853d251d91cadb9650992a6aa98248619f \
-	size    2947998 \
+       rmd160  300417853d251d91cadb9650992a6aa98248619f \
+       size    2947998 \
   ws2_32-sys-0.2.1.crate \
-	rmd160  883038c3ec6db615e0c96f0788f1a24892a855b2 \
-	size    4697
+       rmd160  883038c3ec6db615e0c96f0788f1a24892a855b2 \
+       size    4697


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
