### PR TITLE
lighttpd: update mysql variants

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -116,16 +116,14 @@ post-activate {
     }
 }
 
-variant mysql4 conflicts mysql5 description {Enable MySQL 4 support} {
-    depends_lib-append      port:mysql4
-    configure.args-append   --with-mysql=${prefix}/bin/mysql_config
-    #configure.cppflags-append -I${prefix}/include/mysql
-}
+# Remove after 2020-08-04
+variant mysql4 requires mysql57 description {Legacy compatibility variant} {}
+variant mysql5 requires mysql57 description {Legacy compatibility variant} {}
 
-variant mysql5 conflicts mysql4 description {Enable MySQL 5 support} {
-    depends_lib-append      path:bin/mysql_config5:mysql5
-    configure.args-append   --with-mysql=${prefix}/bin/mysql_config5
-    #configure.cppflags-append -I${prefix}/include/mysql5/mysql
+variant mysql57 description {Enable MySQL 5.7 support} {
+    depends_lib-append      port:mysql57
+    configure.args-append   --with-mysql=${prefix}/lib/mysql57/bin/mysql_config
+    #configure.cppflags-append -I${prefix}/include/mysql57/mysql
 }
 
 variant ssl description {Enable serving secure web sites with SSL} {


### PR DESCRIPTION
Use `mysql57` instead of `mysql4` and `mysql5` (which are EOL)

See: https://trac.macports.org/ticket/43431

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G84
Xcode 10.3 10G8


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
