### PR TITLE
gitlab-runner: update to 12.2.0

### DIFF
--- a/devel/gitlab-runner/Portfile
+++ b/devel/gitlab-runner/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            gitlab.com/gitlab-org/gitlab-runner 12.1.0 v
+go.setup            gitlab.com/gitlab-org/gitlab-runner 12.2.0 v
 
 categories          devel
 platforms           darwin
@@ -23,9 +23,9 @@ homepage            https://docs.gitlab.com/runner/
 master_sites        https://gitlab.com/gitlab-org/gitlab-runner/-/archive/v${version}/
 distname            gitlab-runner-v${version}
 
-checksums           rmd160  e7ccfce8612339f73e77deac0b02b3e1a50cb312 \
-                    sha256  e6e89a3dd7039ecd34403830eee70aa1de4e3831c61a8da5c6925942ae071c32 \
-                    size    27134684
+checksums           rmd160  e3adf0f31645f0c3026d2f88fa1fbbf241eb12dc \
+                    sha256  3194bce4db332b3694e8ad9657cb7800bdd5a3e0574858cd0a77d8baf3a5b9b9 \
+                    size    27165140
 
 # Reproduce the "build_simple" target from the upstream Makefile
 set go_ldflags      "-X ${go.package}/common.NAME=${go.package} \


### PR DESCRIPTION
#### Description

Update to GitLab Runner 12.2.0.

###### Tested on

macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?