### PR TITLE
fpc: improve config file fpc.cfg

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                fpc
 version             3.0.4
+revision            1
 categories          lang
 platforms           darwin
 license             GPL-2 LGPL-2
@@ -136,6 +137,7 @@ if {${subport} eq "${name}"} {
                 -o ${destroot}${fpcbasepath}/etc/fpc.cfg
         "
         ln -s ${fpcbasepath}/etc/fpc.cfg ${destroot}${prefix}/etc
+        system "patch ${destroot}${fpcbasepath}/etc/fpc.cfg ${filespath}/fpc.cfg.patch"
 
         # install man
         xinstall -d ${destroot}${fpcbasepath}/man

--- a/lang/fpc/files/fpc.cfg.patch
+++ b/lang/fpc/files/fpc.cfg.patch
@@ -1,0 +1,24 @@
+--- etc/fpc.cfg	2019-06-14 15:54:16.000000000 +0200
++++ fpc.cfg-new	2019-08-17 10:54:57.000000000 +0200
+@@ -247,7 +247,7 @@
+ #-k-s
+ 
+ # Always strip debuginfo from the executable
+--Xs
++#-Xs
+ 
+ # Always use smartlinking on i8086, because the system unit exceeds the 64kb
+ # code limit
+@@ -256,6 +256,12 @@
+ -XX
+ #endif
+ 
++# Explicitly set minimum version of OS X
++# Avoids harmless but annoying ld warning
++# Keep in sync with fpc
++#ifdef darwin
++-WM10.9
++#endif
+ 
+ # -------------
+ # Miscellaneous


### PR DESCRIPTION
## Description
This avoids harmless, but annoying warnings from ld.
###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6
Xcode 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?