### PR TITLE
gr-limesdr-devel: update version to 14b29b3b

### DIFF
--- a/science/gr-limesdr/Portfile
+++ b/science/gr-limesdr/Portfile
@@ -17,11 +17,11 @@ homepage            https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio
 subport gr-limesdr-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup myriadrf gr-limesdr 47c6d40d369efc68f3f0d19d5a0105cd2d68732b
-    version   20190617
-    checksums rmd160 dd5b0ea9624f2d620ea56fabc7acd7a814f81af1 \
-              sha256 297d7ab8ef50c306ac0cfc12574e1ce7fedfabc8dbde7e2119ca11d77315ed03 \
-              size   3086257
+    github.setup myriadrf gr-limesdr 14b29b3b9c46571fe6dbfd4c818ae5db419d1aa7
+    version   20190703-[string range ${github.version} 0 7]
+    checksums rmd160 eb504fc373e10766a3231c3ad6809d02885a3e9d \
+              sha256 288bc879cd7b8097070ac10678a9a15167c99117e87c55522f3792944b6e24d2 \
+              size   3086332
     revision  0
 
     name            gr-limesdr-devel


### PR DESCRIPTION


#### Description

- bump version to commit 14b29b3b

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->