### PR TITLE
kaffe: deprecate

### DIFF
--- a/lang/kaffe/Portfile
+++ b/lang/kaffe/Portfile
@@ -1,4 +1,14 @@
 PortSystem          1.0
+PortGroup           deprecated 1.0
+
+# Project is dormant: no releases since 2008,
+# no git activity since 2011
+deprecated.upstream_support no
+
+# Port is outdated; efforts to update to 1.1.9 are unsuccessful.
+# Dependents should use the Java portgroup instead.
+# See https://trac.macports.org/ticket/45198
+deprecated.macports_support no
 
 name                kaffe
 version             1.1.7


### PR DESCRIPTION
Mark as unsupported by upstream and MacPorts: upstream project is dormant, and port has been stuck on an outdated version.

Dependents should be migrated to the Java portgroup.

See https://trac.macports.org/ticket/45198

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->




###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
