### PR TITLE
mpstats: add support for cxx_stdlib submission

### DIFF
--- a/sysutils/mpstats/Portfile
+++ b/sysutils/mpstats/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mpstats
 version             0.1.8
-revision            2
+revision            3
 categories          sysutils macports
 license             BSD
 platforms           darwin

--- a/sysutils/mpstats/files/mpstats.tcl
+++ b/sysutils/mpstats/files/mpstats.tcl
@@ -370,6 +370,7 @@ proc action_stats {subcommands} {
     dict set os os_arch ${macports::os_arch}
     dict set os os_platform ${macports::os_platform}
     dict set os build_arch ${macports::build_arch}
+    dict set os cxx_stdlib ${macports::cxx_stdlib}
     dict set os gcc_version [getgccinfo]
     dict set os xcode_version ${macports::xcodeversion}
 


### PR DESCRIPTION
Trivial fix to support inclusion of the C++ stdlib when submitting statistics of installed ports.

See: https://github.com/macports/macports-webapp/issues/35

@arjunsalyan: Please test. Since the fix was so trivial, I decided to simply submit it and leave it up to you to add the necessary graph to webapp. Starting from assumption that the same UUID will probably not change stdlib settings, we might be able to populate the values from older submissions after a while as well. This value is only of interest to us for < 10.9.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
