### PR TITLE
zabbix42: New(-ish) port.

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -3,7 +3,6 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                zabbix4
-version             4.0.11
 revision            0
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
@@ -20,34 +19,65 @@ long_description    Zabbix is the ultimate open source availability and \
                     which are missing in other monitoring systems, even some \
                     of the best commercial ones. 
 
+array set VERSIONS {
+    4  4.0.11
+    42 4.2.5
+}
+
+set zver            [regsub -all {[^\d]} ${subport} {}]
+version             $VERSIONS(${zver})
+
 distname            zabbix-${version}
 livecheck.name      zabbix
-livecheck.regex     "Stable\/(4\.0\.\[0-9\]+)\/"
+
 livecheck.url \
     http://sourceforge.net/projects/zabbix/files/ZABBIX%20Latest%20Stable/
 homepage            http://www.zabbix.com/
 master_sites \
     sourceforge:project/zabbix/ZABBIX%20Latest%20Stable/${version} \
     sourceforge:project/zabbix/ZABBIX%20Release%20Candidates/${version}
-dist_subdir         zabbix4
+dist_subdir         zabbix${zver}
 
-checksums \
-    rmd160  4b752d23438cfea41f04878a1e6f4a039104c146 \
-    sha256  b0af25c31c622d14cb7780db5941d76579b9f9a6ee449613d847b0b505628409 \
-    size    17174772
+if {$zver == 4} {
+    livecheck.regex     "Stable\/(4\.0\.\[0-9\]+)\/"
+    checksums \
+        rmd160  4b752d23438cfea41f04878a1e6f4a039104c146 \
+        sha256  b0af25c31c622d14cb7780db5941d76579b9f9a6ee449613d847b0b505628409 \
+        size    17174772
+}
+if {$zver == 42} {
+    livecheck.regex     "Stable\/(4\.2\.\[0-9\]+)\/"
+    checksums \
+        rmd160  0c07b785840825ea05a7b1400331218d23862049 \
+        sha256  4dba94cc8c5f1d97b596e636ff9346c3bdea59ac04a97f1236a6d5e69d72ab8c \
+        size    18301157
+}
 
 patchfiles          log_and_pid_locations.patch
 
 universal_variant   no
 
-subport             zabbix4-agent {}
-subport             zabbix4-frontend {}
+subport             zabbix42            {conflicts zabbix4}
+
+subport             zabbix4-agent       {conflicts zabbix42-agent}
+subport             zabbix42-agent      {conflicts zabbix4-agent}
+
+subport             zabbix4-frontend    {conflicts zabbix42-frontend}
+subport             zabbix42-frontend   {conflicts zabbix4-frontend}
+
+proc isFlavor {desc subp} {
+    if {[string first ${desc} ${subp}] >= 0} {
+        return 1
+    } else {
+        return 0
+    }
+}
 
 configure.args      --bindir=${prefix}/bin/zabbix \
                     --sbindir=${prefix}/sbin/zabbix \
                     --libexecdir=${prefix}/libexec/zabbix \
                     --datadir=${prefix}/share/zabbix \
-                    --sysconfdir=${prefix}/etc/zabbix4 \
+                    --sysconfdir=${prefix}/etc/zabbix${zver} \
                     --localstatedir=${prefix}/var/zabbix \
                     --with-gnutls=${prefix} \
                     --enable-ipv6 \
@@ -56,7 +86,7 @@ configure.args      --bindir=${prefix}/bin/zabbix \
 
 configure.ldflags-append    -lresolv
 
-if { ${subport} ne "zabbix4-frontend" } {
+if {![isFlavor frontend ${subport}]} {
     startupitem.create      yes
     depends_lib-append      port:libiconv \
                             port:gnutls \
@@ -64,24 +94,24 @@ if { ${subport} ne "zabbix4-frontend" } {
                             port:libevent
 }
 
-if { ${subport} eq "zabbix4-agent" } {
-    long_description-append "This port provides the local monitoring agent."
-    conflicts               zabbix2-agent zabbix3-agent
-    startupitem.name        zabbix4-agentd
+if {[isFlavor agent ${subport}]} {
+    long_description-append "\n * ${subport} provides a local monitoring agent."
+    conflicts-append        zabbix2-agent zabbix3-agent
+    startupitem.name        zabbix${zver}-agentd
     startupitem.executable  \
         ${prefix}/sbin/zabbix/zabbix_agentd \
-        -c ${prefix}/etc/zabbix4/zabbix_agentd.conf
+        -c ${prefix}/etc/zabbix${zver}/zabbix_agentd.conf
     startupitem.pidfile     auto ${prefix}/var/run/zabbix/zabbix_agentd.pid
     startupitem.logfile     ${prefix}/var/log/zabbix/zabbix_agentd.launch
 
     configure.args-append   --enable-agent
 
     destroot.keepdirs \
-        ${destroot}${prefix}/etc/zabbix4/zabbix_agentd.conf.d \
+        ${destroot}${prefix}/etc/zabbix${zver}/zabbix_agentd.conf.d \
         ${destroot}${prefix}/var/run/zabbix \
         ${destroot}${prefix}/var/log/zabbix
-} elseif { ${subport} eq "zabbix4-frontend" } {
-    long_description-append "This port provides the web (PHP) frontend."
+} elseif {[isFlavor frontend ${subport}]} {
+    long_description-append "\n * ${subport} provides the web (PHP) frontend."
     supported_archs         noarch
     depends_run-append      port:apache2
 
@@ -111,7 +141,7 @@ if { ${subport} eq "zabbix4-agent" } {
     destroot {}
 } else {
     long_description-append "This port provides the central server component."
-    conflicts               zabbix zabbix2 zabbix3
+    conflicts-append        zabbix zabbix2 zabbix3
 
     depends_lib-append      port:curl \
                             port:OpenIPMI \
@@ -131,7 +161,7 @@ if { ${subport} eq "zabbix4-agent" } {
                             --with-libxml2=${prefix}/bin/xml2-config\
                             --with-zlib=${prefix}
 
-    startupitem.name        zabbix4-server
+    startupitem.name        zabbix${zver}-server
     startupitem.start       ${prefix}/sbin/zabbix/zabbix_server
     set pidfile             ${prefix}/var/run/zabbix/zabbix_server.pid
     # Gracefully wait up to two minutes for zabbix to shut down / clean up
@@ -142,8 +172,8 @@ if { ${subport} eq "zabbix4-agent" } {
     startupitem.netchange   yes
 
     destroot.keepdirs \
-        ${destroot}${prefix}/etc/zabbix4/zabbix_server.conf.d \
-        ${destroot}${prefix}/var/run/zabbix4 \
+        ${destroot}${prefix}/etc/zabbix${zver}/zabbix_server.conf.d \
+        ${destroot}${prefix}/var/run/zabbix${zver} \
         ${destroot}${prefix}/var/log/zabbix
 
     variant full_server description {
@@ -151,13 +181,13 @@ if { ${subport} eq "zabbix4-agent" } {
     } {}
     
     variant frontend description {Include frontend PHP files / deps} {
-        depends_run-append  port:zabbix4-frontend
+        depends_run-append  port:zabbix${zver}-frontend
     }
 
     default_variants-append +frontend
 }
 
-if { ${subport} ne "zabbix4-agent" } {
+if {![isFlavor agent ${subport}]} {
     # Logic for database backends. Needed for -frontend and -server
     # Items are "display name" "port name" "config arg" "php interface"
     array set DBLIST {
@@ -201,7 +231,7 @@ if { ${subport} ne "zabbix4-agent" } {
             set ::MYSQL_MODE        [string equal [lindex ${prms} 3] mysql]
             configure.args-append   --with-[lindex ${prms} 2]
 
-            if { \"${subport}\" eq {zabbix4-frontend} } {
+            if {[isFlavor frontend ${subport}]} {
                 if {[variant_isset php56]} {
                     depends_run-append \
                         port:php56-[lindex ${prms} 3]
@@ -228,7 +258,7 @@ if { ${subport} ne "zabbix4-agent" } {
                 }
             } else {
                 depends_lib-append      port:[lindex ${prms} 1]
-                require_active_variants port:zabbix4-agent ${dbitem}
+                require_active_variants port:zabbix${zver}-agent ${dbitem}
             }
 
             if {[string compare ${dbitem} sqlite3] && \
@@ -255,7 +285,7 @@ if { ${subport} ne "zabbix4-agent" } {
 }
 
 post-extract {
-    if { ${name} == ${subport} } {
+    if {[string first - ${subport}] == -1} {
         if { ${MYSQL_MODE} == 1 &&
              [variant_isset full_server] } {
                 set repstr "s|# DBSocket=|"
@@ -271,24 +301,24 @@ post-extract {
 post-patch {
     reinplace "s|%%PREFIX%%|${prefix}|" \
         conf/zabbix_agentd.conf conf/zabbix_server.conf
-    reinplace "s|/usr/local/etc|${prefix}/etc/zabbix4|" \
+    reinplace "s|/usr/local/etc|${prefix}/etc/zabbix${zver}|" \
         conf/zabbix_agentd.conf conf/zabbix_server.conf
 }
 
 add_users zabbix group=zabbix
 
 post-destroot {
-    if { ${subport} eq "zabbix4-agent" } {
+    if {[isFlavor agent ${subport}]} {
      ####### AGENT #######
 # Copy sample agent .conf files
         xinstall -m 755 -d \
-            ${destroot}${prefix}/etc/zabbix4/zabbix_agentd.conf.d
+            ${destroot}${prefix}/etc/zabbix${zver}/zabbix_agentd.conf.d
         xinstall -m 755  ${worksrcpath}/conf/zabbix_agentd.conf \
-            ${destroot}${prefix}/etc/zabbix4/zabbix_agentd.conf.sample
+            ${destroot}${prefix}/etc/zabbix${zver}/zabbix_agentd.conf.sample
 
 # Don't overwrite user settings on each install
-        delete ${destroot}${prefix}/etc/zabbix4/zabbix_agentd.conf
-    } elseif { ${subport} eq "zabbix4-frontend" } {
+        delete ${destroot}${prefix}/etc/zabbix${zver}/zabbix_agentd.conf
+    } elseif {[isFlavor frontend ${subport}]} {
 # Copy the front end files
         set fedir ${destroot}${prefix}/share/zabbix/frontends
         file mkdir ${fedir}
@@ -311,11 +341,11 @@ post-destroot {
      ####### SERVER #######
 # Copy sample server and agent .conf files
         xinstall -m 755 -d \
-            ${destroot}${prefix}/etc/zabbix4/zabbix_server.conf.d
+            ${destroot}${prefix}/etc/zabbix${zver}/zabbix_server.conf.d
 
 # Don't overwrite user settings on each install
-        move ${destroot}${prefix}/etc/zabbix4/zabbix_server.conf \
-            ${destroot}${prefix}/etc/zabbix4/zabbix_server.conf.sample
+        move ${destroot}${prefix}/etc/zabbix${zver}/zabbix_server.conf \
+            ${destroot}${prefix}/etc/zabbix${zver}/zabbix_server.conf.sample
 
 # Copy database data and schemas
         xinstall -m 755 -d ${destroot}${prefix}/share/zabbix/scripts
@@ -328,8 +358,8 @@ post-destroot {
         #    ${destroot}${prefix}/share/zabbix/
 
         # Set permissions for etc (protect passwords) 
-        system "chmod ug+rwX,o-rwx ${destroot}${prefix}/etc/zabbix4/*"
-        system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix4"
+        system "chmod ug+rwX,o-rwx ${destroot}${prefix}/etc/zabbix${zver}/*"
+        system "chown -R zabbix:zabbix ${destroot}${prefix}/etc/zabbix${zver}"
     }
 
     foreach dname {run log} {
@@ -339,12 +369,12 @@ post-destroot {
 
 }
 
-if { ${subport} eq "zabbix4-agent" } {
+if {[isFlavor agent ${subport}]} {
     notes "
-####                                        ####
-#### ZABBIX4 agent installation section     ####
+####
+#### ZABBIX${zver} agent installation section
 
-1) Edit the sample .conf file ${prefix}/etc/zabbix4/zabbix_agentd.conf.sample
+1) Edit the sample .conf file ${prefix}/etc/zabbix${zver}/zabbix_agentd.conf.sample
    (rename & omit .sample)
 
    Set the following variable to the ip address of your ZABBIX server to\
@@ -355,15 +385,15 @@ if { ${subport} eq "zabbix4-agent" } {
 
 2) Set zabbix_agentd to run at system boot
 
-     sudo port load zabbix4-agent
+     sudo port load zabbix${zver}-agent
 
-#### End ZABBIX4 agent installation section ####
-####                                        ####
+#### End ZABBIX${zver} agent installation section ####
+####
 "
-} elseif { ${subport} eq "zabbix4-frontend" } {
+} elseif {[isFlavor frontend ${subport}]} {
     notes "
-####                                              ####
-#### Begin ZABBIX4 frontend installastion section ####
+####
+#### Begin ZABBIX${zver} frontend installastion section ####
 
 1) Set a symbolic link in your Apache document root pointing to the PHP
    frontend files
@@ -389,13 +419,14 @@ if { ${subport} eq "zabbix4-agent" } {
 
 4) Read the fine manual at http://www.zabbix.com/documentation/
 
-#### End ZABBIX4 frontend installation section   ####
-####                                             ####
+#### End ZABBIX${zver} frontend installation section   ####
+####
 "
 } else {
+    set shortver [regsub {\.\d+$} ${version} {}]
     notes "
-####                                                 ####
-#### Begin ZABBIX4 local server installation section ####
+####
+#### Begin ZABBIX${zver} local server installation section ####
 
  (Installing with +full_server will add all of the dependants; configuration
   will still be required.)
@@ -409,13 +440,13 @@ if { ${subport} eq "zabbix4-agent" } {
 
     Follow the directions at :
 
-  https://www.zabbix.com/documentation/4.0/manual/appendix/install/db_scripts
+  https://www.zabbix.com/documentation/${shortver}/manual/appendix/install/db_scripts
 
     The *.sql files it refers to are in ${prefix}/share/zabbix/scripts/
     ** NOTE THAT THESE ARE FOR YOUR SELECTED DATABASE VARIANT!!! **
 
 
-3) Edit the sample .conf file ${prefix}/etc/zabbix4/zabbix_server.conf
+3) Edit the sample .conf file ${prefix}/etc/zabbix${zver}/zabbix_server.conf
    (rename & omit .sample)
 
    Modify these variables at the very least:
@@ -429,33 +460,33 @@ if { ${subport} eq "zabbix4-agent" } {
 
 4) Set zabbix_server to run at system boot (also starts it immediately):
 
-    sudo port load zabbix4
+    sudo port load zabbix${zver}
 
 
 5) Read the fine manual at http://www.zabbix.com/documentation/
 
 
-#### End ZABBIX4 local server installation section   ####
+#### End ZABBIX${zver} local server installation section   ####
 ####                                                 ####
 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! ZABBIX3 -> ZABBIX4 Server Upgrade process !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! ZABBIX${zver} Server Version Upgrade process
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!  0) Be sure to use 'sudo port unload zabbix3' to stop the background   !!
-!!     server before deactivating zabbix3.                                !!
-!!                                                                        !!
-!!  1) BACK UP YOUR DATABASE                                              !!
-!!                                                                        !!
-!!  2) Create/edit ${prefix}/etc/zabbix4/zabbix_server.conf              !!
-!!        zabbix_server.conf.sample is available for reference.           !!
-!!        There are new features to consider.                             !!
-!!        ** NOTE conf dir is etc/zabbix4 **                              !!
-!!                                                                        !!
-!!  3) 'sudo port load zabbix4' after installing.                         !!
-!!                                                                        !!
-!!  For complete upgrade directions, please see:                          !!
-!!    http://www.zabbix.com/documentation/4.0/manual/installation/upgrade !!
+!!  0) Be sure to use 'sudo port unload zabbixN' to stop the background
+!!     server before deactivating zabbixN. (Whatever version you are running.)
+!!
+!!  1) BACK UP YOUR DATABASE
+!!
+!!  2) Create/edit ${prefix}/etc/zabbix${zver}/zabbix_server.conf
+!!        zabbix_server.conf.sample is available for reference.
+!!        There are new features to consider.
+!!        ** NOTE conf dir is etc/zabbix${zver} **
+!!
+!!  3) 'sudo port load zabbix${zver}' after installing.
+!!
+!!  For complete upgrade directions, please see:
+!!    http://www.zabbix.com/documentation/${shortver}/manual/installation/upgrade
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
Maintainer "update" of zabbix4 to zabbix42.

zabbix 4.0 is a LTS branch, so I intend to keep it around at least until the next LTS.

4.2 is the current latest release. Very minor (99% just s/zabbix4/zabbix42/g) changes from previous Portfile. I also plan to start obsoleting old versions (zabbix/zabbix2/zabbix3) in the near future. Not sure if anyone else out there is using them via MP, but just FYI...