### PR TITLE
obsolete-1.0.tcl: prevent "no license set" lint warning

### DIFF
--- a/_resources/port1.0/group/obsolete-1.0.tcl
+++ b/_resources/port1.0/group/obsolete-1.0.tcl
@@ -21,6 +21,7 @@ proc obsolete.set_descriptions {replaced_by} {
     default platforms       darwin
     default maintainers     nomaintainer
     default homepage        https://www.macports.org
+    default license         none
 
     archive_sites
     patchfiles


### PR DESCRIPTION
#### Description
It should not be necessary to specify the license of obsolete ports.
<!-- Note: it is best make pull requests from a branch rather than from master -->

Before:

```
$ port lint jruby-devel
--->  Verifying Portfile for jruby-devel
Warning: no license set
--->  0 errors and 1 warnings found.
```

After:

```
$ port lint jruby-devel
--->  Verifying Portfile for jruby-devel
--->  0 errors and 0 warnings found.
```

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
