### PR TITLE
gnucash-docs: provide workaround for +quartz

### DIFF
--- a/gnome/gnucash-docs/Portfile
+++ b/gnome/gnucash-docs/Portfile
@@ -33,7 +33,15 @@ depends_lib     bin:scrollkeeper-config:rarian \
                 port:libxml2 \
                 bin:xsltproc:libxslt
 
-depends_run     bin:yelp:yelp
+variant x11 conflicts quartz {
+    depends_run     bin:yelp:yelp
+}
+variant quartz conflicts x11 {
+    notes-append "The Gnome program documentation reader, yelp, will not currently install with +quartz. Until fixed, please refer to https://www.gnucash.org/docs.phtml for gnucash documentation."
+}
+if {![variant_isset quartz]} {
+    default_variants +x11
+}
 
 supported_archs noarch
 


### PR DESCRIPTION
* created quartz and x11 variants
* quartz variant skips yelp dependency

#### Description
See https://trac.macports.org/ticket/55345 for a description of the yelp +quartz problem.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
