### PR TITLE
Updates for nsd and unbound

### DIFF
--- a/net/nsd/Portfile
+++ b/net/nsd/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                nsd
-version             4.1.22
+version             4.2.1
 categories          net
 platforms           darwin
 license             BSD
-maintainers         nomaintainer
+maintainers         {rna.nl:gerben.wierda @gctwnl} openmaintainer
 
 description         Authoritative only, high performance, simple name server.
 long_description    NSD is an authoritative only, high performance, simple and \
@@ -19,9 +19,9 @@ set nsdgroup        nsd
 homepage            https://www.nlnetlabs.nl/projects/nsd/about/
 master_sites        https://www.nlnetlabs.nl/downloads/nsd/
 
-checksums           rmd160  f36762fa9b816ba63bf9a39a1df986b435219883 \
-                    sha256  f186e86705768a35ecb6ac18d1ee4eeec2745fcd1feab38e64f89c5eb5aa049c \
-                    size    1099463
+checksums           rmd160  79ba64d55ca1d473be16f00dbedf80e5122a13ce \
+                    sha256  d17c0ea3968cb0eb2be79f2f83eb299b7bfcc554b784007616eed6ece828871f \
+                    size    1145713
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl
@@ -57,3 +57,14 @@ variant stats description {Enable BIND8-style statistics} {
 livecheck.type  regex
 livecheck.url   ${master_sites}
 livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+
+# Make it run at boot
+# Redirect stderr on launchd-started items because launchd redirects stderr to a black hole
+# Let macports (daemondo) manage the availability of process and pidfile (works without for now, but is more robust)
+startupitem.create	yes
+startupitem.name	nsd
+startupitem.logfile	/Library/Logs/nsd-startupitem.log
+startupitem.logevents	yes
+startupitem.start	"(${prefix}/sbin/nsd 2>&1)"
+startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/${name}.pid) 2>&1)"
+startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid

--- a/net/nsd/Portfile
+++ b/net/nsd/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 
 name                nsd
-version             4.2.1
-revision            1
+version             4.1.22
 categories          net
 platforms           darwin
 license             BSD
-maintainers         {rna.nl:gerben.wierda @gctwnl} openmaintainer
+maintainers         nomaintainer
 
 description         Authoritative only, high performance, simple name server.
 long_description    NSD is an authoritative only, high performance, simple and \
@@ -20,9 +19,9 @@ set nsdgroup        nsd
 homepage            https://www.nlnetlabs.nl/projects/nsd/about/
 master_sites        https://www.nlnetlabs.nl/downloads/nsd/
 
-checksums           rmd160  79ba64d55ca1d473be16f00dbedf80e5122a13ce \
-                    sha256  d17c0ea3968cb0eb2be79f2f83eb299b7bfcc554b784007616eed6ece828871f \
-                    size    1145713
+checksums           rmd160  f36762fa9b816ba63bf9a39a1df986b435219883 \
+                    sha256  f186e86705768a35ecb6ac18d1ee4eeec2745fcd1feab38e64f89c5eb5aa049c \
+                    size    1099463
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl
@@ -58,14 +57,3 @@ variant stats description {Enable BIND8-style statistics} {
 livecheck.type  regex
 livecheck.url   ${master_sites}
 livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
-
-# Make it run at boot
-# Redirect stderr on launchd-started items because launchd redirects stderr to a black hole
-# Let macports (daemondo) manage the availability of process and pidfile (works without for now, but is more robust)
-startupitem.create	yes
-startupitem.name	nsd
-startupitem.logfile	/Library/Logs/nsd-startupitem.log
-startupitem.logevents	yes
-startupitem.start	"(${prefix}/sbin/nsd 2>&1)"
-startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/${name}.pid) 2>&1)"
-startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid

--- a/net/nsd/Portfile
+++ b/net/nsd/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 
 name                nsd
-version             4.1.22
+version             4.2.1
+revision            1
 categories          net
 platforms           darwin
 license             BSD
-maintainers         nomaintainer
+maintainers         {rna.nl:gerben.wierda @gctwnl} openmaintainer
 
 description         Authoritative only, high performance, simple name server.
 long_description    NSD is an authoritative only, high performance, simple and \
@@ -19,9 +20,9 @@ set nsdgroup        nsd
 homepage            https://www.nlnetlabs.nl/projects/nsd/about/
 master_sites        https://www.nlnetlabs.nl/downloads/nsd/
 
-checksums           rmd160  f36762fa9b816ba63bf9a39a1df986b435219883 \
-                    sha256  f186e86705768a35ecb6ac18d1ee4eeec2745fcd1feab38e64f89c5eb5aa049c \
-                    size    1099463
+checksums           rmd160  79ba64d55ca1d473be16f00dbedf80e5122a13ce \
+                    sha256  d17c0ea3968cb0eb2be79f2f83eb299b7bfcc554b784007616eed6ece828871f \
+                    size    1145713
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl
@@ -57,3 +58,14 @@ variant stats description {Enable BIND8-style statistics} {
 livecheck.type  regex
 livecheck.url   ${master_sites}
 livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
+
+# Make it run at boot
+# Redirect stderr on launchd-started items because launchd redirects stderr to a black hole
+# Let macports (daemondo) manage the availability of process and pidfile (works without for now, but is more robust)
+startupitem.create	yes
+startupitem.name	nsd
+startupitem.logfile	/Library/Logs/nsd-startupitem.log
+startupitem.logevents	yes
+startupitem.start	"(${prefix}/sbin/nsd 2>&1)"
+startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/${name}.pid) 2>&1)"
+startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid

--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.9.2
+revision            1
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -67,9 +68,15 @@ post-activate {
 }
 
 # Make it run on boot
-startupitem.create  yes
-startupitem.name    unbound
-startupitem.start   "${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key || : && chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key && ${prefix}/sbin/unbound"
-startupitem.stop    "/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid)"
+# Redirect stderr on launchd-started items because launchd redirects stderr to a black hole
+# Let macports (daemondo) manage the availability of process and pidfile as unbound fails to start at the first attempt
+# because unbound is unable to get port 53. Unbound starts successfully at second attempt.
+startupitem.create	yes
+startupitem.name	unbound
+startupitem.logfile	/Library/Logs/unbound-startupitem.log
+startupitem.logevents	yes
+startupitem.start	"(${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key 2>&1) || : && (chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key 2>&1) && (${prefix}/sbin/unbound 2>&1)"
+startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid) 2>&1)"
+startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid
 
 notes-append        "An example configuration is provided at ${prefix}/etc/${name}/${name}.conf-dist."

--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,7 +5,6 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.9.2
-revision            2
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -68,15 +67,9 @@ post-activate {
 }
 
 # Make it run on boot
-# Redirect stderr on launchd-started items because launchd redirects stderr to a black hole
-# Let macports (daemondo) manage the availability of process and pidfile as unbound fails to start at the first attempt
-# because unbound is unable to get port 53. Unbound starts successfully at second attempt.
-startupitem.create	yes
-startupitem.name	unbound
-startupitem.logfile	/Library/Logs/unbound-startupitem.log
-startupitem.logevents	yes
-startupitem.start	"(${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key 2>&1) || : && (chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key 2>&1) && (${prefix}/sbin/unbound 2>&1)"
-startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid) 2>&1)"
-startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid
+startupitem.create  yes
+startupitem.name    unbound
+startupitem.start   "${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key || : && chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key && ${prefix}/sbin/unbound"
+startupitem.stop    "/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid)"
 
 notes-append        "An example configuration is provided at ${prefix}/etc/${name}/${name}.conf-dist."

--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,6 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.9.2
+revision            2
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -67,9 +68,15 @@ post-activate {
 }
 
 # Make it run on boot
-startupitem.create  yes
-startupitem.name    unbound
-startupitem.start   "${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key || : && chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key && ${prefix}/sbin/unbound"
-startupitem.stop    "/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid)"
+# Redirect stderr on launchd-started items because launchd redirects stderr to a black hole
+# Let macports (daemondo) manage the availability of process and pidfile as unbound fails to start at the first attempt
+# because unbound is unable to get port 53. Unbound starts successfully at second attempt.
+startupitem.create	yes
+startupitem.name	unbound
+startupitem.logfile	/Library/Logs/unbound-startupitem.log
+startupitem.logevents	yes
+startupitem.start	"(${prefix}/sbin/unbound-anchor -a ${prefix}/etc/${name}/root.key 2>&1) || : && (chown ${unbounduser}:${unboundgroup} ${prefix}/etc/${name}/root.key 2>&1) && (${prefix}/sbin/unbound 2>&1)"
+startupitem.stop	"(/bin/kill \$(cat ${prefix}/var/run/${name}/unbound.pid) 2>&1)"
+startupitem.pidfile	clean ${prefix}/var/run/${name}/${name}.pid
 
 notes-append        "An example configuration is provided at ${prefix}/etc/${name}/${name}.conf-dist."

--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.56.3 v
+go.setup            github.com/gohugoio/hugo 0.57.0 v
 revision            0
-checksums           rmd160  27a3c7093f5696c0a00df9dc54478301c23c6ea1 \
-                    sha256  7fffb82ffcb06c7d33408742ee4614a3168b21c78f37c6e8fc5763afbdb6bd0d \
-                    size    27655088
+checksums           rmd160  09066a7fef002c2cc2843c2266d857ab84a2e15d \
+                    sha256  6893b6d621bebf5e6216a88fc98ef6c467fe64d4608961f8344c1f773d5b0f58 \
+                    size    27664887
 
 categories          www
 platforms           darwin


### PR DESCRIPTION
#### Description
Changed the startupitem for unbound so it works after reboot and outputs stderr
Updated nsd to 4.2.1 and added a startupitem (same format as for unbound)
https://trac.macports.org/ticket/58844
https://trac.macports.org/ticket/58822

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->