### PR TITLE
py-pint: update to 0.9 and enable python 37

### DIFF
--- a/python/py-pint/Portfile
+++ b/python/py-pint/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        hgrecco pint 0.8.1
+github.setup        hgrecco pint 0.9
+distname            ${github.version}
 
 name                py-pint
 categories-append   science
@@ -22,13 +23,14 @@ long_description    Pint is Python module/package to define, operate and \
 
 homepage            https://pint.readthedocs.org/
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
     depends_run-append      port:py${python.version}-setuptools
 
-    checksums               rmd160  cdf6eaf626d01224c202ae8a03644ee3234e59e9 \
-                            sha256  05b81801249543c3921ac9e031048f153cddb67deb9964577be96e9bfff9830a
+    checksums               rmd160  e181cfa8aa84a47f930830e940f64d48831759b3 \
+                            sha256  4d7a3c78e68991ad1a254a2f792c0c2fdb27aeb0debb7fcecc529a9df3320ae4 \
+                            size    166980
 
     livecheck.type          none
 }


### PR DESCRIPTION
#### Description

* update to version 0.9
* enable python 37 in Portfile

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
  (yes, but there are no tests for this port)
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->