### PR TITLE
upt, upt-macports: Update for recursive packaging support

### DIFF
--- a/python/py-upt-macports/Portfile
+++ b/python/py-upt-macports/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-set git_hash        9694e263ef7df77f812e60272880438ef541f2bb
+set git_hash        f3c01cfd8ea12bf8d1ba1329849311bd6719d98c
 github.setup        macports upt-macports ${git_hash}
-version             0.1-20190702
+version             0.1-20190801
 name                py-${github.project}
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {@korusuke somaiya.edu:karan.sheth} openmaintainer
 description         MacPorts backend for upt.
 long_description    ${description}
 
-checksums           sha256  37e65ae65a102021bef08143d7b0e0a7a6e49641b13e352b5e124002e0576255 \
-                    rmd160  1b960dcf245d2c69317730967d5d2f4b85e2d68e \
-                    size    9174
+checksums           rmd160  89165715208e905417515407b874faf00152a434 \
+                    sha256  62a769686c3da3eb971b074dc77177daa906a38ce0b4c2ea0483e104128cf78c \
+                    size    10141
 
 python.versions     37
 
@@ -29,7 +29,8 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-setuptools
 
     depends_lib-append \
-                    port:py${python.version}-jinja2
+                    port:py${python.version}-jinja2 \
+                    port:py${python.version}-requests
 
     test.run        yes
     test.cmd        ${python.bin} -m unittest

--- a/sysutils/upt/Portfile
+++ b/sysutils/upt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                upt
-version             0.9
+version             0.10.3
 revision            0
 
 categories-prepend  sysutils
@@ -20,13 +20,14 @@ homepage            https://framagit.org/upt/upt
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           sha256  b967cda25e8e5a634a450886e98ebeaf5aa51220e8888a17a34d78d001f96035 \
-                    rmd160  aac9b9c2f52ac75eec0700ac996a87f0151923f9 \
-                    size    25969
+checksums           rmd160  c7335c931d512f2d70da45961258c059415dfd8c \
+                    sha256  e08fcea114cf71ed98dd5f9085c40892301b22ebba9448d2940be77737596258 \
+                    size    28655
 
 python.default_version  37
 
 depends_lib-append \
+                port:py${python.version}-packaging \
                 port:py${python.version}-spdx-lookup \
                 port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->
py-upt-macports: update includes recursive packaging feature
upt : update to version 0.10.3

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
Ubuntu 18.04

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
