### PR TITLE
tmux: update tmux-devel to latest commit

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -8,8 +8,8 @@ if {${subport} eq ${name}} {
     conflicts       tmux-devel
 }
 subport tmux-devel {
-    github.setup    tmux tmux 4d16df931274e12a42348f3bc09d9810a52e2e00
-    version         20190501-[string range ${github.version} 0 6]
+    github.setup    tmux tmux 47712fc113fbc602e27aa1f24e5ada3c2f061a94
+    version         20190719-[string range ${github.version} 0 6]
     conflicts       tmux
 }
 categories      sysutils
@@ -33,9 +33,9 @@ if {${subport} eq ${name}} {
                             size    510915
 }
 subport tmux-devel {
-    checksums               rmd160  4d26ccf2412883e14eb033371607969410b524d7 \
-                            sha256  392080159d4f8c97de9d7aa73aa5f49156965cd1db4243f2ca359d515166a550 \
-                            size    663996
+    checksums               rmd160  c702c5bb37bb76aa9becb44fae129ea4a3ca84a1 \
+                            sha256  fc354f8f0452a1c15a0002dd28ea3ca6406e42c972809d9207653b0342be1c22 \
+                            size    710171
 
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
tmux: update tmux-devel to latest commit (47712fc113fbc602e27aa1f24e5ada3c2f061a94)

#### Description

###### Type(s)

- [x] update

###### Tested on

macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?