### PR TITLE
pascal-p5: new port

### DIFF
--- a/lang/pascal-p5/Portfile
+++ b/lang/pascal-p5/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                pascal-p5
+version             1.4
+revision            0
+categories          lang
+platforms           darwin
+license             GPL-2
+maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
+
+description         P5, Zuerich type ISO 7185 Pascal compiler
+long_description    This is the 5th version of the Pascal-P compiler from Zuerich. \
+                    It is modified to be ISO 7185 Pascal compliant, both in \
+                    the implementation language, and in the language it processes.
+homepage            https://www.standardpascal.com/p5.html
+
+fetch.type          git
+git.url             https://git.code.sf.net/p/pascalp5/code
+git.branch          75a0a8
+
+depends_build       port:fpc
+
+supported_archs     x86_64
+
+installs_libs       no
+use_configure       no
+universal_variant   no
+
+# patching the Makefile is more involved.
+build {
+    file mkdir ${worksrcpath}/build
+    system  -W ${worksrcpath} " \
+            fpc -Miso -ap -FEbuild source/pcom.pas && \
+            fpc -Miso -ap -FEbuild source/pint.pas "
+}
+
+destroot {
+    xinstall -m 755 -d                        ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/build/pint ${destroot}${prefix}/bin/
+    xinstall -m 755 ${worksrcpath}/build/pcom ${destroot}${prefix}/bin/
+    xinstall -m 755 ${filespath}/p5           ${destroot}${prefix}/bin/
+}
+
+notes "\
+p5 is a shell script, which calls the compiler pcom and the interpreter pint. \
+The compiler pcom creates an intermediate file NAME.p5, which is run by \
+the interpreter pint. \
+"

--- a/lang/pascal-p5/files/p5
+++ b/lang/pascal-p5/files/p5
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Compile with P5 using FreePascal
+#
+# Execute with:
+#
+# p5 <file>
+#
+# Where <file> is the name of the source file without
+# extention. The Pascal file is compiled and run.
+# Any compiler errors are output to the screen.
+# Input and output to and from the running program
+# are from the console.
+# The intermediate code is placed in <file>.p5.
+#
+
+if [ -z "\$1" ]
+then
+
+   echo "*** Error: Missing parameter"
+   exit 1
+
+fi
+
+if [ ! -f \$1.pas ]
+then
+
+   echo "*** Error: Missing \$1.pas file"
+   exit 1
+
+fi
+
+echo Compiling and running \$1
+echo
+pcom < \$1.pas > \$1.p5
+pint < \$1.p5


### PR DESCRIPTION
#### Description
pascal-P5 is a Zuerich type ISO 7185 Pascal compiler.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6
Xcode 10.3

###### Verification <!-- (delete not applicable items) -->
Have you
- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
