### PR TITLE
new port: sequoia-pgp

### DIFF
--- a/security/sequoia-pgp/Portfile
+++ b/security/sequoia-pgp/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                sequoia-pgp
+version             0.9.0
+categories          security
+maintainers         {jann @roederja} openmaintainer
+license             GPL-3+
+description         Sequoia PGP
+long_description    Sequoia is a cool new OpenPGP implementation.  It consists of several \
+                    crates, providing both a low-level and a high-level API for dealing \
+                    with OpenPGP data.
+homepage            https://sequoia-pgp.org/
+distname            sequoia-v${version}
+master_sites        https://gitlab.com/sequoia-pgp/sequoia/-/archive/v${version}/
+
+platforms           darwin
+use_bzip2           yes
+use_configure       no
+use_parallel_build  no
+build.target        build-release
+build.post_args-append     PYTHON=disable PREFIX=${prefix}
+destroot.post_args-append  PYTHON=disable PREFIX=${prefix}
+
+checksums           rmd160  4ca8ac7828e9a08ccdeec6421cb900fd93841fa1 \
+                    sha256  5a9549ddeb7f09f6217bfa25ded5cbea91df2fef71e66884a0e054745aa21723 \
+                    size    1572197
+
+depends_build       port:pkgconfig \
+                    bin:ginstall:coreutils \
+                    port:cargo \
+                    port:rust
+depends_lib         port:capnproto \
+                    port:nettle \
+                    port:sqlite3 \
+                    port:openssl
+
+livecheck.type      regex
+livecheck.url       https://gitlab.com/sequoia-pgp/sequoia/-/tags
+livecheck.regex     v(\\d+\\.\\d+\\.\\d+)


### PR DESCRIPTION
#### Description

New port:
https://sequoia-pgp.org/

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G7024
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
