### PR TITLE
mpstats: Update submissions url

### DIFF
--- a/sysutils/mpstats/Portfile
+++ b/sysutils/mpstats/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mpstats
 version             0.1.8
-revision            4
+revision            5
 categories          sysutils macports
 license             BSD
 platforms           darwin

--- a/sysutils/mpstats/files/stats.conf
+++ b/sysutils/mpstats/files/stats.conf
@@ -1,4 +1,4 @@
 # configuration for mpstats
 
 # Where to submit usage data
-stats_url       http://stats.macports.neverpanic.de/submissions
+stats_url       https://ports.macports.org/statistics/submit/


### PR DESCRIPTION
Update the submissions URL to https://ports.macports.org/statistics/submit/
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.2.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->