### PR TITLE
buildbot-2: update to 2.4.0

### DIFF
--- a/devel/buildbot-2/Portfile
+++ b/devel/buildbot-2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                buildbot-2
-version             2.3.1
+version             2.4.0
 revision            0
 
 categories          devel python
@@ -27,9 +27,9 @@ master_sites        pypi:b/buildbot/
 distname            buildbot-${version}
 dist_subdir         buildbot
 
-checksums           sha256  cf35d2a87b11aba29c59e47e843deba1be9649114e792e830252ed8f7c35f963 \
-                    rmd160  f6136aa647589b40520db1383d05ff477324e2b9 \
-                    size    3138465
+checksums           rmd160  941fb9aea02e72b46d09873be877965dd39360fe \
+                    sha256  bf6e41f86be35887cdca05f9593e95f801ad4ba92834db58b1c017199e682a90 \
+                    size    3154696
 
 python.default_version \
                     37

--- a/devel/buildbot-worker/Portfile
+++ b/devel/buildbot-worker/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                buildbot-worker
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -20,9 +20,9 @@ master_sites        pypi:[string index ${name} 0]/${name}
 
 license             GPL-2
 
-checksums           sha256  a26c68debb70f15abee307aff7b225e91a2eedca9c8d571212c391e615c36f53 \
-                    rmd160  02688cb6233c80e46038a528f5e0b938353ef325 \
-                    size    110554
+checksums           rmd160  c679f8dfc6847a20274449a0f746ac8019e0425f \
+                    sha256  6279211b135d1b10ce0a0cda7bf9f6114a8c6fa0c7de234f6519600f9e0cb311 \
+                    size    111619
 
 python.default_version \
                     37

--- a/python/py-buildbot-console-view/Portfile
+++ b/python/py-buildbot-console-view/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-buildbot-console-view
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -20,9 +20,9 @@ distname            ${python.rootname}-${version}
 
 license             GPL-2
 
-checksums           sha256  2a6370db2141aebd7466fee390824fb7190d1e7122d6ebb844690cde141ca2f8 \
-                    rmd160  238e90a9f48f3f1420b535303e022095205f1b25 \
-                    size    607024
+checksums           sha256  f9a926abf1d7e8e528b46bc98cfc4ef8f94f1d47829f21015d8425b06afaea5c \
+                    rmd160  c8a31c6a52999cf48e5c8dc5fea80adcbf307f26 \
+                    size    22631
 
 python.versions     37
 

--- a/python/py-buildbot-grid-view/Portfile
+++ b/python/py-buildbot-grid-view/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-buildbot-grid-view
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -20,9 +20,9 @@ distname            ${python.rootname}-${version}
 
 license             GPL-2
 
-checksums           sha256  b25317adb7b526a4582d495e3f55db67a16cd7fe3f0d01b4d0d6df2b3b8f78f6 \
-                    rmd160  a9bd72d550624e8c4e8c9583977439955bbcae69 \
-                    size    605141
+checksums           sha256  9ba506a7c6612d0eac676376eaecbb297d2126e395365471cf6bb9fa25846c37 \
+                    rmd160  7c3561c613503f29d8c8072b4634d6675d4efc5a \
+                    size    18422
 
 python.versions     37
 

--- a/python/py-buildbot-pkg/Portfile
+++ b/python/py-buildbot-pkg/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-buildbot-pkg
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -20,9 +20,9 @@ distname            ${python.rootname}-${version}
 
 license             GPL-2
 
-checksums           sha256  25968ace0c62cb773ed85d4ddbe07fd5aee68f4455909243ffb3ac12608cf82e \
-                    rmd160  b917b5d58d24874068eede4bc7312cb3c58185e1 \
-                    size    4754
+checksums           sha256  7e57a25f44e08bcc2815032305ea9c84688f5f885392ec508febadc8a5194359 \
+                    rmd160  e731be55984e462c2b4c685d1eb7f8f16dfb9c1e \
+                    size    4750
 
 python.versions     37
 

--- a/python/py-buildbot-waterfall-view/Portfile
+++ b/python/py-buildbot-waterfall-view/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-buildbot-waterfall-view
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -20,9 +20,9 @@ distname            ${python.rootname}-${version}
 
 license             GPL-2
 
-checksums           sha256  949ae00cadb50f280709353feeccdc267c6ea68119e2be9b7faab21707c82edf \
-                    rmd160  6d8a037995c6e081b29c801eaf84e4638479550f \
-                    size    683181
+checksums           sha256  41c291d24987c1bb72ac59353b75396911cd66a3497717f78dfac478f051402d \
+                    rmd160  4fbc2481b8e241c462475bd7d13edd6af40a28bb \
+                    size    194341
 
 python.versions     37
 

--- a/python/py-buildbot-www/Portfile
+++ b/python/py-buildbot-www/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-buildbot-www
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -20,9 +20,9 @@ distname            ${python.rootname}-${version}
 
 license             GPL-2
 
-checksums           sha256  ff8546b7769f156f06e418cdd5621c78086924dbc81d48fbe35f4c98c7e1eb79 \
-                    rmd160  6a31272a9446a57b65b793c329e6d46fb48e1022 \
-                    size    721159
+checksums           sha256  adf6fa7958c2b8abf1b05828f6491c66a1bcc82ac8a61e7221424dedd12f753c \
+                    rmd160  e75571bbf396cf4978ae8ba92c1e52c7463e6490 \
+                    size    3660166
 
 python.versions     37
 

--- a/python/py-buildbot/Portfile
+++ b/python/py-buildbot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-buildbot
-version             2.3.1
+version             2.4.0
 revision            0
 
 maintainers         {ryandesign @ryandesign} {rajdeep @rajdeepbharati} {mojca @mojca} openmaintainer
@@ -22,9 +22,9 @@ distname            ${python.rootname}-${version}
 
 license             GPL-2
 
-checksums           sha256  cf35d2a87b11aba29c59e47e843deba1be9649114e792e830252ed8f7c35f963 \
-                    rmd160  f6136aa647589b40520db1383d05ff477324e2b9 \
-                    size    3138465
+checksums           sha256  bf6e41f86be35887cdca05f9593e95f801ad4ba92834db58b1c017199e682a90 \
+                    rmd160  941fb9aea02e72b46d09873be877965dd39360fe \
+                    size    3154696
 
 python.versions     37
 


### PR DESCRIPTION
#### Description
Update buildbot ports to 2.4.0
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
