### PR TITLE
openjdk12: update to 12.0.2

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -62,10 +62,10 @@ subport openjdk11-openj9-large-heap {
 }
 
 subport openjdk12 {
-    version      12.0.1
+    version      12.0.2
     revision     0
 
-    set build    12
+    set build    10
     set major    12
 }
 
@@ -227,9 +227,9 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
     distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
 
-    checksums    rmd160  b17d9deca70b2f6f6fa614314937c9fa4f5438e3 \
-                 sha256  dcb2ab681247298eda018df24166ba01674127083fb02892acf087e6181d8c56 \
-                 size    198112975
+    checksums    rmd160  298235796f231dcd79baa1eccce40b4eb4aba456 \
+                 sha256  9919eee037554d40c7d2f219bbd654f2bf119e16a2f4d284d8dedaf525ee59e6 \
+                 size    198392994
 
     worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk12-openj9"} {


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 12.0.2+10 (HotSpot VM).

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?