### PR TITLE
php-phalcon4 4.0.0-beta.1

### DIFF
--- a/php/php-phalcon/Portfile
+++ b/php/php-phalcon/Portfile
@@ -1,35 +1,50 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               github 1.0
-PortGroup               php 1.1
+PortGroup               obsolete 1.0
+
+# Though this port is "obsolete", it provides a way for a user to find out
+# the current major version of Phalcon for a given PHP version, so please
+# keep it updated and don't delete it.
 
 name                    php-phalcon
+version                 3.4.4
+revision                1
+categories              php
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 BSD
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3
-
-if {[vercmp ${php.branch} 5.5] >= 0} {
-    github.setup        phalcon cphalcon 3.4.4 v
-    revision            0
-    checksums           rmd160  745e5eaed58fa32cc6d44a748d8a2a9505eba34c \
-                        sha256  3e1204105e10d94759ad51dae36aebcd5a2a3634dd753eb46f3c55f46d7bc4b0 \
-                        size    6707908
-} elseif {[vercmp ${php.branch} 5.4] >= 0} {
-    github.setup        phalcon cphalcon 2.0.13 phalcon-v
-    revision            0
-    checksums           rmd160  c94dadcf628d8611cbcb44f35b1b536c9b0e3fc9 \
-                        sha256  00f7e45282e6e793c37c75742da696ebb031cf5b880d324eefd19039bd27b74e \
-                        size    5226597
-} else {
-    github.setup        phalcon cphalcon 2.0.9 phalcon-v
-    revision            0
-    checksums           rmd160  3955e097b18c3ea8b29264bb184b70ad2a7eebd7 \
-                        sha256  d4607491b801da973796c44eaed9f909787d9a588ec5a7ea7c84d74d43106a46 \
-                        size    5072670
+subport php73-phalcon {
 }
+
+subport php72-phalcon {
+}
+
+subport php71-phalcon {
+}
+
+subport php70-phalcon {
+}
+
+subport php56-phalcon {
+}
+
+subport php55-phalcon {
+}
+
+subport php54-phalcon {
+    version             2.0.13
+    revision            1
+}
+
+subport php53-phalcon {
+    version             2.0.9
+    revision            1
+}
+
+set major               [lindex [split ${version} .] 0]
+replaced_by             ${subport}${major}
 
 description             full stack PHP framework written as an extension
 
@@ -43,27 +58,4 @@ long_description        Phalcon is an open source full stack framework for \
 
 homepage                https://phalconphp.com
 
-if {${name} ne ${subport}} {
-    # The build/install script makes all sorts of assumptions I don't like
-    # so I'm ignoring it.
-
-    set build           build
-    if {[vercmp ${version} 3] >= 0} {
-        set phpmajor    [lindex [split ${php.branch} .] 0]
-        set build       ${build}/php${phpmajor}
-    }
-
-    if {[string match *64 ${build_arch}]} {
-        set build       ${build}/64bits
-    } else {
-        set build       ${build}/32bits
-    }
-
-    worksrcdir          ${worksrcdir}/${build}
-
-    # Separate dir for each arch means using the muniversal portgroup
-    # but it doesn't get along with the php portgroup.
-    universal_variant   no
-
-    configure.args      --enable-phalcon
-}
+livecheck.type          none

--- a/php/php-phalcon2/Portfile
+++ b/php/php-phalcon2/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               php 1.1
+
+name                    php-phalcon2
+platforms               darwin
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 BSD
+
+php.branches            5.3 5.4 5.5 5.6
+
+if {[vercmp ${php.branch} 5.5] >= 0} {
+    conflicts-append    ${php}-phalcon3
+}
+
+if {[vercmp ${php.branch} 5.4] >= 0} {
+    github.setup        phalcon cphalcon 2.0.13 phalcon-v
+    revision            0
+    checksums           rmd160  c94dadcf628d8611cbcb44f35b1b536c9b0e3fc9 \
+                        sha256  00f7e45282e6e793c37c75742da696ebb031cf5b880d324eefd19039bd27b74e \
+                        size    5226597
+} elseif {[vercmp ${php.branch} 5.3] >= 0} {
+    github.setup        phalcon cphalcon 2.0.9 phalcon-v
+    revision            0
+    checksums           rmd160  3955e097b18c3ea8b29264bb184b70ad2a7eebd7 \
+                        sha256  d4607491b801da973796c44eaed9f909787d9a588ec5a7ea7c84d74d43106a46 \
+                        size    5072670
+}
+
+description             full stack PHP framework written as an extension
+
+long_description        Phalcon is an open source full stack framework for \
+                        PHP, written as a C-extension. Phalcon is optimized \
+                        for high performance. Its unique architecture allows \
+                        the framework to always be memory resident, offering \
+                        its functionality whenever it's needed, without \
+                        expensive file stats and file reads that traditional \
+                        PHP frameworks employ.
+
+homepage                https://phalconphp.com
+dist_subdir             php-phalcon
+
+if {${name} ne ${subport}} {
+    # The build/install script makes all sorts of assumptions I don't like
+    # so I'm ignoring it.
+
+    set build           build
+    if {[string match *64 ${build_arch}]} {
+        set build       ${build}/64bits
+    } else {
+        set build       ${build}/32bits
+    }
+
+    worksrcdir          ${worksrcdir}/${build}
+
+    # Separate dir for each arch means using the muniversal portgroup
+    # but it doesn't get along with the php portgroup.
+    universal_variant   no
+
+    configure.args      --enable-phalcon
+}
+
+livecheck.type          none

--- a/php/php-phalcon3/Portfile
+++ b/php/php-phalcon3/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               php 1.1
+
+name                    php-phalcon3
+platforms               darwin
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 BSD
+
+php.branches            5.5 5.6 7.0 7.1 7.2 7.3
+
+if {[vercmp ${php.branch} 7.0] < 0} {
+    conflicts-append    ${php}-phalcon2
+}
+
+if {[vercmp ${php.branch} 5.5] >= 0} {
+    github.setup        phalcon cphalcon 3.4.4 v
+    revision            0
+    checksums           rmd160  745e5eaed58fa32cc6d44a748d8a2a9505eba34c \
+                        sha256  3e1204105e10d94759ad51dae36aebcd5a2a3634dd753eb46f3c55f46d7bc4b0 \
+                        size    6707908
+}
+
+description             full stack PHP framework written as an extension
+
+long_description        Phalcon is an open source full stack framework for \
+                        PHP, written as a C-extension. Phalcon is optimized \
+                        for high performance. Its unique architecture allows \
+                        the framework to always be memory resident, offering \
+                        its functionality whenever it's needed, without \
+                        expensive file stats and file reads that traditional \
+                        PHP frameworks employ.
+
+homepage                https://phalconphp.com
+dist_subdir             php-phalcon
+
+if {${name} ne ${subport}} {
+    # The build/install script makes all sorts of assumptions I don't like
+    # so I'm ignoring it.
+
+    set phpmajor        [lindex [split ${php.branch} .] 0]
+    set build           build/php${phpmajor}
+    if {[string match *64 ${build_arch}]} {
+        set build       ${build}/64bits
+    } else {
+        set build       ${build}/32bits
+    }
+
+    worksrcdir          ${worksrcdir}/${build}
+
+    # Separate dir for each arch means using the muniversal portgroup
+    # but it doesn't get along with the php portgroup.
+    universal_variant   no
+
+    configure.args      --enable-phalcon
+}

--- a/php/php-phalcon4/Portfile
+++ b/php/php-phalcon4/Portfile
@@ -4,26 +4,23 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               php 1.1
 
-name                    php-phalcon3
+name                    php-phalcon4
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 BSD
 
-php.branches            5.5 5.6 7.0 7.1 7.2 7.3
+php.branches            7.2 7.3
 
-if {[vercmp ${php.branch} 7.0] < 0} {
-    conflicts-append    ${php}-phalcon2
+if {[vercmp ${php.branch} 7.5] < 0} {
+    conflicts-append    ${php}-phalcon3
 }
+
 if {[vercmp ${php.branch} 7.2] >= 0} {
-    conflicts-append    ${php}-phalcon4
-}
-
-if {[vercmp ${php.branch} 5.5] >= 0} {
-    github.setup        phalcon cphalcon 3.4.4 v
+    github.setup        phalcon cphalcon 4.0.0-beta.1 v
     revision            0
-    checksums           rmd160  745e5eaed58fa32cc6d44a748d8a2a9505eba34c \
-                        sha256  3e1204105e10d94759ad51dae36aebcd5a2a3634dd753eb46f3c55f46d7bc4b0 \
-                        size    6707908
+    checksums           rmd160  cf1591efada92bde9cfddb5f92b6601e2e9cd671 \
+                        sha256  58bd1b2fc1a3df1c0981ccfb3b4dc4a2998fdbfae8aedb13188d654071f33cae \
+                        size    7087376
 }
 
 description             full stack PHP framework written as an extension
@@ -40,6 +37,8 @@ homepage                https://phalconphp.com
 dist_subdir             php-phalcon
 
 if {${name} ne ${subport}} {
+    depends_lib-append  port:${php}-psr
+
     # The build/install script makes all sorts of assumptions I don't like
     # so I'm ignoring it.
 

--- a/php/php-psr/Portfile
+++ b/php/php-psr/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               php 1.1
+
+name                    php-psr
+platforms               darwin
+maintainers             {ryandesign @ryandesign} openmaintainer
+license                 BSD
+
+php.branches            7.2 7.3
+php.pecl                yes
+
+if {[vercmp ${php.branch} 7.0] >= 0} {
+    version             0.6.1
+    revision            0
+    checksums           rmd160  72ace28d744a059a0c6594b5642839581f997cef \
+                        sha256  57ccc6293ddb56b3cae2620bb3dc00f145d5edb42e38b160d93ed968fcbb1bae \
+                        size    25747
+}
+
+description             interfaces to PHP Standards Recommendations
+
+long_description        ${name} provides ${description} so they can be used \
+                        in an extension.
+
+configure.args-append   --enable-psr


### PR DESCRIPTION
### Description

This PR splits php-phalcon into php-phalcon2 and php-phalcon3 and adds a new port php-phalcon4. The major versions are not fully compatible with one another so it is expected that a user would want to be able to install a specific major version. With version 4, phalcon now requires psr, so a new php-psr port is also added.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G65
Xcode 9.4.1 9F2000

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

