### PR TITLE
folly: fix build on darwin < 15

### DIFF
--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -44,11 +44,15 @@ configure.args-append -DBUILD_SHARED_LIBS=ON
 
 configure.cxxflags-append -std=c++14
 
-# https://github.com/facebook/folly/issues/864
 platform darwin {
+    # https://github.com/facebook/folly/issues/864
     if {${os.major} <= 16} {
         configure.args-append     -DCOMPILER_HAS_F_ALIGNED_NEW=OFF
         configure.cxxflags-append -fno-aligned-allocation
+    }
+    # Support for TCP fast-open was only added to macOS 10.11+
+    if {${os.major} < 15} {
+        configure.cxxflags-append -DFOLLY_ALLOW_TFO=0
     }
 }
 


### PR DESCRIPTION
#### Description

Tentative build fix for darwin < 15.
See https://github.com/macports/macports-ports/pull/4866#issuecomment-518022558

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
