### PR TITLE
mtr: Drop unnecessary reinplace and workaround

### DIFF
--- a/net/mtr/Portfile
+++ b/net/mtr/Portfile
@@ -32,16 +32,6 @@ checksums           rmd160  221c6c7edfb1769dbc9a61405be9c8e1e1c89c2f \
                     size    291015
 
 configure.args      --without-gtk
-pre-configure {
-    # For some reason, config.h.in is older than aclocal.m4 and configure.ac,
-    # which causes the mtr build system to attempt to re-generate it.
-    # Re-generating requires an autoconf dependency, so let's avoid it,
-    # especially since the file does not change.
-    file mtime ${worksrcpath}/config.h.in [file mtime ${worksrcpath}/aclocal.m4]
-
-    # Fix version string
-    reinplace "s|0.91.1-4c982|${version}|" ${worksrcpath}/configure
-}
 
 post-destroot {
     file attributes ${destroot}${prefix}/sbin/mtr-packet -permissions +s


### PR DESCRIPTION
#### Description
The reinplace no longer matches anything and the timestamps of the shipped `config.h.in` also seem to be fine, since building in trace mode now works again without this change.

Reverts 5ba5586109a2a8fdb5048c3b20a888951982484e and c93f614233d2e2eed505f91c9b6dd9ced5ff557a.

See: https://trac.macports.org/ticket/56627

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
