### PR TITLE
new port: wtfutil

### DIFF
--- a/sysutils/wtfutil/Portfile
+++ b/sysutils/wtfutil/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        wtfutil wtf 0.20.0 v
+homepage            https://wtfutil.com
+
+name                wtfutil
+categories          sysutils
+platforms           darwin
+license             MPL-2
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         A personal terminal-based dashboard utility, designed for \
+                    displaying infrequently-needed, but very important, daily \
+                    data.
+long_description    ${description}
+
+fetch.type          git
+
+depends_build       port:go
+
+use_configure       no
+use_parallel_build  no
+
+build.env           GOPATH=${workpath} \
+                    PATH=$env(PATH):${workpath}/bin
+
+build.target        install
+
+post-extract {
+    reinplace "s|@mv ~/go/bin/wtf ~/go/bin/wtfutil|@mv \$\$GOPATH/bin/wtf \$\$GOPATH/bin/wtfutil|g" ${worksrcpath}/Makefile
+}
+
+post-build {
+    exec go clean
+}
+
+destroot {
+    xinstall -m 755 ${workpath}/bin/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -d -m 0755 ${destroot}${prefix}/share/${name}
+    xinstall -d -m 0755 ${destroot}${prefix}/share/${name}/sample_configs
+
+    xinstall -m 644 {*}[glob ${worksrcpath}/_sample_configs/*] \
+                      ${destroot}${prefix}/share/${name}/sample_configs
+}
+
+notes "
+Examples of configuration for wtfutil can be found in:
+
+${prefix}/share/${name}/sample_configs
+"


### PR DESCRIPTION
New port for the wtfutil terminal dashboard ( https://wtfutil.com/ )

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
