### PR TITLE
nettle: blacklist compilers that don't support asm

### DIFF
--- a/devel/nettle/Portfile
+++ b/devel/nettle/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 name                nettle
 version             3.5.1
@@ -31,6 +32,11 @@ long_description    Nettle is a cryptographic library that is designed to fit \
 
 homepage            https://www.lysator.liu.se/~nisse/nettle/
 master_sites        gnu
+
+# error: invalid instruction mnemonic 'sha1rnds4'
+compiler.blacklist-append  *gcc-3.* *gcc-4.* {clang < 426} \
+                           macports-clang-3.4 macports-clang-3.7
+compiler.fallback-append   macports-clang-8.0 macports-clang-7.0
 
 depends_lib         port:gmp
 


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/58740
