### PR TITLE
p5-devel-mat-dumper: remove conflict handler

### DIFF
--- a/perl/p5-devel-mat-dumper/Portfile
+++ b/perl/p5-devel-mat-dumper/Portfile
@@ -19,17 +19,4 @@ checksums           rmd160  b465ab9b7e24674121ce574694e903df3d0c400d \
 if {${perl5.major} != ""} {
     perl5.use_module_build
     supported_archs noarch
-
-    # p5-devel-mat-dumper was previously part of p5-devel-mat now separate
-    # deactivate old conflicting p5-devel-mat before activation
-
-    pre-activate {
-        set pname p${perl5.major}-devel-mat
-        if {![catch {set installed [lindex [registry_active $pname] 0]}]} {
-            set _version [lindex $installed 1]
-            if {[vercmp $_version 0.360.0] < 0} {
-                registry_deactivate_composite $pname "" [list ports_nodepcheck 1]
-            }
-        }
-    }
 }


### PR DESCRIPTION
It has now been one year since port was split from `p5-devel-mat` in 288d231a45.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
