### PR TITLE
llvm-3.4: always use libstdc++ on <= 10.6

### DIFF
--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -248,6 +248,12 @@ platform darwin {
         macosx_deployment_target 10.9
     }
 
+    if {${os.major} < 11} {
+        # Because this port is needed to bootstrap libc++ on 10.6, we can't
+        # use it even when it's configured as the default.
+        configure.cxx_stdlib    libstdc++
+    }
+
     if {${os.major} < 10} {
         post-patch {
             reinplace "/TARGETS_TO_BUILD=/s/R600//" ${worksrcpath}/configure


### PR DESCRIPTION
This version of clang is needed to bootstrap libc++, so can't use
libc++ itself.
