### PR TITLE
afscompress: new port

### DIFF
--- a/sysutils/afscompress/Portfile
+++ b/sysutils/afscompress/Portfile
@@ -1,0 +1,68 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem           1.0
+PortGroup            cmake 1.1
+PortGroup            github 1.0
+
+github.setup         RJVB afsctool 1.7.0
+
+name                 afscompress
+categories           sysutils
+platforms            darwin
+license              GPL-3
+maintainers          {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
+description          A fork of brkirch's afsctool utility, featuring several improvements.
+long_description     AFSC (Apple File System Compression) tool is a utility that can be used to \
+    apply HFS+/APFS compression to file(s), decompress HFS+/APFS compressed file(s), \
+    or get information about existing HFS+/APFS compressed file(s). macOS 10.6 or \
+    later is required. This fork has several modifications, mostly concerning the \
+    compression feature, including: improved error reporting, an attempt to reduce \
+    memory pressure pressure compressing large files, support for multiple \
+    files/folders specified on the commandline, a backup option while compressing \
+    (that comes in addition to the existing undo if something went wrong), and \
+    support for files that are read-only (and/or write-only) by changing their \
+    permissions temporarily. No error checking is done for this feature\; failure \
+    will lead to errors that are already caught. The main new feature that justifies \
+    the version bump, however, is the parallel processing feature, allowing the user \
+    to specify an arbitrary (though positive :)) number of threads that will \
+    compress the specified files in parallel.
+
+checksums            sha256  911ae33960560e36d854753cca1fcb83bb4674123b83f04b5642980670bc747d \
+                     rmd160  b2ec4858164723532bee7d3b00f796d42aefbaea \
+                     size    110026
+
+depends_lib          port:sparsehash \
+                     port:zlib
+
+universal_variant    yes
+
+pre-fetch {
+    if {${os.platform} eq "darwin" && ${os.major} < 10} {
+        ui_error "${name} is only compatible with Mac OS X 10.6 or later; earlier versions lack support for HFS compression."
+        return -code error "incompatible Mac OS X version"
+    }
+}
+
+
+configure.args-append \
+    -DCMAKE_STRIP:PATH=/bin/echo
+
+cmake.save_configure_cmd
+
+post-destroot {
+    if {[variant_isset original_name]} {
+        xinstall -m 755 ${build.dir}/zfsctool ${destroot}/${prefix}/bin/zfsctool
+    } else {
+        xinstall -m 755 ${build.dir}/zfscompress ${destroot}/${prefix}/bin/zfscompress
+    }
+}
+
+variant {original_name} description {Install the program as "afsctool" instead of "afscompress"} {}
+
+if {[variant_isset original_name]} {
+    configure.args-append \
+        -DNEW_DRIVER_NAMES=OFF
+} else {
+    configure.args-append \
+        -DNEW_DRIVER_NAMES=ON
+}


### PR DESCRIPTION
#### Description

This adds a port for @RJVB's [fork of `afsctool`.](https://github.com/RJVB/afsctool) There is already a port for the original program by @brkirch, but this is a newer fork which adds several improvements. [Some folks tried getting this fork into Homebrew](https://github.com/Homebrew/homebrew-core/pull/20898) about 2 years ago, but as usual the maintainers of Homebrew made things into an unnecessary drama and rejected it. Then they proceeded to deride people over complaining about how difficult they were making the submission process... but I digress 😅. I have given this port a different name, [as per @brkirch's request.](https://github.com/Homebrew/homebrew-core/pull/20898#issuecomment-380727547) Hopefully we can have an easier time here than the folks at Homebrew 😄 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? **(not applicable)**
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? **(not applicable)**
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
