### PR TITLE
libfmt: update version to 5.3.0

### DIFF
--- a/devel/libfmt/Portfile
+++ b/devel/libfmt/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake  1.1
 PortGroup           cxx11  1.1
 
-github.setup        fmtlib fmt 4.1.0
+github.setup        fmtlib fmt 5.3.0
 name                libfmt
 homepage            http://fmtlib.net
 categories          devel
@@ -18,8 +18,8 @@ long_description    \
     fmt (formerly cppformat) is an open-source formatting library. \
     It can be used as a safe alternative to printf or as a fast alternative to C++ IOStreams.
 
-checksums           rmd160  cae7445443637ce7887bb6b2ef8136d7f57ded1b \
-                    sha256  4c322d3976cb4de91263fbcc1e8ddeffa6c5f32049b3ca2f740ba6a053df7052
+checksums           rmd160  7ab5001c8144d8d3d25b1726295e1447d065d694 \
+                    sha256  7b40e266c16cbcc16a9d8743713d012be3188872c4bce5dde3556cdf3b5846d2
 
 configure.args-append \
     -DBUILD_SHARED_LIBS=ON

--- a/devel/libfmt/Portfile
+++ b/devel/libfmt/Portfile
@@ -19,7 +19,8 @@ long_description    \
     It can be used as a safe alternative to printf or as a fast alternative to C++ IOStreams.
 
 checksums           rmd160  7ab5001c8144d8d3d25b1726295e1447d065d694 \
-                    sha256  7b40e266c16cbcc16a9d8743713d012be3188872c4bce5dde3556cdf3b5846d2
+                    sha256  7b40e266c16cbcc16a9d8743713d012be3188872c4bce5dde3556cdf3b5846d2 \
+                    size 662560
 
 configure.args-append \
     -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

This PR updates libfmt to 5.3.0. I had previously submitted a PR (#4898) but closed it since I wanted to make the PR from a non-master branch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->