### PR TITLE
kubectx: updated runtime dependency due to obsoletion of kubectl port

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        ahmetb kubectx 0.6.3 v
+revision            1
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -18,7 +19,7 @@ checksums           rmd160  35712f70bc6729e5126f6ae83a76744edc6e8f59 \
                     sha256  3bfab7c5c5d2285afbdb74a6f7f46ab55561135a87a4bb8fc7d79e17bfdbd080 \
                     size    483475
 
-depends_run         port:bash-completion port:kubectl
+depends_run         port:bash-completion path:${prefix}/bin/kubectl:kubectl-1.15
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

In https://github.com/macports/macports-ports/pull/4829 the `kubectl` port was made obsolete. Since `kubectl` was a runtime dependency of `kubectx`, it was no longer possible to install `kubectx`. This change fixes this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?