### PR TITLE
json-modern-cpp: update version to 3.7.0

### DIFF
--- a/devel/json-modern-cpp/Portfile
+++ b/devel/json-modern-cpp/Portfile
@@ -14,10 +14,10 @@ maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
 description         JSON for Modern C++
 long_description    ${description}
 
-github.setup        nlohmann json 3.6.1 v
-checksums           rmd160  5c95d8a412b163644f4aad3780e74048437725f1 \
-                    sha256  4e22a4390a225bef8afbdb23670d289d7f8a8b16036005bd07503aed8f3d859f \
-                    size    118863051
+github.setup        nlohmann json 3.7.0 v
+checksums           rmd160  de5bb385af6c16d14d4ba5632a4c728f7a492d8d \
+    sha256  fd6f4516a9122dc16dd0ad793a9d5f17fe59c12702f24502f70da9dab343eaa6 \
+    size    118869453
 revision            0
 
 configure.args-append \


### PR DESCRIPTION


#### Description

- bump version to 3.7.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->