### PR TITLE
folly: blacklist compilers and fix build for darwin <= 16

### DIFF
--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        facebook folly 2019.06.17.00 v
-revision            1
+revision            2
 categories          devel
 platforms           darwin
 license             Apache-2
@@ -35,13 +36,20 @@ depends_lib-append  port:boost \
                     port:zlib \
                     port:zstd
 
+compiler.blacklist-append {clang < 920} macports-clang-3.* macports-clang-4.0 \
+    macports-clang-5.0
+compiler.fallback-append macports-clang-8.0 macports-clang-7.0 macports-clang-6.0
+
 configure.args-append -DBUILD_SHARED_LIBS=ON
 
 configure.cxxflags-append -std=c++14
 
 # https://github.com/facebook/folly/issues/864
-platform darwin 16 {
-    configure.args-append -DCOMPILER_HAS_F_ALIGNED_NEW=OFF
+platform darwin {
+    if {${os.major} <= 16} {
+        configure.args-append     -DCOMPILER_HAS_F_ALIGNED_NEW=OFF
+        configure.cxxflags-append -fno-aligned-allocation
+    }
 }
 
 variant jemalloc description {Use je_malloc} {


### PR DESCRIPTION
#### Description

Cf. https://trac.macports.org/ticket/58719
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.2 10E125

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
