### PR TITLE
new port: lazygit

### DIFF
--- a/devel/lazygit/Portfile
+++ b/devel/lazygit/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/jesseduffield/lazygit 0.8.1 v
+categories          devel
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         A simple terminal UI for git commands, written in Go
+long_description    $description
+
+checksums           rmd160  d8d1e617b90efb9f7ed2461e6c09d46ee917d4fa \
+                    sha256  929ad88bb50f56d6f3ce86edda01c89428faf56ac500c0f88287bede70bef81a \
+                    size    6666489
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    file copy ${worksrcpath}/docs ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
New port for lazygit ( https://github.com/jesseduffield/lazygit )

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
