### PR TITLE
py-fipy: update to version 3.3

### DIFF
--- a/python/py-ez_setup/Portfile
+++ b/python/py-ez_setup/Portfile
@@ -20,7 +20,7 @@ distname            ez_setup-${version}
 checksums           rmd160  796b5364e8e64455468b76b4f8a2fd10f0389d1b \
                     sha256  303c5b17d552d1e3fb0505d80549f8579f557e13d8dc90e5ecef3c07d7f58642
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 python.default_version 27
 
 if {${name} ne ${subport}} {

--- a/python/py-fipy/Portfile
+++ b/python/py-fipy/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 PortGroup           python 1.0
 
+github.setup        usnistgov fipy 3.3
+
 name                py-fipy
-version             3.1
 categories-append   math
 platforms           darwin
 supported_archs     noarch
@@ -18,23 +20,26 @@ long_description    FiPy is an object oriented, partial differential \
                     for viewing.
 
 homepage            http://www.ctcms.nist.gov/fipy/
-master_sites        http://www.ctcms.nist.gov/fipy/download/
-distname            FiPy-${version}
 
-checksums           rmd160  19891efaf2371fce3baa0acf0f4360116d7dc854 \
-                    sha256  54a4bc2ed6562bd402890ddd257220cf092438db1941427035412813415bd0c7
+checksums           rmd160  0454eb328b6ff315e53cb3a9f38494a6c5aa7f26 \
+                    sha256  a71cadc7717f464c6daf29df7b4c9ce10bc1753e0f1b397124078b67182ef467 \
+                    size    10331174
 
-python.versions     27
+python.versions     27 36 37
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools \
                             port:py${python.version}-ez_setup
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-matplotlib \
-                        port:py${python.version}-pysparse \
                         port:py${python.version}-scipy \
                         port:py${python.version}-ipython \
-                        port:gmsh
+                        port:gmsh \
+                        port:py${python.version}-future
+
+    if {${python.version} < 30} {
+        depends_lib-append  port:py${python.version}-pysparse
+    }
 
     post-destroot {
         # Fix permissions problems on these files
@@ -42,6 +47,4 @@ if {${name} ne ${subport}} {
             ${destroot}${python.pkgd}/FiPy-${version}-py${python.branch}.egg-info
     }
     livecheck.type      none
-} else {
-    livecheck.regex     FiPy-(\[0-9.\]+)${extract.suffix}
 }


### PR DESCRIPTION
* update to version 3.3
* allows Python 36

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
