### PR TITLE
bcprov: new port

### DIFF
--- a/java/bcprov/Portfile
+++ b/java/bcprov/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           java 1.0
+
+name                bcprov
+version             1.62
+
+categories          java devel security
+license             MIT
+maintainers         nomaintainer
+platforms           darwin
+supported_archs     noarch
+
+description         A Java implementation of cryptographic algorithms
+long_description    ${description}
+homepage            https://www.bouncycastle.org/java.html
+
+master_sites        https://search.maven.org/remotecontent?filepath=org/bouncycastle/${name}-jdk15on/${version}/
+
+distname            ${name}-jdk15on-${version}
+distfiles           ${distname}.jar
+worksrcdir          ${distname}
+
+checksums           rmd160  288577b36c0385dcd4b9f5614929727f4b039a27 \
+                    sha256  2fa0ab71b154da29ac134097bc6bbacd90987dd4c4005516159e6494d1d52ea2 \
+                    size    4558151
+
+extract {
+    file copy ${distpath}/${distname}.jar ${workpath}
+}
+
+use_configure       no
+
+build {}
+
+destroot {
+    set javadir ${destroot}${prefix}/share/java
+    xinstall -d -m 755 -d ${javadir}/${name}
+    xinstall -m 644 ${workpath}/${distname}.jar ${javadir}/${name}/${name}.jar
+}
+
+livecheck.type      regex
+livecheck.url       https://repo1.maven.org/maven2/org/bouncycastle/${name}-jdk15on/maven-metadata.xml
+livecheck.regex     >(\\d+\\.\\d+(\\.\\d+)*)</


### PR DESCRIPTION
Based on submission by @someuser12: https://trac.macports.org/ticket/58755


#### Description

To be used with a future `pdftk-java` port.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
