### PR TITLE
py-mpi4py:  update to version 3.0.2

### DIFF
--- a/python/py-mpi4py/Portfile
+++ b/python/py-mpi4py/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           bitbucket 1.0
 PortGroup           mpi 1.0
 
-bitbucket.setup     mpi4py mpi4py 3.0.0
+bitbucket.setup     mpi4py mpi4py 3.0.2
 revision            0
 name                py-mpi4py
 license             BSD
@@ -26,8 +26,9 @@ long_description    \
 
 maintainers         nomaintainer
 
-checksums           rmd160  b77ebcb1cb61c7cfd534bd2454b8109a53fdee7e \
-                    sha256  41a206ae34814f87ec2496ed2bc38513942f527d0638308f576c8af843e49088
+checksums           rmd160  7a74de21b142eaf21ab699968c17e14386f2c29b \
+                    sha256  0218ef066f1e550da992713aacb35030961345635c2b4c1779cd18e81186766e \
+                    size    305302
 
 mpi.setup           require
 


### PR DESCRIPTION
* update to version 3.0.2
* resolves a build problem for +openmpi

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G2016
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
