### PR TITLE
google-cloud-sdk: update to 257.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             254.0.0
+version             257.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  50942c7e0385dc1305fc7c15fd21326b540870a7 \
-                    sha256  2fce2d0ab6c6d58658343c4d23e03f6ac84fda0e575401839e14ad7cd064d3fd \
-                    size    20205241
+checksums           rmd160  b8da8158b0eca710d893ad13845926ba16f8d08b \
+                    sha256  85eafdaf6345f4c456dde2e5761328411f0ecfbb2758b558a1df8d7e038b9ca6 \
+                    size    20408852
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 257.0.0.

###### Tested on

macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?