### PR TITLE
codec2: update version to 201908129-56734681

### DIFF
--- a/audio/codec2/Portfile
+++ b/audio/codec2/Portfile
@@ -22,12 +22,11 @@ long_description    Codec 2 is an open source speech codec designed for \
     designed for digital voice over HF radio.
 homepage            http://www.rowetel.com/codec2.html
 
-# migrated from https://svn.code.sf.net/p/freetel/code/codec2/tags/${version}
-github.setup        drowe67 codec2 ff5841a18bfd9df0e8a250dc57fb7388cabccda1
-version             0.8.1
-checksums           rmd160  0e4c0d91e893b4e20e609be77fca037c246999c5 \
-                    sha256  2aa2db1abb7ef4878341e4858deb02a795fb136e3692eb35a5bd677f2aedecc9 \
-                    size    12272696
+github.setup        drowe67 codec2 567346818c0d4d697773cf66d925fdb031e15668
+version             20190819-[string range ${github.version} 0 7]
+checksums           rmd160  0f1dc0614610c458ef0e2a9b326f325a86096451 \
+                    sha256  329b5b1722d6eff666f0a6cef8fd848ec6c2edaa7c13eee258c784d36a1c0f54 \
+                    size    11775234
 revision            0
 
 depends_lib-append \
@@ -36,3 +35,10 @@ depends_lib-append \
 
 configure.args-append \
     -DCMAKE_BUILD_TYPE=Release
+
+variant lpcnet description {Enable lpcnet support (FreeDV 2020 codec)} {
+    depends_lib-append \
+        port:lpcnetfreedv
+    configure.args-append \
+        -DLPCNET=ON
+}


### PR DESCRIPTION
#### Description

- move to HEAD from release 0.8.1 (imported from sf.net)
  because from 2018 the developers use only commits without release

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->