### PR TITLE
groovy: update to 2.5.8

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -1,7 +1,7 @@
 PortSystem 1.0
 
 name            groovy
-version         2.5.7
+version         2.5.8
 
 categories      lang java
 maintainers     {breun.nl:nils @breun} openmaintainer
@@ -37,9 +37,9 @@ master_sites    https://dl.bintray.com/${name}/maven/
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  fd3b3ba43b53e67b3aa86286633cf8f455295dc0 \
-                sha256  3d905dfe4f739c8c0d9dd181e6687ac816e451bf327a9ec0740da473cfebc9e0 \
-                size    30058416
+checksums       rmd160  2df28ec5e7c917570827578bda24b8e3a063ad4b \
+                sha256  49fb14b98f9fed1744781e4383cf8bff76440032f58eb5fabdc9e67a5daa8742 \
+                size    30368648
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 2.5.8.

###### Tested on

macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?