### PR TITLE
maven31: use Java portgroup

### DIFF
--- a/java/maven31/Portfile
+++ b/java/maven31/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup java 1.0
 PortGroup select 1.0
 
 name            maven31
@@ -20,7 +21,7 @@ long_description \
                 concept of a project object model (POM) in that \
                 all the artifacts produced by Maven are a result \
                 of consulting a well defined model for your \
-                project.Builds, documentation, source metrics, \
+                project.  Builds, documentation, source metrics, \
                 and source cross-references are all controlled by \
                 your POM.  Maven 3 aims to ensure backward \
                 compatibility with Maven 2, improve usability, \
@@ -37,6 +38,9 @@ worksrcdir      apache-maven-${version}
 checksums       md5    6342fdf6b0aabc1457c7f8cc218127ed \
                 sha1   630eea2107b0742acb315b214009ba08602dda5f \
                 sha256 077ed466455991d5abb4748a1d022e2d2a54dc4d557c723ecbacdc857c61d51b
+
+java.version    1.5+
+java.fallback   openjdk11
 
 depends_run     port:maven_select 
 


### PR DESCRIPTION
#### Description

For some reason this port had no Java (runtime) dependency, unlike the other Maven ports.

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
