### PR TITLE
llvm/clang/lldb 3.9+ fix rpath handling, revbump

### DIFF
--- a/lang/llvm-3.9/Portfile
+++ b/lang/llvm-3.9/Portfile
@@ -10,8 +10,8 @@ PortGroup cmake         1.0
 set llvm_version        3.9
 set llvm_version_no_dot 39
 name                    llvm-${llvm_version}
-revision                5
-subport                 clang-${llvm_version} { revision 9 }
+revision                6
+subport                 clang-${llvm_version} { revision 10 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -175,14 +175,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix        ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not all installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"

--- a/lang/llvm-4.0/Portfile
+++ b/lang/llvm-4.0/Portfile
@@ -12,9 +12,9 @@ set llvm_version_no_dot 40
 set clang_executable_version 4.0
 set lldb_executable_version 4.0.1
 name                    llvm-${llvm_version}
-revision                2
-subport                 clang-${llvm_version} { revision 6 }
-subport                 lldb-${llvm_version} {}
+revision                3
+subport                 clang-${llvm_version} { revision 7 }
+subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -217,14 +217,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not all installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -12,8 +12,9 @@ set llvm_version_no_dot 50
 set clang_executable_version 5.0
 set lldb_executable_version 5.0.2
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} { revision 3 }
-subport                 lldb-${llvm_version} {}
+revision                1
+subport                 clang-${llvm_version} { revision 4 }
+subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -224,14 +225,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -12,8 +12,9 @@ set llvm_version_no_dot 60
 set clang_executable_version 6.0
 set lldb_executable_version 6.0.1
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} { revision 2 }
-subport                 lldb-${llvm_version} {}
+revision                1
+subport                 clang-${llvm_version} { revision 3 }
+subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -219,14 +220,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not all installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -12,9 +12,9 @@ set llvm_version_no_dot 70
 set clang_executable_version 7
 set lldb_executable_version 7.0.1
 name                    llvm-${llvm_version}
-revision                1
-subport                 clang-${llvm_version} {}
-subport                 lldb-${llvm_version} { revision 0 }
+revision                2
+subport                 clang-${llvm_version} { revision 1 }
+subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -219,14 +219,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not all installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -12,8 +12,9 @@ set llvm_version_no_dot 80
 set clang_executable_version 8
 set lldb_executable_version 8.0.0
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} {}
-subport                 lldb-${llvm_version} {}
+revision                1
+subport                 clang-${llvm_version} { revision 1 }
+subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -219,14 +220,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not all installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -12,8 +12,9 @@ set llvm_version_no_dot devel
 set clang_executable_version 9
 set lldb_executable_version 9.0.0
 name                    llvm-${llvm_version}
-subport                 clang-${llvm_version} {}
-subport                 lldb-${llvm_version} {}
+revision                1
+subport                 clang-${llvm_version} { revision 1 }
+subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
 dist_subdir             llvm
@@ -196,14 +197,14 @@ default build.dir           {${workpath}/build}
 
 cmake.install_prefix ${sub_prefix}
 
-# Adjust this once cmake-1.0.tcl is fixed:
-#     https://github.com/macports/macports-ports/pull/103
-# Also see:
+# clang shared libraries are not all installed in ${cmake.install_prefix}/lib
+# so we have to let the llvm/clang cmake scripts handle the @rpath setting
+# See:
 #     https://llvm.org/bugs/show_bug.cgi?id=31425
 #     https://trac.macports.org/ticket/53299
 configure.args-delete \
-    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib \
-    -DCMAKE_INSTALL_RPATH=${prefix}/lib \
+    -DCMAKE_INSTALL_NAME_DIR=${cmake.install_prefix}/lib \
+    -DCMAKE_INSTALL_RPATH=${cmake.install_prefix}/lib \
     -DCMAKE_SYSTEM_PREFIX_PATH="${prefix}\;/usr"
 configure.args-append \
     -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;${prefix}\;/usr"


### PR DESCRIPTION
this was originally fixed in
<https://github.com/macports/macports-ports/commit/e75a4491bbaf8e8346068ac6c9f52e082e3634b3>

but once
<https://github.com/macports/macports-ports/pull/103/commits/4cddb7db3a182f366d605e8db97944cd9d1e0e87>
was merged, the configure.args-delete in the portfile no longer deleted the install_name and install_rpath settings

this resulted in llvm/clang/lldb dylibs sometimes being installed with incorrect library names
and caused errors using the sanitizer libs and similar in clang

the PR restores the previous intended behaviour to allow the cmake scripts in llvm* to set the rpaths

see: https://trac.macports.org/ticket/53299
closes: https://trac.macports.org/ticket/57152
see: https://trac.macports.org/ticket/58889

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix
