### PR TITLE
duti: add support for macOS 10.15

### DIFF
--- a/sysutils/duti/files/mojave.diff
+++ b/sysutils/duti/files/mojave.diff
@@ -1,14 +1,5 @@
-From 825b5e6a92770611b000ebdd6e3d3ef8f47f1c47 Mon Sep 17 00:00:00 2001
-From: Grigory Entin <grigory.entin@gmail.com>
-Date: Thu, 4 Oct 2018 20:48:34 +0200
-Subject: [PATCH] Added support for macOS 10.14.
-
----
- aclocal.m4 | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
-
 diff --git a/aclocal.m4 b/aclocal.m4
-index 8fd4cd1..c6836d6 100644
+index 8fd4cd1..f6e74d2 100644
 --- a/aclocal.m4
 +++ b/aclocal.m4
 @@ -40,7 +40,7 @@ AC_DEFUN([DUTI_CHECK_SDK],
@@ -16,18 +7,22 @@ index 8fd4cd1..c6836d6 100644
  	    ;;
  
 -	darwin15*|darwin16*|darwin17*)
-+	darwin15*|darwin16*|darwin17*|darwin18*)
++	darwin15*|darwin16*|darwin17*|darwin18*|darwin19*)
  	    sdk_path="${sdk_path}/MacOSX.sdk"
  	    macosx_arches=""
  	    ;;
-@@ -106,6 +106,10 @@ AC_DEFUN([DUTI_CHECK_DEPLOYMENT_TARGET],
+@@ -106,6 +106,14 @@ AC_DEFUN([DUTI_CHECK_DEPLOYMENT_TARGET],
  	darwin17*)
  	    dep_target="10.13"
  	    ;;
 +
 +	darwin18*)
-+	    dep_target="10.14"
-+	    ;;
++		dep_target="10.14"
++		;;
++
++	darwin19*)
++		dep_target="10.15"
++		;;
      esac
  
      if test -z "$macosx_dep_target"; then


### PR DESCRIPTION
#### Description

This makes Duti build on the upcoming macOS version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A536g
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
