### PR TITLE
notmuch: Fix output file being closed twice

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           conflicts_build 1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           conflicts_build             1.0
 
 name                notmuch
 version             0.29.1
+revision            1
 categories          mail
 platforms           darwin
 license             GPL-3+
@@ -40,6 +42,7 @@ depends_lib         port:gmime3 \
                     port:zlib
 
 patchfiles          ${distname}-configure.patch \
+                    ${distname}-fix-sigabrt.patch \
                     patch-bindings-python-notmuch-globals.py.diff
 
 post-patch {
@@ -48,7 +51,7 @@ post-patch {
 
 conflicts_build     ${name} xcbuild
 
-compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 300}
+compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 300} llvm-g++-4.2
 compiler.whitelist clang macports-clang-5.0 
 
 configure.args      --with-docs \

--- a/mail/notmuch/files/notmuch-0.29.1-fix-sigabrt.patch
+++ b/mail/notmuch/files/notmuch-0.29.1-fix-sigabrt.patch
@@ -1,0 +1,20 @@
+--- notmuch-dump.c.orig	2019-07-24 17:11:02.899384482 +0200
++++ notmuch-dump.c	2019-07-24 17:12:08.100487117 +0200
+@@ -329,13 +329,15 @@
+ 	}
+     }
+ 
+-    if (gzclose_w (output) != Z_OK) {
++    ret = gzclose_w (output);
++    if (ret) {
+ 	fprintf (stderr, "Error closing %s: %s\n", name_for_error,
+ 		 gzerror (output, NULL));
+ 	ret = EXIT_FAILURE;
+ 	output = NULL;
+ 	goto DONE;
+-    }
++    } else
++        output = NULL;
+ 
+     if (output_file_name) {
+ 	ret = rename (tempname, output_file_name);


### PR DESCRIPTION
#### Description
Fixed: If the output file for a dump was non-writeable, gzclose_w() was called twice on the output file handle, resulting in SIGABRT.

This fix has also been submitted upstream, but not yet been accepted.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.5 18F132
Xcode 10.3 10G8
