### PR TITLE
nmap: add stdlib to LDFLAGS

### DIFF
--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -41,6 +41,14 @@ configure.args	--without-zenmap --without-ndiff \
 		--with-liblua=included \
 		--without-subversion
 		
+# https://trac.macports.org/ticket/58837
+# build system does not pass the stdlib on the link line resulting in link errors
+# for some build configurations using non-default stdlib settings
+if {${os.platform} eq "darwin" && ${os.version} < 13} {
+  if {[string match *clang* ${configure.cxx}]} {
+    configure.ldflags-append -stdlib=${configure.cxx_stdlib}
+  }
+}
 
 # nmap's configure script in nselib-bin does not respect --with-liblua=included
 configure.env ac_cv_header_lua_h=no


### PR DESCRIPTION
fixes build with some build configurations
see https://trac.macports.org/ticket/58837
see https://trac.macports.org/ticket/53995
