### PR TITLE
libomp: add 8.0 to list of clang versions

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -97,7 +97,7 @@ compiler.blacklist-append {clang < 500} *gcc*
 
 # Avoid dependency cycle
 # https://trac.macports.org/ticket/53110
-foreach ver {3.8 3.9 4.0 5.0 6.0 7.0 devel} {
+foreach ver {3.8 3.9 4.0 5.0 6.0 7.0 8.0 devel} {
     if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
         compiler.blacklist-append macports-clang-${ver}
     }


### PR DESCRIPTION
It was missing from the dependency cycle avoidance.