### PR TITLE
jython: always use Java portgroup

### DIFF
--- a/lang/jython/Portfile
+++ b/lang/jython/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           java 1.0
 
 name                jython
 version             2.7.1
@@ -18,7 +19,12 @@ long_description    \
 
 homepage            http://www.jython.org/
 
-depends_lib         bin:java:kaffe
+# Jython 2.7.1 is only compatible with Java 7/8, and is known to be
+# incompatible with Java 9+ (this will likely be resolved by Jython 2.7.2).
+# Since the Java portgroup doesn't support specifying a maximum Java version
+# but supports specifying an exact version, only use Java 8 for now.
+java.version        1.8
+java.fallback       openjdk8
 
 use_configure       no
 
@@ -52,10 +58,6 @@ default_variants +installer
 # Install from source.
 # This block must come after the installer variant definition.
 if {![variant_isset installer]} {
-    PortGroup       java 1.0
-
-    java.version    1.8
-
     fetch.type      hg
     hg.url          https://hg.python.org/jython
     hg.tag          v${version}


### PR DESCRIPTION
…even for the `-installer` variant to eliminate fallback dependency on `jikes`; use `openjdk8` as fallback.
Add note explaining current/future Java version compatibility.

Closes: https://trac.macports.org/ticket/53963

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
