### PR TITLE
py-h5py: remove obsolete -devel subports

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -26,17 +26,7 @@ long_description  \
     datatypes and data structures and their HDF5 equivalents vastly \
     simplifies the process of reading and writing data from Python.
 
-homepage                http://www.h5py.org
-
-# Dropping -devel versions; mature & stable
-# Can be removed after 6/13/2019
-# Support for -devel
-set DEV_VERSION     0
-
-subport                 py27-h5py-devel {set DEV_VERSION 27}
-subport                 py34-h5py-devel {set DEV_VERSION 34}
-subport                 py35-h5py-devel {set DEV_VERSION 35}
-subport                 py36-h5py-devel {set DEV_VERSION 36}
+homepage                https://www.h5py.org
 
 python.versions         27 34 35 36 37
 python.default_version  27
@@ -45,15 +35,6 @@ checksums \
     rmd160  5e2c0025768dc4a0ef7ae53e11ebdd67c4224509 \
     sha256  aa1ae897c63cfc62f600bb5ed2be7ba771eff42745e0bdfa08b668fdb11f86c6 \
     size    296584
-
-if {${DEV_VERSION}} {
-    # Dropping -devel versions; mature & stable
-    # Can be removed after 6/13/2019
-    PortGroup   obsolete 1.0
-    replaced_by py${python.version}-h5py
-} elseif {${name} ne ${subport}} {
-    conflicts               py${python.version}-h5py-devel
-}
 
 # Only check against releases.
 livecheck.regex             "archive/(\[0-9.\]+)\.tar\.gz"


### PR DESCRIPTION
Were marked obsolete one year ago in a2e128e268

Use HTTPS homepage

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
