### PR TITLE
xcodeversion: repeal use_xcode yes

### DIFF
--- a/_resources/port1.0/group/xcodeversion-1.0.tcl
+++ b/_resources/port1.0/group/xcodeversion-1.0.tcl
@@ -14,11 +14,6 @@
 options minimum_xcodeversions
 default minimum_xcodeversions {}
 
-# Xcode should be used for this port
-if {[info exists use_xcode]} {
-    use_xcode yes
-}
-
 platform macosx {
     pre-extract {
         foreach {darwin_major minimum_xcodeversion} [join ${minimum_xcodeversions}] {
@@ -26,8 +21,8 @@ platform macosx {
                 if {![info exists xcodeversion] || $xcodeversion == "none"} {
                     ui_error "Couldn't determine your Xcode version (from '/usr/bin/xcodebuild -version')."
                     ui_error ""
-                    ui_error "If you have not installed Xcode, install it now; see:"
-                    ui_error "https://guide.macports.org/chunked/installing.xcode.html"
+                    ui_error "On macOS ${macosx_version}, ${name} @${version} requires Xcode ${minimum_xcodeversion} or later but you have none installed."
+                    ui_error "See https://guide.macports.org/chunked/installing.xcode.html for download links."
                     ui_error ""
                     return -code error "unable to find Xcode"
                 }


### PR DESCRIPTION
#### Description

I've [tested] installing 58 xcodeversion ports without Xcode, 62.07% percent of them install successfully. Thus the xcodeverion's use_xcode change needs to be reverted. I've also refactored the error message to be more clarifying.

I will patch the individual ports that caused this change in the first place.

[tested]: https://docs.google.com/spreadsheets/d/1NYmJsedVFLn7PeYFB08gCimqYANsbv7xwd78k4yaQPs/edit#gid=664131806

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode none

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->