### PR TITLE
qt5,qmake: fix account for configure.developer_dir

### DIFF
--- a/_resources/port1.0/group/qmake5-1.0.tcl
+++ b/_resources/port1.0/group/qmake5-1.0.tcl
@@ -29,6 +29,15 @@ configure.cmd                   ${qt_qmake_cmd}
 configure.pre_args-replace      --prefix=${prefix} "PREFIX=${prefix}"
 configure.universal_args-delete --disable-dependency-tracking
 
+platform macosx {
+    # Use Xcode on macOS <= 10.9 (os.major 13) because CLT doesn't ship with an SDK on 10.9-
+    # Better way is to just check if CLT SDK works correctly rather than hardcode OS
+    # See: https://trac.macports.org/ticket/58779
+    if { [info exists use_xcode] && ${os.major} <= 13 } {
+        use_xcode yes
+    }
+}
+
 pre-configure {
     #
     # -spec specifies build configuration (compiler, 32-bit/64-bit, etc.)
@@ -52,6 +61,11 @@ pre-configure {
         # see https://trac.macports.org/ticket/53597
         set sdks_dir ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
         if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
+            configure.sdk_version
+        }
+
+        # same check as before, but if macports wants to use CLT's developer_dir instead of Xcode, then we check if the build OS version is available on CLT.
+        if { [info exists configure.developer_dir] && ${developer_dir} ne ${configure.developer_dir} && ![file exists ${configure.developer_dir}/SDKs/MacOSX${configure.sdk_version}.sdk] } {
             configure.sdk_version
         }
     }

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -983,7 +983,13 @@ foreach {module module_info} [array get modules] {
                 # starting with Xcode 7.0, the SDK for build OS version might not be available
                 # see https://trac.macports.org/ticket/53597
 
-                if { ![file exists ${configure.sdkroot}/MacOSX${configure.sdk_version}.sdk] } {
+                set sdks_dir ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs
+                if { ![file exists ${sdks_dir}/MacOSX${configure.sdk_version}.sdk] } {
+                    configure.sdk_version
+                }
+
+                # same check as before, but if macports wants to use CLT's developer_dir instead of Xcode, then we check if the build OS version is available on CLT.
+                if {[info exists configure.developer_dir] && ${developer_dir} ne ${configure.developer_dir} && ![file exists ${configure.developer_dir}/SDKs/MacOSX${configure.sdk_version}.sdk]} {
                     configure.sdk_version
                 }
             }


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode none

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->