### PR TITLE
ghc: add missing build dependencies, fix notes: PDF docs arent't built, fix typo, drop maintainership

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -258,7 +258,6 @@ test.run            yes
 notes "The GHC User Manual is available at:
 
     file://${prefix}/share/doc/${distname}/html/index.html
-    ${prefix}/share/doc/${distname}/users_guide.pdf
 
 Copy/edit ${prefix}/etc/ghci.conf to your directory ~/.ghc
-for a user-specific starup configuration."
+for a user-specific startup configuration."

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                ghc
 version             8.6.5
 categories          lang haskell
-maintainers         {cal @neverpanic} {ieee.org:s.t.smith @essandess} openmaintainer
+maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
 license             BSD
 platforms           darwin
 
@@ -55,7 +55,7 @@ if {[variant_isset "bootstrap"]} {
                     sha256  4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361 \
                     size    19092168
 
-    # use these to specify python versions, python3 required 
+    # use these to specify python versions, python3 required
     set python3_version 3.7
     set python3_version_nickname \
                     [join [lrange [split ${python3_version} .] 0 1] {}]

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -61,6 +61,8 @@ if {[variant_isset "bootstrap"]} {
                     [join [lrange [split ${python3_version} .] 0 1] {}]
 
     depends_build-append \
+                    port:autoconf \
+                    port:automake \
                     port:python${python3_version_nickname} \
                     port:texlive \
                     port:texlive-fonts-extra \


### PR DESCRIPTION
#### Description

Cc: @essandess.

This is a combination of three commits:

 * ghc: Add missing build dependencies 
    The bootstrap variant now requires autoconf and automake to be installed
    for the build to succeed. This was caught by trace mode.
 * ghc: Fix notes: PDF docs arent't built, fix typo 
    The PDF documentation wasn't built in my local build with trace mode, so
    remove the line from the notes section since it points to a non-existant
    file. 
    Additionally, fix a typo in the notes message.
 * ghc: Drop maintainership 
    I clearly don't have the time to maintain this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2128
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?