### PR TITLE
graalvm: update to 19.2.0

### DIFF
--- a/java/graalvm/Portfile
+++ b/java/graalvm/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 name             graalvm
-version          19.1.1
+version          19.2.0
 revision         0
 
 categories       java devel
@@ -21,9 +21,9 @@ homepage         https://www.graalvm.org/
 
 master_sites     https://github.com/oracle/graal/releases/download/vm-${version}/
     
-checksums        rmd160  213b425af4e94e6461e519cc2503cbc57d63faa2 \
-                 sha256  85711322866ddacda88d3a592c76520188b3d7c40b6c39cd9943856e72eb6c72 \
-                 size    315234048
+checksums        rmd160  9f62f72b6a5bd6996f4fb4a0e46d0e642738ef10 \
+                 sha256  54bd7f7398ee0fb2d1c9eb8a939a5ccb05166cb9c544bc700020fc37dc661483 \
+                 size    347941204
 
 distname         ${name}-ce-darwin-amd64-${version}
 worksrcdir       ${name}-ce-${version}


### PR DESCRIPTION
#### Description

Update to GraalVM CE 19.2.0.

###### Tested on

macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?