### PR TITLE
py-pymvpa: fix installation issue

### DIFF
--- a/python/py-pymvpa/Portfile
+++ b/python/py-pymvpa/Portfile
@@ -49,11 +49,28 @@ if {${name} ne ${subport}} {
 
     build.args-append   --with-system-libsvm
 
+    if {${python.version} ne 27} {
+        pre-destroot {
+            xinstall -d ${worksrcpath}/build/py3k/bin
+            xinstall -m 0755 {*}[glob ${worksrcpath}/bin/*] ${worksrcpath}/build/py3k/bin
+        }
+
+        notes "Upstream states: Python 3.X should work, but none of the core developers\
+            are using it in production (yet), hence it should be considered as less tested."
+    }
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} README.rst Changelog \
             COPYING AUTHOR ${destroot}${docdir}
+
+        if {${python.version} ne 27} {
+            # make scripts Python 3 compatible using the 2to3 tool
+            foreach f [glob -type f -dir ${destroot}${python.prefix}/bin *] {
+                system -W ${destroot}${python.prefix}/bin "2to3-${python.branch} -w -n ${f}"
+            }
+        }
     }
 
     livecheck.type      none

--- a/python/py-pymvpa/Portfile
+++ b/python/py-pymvpa/Portfile
@@ -49,6 +49,13 @@ if {${name} ne ${subport}} {
 
     build.args-append   --with-system-libsvm
 
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} README.rst Changelog \
+            COPYING AUTHOR ${destroot}${docdir}
+    }
+
     livecheck.type      none
 } else {
     livecheck.regex     "archive/upstream/(\[^\"\]+)${extract.suffix}"

--- a/python/py-pymvpa/Portfile
+++ b/python/py-pymvpa/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 github.setup        PyMVPA PyMVPA 2.6.5 upstream/
 
 name                py-pymvpa
-revision            0
+revision            1
 categories-append   science math
 platforms           darwin
 license             MIT
@@ -34,9 +34,12 @@ checksums           rmd160  6d208bb32a9546a7937595e8308665448cfb9f8a \
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools
+                        port:swig-python
+
     depends_lib-append  port:py${python.version}-numpy \
-                        port:libsvm
+                        port:py${python.version}-scipy \
+                        port:py${python.version}-nibabel \
+                        port:libsvm \
 
     patchfiles-append   patch-setup.py.diff
 

--- a/python/py-pymvpa/files/patch-setup.py.diff
+++ b/python/py-pymvpa/files/patch-setup.py.diff
@@ -1,7 +1,7 @@
---- setup.py.orig	2013-03-30 17:53:02.000000000 +0400
-+++ setup.py	2013-03-30 17:54:16.000000000 +0400
-@@ -15,7 +15,7 @@
- from glob import glob
+--- setup.py.orig	2019-08-07 10:46:04.000000000 -0400
++++ setup.py	2019-08-07 10:47:01.000000000 -0400
+@@ -20,7 +20,7 @@
+     raise RuntimeError("PyMVPA requires Python 2.6 or higher")
  
  # some config settings
 -bind_libsvm = 'local' # choices: 'local', 'system', None
@@ -9,7 +9,7 @@
  
  libsvmc_extra_sources = []
  libsvmc_include_dirs = []
-@@ -63,12 +63,7 @@
+@@ -75,12 +75,7 @@
      libsvmc_libraries += ['svm']
      if not sys.platform.startswith('win'):
          libsvmc_include_dirs += [


### PR DESCRIPTION
#### Description
This PR updates the dependencies (including adding ```swig-python``` as a build dependency to fix the (recently) reported installation failures). Additionally, for PY3 versions the scripts in the ```bin``` directory were not installed, that is also fixed in this PR.

Finally, the patch was updated to apply cleanly and we are now installing files in the post-destroot phase.

Please not that PY3 is not yet fully supported as reported by upstream and that there are indeed many more failures when running ```import mvpa2 ; mvpa2.test(verbosity=3)``` in the Python shell. Also, it seems to me that the ```pymvpa2-3.7``` script isn't functioning correctly compared to ```pymvpa2-2.7```, but I haven't tested anything more than that (the message about missing ```duecredit``` package is harmless according to upstream). In short, PY2 should work fine - I cannot guarantee anything for PY3. 
<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
