### PR TITLE
gitlab-runner: update to 12.1.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.0.2 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.1.0 v
 
 categories          devel
 platforms           darwin
 supported_archs     x86_64
-maintainers         @breun openmaintainer
+maintainers         {breun.nl:nils @breun} openmaintainer
 license             MIT
 
 description         GitLab Runner
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  fe34d9567b670dd7c263ec93753634fa4bcee764 \
-                    sha256  bc8e6e19621c4389ff74ac2014305f53db4d4355185ee5a14ae5acec6e35a853 \
-                    size    27120401
+checksums           rmd160  e7ccfce8612339f73e77deac0b02b3e1a50cb312 \
+                    sha256  e6e89a3dd7039ecd34403830eee70aa1de4e3831c61a8da5c6925942ae071c32 \
+                    size    27134684
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.1.0.

###### Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?