### PR TITLE
commons-lang: update to 2.6, fix livecheck and whitespace

### DIFF
--- a/java/commons-lang/Portfile
+++ b/java/commons-lang/Portfile
@@ -1,50 +1,50 @@
 PortSystem 1.0
 
-name				commons-lang
-version				2.4
+name                commons-lang
+version             2.4
 
-categories			java
-license				Apache-2
-maintainers			nomaintainer
-platforms			darwin
+categories          java
+license             Apache-2
+maintainers         nomaintainer
+platforms           darwin
 
-description			Jakarta Commons-Lang
-long_description	The Lang Component provides a host of helper utilities for \
-					the java.lang API, notably String manipulation methods, basic \
-					numerical methods, object reflection, creation and serialization, \
-					and System properties. Additionally it contains an inheritable \
-					enum type, an exception structure that supports multiple types \
-					of nested-Exceptions, basic enhancements to java.util.Date and \
-					a series of utlities dedicated to help with building methods, \
-					such as hashCode, toString and equals.
-homepage			https://commons.apache.org/lang/
-				
-distname			${name}-${version}-src
-master_sites		apache:commons/lang/source/
+description         Jakarta Commons-Lang
+long_description    The Lang Component provides a host of helper utilities for \
+                    the java.lang API, notably String manipulation methods, basic \
+                    numerical methods, object reflection, creation and serialization, \
+                    and System properties. Additionally it contains an inheritable \
+                    enum type, an exception structure that supports multiple types \
+                    of nested-Exceptions, basic enhancements to java.util.Date and \
+                    a series of utlities dedicated to help with building methods, \
+                    such as hashCode, toString and equals.
+homepage            https://commons.apache.org/lang/
+
+distname            ${name}-${version}-src
+master_sites        apache:commons/lang/source/
 checksums           md5     625ff5f2f968dd908bca43c9469d6e6b \
                     sha1    61ec8be8c2cf8f4c4272545666f936dd9f7e2a29
 
-depends_build		bin:ant:apache-ant
-depends_lib			bin:java:kaffe
-				
-use_configure		no
+depends_build       bin:ant:apache-ant
+depends_lib         bin:java:kaffe
 
-build.cmd			ant
-build.target		dist
-build.args			-Dfinal.name=${name}
+use_configure       no
+
+build.cmd           ant
+build.target        dist
+build.args          -Dfinal.name=${name}
 
 destroot {
-	# Ensure needed directories
-	xinstall -m 755 -d ${destroot}${prefix}/share/java \
-		${destroot}${prefix}/share/doc
-		
-	# Install jar
-	xinstall -m 644 ${worksrcpath}/${name}.jar \
-		${destroot}${prefix}/share/java
-		
-	# Install docs
-	file copy ${worksrcpath}/xdocs \
-		${destroot}${prefix}/share/doc/${name}
+    # Ensure needed directories
+    xinstall -m 755 -d ${destroot}${prefix}/share/java \
+        ${destroot}${prefix}/share/doc
+
+    # Install jar
+    xinstall -m 644 ${worksrcpath}/${name}.jar \
+        ${destroot}${prefix}/share/java
+
+    # Install docs
+    file copy ${worksrcpath}/xdocs \
+        ${destroot}${prefix}/share/doc/${name}
 }
 
 livecheck.type  regex

--- a/java/commons-lang/Portfile
+++ b/java/commons-lang/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name                commons-lang
-version             2.4
+version             2.6
 
 categories          java
 license             Apache-2
@@ -21,8 +21,9 @@ homepage            https://commons.apache.org/lang/
 
 distname            ${name}-${version}-src
 master_sites        apache:commons/lang/source/
-checksums           md5     625ff5f2f968dd908bca43c9469d6e6b \
-                    sha1    61ec8be8c2cf8f4c4272545666f936dd9f7e2a29
+checksums           rmd160  9542bcc3323ddf1e93400e68f9e4d527c71bffd0 \
+                    sha256  05479771851be0af057032fa26ad90aa0c91c10e1fc4439558a1ffa6f053bcd7 \
+                    size    564032
 
 depends_build       bin:ant:apache-ant
 depends_lib         bin:java:kaffe
@@ -39,14 +40,14 @@ destroot {
         ${destroot}${prefix}/share/doc
 
     # Install jar
-    xinstall -m 644 ${worksrcpath}/${name}.jar \
+    xinstall -m 644 ${worksrcpath}/target/${name}.jar \
         ${destroot}${prefix}/share/java
 
     # Install docs
-    file copy ${worksrcpath}/xdocs \
+    file copy ${worksrcpath}/src/site/xdoc \
         ${destroot}${prefix}/share/doc/${name}
 }
 
 livecheck.type  regex
-livecheck.url   https://commons.apache.org/downloads/download_lang.cgi
+livecheck.url   https://commons.apache.org/proper/commons-lang/download_lang.cgi
 livecheck.regex "${name}-(\\d+\\.\\d+(\\.\\d+)?)-src.tar.gz"


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
