### PR TITLE
proftpd, nagios-plugins: use `port:` in mysql variants

### DIFF
--- a/net/nagios-plugins/Portfile
+++ b/net/nagios-plugins/Portfile
@@ -52,13 +52,13 @@ configure.args      --sbindir=${prefix}/share/nagios/cgi-bin \
                     --with-ps-varlist="procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procpcpu,procprog,&pos"
 
 variant mysql56 conflicts mysql57 {
-    depends_lib-append path:bin/mysql_config56:mysql56
+    depends_lib-append port:mysql56
     configure.args-delete --without-mysql
     configure.args-append --with-mysql=${prefix}/lib/mysql56
 }
 
 variant mysql57 conflicts mysql56 {
-    depends_lib-append path:bin/mysql_config57:mysql57
+    depends_lib-append port:mysql57
     configure.args-delete --without-mysql
     configure.args-append --with-mysql=${prefix}/lib/mysql57
 }

--- a/net/proftpd/Portfile
+++ b/net/proftpd/Portfile
@@ -52,7 +52,7 @@ pre-destroot {
 }
 
 variant mysql57 conflicts postgresql11 sqlite3 description {Build with mysql 5.7 support} {
-    depends_lib-append   path:bin/mysql_config57:mysql57
+    depends_lib-append   port:mysql57
     lappend modules mod_sql mod_sql_mysql
     lappend includes ${prefix}/include/mysql57/mysql
     lappend libs ${prefix}/lib/mysql57/mysql


### PR DESCRIPTION
The `mysql56` and `mysql57` ports do not install a version-suffixed `mysql_config` command in `${prefix}/bin`.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
