### PR TITLE
cppreference: new port.

### DIFF
--- a/lang/cppreference/Portfile
+++ b/lang/cppreference/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+name                    cppreference
+version                 20190607
+maintainers             {eborisch @eborisch} \
+                        openmaintainer
+categories              lang
+license                 GFDL
+platforms               darwin
+supported_archs         noarch
+
+homepage                https://cppreference.com/
+
+description             C++ reference pages (and Doxygen tags files)
+long_description        ${description}. Offline version.
+
+master_sites            http://upload.cppreference.com/mwiki/images/1/16/
+distname                html_book_${version}
+use_xz                  yes
+
+checksums \
+    rmd160  5b197a0107d53324d2eead5201a9cb6d51f5d581 \
+    sha256  8f97b2baa749c748a2e022d785f1a2e95aa851a3075987dfcf38baf65e0e486d \
+    size    4172152
+
+extract.mkdir           yes
+
+use_configure           no
+build {}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    move ${worksrcpath}/reference/en ${worksrcpath}/reference/common \
+        ${destroot}${prefix}/share/doc/${name}/
+    move ${worksrcpath}/cppreference-doxygen-local.tag.xml \
+        ${destroot}${prefix}/share/doc/${name}/
+    system -W ${destroot}${prefix}/share/doc \
+        "chown -R ${install.user}:${install.group} ${name}"
+}
+
+notes "
+    C++ STL documentation installed at:
+      file://${prefix}/share/doc/${name}/en/index.html
+    Doxygen tag linking with:
+      TAGFILES += \"${prefix}/share/doc/${name}/cppreference-doxygen-local.tag.xml=${prefix}/share/doc/${name}/en/\"
+"
+
+livecheck.type          regex
+livecheck.url           https://en.cppreference.com/w/Cppreference:Archives
+livecheck.regex         {File:html_book_([^.]+).tar.xz}


### PR DESCRIPTION
#### Description

Offline version of http://cppreference.com. Includes Doxygen tag file for linking.

###### Type(s)
New port

- [X] enhancement

###### Tested on
macOS 10.13.6 17G7024
Xcode 10.1 10B61
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
