### PR TITLE
openjdk12-openj9: update to 12.0.2

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -70,21 +70,21 @@ subport openjdk12 {
 }
 
 subport openjdk12-openj9 {
-    version      12.0.1
+    version      12.0.2
     revision     0
 
-    set build    12
+    set build    10
     set major    12
-    set openj9_version 0.14.1
+    set openj9_version 0.15.1
 }
 
 subport openjdk12-openj9-large-heap {
-    version      12.0.1
+    version      12.0.2
     revision     0
 
-    set build    12
+    set build    10
     set major    12
-    set openj9_version 0.14.1
+    set openj9_version 0.15.1
 }
 
 categories       java devel
@@ -236,9 +236,9 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  ea890ecf79a9b246410fc55ee58715b9054cb973 \
-                 sha256  c66064d695ec56e9b7ac62c9b29c9b499d3b72eada18cab81b37e8f9bb15e87a \
-                 size    197161287
+    checksums    rmd160  eb8b931dc23ff3adb998e9c880e027e03b11e7cf \
+                 sha256  20d19ec20f65335edbf4db3861421be393d48720d5a389cd76e1c81a8aff8fee \
+                 size    197951754
 
     worksrcdir   jdk-${version}+${build}
 
@@ -253,9 +253,9 @@ if {${subport} eq "openjdk8"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_macosXL_${version}_${build}_openj9-${openj9_version}
 
-    checksums    rmd160  cc8307046fd77663796d7d8dde7f5910593e0c90 \
-                 sha256  56b94c90ee0cf46d597a295a4c8f09cc8db8d7d1f35d32008dce3714455ba656 \
-                 size    197158114
+    checksums    rmd160  01c7e4723cbee7e8a34e605a369a3986ace9d07a \
+                 sha256  d7c4c75f04f75767e26ffa0083c8a365ec95e8f5ccddcc0005dbd538954064b4 \
+                 size    197960269
 
     worksrcdir   jdk-${version}+${build}
 


### PR DESCRIPTION
#### Description

Update to AdoptOpenJDK 12.0.2 (Eclipse OpenJ9 VM).

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?