### PR TITLE
gegl-0.3: fix build against new exiv2 0.27.1

### DIFF
--- a/graphics/gegl-0.3/Portfile
+++ b/graphics/gegl-0.3/Portfile
@@ -57,7 +57,8 @@ depends_lib         port:babl \
                     port:vala \
                     port:webp
 
-patchfiles          patch-configure.ac.diff
+patchfiles          patch-configure.ac.diff \
+                    patch-gegl-0.3-exiv2.diff
 
 # disable external operation ff-save for now
 # AVFMT_RAWPICTURE removed in ffmpeg-devel

--- a/graphics/gegl-0.3/files/patch-gegl-0.3-exiv2.diff
+++ b/graphics/gegl-0.3/files/patch-gegl-0.3-exiv2.diff
@@ -1,0 +1,12 @@
+--- tools/exp_combine.cpp.orig	2019-08-17 20:50:20.000000000 -0700
++++ tools/exp_combine.cpp	2019-08-17 20:50:37.000000000 -0700
+@@ -8,8 +8,7 @@
+ 
+ #include <iostream>
+ 
+-#include <exiv2/image.hpp>
+-#include <exiv2/exif.hpp>
++#include <exiv2/exiv2.hpp>
+ 
+ using namespace std;
+ 


### PR DESCRIPTION
there was some shuffling of the headers in exiv2
it is now recommended to include just one header rather
than individual headers
see <https://github.com/Exiv2/exiv2/issues/893>

this fixes the build of gegl-0.3 against the new exiv2 headers

no revbump as no files are changed.