### PR TITLE
fpc-sources: new port

### DIFF
--- a/lang/fpc-sources/Portfile
+++ b/lang/fpc-sources/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                fpc-sources
+version             3.0.4
+categories          lang
+platforms           darwin
+license             GPL-2 LGPL-2
+supported_archs     noarch
+maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
+description         Sources of the FreePascal compiler
+long_description    Sources of the compiler, the runtime library (rtl), \
+                    packages and utils. Used by lazarus.
+homepage            http://www.freepascal.org
+master_sites        sourceforge:freepascal
+
+dist_subdir         ${name}/${version}/source
+distname            fpc-${version}.source
+checksums           rmd160 40e1be365e69ed30b4114303c6891cbc60d4b8f3 \
+                    sha256 69b3b7667b72b6759cf27226df5eb54112ce3515ff5efb79d95ac14bac742845 \
+                    size   40347617
+
+set worksrcpath     ${workpath}/fpc-${version}
+
+use_configure       no
+build               {}
+
+# Using file copy instead of xinstall, since it works recursively
+destroot {
+    xinstall -d                       ${destroot}${prefix}/share/fpcsrc
+    file copy ${worksrcpath}/compiler ${destroot}${prefix}/share/fpcsrc
+    file copy ${worksrcpath}/rtl      ${destroot}${prefix}/share/fpcsrc
+    file copy ${worksrcpath}/packages ${destroot}${prefix}/share/fpcsrc
+    file copy ${worksrcpath}/utils    ${destroot}${prefix}/share/fpcsrc
+    system "chmod -R 755              ${destroot}${prefix}/share/fpcsrc/*"
+}


### PR DESCRIPTION
#### Description
fpc-sources contains the sources of the FreePascal compiler and is used by lazarus.

###### Type(s)
- [*] enhancement

###### Tested on
macOS 10.14.6
Xcode 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [*] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [*] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [*] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [*] checked your Portfile with `port lint`?
- [*] tried existing tests with `sudo port test`?
- [*] tried a full install with `sudo port -vst install`?
- [*] tested basic functionality of all binary files?
