### PR TITLE
getmail: update to version 5.13

### DIFF
--- a/mail/getmail/Portfile
+++ b/mail/getmail/Portfile
@@ -1,14 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 PortSystem 1.0
 PortGroup python 1.0
 
 name                getmail
-version             5.6
+version             5.13
 categories          mail python
 platforms           darwin
 maintainers         nomaintainer
 license             GPL-2
 description         extensible mail retrieval system with POP3, IMAP4, SSL support
-long_description    getmail version 4 is a flexible, extensible mail retrieval \
+long_description    getmail version 5 is a flexible, extensible mail retrieval \
                     system with support for POP3, IMAP4, SSL variants of both, \
                     maildirs, mboxrd files, external MDAs, arbitrary message \
                     filtering, single-user and domain-mailboxes, and many \
@@ -18,8 +19,9 @@ supported_archs     noarch
 
 homepage            http://pyropus.ca/software/getmail/
 master_sites        ${homepage}old-versions/
-checksums           rmd160  26a36c404cc07c29704aedc862cb8af0a376af12 \
-                    sha256  460d2c8834936df88d594095d789c4585edca9b0bdbeded9f6267f0d90dcd59a
+checksums           rmd160  c2f43c7d3f6a87e9663cb6b7d2d3ed77b66123a1 \
+                    sha256  04d52f6475f09e9f99b4e3d2f1d2eb967a68b67f09af2a6a5151857f060b0a9d \
+                    size 199073
 dist_subdir         ${name}
 patchfiles          patch-setup.py.diff
 


### PR DESCRIPTION
#### Description

Getmail had not been updated for a year. This updates it to version 5.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G7024
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->