### PR TITLE
paraview: Patch case sensitivity of IceT and QtTesting

### DIFF
--- a/devel/qttesting/Portfile
+++ b/devel/qttesting/Portfile
@@ -6,7 +6,7 @@ PortGroup               qt5   1.0
 
 name                    qttesting
 version                 20190802
-revision                0
+revision                1
 categories              devel
 # same license as ParaView
 license                 BSD

--- a/devel/qttesting/files/patch-variable_name.diff
+++ b/devel/qttesting/files/patch-variable_name.diff
@@ -1,9 +1,9 @@
 --- QtTestingConfig-install.cmake.in.orig	2019-07-12 00:54:52.000000000 -0700
 +++ QtTestingConfig-install.cmake.in	2019-07-12 00:56:26.000000000 -0700
-@@ -1,4 +1,6 @@
+@@ -1,4 +1,5 @@
  set(QtTesting_INCLUDE_DIRS "@QtTesting_INSTALL_INCLUDE_FULL_DIR@")
  set(QtTesting_LIBRARY_DIR "@QtTesting_INSTALL_LIB_FULL_DIR@")
- set(QtTesting_LIBRARIES QtTesting)
-+set(QTTESTING_INCLUDE_DIRS "${QtTesting_INCLUDE_DIRS}")
-+set(QTTESTING_LIBRARIES "${QtTesting_LIBRARY_DIR}/libQtTesting.dylib")
+-set(QtTesting_LIBRARIES QtTesting)
++set(QtTesting_LIBRARIES "${QtTesting_LIBRARY_DIR}/libQtTesting.dylib")
++set(QtTesting_INCLUDE_DIRS "${QtTesting_INCLUDE_DIRS}")
  include("${CMAKE_CURRENT_LIST_DIR}/QtTestingTargets.cmake")

--- a/science/paraview/Portfile
+++ b/science/paraview/Portfile
@@ -45,7 +45,8 @@ checksums           sha256  50ef01f54db6358b402e50d1460ef47c04d675bf26f250c69377
 patchfiles          patch-icon-size.diff \
                     patch-vtk_target_export.diff \
                     patch-ogg_dependency.diff \
-                    patch-system_ok.diff
+                    patch-system_ok.diff \
+                    patch-case-sensitivity.diff
 
 depends_lib-append  path:include/eigen3/Eigen/Eigen:eigen3 \
                     port:glew \

--- a/science/paraview/files/patch-case-sensitivity.diff
+++ b/science/paraview/files/patch-case-sensitivity.diff
@@ -1,0 +1,26 @@
+diff --git ThirdParty/IceT/CMakeLists.txt ThirdParty/IceT/CMakeLists.txt
+index 383f8abb85..e728660664 100644
+--- ThirdParty/IceT/CMakeLists.txt
++++ ThirdParty/IceT/CMakeLists.txt
+@@ -61,7 +61,7 @@ set(ICET_INSTALL_NO_DEVELOPMENT ${VTK_INSTALL_NO_DEVELOPMENT})
+ set(ICET_INSTALL_NO_LIBRARIES ${VTK_INSTALL_NO_LIBRARIES})
+ set(ICET_INSTALL_EXPORT_NAME ${VTK_INSTALL_EXPORT_NAME})
+ 
+-vtk_module_third_party(icet
++vtk_module_third_party(IceT
+   INCLUDE_DIRS
+     ${CMAKE_CURRENT_SOURCE_DIR}/vtkicet/src/include
+     ${CMAKE_CURRENT_BINARY_DIR}/vtkicet/src/include
+diff --git ThirdParty/QtTesting/CMakeLists.txt ThirdParty/QtTesting/CMakeLists.txt
+index 65783ca583..f04fd85746 100644
+--- ThirdParty/QtTesting/CMakeLists.txt
++++ ThirdParty/QtTesting/CMakeLists.txt
+@@ -41,7 +41,7 @@ set (QtTesting_QT_VERSION ${PARAVIEW_QT_VERSION})
+ set (QT_TESTING_CUSTOM_LIBRARY_SUFFIX ${VTK_CUSTOM_LIBRARY_SUFFIX})
+ ##########################################################################
+ # import Qt build settings
+-vtk_module_third_party(qttesting
++vtk_module_third_party(QtTesting
+   INCLUDE_DIRS
+     ${CMAKE_CURRENT_SOURCE_DIR}/vtkqttesting
+     ${CMAKE_CURRENT_BINARY_DIR}/vtkqttesting


### PR DESCRIPTION
Otherwise it won't build on system with a case-sensitive filesystem

#### Description
It seems that the recently landed update on the `paraview` port doesn't build on buildbots machine. I think it's related to the filesystem being case-sensitive. So I'm trying a tentative fix here (since I cannot test it locally)

Ref: #4045 

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
