### PR TITLE
clang-8.0 deps: allow bootstrapping on 10.6/libc++

### DIFF
--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -1,0 +1,13 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+# This portgroup is to help prevent circular dependencies for ports that
+# recent clang builds depend on, by blacklisting any clang compiler not already
+# installed
+
+PortGroup compiler_blacklist_versions 1.0
+
+foreach ver {8.0 7.0 6.0 5.0} {
+    if {![file exists ${prefix}/bin/clang-mp-${ver}]} {
+        compiler.blacklist-append macports-clang-${ver}
+    }
+}

--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup clang_dependency 1.0
 
 name             libarchive
 
@@ -23,6 +24,7 @@ checksums        rmd160  c59dd17f764e33c2984058091ea00b5768e35ce4 \
 
 homepage         https://libarchive.org/
 master_sites     ${homepage}downloads/
+
 
 depends_lib      port:bzip2 port:zlib port:libxml2 port:xz \
                  port:lzo2 port:libiconv \

--- a/archivers/lz4/Portfile
+++ b/archivers/lz4/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
+PortGroup           clang_dependency 1.0
 
 github.setup        lz4 lz4 1.9.1 v
 categories          archivers

--- a/archivers/lzo2/Portfile
+++ b/archivers/lzo2/Portfile
@@ -1,14 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem      1.0
 PortGroup       muniversal 1.0
+PortGroup       clang_dependency 1.0
 
-name			lzo2
+name		    lzo2
 set my_name     lzo
-version			2.10
-categories		archivers
-license			GPL-2+
-platforms		darwin
-maintainers		nomaintainer
-description		Real-time data compression library
+version		    2.10
+categories	    archivers
+license		    GPL-2+
+platforms	    darwin
+maintainers	    nomaintainer
+description	    Real-time data compression library
 
 long_description \
 	LZO is a portable lossless data compression library written in ANSI C. \

--- a/archivers/unzip/Portfile
+++ b/archivers/unzip/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           clang_dependency 1.0
 
 name                unzip
 version             6.0

--- a/archivers/xar/Portfile
+++ b/archivers/xar/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           clang_dependency 1.0
 
 github.setup        mackyle xar 1.6.1 xar-
 

--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           clang_dependency 1.0
 
 github.setup        facebook zstd 1.4.2 v
 

--- a/devel/autoconf/Portfile
+++ b/devel/autoconf/Portfile
@@ -11,6 +11,7 @@ categories          devel
 # https://www.gnu.org/licenses/autoconf-exception.html
 platforms           darwin
 supported_archs     noarch
+configure.cxx_stdlib
 license             {Autoconf GPL-3+}
 maintainers         {larryv @larryv}
 

--- a/devel/automake/Portfile
+++ b/devel/automake/Portfile
@@ -15,6 +15,7 @@ revision            1
 categories          devel
 platforms           darwin freebsd
 supported_archs     noarch
+configure.cxx_stdlib
 license             {GPL-2+ Permissive}
 maintainers         nomaintainer
 

--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem                  1.0
 PortGroup                   compiler_blacklist_versions 1.0
+PortGroup                   clang_dependency 1.0
 
 # Please keep the glib2 and glib2-devel ports as similar as possible.
 

--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           clang_dependency 1.0
 
 name                legacy-support
 categories          devel

--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           clang_dependency 1.0
 
 name                libtool
 version             2.4.6

--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -3,6 +3,7 @@
 PortSystem       1.0
 PortGroup        github 1.0
 PortGroup        legacysupport 1.0
+PortGroup        clang_dependency 1.0
 
 name             libuv
 categories       devel

--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -54,6 +54,7 @@ configure.args      --disable-silent-rules \
                     --enable-${subport}grep-libz \
                     --enable-${subport}test-libedit
 subport pcre {
+    PortGroup clang_dependency 1.0
     configure.args-append --enable-unicode-properties
 }
 

--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup clang_dependency 1.0
 
 name                python37
 
@@ -50,7 +51,7 @@ depends_run         port:python_select \
                     port:python3_select
 
 # blacklist llvm-gcc-4.2 compiler known to produce bad code
-compiler.blacklist  *llvm-gcc-4.2
+compiler.blacklist-append *llvm-gcc-4.2
 
 # ensurepip arg may be removed later, now conflicts with pip and setuptools
 # packages

--- a/mail/libidn2/Portfile
+++ b/mail/libidn2/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           clang_dependency 1.0
 
 name                libidn2
 version             2.2.0

--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
+PortGroup                       clang_dependency 1.0
 
 name                            curl
 version                         7.65.3

--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -2,6 +2,7 @@
                     
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           clang_dependency 1.0
 
 github.setup        rockdaboot libpsl 0.21.0 libpsl-
 # when incrementing version or revision please check

--- a/perl/p5-locale-gettext/Portfile
+++ b/perl/p5-locale-gettext/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           perl5 1.0
+PortGroup           clang_dependency 1.0
 
 perl5.branches      5.26 5.28
 perl5.setup         Locale-gettext 1.07

--- a/sysutils/python3_select/Portfile
+++ b/sysutils/python3_select/Portfile
@@ -9,6 +9,7 @@ revision            1
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
+configure.cxx_stdlib
 license             BSD
 maintainers         {yan12125 @yan12125} openmaintainer
 

--- a/textproc/help2man/Portfile
+++ b/textproc/help2man/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       clang_dependency 1.0
 
 name            help2man
 version         1.47.10

--- a/textproc/libunistring/Portfile
+++ b/textproc/libunistring/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           clang_dependency 1.0
 
 name                libunistring
 version             0.9.10

--- a/textproc/texinfo/Portfile
+++ b/textproc/texinfo/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           clang_dependency 1.0
 
 name                texinfo
 version             6.6


### PR DESCRIPTION
Avoid use of recent clang versions unless already installed, since
these ports are in the recursive dependencies of those clangs.

###### Tested on
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
