### PR TITLE
postgresql93: mark unsupported by upstream

### DIFF
--- a/databases/postgresql93-doc/Portfile
+++ b/databases/postgresql93-doc/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2018-11-08
+deprecated.upstream_support no
 
 name			postgresql93-doc
 conflicts       postgresql90-doc postgresql91-doc postgresql92-doc \

--- a/databases/postgresql93-server/Portfile
+++ b/databases/postgresql93-server/Portfile
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2018-11-08
+deprecated.upstream_support no
 
 name			postgresql93-server
 version			9.3.25

--- a/databases/postgresql93/Portfile
+++ b/databases/postgresql93/Portfile
@@ -4,6 +4,10 @@ PortSystem 1.0
 PortGroup select 1.0
 PortGroup compiler_blacklist_versions 1.0
 PortGroup muniversal 1.0
+PortGroup deprecated 1.0
+
+# Final release was on 2018-11-08
+deprecated.upstream_support no
 
 #remember to update the -doc and -server as well
 name			postgresql93


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
