### PR TITLE
flrig: update version to 1.3.48

### DIFF
--- a/science/flrig/Portfile
+++ b/science/flrig/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                flrig
-version             1.3.47
+version             1.3.48
 categories          science
 platforms           darwin macosx
 license             GPL-3
@@ -18,9 +18,9 @@ long_description    FLRIG is a transceiver control program designed to be \
 homepage            http://www.w1hkj.com
 master_sites        http://www.w1hkj.com/files/${name}/
 
-checksums           rmd160  f18b3e9e7b67c28d350a6b9eaf84f3851133e330 \
-    sha256  81046cf85586d7909913b366d46a3f19e996d9454220d229204aeb56661c30f6 \
-    size    813327
+checksums           rmd160  48c724b70fef2bb95a3509d1dfbf9c177e25295f \
+                    sha256  3869a7e56847291a9a31ef27dcfd77ff4518b95f41b9a51d92f02a9473cd8638 \
+                    size    813746
 
 depends_build-append \
     port:pkgconfig


### PR DESCRIPTION
#### Description

- bump version to 1.3.48

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->