### PR TITLE
healpix-java: use Java portgroup

### DIFF
--- a/science/healpix/Portfile
+++ b/science/healpix/Portfile
@@ -46,13 +46,17 @@ if {${name} eq ${subport}} {
 }
 
 subport ${name}-java {
+    PortGroup       java 1.0
+
     description         Java language implementation of HEALPix
     long_description    ${long_description} This is the ${description}.
 
     supported_archs noarch
 
-    depends_build   bin:javac:jikes bin:jar:jikes bin:ant:apache-ant
-    depends_lib     bin:java:kaffe
+    java.version    1.4+
+    java.fallback   openjdk11
+
+    depends_build   bin:ant:apache-ant
 
     use_configure   no
 


### PR DESCRIPTION
#### Description

Eliminates fallback dependency on `jikes` and `kaffe`. Uses latest LTS Java (`openjdk11`) as fallback.

<!-- Note: it is best make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
