### PR TITLE
commons-logging: update to 1.2, fix livecheck and whitespace

### DIFF
--- a/java/commons-logging/Portfile
+++ b/java/commons-logging/Portfile
@@ -1,49 +1,49 @@
 PortSystem 1.0
 PortGroup java 1.0
 
-name			commons-logging
-version			1.1.1
+name                commons-logging
+version             1.1.1
 
-categories		java
-license			Apache-2
-maintainers		nomaintainer
-platforms		darwin
+categories          java
+license             Apache-2
+maintainers         nomaintainer
+platforms           darwin
 
-description		Jakarta Commons-Logging
-long_description	Commons-Logging is a wrapper around a variety of \
-				logging API implementations.
-homepage		https://commons.apache.org/logging/
-				
-distname		${name}-${version}-src
-master_sites		apache:commons/logging/source/
-checksums		md5 e5cfa8cca13152d7545fde6b1783c60a \
-				sha1 9f5197e32d8b94dfecbb13d4099063b7b2743c96 \
-				rmd160 ddf1c4efe66f13b53341ba78d0b4ba6991e5f16d
+description         Jakarta Commons-Logging
+long_description    Commons-Logging is a wrapper around a variety of \
+                    logging API implementations.
+homepage            https://commons.apache.org/logging/
 
-depends_build		bin:ant:apache-ant \
-				port:junit
-depends_lib		bin:java:kaffe \
-				port:jakarta-log4j \
-				port:servlet23-api
-				
-use_configure		no
+distname            ${name}-${version}-src
+master_sites        apache:commons/logging/source/
+checksums           md5 e5cfa8cca13152d7545fde6b1783c60a \
+                    sha1 9f5197e32d8b94dfecbb13d4099063b7b2743c96 \
+                    rmd160 ddf1c4efe66f13b53341ba78d0b4ba6991e5f16d
 
-build.cmd		ant
-build.target		all
-build.args		-lib ${prefix}/share/java/junit.jar \
-				-Dcomponent.version=${version} \
-				-Dlog4j12.jar=${prefix}/share/java/jakarta-log4j.jar \
-				-Dlogkit.jar=NONE \
-				-Davalon-framework.jar=NONE \
-				-Dservletapi.jar=${prefix}/share/java/servlet23-api.jar
+depends_build       bin:ant:apache-ant \
+                    port:junit
+depends_lib         bin:java:kaffe \
+                    port:jakarta-log4j \
+                    port:servlet23-api
 
-destroot	{
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-	xinstall -m 644 ${worksrcpath}/target/commons-logging-${version}.jar \
-		${destroot}${prefix}/share/java/commons-logging.jar
-	xinstall -m 644 ${worksrcpath}/target/commons-logging-api-${version}.jar \
-		${destroot}${prefix}/share/java/commons-logging-api.jar
+use_configure       no
+
+build.cmd           ant
+build.target        all
+build.args          -lib ${prefix}/share/java/junit.jar \
+                    -Dcomponent.version=${version} \
+                    -Dlog4j12.jar=${prefix}/share/java/jakarta-log4j.jar \
+                    -Dlogkit.jar=NONE \
+                    -Davalon-framework.jar=NONE \
+                    -Dservletapi.jar=${prefix}/share/java/servlet23-api.jar
+
+destroot    {
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+    xinstall -m 644 ${worksrcpath}/target/commons-logging-${version}.jar \
+        ${destroot}${prefix}/share/java/commons-logging.jar
+    xinstall -m 644 ${worksrcpath}/target/commons-logging-api-${version}.jar \
+        ${destroot}${prefix}/share/java/commons-logging-api.jar
 }
 
 livecheck.type  regex

--- a/java/commons-logging/Portfile
+++ b/java/commons-logging/Portfile
@@ -2,28 +2,35 @@ PortSystem 1.0
 PortGroup java 1.0
 
 name                commons-logging
-version             1.1.1
+version             1.2
 
 categories          java
 license             Apache-2
 maintainers         nomaintainer
 platforms           darwin
 
-description         Jakarta Commons-Logging
+description         Apache Commons-Logging
 long_description    Commons-Logging is a wrapper around a variety of \
                     logging API implementations.
 homepage            https://commons.apache.org/logging/
 
 distname            ${name}-${version}-src
 master_sites        apache:commons/logging/source/
-checksums           md5 e5cfa8cca13152d7545fde6b1783c60a \
-                    sha1 9f5197e32d8b94dfecbb13d4099063b7b2743c96 \
-                    rmd160 ddf1c4efe66f13b53341ba78d0b4ba6991e5f16d
+checksums           rmd160  ff628c8de57f7da8572de3554196ee033e255312 \
+                    sha256  49665da5a60d033e6dff40fe0a7f9173e886ae859ce6096c1afe34c48b677c81 \
+                    size    188536
+
+# This port would normally be compatible with Java 1.2+,
+# but because it doesn't build with JDK 9 or higher,
+# and there is currently no way to specify a maximum JDK version
+# for the Java portgroup, force JDK 8 to be used.
+#java.version       1.2+
+java.version        1.8
+java.fallback       openjdk8
 
 depends_build       bin:ant:apache-ant \
                     port:junit
-depends_lib         bin:java:kaffe \
-                    port:jakarta-log4j \
+depends_lib         port:jakarta-log4j \
                     port:servlet23-api
 
 use_configure       no
@@ -47,5 +54,5 @@ destroot    {
 }
 
 livecheck.type  regex
-livecheck.url   https://commons.apache.org/downloads/download_logging.cgi
+livecheck.url   https://commons.apache.org/proper/commons-logging/download_logging.cgi
 livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/58675

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
