### PR TITLE
py-exifread: update to 2.2.0, adopt port

### DIFF
--- a/python/py-exif/Portfile
+++ b/python/py-exif/Portfile
@@ -1,25 +1,18 @@
 PortSystem          1.0
-PortGroup           python 1.0
-PortGroup           github 1.0
+PortGroup           obsolete 1.0
 
-github.setup        ianare exif-py 2.1.2
+# Renamed to be consistent with PyPI
 name                py-exif
+replaced_by         py-exifread
+version             2.1.2
+revision            1
+categories-append   python
 license             BSD
-platforms           darwin
-supported_archs     noarch
-maintainers         nomaintainer
-description         Python interface to the EXIF meta-data
-long_description    Exchangeable Image File Format for Digital Still \
-                    Cameras is a meta-information tag that can be embedded \
-                    in tiff or jpeg image files. py-exif is a Python \
-                    interface to this data.
 
-checksums           rmd160  c24bf810a72a7a176833b7e1d564349d316fe868 \
-                    sha256  53b0fa8e33071320ab1d8ae4713a7bea859ec166bc3774df9003b25ffea94b90 \
-                    size    32200
-
-python.versions     27 37
-
-if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+foreach v {27 37} {
+    subport py${v}-exif "
+        replaced_by py${v}-exifread
+    "
 }
+
+# remove after 2020-07-25

--- a/python/py-exifread/Portfile
+++ b/python/py-exifread/Portfile
@@ -1,0 +1,26 @@
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        ianare exif-py 2.2.0
+name                py-exifread
+revision            0
+license             BSD
+platforms           darwin
+supported_archs     noarch
+maintainers         {gmx.us:chrischavez @chrstphrchvz} openmaintainer
+description         EXIF.py - Python interface to the EXIF meta-data
+long_description    Exchangeable Image File Format for Digital Still \
+                    Cameras is a meta-information tag that can be embedded \
+                    in tiff or jpeg image files. EXIF.py is a Python \
+                    interface to this data.
+
+checksums           rmd160  deaea5d19bf9532b3a31e8c745a381a78d549830 \
+                    sha256  673cabc0ca73656494efbf9f1e0bcaf493892c8e8748f67710a53b9ebeed72cc \
+                    size    35326
+
+python.versions     27 37
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+}


### PR DESCRIPTION
Renamed from `py-exif` for consistency with name used on PyPI
Refer to project as EXIF.py in description

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
