### PR TITLE
xorg-*xcb*: use python37 by default and more

### DIFF
--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -50,33 +50,23 @@ variant docs description "Install extra documentation" {
         DOXYGEN=${prefix}/bin/doxygen
 }
 
-variant python27 conflicts python34 python35 python36 python37 description {Use python 2.7} {
-    depends_run-append      port:python27
-    configure.python        ${prefix}/bin/python2.7
-}
-
-variant python34 conflicts python27 python35 python36 python37 description {Use python 3.4} {
-    depends_run-append      port:python34
-    configure.python        ${prefix}/bin/python3.4
-}
-
-variant python35 conflicts python27 python34 python36 python37 description {Use python 3.5} {
-    depends_run-append      port:python35
+variant python35 conflicts python36 python37 description {Use python 3.5} {
+    depends_build-append    port:python35
     configure.python        ${prefix}/bin/python3.5
 }
 
-variant python36 conflicts python27 python34 python35 python37 description {Use python 3.6} {
-    depends_run-append      port:python36
+variant python36 conflicts python35 python37 description {Use python 3.6} {
+    depends_build-append    port:python36
     configure.python        ${prefix}/bin/python3.6
 }
 
-variant python37 conflicts python27 python34 python35 python36 description {Use python 3.7} {
-    depends_run-append      port:python37
+variant python37 conflicts python35 python36 description {Use python 3.7} {
+    depends_build-append    port:python37
     configure.python        ${prefix}/bin/python3.7
 }
 
-if {![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
-    default_variants +python27
+if {![variant_isset python35] && ![variant_isset python36]} {
+    default_variants +python37
 }
 
 livecheck.type  regex

--- a/x11/xorg-xcb-proto/Portfile
+++ b/x11/xorg-xcb-proto/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            xorg-xcb-proto
 version         1.13
-revision        1
+revision        2
 categories      x11 devel
 license         X11
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -27,38 +27,26 @@ use_autoreconf  yes
 
 depends_run     port:libxml2
 
-variant python27 conflicts python34 python35 python36 python37 description {Use python 2.7} {
-    depends_lib-append      port:python27
-    configure.python        ${prefix}/bin/python2.7
-    license_noconflict      python27
-}
-
-variant python34 conflicts python27 python35 python36 python37 description {Use python 3.4} {
-    depends_lib-append      port:python34
-    configure.python        ${prefix}/bin/python3.4
-    license_noconflict      python34
-}
-
-variant python35 conflicts python27 python34 python36 python37 description {Use python 3.5} {
-    depends_lib-append      port:python35
+variant python35 conflicts python36 python37 description {Use python 3.5} {
+    depends_build-append    port:python35
     configure.python        ${prefix}/bin/python3.5
     license_noconflict      python35
 }
 
-variant python36 conflicts python27 python34 python35 python37 description {Use python 3.6} {
-    depends_lib-append      port:python36
+variant python36 conflicts python35 python37 description {Use python 3.6} {
+    depends_build-append    port:python36
     configure.python        ${prefix}/bin/python3.6
     license_noconflict      python36
 }
 
-variant python37 conflicts python27 python34 python35 python36 description {Use python 3.7} {
-    depends_lib-append      port:python37
+variant python37 conflicts python35 python36 description {Use python 3.7} {
+    depends_build-append    port:python37
     configure.python        ${prefix}/bin/python3.7
     license_noconflict      python37
 }
 
-if {![variant_isset python34] && ![variant_isset python35] && ![variant_isset python36] && ![variant_isset python37]} {
-    default_variants +python27
+if {![variant_isset python35] && ![variant_isset python36]} {
+    default_variants +python37
 }
 
 livecheck.type  regex


### PR DESCRIPTION
#### Description

 xorg-xcb-proto: update python dependencies

* Make python37 variant the default
* Make python depends_build only. Python is not necessary to use ports
depending on XCB. Instead, python is used to build xorg-libxcb only.
* Remove python34. Python 3.4 has reached EOL on March 18, 2019.

Closes: https://trac.macports.org/ticket/58727
See: https://trac.macports.org/ticket/58582

[1] https://www.python.org/downloads/release/python-3410/

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G84
Command Line Tools 10.3.0.0.1.1562985497

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
