### PR TITLE
mpstats: add support for commandlinetools version

### DIFF
--- a/sysutils/mpstats/Portfile
+++ b/sysutils/mpstats/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mpstats
 version             0.1.8
-revision            3
+revision            4
 categories          sysutils macports
 license             BSD
 platforms           darwin

--- a/sysutils/mpstats/files/mpstats.tcl
+++ b/sysutils/mpstats/files/mpstats.tcl
@@ -102,6 +102,22 @@ proc getgccinfo {} {
     }
 }
 
+# extraction of CommandLineTools version
+proc getcltinfo {} {
+    if {[file exists /usr/lib/libxcselect.dylib]} {
+        set pkgname "CLTools_Executables"
+    } else {
+        # Mountain Lion (10.8) and below. Note that we prefer Xcode over CLT for <= 10.8
+        set pkgname "DeveloperToolsCLI"
+    }
+
+    if {![catch {exec pkgutil --pkg-info=com.apple.pkg.${pkgname}} results]} {
+        return [lindex $results 3]
+    }
+
+    return none
+}
+
 ###### JSON Encoding helper procs ######
 
 ##
@@ -373,6 +389,7 @@ proc action_stats {subcommands} {
     dict set os cxx_stdlib ${macports::cxx_stdlib}
     dict set os gcc_version [getgccinfo]
     dict set os xcode_version ${macports::xcodeversion}
+    dict set os clt_version [getcltinfo]
 
     # Build dictionary of port information
     dict set ports active   [get_installed_ports yes]


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] enhancement

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode -

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->