### PR TITLE
xorg-{xcb-proto,libxcb}: add notes about Python dependencies

### DIFF
--- a/x11/xorg-libxcb/Portfile
+++ b/x11/xorg-libxcb/Portfile
@@ -50,6 +50,14 @@ variant docs description "Install extra documentation" {
         DOXYGEN=${prefix}/bin/doxygen
 }
 
+# No need to use require_active_variants here. Technically, `xorg-libxcb +python37` builds fine
+# with `xorg-xcb-proto +python36` as the xcbgen module in xorg-xcb-proto is not located using
+# usual Python import mechanism. Instead, the path for xcbgen is recorded in
+# `$prefix/lib/pkgconfig/xcb-proto.pc` as the pythondir variable when building xorg-xcb-proto
+# and the build system of libxcb loads xcbgen using that pkg-config variable [1].
+#
+# [1] https://gitlab.freedesktop.org/xorg/lib/libxcb/blob/1.13.1/configure.ac#L85
+
 variant python35 conflicts python36 python37 description {Use python 3.5} {
     depends_build-append    port:python35
     configure.python        ${prefix}/bin/python3.5

--- a/x11/xorg-xcb-proto/Portfile
+++ b/x11/xorg-xcb-proto/Portfile
@@ -27,6 +27,13 @@ use_autoreconf  yes
 
 depends_run     port:libxml2
 
+# Using depends_build instead of depends_lib for pythonXY even if there is a Python module xcbgen
+# as the xcbgen module is only used to build X bindings like libxcb or xpp [1]. It's intended for
+# neither applications nor end users. In other words, xcbgen is not needed to run applications
+# using XCB.
+#
+# [1] https://github.com/polybar/xpp
+
 variant python35 conflicts python36 python37 description {Use python 3.5} {
     depends_build-append    port:python35
     configure.python        ${prefix}/bin/python3.5


### PR DESCRIPTION
#### Description

See discussions in my previous commits [1][2].

[1] https://github.com/macports/macports-ports/commit/ae53b6b0f446bfb57eeedaa778c3895974c0a665
[2] https://github.com/macports/macports-ports/commit/ebf645f6789d57183fef6a525cff1a31e19349aa

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?