### PR TITLE
Update to py-isce2  v2.3.2

### DIFF
--- a/python/py-isce2/Portfile
+++ b/python/py-isce2/Portfile
@@ -6,21 +6,22 @@ PortGroup           python 1.0
 PortGroup           active_variants 1.1
 PortGroup           compilers 1.0
 
-github.setup        isce-framework isce2 2.3.1 v
+github.setup        isce-framework isce2 2.3.2 v
 revision            0
 name                py-isce2
 platforms           darwin
 license             Apache
 
 maintainers         {gps.caltech.edu:piyush @piyushrpt} \
+                    {univ-lyon1.fr:matthieu.volat @mazhe} \
                     openmaintainer
 
 description         Library for SAR data processing
 long_description    ${description}
 
-checksums           sha256  abe83267967727e7a474faa42150cf5c0ed25a3001445797b6e9297fb7fe395c \
-                    rmd160  3608d94774212b03ed5d55d049cc0a1e586b6476 \
-                    size    5370341
+checksums           sha256  86ea039f5f98a61f21e1e5f446c366f8c45432c2b13b482125acbc52d221b37b \
+                    rmd160  2d1716a6ed2b78983085adad936683d3aa578731 \
+                    size    5240075
 
 use_configure       no
 
@@ -141,6 +142,8 @@ Other important notes
     destroot {
         xinstall -m 755 -d ${destroot}${python.pkgd}
         file copy -force ${workinstallpath} ${destroot}${python.pkgd}/
+        xinstall -m 755 -d ${destroot}${python.pkgd}/isce/helper
+        touch ${destroot}${python.pkgd}/isce/helper/completed
         xinstall -m 755 -d \
             ${destroot}${prefix}/share/${subport}/stack \
             ${destroot}${prefix}/share/${subport}/stack/stripmapStack \


### PR DESCRIPTION
#### Description

This PR updates py-isce2 to v2.3.2 

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 
Xcode 10.3 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
