### PR TITLE
bazel: mark use xcode

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -114,6 +114,13 @@ patch.pre_args        -p1
 # Note setting here should be in sync with that in py-tensorflow
 set bazel_min_xcode   9.0
 
+# Even though bazel can build without Xcode, mark use Xcode for now since it fails to
+# build with tracemode on latest master if both CLT and Xcode are available.
+# Better solution is to respect MacPorts environment configure.developer_dir
+if {[info exists use_xcode]} {
+    use_xcode yes
+}
+
 # python versions. Build needs both 'python2' and 'python3'
 set py3ver 3.7
 set py2ver 2.7


### PR DESCRIPTION
#### Description

Fixes build on latest master for now. Better solution is to make build system respect macports environment configure.developer_dir instead

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G65
Xcode none

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->