### PR TITLE
redland: update SQL variants

### DIFF
--- a/www/redland/Portfile
+++ b/www/redland/Portfile
@@ -82,40 +82,24 @@ variant db48 conflicts db46 db47 description {Enable Berkeley DB 4.8 backend sto
     depends_lib-append      port:db48
 }
 
-variant mysql4 conflicts mysql5 {
+# Remove after 2020-08-03
+variant mysql4       requires mysql57      description {Legacy compatibility variant} {}
+variant mysql5       requires mysql57      description {Legacy compatibility variant} {}
+variant postgresql7  requires postgresql11 description {Legacy compatibility variant} {}
+variant postgresql80 requires postgresql11 description {Legacy compatibility variant} {}
+variant postgresql81 requires postgresql11 description {Legacy compatibility variant} {}
+variant postgresql82 requires postgresql11 description {Legacy compatibility variant} {}
+variant postgresql83 requires postgresql11 description {Legacy compatibility variant} {}
+
+variant mysql57 {
     configure.args-delete --with-mysql=no
-    depends_lib-append port:mysql4
+    configure.args-append --with-mysql=${prefix}/lib/mysql57/bin/mysql_config
+    depends_lib-append port:mysql57
 }
 
-variant mysql5 conflicts mysql4 {
-    configure.args-delete --with-mysql=no
-    configure.args-append --with-mysql=${prefix}/bin/mysql_config5
-    depends_lib-append path:bin/mysql_config5:mysql5
-}
-
-variant postgresql7 conflicts postgresql80 postgresql81 postgresql82 postgresql83 {
+variant postgresql11 {
     configure.args-delete --with-postgresql=no
-    depends_lib-append port:postgresql7
-}
-
-variant postgresql80 conflicts postgresql7 postgresql81 postgresql82 postgresql83 {
-    configure.args-delete --with-postgresql=no
-    depends_lib-append port:postgresql80
-}
-
-variant postgresql81 conflicts postgresql7 postgresql80 postgresql82 postgresql83 {
-    configure.args-delete --with-postgresql=no
-    depends_lib-append port:postgresql81
-}
-
-variant postgresql82 conflicts postgresql7 postgresql80 postgresql81 postgresql83 {
-    configure.args-delete --with-postgresql=no
-    depends_lib-append port:postgresql82
-}
-
-variant postgresql83 conflicts postgresql7 postgresql80 postgresql81 postgresql82 {
-    configure.args-delete --with-postgresql=no
-    depends_lib-append port:postgresql83
+    depends_lib-append port:postgresql11
 }
 
 variant sqlite3 {


### PR DESCRIPTION
Replace variants using EOL ports with `mysql57` and `postgresql11`

See: https://trac.macports.org/ticket/43431

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G84
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
