### PR TITLE
julia: update to version 1.2.0

### DIFF
--- a/lang/julia/Portfile
+++ b/lang/julia/Portfile
@@ -7,7 +7,7 @@ PortGroup           compilers 1.0
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95
 
-github.setup        JuliaLang julia 1.1.1 v
+github.setup        JuliaLang julia 1.2.0 v
 revision            0
 categories-append   lang math science
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
@@ -25,9 +25,9 @@ github.tarball_from releases
 distfiles           ${name}-${version}-full${extract.suffix}
 
 checksums           ${name}-${version}-full${extract.suffix} \
-                    rmd160  8eac1e29a71bac430c93810afac15be07c8ed62b \
-                    sha256  3c5395dd3419ebb82d57bcc49dc729df3b225b9094e74376f8c649ee35ed79c2 \
-                    size    96079453
+                    rmd160  79eda79405d7148c3123c4103b4a096d54112a5f \
+                    sha256  2419b268fc5c3666dd9aeb554815fe7cf9e0e7265bc9b94a43957c31a68d9184 \
+                    size    123450012
 
 set verify_gpg_signature false
 


### PR DESCRIPTION
* update to version 1.2.0

#### Description

With the current commit, I only updated version number and checksums for the distfile. I don't know what to do with the gpg stuff, and I couldn't find it documented anywhere.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.12.6 16G2128
Xcode 9.0 9A235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
