### PR TITLE
libvirt: tweak blacklisting to fix build on older systems

### DIFF
--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 # Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
@@ -36,7 +37,8 @@ depends_lib         port:curl \
                     port:yajl \
                     port:zlib
 
-compiler.blacklist-append apple-gcc* gcc-3.3 gcc-4.* *llvm-gcc-4.2 macports-gcc-4.3
+# see https://trac.macports.org/ticket/58726
+compiler.blacklist-append apple-gcc* gcc-3.3 *gcc-4.* {clang < 425}
 
 # libvirt build scripts work with python 2.x only
 configure.python    ${prefix}/bin/python2.7


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/58726

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 3.2.6 DevToolsSupport-1806.0 10M2518 

macOS 10.14.5 18F132
Xcode 10.2.1 10E1001 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
