### PR TITLE
xcodeversion-1.0: set use_xcode yes

### DIFF
--- a/_resources/port1.0/group/xcodeversion-1.0.tcl
+++ b/_resources/port1.0/group/xcodeversion-1.0.tcl
@@ -14,6 +14,11 @@
 options minimum_xcodeversions
 default minimum_xcodeversions {}
 
+# Xcode should be used for this port
+if {[info exists use_xcode]} {
+    use_xcode yes
+}
+
 platform macosx {
     pre-extract {
         foreach {darwin_major minimum_xcodeversion} [join ${minimum_xcodeversions}] {


### PR DESCRIPTION
* set new Xcode dependency flag (forward-compatible)

Latest changes on macports-base master force ports to use CommandLineTools unless the port is Xcode-dependent or CLT isn't installed. With this this change, xcodeversion ports is also considered to be Xcode-dependent.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.2.1 10E1001
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->