### PR TITLE
ruby ports: mark EOL versions as unsupported

### DIFF
--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -5,6 +5,10 @@ PortGroup		muniversal 1.0
 PortGroup		compiler_blacklist_versions 1.0
 PortGroup		select 1.0
 PortGroup		old_openssl 1.0
+PortGroup		deprecated 1.0
+
+# Reached EOL on 2014-07-31
+deprecated.upstream_support no
 
 name			ruby
 version			1.8.7-p374

--- a/lang/ruby186/Portfile
+++ b/lang/ruby186/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup		deprecated 1.0
+
+# Reached EOL in 2011
+deprecated.upstream_support no
 
 name			ruby186
 conflicts               ruby

--- a/lang/ruby19/Portfile
+++ b/lang/ruby19/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem			1.0
 PortGroup			select 1.0
+PortGroup			deprecated 1.0
+
+# Reached EOL on 2015-02-23
+deprecated.upstream_support no
 
 name				ruby19
 version				1.9.3-p551

--- a/lang/ruby20/Portfile
+++ b/lang/ruby20/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           select 1.0
+PortGroup           deprecated 1.0
+
+# Reached EOL on 2016-02-24
+deprecated.upstream_support no
 
 name                ruby20
 version             2.0.0-p648

--- a/lang/ruby21/Portfile
+++ b/lang/ruby21/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           select 1.0
+PortGroup           deprecated 1.0
+
+# Reached EOL on 2017-03-31
+deprecated.upstream_support no
 
 name                ruby21
 version             2.1.9

--- a/lang/ruby22/Portfile
+++ b/lang/ruby22/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           select 1.0
+PortGroup           deprecated 1.0
+
+# Reached EOL on 2018-03-31
+deprecated.upstream_support no
 
 name                ruby22
 version             2.2.10

--- a/lang/ruby23/Portfile
+++ b/lang/ruby23/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem          1.0
 PortGroup           select 1.0
+PortGroup           deprecated 1.0
+
+# Reached EOL on 2019-03-31
+deprecated.upstream_support no
 
 name                ruby23
 version             2.3.8


### PR DESCRIPTION
#### Description

Versions 1.8.6-2.3 have all reached EOL.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
