### PR TITLE
google-cloud-sdk: update to 260.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             259.0.0
+version             260.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  c062fb7c59e23166fbe73d0db00b772c958a4504 \
-                    sha256  b9e7ab4c3fff96cb664cebe8b478560bf0f672e5c4dab4e7576b3704d9c3d7eb \
-                    size    21498231
+checksums           rmd160  ca17308e9e1cd64a4fe55b34bc3edbc66d50ba62 \
+                    sha256  325ee7cbf6dd006111d9b8f68b9e99fba01d3b8bcf11365ad91ad9bf3237975f \
+                    size    21519211
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 260.0.0.

###### Tested on

macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?