### PR TITLE
vtk: use MacPorts libs instead of local versions

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -8,7 +8,7 @@ PortGroup           cxx11 1.1
 
 name                vtk
 version             8.1.2
-revision            0
+revision            1
 categories          graphics devel
 platforms           darwin
 license             BSD
@@ -38,9 +38,12 @@ mpi.setup
 depends_lib-append \
     port:expat \
     port:freetype \
+    port:gl2ps \
     port:hdf5 \
     port:jpeg \
     port:jsoncpp \
+    port:libharu \
+    port:libogg \
     port:libtheora \
     port:lz4 \
     port:netcdf-cxx \
@@ -61,8 +64,6 @@ configure.args-append \
                     -DVTK_WRAP_TCL:BOOL=OFF \
                     -DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON \
                     -DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF \
-                    -DVTK_USE_SYSTEM_GL2PS:BOOL=OFF \
-                    -DVTK_USE_SYSTEM_LIBHARU:BOOL=OFF \
                     -DVTK_USE_COCOA:BOOL=ON
 
 # As proposed at #46890
@@ -157,10 +158,10 @@ variant python37 conflicts python27 python35 python36 description {Add Python 3.
 }
 
 variant hdf5 description {Add hdf5 readers} {
-    depends_lib-append port:boost
+    depends_lib-append port:boost \
+                       port:xdmf
     configure.args-append \
     -DVTK_USE_SYSTEM_XDMF2:BOOL=OFF \
-    -DVTK_USE_SYSTEM_XDMF3:BOOL=OFF \
     -DNETCDF_DIR=${prefix} \
     -DBOOST_ROOT=${prefix} \
     -DModule_vtkIOXdmf2:BOOL=ON \
@@ -170,9 +171,9 @@ variant hdf5 description {Add hdf5 readers} {
 }
 
 if {[mpi_variant_isset]} {
+    depends_lib-append port:diy2
     configure.args-append \
-        -DVTK_Group_MPI:BOOL=ON \
-        -DVTK_USE_SYSTEM_DIY2:BOOL=OFF
+        -DVTK_Group_MPI:BOOL=ON
 
 }
 

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -159,8 +159,6 @@ variant python37 conflicts python27 python35 python36 description {Add Python 3.
 variant hdf5 description {Add hdf5 readers} {
     depends_lib-append port:boost
     configure.args-append \
-    -DVTK_USE_SYSTEM_HDF5:BOOL=ON \
-    -DVTK_USE_SYSTEM_NETCDF:BOOL=ON \
     -DVTK_USE_SYSTEM_XDMF2:BOOL=OFF \
     -DVTK_USE_SYSTEM_XDMF3:BOOL=OFF \
     -DNETCDF_DIR=${prefix} \

--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -47,6 +47,8 @@ depends_lib-append \
     port:tiff \
     port:zlib
 
+mpi.enforce_variant hdf5
+
 configure.args-delete \
                     -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
 
@@ -167,8 +169,6 @@ variant hdf5 description {Add hdf5 readers} {
     -DModule_vtkxdmf2:BOOL=ON \
     -DModule_vtkxdmf3:BOOL=ON \
     -DModule_vtkIOXdmf3:BOOL=ON
-
-    mpi.enforce_variant hdf5
 }
 
 if {[mpi_variant_isset]} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5
Xcode 10.2.1 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->