### PR TITLE
GPXSee: update to 7.12

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.11
+github.setup        tumic0 GPXSee 7.12
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  f4ef35269600c51057cbffc2f7534eefe8554671 \
-                    sha256  8cf8835967a1476ace95b2337901129456cdf1b37dbeda8743a6cb73a9c67b2e \
-                    size    4350771
+checksums           rmd160  f037e8cb4033beabf066dbebe885ff4968baad23 \
+                    sha256  ea7186143b92eff7381da7226544f9562133ae4cc4b944fdd875f952b97dd1a0 \
+                    size    4688218
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.12

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for SeeYou CUP files.
>   * Added support for Geographic 2D projection in vector maps.
>   * Fixed lat/lon reference parsing in big endian EXIF entries.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

