### PR TITLE
openjdk11-openj9: update to 11.0.4

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -44,21 +44,21 @@ subport openjdk11 {
 }
 
 subport openjdk11-openj9 {
-    version      11.0.3
-    revision     1
+    version      11.0.4
+    revision     0
 
-    set build    7
+    set build    11
     set major    11
-    set openj9_version 0.14.3
+    set openj9_version 0.15.1
 }
 
 subport openjdk11-openj9-large-heap {
-    version      11.0.3
-    revision     1
+    version      11.0.4
+    revision     0
 
-    set build    7
+    set build    11
     set major    11
-    set openj9_version 0.14.3
+    set openj9_version 0.15.1
 }
 
 subport openjdk12 {
@@ -190,9 +190,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  85cd395bff370b5bbd991a577ba8075053100ea4 \
-                 sha256  9217cab0b5dc6301b386ea837d6df38f93adcb5139e5f67a93bb42c3e36df624 \
-                 size    194958783
+    checksums    rmd160  9f71da3e233feb16a84d4369611033a00d7ee4ed \
+                 sha256  7c09678d9c2d9dd0366693c6ab27bed39c76a23e7ac69b8a25c794e99dcf3ba7 \
+                 size    196042493
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}
@@ -207,9 +207,9 @@ if {${subport} eq "openjdk8"} {
 } elseif {${subport} eq "openjdk11-openj9-large-heap"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
 
-    checksums    rmd160  160e2d91cb66db602bb1a142adf560726fb46471 \
-                 sha256  f37b06dc585c15af4987a81a79f774a1f6d50ea5e2fc0b4b06cacfd4d23ad124 \
-                 size    194945805
+    checksums    rmd160  049469ea87ee1abe83a9cb65e551c82962c8964f \
+                 sha256  f0769c458982efb927325d7892c6a7b7dcf3f71265992830025574275dcb3cc8 \
+                 size    196031578
 
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
     worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 11.0.4 (OpenJ9 VM).

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?