### PR TITLE
update to salt Fluorine release 2019.2.0

### DIFF
--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -3,7 +3,7 @@
 PortSystem        1.0
 
 name               salt
-version            2017.7.4
+version            2019.2.0
 categories         sysutils python
 platforms          darwin
 maintainers        {gmail.com:jeremy.mcmillan @aphor} openmaintainer
@@ -26,8 +26,9 @@ if {$subport eq $name} {
     python.versions         27 34 35 36
     categories              sysutils python
 
-    checksums           rmd160  ddb1cbf6f26890360cc06592bb4ba17decf4b772 \
-                        sha256  2698745b572541ccf2e2b1cec48c0c1646b6cad5f56d372a29c4a2a93655e592
+    checksums       rmd160  47b77490e40fdc2ec4c5d262003afecdb0b8e94a \
+                    sha256  0a65913142577a70924a283a99dc67612630a9601fd5c83d660bad74b84357d4 \
+                    size    14987367
 
     notes    "Salt startupitems are installed by subports salt-minion, salt-master, salt-syndic, salt-api."
 


### PR DESCRIPTION
#### Description

Update salt port to Fluorine release v2019.2.0

###### Tested on
macOS 10.14.5 18F132
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

[skip notification]
