### PR TITLE
unbound: Fix build in non-default prefix & enable parallel build

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -37,7 +37,8 @@ checksums           rmd160  63411e761d70b5ce7c5e939dceebd8e7d4818c94 \
 
 configure.args-append   --with-pidfile=${prefix}/var/run/${name}/${name}.pid \
                         --with-ssl=${prefix} \
-                        --with-rootkey-file=${prefix}/etc/${name}/root.key
+                        --with-rootkey-file=${prefix}/etc/${name}/root.key \
+                        --with-libexpat=${prefix}
 
 if {${os.major} == 10} {
     compiler.blacklist  *llvm-gcc-4.2 *gcc-4.0 gcc-3.3 clang

--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -72,6 +72,4 @@ startupitem.name    unbound
 startupitem.start   "${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key || : && chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key && ${prefix}/sbin/unbound"
 startupitem.stop    "/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid)"
 
-use_parallel_build  no
-
 notes-append        "An example configuration is provided at ${prefix}/etc/${name}/${name}.conf-dist."


### PR DESCRIPTION
#### Description
Unbound needs to be told where to look for libexpat, because it will otherwise always attempt to use it from /opt/local.

Additionally, it seems inhibiting parallel builds is no longer required for unbound which seems likely given that the ticket that caused the introduction of this line was filed 10 years ago.

Closes: https://trac.macports.org/ticket/58815
See: https://trac.macports.org/ticket/20292

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2128
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
