### PR TITLE
web-ext: update to 3.1.1

### DIFF
--- a/devel/web-ext/Portfile
+++ b/devel/web-ext/Portfile
@@ -1,37 +1,38 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem              1.0
+PortSystem          1.0
 
-name                    web-ext
-version                 3.1.0
-revision                0
-checksums               rmd160  fc472f846a52da6c047b0537a6e6e8b9520670ad \
-                        sha256  3b444cb0369d59873aab7113a85bb0a01d2f108a20d8083b4d92fd9616323a83 \
-                        size    194790
+name                web-ext
+version             3.1.1
+revision            0
+checksums           rmd160  a060be34be554d72e7f587925889eef711559a05 \
+                    sha256  d8302e9f62e6200ef91e3ecf0148fadd033783891df3a14dd837ee4610173910 \
+                    size    195160
 
-categories              devel
-maintainers             nomaintainer
-license                 MPL-2
-description             A command line tool to help build, run, and test web extensions
+categories          devel
+maintainers         nomaintainer
+license             MPL-2
+description         A command line tool to help build, run, and test web extensions
 
-long_description        ${description}
+long_description    ${description}
 
-homepage                https://github.com/mozilla/web-ext
-master_sites            https://registry.npmjs.org/${name}/-
+homepage            https://github.com/mozilla/web-ext
+master_sites        https://registry.npmjs.org/${name}/-
 
-extract.suffix          .tgz
+extract.suffix      .tgz
 
-platforms               darwin
+platforms           darwin
 
-depends_lib-append      path:bin/node:nodejs10
+depends_lib-append  path:bin/node:nodejs10
 
-depends_build-append    path:bin/npm:npm6
+depends_build-append \
+                    path:bin/npm:npm6
 
-worksrcdir              package
+worksrcdir          package
 
-use_configure           no
+use_configure       no
 
-build                   {}
+build               {}
 
 destroot {
     xinstall -m 755 -d "${destroot}${prefix}/lib/node_modules"
@@ -39,3 +40,7 @@ destroot {
     system -W "${destroot}${prefix}/lib/node_modules/${name}" "npm install --production"
     ln -s ${prefix}/lib/node_modules/.bin/${name} ${destroot}${prefix}/bin/${name}
 }
+
+livecheck.type      regex
+livecheck.url       https://registry.npmjs.org/${name}
+livecheck.regex     {"latest":"(.*?)"}


### PR DESCRIPTION
###### Tested on
macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?