### PR TITLE
cl-quicklisp: New port

### DIFF
--- a/devel/cl-quicklisp/Portfile
+++ b/devel/cl-quicklisp/Portfile
@@ -1,0 +1,61 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                cl-quicklisp
+categories          devel
+license             permissive
+github.setup        quicklisp quicklisp-bootstrap 2015-01-28 version-
+
+platforms           darwin
+maintainers         @jrjsmrtn openmaintainer
+description         Quicklisp is a library manager for Common Lisp
+long_description    ${description}. It works with your existing Common Lisp \
+                    implementation to download, install, and load any of \
+                    over 1,500 libraries with a few simple commands.
+
+homepage            https://www.quicklisp.org/beta/
+
+checksums           rmd160  b0d6482491853919566b4a6dc7e86c731f949cbe \
+                    sha256  be2c4bf2d3d630b82c6081d2c01563980464810552b343ef84f6bfe75003127e \
+                    size    13941
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}/share/${name}
+    xinstall -m 644 -W ${worksrcpath} \
+        quicklisp.lisp \
+        ${destroot}${prefix}/share/${name}
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} \
+        README.txt LICENSE.txt \
+        ${destroot}${prefix}/share/doc/${name}
+}
+
+set bootstrap_path  "${prefix}/share/${name}/quicklisp.lisp"
+set load_exp        "(load \"${bootstrap_path}\")"
+set install_exp     "(quicklisp-quickstart:install)"
+
+notes "\
+To install Quicklisp in your environment, execute one of:
+
+  \$ abcl --load '${bootstrap_path}' --eval '${install_exp}' --batch
+  \$ clisp -x '${load_exp}' -x '${install_exp}'
+  \$ ecl --load '${bootstrap_path}' --eval '${install_exp}' --eval '(quit)'
+  \$ sbcl --load '${bootstrap_path}' --eval '${install_exp}' --quit
+
+To load Quicklisp into a running session, use:
+
+  (load \"~/quicklisp/setup.lisp\")
+
+To load Quicklisp when you start Lisp, use:
+
+  (ql:add-to-init-file)
+
+Quicklisp will append code to your Lisp's init file that will load Quicklisp on startup."
+
+livecheck.regex     "version-(\\d{4}-\\d{2}-\\d{2})"


### PR DESCRIPTION
#### Description

cl-quicklisp - Quicklisp is a library manager for Common Lisp. It works with your existing Common implementation to download, install, and load any of over 1,500 libraries with a few simple commands.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

abcl 1.5.0 (openjdk8)
clisp 2.49
gcl 2.6.12
sbcl 1.5.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
