### PR TITLE
mysql57: add legacysupport portgroup

### DIFF
--- a/databases/mysql57/Portfile
+++ b/databases/mysql57/Portfile
@@ -21,6 +21,7 @@ if {$subport eq $name} {
     PortGroup           muniversal 1.0
     PortGroup           cmake 1.0
     PortGroup           select 1.0
+    PortGroup           legacysupport 1.0
 
     PortGroup           cxx11 1.1
     configure.cxxflags-append -std=c++11


### PR DESCRIPTION
For `clock_gettime()` on 10.11 and lower.

Closes: https://trac.macports.org/ticket/58801

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
