### PR TITLE
maven2, maven32: use Java portgroup

### DIFF
--- a/java/maven2/Portfile
+++ b/java/maven2/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup java 1.0
 
 name            maven2
 version         2.2.1
@@ -19,7 +20,7 @@ long_description \
                 concept of a project object model (POM) in that \
                 all the artifacts produced by Maven are a result \
                 of consulting a well defined model for your \
-                project.Builds, documentation, source metrics, \
+                project.  Builds, documentation, source metrics, \
                 and source cross-references are all controlled by \
                 your POM.  Maven 2.0 is a complete rewrite of \
                 Maven 1.0 and as such is better organized, faster \
@@ -35,8 +36,10 @@ checksums       md5    c581a15cb0001d9b771ad6df7c8156f8 \
                 sha1   47ac0417a200cbc6d1b967d6b7c6ae1138e9e3e0 \
                 rmd160 25d523d3dc86cf4695b0e343cf0f6e58ea8a54e3
 
+java.version    1.5+
+java.fallback   openjdk11
+
 depends_run     port:maven_select
-depends_build   bin:java:kaffe
 
 use_configure   no
 universal_variant no

--- a/java/maven32/Portfile
+++ b/java/maven32/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup java 1.0
 
 name            maven32
 version         3.2.5
@@ -20,7 +21,7 @@ long_description \
                 concept of a project object model (POM) in that \
                 all the artifacts produced by Maven are a result \
                 of consulting a well defined model for your \
-                project.Builds, documentation, source metrics, \
+                project.  Builds, documentation, source metrics, \
                 and source cross-references are all controlled by \
                 your POM.  Maven 3 aims to ensure backward \
                 compatibility with Maven 2, improve usability, \
@@ -39,8 +40,10 @@ checksums       rmd160 875c93c8dcdd949928ba9a3ec7ef927a164251d0 \
 
 patchfiles      patch-bin-mvn.diff
 
-depends_run     port:maven_select \
-                bin:java:kaffe
+java.version    1.6+
+java.fallback   openjdk11
+
+depends_run     port:maven_select
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Eliminates fallback dependency on `kaffe`. Uses latest LTS Java version (`openjdk11`) as fallback.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
