### PR TITLE
ccache, ccache-devel: update to 3.7.2

### DIFF
--- a/devel/ccache-devel/Portfile
+++ b/devel/ccache-devel/Portfile
@@ -4,11 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 epoch               1
-github.setup        ccache ccache 3.7.1 v
+github.setup        ccache ccache 3.7.2 v
 revision            0
-checksums           rmd160  ea189d1a42490050d591551e4396a89d4c611e23 \
-                    sha256  d618e6c257d000d974a7ebb46aaefd872f77a1efeaefe33829d7396b2ec60420 \
-                    size    384420
+# Use tarball, since the releases archive discourages running ./autogen.sh
+github.tarball_from tarball
+checksums           rmd160  a2aa777967d47700e6de73fc33e844c282222aeb \
+                    sha256  cbaafc73944864f76f910695b68ab82162b02c2ff0cec0e25292c553befaca0b \
+                    size    386099
 
 name                ccache-devel
 categories          devel
@@ -40,10 +42,9 @@ autoconf.cmd        ./autogen.sh
 
 depends_build       port:autoconf \
                     port:automake \
-                    port:libtool \
-                    bin:perl:perl5
+                    port:libtool
 
 depends_lib         port:asciidoc \
                     port:zlib
-    
+
 conflicts           ccache

--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -3,11 +3,13 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ccache ccache 3.7.1 v
+github.setup        ccache ccache 3.7.2 v
 revision            0
-checksums           rmd160  ea189d1a42490050d591551e4396a89d4c611e23 \
-                    sha256  d618e6c257d000d974a7ebb46aaefd872f77a1efeaefe33829d7396b2ec60420 \
-                    size    384420
+# Use tarball, since the releases archive discourages running ./autogen.sh
+github.tarball_from tarball
+checksums           rmd160  a2aa777967d47700e6de73fc33e844c282222aeb \
+                    sha256  cbaafc73944864f76f910695b68ab82162b02c2ff0cec0e25292c553befaca0b \
+                    size    386099
 
 categories          devel
 platforms           darwin freebsd


### PR DESCRIPTION
`ccache-devel`: remove unneeded build dependency `perl5`

Closes: https://trac.macports.org/ticket/58481

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G84
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
