### PR TITLE
postgresql ports: mark versions 8.0-9.2 as unsupported

### DIFF
--- a/databases/postgresql80-doc/Portfile
+++ b/databases/postgresql80-doc/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2010-10-01
+deprecated.upstream_support no
 
 name			postgresql80-doc
 version			8.0.26

--- a/databases/postgresql80-server/Portfile
+++ b/databases/postgresql80-server/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2010-10-01
+deprecated.upstream_support no
 
 name			postgresql80-server
 version			8.0.26

--- a/databases/postgresql80/Portfile
+++ b/databases/postgresql80/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2010-10-01
+deprecated.upstream_support no
 
 name			postgresql80
 version			8.0.26

--- a/databases/postgresql81-doc/Portfile
+++ b/databases/postgresql81-doc/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2010-11-08
+deprecated.upstream_support no
 
 name			postgresql81-doc
 version			8.1.23

--- a/databases/postgresql81-server/Portfile
+++ b/databases/postgresql81-server/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2010-11-08
+deprecated.upstream_support no
 
 name			postgresql81-server
 version			8.1.23

--- a/databases/postgresql81/Portfile
+++ b/databases/postgresql81/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2010-11-08
+deprecated.upstream_support no
 
 name			postgresql81
 version			8.1.23

--- a/databases/postgresql82-doc/Portfile
+++ b/databases/postgresql82-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2011-12-05
+deprecated.upstream_support no
 
 name			postgresql82-doc
 version			8.2.23

--- a/databases/postgresql82-server/Portfile
+++ b/databases/postgresql82-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2011-12-05
+deprecated.upstream_support no
 
 name			postgresql82-server
 version			8.2.23

--- a/databases/postgresql82/Portfile
+++ b/databases/postgresql82/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2011-12-05
+deprecated.upstream_support no
 
 name			postgresql82
 version			8.2.23

--- a/databases/postgresql83-doc/Portfile
+++ b/databases/postgresql83-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2013-02-07
+deprecated.upstream_support no
 
 name			postgresql83-doc
 version			8.3.23

--- a/databases/postgresql83-server/Portfile
+++ b/databases/postgresql83-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2013-02-07
+deprecated.upstream_support no
 
 name			postgresql83-server
 version			8.3.23

--- a/databases/postgresql83/Portfile
+++ b/databases/postgresql83/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2013-02-07
+deprecated.upstream_support no
 
 name			postgresql83
 version			8.3.23

--- a/databases/postgresql84-doc/Portfile
+++ b/databases/postgresql84-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2014-07-24
+deprecated.upstream_support no
 
 name			postgresql84-doc
 conflicts       postgresql90-doc postgresql91-doc postgresql92-doc \

--- a/databases/postgresql84-server/Portfile
+++ b/databases/postgresql84-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2014-07-24
+deprecated.upstream_support no
 
 name			postgresql84-server
 version			8.4.22

--- a/databases/postgresql84/Portfile
+++ b/databases/postgresql84/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2014-07-24
+deprecated.upstream_support no
 
 name			postgresql84
 version			8.4.22

--- a/databases/postgresql90-doc/Portfile
+++ b/databases/postgresql90-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2015-10-08
+deprecated.upstream_support no
 
 name			postgresql90-doc
 conflicts       postgresql84-doc postgresql91-doc postgresql92-doc \

--- a/databases/postgresql90-server/Portfile
+++ b/databases/postgresql90-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2015-10-08
+deprecated.upstream_support no
 
 name			postgresql90-server
 version			9.0.23

--- a/databases/postgresql90/Portfile
+++ b/databases/postgresql90/Portfile
@@ -4,6 +4,10 @@ PortSystem 1.0
 PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2015-10-08
+deprecated.upstream_support no
 
 #remember to update the -doc and -server as well
 name			postgresql90

--- a/databases/postgresql91-doc/Portfile
+++ b/databases/postgresql91-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2016-10-27
+deprecated.upstream_support no
 
 name			postgresql91-doc
 conflicts       postgresql90-doc postgresql92-doc postgresql93-doc \

--- a/databases/postgresql91-server/Portfile
+++ b/databases/postgresql91-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2016-10-27
+deprecated.upstream_support no
 
 name			postgresql91-server
 version			9.1.24

--- a/databases/postgresql91/Portfile
+++ b/databases/postgresql91/Portfile
@@ -4,6 +4,10 @@ PortSystem 1.0
 PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2016-10-27
+deprecated.upstream_support no
 
 #remember to update the -doc and -server as well
 name			postgresql91

--- a/databases/postgresql92-doc/Portfile
+++ b/databases/postgresql92-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2017-11-09
+deprecated.upstream_support no
 
 name			postgresql92-doc
 conflicts       postgresql84-doc postgresql90-doc postgresql91-doc \

--- a/databases/postgresql92-server/Portfile
+++ b/databases/postgresql92-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2017-11-09
+deprecated.upstream_support no
 
 name			postgresql92-server
 version			9.2.24

--- a/databases/postgresql92/Portfile
+++ b/databases/postgresql92/Portfile
@@ -4,6 +4,10 @@ PortSystem 1.0
 PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2017-11-09
+deprecated.upstream_support no
 
 #remember to update the -doc and -server as well
 name			postgresql92


### PR DESCRIPTION
Note that 7.0 and 9.3 are also unsupported, but I might try deleting 7.0 soon, and since 9.3 is not `nomaintainer`/`openmaintainer` I will open a separate PR.
 #### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
