### PR TITLE
jikes: mark as unsupported by upstream

### DIFF
--- a/lang/jikes/Portfile
+++ b/lang/jikes/Portfile
@@ -1,4 +1,8 @@
 PortSystem 1.0
+PortGroup   deprecated 1.0
+
+# Project has had no releases since 2005.
+deprecated.upstream_support no
 
 name		jikes
 version		1.22


### PR DESCRIPTION
Last release was in 2005 (version 1.22)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
