### PR TITLE
servlet23-api, servlet24-api: EOL, mark unsupported

### DIFF
--- a/java/servlet23-api/Portfile
+++ b/java/servlet23-api/Portfile
@@ -1,5 +1,10 @@
 PortSystem 1.0
 PortGroup java 1.0
+PortGroup deprecated 1.0
+
+# Servlet API 2.3 was developed as part of Tomcat 4.x, which is now end-of-life.
+# See https://tomcat.apache.org/whichversion.html
+deprecated.upstream_support no
 
 name            servlet23-api
 epoch           20061005

--- a/java/servlet24-api/Portfile
+++ b/java/servlet24-api/Portfile
@@ -1,5 +1,10 @@
 PortSystem 1.0
 PortGroup java 1.0
+PortGroup deprecated 1.0
+
+# Servlet API 2.4 was developed as part of Tomcat 5.x, which is now end-of-life.
+# See https://tomcat.apache.org/whichversion.html
+deprecated.upstream_support no
 
 name            servlet24-api
 version         5.5.28


### PR DESCRIPTION
See: https://trac.macports.org/ticket/58389

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
