### PR TITLE
mico: Fix compilation on modern OS X

### DIFF
--- a/devel/mico/Portfile
+++ b/devel/mico/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mico
 version             2.3.13
-revision            3
+revision            4
 homepage            http://www.mico.org/
 description         Fully compliant CORBA implementation
 long_description    MICO is a mature, secure, robust, fully \
@@ -20,7 +20,8 @@ checksums           ${distname}${extract.suffix} md5 a8e5d5a0e32dba2ef767eb5189f
                     ${distname}${extract.suffix} rmd160 70c8b9e68deac853ed2a28f48cd719bdef4e60fb
 patchfiles          patch-mico-shld.def.in.diff \
                     patch-configure.diff \
-                    patch-main-sig.diff
+                    patch-main-sig.diff \
+                    patch-os-math.h.diff
 worksrcdir          mico
 patch.pre_args      -p1
 post-patch          {

--- a/devel/mico/files/patch-os-math.h.diff
+++ b/devel/mico/files/patch-os-math.h.diff
@@ -1,0 +1,27 @@
+--- mico/include/mico/os-math.h.orig	2008-07-25 14:41:44.000000000 +0100
++++ mico/include/mico/os-math.h	2019-07-20 23:38:56.000000000 +0100
+@@ -332,24 +332,6 @@
+ #include <sunmath.h>
+ #endif
+ 
+-#if defined(__APPLE__) && defined(__MACH__)
+-// it _IS_ defined on 10.4, 10.5
+-#ifndef isinf
+-#define isinf( x ) ( ( sizeof ( x ) == sizeof(double) ) ?           \
+-                   __isinfd ( x ) :                                 \
+-                   ( sizeof ( x ) == sizeof( float) ) ?             \
+-                   __isinff ( x ) :                                 \
+-                   __isinf  ( x ) )
+-#endif
+-#ifndef isnan
+-#define isnan( x ) ( ( sizeof ( x ) == sizeof(double) ) ?           \
+-                   __isnand ( x ) :                                 \
+-                   ( sizeof ( x ) == sizeof( float) ) ?             \
+-                   __isnanf ( x ) :                                 \
+-                   __isnan  ( x ) )
+-#endif
+-#endif // __APPLE__ && __MACH__
+-
+ #include <mico/lmath.h>
+ 
+ class OSMath {


### PR DESCRIPTION
#### Description

Patch to remove isnan definition that is not necessary on modern os x anymore.

https://trac.macports.org/ticket/58707

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G7024
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
