### PR TITLE
electric: use Java portgroup, fix license

### DIFF
--- a/graphics/electric/Portfile
+++ b/graphics/electric/Portfile
@@ -1,4 +1,5 @@
 PortSystem			1.0
+PortGroup           java 1.0
 PortGroup			app 1.0
 
 name				electric
@@ -6,7 +7,7 @@ version				9.07
 categories			graphics electronics science
 maintainers			nomaintainer
 supported_archs		noarch
-license				GPL-3
+license				GPL-3+
 
 description			CAD system for VLSI circuit design
 long_description \
@@ -16,7 +17,7 @@ long_description \
 
 platforms			darwin
 
-homepage			http://www.staticfreesoft.com/
+homepage			https://www.staticfreesoft.com/
 master_sites		gnu
 set jar				electricBinary-${version}.jar
 distfiles			${jar}
@@ -25,7 +26,8 @@ extract.only
 checksums           rmd160  aac9bda4c233bd11775a837b266097e34f535a3d \
                     sha256  3e383f673183265700e0c13a5f7b1d3348247465c3d8817c845d62e4c92d86ce
 
-depends_run			bin:java:kaffe
+java.version        1.6+
+java.fallback       openjdk11
 
 use_configure		no
 


### PR DESCRIPTION
License is GPLv3 or later

Use HTTPS homepage


#### Description

Eliminates fallback dependency on `kaffe`; uses latest LTS Java version (`openjdk11`) as fallback

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
