### PR TITLE
cocoa-rest-client: new port

### DIFF
--- a/www/CocoaRestClient/Portfile
+++ b/www/CocoaRestClient/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+name                CocoaRestClient
+
+github.setup        mmattozzi cocoa-rest-client 1.4.5
+github.tarball_from releases
+
+categories          www
+platforms           darwin
+supported_archs     x86_64
+license             BSD
+maintainers         {gmx.net:lothar.haeger @lhaeger} openmaintainer
+
+description         A free, native macOS app for testing HTTP/REST endpoints
+long_description    Test and interact with HTTP/REST resources:\
+                    - Make GET, PUT, POST, DELETE, and HEAD calls.\
+                    - Set request headers and display response headers.\
+                    - Automatically pretty print XML and JSON content.\
+                    - Quick save of request URLs, body, and headers in one convenient drawer.\
+                    - Lightweight: Low real memory usage.\
+                    - SSL Support (including untrusted certificates).\
+                    - Optionally follows HTTP redirects.\
+                    - Set HTTP Basic or Digest Auth.\
+                    - Set HTTP request body content to a raw text blob or a list of parameters.\
+                    - Upload files using HTTP multipart requests. HTTP form encoding also supported.\
+                    - Unified diff tool for comparing responses.
+
+homepage            http://mmattozzi.github.io/cocoa-rest-client/
+
+distname            ${name}-${version}
+use_dmg             yes
+
+checksums           rmd160  0136fcc44f38bf9df4e0270e6f6e2de6b4cdac06 \
+                    sha256  dccc638d7b8e9f793055cb1c4fc49da9f0f35e24e89f3559e53810150c77a6b1 \
+                    size    6070132
+
+pre-fetch {
+    if {${os.major} < 16} {
+        return -code error "This port requires at least macOS Sierra (10.12)."
+    }
+}
+
+use_configure       no
+build               {}
+
+destroot {
+    copy "${worksrcpath}/${name}.app" ${destroot}${applications_dir}
+}


### PR DESCRIPTION
###### Tested on

macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
