### PR TITLE
inkscape-gtk3-devel: It builds on my system

### DIFF
--- a/graphics/inkscape-gtk3-devel/Portfile
+++ b/graphics/inkscape-gtk3-devel/Portfile
@@ -9,9 +9,9 @@ cmake.generator     Ninja
 
 name                inkscape-gtk3-devel
 conflicts           inkscape inkscape-devel
-set git_commit      42f2371f
-set git_date        20190429
-revision            2
+set git_commit      727140f9
+set git_date        20190602
+revision            0
 version             1.0alpha-${git_date}
 license             GPL-2 LGPL-2.1
 maintainers         {devans @dbevans}
@@ -56,6 +56,7 @@ depends_lib-append \
                     port:gsl \
                     port:glibmm \
                     port:gtkmm3 \
+                    port:gtk-osx-application-gtk3 \
                     port:gtkspell3 \
                     port:aspell \
                     port:dbus-glib \
@@ -73,15 +74,10 @@ depends_lib-append \
                     port:py${python_version}-lxml \
                     port:py${python_version}-numpy
 
-post-patch {
-    reinplace "s|\"python-interpreter\", \"python\"|\"python-interpreter\", \"python${python_major}.${python_minor}\"|g" ${worksrcpath}/src/extension/implementation/script.cpp
-    reinplace "s|^#include \"Object.h\"|#include \"${prefix}/include/poppler/Object.h\"|" ${worksrcpath}/src/extension/internal/pdfinput/pdf-parser.h
-    reinplace "s|^#include \"Object.h\"|#include \"${prefix}/include/poppler/Object.h\"|" ${worksrcpath}/src/extension/internal/pdfinput/pdf-parser.cpp
-    reinplace "s|lib/inkscape|lib|" ${worksrcpath}/src/CMakeLists.txt
-}
+patchfiles         patch_lib_dir.patch
+patch.pre_args     -p1
 
 # py-numpy is currently not universal (#48263).
-
 universal_variant no
 
 # clang-425.0.28 cannot handle glibmm's headers
@@ -89,7 +85,7 @@ universal_variant no
 compiler.blacklist-append {clang < 500} *gcc-3.* *gcc-4.*
 
 configure.args-append \
-    -DWITH_DBUS:BOOL=ON \
+    -DWITH_DBUS:BOOL=OFF \
     -DWITH_GRAPHICS_MAGICK:BOOL=OFF \
     -DWITH_OPENMP=OFF \
     -DWITH_JEMALLOC=OFF

--- a/graphics/inkscape-gtk3-devel/files/patch_lib_dir.patch
+++ b/graphics/inkscape-gtk3-devel/files/patch_lib_dir.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0905b5dafd..5d929b3679 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -55,7 +55,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
+ 
+ if(APPLE)
+     SET(CMAKE_MACOSX_RPATH TRUE)
+-    SET(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}/inkscape")
++    SET(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+ else()
+     SET(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/inkscape")
+ endif()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d317cbeb14..6fbf75b1f4 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -384,5 +384,5 @@ if(WIN32)
+     install(TARGETS inkscape_com inkview_com)
+ endif()
+ if(BUILD_SHARED_LIBS)
+-    install(TARGETS inkscape_base LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/inkscape)
++    install(TARGETS inkscape_base LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()


### PR DESCRIPTION
#### Description
Ehi, since `inkscape` port does not work anymore on Mojave when using the `quartz` backend, I tried to update the `Portfile` for the `gtk3` version. This port builds correctly on my system (and the graphical appearance is native!) and at first attempt I did, it looks to work as expected. 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6
Xcode 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
