### PR TITLE
xca: Initial commit of xca 2.1.2, a cross-platform GUI certificate an…

### DIFF
--- a/security/xca/PortFile
+++ b/security/xca/PortFile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+PortGroup                   qt5 1.0
+
+github.setup                chris2511 xca 2.1.2 RELEASE.
+github.tarball_from         releases
+
+categories                  security crypto
+platforms                   darwin
+license                     Permissive
+license_noconflict          openssl
+
+maintainers                 {@lhaeger} openmaintainer
+
+description                 X Certificate and Key management
+long_description            XCA is a CA & PKI management tool that supports creating and managing X.509 certificates, \
+                            certificate requests, RSA, DSA and EC private keys, Smartcards and CRLs.
+homepage                    https://www.hohnstaedt.de/xca/
+
+checksums                   rmd160  16717ab6eb2cd33599d9606b7908551ad01bbff3 \
+                            sha256  fc845470a02b0b4534b46590be307f784662071fc412fdcad605c3bce901fe05 \
+                            size    1086563
+
+qt5.depends_component       qtdeclarative \
+                            qtmacextras \
+                            qtmultimedia \
+                            qtsvg \
+                            qttools \
+                            qttranslations \
+                            sqlite-plugin
+
+depends_lib-append          port:libtool \
+                            port:openssl
+
+patchfiles                  patch-disable-codesigning.diff
+
+configure.cppflags-append   -L${prefix}/lib
+
+build.target                xca.app
+
+destroot.violate_mtree      yes
+destroot {
+    copy ${worksrcpath}/${name}-${version}/${name}.app ${destroot}${applications_dir}
+}

--- a/security/xca/files/patch-disable-codesigning.diff
+++ b/security/xca/files/patch-disable-codesigning.diff
@@ -1,0 +1,16 @@
+--- Makefile.orig	2019-07-22 12:17:19.000000000 +0200
++++ Makefile	2019-07-22 12:18:00.000000000 +0200
+@@ -181,9 +181,10 @@
+ 	ln -s xca.html $(DMGSTAGE)/manual/index.html
+ 	otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users" >&2
+ 	$(MACDEPLOYQT) $(DMGSTAGE)/xca.app
+-	rpath="`otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users"`" && \
+-	if test -n "$$rpath"; then echo "  ERROR $$rpath"; false; fi
+-	-codesign --force --deep --signature-size=96000 -s "Christian Hohnstaedt" $(DMGSTAGE)/xca.app --timestamp
++############# disable code signing by original author ###########################################################
++#	rpath="`otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users"`" && \
++#	if test -n "$$rpath"; then echo "  ERROR $$rpath"; false; fi
++#	-codesign --force --deep --signature-size=96000 -s "Christian Hohnstaedt" $(DMGSTAGE)/xca.app --timestamp
+ 
+ xca.dmg: $(MACTARGET).dmg
+ 


### PR DESCRIPTION
xca: Initial commit of new port, a GUI certificate and key management tool

Type(s)

[ ] bugfix
[x] enhancement
[ ] security fix

Tested on

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001

Verification

Have you

[x] followed our Commit Message Guidelines?
[x] checked that there aren't other open pull requests for the same change?
[ ] referenced existing tickets on Trac with full URL?
[x] checked your Portfile with port lint?
[x] tried a full install with sudo port -vst install?
[x] tested basic functionality of all binary files?