### PR TITLE
gnome-control-center: enable patch

### DIFF
--- a/gnome/gnome-control-center/Portfile
+++ b/gnome/gnome-control-center/Portfile
@@ -60,7 +60,8 @@ depends_run         port:gnome-keyring \
 patchfiles          patch-disable-color-panel.diff \
                     patch-disable-display-panel.diff \
                     patch-panels-user-accounts.diff \
-                    patch-remove-gdkcolor-deprecation-warnings.diff
+                    patch-remove-gdkcolor-deprecation-warnings.diff \
+                    patch-printers-pp-printer.c.diff
 
 # reconfigure using upstream autogen.sh for intltool 0.51 compatibility
 


### PR DESCRIPTION
fixes build with older CUPS versions, such as on 10.6.8

This patch was already in the files folder, but not being used for some reason.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
