### PR TITLE
prometheus: update to 2.11.2

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.11.1 v
+github.setup        prometheus prometheus 2.11.2 v
 github.tarball_from archive
 set promu_version   0.5.0
 
@@ -51,9 +51,9 @@ distfiles           prometheus-${version}${extract.suffix}:main \
 
 checksums \
   prometheus-${version}${extract.suffix} \
-    rmd160  31b5b9df47ec1878679df150ac252b2965c4939a \
-    sha256  180ce60faae413308db6bb21d83104ed345797a7a3998966869e564717b73347 \
-    size    12133604 \
+    rmd160  54c02e5c15b94a95c2da8b8b03750022fb610174 \
+    sha256  2d6019c1b58fdd509feb52eea3a01edd0eda3342a32ba0c3af76d30a571d16c5 \
+    size    12132678 \
   ${promu_distfile} \
     rmd160  794fd1112584c13ae95506336578a96716377c8a \
     sha256  17f9b9816e6a5b4304bda34d2ae025732e20837c27a431639731ebbd45eda08f \


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
