### PR TITLE
fltk-devel: update version to 20190819-e16eea32

### DIFF
--- a/aqua/fltk/Portfile
+++ b/aqua/fltk/Portfile
@@ -51,11 +51,11 @@ if {${subport} eq ${name}} {
     long_description ${long_description} \
         This port provides the snapshot released of FLTK, typically updated a few times a month.
 
-    github.setup fltk fltk 8070d645a906ef88b85a1939bea8af649bf8dbe8
-    version   20190814-[string range ${github.version} 0 7]
-    checksums rmd160 daddd4dfbb8a5efa54ae4d551000a57198b5b58e \
-              sha256 3882ed1469ff9e753ebb582a0dfc888ef9adfc3a5d96283f90b54cb75cf0c353 \
-              size   6015690
+    github.setup fltk fltk e16eea32be0cd0a22d9e5d9c334cd93f759d923e
+    version   20190819-[string range ${github.version} 0 7]
+    checksums rmd160 a6b7b316995e2039ccb2db35f1a27ba2b9320097 \
+              sha256 d099286a8b32fbc4d29dbe96cb3b79f94b7663743a60302f560b0829d3e77d8b \
+              size   6015286
     revision  0
 
     patchfiles-append \


### PR DESCRIPTION
#### Description

- bump version to commit e16eea32be0cd0a22d9e5d9c334cd93f759d923e
- Improved implementation of layer-backed views under macOS ≥ 10.14
  see https://github.com/fltk/fltk/commit/8c39007b265d978ed16adc06b7b1f56c508f7f51

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->