### PR TITLE
fossil: update version to 2.9

### DIFF
--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                fossil
-version             2.6
+version             2.9
 epoch               20110901182519
 categories          devel
 platforms           darwin
@@ -18,15 +18,16 @@ long_description    Fossil is a distributed software configuration management wh
                     an easy-to-use web interface to access and administrate projects over the \
                     built-in webserver or CGI.
 
-homepage            http://www.fossil-scm.org/
+homepage            https://www.fossil-scm.org/
 
 master_sites        ${homepage}index.html/uv
 distname            ${name}-src-${version}
 
 worksrcdir          ${name}-${version}
 
-checksums           rmd160  5799c0f76a2365ec25240bf3d56476f55c4c951a \
-                    sha256  76a794555918be179850739a90f157de0edb8568ad552b4c40ce186c79ff6ed9
+checksums           rmd160  a95f8c784dbf633ba8f407db01bb151870d4dfb3 \
+                    sha256  1cb2ada92d43e3e7e008fe77f5e743d301c7ea34d4c36c42f255f873e73d8b4f \
+                    size    5440118
 
 test.run            yes
 
@@ -67,5 +68,5 @@ not harm the integrity of a repository.
 "
 
 livecheck.type      regex
-livecheck.url       ${homepage}fossil/uv/download.html
-livecheck.regex     {Version ([\d.]*)}
+livecheck.url       ${homepage}home/juvlist
+livecheck.regex     {fossil-src-([\d.]+).tar.gz}


### PR DESCRIPTION

#### Description

- bump version to 2.9
- move homepage to tls
- update livecheck url and regex


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->