### PR TITLE
gobject-introspection: Switch to Python 3.7

### DIFF
--- a/gnome/gobject-introspection/Portfile
+++ b/gnome/gobject-introspection/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                gobject-introspection
 version             1.58.3
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          gnome
 platforms           darwin
@@ -30,8 +30,8 @@ depends_build       port:pkgconfig \
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libffi \
-                    port:py27-mako \
-                    port:py27-markdown
+                    port:py37-mako \
+                    port:py37-markdown
 
 depends_run         bin:glibtool:libtool
 
@@ -41,32 +41,13 @@ post-patch {
     reinplace "s|libcairo-gobject.2.dylib|${prefix}/lib/libcairo-gobject.2.dylib|g" ${worksrcpath}/configure.ac
 }
 
-configure.python    ${prefix}/bin/python2.7
+configure.python    ${prefix}/bin/python3.7
 
 # use autoreconf to sync with our build tools
 use_autoreconf      yes
 autoreconf.args     -fvi
 
 build.args          CC="${configure.cc} ${configure.cc_archflags}" V=1
-
-# gobject-introspection needs to be aware whether it was compiled against python +ucs4, see #35603
-variant python_ucs4 description {Build against Python with +ucs4} {
-    require_active_variants python27 ucs4
-}
-
-if {![variant_isset python_ucs4]} {
-    pre-configure {
-        if {![active_variants python27 "" ucs4]} {
-            error "You have python installed with the +ucs4 variant. Please build ${name} with +python_ucs4"
-        }
-    }
-}
-
-if {![catch {set result [active_variants python27 ucs4]}]} {
-    if {$result} {
-        default_variants +python_ucs4
-    }
-}
 
 platform darwin 8 {
     # GObject introspection doesn't build with tiger's make, #32358


### PR DESCRIPTION
#### Description

Switch to Python 3.7 in order to get rid of the Python 2.7 dependency. I've tested compiling gobject-introspection and zeitgeist in trace mode and both seem to work fine with this change.

Closes: https://trac.macports.org/ticket/48508

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

