### PR TITLE
lpcnetfreedv: new portfile

### DIFF
--- a/audio/lpcnetfreedv/Portfile
+++ b/audio/lpcnetfreedv/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+name                lpcnetfreedv
+platforms           darwin macosx
+categories          audio
+license             BSD
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+
+description         Experimental Neural Net speech coding for FreeDV
+long_description    Experimental version of LPCNet being developed \
+    for over the air Digital Voice experiments with FreeDV.
+
+github.setup        drowe67 LPCNet 0d5292c4dde78f8b17e1c636fd4aa30508397bc0
+version             20190819-[string range ${github.version} 0 7]
+checksums           rmd160  1e0a987ce86d410e768d2e8981ef78bbf8655010 \
+                    sha256  5fced52b66c9e6c970b8a8cb1bd75abcb7fcd10b9320a8736e384b0e860d7cc5 \
+                    size    3307150
+revision            0
+
+depends_lib-append \
+    port:codec2
+
+# disable AVX and AVX2 for compatibility
+configure.args-append \
+    -DAVX=OFF \
+    -DAVX2=OFF \
+    -DNEON=OFF
+
+# select native cpu flags
+variant native description {Enable auto selection of cpu flags like avx/avx2/neon} {
+    configure.args-delete -DAVX=OFF
+    configure.args-delete -DAVX2=OFF
+    configure.args-delete -DNEON=OFF
+}
+
+notes "To enable lpcnet on codec2 you need to rebuild it manually with
+the respective variant enabled. Aka, circular dependency."


### PR DESCRIPTION

#### Description

Experimental version of LPCNet being developed for over the air
Digital Voice experiments with FreeDV.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->