### PR TITLE
CubicSDR: update version to 20190724-21fc2d60

### DIFF
--- a/science/CubicSDR/Portfile
+++ b/science/CubicSDR/Portfile
@@ -18,11 +18,11 @@ long_description    CubicSDR is the software portion of Software Defined \
     functions in software instead of traditional hardwre.
 homepage            https://www.cubicsdr.com
 
-github.setup        cjcliffe CubicSDR 9bf25b8feb39053ee029b996595c57e06a44b6c3
-version             20190602-[string range ${github.version} 0 7]
-checksums           rmd160 ff8db11f0cfe5994d10fa6e3c09a642d9c1ede5b \
-                    sha256 5fc78962c8c12549d0d71225d6708594d3cbe0d81d2a06d8425f9e06bf409ccf \
-                    size   36025036
+github.setup        cjcliffe CubicSDR 21fc2d605a01d88d08e7cc5e14fea1b7d2ba6610
+version             20190724-[string range ${github.version} 0 7]
+checksums           rmd160  112b7df7bfa4796d6d027d7b374885b81c64e6cf \
+                    sha256  f54b1e0d467dfd103a119b913d96b7c3a56baf42d0afc8c2bc5c551196b100a3 \
+                    size    35735991
 revision            0
 
 # CubicSDR requires wxWidgets.use of wxWidgets-3.1 or newer -- "3.2"


### PR DESCRIPTION
#### Description

- bump version to the latest commit 21fc2d60

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->