### PR TITLE
jmol: update to 14.29.51

### DIFF
--- a/science/jmol/Portfile
+++ b/science/jmol/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                jmol
-version             14.29.46
+version             14.29.51
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          science
 platforms           darwin
@@ -23,9 +23,9 @@ master_sites        sourceforge:project/jmol/Jmol/Version%20${branch}/Jmol%20${v
 
 distname            Jmol-${version}-binary
 
-checksums           rmd160  5e88423653017cc064dd46fd2999c016a88bc034 \
-                    sha256  34957a72ec4e4abf30b91afa08146eb0a4a55fd0db0008aa9a0b97ef820b2f02 \
-                    size    71864850
+checksums           rmd160  bd20357e9ea14ce4b9a185116930ce37b63b1599 \
+                    sha256  4cf9d19f6157e32c3692036b4b4e4606edd331145078efbe22ba69280fc0a453 \
+                    size    71892857
 
 worksrcdir          ${name}-${version}
 


### PR DESCRIPTION
Bug fixes, see
https://sourceforge.net/projects/jmol/files/Jmol/Version%2014.29/Jmol%2014.29.51/README-14.29.51.properties/download
for details

#### Description

Upstream update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G8030
Xcode 10.1 10B61 
Java 1.8.0_152

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
