### PR TITLE
libxml2: fix building against libxml2

### DIFF
--- a/textproc/libxml2/Portfile
+++ b/textproc/libxml2/Portfile
@@ -6,7 +6,7 @@ PortSystem          1.0
 
 name                libxml2
 version             2.9.9
-revision            1
+revision            2
 categories          textproc
 platforms           darwin
 license             MIT
@@ -57,6 +57,7 @@ configure.args      --disable-silent-rules \
 destroot.keepdirs   ${destroot}${prefix}/etc/xml
 post-destroot {
     xinstall -m 0755 -d ${destroot}${prefix}/etc/xml
+    ln -s ${prefix}/include/unicode ${destroot}${prefix}/include/libxml2/unicode
 }
 
 test.run            yes


### PR DESCRIPTION
#### Description

Addresses

* https://trac.macports.org/ticket/58350
* https://trac.macports.org/ticket/57990
* Perl5-Alien/Alien-Libxml2#13

Follows the symlink suggestion so as not to have the same situation as glib2.

```
$ cpanm Alien::Libxml2
--> Working on Alien::Libxml2
Fetching http://www.cpan.org/authors/id/P/PL/PLICEASE/Alien-Libxml2-0.09.tar.gz ... OK
Configuring Alien-Libxml2-0.09 ... OK
Building and testing Alien-Libxml2-0.09 ... OK
Successfully installed Alien-Libxml2-0.09
1 distribution installed
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G7024
Xcode 9.4.1 9F2000 

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
