### PR TITLE
pstoedit: use abs from cmath

### DIFF
--- a/graphics/pstoedit/Portfile
+++ b/graphics/pstoedit/Portfile
@@ -36,6 +36,7 @@ depends_run         port:ghostscript
 
 patchfiles          patch-config-pstoedit.pc.in.diff \
                     patch-configure.ac.diff \
+                    patch-src-dxfacad.h.diff \
                     patch-src-cppcomp.h.diff
 
 use_autoreconf      yes

--- a/graphics/pstoedit/files/patch-src-dxfacad.h.diff
+++ b/graphics/pstoedit/files/patch-src-dxfacad.h.diff
@@ -1,0 +1,16 @@
+--- src/dxfacad.h.orig	2019-01-06 12:59:59.000000000 +0100
++++ src/dxfacad.h	2019-07-21 00:50:07.000000000 +0200
+@@ -1,3 +1,4 @@
++#include <cmath>
+ static const char  dxf14acadheader_prelayer1 [] =
+ "  0\n"
+ "SECTION\n"
+@@ -245,7 +246,7 @@
+ 	friend ostream & operator << (ostream & out, const DXF_LineType & lt) {
+ 
+ 		double length = 0.0;
+-		for (auto l : lt.m_pattern) length += abs(l);
++		for (auto l : lt.m_pattern) length += std::abs(l);
+ 		
+ 		out <<
+ 			"  0\n"


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58602

#### Description

The change solves a bug which prevented the build from succeeding on some versions of macOS and Xcode.
On systems not affected by the bug, the change should be harmless, resulting in unchanged behavior.
For these reasons, I believe that there is no need to increase the revision.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
