### PR TITLE
ghc: Add port:autoconf build dependency

### DIFF
--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                ghc
 version             8.6.5
+revision            1
 categories          lang haskell
 maintainers         {cal @neverpanic} {ieee.org:s.t.smith @essandess} openmaintainer
 license             BSD
@@ -61,6 +62,7 @@ if {[variant_isset "bootstrap"]} {
                     [join [lrange [split ${python3_version} .] 0 1] {}]
 
     depends_build-append \
+                    port:autoconf \
                     port:python${python3_version_nickname} \
                     port:texlive \
                     port:texlive-fonts-extra \


### PR DESCRIPTION
ghc: Add port:autoconf build dependency

* See https://github.com/macports/macports-ports/pull/4715#issuecomment-522674561

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] dependency
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->