### PR TITLE
clang-3.4 and deps: allow bootstrapping libcxx on 10.6

### DIFF
--- a/archivers/bzip2/Portfile
+++ b/archivers/bzip2/Portfile
@@ -33,6 +33,12 @@ use_parallel_build      yes
 
 variant universal {}
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Having the stdlib set to libc++ on 10.6 causes a dependency on a
+    # macports-clang compiler to be added, which would be a dep cycle.
+    configure.cxx_stdlib
+}
+
 build.args              CC="${configure.cc} [get_canonical_archflags cc]" \
                         PREFIX=${prefix}
 

--- a/archivers/xz/Portfile
+++ b/archivers/xz/Portfile
@@ -27,6 +27,25 @@ checksums       rmd160  0c5a6ffd47d657fed0c7192f413422e503b79c69 \
 
 depends_lib     port:libiconv port:gettext
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        depends_lib-replace     port:libiconv port:libiconv-bootstrap \
+                                port:gettext port:gettext-bootstrap
+        # Avoid macports-clang dep (doesn't use C++ anyway)
+        configure.cxx_stdlib
+    }
+    if {${cxx_stdlib} eq "libc++"} {
+        # This port is in the dependency chain for clang 3.7 and later
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 patchfiles      c89.patch
 
 configure.args  --with-libiconv-prefix=${prefix} --with-libintl-prefix=${prefix}

--- a/archivers/zlib/Portfile
+++ b/archivers/zlib/Portfile
@@ -19,7 +19,18 @@ long_description        zlib is designed to be a free, general-purpose, \
                         and operating system.
 
 master_sites            ${homepage}
-use_xz                  yes
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${configure.cxx_stdlib} eq "libc++"} {
+    # This port is used by clang-3.4 to bootstrap libcxx, which is
+    # indirectly used by the normal xz port.
+    depends_extract     port:xz-bootstrap
+    extract.suffix      .tar.xz
+    extract.cmd         ${prefix}/libexec/libcxx-bootstrap/bin/xz
+    # Doesn't actually use C++, and having the stdlib set to libc++
+    # on 10.6 causes a macports-clang compiler to be selected.
+    configure.cxx_stdlib
+} else {
+    use_xz              yes
+}
 
 checksums               rmd160  3f3ecd35efa6d41ba7b90e5f6e872e2ee8e42044 \
                         sha256  4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066 \

--- a/databases/db48/Portfile
+++ b/databases/db48/Portfile
@@ -30,6 +30,15 @@ checksums       md5     f80022099c5742cd179343556179aa8c \
                 sha1    ab36c170dda5b2ceaad3915ced96e41c6b7e493c \
                 rmd160  dd2fcd4c9b857a91e2f491fd4fadb0c51b993a9c
 
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    # This port is in the dependency chain for clang 3.7 and later
+    foreach ver {8.0 7.0 6.0 5.0 3.7} {
+        if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+            compiler.blacklist-append   macports-clang-${ver}
+        }
+    }
+}
+
 patchfiles      patch-dbinc_atomic.h
 
 # Don't link with "-flat_namespace -undefined suppress" on Yosemite and

--- a/databases/gdbm/Portfile
+++ b/databases/gdbm/Portfile
@@ -31,6 +31,15 @@ checksums           rmd160  041c0dd2ae49d724ba509ce70a4349d246a9767d \
 # later (#45709).
 patchfiles          yosemite-libtool.patch
 
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    # This port is in the dependency chain for clang 3.7 and later
+    foreach ver {8.0 7.0 6.0 5.0 3.7} {
+        if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+            compiler.blacklist-append   macports-clang-${ver}
+        }
+    }
+}
+
 configure.ccache    no
 
 configure.args      --disable-silent-rules \

--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -36,6 +36,15 @@ depends_lib         port:libedit \
                     port:ncurses \
                     port:zlib
 
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    # This port is in the dependency chain for clang 3.7 and later
+    foreach ver {8.0 7.0 6.0 5.0 3.7} {
+        if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+            compiler.blacklist-append   macports-clang-${ver}
+        }
+    }
+}
+
 configure.args      --enable-threadsafe \
                     --enable-dynamic-extensions \
                     --disable-readline \

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -91,6 +91,11 @@ if { ![some_llvm_variant_set] && ![variant_isset xcode] } {
     }
 }
 
+if {[variant_isset llvm34] && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    configure.cxx_stdlib    libstdc++
+}
+
 variant xcode conflicts universal description "Use Xcode supplied cctools" {
     supported_archs noarch
     patchfiles

--- a/devel/gettext/Portfile
+++ b/devel/gettext/Portfile
@@ -45,6 +45,27 @@ post-patch {
     }
 }
 
+depends_lib             port:libiconv \
+                        port:ncurses
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        depends_lib-replace     port:libiconv port:libiconv-bootstrap \
+                                port:ncurses port:ncurses-bootstrap
+        configure.cxx_stdlib    libstdc++
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 configure.env-append    PATH=${localbindir}:$env(PATH)
 
 configure.cppflags      -no-cpp-precomp
@@ -70,9 +91,6 @@ configure.args          ac_cv_prog_AWK=/usr/bin/awk \
 configure.args-append   --without-cvs \
                         --without-git \
                         --without-xz
-
-depends_lib             port:libiconv \
-                        port:ncurses
 
 test.run                yes
 test.target             check

--- a/devel/gperf/Portfile
+++ b/devel/gperf/Portfile
@@ -22,6 +22,22 @@ checksums       md5     9e251c0a618ad0824b51117d5d9db87e \
 
 installs_libs   no
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        configure.cxx_stdlib    libstdc++
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 configure.args  --infodir=${prefix}/share/info
 
 test.run        yes

--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -32,6 +32,22 @@ distfiles                   ${distname}-src${extract.suffix}
 checksums                   rmd160  df06e7b18a87e383d3762564f2e9a59fd75865f9 \
                             sha256  2b0a4410153a9b20de0e20c7d8b66049a72aef244b53683d0d7521371683da0c
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        configure.cxx_stdlib    libstdc++
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 worksrcdir      ${name}/source
 set docdir      ${prefix}/share/doc/${name}
 

--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -181,6 +181,8 @@ if {${subport} eq ${name}} {
     distfiles
     build {}
     use_configure no
+    # avoid cyclic macports-clang dep on 10.6/libc++
+    configure.cxx_stdlib
 
     variant ld64_97 conflicts ld64_127 ld64_236 ld64_xcode description {Use ld64-97 as the default linker (last version that works on Tiger)} {}
     variant ld64_127 conflicts ld64_97 ld64_236 ld64_xcode description {Use ld64-127 as the default linker (last version that supports ppc and works on Leopard)} {}
@@ -304,6 +306,11 @@ if {${subport} eq ${name}} {
                 return -code error "Your platform cannot be configured without LTO support in ld64.  Please enable one of the llvmXX variants, and try again."
             }
         }
+    }
+
+    if {${os.platform} eq "darwin" && ${os.major} < 11 && ${subport} eq "ld64-127" && [variant_isset llvm34]} {
+        # This port is used by clang-3.4 to bootstrap libcxx.
+        configure.cxx_stdlib    libstdc++
     }
 
     if {${os.major} < 10} {

--- a/devel/libedit/Portfile
+++ b/devel/libedit/Portfile
@@ -26,6 +26,15 @@ checksums           rmd160  213fb25fe0546ff99690b3d0f1f32bfd0ee08826 \
 
 depends_lib         port:ncurses
 
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    # This port is required by clang 3.7 and later
+    foreach ver {8.0 7.0 6.0 5.0 3.7} {
+        if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+            compiler.blacklist-append   macports-clang-${ver}
+        }
+    }
+}
+
 # rename man files to avoid conflict with readline
 # see https://trac.macports.org/ticket/51891
 # see https://github.com/macports/macports-ports/commit/86fdc2922ed2b932b8c1d7a676e9ca3acc8ed85a

--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -32,6 +32,12 @@ patchfiles-append   PR-44170.patch
 # Don't use macports gcc or clang toolchains to build this due to dependency cycles
 compiler.blacklist-append macports-*
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Doesn't actually use C++, and having the stdlib set to libc++
+    # on 10.6 causes a macports-clang compiler to be chosen.
+    configure.cxx_stdlib
+}
+
 # Older versions of cctools have a history of being problematic with complex
 # asm like libffi has, so opt for the integrated assembler if it's available
 if {[string match *clang* ${configure.compiler}]} {

--- a/devel/libmacho/Portfile
+++ b/devel/libmacho/Portfile
@@ -26,7 +26,7 @@ patchfiles              cctools-921-noavx512.patch
 
 use_configure           no
 
-if {${subport} == "${name}-headers"} {
+if {${subport} eq "${name}-headers"} {
     supported_archs         noarch
     universal_variant       no
     use_configure           no
@@ -39,7 +39,10 @@ if {${subport} == "${name}-headers"} {
         file rename -force ${destroot}${prefix}/usr/include ${destroot}${prefix}/
         file delete -force ${destroot}${prefix}/usr
     }
-} elseif {${subport} == "${name}"} {
+    # Having the stdlib set to libc++ on 10.6 causes a macports-clang
+    # compiler to be selected (which is a problem for bootstrapping).
+    configure.cxx_stdlib
+} elseif {${subport} eq "${name}"} {
     # Technically not needed, but subports will expect depending on libunwind to pull in the headers
     depends_lib-append port:libmacho-headers
 

--- a/devel/libunwind/Portfile
+++ b/devel/libunwind/Portfile
@@ -46,7 +46,7 @@ post-patch {
 build.dir       ${worksrcpath}/src
 destroot.dir    ${build.dir}
 
-if {${subport} == "${name}-headers"} {
+if {${subport} eq "${name}-headers"} {
     revision 0
 
     supported_archs noarch
@@ -56,6 +56,19 @@ if {${subport} == "${name}-headers"} {
     destroot.target installhdrs
     destroot.args \
         PREFIX="${prefix}"
+    
+    if {${os.platform} eq "darwin" && ${os.major} < 11 && ${configure.cxx_stdlib} eq "libc++"} {
+        # This port is used by clang-3.4 to bootstrap libcxx, which is
+        # indirectly used by the normal xz port.
+        use_xz              no
+        depends_extract     port:xz-bootstrap
+        extract.suffix      .tar.xz
+        extract.cmd         ${prefix}/libexec/libcxx-bootstrap/bin/xz
+    }
+
+    # Having the stdlib set to libc++ on 10.6 causes a macports-clang
+    # compiler to be selected.
+    configure.cxx_stdlib
 } else {
     revision 0
 

--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -22,6 +22,22 @@ checksums       rmd160 938235f3922f9c6ef0f1081d643ecb2da1347a17 \
 # hex.diff from https://opensource.apple.com/source/ncurses/ncurses-44/patches.applied/
 patchfiles      hex.diff
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        configure.cxx_stdlib    libstdc++
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 configure.cppflags
 configure.ldflags
 configure.args  --enable-widec \

--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -49,6 +49,12 @@ patchfiles          install-headers-HFS+.patch \
                     parallel-building.patch \
                     remove-duplicate-bn_print-doc.patch
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Having the stdlib set to libc++ on 10.6 causes a dependency on a
+    # macports-clang compiler to be added, which would be a dep cycle.
+    configure.cxx_stdlib
+}
+
 configure.ccache    no
 configure.perl      /usr/bin/perl
 configure.cmd       ./Configure

--- a/devel/pkgconfig/Portfile
+++ b/devel/pkgconfig/Portfile
@@ -29,13 +29,38 @@ depends_lib         port:libiconv
 patchfiles          patch-glib-configure.diff \
                     patch-glib-glib-gmessages.c.diff
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        set stdprefix ${prefix}
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        depends_lib-replace     port:libiconv port:libiconv-bootstrap
+        # Avoid macports-clang dep (doesn't use C++ anyway)
+        configure.cxx_stdlib
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 set docdir          ${prefix}/share/doc/${name}
 
 configure.args      --disable-silent-rules \
                     --disable-host-tool \
-                    --with-pc-path=${prefix}/lib/pkgconfig:${prefix}/share/pkgconfig \
                     --with-internal-glib \
                     --docdir=${docdir}
+
+if {$subport eq "${name}-bootstrap"} {
+    # search bootstrap prefix and then normal prefix
+    configure.args-append   --with-pc-path=${prefix}/lib/pkgconfig:${prefix}/share/pkgconfig:${stdprefix}/lib/pkgconfig:${stdprefix}/share/pkgconfig
+} else {
+    configure.args-append   --with-pc-path=${prefix}/lib/pkgconfig:${prefix}/share/pkgconfig
+}
 
 configure.env       PKG_CONFIG=false
 

--- a/devel/readline/Portfile
+++ b/devel/readline/Portfile
@@ -44,6 +44,15 @@ checksums           rmd160  25b23261140f5a37225470faecf22663f070cde4 \
                     sha256  e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461 \
                     size    2975937
 
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    # This port is in the dependency chain for clang 3.7 and later
+    foreach ver {8.0 7.0 6.0 5.0 3.7} {
+        if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+            compiler.blacklist-append   macports-clang-${ver}
+        }
+    }
+}
+
 configure.args  --with-curses
 
 configure.universal_args-delete --disable-dependency-tracking

--- a/lang/libcxx/Portfile
+++ b/lang/libcxx/Portfile
@@ -24,7 +24,17 @@ homepage                https://libcxx.llvm.org/
 master_sites            https://releases.llvm.org/${version}/
 dist_subdir             llvm
 
-use_xz                  yes
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${configure.cxx_stdlib} eq "libc++"} {
+    # Bootstrap problem, libcxx is indirectly used by the normal xz port.
+    depends_extract     port:xz-bootstrap
+    extract.suffix      .tar.xz
+    extract.cmd         ${prefix}/libexec/libcxx-bootstrap/bin/xz
+    # And having the stdlib set to libc++ on 10.6 causes a
+    # macports-clang compiler to be selected.
+    configure.cxx_stdlib
+} else {
+    use_xz              yes
+}
 
 set libcxxabi_distname  libcxxabi-${version}.src
 set libcxx_distname     libcxx-${version}.src
@@ -79,7 +89,7 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
 
         # only selected clang versions support emulated_tls, and the emulated_tls variant
         # needs to be enabled to build libcxx with emulated_tls support
-        foreach ver {5.0 6.0 7.0} {
+        foreach ver {5.0 6.0 7.0 8.0} {
             if {[file exists ${prefix}/bin/clang-mp-${ver}]} {
                 if {[active_variants clang-${ver} emulated_tls]} {
                   default_variants-append +emulated_tls
@@ -92,7 +102,7 @@ if {${os.major} < 11 || [variant_isset replacemnt_libcxx]} {
     compiler.blacklist *gcc* {clang < 500}
 
     # clang 3.5 and newer are conditionally blacklisted to prevent dependency cycles
-    foreach ver {3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 7.0 devel} {
+    foreach ver {3.5 3.6 3.7 3.8 3.9 4.0 5.0 6.0 7.0 8.0 devel} {
         if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
             compiler.blacklist-append macports-clang-${ver}
         }

--- a/lang/llvm-3.4/Portfile
+++ b/lang/llvm-3.4/Portfile
@@ -13,6 +13,8 @@ revision                12
 subport                 clang-${llvm_version} { revision 12 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
+# prefix for deps using libstdc++ on a libc++ system
+set bootstrap_prefix    ${prefix}/libexec/libcxx-bootstrap
 dist_subdir             llvm
 categories              lang
 platforms               darwin
@@ -55,7 +57,22 @@ if {${subport} eq "llvm-${llvm_version}"} {
     # after #46040 is resolved.
     depends_lib-append  port:libffi port:ncurses port:zlib
 
-    default_variants    +analyzer
+    # Avoid requiring a bootstrap version of perl5 on 10.6.
+    if {${os.major} >= 11} {
+        default_variants    +analyzer
+    }
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+    configure.cxx_stdlib    libstdc++
+    # Have to also use bootstrap versions of deps that use libstdc++ in
+    # order to be able to build libc++.
+    depends_lib-replace port:libxml2 port:libxml2-bootstrap \
+                        port:python27 port:python27-bootstrap \
+                        port:ncurses port:ncurses-bootstrap
+    configure.cppflags-prepend  -I${bootstrap_prefix}/include
+    configure.ldflags-prepend   -L${bootstrap_prefix}/lib
+    configure.env-append    PATH=${bootstrap_prefix}/bin:$::env(PATH)
 }
 
 #fetch.type              svn
@@ -173,7 +190,11 @@ if {${subport} eq "llvm-${llvm_version}"} {
     select.group        clang
     select.file         ${filespath}/mp-${subport}
 
-    configure.args-append --with-python=${prefix}/bin/python2.7
+    if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+        configure.args-append --with-python=${bootstrap_prefix}/bin/python2.7
+    } else {
+        configure.args-append --with-python=${prefix}/bin/python2.7
+    }
 }
 
 # g++-4.0 fails to build some of the newer C++ for ppc. Intel looks ok, but I prefer using gcc-4.2 for consistency

--- a/lang/llvm-3.7/Portfile
+++ b/lang/llvm-3.7/Portfile
@@ -88,7 +88,14 @@ if {${subport} eq "llvm-${llvm_version}"} {
 version                 ${llvm_version}.1
 epoch                   1
 master_sites            https://releases.llvm.org/${version}
-use_xz                  yes
+if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++" && ![file executable ${prefix}/bin/xz]} {
+    # xz needs a macports-clang compiler to build in this configuration
+    depends_extract     port:xz-bootstrap
+    extract.suffix      .tar.xz
+    extract.cmd         ${prefix}/libexec/libcxx-bootstrap/bin/xz
+} else {
+    use_xz              yes
+}
 distfiles               llvm-${version}.src${extract.suffix}
 worksrcdir              llvm-${version}.src
 

--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -51,6 +51,15 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
         depends_lib-append  port:db48 \
                             port:gdbm
 
+        if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
+            # This port is in the dependency chain for clang 3.7 and later
+            foreach ver {8.0 7.0 6.0 5.0 3.7} {
+                if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                    compiler.blacklist-append   macports-clang-${ver}
+                }
+            }
+        }
+
         distname            perl-${perl5.major}.${perl5.subversion}
         dist_subdir         perl${perl5.major}
         if {${perl5.major} >= 5.28} {
@@ -207,6 +216,7 @@ if {$subport eq $name} {
     long_description        ${description}
 
     supported_archs         noarch
+    configure.cxx_stdlib
 
     perl5.require_variant   yes
     perl5.conflict_variants yes

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -54,6 +54,41 @@ depends_lib         port:bzip2 \
 depends_run         port:python_select \
                     port:python2_select
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        set stdprefix ${prefix}
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        set frameworks_dir  ${prefix}/Library/Frameworks
+        set applications_dir    ${prefix}/Applications
+        configure.cppflags-append   -I${stdprefix}/include
+        configure.ldflags-append    -L${stdprefix}/lib
+        configure.env-append    PATH=${prefix}/bin:$::env(PATH)
+        configure.cxx_stdlib
+        patchfiles-delete       patch-libedit.diff
+        depends_build-replace   port:pkgconfig port:pkgconfig-bootstrap
+        depends_lib-replace     port:gettext port:gettext-bootstrap \
+                                port:ncurses port:ncurses-bootstrap
+        depends_lib-delete      port:db48 \
+                                port:libedit \
+                                port:sqlite3
+        # no need to be 'port select'able
+        depends_run
+        use_xz              no
+        depends_extract     port:xz-bootstrap
+        extract.suffix      .tar.xz
+        extract.cmd         ${prefix}/bin/xz
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 configure.args      --enable-framework=${frameworks_dir} \
                     --enable-ipv6 \
                     --with-system-expat \

--- a/sysutils/clang_select/Portfile
+++ b/sysutils/clang_select/Portfile
@@ -26,3 +26,9 @@ destroot {
 }
 
 livecheck.type	none
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Having the stdlib set to libc++ on 10.6 causes a dependency on a
+    # macports-clang compiler to be added, which would be a dep cycle.
+    configure.cxx_stdlib
+}

--- a/sysutils/llvm_select/Portfile
+++ b/sysutils/llvm_select/Portfile
@@ -26,3 +26,9 @@ destroot {
 }
 
 livecheck.type	none
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Having the stdlib set to libc++ on 10.6 causes a dependency on a
+    # macports-clang compiler to be added, which would be a dep cycle.
+    configure.cxx_stdlib
+}

--- a/sysutils/python2_select/Portfile
+++ b/sysutils/python2_select/Portfile
@@ -9,6 +9,7 @@ revision            3
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
+configure.cxx_stdlib
 license             BSD
 maintainers         {yan12125 @yan12125} openmaintainer
 

--- a/sysutils/python_select/Portfile
+++ b/sysutils/python_select/Portfile
@@ -9,6 +9,7 @@ revision            8
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
+configure.cxx_stdlib
 license             BSD
 maintainers         {yan12125 @yan12125} openmaintainer
 

--- a/textproc/expat/Portfile
+++ b/textproc/expat/Portfile
@@ -28,6 +28,12 @@ homepage            http://www.libexpat.org/
 master_sites        sourceforge:project/${name}/${name}/${version}
 use_bzip2           yes
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Having the stdlib set to libc++ on 10.6 causes a dependency on a
+    # macports-clang compiler to be added, which would be a dep cycle.
+    configure.cxx_stdlib
+}
+
 configure.args      --without-docbook
 
 use_parallel_build  yes

--- a/textproc/libiconv/Portfile
+++ b/textproc/libiconv/Portfile
@@ -32,6 +32,24 @@ patchfiles \
     patch-src-Makefile.in-darwin.diff \
     patch-c99.diff
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        depends_build-replace     port:gperf port:gperf-bootstrap
+        # Avoid macports-clang dep (doesn't use C++ anyway)
+        configure.cxx_stdlib
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 configure.cppflags
 configure.ldflags
 configure.args \

--- a/textproc/libxml2/Portfile
+++ b/textproc/libxml2/Portfile
@@ -33,6 +33,30 @@ checksums           rmd160  a7d5f9ca4a24db329108f4bfb6bd4eed0f61ab21 \
                     sha256  94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871 \
                     size    5476717
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # This port is used by clang-3.4 to bootstrap libcxx
+    subport ${name}-bootstrap {
+        set stdprefix ${prefix}
+        prefix      ${prefix}/libexec/libcxx-bootstrap
+        configure.cppflags-append   -I${stdprefix}/include
+        configure.ldflags-append    -L${stdprefix}/lib
+        configure.env-append    PATH=${prefix}/bin:$::env(PATH)
+        configure.cxx_stdlib
+        depends_build-replace   port:pkgconfig port:pkgconfig-bootstrap
+        depends_lib-replace     port:libiconv port:libiconv-bootstrap \
+                                port:icu port:icu-bootstrap \
+                                port:xz port:xz-bootstrap
+    }
+    # Also needed by later clangs.
+    if {${cxx_stdlib} eq "libc++"} {
+        foreach ver {8.0 7.0 6.0 5.0 3.7} {
+            if {![file executable ${prefix}/bin/clang-mp-${ver}]} {
+                compiler.blacklist-append   macports-clang-${ver}
+            }
+        }
+    }
+}
+
 patchfiles-append   include.patch
 
 post-patch {


### PR DESCRIPTION
This involves non-conflicting subports that use libstdc++ for ports
that use a C++ stdlib and their dependents, and clearing
configure.cxx_stdlib for the ports that don't use a C++ stdlib so that
a macports-clang compiler won't be used.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
