### PR TITLE
commons-lang3: new port

### DIFF
--- a/java/commons-lang3/Portfile
+++ b/java/commons-lang3/Portfile
@@ -1,0 +1,63 @@
+PortSystem 1.0
+PortGroup           java 1.0
+
+name                commons-lang3
+version             3.9
+
+categories          java
+license             Apache-2
+maintainers         nomaintainer
+platforms           darwin
+
+description         Apache Commons Lang
+long_description    The Lang Component provides a host of helper utilities for \
+                    the java.lang API, notably String manipulation methods, basic \
+                    numerical methods, object reflection, creation and serialization, \
+                    and System properties. Additionally it contains an inheritable \
+                    enum type, an exception structure that supports multiple types \
+                    of nested-Exceptions, basic enhancements to java.util.Date and \
+                    a series of utlities dedicated to help with building methods, \
+                    such as hashCode, toString and equals.
+homepage            https://commons.apache.org/lang/
+                
+distname            ${name}-${version}-src
+master_sites        apache:commons/lang/source/
+
+checksums           rmd160  c63c683570ae7a1391434b7e238c2358cb63380b \
+                    sha256  66415e0d1c843b04c61dea6b7e7e85a8f1469eaeb1174241622650aff7728e68 \
+                    size    987753
+
+# Currently has issues building on later JDK versions,
+# see https://github.com/macports/macports-ports/pull/4925#issuecomment-519172241
+#java.version       1.8+
+java.version        1.8
+java.fallback       openjdk8
+
+depends_build       bin:mvn3:maven3
+                
+use_configure       no
+
+set maven_local_repository ${worksrcpath}/.m2/repository
+pre-build {
+    file mkdir ${maven_local_repository}
+}
+
+build.cmd           mvn3
+build.target        site
+build.pre_args      -Dmaven.repo.local=${maven_local_repository} \
+                    -Drat.ignoreErrors=true \
+                    -DskipTests
+
+destroot {
+    # Ensure needed directories
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+        
+    # Install jar
+    xinstall -m 644 ${worksrcpath}/target/${name}-${version}.jar \
+        ${destroot}${prefix}/share/java/${name}.jar
+}
+
+livecheck.type  regex
+livecheck.url   https://commons.apache.org/proper/commons-lang/download_lang.cgi
+livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"


### PR DESCRIPTION
Based on submission by @someuser12: https://trac.macports.org/ticket/58756 (I have also fixed whitespace and livecheck, and removed sha1 and md5 checksums since upstream only provides sha512 and PGP signature.)

#### Description
To be used with a future `pdftk-java` port.
<!-- Note: it is best make pull requests from a branch rather than from master -->
###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
