### PR TITLE
prometheus: update to 2.12.0

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,9 +1,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.11.2 v
+github.setup        prometheus prometheus 2.12.0 v
 github.tarball_from archive
-set promu_version   0.5.0
 
 description         The Prometheus monitoring system and time series database
 
@@ -21,7 +20,8 @@ license             Apache-2
 
 maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
 
-depends_build       port:go
+depends_build       port:go \
+                    port:promu
 
 build.env           GOPATH=${workpath} \
                     PATH=${workpath}/bin:$env(PATH)
@@ -32,8 +32,6 @@ use_configure       no
 installs_libs       no
 use_parallel_build  no
 
-master_sites-append https://github.com/prometheus/promu/releases/download/v${promu_version}:promu
-
 set prom_user       ${name}
 set prom_conf_dir   ${prefix}/etc/${name}
 set prom_conf_file  ${prom_conf_dir}/prometheus.yml
@@ -43,30 +41,18 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-set promu_distname  promu-${promu_version}.darwin-amd64
-set promu_distfile  ${promu_distname}${extract.suffix}
-
-distfiles           prometheus-${version}${extract.suffix}:main \
-                    ${promu_distfile}:promu
-
-checksums \
-  prometheus-${version}${extract.suffix} \
-    rmd160  54c02e5c15b94a95c2da8b8b03750022fb610174 \
-    sha256  2d6019c1b58fdd509feb52eea3a01edd0eda3342a32ba0c3af76d30a571d16c5 \
-    size    12132678 \
-  ${promu_distfile} \
-    rmd160  794fd1112584c13ae95506336578a96716377c8a \
-    sha256  17f9b9816e6a5b4304bda34d2ae025732e20837c27a431639731ebbd45eda08f \
-    size    7132062
+checksums   rmd160  67d675dc3666b02d353441d34368c0c179b1b5f4 \
+            sha256  9bd9ae6df02777a9ba3f6f544338865861decabd02054aa64975449bd6009e5a \
+            size    15221347
 
 add_users           ${prom_user} \
                     group=${prom_user} \
                     realname=Prometheus
 
 post-extract {
-    # Install promu in the workpath
+    # Link promu into the workpath
     xinstall -d ${workpath}/bin
-    ln -s ${workpath}/${promu_distname}/promu ${workpath}/bin/
+    ln -s ${prefix}/bin/promu ${workpath}/bin/
 
     copy  ${filespath}/org.macports.prometheus.plist \
           ${workpath}/org.macports.prometheus.plist


### PR DESCRIPTION
Also stops fetching promu binary, and uses promu in Ports.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
