### PR TITLE
maven-ant-tasks: EOL, use Java portgroup

### DIFF
--- a/devel/maven-ant-tasks/Portfile
+++ b/devel/maven-ant-tasks/Portfile
@@ -1,4 +1,9 @@
 PortSystem          1.0
+PortGroup           java 1.0
+PortGroup           deprecated 1.0
+
+# The homepage states that this project is retired and no longer maintained.
+deprecated.upstream_support no
 
 name                maven-ant-tasks
 version             2.1.3
@@ -9,6 +14,10 @@ description         Use many of Maven's artifact handling features from Ant.
 long_description    ${description}
 homepage            https://maven.apache.org/ant-tasks/
 platforms           darwin
+
+java.version        1.5+
+java.fallback       openjdk11
+
 depends_build       port:maven2
 
 use_zip             yes
@@ -35,6 +44,4 @@ destroot {
     xinstall -m 0644 ${worksrcpath}/target/${jarfile} ${jardir}
 }
 
-livecheck.type      regex
-livecheck.url       ${homepage}download.html
-livecheck.regex     ${name}-(2\\.\[0-9.\]+).jar
+livecheck.type      none


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/41876

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
