### PR TITLE
BGHUDAppKit: patch for Xcode 10.1+

### DIFF
--- a/aqua/BGHUDAppKit/Portfile
+++ b/aqua/BGHUDAppKit/Portfile
@@ -21,7 +21,7 @@ platform darwin 9 {
     patchfiles-append leopard.patch
 }
 
-if {[vercmp $xcodeversion 5] >=0} {
+if {[vercmp $xcodeversion 5] >= 0 && [vercmp $xcodeversion 10.0] < 0} {
     patchfiles-append xcode5.patch
 }
 
@@ -29,6 +29,7 @@ if {[vercmp $xcodeversion 5] >=0} {
 # build and destroot this for reasons that are poorly understood.
 # Remove this when a better fix is known.
 if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    patchfiles-append xcode-10-1.patch
     build.pre_args      -UseNewBuildSystem=NO
     destroot.pre_args   -UseNewBuildSystem=NO
 }

--- a/aqua/BGHUDAppKit/files/xcode-10-1.patch
+++ b/aqua/BGHUDAppKit/files/xcode-10-1.patch
@@ -1,0 +1,3029 @@
+diff --git BGHUDAppKit.xcodeproj/project.pbxproj BGHUDAppKit.xcodeproj/project.pbxproj
+index c3801c1..72a7f58 100755
+--- BGHUDAppKit.xcodeproj/project.pbxproj
++++ BGHUDAppKit.xcodeproj/project.pbxproj
+@@ -823,6 +823,9 @@
+ /* Begin PBXProject section */
+ 		0259C573FE90428111CA0C5A /* Project object */ = {
+ 			isa = PBXProject;
++			attributes = {
++				LastUpgradeCheck = 1010;
++			};
+ 			buildConfigurationList = C056398B08A954F8003078D8 /* Build configuration list for PBXProject "BGHUDAppKit" */;
+ 			compatibilityVersion = "Xcode 3.1";
+ 			developmentRegion = English;
+@@ -904,7 +907,7 @@
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 0;
+ 			shellPath = /bin/sh;
+-			shellScript = "if [ -f \"/usr/bin/install_name_tool\" ]; then\n\n    /usr/bin/install_name_tool -change @executable_path/../Frameworks/BGHUDAppKit.framework/Versions/A/BGHUDAppKit @loader_path/../../../../../../../BGHUDAppKit.framework/Versions/A/BGHUDAppKit \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}.ibplugin/Contents/MacOS/${PRODUCT_NAME}\"\n\nelse\n\n    /Developer/usr/bin/install_name_tool -change @executable_path/../Frameworks/BGHUDAppKit.framework/Versions/A/BGHUDAppKit @loader_path/../../../../../../../BGHUDAppKit.framework/Versions/A/BGHUDAppKit \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}.ibplugin/Contents/MacOS/${PRODUCT_NAME}\"\n\nfi";
++			shellScript = "if [ -f \"/usr/bin/install_name_tool\" ]; then\n\n    /usr/bin/install_name_tool -change @executable_path/../Frameworks/BGHUDAppKit.framework/Versions/A/BGHUDAppKit @loader_path/../../../../../../../BGHUDAppKit.framework/Versions/A/BGHUDAppKit \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}.ibplugin/Contents/MacOS/${PRODUCT_NAME}\"\n\nelse\n\n    /Developer/usr/bin/install_name_tool -change @executable_path/../Frameworks/BGHUDAppKit.framework/Versions/A/BGHUDAppKit @loader_path/../../../../../../../BGHUDAppKit.framework/Versions/A/BGHUDAppKit \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}.ibplugin/Contents/MacOS/${PRODUCT_NAME}\"\n\nfi\n";
+ 		};
+ /* End PBXShellScriptBuildPhase section */
+ 
+@@ -1009,16 +1012,15 @@
+ 		3D9BABBF1166D18F008CEA8B /* Release_10.6_10.5_32_64_GC_embed */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+ 				GCC_ENABLE_OBJC_GC = supported;
+ 				GCC_MODEL_TUNING = "";
+ 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+ 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+ 				LLVM_LTO = YES;
+-				MACOSX_DEPLOYMENT_TARGET = 10.5;
++				MACOSX_DEPLOYMENT_TARGET = 10.6;
+ 				PREBINDING = NO;
+-				SDKROOT = macosx10.6;
++				SDKROOT = macosx;
+ 			};
+ 			name = Release_10.6_10.5_32_64_GC_embed;
+ 		};
+@@ -1042,6 +1044,7 @@
+ 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)/BGHUDAppKit.framework/Resources/";
+ 				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)";
+ 				COPY_PHASE_STRIP = NO;
++				DEVELOPMENT_TEAM = "";
+ 				FRAMEWORK_SEARCH_PATHS = (
+ 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
+ 					$inherited,
+@@ -1067,6 +1070,7 @@
+ 			buildSettings = {
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
+ 				DEPLOYMENT_POSTPROCESSING = YES;
++				DEVELOPMENT_TEAM = "";
+ 				DYLIB_COMPATIBILITY_VERSION = 1;
+ 				DYLIB_CURRENT_VERSION = 1;
+ 				FRAMEWORK_VERSION = A;
+@@ -1091,8 +1095,8 @@
+ 		C056398008A954F8003078D8 /* Debug */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+ 				COPY_PHASE_STRIP = NO;
++				DEVELOPMENT_TEAM = "";
+ 				DYLIB_COMPATIBILITY_VERSION = 1;
+ 				DYLIB_CURRENT_VERSION = 1;
+ 				FRAMEWORK_VERSION = A;
+@@ -1137,9 +1141,9 @@
+ 		C056398108A954F8003078D8 /* Release */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
+ 				DEPLOYMENT_POSTPROCESSING = YES;
++				DEVELOPMENT_TEAM = "";
+ 				DYLIB_COMPATIBILITY_VERSION = 1;
+ 				DYLIB_CURRENT_VERSION = 1;
+ 				FRAMEWORK_VERSION = A;
+@@ -1164,9 +1168,9 @@
+ 		C056398408A954F8003078D8 /* Debug */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+ 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)/BGHUDAppKit.framework/Resources/";
+ 				COPY_PHASE_STRIP = NO;
++				DEVELOPMENT_TEAM = "";
+ 				FRAMEWORK_SEARCH_PATHS = (
+ 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
+ 					$inherited,
+@@ -1193,11 +1197,11 @@
+ 		C056398508A954F8003078D8 /* Release */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+ 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)/BGHUDAppKit.framework/Resources/";
+ 				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)";
+ 				COPY_PHASE_STRIP = NO;
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
++				DEVELOPMENT_TEAM = "";
+ 				FRAMEWORK_SEARCH_PATHS = (
+ 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
+ 					$inherited,
+@@ -1253,29 +1257,26 @@
+ 		C056398C08A954F8003078D8 /* Debug */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+ 				GCC_ENABLE_OBJC_GC = supported;
+ 				GCC_MODEL_TUNING = "";
+ 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
++				MACOSX_DEPLOYMENT_TARGET = 10.6;
+ 				PREBINDING = NO;
+-				SDKROOT = macosx10.5;
++				SDKROOT = macosx;
+ 			};
+ 			name = Debug;
+ 		};
+ 		C056398D08A954F8003078D8 /* Release */ = {
+ 			isa = XCBuildConfiguration;
+ 			buildSettings = {
+-				ARCHS = (
+-					ppc,
+-					i386,
+-				);
+ 				GCC_ENABLE_OBJC_GC = supported;
+ 				GCC_MODEL_TUNING = "";
+ 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
++				MACOSX_DEPLOYMENT_TARGET = 10.6;
+ 				PREBINDING = NO;
+-				SDKROOT = macosx10.5;
++				SDKROOT = macosx;
+ 			};
+ 			name = Release;
+ 		};
+diff --git BGHUDColorWellInspector.xib BGHUDColorWellInspector.xib
+index cc9fd19..2a447e7 100644
+--- BGHUDColorWellInspector.xib
++++ BGHUDColorWellInspector.xib
+@@ -1,790 +1,55 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
+-	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
+-		<string key="IBDocument.SystemVersion">10F569</string>
+-		<string key="IBDocument.InterfaceBuilderVersion">788</string>
+-		<string key="IBDocument.AppKitVersion">1038.29</string>
+-		<string key="IBDocument.HIToolboxVersion">461.00</string>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
+-			<string key="NS.object.0">788</string>
+-		</object>
+-		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-		</object>
+-		<object class="NSArray" key="IBDocument.PluginDependencies">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-		</object>
+-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<object class="NSArray" key="dict.sortedKeys" id="0">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-			</object>
+-			<object class="NSMutableArray" key="dict.values">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-			</object>
+-		</object>
+-		<object class="NSMutableArray" key="IBDocument.RootObjects" id="110858478">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<object class="NSCustomObject" id="762632889">
+-				<string key="NSClassName">IBInspector</string>
+-			</object>
+-			<object class="NSCustomObject" id="932410077">
+-				<string key="NSClassName">FirstResponder</string>
+-			</object>
+-			<object class="NSCustomObject" id="858592610">
+-				<string key="NSClassName">NSApplication</string>
+-			</object>
+-			<object class="NSCustomView" id="975060614">
+-				<nil key="NSNextResponder"/>
+-				<int key="NSvFlags">256</int>
+-				<object class="NSMutableArray" key="NSSubviews">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<object class="NSTextField" id="66619208">
+-						<reference key="NSNextResponder" ref="975060614"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{84, 31}, {180, 19}}</string>
+-						<reference key="NSSuperview" ref="975060614"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="980132319">
+-							<int key="NSCellFlags">-1804468671</int>
+-							<int key="NSCellFlags2">-1874721792</int>
+-							<string key="NSContents"/>
+-							<object class="NSFont" key="NSSupport" id="26">
+-								<string key="NSName">LucidaGrande</string>
+-								<double key="NSSize">11</double>
+-								<int key="NSfFlags">3100</int>
+-							</object>
+-							<reference key="NSControlView" ref="66619208"/>
+-							<bool key="NSDrawsBackground">YES</bool>
+-							<object class="NSColor" key="NSBackgroundColor">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">textBackgroundColor</string>
+-								<object class="NSColor" key="NSColor">
+-									<int key="NSColorSpace">3</int>
+-									<bytes key="NSWhite">MQA</bytes>
+-								</object>
+-							</object>
+-							<object class="NSColor" key="NSTextColor">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">textColor</string>
+-								<object class="NSColor" key="NSColor" id="1000306496">
+-									<int key="NSColorSpace">3</int>
+-									<bytes key="NSWhite">MAA</bytes>
+-								</object>
+-							</object>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="769135442">
+-						<reference key="NSNextResponder" ref="975060614"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{8, 33}, {70, 14}}</string>
+-						<reference key="NSSuperview" ref="975060614"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="1019596888">
+-							<int key="NSCellFlags">67239488</int>
+-							<int key="NSCellFlags2">4326400</int>
+-							<string key="NSContents">Theme Key</string>
+-							<object class="NSFont" key="NSSupport">
+-								<string key="NSName">LucidaGrande-Bold</string>
+-								<double key="NSSize">11</double>
+-								<int key="NSfFlags">16</int>
+-							</object>
+-							<reference key="NSControlView" ref="769135442"/>
+-							<object class="NSColor" key="NSBackgroundColor">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">controlColor</string>
+-								<object class="NSColor" key="NSColor">
+-									<int key="NSColorSpace">3</int>
+-									<bytes key="NSWhite">MC42NjY2NjY2ODY1AA</bytes>
+-								</object>
+-							</object>
+-							<object class="NSColor" key="NSTextColor">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">controlTextColor</string>
+-								<reference key="NSColor" ref="1000306496"/>
+-							</object>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="504018525">
+-						<reference key="NSNextResponder" ref="975060614"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 7}, {185, 18}}</string>
+-						<reference key="NSSuperview" ref="975060614"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="727074188">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Use Transparent Well</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="504018525"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<object class="NSCustomResource" key="NSNormalImage">
+-								<string key="NSClassName">NSImage</string>
+-								<string key="NSResourceName">NSSwitch</string>
+-							</object>
+-							<object class="NSButtonImageSource" key="NSAlternateImage">
+-								<string key="NSImageName">NSSwitch</string>
+-							</object>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-				</object>
+-				<string key="NSFrameSize">{273, 54}</string>
+-				<string key="NSClassName">NSView</string>
+-				<string key="NSExtension">NSResponder</string>
+-			</object>
+-		</object>
+-		<object class="IBObjectContainer" key="IBDocument.Objects">
+-			<object class="NSMutableArray" key="connectionRecords">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<object class="IBConnectionRecord">
+-					<object class="IBOutletConnection" key="connection">
+-						<string key="label">inspectorView</string>
+-						<reference key="source" ref="762632889"/>
+-						<reference key="destination" ref="975060614"/>
+-					</object>
+-					<int key="connectionID">116</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.themeKey</string>
+-						<reference key="source" ref="66619208"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="66619208"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.themeKey</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.themeKey</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">120</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.useTransparentWell</string>
+-						<reference key="source" ref="504018525"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="504018525"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.useTransparentWell</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.useTransparentWell</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">122</int>
+-				</object>
+-			</object>
+-			<object class="IBMutableOrderedSet" key="objectRecords">
+-				<object class="NSArray" key="orderedObjects">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">0</int>
+-						<reference key="object" ref="0"/>
+-						<reference key="children" ref="110858478"/>
+-						<nil key="parent"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">-2</int>
+-						<reference key="object" ref="762632889"/>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">File's Owner</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">-1</int>
+-						<reference key="object" ref="932410077"/>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">First Responder</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">-3</int>
+-						<reference key="object" ref="858592610"/>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">Application</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">111</int>
+-						<reference key="object" ref="975060614"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="769135442"/>
+-							<reference ref="66619208"/>
+-							<reference ref="504018525"/>
+-						</object>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">Inspector View</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">112</int>
+-						<reference key="object" ref="769135442"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="1019596888"/>
+-						</object>
+-						<reference key="parent" ref="975060614"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">113</int>
+-						<reference key="object" ref="66619208"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="980132319"/>
+-						</object>
+-						<reference key="parent" ref="975060614"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">114</int>
+-						<reference key="object" ref="980132319"/>
+-						<reference key="parent" ref="66619208"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">115</int>
+-						<reference key="object" ref="1019596888"/>
+-						<reference key="parent" ref="769135442"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">117</int>
+-						<reference key="object" ref="504018525"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="727074188"/>
+-						</object>
+-						<reference key="parent" ref="975060614"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">118</int>
+-						<reference key="object" ref="727074188"/>
+-						<reference key="parent" ref="504018525"/>
+-					</object>
+-				</object>
+-			</object>
+-			<object class="NSMutableDictionary" key="flattenedProperties">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<object class="NSArray" key="dict.sortedKeys">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<string>-3.IBPluginDependency</string>
+-					<string>-3.ImportedFromIB2</string>
+-					<string>111.GUserGuides</string>
+-					<string>111.IBEditorWindowLastContentRect</string>
+-					<string>111.IBPluginDependency</string>
+-					<string>111.IBUserGuides</string>
+-					<string>111.ImportedFromIB2</string>
+-					<string>111.WindowOrigin</string>
+-					<string>111.editorWindowContentRectSynchronizationRect</string>
+-					<string>112.IBPluginDependency</string>
+-					<string>113.IBPluginDependency</string>
+-					<string>114.IBPluginDependency</string>
+-					<string>115.IBPluginDependency</string>
+-					<string>117.IBPluginDependency</string>
+-					<string>118.IBPluginDependency</string>
+-				</object>
+-				<object class="NSMutableArray" key="dict.values">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<integer value="1"/>
+-					<object class="NSMutableArray">
+-						<bool key="EncodedWithXMLCoder">YES</bool>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="975060614"/>
+-							<double key="location">90</double>
+-							<int key="affinity">0</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="975060614"/>
+-							<double key="location">227</double>
+-							<int key="affinity">0</int>
+-						</object>
+-					</object>
+-					<string>{{724, 855}, {273, 54}}</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<object class="NSMutableArray">
+-						<bool key="EncodedWithXMLCoder">YES</bool>
+-					</object>
+-					<integer value="1"/>
+-					<string>{155, 478}</string>
+-					<string>{{535, 792}, {275, 29}}</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-				</object>
+-			</object>
+-			<object class="NSMutableDictionary" key="unlocalizedProperties">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<reference key="dict.sortedKeys" ref="0"/>
+-				<object class="NSMutableArray" key="dict.values">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-				</object>
+-			</object>
+-			<nil key="activeLocalization"/>
+-			<object class="NSMutableDictionary" key="localizations">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<reference key="dict.sortedKeys" ref="0"/>
+-				<object class="NSMutableArray" key="dict.values">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-				</object>
+-			</object>
+-			<nil key="sourceID"/>
+-			<int key="maxID">122</int>
+-		</object>
+-		<object class="IBClassDescriber" key="IBDocument.Classes">
+-			<object class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSActionCell</string>
+-					<string key="superclassName">NSCell</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSActionCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<string key="superclassName">NSResponder</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="234685793">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSApplication.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="72896427">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSApplicationScripting.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="698094934">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSColorPanel.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSHelpManager.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSPageLayout.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSUserInterfaceItemSearching.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSButton</string>
+-					<string key="superclassName">NSControl</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSButton.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSButtonCell</string>
+-					<string key="superclassName">NSActionCell</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSButtonCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSCell</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSControl</string>
+-					<string key="superclassName">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="366668011">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSControl.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSFormatter</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSFormatter.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSMenu</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="1026050687">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSMenu.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AddressBook.framework/Headers/ABActions.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSAccessibility.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="234685793"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="72896427"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="698094934"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="366668011"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSDictionaryController.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSDragging.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSFontManager.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSFontPanel.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSKeyValueBinding.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="1026050687"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSNibLoading.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSOutlineView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSPasteboard.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSSavePanel.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSTableView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSToolbarItem.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="266611157">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSArchiver.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSClassDescription.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSError.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSFileManager.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueCoding.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueObserving.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSKeyedArchiver.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSObjectScripting.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSPortCoder.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptClassDescription.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptKeyValueCoding.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptObjectSpecifiers.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptWhoseTests.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSThread.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSURL.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSURLDownload.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Sparkle.framework/Headers/SUAppcast.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Sparkle.framework/Headers/SUUpdater.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSResponder</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSInterfaceStyle.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSResponder</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSResponder.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSTextField</string>
+-					<string key="superclassName">NSControl</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSTextField.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSTextFieldCell</string>
+-					<string key="superclassName">NSActionCell</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSTextFieldCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSClipView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSMenuItem.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSRulerView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<string key="superclassName">NSResponder</string>
+-					<reference key="sourceIdentifier" ref="266611157"/>
+-				</object>
+-			</object>
+-		</object>
+-		<int key="IBDocument.localizationMode">0</int>
+-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
+-			<integer value="1050" key="NS.object.0"/>
+-		</object>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
+-			<integer value="3000" key="NS.object.0"/>
+-		</object>
+-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+-		<string key="IBDocument.LastKnownRelativeProjectPath">BGHUDAppKit.xcodeproj</string>
+-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
+-			<string key="NS.key.0">NSSwitch</string>
+-			<string key="NS.object.0">{15, 15}</string>
+-		</object>
+-	</data>
+-</archive>
++<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
++    <dependencies>
++        <deployment identifier="macosx"/>
++        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
++        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
++    </dependencies>
++    <objects>
++        <customObject id="-2" userLabel="File's Owner" customClass="IBInspector">
++            <connections>
++                <outlet property="inspectorView" destination="111" id="116"/>
++            </connections>
++        </customObject>
++        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
++        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
++        <customView id="111" userLabel="Inspector View">
++            <rect key="frame" x="0.0" y="0.0" width="273" height="54"/>
++            <autoresizingMask key="autoresizingMask"/>
++            <subviews>
++                <button imageHugsTitle="YES" id="117">
++                    <rect key="frame" x="81" y="7" width="185" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Use Transparent Well" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="118">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.useTransparentWell" id="122"/>
++                    </connections>
++                </button>
++                <textField verticalHuggingPriority="750" id="112">
++                    <rect key="frame" x="8" y="33" width="70" height="14"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Theme Key" id="115">
++                        <font key="font" metaFont="smallSystemBold"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++                <textField verticalHuggingPriority="750" id="113">
++                    <rect key="frame" x="84" y="31" width="180" height="19"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
++                        <font key="font" metaFont="controlContent" size="11"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.themeKey" id="120"/>
++                    </connections>
++                </textField>
++            </subviews>
++        </customView>
++    </objects>
++</document>
+diff --git BGHUDViewInspector.xib BGHUDViewInspector.xib
+index 957aaca..02a9544 100644
+--- BGHUDViewInspector.xib
++++ BGHUDViewInspector.xib
+@@ -1,1787 +1,252 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
+-	<data>
+-		<int key="IBDocument.SystemTarget">1050</int>
+-		<string key="IBDocument.SystemVersion">10A432</string>
+-		<string key="IBDocument.InterfaceBuilderVersion">732</string>
+-		<string key="IBDocument.AppKitVersion">1038</string>
+-		<string key="IBDocument.HIToolboxVersion">437.00</string>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
+-			<string key="NS.object.0">732</string>
+-		</object>
+-		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<integer value="1"/>
+-		</object>
+-		<object class="NSArray" key="IBDocument.PluginDependencies">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-		</object>
+-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<object class="NSArray" key="dict.sortedKeys" id="0">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-			</object>
+-			<object class="NSMutableArray" key="dict.values">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-			</object>
+-		</object>
+-		<object class="NSMutableArray" key="IBDocument.RootObjects" id="110858478">
+-			<bool key="EncodedWithXMLCoder">YES</bool>
+-			<object class="NSCustomObject" id="762632889">
+-				<string key="NSClassName">IBInspector</string>
+-			</object>
+-			<object class="NSCustomObject" id="932410077">
+-				<string key="NSClassName">FirstResponder</string>
+-			</object>
+-			<object class="NSCustomObject" id="858592610">
+-				<string key="NSClassName">NSApplication</string>
+-			</object>
+-			<object class="NSCustomView" id="537708911">
+-				<reference key="NSNextResponder"/>
+-				<int key="NSvFlags">268</int>
+-				<object class="NSMutableArray" key="NSSubviews">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<object class="NSTextField" id="900208769">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{8, 146}, {70, 14}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="959902889">
+-							<int key="NSCellFlags">67239488</int>
+-							<int key="NSCellFlags2">4326400</int>
+-							<string key="NSContents">Gradient:</string>
+-							<object class="NSFont" key="NSSupport" id="748071864">
+-								<string key="NSName">LucidaGrande-Bold</string>
+-								<double key="NSSize">11</double>
+-								<int key="NSfFlags">16</int>
+-							</object>
+-							<reference key="NSControlView" ref="900208769"/>
+-							<object class="NSColor" key="NSBackgroundColor" id="106251383">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">controlColor</string>
+-								<object class="NSColor" key="NSColor">
+-									<int key="NSColorSpace">3</int>
+-									<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
+-								</object>
+-							</object>
+-							<object class="NSColor" key="NSTextColor" id="786843933">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">controlTextColor</string>
+-								<object class="NSColor" key="NSColor" id="1000306496">
+-									<int key="NSColorSpace">3</int>
+-									<bytes key="NSWhite">MAA</bytes>
+-								</object>
+-							</object>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="720351765">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{8, 91}, {70, 14}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="505645570">
+-							<int key="NSCellFlags">67239488</int>
+-							<int key="NSCellFlags2">4326400</int>
+-							<string key="NSContents">Borders:</string>
+-							<reference key="NSSupport" ref="748071864"/>
+-							<reference key="NSControlView" ref="720351765"/>
+-							<reference key="NSBackgroundColor" ref="106251383"/>
+-							<reference key="NSTextColor" ref="786843933"/>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="142515939">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{8, 40}, {70, 14}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="27593378">
+-							<int key="NSCellFlags">67239488</int>
+-							<int key="NSCellFlags2">4326400</int>
+-							<string key="NSContents">Shadows:</string>
+-							<reference key="NSSupport" ref="748071864"/>
+-							<reference key="NSControlView" ref="142515939"/>
+-							<reference key="NSBackgroundColor" ref="106251383"/>
+-							<reference key="NSTextColor" ref="786843933"/>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="130094003">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 120}, {185, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="786369834">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Flip Gradient</string>
+-							<object class="NSFont" key="NSSupport" id="26">
+-								<string key="NSName">LucidaGrande</string>
+-								<double key="NSSize">11</double>
+-								<int key="NSfFlags">3100</int>
+-							</object>
+-							<reference key="NSControlView" ref="130094003"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<object class="NSCustomResource" key="NSNormalImage" id="186896346">
+-								<string key="NSClassName">NSImage</string>
+-								<string key="NSResourceName">NSSwitch</string>
+-							</object>
+-							<object class="NSButtonImageSource" key="NSAlternateImage" id="747737130">
+-								<string key="NSImageName">NSSwitch</string>
+-							</object>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="9188110">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 89}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="152253512">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Top</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="9188110"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="294246284">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 69}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="170108317">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Left</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="294246284"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="131047301">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{147, 69}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="916460839">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Right</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="131047301"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="974025553">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{147, 89}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="161438625">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Bottom</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="974025553"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSColorWell" id="807886487">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<object class="NSMutableSet" key="NSDragTypes">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<object class="NSArray" key="set.sortedObjects">
+-								<bool key="EncodedWithXMLCoder">YES</bool>
+-								<string>NSColor pasteboard type</string>
+-							</object>
+-						</object>
+-						<string key="NSFrame">{{227, 71}, {37, 34}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<bool key="NSIsBordered">YES</bool>
+-						<object class="NSColor" key="NSColor" id="509237073">
+-							<int key="NSColorSpace">1</int>
+-							<bytes key="NSRGB">MCAwIDAAA</bytes>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="1034270235">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 38}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="357003664">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Top</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="1034270235"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="576712833">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 18}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="136965298">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Left</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="576712833"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="468630715">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{147, 18}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="292484926">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Right</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="468630715"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="994223698">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{147, 38}, {63, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="257285394">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Bottom</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="994223698"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSColorWell" id="164307968">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<object class="NSMutableSet" key="NSDragTypes">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<object class="NSArray" key="set.sortedObjects">
+-								<bool key="EncodedWithXMLCoder">YES</bool>
+-								<string>NSColor pasteboard type</string>
+-							</object>
+-						</object>
+-						<string key="NSFrame">{{227, 20}, {37, 34}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<bool key="NSIsBordered">YES</bool>
+-						<reference key="NSColor" ref="509237073"/>
+-					</object>
+-					<object class="NSBox" id="420014560">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">12</int>
+-						<string key="NSFrame">{{12, 111}, {252, 5}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<string key="NSOffsets">{0, 0}</string>
+-						<object class="NSTextFieldCell" key="NSTitleCell">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">0</int>
+-							<string key="NSContents">Box</string>
+-							<object class="NSFont" key="NSSupport" id="170470887">
+-								<string key="NSName">LucidaGrande</string>
+-								<double key="NSSize">13</double>
+-								<int key="NSfFlags">1044</int>
+-							</object>
+-							<object class="NSColor" key="NSBackgroundColor" id="705593109">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">textBackgroundColor</string>
+-								<object class="NSColor" key="NSColor">
+-									<int key="NSColorSpace">3</int>
+-									<bytes key="NSWhite">MQA</bytes>
+-								</object>
+-							</object>
+-							<object class="NSColor" key="NSTextColor">
+-								<int key="NSColorSpace">3</int>
+-								<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
+-							</object>
+-						</object>
+-						<int key="NSBorderType">3</int>
+-						<int key="NSBoxType">2</int>
+-						<int key="NSTitlePosition">0</int>
+-						<bool key="NSTransparent">NO</bool>
+-					</object>
+-					<object class="NSBox" id="154239848">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">12</int>
+-						<string key="NSFrame">{{12, 60}, {252, 5}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<string key="NSOffsets">{0, 0}</string>
+-						<object class="NSTextFieldCell" key="NSTitleCell">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">0</int>
+-							<string key="NSContents">Box</string>
+-							<reference key="NSSupport" ref="170470887"/>
+-							<reference key="NSBackgroundColor" ref="705593109"/>
+-							<object class="NSColor" key="NSTextColor">
+-								<int key="NSColorSpace">3</int>
+-								<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
+-							</object>
+-						</object>
+-						<int key="NSBorderType">3</int>
+-						<int key="NSBoxType">2</int>
+-						<int key="NSTitlePosition">0</int>
+-						<bool key="NSTransparent">NO</bool>
+-					</object>
+-					<object class="NSColorWell" id="714171131">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<object class="NSMutableSet" key="NSDragTypes">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<object class="NSArray" key="set.sortedObjects">
+-								<bool key="EncodedWithXMLCoder">YES</bool>
+-								<string>NSColor pasteboard type</string>
+-							</object>
+-						</object>
+-						<string key="NSFrame">{{126, 141}, {44, 23}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<bool key="NSIsBordered">YES</bool>
+-						<object class="NSColor" key="NSColor">
+-							<int key="NSColorSpace">1</int>
+-							<bytes key="NSRGB">MC4wNTgxMzA0OTkgMC4wNTU1NDE4OTkgMQA</bytes>
+-						</object>
+-					</object>
+-					<object class="NSColorWell" id="880293883">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<object class="NSMutableSet" key="NSDragTypes">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<object class="NSArray" key="set.sortedObjects">
+-								<bool key="EncodedWithXMLCoder">YES</bool>
+-								<string>NSColor pasteboard type</string>
+-							</object>
+-						</object>
+-						<string key="NSFrame">{{220, 141}, {44, 23}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<bool key="NSIsBordered">YES</bool>
+-						<object class="NSColor" key="NSColor">
+-							<int key="NSColorSpace">1</int>
+-							<bytes key="NSRGB">MC4wNTgxMzA0OTkgMC4wNTU1NDE4OTkgMQA</bytes>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="494030977">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{86, 147}, {44, 11}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="97491710">
+-							<int key="NSCellFlags">68288064</int>
+-							<int key="NSCellFlags2">272892928</int>
+-							<string key="NSContents">Color 1</string>
+-							<object class="NSFont" key="NSSupport" id="22">
+-								<string key="NSName">LucidaGrande</string>
+-								<double key="NSSize">9</double>
+-								<int key="NSfFlags">3614</int>
+-							</object>
+-							<reference key="NSControlView" ref="494030977"/>
+-							<reference key="NSBackgroundColor" ref="106251383"/>
+-							<reference key="NSTextColor" ref="786843933"/>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="941392499">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{180, 147}, {44, 11}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="869196759">
+-							<int key="NSCellFlags">68288064</int>
+-							<int key="NSCellFlags2">272892928</int>
+-							<string key="NSContents">Color 2</string>
+-							<reference key="NSSupport" ref="22"/>
+-							<reference key="NSControlView" ref="941392499"/>
+-							<reference key="NSBackgroundColor" ref="106251383"/>
+-							<reference key="NSTextColor" ref="786843933"/>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="17315972">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{84, 203}, {180, 19}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="725915110">
+-							<int key="NSCellFlags">-1804468671</int>
+-							<int key="NSCellFlags2">-1874721792</int>
+-							<string key="NSContents"/>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="17315972"/>
+-							<bool key="NSDrawsBackground">YES</bool>
+-							<reference key="NSBackgroundColor" ref="705593109"/>
+-							<object class="NSColor" key="NSTextColor">
+-								<int key="NSColorSpace">6</int>
+-								<string key="NSCatalogName">System</string>
+-								<string key="NSColorName">textColor</string>
+-								<reference key="NSColor" ref="1000306496"/>
+-							</object>
+-						</object>
+-					</object>
+-					<object class="NSTextField" id="288657989">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{8, 205}, {70, 14}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSTextFieldCell" key="NSCell" id="17973583">
+-							<int key="NSCellFlags">67239488</int>
+-							<int key="NSCellFlags2">4326400</int>
+-							<string key="NSContents">Theme Key</string>
+-							<reference key="NSSupport" ref="748071864"/>
+-							<reference key="NSControlView" ref="288657989"/>
+-							<reference key="NSBackgroundColor" ref="106251383"/>
+-							<reference key="NSTextColor" ref="786843933"/>
+-						</object>
+-					</object>
+-					<object class="NSButton" id="103795753">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">268</int>
+-						<string key="NSFrame">{{81, 179}, {82, 18}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<bool key="NSEnabled">YES</bool>
+-						<object class="NSButtonCell" key="NSCell" id="304690009">
+-							<int key="NSCellFlags">-2080244224</int>
+-							<int key="NSCellFlags2">131072</int>
+-							<string key="NSContents">Use Theme</string>
+-							<reference key="NSSupport" ref="26"/>
+-							<reference key="NSControlView" ref="103795753"/>
+-							<int key="NSButtonFlags">1211912703</int>
+-							<int key="NSButtonFlags2">2</int>
+-							<reference key="NSNormalImage" ref="186896346"/>
+-							<reference key="NSAlternateImage" ref="747737130"/>
+-							<string key="NSAlternateContents"/>
+-							<string key="NSKeyEquivalent"/>
+-							<int key="NSPeriodicDelay">200</int>
+-							<int key="NSPeriodicInterval">25</int>
+-						</object>
+-					</object>
+-					<object class="NSBox" id="458953956">
+-						<reference key="NSNextResponder" ref="537708911"/>
+-						<int key="NSvFlags">12</int>
+-						<string key="NSFrame">{{12, 170}, {252, 5}}</string>
+-						<reference key="NSSuperview" ref="537708911"/>
+-						<string key="NSOffsets">{0, 0}</string>
+-						<object class="NSTextFieldCell" key="NSTitleCell">
+-							<int key="NSCellFlags">67239424</int>
+-							<int key="NSCellFlags2">0</int>
+-							<string key="NSContents">Box</string>
+-							<reference key="NSSupport" ref="170470887"/>
+-							<reference key="NSBackgroundColor" ref="705593109"/>
+-							<object class="NSColor" key="NSTextColor">
+-								<int key="NSColorSpace">3</int>
+-								<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
+-							</object>
+-						</object>
+-						<int key="NSBorderType">3</int>
+-						<int key="NSBoxType">2</int>
+-						<int key="NSTitlePosition">0</int>
+-						<bool key="NSTransparent">NO</bool>
+-					</object>
+-				</object>
+-				<string key="NSFrameSize">{271, 226}</string>
+-				<reference key="NSSuperview"/>
+-				<string key="NSClassName">NSView</string>
+-			</object>
+-		</object>
+-		<object class="IBObjectContainer" key="IBDocument.Objects">
+-			<object class="NSMutableArray" key="connectionRecords">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<object class="IBConnectionRecord">
+-					<object class="IBOutletConnection" key="connection">
+-						<string key="label">inspectorView</string>
+-						<reference key="source" ref="762632889"/>
+-						<reference key="destination" ref="537708911"/>
+-					</object>
+-					<int key="connectionID">16</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.themeKey</string>
+-						<reference key="source" ref="17315972"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="17315972"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.themeKey</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.themeKey</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">169</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.useTheme</string>
+-						<reference key="source" ref="103795753"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="103795753"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.useTheme</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.useTheme</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">171</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.color1</string>
+-						<reference key="source" ref="714171131"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="714171131"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.color1</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.color1</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">173</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.color2</string>
+-						<reference key="source" ref="880293883"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="880293883"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.color2</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.color2</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">175</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.flipGradient</string>
+-						<reference key="source" ref="130094003"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="130094003"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.flipGradient</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.flipGradient</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">177</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawTopBorder</string>
+-						<reference key="source" ref="9188110"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="9188110"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawTopBorder</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawTopBorder</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">179</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawLeftBorder</string>
+-						<reference key="source" ref="294246284"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="294246284"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawLeftBorder</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawLeftBorder</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">181</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawBottomBorder</string>
+-						<reference key="source" ref="974025553"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="974025553"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawBottomBorder</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawBottomBorder</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">183</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawRightBorder</string>
+-						<reference key="source" ref="131047301"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="131047301"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawRightBorder</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawRightBorder</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">185</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.borderColor</string>
+-						<reference key="source" ref="807886487"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="807886487"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.borderColor</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.borderColor</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">187</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.shadowColor</string>
+-						<reference key="source" ref="164307968"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="164307968"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.shadowColor</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.shadowColor</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">189</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawTopShadow</string>
+-						<reference key="source" ref="1034270235"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="1034270235"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawTopShadow</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawTopShadow</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">191</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawLeftShadow</string>
+-						<reference key="source" ref="576712833"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="576712833"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawLeftShadow</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawLeftShadow</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">193</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawBottomShadow</string>
+-						<reference key="source" ref="994223698"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="994223698"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawBottomShadow</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawBottomShadow</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">195</int>
+-				</object>
+-				<object class="IBConnectionRecord">
+-					<object class="IBBindingConnection" key="connection">
+-						<string key="label">value: inspectedObjectsController.selection.drawRightShadow</string>
+-						<reference key="source" ref="468630715"/>
+-						<reference key="destination" ref="762632889"/>
+-						<object class="NSNibBindingConnector" key="connector">
+-							<reference key="NSSource" ref="468630715"/>
+-							<reference key="NSDestination" ref="762632889"/>
+-							<string key="NSLabel">value: inspectedObjectsController.selection.drawRightShadow</string>
+-							<string key="NSBinding">value</string>
+-							<string key="NSKeyPath">inspectedObjectsController.selection.drawRightShadow</string>
+-							<int key="NSNibBindingConnectorVersion">2</int>
+-						</object>
+-					</object>
+-					<int key="connectionID">197</int>
+-				</object>
+-			</object>
+-			<object class="IBMutableOrderedSet" key="objectRecords">
+-				<object class="NSArray" key="orderedObjects">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">0</int>
+-						<reference key="object" ref="0"/>
+-						<reference key="children" ref="110858478"/>
+-						<nil key="parent"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">-2</int>
+-						<reference key="object" ref="762632889"/>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">File's Owner</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">-1</int>
+-						<reference key="object" ref="932410077"/>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">First Responder</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">-3</int>
+-						<reference key="object" ref="858592610"/>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">Application</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">1</int>
+-						<reference key="object" ref="537708911"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="900208769"/>
+-							<reference ref="720351765"/>
+-							<reference ref="142515939"/>
+-							<reference ref="130094003"/>
+-							<reference ref="9188110"/>
+-							<reference ref="294246284"/>
+-							<reference ref="131047301"/>
+-							<reference ref="974025553"/>
+-							<reference ref="807886487"/>
+-							<reference ref="1034270235"/>
+-							<reference ref="576712833"/>
+-							<reference ref="468630715"/>
+-							<reference ref="994223698"/>
+-							<reference ref="164307968"/>
+-							<reference ref="420014560"/>
+-							<reference ref="154239848"/>
+-							<reference ref="880293883"/>
+-							<reference ref="714171131"/>
+-							<reference ref="494030977"/>
+-							<reference ref="941392499"/>
+-							<reference ref="17315972"/>
+-							<reference ref="288657989"/>
+-							<reference ref="103795753"/>
+-							<reference ref="458953956"/>
+-						</object>
+-						<reference key="parent" ref="0"/>
+-						<string key="objectName">Inspector View</string>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">112</int>
+-						<reference key="object" ref="900208769"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="959902889"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">113</int>
+-						<reference key="object" ref="720351765"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="505645570"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">114</int>
+-						<reference key="object" ref="142515939"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="27593378"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">115</int>
+-						<reference key="object" ref="130094003"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="786369834"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">116</int>
+-						<reference key="object" ref="9188110"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="152253512"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">117</int>
+-						<reference key="object" ref="294246284"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="170108317"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">118</int>
+-						<reference key="object" ref="131047301"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="916460839"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">119</int>
+-						<reference key="object" ref="974025553"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="161438625"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">120</int>
+-						<reference key="object" ref="807886487"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">121</int>
+-						<reference key="object" ref="1034270235"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="357003664"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">122</int>
+-						<reference key="object" ref="576712833"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="136965298"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">123</int>
+-						<reference key="object" ref="468630715"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="292484926"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">124</int>
+-						<reference key="object" ref="994223698"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="257285394"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">125</int>
+-						<reference key="object" ref="164307968"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">126</int>
+-						<reference key="object" ref="420014560"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">127</int>
+-						<reference key="object" ref="154239848"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">128</int>
+-						<reference key="object" ref="257285394"/>
+-						<reference key="parent" ref="994223698"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">129</int>
+-						<reference key="object" ref="292484926"/>
+-						<reference key="parent" ref="468630715"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">130</int>
+-						<reference key="object" ref="136965298"/>
+-						<reference key="parent" ref="576712833"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">131</int>
+-						<reference key="object" ref="357003664"/>
+-						<reference key="parent" ref="1034270235"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">132</int>
+-						<reference key="object" ref="161438625"/>
+-						<reference key="parent" ref="974025553"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">133</int>
+-						<reference key="object" ref="916460839"/>
+-						<reference key="parent" ref="131047301"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">134</int>
+-						<reference key="object" ref="170108317"/>
+-						<reference key="parent" ref="294246284"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">135</int>
+-						<reference key="object" ref="152253512"/>
+-						<reference key="parent" ref="9188110"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">136</int>
+-						<reference key="object" ref="786369834"/>
+-						<reference key="parent" ref="130094003"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">137</int>
+-						<reference key="object" ref="27593378"/>
+-						<reference key="parent" ref="142515939"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">138</int>
+-						<reference key="object" ref="505645570"/>
+-						<reference key="parent" ref="720351765"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">139</int>
+-						<reference key="object" ref="959902889"/>
+-						<reference key="parent" ref="900208769"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">153</int>
+-						<reference key="object" ref="714171131"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">154</int>
+-						<reference key="object" ref="880293883"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">155</int>
+-						<reference key="object" ref="494030977"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="97491710"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">156</int>
+-						<reference key="object" ref="97491710"/>
+-						<reference key="parent" ref="494030977"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">157</int>
+-						<reference key="object" ref="941392499"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="869196759"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">158</int>
+-						<reference key="object" ref="869196759"/>
+-						<reference key="parent" ref="941392499"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">159</int>
+-						<reference key="object" ref="17315972"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="725915110"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">160</int>
+-						<reference key="object" ref="288657989"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="17973583"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">161</int>
+-						<reference key="object" ref="17973583"/>
+-						<reference key="parent" ref="288657989"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">162</int>
+-						<reference key="object" ref="725915110"/>
+-						<reference key="parent" ref="17315972"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">163</int>
+-						<reference key="object" ref="103795753"/>
+-						<object class="NSMutableArray" key="children">
+-							<bool key="EncodedWithXMLCoder">YES</bool>
+-							<reference ref="304690009"/>
+-						</object>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">164</int>
+-						<reference key="object" ref="304690009"/>
+-						<reference key="parent" ref="103795753"/>
+-					</object>
+-					<object class="IBObjectRecord">
+-						<int key="objectID">165</int>
+-						<reference key="object" ref="458953956"/>
+-						<reference key="parent" ref="537708911"/>
+-					</object>
+-				</object>
+-			</object>
+-			<object class="NSMutableDictionary" key="flattenedProperties">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<object class="NSArray" key="dict.sortedKeys">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<string>-3.IBPluginDependency</string>
+-					<string>-3.ImportedFromIB2</string>
+-					<string>1.IBEditorWindowLastContentRect</string>
+-					<string>1.IBPluginDependency</string>
+-					<string>1.IBUserGuides</string>
+-					<string>1.ImportedFromIB2</string>
+-					<string>1.WindowOrigin</string>
+-					<string>1.editorWindowContentRectSynchronizationRect</string>
+-					<string>112.IBPluginDependency</string>
+-					<string>113.IBPluginDependency</string>
+-					<string>114.IBPluginDependency</string>
+-					<string>115.IBPluginDependency</string>
+-					<string>116.IBPluginDependency</string>
+-					<string>117.IBPluginDependency</string>
+-					<string>118.IBPluginDependency</string>
+-					<string>119.IBPluginDependency</string>
+-					<string>120.IBPluginDependency</string>
+-					<string>121.IBPluginDependency</string>
+-					<string>122.IBPluginDependency</string>
+-					<string>123.IBPluginDependency</string>
+-					<string>124.IBPluginDependency</string>
+-					<string>125.IBPluginDependency</string>
+-					<string>126.IBPluginDependency</string>
+-					<string>127.IBPluginDependency</string>
+-					<string>128.IBPluginDependency</string>
+-					<string>129.IBPluginDependency</string>
+-					<string>130.IBPluginDependency</string>
+-					<string>131.IBPluginDependency</string>
+-					<string>132.IBPluginDependency</string>
+-					<string>133.IBPluginDependency</string>
+-					<string>134.IBPluginDependency</string>
+-					<string>135.IBPluginDependency</string>
+-					<string>136.IBPluginDependency</string>
+-					<string>137.IBPluginDependency</string>
+-					<string>138.IBPluginDependency</string>
+-					<string>139.IBPluginDependency</string>
+-					<string>153.IBPluginDependency</string>
+-					<string>154.IBPluginDependency</string>
+-					<string>155.IBPluginDependency</string>
+-					<string>156.IBPluginDependency</string>
+-					<string>157.IBPluginDependency</string>
+-					<string>158.IBPluginDependency</string>
+-					<string>159.IBPluginDependency</string>
+-					<string>160.IBPluginDependency</string>
+-					<string>161.IBPluginDependency</string>
+-					<string>162.IBPluginDependency</string>
+-					<string>163.IBPluginDependency</string>
+-					<string>164.IBPluginDependency</string>
+-					<string>165.IBPluginDependency</string>
+-				</object>
+-				<object class="NSMutableArray" key="dict.values">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<integer value="1"/>
+-					<string>{{648, 601}, {271, 226}}</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<object class="NSMutableArray">
+-						<bool key="EncodedWithXMLCoder">YES</bool>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">11</double>
+-							<int key="affinity">0</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">8</double>
+-							<int key="affinity">2</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">84</double>
+-							<int key="affinity">0</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">170</double>
+-							<int key="affinity">0</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">178</double>
+-							<int key="affinity">0</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">4</double>
+-							<int key="affinity">3</int>
+-						</object>
+-						<object class="IBUserGuide">
+-							<reference key="view" ref="537708911"/>
+-							<double key="location">15</double>
+-							<int key="affinity">1</int>
+-						</object>
+-					</object>
+-					<integer value="1"/>
+-					<string>{84, 761}</string>
+-					<string>{{767, 669}, {272, 296}}</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+-				</object>
+-			</object>
+-			<object class="NSMutableDictionary" key="unlocalizedProperties">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<reference key="dict.sortedKeys" ref="0"/>
+-				<object class="NSMutableArray" key="dict.values">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-				</object>
+-			</object>
+-			<nil key="activeLocalization"/>
+-			<object class="NSMutableDictionary" key="localizations">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<reference key="dict.sortedKeys" ref="0"/>
+-				<object class="NSMutableArray" key="dict.values">
+-					<bool key="EncodedWithXMLCoder">YES</bool>
+-				</object>
+-			</object>
+-			<nil key="sourceID"/>
+-			<int key="maxID">197</int>
+-		</object>
+-		<object class="IBClassDescriber" key="IBDocument.Classes">
+-			<object class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
+-				<bool key="EncodedWithXMLCoder">YES</bool>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">IBInspector</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="NSMutableDictionary" key="outlets">
+-						<string key="NS.key.0">inspectorView</string>
+-						<string key="NS.object.0">NSView</string>
+-					</object>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">InterfaceBuilderKit.framework/Headers/IBInspector.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSActionCell</string>
+-					<string key="superclassName">NSCell</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSActionCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<string key="superclassName">NSResponder</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="736898405">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSApplication.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="888364392">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSApplicationScripting.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="63348460">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSColorPanel.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSHelpManager.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSPageLayout.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSApplication</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSUserInterfaceItemSearching.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSBox</string>
+-					<string key="superclassName">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSBox.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSButton</string>
+-					<string key="superclassName">NSControl</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSButton.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSButtonCell</string>
+-					<string key="superclassName">NSActionCell</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSButtonCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSCell</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSColorWell</string>
+-					<string key="superclassName">NSControl</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSColorWell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSControl</string>
+-					<string key="superclassName">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="371730654">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSControl.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSFormatter</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSFormatter.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSMenu</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="239205797">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSMenu.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSAccessibility.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="736898405"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="888364392"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="63348460"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="371730654"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSDictionaryController.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSDragging.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSFontManager.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSFontPanel.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSKeyValueBinding.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<reference key="sourceIdentifier" ref="239205797"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSNibLoading.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSOutlineView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSPasteboard.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSSavePanel.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSTableView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSToolbarItem.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="326037444">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSArchiver.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSClassDescription.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSError.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSFileManager.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueCoding.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueObserving.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSKeyedArchiver.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSObjectScripting.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSPortCoder.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptClassDescription.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptKeyValueCoding.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptObjectSpecifiers.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSScriptWhoseTests.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSThread.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSURL.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">Foundation.framework/Headers/NSURLDownload.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">InterfaceBuilderKit.framework/Headers/IBObjectIntegration.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSResponder</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSInterfaceStyle.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSResponder</string>
+-					<string key="superclassName">NSObject</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSResponder.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSTextField</string>
+-					<string key="superclassName">NSControl</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSTextField.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSTextFieldCell</string>
+-					<string key="superclassName">NSActionCell</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSTextFieldCell.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSClipView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSMenuItem.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">AppKit.framework/Headers/NSRulerView.h</string>
+-					</object>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<string key="superclassName">NSResponder</string>
+-					<reference key="sourceIdentifier" ref="326037444"/>
+-				</object>
+-				<object class="IBPartialClassDescription">
+-					<string key="className">NSView</string>
+-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+-						<string key="majorKey">IBFrameworkSource</string>
+-						<string key="minorKey">InterfaceBuilderKit.framework/Headers/IBViewIntegration.h</string>
+-					</object>
+-				</object>
+-			</object>
+-		</object>
+-		<int key="IBDocument.localizationMode">0</int>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
+-			<integer value="1050" key="NS.object.0"/>
+-		</object>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
+-			<integer value="1050" key="NS.object.0"/>
+-		</object>
+-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
+-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
+-			<integer value="3000" key="NS.object.0"/>
+-		</object>
+-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+-		<string key="IBDocument.LastKnownRelativeProjectPath">BGHUDAppKit.xcodeproj</string>
+-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+-	</data>
+-</archive>
++<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
++    <dependencies>
++        <deployment identifier="macosx"/>
++        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
++        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
++    </dependencies>
++    <objects>
++        <customObject id="-2" userLabel="File's Owner" customClass="IBInspector">
++            <connections>
++                <outlet property="inspectorView" destination="1" id="16"/>
++            </connections>
++        </customObject>
++        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
++        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
++        <customView id="1" userLabel="Inspector View">
++            <rect key="frame" x="0.0" y="0.0" width="271" height="226"/>
++            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++            <userGuides>
++                <userLayoutGuide location="11" affinity="minX"/>
++                <userLayoutGuide location="8" affinity="maxX"/>
++                <userLayoutGuide location="84" affinity="minX"/>
++                <userLayoutGuide location="170" affinity="minX"/>
++                <userLayoutGuide location="178" affinity="minX"/>
++                <userLayoutGuide location="4" affinity="maxY"/>
++                <userLayoutGuide location="15" affinity="minY"/>
++            </userGuides>
++            <subviews>
++                <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" id="165">
++                    <rect key="frame" x="12" y="170" width="252" height="5"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                </box>
++                <button imageHugsTitle="YES" id="163">
++                    <rect key="frame" x="81" y="179" width="82" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Use Theme" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" state="on" inset="2" id="164">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.useTheme" id="171"/>
++                    </connections>
++                </button>
++                <textField verticalHuggingPriority="750" id="160">
++                    <rect key="frame" x="8" y="205" width="70" height="14"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Theme Key" id="161">
++                        <font key="font" metaFont="smallSystemBold"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++                <textField verticalHuggingPriority="750" id="159">
++                    <rect key="frame" x="84" y="203" width="180" height="19"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="162">
++                        <font key="font" metaFont="controlContent" size="11"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.themeKey" id="169"/>
++                    </connections>
++                </textField>
++                <textField verticalHuggingPriority="750" id="157">
++                    <rect key="frame" x="180" y="147" width="44" height="11"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Color 2" id="158">
++                        <font key="font" metaFont="miniSystem"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++                <textField verticalHuggingPriority="750" id="155">
++                    <rect key="frame" x="86" y="147" width="44" height="11"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Color 1" id="156">
++                        <font key="font" metaFont="miniSystem"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++                <colorWell id="154">
++                    <rect key="frame" x="220" y="141" width="44" height="23"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <color key="color" red="0.058130499000000002" green="0.055541898999999999" blue="1" alpha="1" colorSpace="calibratedRGB"/>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.color2" id="175"/>
++                    </connections>
++                </colorWell>
++                <colorWell id="153">
++                    <rect key="frame" x="126" y="141" width="44" height="23"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <color key="color" red="0.058130499000000002" green="0.055541898999999999" blue="1" alpha="1" colorSpace="calibratedRGB"/>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.color1" id="173"/>
++                    </connections>
++                </colorWell>
++                <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" id="127">
++                    <rect key="frame" x="12" y="60" width="252" height="5"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                </box>
++                <box autoresizesSubviews="NO" verticalHuggingPriority="750" boxType="separator" id="126">
++                    <rect key="frame" x="12" y="111" width="252" height="5"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                </box>
++                <colorWell id="125">
++                    <rect key="frame" x="227" y="20" width="37" height="34"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.shadowColor" id="189"/>
++                    </connections>
++                </colorWell>
++                <button imageHugsTitle="YES" id="124">
++                    <rect key="frame" x="147" y="38" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Bottom" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="128">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawBottomShadow" id="195"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="123">
++                    <rect key="frame" x="147" y="18" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Right" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="129">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawRightShadow" id="197"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="122">
++                    <rect key="frame" x="81" y="18" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Left" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="130">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawLeftShadow" id="193"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="121">
++                    <rect key="frame" x="81" y="38" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Top" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="131">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawTopShadow" id="191"/>
++                    </connections>
++                </button>
++                <colorWell id="120">
++                    <rect key="frame" x="227" y="71" width="37" height="34"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.borderColor" id="187"/>
++                    </connections>
++                </colorWell>
++                <button imageHugsTitle="YES" id="119">
++                    <rect key="frame" x="147" y="89" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Bottom" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="132">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawBottomBorder" id="183"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="118">
++                    <rect key="frame" x="147" y="69" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Right" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="133">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawRightBorder" id="185"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="117">
++                    <rect key="frame" x="81" y="69" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Left" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="134">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawLeftBorder" id="181"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="116">
++                    <rect key="frame" x="81" y="89" width="63" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Top" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="135">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.drawTopBorder" id="179"/>
++                    </connections>
++                </button>
++                <button imageHugsTitle="YES" id="115">
++                    <rect key="frame" x="81" y="120" width="185" height="18"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <buttonCell key="cell" type="check" title="Flip Gradient" bezelStyle="regularSquare" imagePosition="leading" alignment="left" controlSize="small" inset="2" id="136">
++                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
++                        <font key="font" metaFont="controlContent" size="11"/>
++                    </buttonCell>
++                    <connections>
++                        <binding destination="-2" name="value" keyPath="inspectedObjectsController.selection.flipGradient" id="177"/>
++                    </connections>
++                </button>
++                <textField verticalHuggingPriority="750" id="114">
++                    <rect key="frame" x="8" y="40" width="70" height="14"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Shadows:" id="137">
++                        <font key="font" metaFont="smallSystemBold"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++                <textField verticalHuggingPriority="750" id="113">
++                    <rect key="frame" x="8" y="91" width="70" height="14"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Borders:" id="138">
++                        <font key="font" metaFont="smallSystemBold"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++                <textField verticalHuggingPriority="750" id="112">
++                    <rect key="frame" x="8" y="146" width="70" height="14"/>
++                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
++                    <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Gradient:" id="139">
++                        <font key="font" metaFont="smallSystemBold"/>
++                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
++                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
++                    </textFieldCell>
++                </textField>
++            </subviews>
++        </customView>
++    </objects>
++</document>


### PR DESCRIPTION
#### Description

This makes BGHUDAppKit build with newer Xcode versions. Tested against Xcode 10.1.

The binary still works fine but this fixes source building.

Related to https://trac.macports.org/ticket/57234

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
