### PR TITLE
unibilium: allow to use MacPorts terminfo if installed (again)

### DIFF
--- a/devel/unibilium/Portfile
+++ b/devel/unibilium/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 PortGroup github 1.0
 
 github.setup        mauke unibilium 2.0.0 v
+revision            1
 categories          devel
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -22,6 +23,9 @@ checksums           rmd160  7dcb792282fbe353c145cb8727a97bf0927fda99 \
                     size    112610
 
 depends_build       port:libtool
+
+patchfiles          patch-Makefile.diff
+patch.pre_args      -p1
 
 use_configure no
 


### PR DESCRIPTION
#### Description

The patch devel/unibilium/files/patch-Makefile.diff is added in [1] to
"use MacPorts terminfo if installed". The patch is later disabled during
upgrading unibilium to 2.0 [2]. From discussions at [2], I assume the
disablement of that patch is not intentional, so I restore it.

/cc @lbschenkel - could you check if I misinterpret your previous intention or not?

[1] https://github.com/macports/macports-ports/pull/710
[2] https://github.com/macports/macports-ports/pull/2574

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

Before this patch, neovim does not save/restore window/icon titles as the smcup & rmcup strings of Apple's terminfo (ncurses 5.4) does not contain `CSI 2 2 t` and `CSI 2 3 t` (ref: [3]). After this patch, window/icon titles are saved/restored by neovim if the ncurses port is installed.

[3] https://invisible-island.net/xterm/ctlseqs/ctlseqs.html