### PR TITLE
freedv-gui: update to version 20190811-e497a234

### DIFF
--- a/science/freedv-gui/Portfile
+++ b/science/freedv-gui/Portfile
@@ -14,11 +14,11 @@ description         GUI Application for FreeDV – an open source digital \
     voice protocol that integrates the modems, codecs, and FEC
 long_description    ${description}
 
-github.setup        drowe67 freedv-gui 9b66784d31102d7d63cc5f67208e24fff95beb66
-version             1.3.1
-checksums           rmd160  222b7b15f4fe8b7c427506a48a20e82fe1c17be4 \
-                    sha256  e8da1d5843cebd9b4c9e53a604eec7c26ce00d2f70c5ebb049bfb893199003af \
-                    size    618399
+github.setup        drowe67 freedv-gui 05c03348994849008fefc8fbbbe0069b03da8d3b
+version             20190821
+checksums           rmd160  8a19ecbac2f94f9540b0d535af3f6dcddc211fd3 \
+                    sha256  7b1b168e2fb9fc3581513088f01179dcb021960857a7bed1834d979ee749f648 \
+                    size    5793777
 revision            0
 
 depends_build-append \
@@ -33,15 +33,18 @@ depends_lib-append \
     port:libsamplerate \
     port:libao \
     port:codec2 \
+    port:lpcnetfreedv \
     port:speexDSP
 
 configure.args-append \
-    -DUSE_STATIC_CODEC2=FALSE \
+    -DUSE_INTERNAL_CODEC2=FALSE \
     -DWXCONFIG=${wxWidgets.wxconfig} \
     -DWXRC=${wxWidgets.wxrc}
 
-# avoid dmg
-patchfiles          patch-src_cmakelists.txt.diff
+# avoid dmg and fix Info.plist
+patchfiles-append \
+    patch-src_cmakelists.txt.diff \
+    patch-info.plist.diff
 
 variant bundle description {Enable the optional macOS bundle of FreeDV} {
     post-destroot {

--- a/science/freedv-gui/files/patch-info.plist.diff
+++ b/science/freedv-gui/files/patch-info.plist.diff
@@ -1,0 +1,122 @@
+diff --git a/src/Info.plist b/src/Info.plist
+index 8f0d4c3..13003c2 100644
+--- src/Info.plist
++++ src/Info.plist
+@@ -2,103 +2,31 @@
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
+-	<key>CFBundleDevelopmentRegion</key>
+-	<string>en</string>
+-	<key>CFBundleExecutable</key>
+-	<string>freedv</string>
+-	<key>CFBundleIconFile</key>
+-	<string></string>
+-	<key>CFBundleIdentifier</key>
+-	<string>org.freedv.freedv</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+-	<key>CFBundleName</key>
+-	<string>FreeDV</string>
+-	<key>CFBundlePackageType</key>
+-	<string>APPL</string>
+-	<key>CFBundleShortVersionString</key>
+-	<string>1.0</string>
+-	<key>CFBundleSignature</key>
+-	<string>????</string>
+-	<key>CFBundleVersion</key>
+-	<string>1</string>
+-	<key>LSMinimumSystemVersion</key>
+-	<string>10.5</string>
+-	<key>NSHumanReadableCopyright</key>
+-	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
+-	<!--<key>NSMainNibFile</key>
+-	<string>MainMenu</string>-->
+-	<key>CFBundleIconFile</key>
+-	<string>freedv</string>
+-	<key>NSPrincipalClass</key>
+-	<string>NSApplication</string>
+-</dict>
+-</plist>
+-<?xml version="1.0" encoding="UTF-8"?>
+-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+-<plist version="1.0">
+-<dict>
+-	<key>CFBundleDevelopmentRegion</key>
+-	<string>en</string>
+-	<key>CFBundleExecutable</key>
+-	<string>freedv</string>
+-	<key>CFBundleIconFile</key>
+-	<string></string>
+ 	<key>CFBundleIdentifier</key>
+ 	<string>org.freedv.freedv</string>
+-	<key>CFBundleInfoDictionaryVersion</key>
+-	<string>6.0</string>
+ 	<key>CFBundleName</key>
+ 	<string>FreeDV</string>
+ 	<key>CFBundlePackageType</key>
+ 	<string>APPL</string>
+-	<key>CFBundleShortVersionString</key>
+-	<string>1.0</string>
+-	<key>CFBundleSignature</key>
+-	<string>????</string>
+-	<key>CFBundleVersion</key>
+-	<string>1</string>
+-	<key>LSMinimumSystemVersion</key>
+-	<string>10.5</string>
+-	<key>NSHumanReadableCopyright</key>
+-	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
+-	<!--<key>NSMainNibFile</key>
+-	<string>MainMenu</string>-->
+-	<key>NSPrincipalClass</key>
+-	<string>NSApplication</string>
+-</dict>
+-</plist>
+-<?xml version="1.0" encoding="UTF-8"?>
+-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+-<plist version="1.0">
+-<dict>
+ 	<key>CFBundleDevelopmentRegion</key>
+-	<string>en</string>
++	<string>English</string>
+ 	<key>CFBundleExecutable</key>
+-	<string>freedv</string>
+-	<key>CFBundleIconFile</key>
+-	<string></string>
+-	<key>CFBundleIdentifier</key>
+-	<string>org.freedv.freedv</string>
+-	<key>CFBundleInfoDictionaryVersion</key>
+-	<string>6.0</string>
+-	<key>CFBundleName</key>
+ 	<string>FreeDV</string>
+-	<key>CFBundlePackageType</key>
+-	<string>APPL</string>
+-	<key>CFBundleShortVersionString</key>
+-	<string>1.0</string>
+-	<key>CFBundleSignature</key>
+-	<string>????</string>
+ 	<key>CFBundleVersion</key>
+-	<string>1</string>
+-	<key>LSMinimumSystemVersion</key>
+-	<string>10.5</string>
++	<string>1.4</string>
++	<key>CFBundleIconFile</key>
++	<string>freedv.icns</string>
++	<key>NSAppleScriptEnabled</key>
++	<string>No</string>
+ 	<key>NSHumanReadableCopyright</key>
+ 	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
+-	<!--<key>NSMainNibFile</key>
+-	<string>MainMenu</string>-->
+-	<key>NSPrincipalClass</key>
+-	<string>NSApplication</string>
++        <key>NSPrincipalClass</key>
++        <string>NSApplication</string>
++        <key>NSRequiresAquaSystemAppearance</key>
++	<string>True</string>
++        <key>NSMicrophoneUsageDescription</key>
++        <string>Allow for using Sound input devices</string>
+ </dict>
+-</plist>
+\ No newline at end of file
++</plist>

--- a/science/freedv-gui/files/patch-src_cmakelists.txt.diff
+++ b/science/freedv-gui/files/patch-src_cmakelists.txt.diff
@@ -1,10 +1,17 @@
---- src/CMakeLists.txt.old	2019-04-10 21:29:07.000000000 +0200
-+++ src/CMakeLists.txt	2019-04-10 21:29:37.000000000 +0200
-@@ -70,10 +70,5 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 42e267d..904d71c 100644
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -82,14 +82,8 @@ if(APPLE)
+         POST_BUILD
+         COMMAND mkdir ARGS -p FreeDV.app/Contents/MacOS
+         COMMAND mkdir ARGS -p FreeDV.app/Contents/Resources/English.lproj
+-        COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/info.plist FreeDV.app/Contents
++        COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist FreeDV.app/Contents
          COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/freedv.icns FreeDV.app/Contents/Resources
-         COMMAND echo ARGS -n "APPL????" > FreeDV.app/Contents/PkgInfo
+-        COMMAND echo ARGS -n "APPL????" > FreeDV.app/Contents/PkgInfo
          COMMAND cp ARGS freedv FreeDV.app/Contents/MacOS/FreeDV
--        COMMAND dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @executable_path/../libs/
+-        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${LPCNET_BUILD_DIR}/src:${DYLD_LIBRARY_PATH} dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @executable_path/../libs/
 -        COMMAND mkdir dist_tmp
 -        COMMAND cp -r FreeDV.app dist_tmp
 -        COMMAND hdiutil create -srcfolder dist_tmp/ -volname FreeDV -format UDZO ./FreeDV.dmg


### PR DESCRIPTION
#### Description

- move to commit e497a234 from release 1.3.1 because the developers
  use only commits without release
- add lcpnet for freedv as dependency

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->