### PR TITLE
openjdk8: update to 8u222

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -3,28 +3,28 @@
 PortSystem       1.0
 
 name             openjdk8
-version          8u212
-revision         1
+version          8u222
+revision         0
 
-set build        04
+set build        10
 set major        8
 
 subport openjdk8-openj9 {
-    version      8u212
-    revision     1
+    version      8u222
+    revision     0
 
-    set build    04
+    set build    10
     set major    8
-    set openj9_version 0.14.2
+    set openj9_version 0.15.1
 }
 
 subport openjdk8-openj9-large-heap {
-    version      8u212
-    revision     1
+    version      8u222
+    revision     0
 
-    set build    04
+    set build    10
     set major    8
-    set openj9_version 0.14.2
+    set openj9_version 0.15.1
 }
 
 subport openjdk10 {
@@ -114,9 +114,9 @@ if {${subport} eq "openjdk8"} {
 if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}/
     
-    checksums    rmd160  05e4da37f972cc986c6d555740e02d8d7e6fb217 \
-                 sha256  6f16c4c09e66a422db8a420e180f8a10e3009e330822fd03a2586847bc1bee49 \
-                 size    102150841
+    checksums    rmd160  b56170dfdc1da40b18b1f17f3f59a54eee7a5c79 \
+                 sha256  9605fd00d2960934422437f601c7a9a1c5537309b9199d5bc75f84f20cd29a76 \
+                 size    102266954
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}b${build}
     worksrcdir   jdk${version}-b${build}
@@ -126,9 +126,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  75c03713518b6dbee1be1add220a07e6a2058124 \
-                 sha256  7bb6e7b8e2c29efc1fc1de2802d7e4cb002e178d1fb01f9ad1e4110da714aca7 \
-                 size    113300023
+    checksums    rmd160  ca2295364eb5ec2d8e96f4d67821347ecc0b990a \
+                 sha256  df185e167756332163633a826b329db067f8a721f7d5d27f0b353a35fc415de0 \
+                 size    113687040
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}
@@ -143,9 +143,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk8-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk${version}-b${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  a64dea8a6d0cb7d6b51771f6285d7643792a8e08 \
-                 sha256  827a783e10842a053642659cd06bddaf0788a7b37bdfd02e26d5d00ca1c7073f \
-                 size    113293115
+    checksums    rmd160  ebadd190bd0b1bc31e95a286837b9b8c5e83f647 \
+                 sha256  a55adfc18ab175510b1f5dced82d9ca660c4f4636f992c301f6db2f49cae4759 \
+                 size    113678902
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}b${build}_openj9-${openj9_version}
     worksrcdir   jdk${version}-b${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 8u222.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?