### PR TITLE
paraview: Fix build with DIY2.

### DIFF
--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -69,7 +69,6 @@ depends_lib-append  path:include/eigen3/Eigen/Eigen:eigen3 \
                     port:gl2ps \
                     port:cgnslib \
                     port:icet \
-                    port:diy2 \
                     port:PEGTL \
                     port:qttesting \
                     port:readline
@@ -97,9 +96,6 @@ configure.pre_args-delete \
 configure.post_args-append \
     -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
-# avoid `Exit code: 2`
-use_parallel_build      no
-
 # ${destroot} needs to be part of MACOSX_APP_INSTALL_PREFIX; see further
 # comments below, JJS 12/21/15
 configure.args-append \
@@ -123,7 +119,8 @@ pre-configure {
                -DMPI_C_COMPILER=${mpi.cc} \
                -DMPI_CXX_COMPILER=${mpi.cxx} \
                -DMPIEXEC=${mpi.exec} \
-               -DMPI_Fortran_COMPILER=${mpi.fc}
+               -DMPI_Fortran_COMPILER=${mpi.fc} \
+               -DVTK_USE_SYSTEM_DIY2:BOOL=OFF
        }
 }
 


### PR DESCRIPTION
Meanwhile we wait to fix python variant with #4045, #4707 was merged with the new version. Unfortunately `diy2` that is shipped with Paraview is patched w.r.t. the one present in the ports. So it needs to be compiled again from the source shipped with Paraview. Otherwise the build does not go on.

Moreover  the parallel build works. 

PS: Is there any chance we could extend build time for the CI workers in order to complete such long build jobs?

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

/cc @MarcusCalhoun-Lopez 
