### PR TITLE
ImageMagick: Bump version and revbump dependents

### DIFF
--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -7,7 +7,7 @@ PortGroup           cxx11 1.1
 name                LyX
 conflicts           LyX1
 version             2.3.3
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          aqua
 license             GPL-2+

--- a/aqua/LyX1/Portfile
+++ b/aqua/LyX1/Portfile
@@ -5,7 +5,7 @@ PortGroup           qt4 1.0
 
 name                LyX1
 version             1.6.10
-revision            2
+revision            3
 categories          aqua
 platforms           darwin
 license             GPL-2+

--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -9,7 +9,7 @@ set emacs_mac_ver   7.7
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
 version             ${emacs_mac_ver}
-revision            0
+revision            1
 categories          aqua editors
 maintainers         nomaintainer
 

--- a/databases/psiconv/Portfile
+++ b/databases/psiconv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                psiconv
 version             0.9.9
-revision            3
+revision            4
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/devel/libtuxcap/Portfile
+++ b/devel/libtuxcap/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                libtuxcap
 version             1.4.0
-revision            6
+revision            7
 categories          devel games
 platforms           darwin
 maintainers         ryandesign openmaintainer

--- a/devel/pficommon/Portfile
+++ b/devel/pficommon/Portfile
@@ -6,6 +6,7 @@ PortGroup           waf 1.0
 
 epoch               1
 github.setup        retrieva pficommon 2.0.0
+revision            1
 categories          devel
 maintainers         nomaintainer
 

--- a/editors/abiword/Portfile
+++ b/editors/abiword/Portfile
@@ -1,6 +1,7 @@
 PortSystem 1.0
 name		abiword
 version		2.4.5
+revision    1
 description	A word processor with gnome support.
 long_description        A word processor with gnome support.
 license         GPL-3

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -73,7 +73,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         26.3
-    revision        0
+    revision        1
 
     checksums       rmd160  263c0152f538d3371c60accb710f3825b01ae097 \
                     sha256  09c747e048137c99ed35747b012910b704e0974dde4db6696fde7054ce387591 \

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -206,7 +206,7 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
     }
 
     if {$subport eq "emacs-app"} {
-        revision 3
+        revision 4
     }
 
     variant multicolor_font description {Apply multicolor font patch} {

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -107,7 +107,8 @@ configure.args              --enable-shared \
                             --without-lqr \
                             --without-pango \
                             --without-x \
-                            --with-gs-font-dir=${prefix}/share/fonts/urw-fonts
+                            --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \
+                            --disable-openmp
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     configure.args-append   --disable-opencl

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -9,9 +9,9 @@ PortGroup                   conflicts_build 1.0
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.9-40
-revision                    7
+version                     6.9.10-60
 set reasonable_version      [lindex [split ${version} -] 0]
+revision                    0
 homepage                    http://www.imagemagick.org/
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}
@@ -42,9 +42,9 @@ master_sites                http://www.imagemagick.org/download/ \
                             ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick \
                             ftp://sunsite.icm.edu.pl/packages/ImageMagick
 
-checksums                   rmd160  d01d39b0da259c1296acaa37867f1a428928b72e \
-                            sha256  62f25d46bfbcffe00b84e167994d593868a9a47d4defc489a429cae1d6aab9f7 \
-                            size    8919136
+checksums                   rmd160  1a2b117ebf5b7a417c6f0ff1d66562de1a8eb4e3 \
+                            sha256  d94504e827bdc8a7c7f153f2e7f354bf5438e8170cd6504867a2f04ec8cdee74 \
+                            size    8939576
 
 depends_lib                 port:bzip2 \
                             port:djvulibre \

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -9,7 +9,7 @@ PortGroup                   conflicts_build 1.0
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.10-60
+version                     6.9.10-71
 set reasonable_version      [lindex [split ${version} -] 0]
 revision                    0
 homepage                    http://www.imagemagick.org/
@@ -42,9 +42,9 @@ master_sites                http://www.imagemagick.org/download/ \
                             ftp://ftp.sunet.se/pub/multimedia/graphics/ImageMagick \
                             ftp://sunsite.icm.edu.pl/packages/ImageMagick
 
-checksums                   rmd160  1a2b117ebf5b7a417c6f0ff1d66562de1a8eb4e3 \
-                            sha256  d94504e827bdc8a7c7f153f2e7f354bf5438e8170cd6504867a2f04ec8cdee74 \
-                            size    8939576
+checksums                   rmd160  4bc81090ea861f92900a33aea310c4306be5785a \
+                            sha256  fec2d279c067ab2cf453589dd225e1cb7d5cfaffb7acfec529f911fc72bf9c4f \
+                            size    9071596
 
 depends_lib                 port:bzip2 \
                             port:djvulibre \

--- a/graphics/ale/Portfile
+++ b/graphics/ale/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ale
 version             0.8.7
-revision            4
+revision            5
 categories          graphics
 platforms           darwin
 maintainers         nomaintainer

--- a/graphics/autotrace/Portfile
+++ b/graphics/autotrace/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    autotrace
 version                 0.31.1
-revision                13
+revision                14
 categories              graphics
 platforms               darwin
 maintainers             nomaintainer

--- a/graphics/dmtx-utils/Portfile
+++ b/graphics/dmtx-utils/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dmtx dmtx-utils 0.7.6 v
+revision            1
 categories          graphics
 platforms           darwin
 maintainers         nomaintainer

--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -12,6 +12,7 @@ epoch               1
 set git_commit      39435a2e
 set git_date        20190925
 version             0.92.4-${git_date}
+revision            1
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}
 categories          graphics gnome

--- a/graphics/inkscape-gtk3-devel/Portfile
+++ b/graphics/inkscape-gtk3-devel/Portfile
@@ -11,7 +11,7 @@ name                inkscape-gtk3-devel
 conflicts           inkscape inkscape-devel
 set git_commit      42f2371f
 set git_date        20190429
-revision            2
+revision            3
 version             1.0alpha-${git_date}
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}

--- a/graphics/synfig/Portfile
+++ b/graphics/synfig/Portfile
@@ -14,7 +14,7 @@ master_sites        sourceforge:project/synfig/releases/${version}/source/
 dist_subdir         ${subport}
 
 if {${subport} eq ${name}} {
-    revision            5
+    revision            6
 
     description         vector-based 2-D animation package
 

--- a/graphics/vcs/Portfile
+++ b/graphics/vcs/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                vcs
 version             1.13.2
+revision            0
 categories          graphics
 platforms           darwin
 maintainers         ryandesign openmaintainer

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 
 github.setup        libvips libvips 8.8.3 v
-revision            0
+revision            1
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/kde/digikam/Portfile
+++ b/kde/digikam/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                digikam
 version             4.9.0
-revision            9
+revision            10
 categories          kde kde4
 license             GPL-2+
 maintainers         hyper-world.de:jan openmaintainer \

--- a/multimedia/dvdauthor/Portfile
+++ b/multimedia/dvdauthor/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                dvdauthor
 version             0.7.2
+revision            1
 categories          multimedia
 platforms           darwin
 maintainers         {perry.ch:maurice @robbyn}

--- a/multimedia/dvdrip/Portfile
+++ b/multimedia/dvdrip/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                dvdrip
 perl5.branches      5.28
 perl5.setup         ${name} 0.98.11
-revision            5
+revision            6
 categories          multimedia
 maintainers         nomaintainer
 license             {Artistic-1 GPL}

--- a/multimedia/gnupod/Portfile
+++ b/multimedia/gnupod/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                gnupod
 version             0.99.8
-revision            5
+revision            6
 categories          multimedia perl
 maintainers         nomaintainer
 platforms           darwin

--- a/multimedia/tovid/Portfile
+++ b/multimedia/tovid/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        tovid-suite tovid 0.35.2
-revision            1
+revision            2
 categories          multimedia
 maintainers         nomaintainer
 installs_libs       no

--- a/multimedia/transcode/Portfile
+++ b/multimedia/transcode/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name        transcode
 version     1.1.7
-revision    24
+revision    25
 epoch       1
 license     GPL-2+
 categories  multimedia

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,7 +7,7 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.26 5.28 5.30
-perl5.setup         PerlMagick 6.9.10-60
+perl5.setup         PerlMagick 6.9.10-71
 set reasonable_version \
                     [lindex [split ${version} -] 0]
 revision            0
@@ -31,9 +31,9 @@ master_sites        http://www.imagemagick.org/download/ \
 dist_subdir         ImageMagick
 distname            ${my_name}-${version}
 
-checksums           rmd160  1a2b117ebf5b7a417c6f0ff1d66562de1a8eb4e3 \
-                    sha256  d94504e827bdc8a7c7f153f2e7f354bf5438e8170cd6504867a2f04ec8cdee74 \
-                    size    8939576
+checksums           rmd160  4bc81090ea861f92900a33aea310c4306be5785a \
+                    sha256  fec2d279c067ab2cf453589dd225e1cb7d5cfaffb7acfec529f911fc72bf9c4f \
+                    size    9071596
 
 if {${perl5.major} != ""} {
 depends_lib-append  port:ImageMagick

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,9 +7,10 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.26 5.28 5.30
-perl5.setup         PerlMagick 6.9.9-40
+perl5.setup         PerlMagick 6.9.10-60
 set reasonable_version \
                     [lindex [split ${version} -] 0]
+revision            0
 set my_name         ImageMagick
 maintainers         {ryandesign @ryandesign}
 description         Perl extension for calling ImageMagick's libMagick methods
@@ -30,9 +31,9 @@ master_sites        http://www.imagemagick.org/download/ \
 dist_subdir         ImageMagick
 distname            ${my_name}-${version}
 
-checksums           rmd160  d01d39b0da259c1296acaa37867f1a428928b72e \
-                    sha256  62f25d46bfbcffe00b84e167994d593868a9a47d4defc489a429cae1d6aab9f7 \
-                    size    8919136
+checksums           rmd160  1a2b117ebf5b7a417c6f0ff1d66562de1a8eb4e3 \
+                    sha256  d94504e827bdc8a7c7f153f2e7f354bf5438e8170cd6504867a2f04ec8cdee74 \
+                    size    8939576
 
 if {${perl5.major} != ""} {
 depends_lib-append  port:ImageMagick

--- a/php/php-imagick/Portfile
+++ b/php/php-imagick/Portfile
@@ -6,7 +6,7 @@ PortGroup               php 1.1
 name                    php-imagick
 epoch                   1
 version                 3.4.4
-revision                0
+revision                1
 categories-append       graphics
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer

--- a/php/php-magickwand/Portfile
+++ b/php/php-magickwand/Portfile
@@ -5,7 +5,7 @@ PortGroup           php 1.1
 
 name                php-magickwand
 version             1.0.9-2
-revision            4
+revision            5
 categories-append   graphics
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer

--- a/python/py-djvubind/Portfile
+++ b/python/py-djvubind/Portfile
@@ -5,7 +5,7 @@ PortGroup                       python 1.0
 
 name                            py-djvubind
 version                         1.2.1
-revision                        1
+revision                        2
 python.versions                 34 35 36
 platforms                       darwin
 supported_archs                 noarch

--- a/python/py-wand/Portfile
+++ b/python/py-wand/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-wand
 version             0.5.7
-revision            0
+revision            1
 categories-append   graphics
 platforms           darwin
 license             MIT

--- a/ruby/rb-rmagick/Portfile
+++ b/ruby/rb-rmagick/Portfile
@@ -7,7 +7,7 @@ PortGroup               active_variants 1.1
 
 github.setup            rmagick rmagick 2-13-3 RMagick_
 version                 [string map {- .} ${github.version}]
-revision                1
+revision                2
 ruby.setup              RMagick ${version} setup.rb {README examples}
 categories-append       graphics
 platforms               darwin

--- a/science/xastir/Portfile
+++ b/science/xastir/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xastir
 version             2.0.8
-revision            6
+revision            7
 categories          science
 license             GPL-2+
 platforms           darwin

--- a/textproc/cuneiform/Portfile
+++ b/textproc/cuneiform/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    cuneiform
 version                 1.1.0
-revision                5
+revision                6
 set branch              [join [lrange [split ${version} .] 0 1] .]
 platforms               darwin
 maintainers             nomaintainer

--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -6,7 +6,7 @@ PortGroup           texlive 1.0
 
 name                dblatex
 version             0.3.10
-revision            2
+revision            3
 categories          textproc tex
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2+

--- a/www/mediawiki/Portfile
+++ b/www/mediawiki/Portfile
@@ -2,6 +2,7 @@ PortSystem          1.0
 
 name                mediawiki
 version             1.23.2
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          www php
 license             GPL-2+

--- a/x11/advi/Portfile
+++ b/x11/advi/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                advi
 version             1.10.2
-revision            3
+revision            4
 categories          x11 graphics
 license             LGPL
 maintainers         nomaintainer

--- a/x11/tango-icon-theme-extras/Portfile
+++ b/x11/tango-icon-theme-extras/Portfile
@@ -2,6 +2,7 @@ PortSystem  1.0
 
 name            tango-icon-theme-extras
 version         0.1.0
+revision        1
 description     A collection of extra icons for the Tango theme.
 long_description tango-icon-theme-extras is an additionnal collection \
                 (mostly ipod variations) of icons adhering to the \

--- a/x11/tango-icon-theme/Portfile
+++ b/x11/tango-icon-theme/Portfile
@@ -2,6 +2,7 @@ PortSystem  1.0
 
 name            tango-icon-theme
 version         0.8.90
+revision        0
 description     A collection of icons from the Tango Desktop Project.
 long_description tango-icon-theme is a collection of bright and vivid icons and \
                 emblems from the Tango Desktop Project. They can replace the gnome-icon-theme.


### PR DESCRIPTION
#### Description

See #5014 for reference. I updated imagemagick to the last version 6 and rev-bumped all the dependents ports (hopefully). This also fix a bug I was experiencing while converting `svgs` and `eps` files.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
