### PR TITLE
VLC: add a +chromecast variant

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -246,7 +246,7 @@ configure.args-append \
                     --with-contrib=${worksrcpath}/contrib \
                     --disable-debug --disable-update-check --enable-gnutls \
                     --disable-notify --disable-dbus --enable-lua \
-                    --disable-sparkle
+                    --disable-sparkle --disable-chromecast
 
 # Input Plugins
 configure.args-append \
@@ -390,8 +390,14 @@ variant freerdp description {Build the FreeRDP support; currently dysfunctional}
     configure.args-replace      --disable-freerdp --enable-freerdp
 }
 
+variant chromecast description {Enable ChromeCast support} {
+    depends_lib-append      path:bin/protoc:protobuf3-cpp
+    configure.args-replace  --disable-chromecast \
+                            --enable-chromecast
+}
+
 variant huge \
-    requires jack shout svg \
+    requires jack shout svg chromecast \
     description {Enable all variants except quartz, smb, freerdp and x11} {}
 
 if {${subport} ne "lib${name}"} {


### PR DESCRIPTION
(part of the +huge preselect)
VLC will build chromecast support when protobuf-cpp >= 2.5.0 is available.
Disable the feature by default, and re-enable it in the new variant that
also adds the required dependency (accepting either protobuf-cpp or
protobuf3-cpp).
