### PR TITLE
limesuite-devel: update version to b785e234

### DIFF
--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -20,12 +20,12 @@ homepage            https://myriadrf.org/projects/lime-suite/
 subport limesuite-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup jmyriadrf LimeSuite 570e879ef5b04b73ab284016160ec87b6b668b14
-    version   20190716-[string range ${github.version} 0 7]
-    checksums rmd160 8c2e5138b3b724c9500ede97c3b6c0f5f765bf6f \
-              sha256  ea6dd59ab56da399851bf535ae0b31e5ea79ee6832f8445d34c51325606c9c50 \
-              size    5363667
-    revision  0
+    github.setup    myriadrf LimeSuite b785e2346063a15e0c46bb6849e20f5b18235ddd
+    version         20190719-[string range ${github.version} 0 7]
+    checksums       rmd160  55b08706404b5696f1a46e24b733a25cb7dcb07f \
+                    sha256  e4b93721840be1770785a01aa01cc53e880d4f93a74e6ca3aad9f4d92c9c70a0 \
+                    size    5363711
+    revision        0
 
     name            limesuite-devel
     long_description ${long_description} This port is kept up with the LimeSuite \


### PR DESCRIPTION


#### Description

- bump version to commit b785e234
- fix wrong github username s/jmyriadrf/myriadrf/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->