### PR TITLE
libevent: remove 'conflicts' with libev

### DIFF
--- a/devel/libevent/Portfile
+++ b/devel/libevent/Portfile
@@ -21,7 +21,10 @@ long_description    The libevent API provides a mechanism to execute \
 
 homepage            http://libevent.org
 
-conflicts           libev
+# https://trac.macports.org/ticket/58733
+# See ticket for context, until we determine long-term solution.
+# 
+# conflicts           libev
 
 checksums           rmd160 a8a158035d7677e9db00f63fab45fbadd3da41df \
                     sha256 e864af41a336bb11dab1a23f32993afe963c1f69618bd9292b89ecf6904845b0 \


### PR DESCRIPTION
At least one port, nghttp2, depends on both libevent and libev.

See https://trac.macports.org/ticket/58733

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.9
Xcode 5.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
