### PR TITLE
gnome-radio: New port of GNOME Radio 0.1.4

### DIFF
--- a/gnome/gnome-radio/Portfile
+++ b/gnome/gnome-radio/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                gnome-radio
+version             0.1.4
+set branch          [join [lrange [split $version .] 0 1] .]
+
+categories          gnome
+platforms           darwin
+license             GPL-3+
+maintainers         {gnome.org:ole @oleaamot} openmaintainer
+description         GNOME Radio
+long_description    GNOME Radio is the Public Network Radio Software for Accessing Free Audio Broadcasts from the Internet on GNOME.
+homepage            http://www.gnomeradio.org/
+master_sites        http://www.gnomeradio.org/${branch}/
+checksums           rmd160  fa781fda4d621ce0ebe699143b6183ee0804c991 \
+                    sha256  6a3fc549342cfc5c5a8fbe7cfe8f8fdb68a32d9270ae2bbd4883ea525f69d3d0 \
+                    size    107695 
+depends_build       port:autoconf \
+                    port:automake \
+                    port:geocode-glib \
+                    port:gnome-common \
+                    port:gstreamer1-gst-plugins-bad \
+                    port:gstreamer1-gst-plugins-good \
+                    port:gstreamer1-gst-plugins-ugly \
+                    port:gtk-doc \
+                    port:intltool \
+                    port:itstool \
+                    port:pkgconfig \
+                    port:yelp-tools
+
+depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/pango.pc:pango \
+                    port:desktop-file-utils \
+                    port:geocode-glib \
+                    port:gstreamer1 \
+                    port:gstreamer1-gst-plugins-base \
+                    port:gtk3 \
+                    port:libchamplain \
+                    port:libxml2 \
+                    port:zlib
+
+depends_run         port:adwaita-icon-theme \
+                    port:gstreamer1-gst-plugins-bad \
+                    port:gstreamer1-gst-plugins-good \
+                    port:gstreamer1-gst-plugins-ugly
+
+use_autoconf        yes
+
+# building with optimization greater than -O0 causes crash on selecting station
+# https://trac.macports.org/ticket/52993
+configure.optflags  -O0
+configure.args      --disable-silent-rules
+
+post-activate {
+   system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
+   system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+}
+
+variant debug description {Build with debug symbols and enable debug messages} {
+    patchfiles-append   patch-enable-debug.diff
+    configure.optflags  -O0 -g
+}
+
+livecheck.type      gnome-with-unstable

--- a/gnome/gnome-radio/Portfile
+++ b/gnome/gnome-radio/Portfile
@@ -17,50 +17,27 @@ master_sites        http://www.gnomeradio.org/${branch}/
 checksums           rmd160  fa781fda4d621ce0ebe699143b6183ee0804c991 \
                     sha256  6a3fc549342cfc5c5a8fbe7cfe8f8fdb68a32d9270ae2bbd4883ea525f69d3d0 \
                     size    107695 
-depends_build       port:autoconf \
-                    port:automake \
-                    port:geocode-glib \
-                    port:gnome-common \
-                    port:gstreamer1-gst-plugins-bad \
-                    port:gstreamer1-gst-plugins-good \
-                    port:gstreamer1-gst-plugins-ugly \
-                    port:gtk-doc \
-                    port:intltool \
-                    port:itstool \
-                    port:pkgconfig \
-                    port:yelp-tools
+
+depends_build       port:pkgconfig
 
 depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/pango.pc:pango \
                     port:desktop-file-utils \
-                    port:geocode-glib \
                     port:gstreamer1 \
                     port:gstreamer1-gst-plugins-base \
-                    port:gtk3 \
-                    port:libchamplain \
-                    port:libxml2 \
-                    port:zlib
-
-depends_run         port:adwaita-icon-theme \
                     port:gstreamer1-gst-plugins-bad \
                     port:gstreamer1-gst-plugins-good \
-                    port:gstreamer1-gst-plugins-ugly
+                    port:gstreamer1-gst-plugins-ugly \
+                    port:gtk3 \
+                    port:libchamplain
 
-use_autoconf        yes
+depends_run         port:adwaita-icon-theme
 
-# building with optimization greater than -O0 causes crash on selecting station
-# https://trac.macports.org/ticket/52993
-configure.optflags  -O0
 configure.args      --disable-silent-rules
 
 post-activate {
    system "${prefix}/bin/gtk-update-icon-cache-3.0 -f -t ${prefix}/share/icons/hicolor"
    system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
-}
-
-variant debug description {Build with debug symbols and enable debug messages} {
-    patchfiles-append   patch-enable-debug.diff
-    configure.optflags  -O0 -g
 }
 
 livecheck.type      gnome-with-unstable

--- a/gnome/gnome-radio/files/autogen.sh
+++ b/gnome/gnome-radio/files/autogen.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Run this to generate all the initial makefiles, etc.
+
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+PKG_NAME="gnome-radio"
+
+(test -f $srcdir/src/gnome-radio-main.c) || {
+    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
+    echo " top-level $PKG_NAME directory"
+    exit 1
+}
+
+which gnome-autogen.sh || {
+    echo "You need to install gnome-common from the GNOME CVS"
+    exit 1
+}
+
+REQUIRED_AUTOCONF_VERSION=2.59
+REQUIRED_AUTOMAKE_VERSION=1.14
+REQUIRED_INTLTOOL_VERSION=0.40.0
+REQUIRED_PKG_CONFIG_VERSION=0.16.0
+REQUIRED_GTK_DOC_VERSION=1.9
+USE_GNOME2_MACROS=1 . gnome-autogen.sh


### PR DESCRIPTION
#### Description

gnome-radio: New port of GNOME Radio 0.1.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
