### PR TITLE
wireguard-go: update to 0.0.20190805

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20190517
+version             0.0.20190805
 revision            0
-checksums           rmd160  cfd41f0dd863e6cc5ed89e55d9ebede8390119ed \
-                    sha256  6877d431847df0afd514e753eed8571bc7e85069b837bc8472b5186fbb004e78 \
-                    size    69496
+checksums           rmd160  f299e6d44951ddd01cdf5b20fe41ded580f82ec0 \
+                    sha256  2f56d2c4ebc3e50d581e92c046ebf3c884c703c4d5b3b484e45f55e50c0034da \
+                    size    76468
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?