### PR TITLE
emacs: update to 26.3 and update -devel

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -72,12 +72,12 @@ platform darwin {
 }
 
 if {$subport eq $name || $subport eq "emacs-app"} {
-    version         26.2
+    version         26.3
     revision        0
 
-    checksums       rmd160  3d9f5d7772e23425bcba7a6edb3183ce58bbb737 \
-                    sha256  4f99e52a38a737556932cc57479e85c305a37a8038aaceb5156625caf102b4eb \
-                    size    65202886
+    checksums       rmd160  263c0152f538d3371c60accb710f3825b01ae097 \
+                    sha256  09c747e048137c99ed35747b012910b704e0974dde4db6696fde7054ce387591 \
+                    size    65207899
 
     patchfiles      patch-configure.diff
 
@@ -88,11 +88,11 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     epoch           1
-    version         20190413
+    version         20190829
 
     fetch.type      git
     git.url         http://git.savannah.gnu.org/r/emacs.git
-    git.branch      f9694a713824d402bcba01064ac2f95156bf4161
+    git.branch      9df285250bc30b5ba86a19c817eea0c56164e022
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"


### PR DESCRIPTION
#### Description

- bump version to 26.3

  Changes:

    ** New option 'help-enable-completion-auto-load'.
       This allows disabling the new feature introduced in Emacs 26.1 which
       loads files during completion of 'C-h f' and 'C-h v' according to
       'definition-prefixes'.

     ** Emacs now supports the new Japanese Era name.
        The newly assigned codepoint U+32FF was added to the Unicode Character
        Database compiled into Emacs.

- bump -devel to latest commit

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->