### PR TITLE
mysql8: update to 8.0.17

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 
 name                    mysql8
-version                 8.0.16
+version                 8.0.17
 set boost_version       1.69.0
 categories              databases
 platforms               darwin
@@ -12,8 +12,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} openmaintainer
 homepage                https://www.mysql.com/
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client 3
-set revision_server 4
+set revision_client 0
+set revision_server 0
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -44,9 +44,9 @@ if {$subport eq $name} {
                         ${boost_distname}${extract.suffix}:boost
 
     checksums           ${distname}${extract.suffix} \
-                        rmd160  2e0d3326331b74fec8ab3e147f330d2d4f75382e \
-                        sha256  8d9fe89920dc8bbbde2857b7b877ad2fa5ec2f231c68e941d484f3b72735eaea \
-                        size    146811037 \
+                        rmd160  aa6f5fe3a890e8e4a7fef8a6c3a30701d925a79f \
+                        sha256  c6e3f38199a77bfd8a4925ca00b252d3b6159b90e4980c7232f1c58d6ca759d6 \
+                        size    190203398 \
                         ${boost_distname}${extract.suffix} \
                         rmd160  ad6cd576a5229a11601986908ff03261582c9f81 \
                         sha256  9a2c2819310839ea373f42d69e733c339b4e9a19deab6bfec448281554aa4dbb \

--- a/databases/mysql8/files/patch-router-cmake-set_rpath.diff
+++ b/databases/mysql8/files/patch-router-cmake-set_rpath.diff
@@ -1,21 +1,30 @@
---- a/router/cmake/set_rpath.cmake.orig	2019-05-27 12:14:40.000000000 -0400
-+++ b/router/cmake/set_rpath.cmake	2019-05-27 18:46:26.000000000 -0400
-@@ -73,6 +73,14 @@
-   SET(ROUTER_INSTALL_DATADIR "/var/opt/mysqlrouter")
-   SET(ROUTER_INSTALL_LOGDIR "/var/opt/mysqlrouter")
-   SET(ROUTER_INSTALL_RUNTIMEDIR "/var/opt/mysqlrouter")
-+ELSEIF(INSTALL_LAYOUT STREQUAL "MACPORTS")
-+  SET(ROUTER_INSTALL_CONFIGDIR "${CMAKE_INSTALL_PREFIX}/etc/@NAME@-router")
-+  SET(ROUTER_INSTALL_DATADIR "${CMAKE_INSTALL_PREFIX}/var/db/@NAME@-router")
-+  SET(ROUTER_INSTALL_LOGDIR "${CMAKE_INSTALL_PREFIX}/var/log/@NAME@-router")
-+  SET(ROUTER_INSTALL_RUNTIMEDIR "${CMAKE_INSTALL_PREFIX}/var/run/@NAME@-router")
-+
-+  SET(ROUTER_INSTALL_DOCDIR "${CMAKE_INSTALL_PREFIX}/share/doc/@NAME@")
-+  SET(ROUTER_INSTALL_SHAREDIR "${CMAKE_INSTALL_PREFIX}/share/@NAME@-router")
- ELSE()
-   SET(ROUTER_INSTALL_CONFIGDIR "/etc/mysqlrouter")
-   SET(ROUTER_INSTALL_DATADIR "/var/lib/mysqlrouter")
-@@ -123,12 +131,12 @@
+--- a/router/cmake/set_rpath.cmake	2019-07-22 13:21:00.000000000 -0400
++++ b/router/cmake/set_rpath.cmake  2019-07-22 13:20:56.000000000 -0400
+@@ -22,7 +22,7 @@
+ 
+ # This follows pattern from cmake/install_layout.cmake
+ #
+-# Supported layouts here are STANDALONE, WIN, RPM, DEB, SVR4 or
++# Supported layouts here are STANDALONE, WIN, RPM, DEB, SVR4, MACPORTS or
+ # FREEBSD.
+ # Layouts GLIBC, OSX, TARGZ and SLES seems unused and are similar to
+ # STANDALONE or RPM any way.
+@@ -112,7 +112,13 @@
+ SET(ROUTER_INSTALL_DATADIR_DEB    "/var/run/mysqlrouter")
+ SET(ROUTER_INSTALL_LOGDIR_DEB     "/var/log/mysqlrouter")
+ SET(ROUTER_INSTALL_RUNTIMEDIR_DEB "/var/run/mysqlrouter")
+-
++#
++# MACPORTS layout
++#
++SET(ROUTER_INSTALL_CONFIGDIR "${CMAKE_INSTALL_PREFIX}/etc/@NAME@-router")
++SET(ROUTER_INSTALL_DATADIR "${CMAKE_INSTALL_PREFIX}/var/db/@NAME@-router")
++SET(ROUTER_INSTALL_LOGDIR "${CMAKE_INSTALL_PREFIX}/var/log/@NAME@-router")
++SET(ROUTER_INSTALL_RUNTIMEDIR "${CMAKE_INSTALL_PREFIX}/var/run/@NAME@-router")
+ # Mimic cmake/install_layout.cmake:
+ # Set ROUTER_INSTALL_FOODIR variables for chosen layout for example,
+ # ROUTER_INSTALL_CONFIGDIR will be defined as
+@@ -179,11 +185,11 @@
  SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
  
@@ -26,7 +35,6 @@
 -#MESSAGE(STATUS "- libdir: ${ROUTER_INSTALL_LIBDIR}")
 -#MESSAGE(STATUS "- plugindir: ${ROUTER_INSTALL_PLUGINDIR}")
 -#MESSAGE(STATUS "- datadir: ${ROUTER_INSTALL_DATADIR}")
--#MESSAGE(STATUS "- sharedir: ${ROUTER_INSTALL_SHAREDIR}")
 -#MESSAGE(STATUS "- rpath: ${CMAKE_INSTALL_RPATH}")
 +MESSAGE(STATUS "Router install directories:")
 +MESSAGE(STATUS "- bindir: ${ROUTER_INSTALL_BINDIR}")
@@ -35,5 +43,4 @@
 +MESSAGE(STATUS "- libdir: ${ROUTER_INSTALL_LIBDIR}")
 +MESSAGE(STATUS "- plugindir: ${ROUTER_INSTALL_PLUGINDIR}")
 +MESSAGE(STATUS "- datadir: ${ROUTER_INSTALL_DATADIR}")
-+MESSAGE(STATUS "- sharedir: ${ROUTER_INSTALL_SHAREDIR}")
 +MESSAGE(STATUS "- rpath: ${CMAKE_INSTALL_RPATH}")


### PR DESCRIPTION
Update MySQL8 to 8.0.17, and update the `mysqlrouter` patch, even though we're still not yet building `mysqlrouter` itself.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F203
Xcode 10.2.1 10E1001

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
