### PR TITLE
apache-solr3: port abandoned, EOL

### DIFF
--- a/java/apache-solr3/Portfile
+++ b/java/apache-solr3/Portfile
@@ -1,12 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           deprecated 1.0
+
+deprecated.upstream_support no
 
 name                apache-solr3
 version             3.6.2
 revision            1
 categories          java textproc
-maintainers         gmail.com:haya10.ito openmaintainer
+maintainers         nomaintainer
 
 description         An open source enterprise search platform.
 


### PR DESCRIPTION
Mark as unsupported by upstream

Closes: https://trac.macports.org/ticket/58669

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detecte-->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?