### PR TITLE
gitless: update to version 0.8.8

### DIFF
--- a/devel/gitless/Portfile
+++ b/devel/gitless/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        sdg-mit gitless 0.8.6 v
+github.setup        sdg-mit gitless 0.8.8 v
 categories          devel python
 platforms           darwin
 license             GPL-2
@@ -17,14 +17,16 @@ long_description    Gitless is a version control system built on top of Git, \
                     any Git repository and be mixed with regular git commands.
 homepage            http://gitless.com/
 
-checksums           rmd160  4f678fe63c3a748a7640d234938b70e0de2e63f2 \
-                    sha256  5ba143b8aee8469a6a3a70bac8f99d862e02f049fc27dd84b8989234798dcfa5 \
-                    size    41788
+checksums           rmd160  bee4c60e28cc698cf006c645583ca9e19355ae65 \
+                    sha256  a5f145f5c8aa56fbd08c4d2f8291a016a2ad00295efb7d1e5df082e03ad75b14 \
+                    size    42454
 
 # git depends on python27; using the same to reduce dependencies,
 # although python3x would be supported
 python.default_version 27
 
+depends_build-append \
+                    port:py${python.version}-setuptools
 depends_run-append  port:git
 depends_lib-append  port:py${python.version}-pygit2 \
                     port:py${python.version}-clint \


### PR DESCRIPTION
* supports py27-pygit2 0.28.2
* add missing build dependency

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
