### PR TITLE
maven3: switch to Java portgroup

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup java 1.0
 
 name            maven3
 version         3.6.1
@@ -19,7 +20,7 @@ long_description \
                 concept of a project object model (POM) in that \
                 all the artifacts produced by Maven are a result \
                 of consulting a well defined model for your \
-                project.Builds, documentation, source metrics, \
+                project.  Builds, documentation, source metrics, \
                 and source cross-references are all controlled by \
                 your POM.  Maven 3 aims to ensure backward \
                 compatibility with Maven 2, improve usability, \
@@ -37,8 +38,10 @@ checksums       rmd160 22eb28a53e5cfe44ed8fd08ff5cc92ee8bdaadde \
                 sha256 2528c35a99c30f8940cc599ba15d34359d58bec57af58c1075519b8cd33b69e7 \
                 size   9136463
 
-depends_run     port:maven_select \
-                bin:java:kaffe
+java.version    1.7+
+java.fallback   openjdk11
+
+depends_run     port:maven_select
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Eliminates fallback dependency on `kaffe`. Uses latest LTS Java version (`openjdk11`) as fallback.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
