### PR TITLE
kube-ps1: new submission

### DIFF
--- a/sysutils/kube-ps1/Portfile
+++ b/sysutils/kube-ps1/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        jonmosco kube-ps1 0.7.0 v
+categories          sysutils
+platforms           darwin
+supported_archs     noarch
+maintainers         {breun.nl:nils @breun} openmaintainer
+license             Apache-2
+
+description         Kubernetes prompt info for bash and zshl
+long_description    A script that lets you add the current Kubernetes context and namespace \
+                    configured on kubectl to your Bash/Zsh prompt strings (i.e. the \$PS1).
+
+checksums           rmd160  0f67b76aa77ca7acbed74700d55e378dc9d3e09f \
+                    sha256  089bed64824784c282837f89f8708ec86d661afe4a8cd2b7bdcb16c2d11ac0e8 \
+                    size    491884
+
+depends_run         port:kubectl
+
+use_configure       no
+build {}
+
+destroot    {
+    xinstall -m 755 -d ${destroot}${prefix}/share/${name}
+    copy ${worksrcpath}/CHANGELOG.md \
+        ${worksrcpath}/CONTRIBUTING.md \
+        ${worksrcpath}/img \
+        ${worksrcpath}/kube-ps1.sh \
+        ${worksrcpath}/LICENSE \
+        ${worksrcpath}/README.md \
+        ${destroot}${prefix}/share/${name}
+}
+
+notes "
+Source the kube-ps1.sh script and then use the kube_ps1 function in your shell prompt definition:
+
+Bash example (~/.bashrc):
+
+    source ${prefix}/share/${name}/kube-ps1.sh
+    PS1=\'\$(kube_ps1)\'\$PS1
+
+Zsh example (~/.zshrc):
+
+    source ${prefix}/share/${name}/kube-ps1.sh
+    PROMPT=\'\$(kube_ps1)\'\$PROMPT
+"


### PR DESCRIPTION
#### Description

New port for `kube-ps1`.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?