### PR TITLE
pango ports: minor improvements

### DIFF
--- a/x11/pango-devel/Portfile
+++ b/x11/pango-devel/Portfile
@@ -17,8 +17,8 @@ checksums               rmd160  e91880e0e9a459bbc2c280ac747ab31f80352000 \
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              x11
 maintainers             {ryandesign @ryandesign} openmaintainer
-license                 LGPL-2
-homepage                http://www.pango.org/
+license                 LGPL-2+
+homepage                https://www.pango.org/
 master_sites            gnome:sources/${my_name}/${branch}
 platforms               darwin
 distname                ${my_name}-${version}

--- a/x11/pango/Portfile
+++ b/x11/pango/Portfile
@@ -18,8 +18,8 @@ checksums               rmd160  e91880e0e9a459bbc2c280ac747ab31f80352000 \
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              x11
 maintainers             {ryandesign @ryandesign} openmaintainer
-license                 LGPL-2
-homepage                http://www.pango.org/
+license                 LGPL-2+
+homepage                https://www.pango.org/
 master_sites            gnome:sources/${my_name}/${branch}
 platforms               darwin
 distname                ${my_name}-${version}

--- a/x11/pangox-compat/Portfile
+++ b/x11/pangox-compat/Portfile
@@ -7,14 +7,14 @@ version             0.0.2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          x11
 platforms           darwin
-maintainers         ryandesign openmaintainer
-license             LGPL
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             LGPL-2+
 
 description         compatibility library for software needing the old pangox library
 
 long_description    ${name} is a ${description}.
 
-homepage            http://www.pango.org/
+homepage            https://www.pango.org/
 master_sites        gnome:sources/${name}/${branch}
 use_xz              yes
 
@@ -38,5 +38,5 @@ post-destroot {
 }
 
 livecheck.type      regex
-livecheck.url       http://ftp.gnome.org/pub/GNOME/sources/${name}/${branch}/
+livecheck.url       https://ftp.gnome.org/pub/GNOME/sources/${name}/${branch}/
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
 - License is LGPL-2+
 - Use HTTPS homepages
 - pangox-compat: add maintainer's GitHub handle, use HTTPS livecheck

See: https://trac.macports.org/ticket/23279
See: https://trac.macports.org/ticket/56050

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
