### PR TITLE
xca: Fix compile error on 10.14.6

### DIFF
--- a/security/xca/PortFile
+++ b/security/xca/PortFile
@@ -4,6 +4,8 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   qt5 1.0
 
+revision                    1
+
 github.setup                chris2511 xca 2.1.2 RELEASE.
 github.tarball_from         releases
 
@@ -40,7 +42,6 @@ configure.cppflags-append   -L${prefix}/lib
 
 build.target                xca.app
 
-destroot.violate_mtree      yes
 destroot {
     copy ${worksrcpath}/${name}-${version}/${name}.app ${destroot}${applications_dir}
 }

--- a/security/xca/files/patch-disable-codesigning.diff
+++ b/security/xca/files/patch-disable-codesigning.diff
@@ -2,11 +2,13 @@
 +++ Makefile	2019-07-22 12:18:00.000000000 +0200
 @@ -181,9 +181,10 @@
  	ln -s xca.html $(DMGSTAGE)/manual/index.html
- 	otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users" >&2
- 	$(MACDEPLOYQT) $(DMGSTAGE)/xca.app
+-	otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users" >&2
+-	$(MACDEPLOYQT) $(DMGSTAGE)/xca.app
 -	rpath="`otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users"`" && \
 -	if test -n "$$rpath"; then echo "  ERROR $$rpath"; false; fi
 -	-codesign --force --deep --signature-size=96000 -s "Christian Hohnstaedt" $(DMGSTAGE)/xca.app --timestamp
++	#otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users" >&2
++	$(MACDEPLOYQT) $(DMGSTAGE)/xca.app
 +############# disable code signing by original author ###########################################################
 +#	rpath="`otool -l $(DMGSTAGE)/xca.app/Contents/MacOS/xca | grep -e "chris\|Users"`" && \
 +#	if test -n "$$rpath"; then echo "  ERROR $$rpath"; false; fi


### PR DESCRIPTION
- fix build error on 10.14.6
- remove unnecessary install warning

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
