### PR TITLE
mariadb{,-10.0,-10.1}: remove +openssl due to incompatibility with openssl 1.1

### DIFF
--- a/databases/mariadb-10.0/Portfile
+++ b/databases/mariadb-10.0/Portfile
@@ -164,13 +164,6 @@ if {$subport eq $name} {
         }
     }
 
-    variant openssl description {Enable OpenSSL support} {
-
-        depends_lib-append      path:lib/libssl.dylib:openssl
-        configure.args-delete   -DWITH_SSL:STRING=no
-        configure.args-append   -DWITH_SSL:STRING=system
-    }
-
     variant system_readline description {Use system readline instead of bundled readline} {
     
         # Add readline support.

--- a/databases/mariadb-10.1/Portfile
+++ b/databases/mariadb-10.1/Portfile
@@ -166,13 +166,6 @@ if {$subport eq $name} {
         }
     }
 
-    variant openssl description {Enable OpenSSL support} {
-
-        depends_lib-append      path:lib/libssl.dylib:openssl
-        configure.args-delete   -DWITH_SSL:STRING=no
-        configure.args-append   -DWITH_SSL:STRING=system
-    }
-
     variant system_readline description {Use system readline instead of bundled readline} {
 
         # Add readline support.

--- a/databases/mariadb/Portfile
+++ b/databases/mariadb/Portfile
@@ -163,13 +163,6 @@ if {$subport eq $name} {
         }
     }
 
-    variant openssl description {Enable OpenSSL support} {
-
-        depends_lib-append      path:lib/libssl.dylib:openssl
-        configure.args-delete   -DWITH_SSL:STRING=no
-        configure.args-append   -DWITH_SSL:STRING=system
-    }
-
     variant system_readline description {Use system readline instead of bundled readline} {
     
         # Add readline support.


### PR DESCRIPTION
#### Description

mariadb +openssl fails during running cmake as the test program does not compile [1].
mariadb-10.1 +openssl fails in mysys_ssl/my_crypt.cc [2].

I didn't test mariadb-10.0. Apparently it's not compatible with OpenSSL 1.1 either [3].

Closes: https://trac.macports.org/ticket/58608

[1] https://github.com/MariaDB/server/blob/5.5/cmake/ssl.cmake#L81-L87
[2] https://github.com/MariaDB/server/blob/10.1/mysys_ssl/my_crypt.cc#L40
[3] https://jira.mariadb.org/browse/MDEV-17510

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
