### PR TITLE
google-glog: update to v0.4.0

### DIFF
--- a/devel/google-glog/Portfile
+++ b/devel/google-glog/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
 name                google-glog
-github.setup        google glog 0.3.5 v
-checksums           rmd160  c03a32db14ed8ffe0835b04df2774567eadfb98c \
-                    sha256  a3a6d44c7f1ce068b6340e93e19a8594faf26b976ced9def23d4eb7caa2aa044 \
-                    size    532350
+github.setup        google glog 0.4.0 v
+checksums           rmd160  c2627b9fc5c92a6f2f6d5475dbed9b8cf012ad86 \
+                    sha256  217fd7e5c52b76d6163459d9b2a1ca790075f6e089887e48257362d4874ed133 \
+                    size    200999
 
 categories          devel
 maintainers         nomaintainer
@@ -20,8 +21,10 @@ long_description    The glog library implements application-level logging. \
 platforms           darwin
 license             BSD
 
+configure.args-append -DWITH_GFLAGS=OFF
+
 variant gflags description {Includes gflags command line control of logging} {
-    configure.args-append --with-gflags=${prefix}
+    configure.args-replace -DWITH_GFLAGS=OFF -DWITH_GFLAGS=ON
     depends_lib-append port:gflags
 }
 


### PR DESCRIPTION
#### Description

Was v0.3.5. 
Port is now built using cmake.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
