### PR TITLE
Add git annex

### DIFF
--- a/devel/git-annex/Portfile
+++ b/devel/git-annex/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell-stack 1.0
+
+name                git-annex
+version             7.20190819
+checksums           rmd160  596f70e63d93b37f449869a84ff6677e9a4e8af4 \
+                    sha256  9e794baf81f3fcc0359ec9c0f22f5d5cad1ea9446958e53acafe747c48ef7ebb \
+                    size    1253032
+
+description         git-annex allows managing files with git, without checking the file contents into git
+long_description    \
+	git-annex allows managing files with git, without checking the file \
+	contents into git. While that may seem paradoxical, it is useful when \
+	dealing with files larger than git can currently easily handle, whether due \
+	to limitations in memory, time, or disk space.
+license             AGPL-3
+homepage            https://git-annex.branchable.com/
+
+maintainers         nomaintainer
+categories          devel haskell
+platforms           macosx
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+# The downloaded copy of GHC assumes utimensat(2) is available, which is not
+# true for older systems
+depends_build-append \
+                    port:ghc
+configure.args-append \
+                    --system-ghc
+build.args-append   --system-ghc
+destroot.args-append \
+                    --system-ghc
+
+# libHSbase shipped with GHC links against system libiconv, which provides the
+# 'iconv' symbol, but not the 'libiconv' symbol. Because the compilation
+# process statically links libHSbase.a, we must have /usr/lib in the library
+# search path first :/
+compiler.library_path
+compiler.cpath
+
+livecheck.type      regex
+livecheck.url       https://hackage.haskell.org/package/${name}
+livecheck.regex     "/package/[quotemeta ${name}]-\[^/\]+/[quotemeta ${name}]-(\[^\"\]+)[quotemeta ${extract.suffix}]"


### PR DESCRIPTION
#### Description
Add git-annex port, closes: https://trac.macports.org/ticket/41466

<s>Rename the `haskell-stack` PortGroup to `haskellstack`. `port lint` complains about dashes in PortGroup filenames, so rename the PortGroup to avoid this lint warning.</s> Will do that in a separate PR.

Cc: @essandess 

###### Tested on
macOS 10.12.6 16G2128
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?