### PR TITLE
Add cl-quicklisp port

### DIFF
--- a/databases/pgloader/Portfile
+++ b/databases/pgloader/Portfile
@@ -6,6 +6,9 @@ PortGroup           github 1.0
 name                pgloader
 categories          databases
 platforms           darwin
+license             Permissive
+homepage            https://pgloader.io
+github.setup        dimitri pgloader 3.6.1 v
 maintainers         @jrjsmrtn
 
 description         Extract, transform and load data into PostgreSQL
@@ -25,33 +28,67 @@ long_description    pgloader imports data from different kind of sources \
                     possible to edit CASTing rules from the pgloader \
                     command directly.
 
-homepage            https://pgloader.io
-github.setup        dimitri pgloader 3.6.1 v
+set cffi_patchfile  ${filespath}/patch-cffi-0.20.0-darwin-fallback-library-path.diff
+set docsrcpath      ${worksrcpath}/docs
+set doc_targets     {}
+
+depends_build       port:freetds \
+                    port:gawk \
+                    port:sbcl
+
+depends_lib         port:curl \
+                    port:libzip \
+                    port:sqlite3 \
+                    port:unzip
+
+variant man description {Build and install man pages} {
+    depends_build-append port:py-sphinx
+    lappend doc_targets man
+}
+
+variant docs requires man description {Build and install documentation} {
+    depends_build-append port:py-sphinx_rtd_theme
+    lappend doc_targets html
+}
+
+default_variants    +man
 
 checksums           rmd160  d3b8f68c54a750c495c11b71270eed6b384b682f \
                     sha256  3969ed5a362848ead94285943f06d99c913139a5b1d5dfed47127f8b8179e66c \
                     size    3691019
 
-depends_lib         port:sbcl \
-                    port:unzip \
-                    port:sqlite3 \
-                    port:curl \
-                    port:gawk \
-                    port:freetds \
-                    port:libzip
-
-set cffi_patchfile  ${filespath}/patch-cffi-0.20.0-darwin-fallback-library-path.diff
 patchfiles          patch-makefile.diff
 
 use_configure       no
 
 pre-build {
-    system -W ${worksrcpath} "make cffi"
+    system -W ${worksrcpath} "${build.cmd} cffi"
     system -W ${worksrcpath} "patch -p0 < ${cffi_patchfile}"
+}
+
+post-build {
+    if {[variant_isset man] || [variant_isset docs]} {
+        system -W ${docsrcpath} "${build.cmd} ${doc_targets}" 
+    }
 }
 
 destroot {
     set bindir ${destroot}${prefix}/bin
     xinstall -d ${bindir}
     xinstall -m 755 ${worksrcpath}/build/bin/pgloader ${bindir}
+
+    if {[variant_isset man]} {
+        set mandir ${destroot}${prefix}/share/man/man1
+        set manfiles [glob ${docsrcpath}/_build/man/*.1]
+        xinstall -m 644 {*}${manfiles} ${mandir}
+    }
+
+    if {[variant_isset docs]} {
+        set docdir ${destroot}${prefix}/share/doc/${name}
+        xinstall -m 755 -d ${docdir}
+        xinstall -m 644 -W ${worksrcpath} \
+            INSTALL.md ISSUE_TEMPLATE.md LICENSE README.md TODO.md \
+            ${docdir}
+        file copy ${docsrcpath}/_build/html ${docdir}
+    }
 }

--- a/databases/pgloader/Portfile
+++ b/databases/pgloader/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                pgloader
+categories          databases
+platforms           darwin
+maintainers         @jrjsmrtn
+
+description         Extract, transform and load data into PostgreSQL
+long_description    pgloader imports data from different kind of sources \
+                    and COPY it into PostgreSQL. \
+                    \
+                    The command language is described in the manual page \
+                    and allows to describe where to find the data source, \
+                    its format, and to describe data processing and \
+                    transformation. \
+                    \
+                    Supported source formats include CSV, fixed width flat \
+                    files, dBase3 files (DBF), and SQLite and MySQL \
+                    databases. In most of those formats, pgloader is able \
+                    to auto-discover the schema and create the tables and \
+                    the indexes in PostgreSQL. In the MySQL case it's \
+                    possible to edit CASTing rules from the pgloader \
+                    command directly.
+
+homepage            https://pgloader.io
+github.setup        dimitri pgloader 3.6.1 v
+
+checksums           rmd160  d3b8f68c54a750c495c11b71270eed6b384b682f \
+                    sha256  3969ed5a362848ead94285943f06d99c913139a5b1d5dfed47127f8b8179e66c \
+                    size    3691019
+
+depends_lib         port:sbcl \
+                    port:unzip \
+                    port:sqlite3 \
+                    port:curl \
+                    port:gawk \
+                    port:freetds \
+                    port:libzip
+
+set cffi_patchfile  ${filespath}/patch-cffi-0.20.0-darwin-fallback-library-path.diff
+patchfiles          patch-makefile.diff
+
+use_configure       no
+
+pre-build {
+    system -W ${worksrcpath} "make cffi"
+    system -W ${worksrcpath} "patch -p0 < ${cffi_patchfile}"
+}
+
+destroot {
+    set bindir ${destroot}${prefix}/bin
+    xinstall -d ${bindir}
+    xinstall -m 755 ${worksrcpath}/build/bin/pgloader ${bindir}
+}

--- a/databases/pgloader/files/patch-cffi-0.20.0-darwin-fallback-library-path.diff
+++ b/databases/pgloader/files/patch-cffi-0.20.0-darwin-fallback-library-path.diff
@@ -1,0 +1,10 @@
+--- build/quicklisp/dists/quicklisp/software/cffi_0.20.0/src/libraries.lisp.orig	2019-03-02 11:06:53.000000000 +0100
++++ build/quicklisp/dists/quicklisp/software/cffi_0.20.0/src/libraries.lisp	2019-03-02 11:02:07.000000000 +0100
+@@ -54,6 +54,7 @@
+ (defun darwin-fallback-library-path ()
+   (or (explode-path-environment-variable "DYLD_FALLBACK_LIBRARY_PATH")
+       (list (merge-pathnames #p"lib/" (user-homedir-pathname))
++            #p"/opt/local/lib/"
+             #p"/usr/local/lib/"
+             #p"/usr/lib/")))
+ 

--- a/databases/pgloader/files/patch-makefile.diff
+++ b/databases/pgloader/files/patch-makefile.diff
@@ -1,0 +1,23 @@
+--- Makefile.orig	2019-01-21 15:02:39.000000000 +0100
++++ Makefile	2019-03-02 13:56:00.000000000 +0100
+@@ -94,6 +94,11 @@
+ 
+ quicklisp: $(QLDIR)/setup.lisp ;
+ 
++cffi: $(QLDIR)/setup.lisp
++	$(CL) $(CL_OPTS) --load $(QLDIR)/setup.lisp \
++             --eval '(ql:quickload "cffi")' \
++             --eval '(quit)'
++
+ clones: $(QLDIR)/local-projects/cl-ixf \
+         $(QLDIR)/local-projects/cl-db3 \
+         $(QLDIR)/local-projects/cl-csv \
+@@ -136,7 +141,7 @@
+ 
+ $(PGLOADER): $(MANIFEST) $(BUILDAPP) $(LISP_SRC)
+ 	mkdir -p $(BUILDDIR)/bin
+-	$(BUILDAPP)      --logfile /tmp/build.log                \
++	$(BUILDAPP)      --logfile ../build.log                \
+                          $(BUILDAPP_OPTS)                        \
+                          --sbcl $(CL)                            \
+                          --asdf-path .                           \

--- a/devel/cl-quicklisp/Portfile
+++ b/devel/cl-quicklisp/Portfile
@@ -1,0 +1,61 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                cl-quicklisp
+categories          devel
+license             permissive
+github.setup        quicklisp quicklisp-bootstrap 2015-01-28 version-
+
+platforms           darwin
+maintainers         @jrjsmrtn openmaintainer
+description         Quicklisp is a library manager for Common Lisp
+long_description    ${description}. It works with your existing Common Lisp \
+                    implementation to download, install, and load any of \
+                    over 1,500 libraries with a few simple commands.
+
+homepage            https://www.quicklisp.org/beta/
+
+checksums           rmd160  b0d6482491853919566b4a6dc7e86c731f949cbe \
+                    sha256  be2c4bf2d3d630b82c6081d2c01563980464810552b343ef84f6bfe75003127e \
+                    size    13941
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/${name}
+    xinstall -m 644 -W ${worksrcpath} \
+        quicklisp.lisp \
+        ${destroot}${prefix}/share/${name}
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} \
+        README.txt LICENSE.txt \
+        ${destroot}${prefix}/share/doc/${name}
+}
+
+set bootstrap_path  "${prefix}/share/${name}/quicklisp.lisp"
+set load_exp        "(load \"${bootstrap_path}\")"
+set install_exp     "(quicklisp-quickstart:install)"
+
+notes "\
+To install Quicklisp in your environment, execute one of:
+
+  \$ abcl --load '${bootstrap_path}' --eval '${install_exp}' --batch
+  \$ clisp -x '${load_exp}' -x '${install_exp}'
+  \$ ecl --load '${bootstrap_path}' --eval '${install_exp}' --eval '(quit)'
+  \$ sbcl --load '${bootstrap_path}' --eval '${install_exp}' --quit
+
+To load Quicklisp into a running session, use:
+
+  (load \"~/quicklisp/setup.lisp\")
+
+To load Quicklisp when you start Lisp, use:
+
+  (ql:add-to-init-file)
+
+Quicklisp will append code to your Lisp's init file that will load Quicklisp on startup."
+
+livecheck.regex     "version-(\\d{4}-\\d{2}-\\d{2})"


### PR DESCRIPTION
#### Description

cl-quicklisp - Quicklisp is a library manager for Common Lisp. It works with your existing Common Lisp implementation to download, install, and load any of over 1,500 libraries with a few simple commands.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

abcl 1.5.0 (openjdk8)
clisp 2.49
acl 16.1.3
sbcl 1.5.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->