### PR TITLE
wireshark3: update deps, installation fix

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                wireshark3
 version             3.0.3
-revision            0
+revision            1
 categories          net
 license             {GPL-2 GPL-3}
 maintainers         {darkart.com:opendarwin.org @ghosthound}
@@ -67,11 +67,9 @@ variant qt5 conflicts no_gui description {Build wireshark with a qt5 GUI} {
     configure.args-replace  -DENABLE_APPLICATION_BUNDLE=OFF -DENABLE_APPLICATION_BUNDLE=ON
     configure.args-replace  -DBUILD_wireshark=OFF -DBUILD_wireshark=ON
     configure.args-append   -DENABLE_QT5=ON
-    qt5.depends_component   qtbase \
-                            qtmacextras \
+    qt5.depends_component   qttools \
                             qtmultimedia \
-                            qtsvg \
-                            qttranslations
+                            qtmacextras
 
     post-destroot {
         move ${destroot}/${prefix}/bin/Wireshark.app ${destroot}${applications_dir}/Wireshark.app
@@ -149,7 +147,7 @@ if {![variant_isset qt5] && ![variant_isset no_gui]} {
     default_variants-append +qt5
 }
 
-## if no python3* variant is specified, add +python37 
+## if no python3* variant is specified, add +python37
 ## XYZZY: it would be better to detect which python3* is already installed and use that...
 if {![variant_isset python34] && ![variant_isset python35] && \
     ![variant_isset python36] && ![variant_isset python37]} {
@@ -162,7 +160,6 @@ post-destroot {
     xinstall -d ${destroot}${prefix}/include/wireshark/epan/dissectors/
     xinstall -d ${destroot}${prefix}/include/wireshark/epan/ftypes/
     xinstall -d ${destroot}${prefix}/include/wireshark/wiretap/
-    xinstall -m 644 -W ${worksrcpath}/ config.h ${destroot}${prefix}/include/wireshark/
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/*.h] ${destroot}${prefix}/include/wireshark/epan/
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/crypt/*.h] ${destroot}${prefix}/include/wireshark/epan/crypt/
     xinstall -m 644 {*}[glob ${worksrcpath}/epan/dfilter/*.h] ${destroot}${prefix}/include/wireshark/epan/dfilter/
@@ -174,4 +171,3 @@ post-destroot {
 livecheck.type      regex
 livecheck.url       ${homepage}download.html
 livecheck.regex     "Stable Release \\((\\d+(?:\\.\\d+)*)"
-


### PR DESCRIPTION
###### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

* Use cmake-1.1 portgroup
* Update Qt dependencies
* Add +libgcrypt variant option
* Fix installation

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A536g
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
