### PR TITLE
openjfx11: add livecheck

### DIFF
--- a/java/openjfx11/Portfile
+++ b/java/openjfx11/Portfile
@@ -51,3 +51,7 @@ destroot {
     # src.zip is already provided by openjdk11
     move ${destroot_target}/lib/src.zip ${destroot_target}/lib/src_javafx.zip
 }
+
+livecheck.type  regex
+livecheck.url   https://gluonhq.com/products/javafx/
+livecheck.regex "href=\"https://download2.gluonhq.com/openjfx/(\[0-9\\.\]+)/openjfx-11\[0-9\\.\]+_osx-x64_bin-sdk.zip.sha256\""


### PR DESCRIPTION
Added livecheck parameters to PortFile

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint`?

