### PR TITLE
py-llvmlite: switch to using clang-8.0.

### DIFF
--- a/python/py-llvmlite/Portfile
+++ b/python/py-llvmlite/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        numba llvmlite 0.29.0 v
 name                py-llvmlite
-revision            0
+revision            1
 categories-append   devel science
 platforms           darwin
 license             BSD
@@ -28,14 +28,14 @@ if {${name} ne ${subport}} {
     patchfiles-append   patch-ffi_Makefile.osx.diff
 
     post-patch {
-        reinplace "s|%%CXX%%|clang++-mp-7.0|" ${worksrcpath}/ffi/Makefile.osx
+        reinplace "s|%%CXX%%|clang++-mp-8.0|" ${worksrcpath}/ffi/Makefile.osx
     }
 
     depends_build-append \
                         port:py${python.version}-setuptools \
-                        port:clang-7.0
+                        port:clang-8.0
 
-    depends_lib-append  port:llvm-7.0 \
+    depends_lib-append  port:llvm-8.0 \
                         port:zlib \
                         port:ncurses \
                         port:libxml2
@@ -44,8 +44,8 @@ if {${name} ne ${subport}} {
         depends_lib-append  port:py${python.version}-enum34
     }
 
-    build.env-append    LLVM_CONFIG=llvm-config-mp-7.0
-    destroot.env-append LLVM_CONFIG=llvm-config-mp-7.0
+    build.env-append    LLVM_CONFIG=llvm-config-mp-8.0
+    destroot.env-append LLVM_CONFIG=llvm-config-mp-8.0
 
     livecheck.type      none
 } else {


### PR DESCRIPTION
###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
