### PR TITLE
openjdk11: update to 11.0.4

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -36,10 +36,10 @@ subport openjdk10 {
 }
 
 subport openjdk11 {
-    version      11.0.3
+    version      11.0.4
     revision     0
 
-    set build    7
+    set build    11
     set major    11
 }
 
@@ -181,9 +181,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
 
-    checksums    rmd160  609fb1032c738e1a3d819ca925741dda1632664d \
-                 sha256  5ca2a24f1827bd7c110db99854693bf418f51ee3093c31332db5cd605278faad \
-                 size    189888613
+    checksums    rmd160  2bdf0011a0ee020841aad2c972b4f4e75ab5132c \
+                 sha256  a50b211f475b9497311c9b65594764d7b852b1653f249582bb20fc3c302846a5 \
+                 size    190345711
 
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.4-b10 (HotSpot VM).

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?