### PR TITLE
py-zipp: Add missing py-more-itertools dependency

### DIFF
--- a/python/py-zipp/Portfile
+++ b/python/py-zipp/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-zipp
 version             0.6.0
-revision            0
+revision            1
 categories-append   devel
 platforms           darwin
 license             MIT
@@ -30,6 +30,8 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-setuptools \
                         port:py${python.version}-setuptools_scm
+
+    depends_lib-append  port:py${python.version}-more-itertools
 
     livecheck.type      none
 }


### PR DESCRIPTION
```
| $> tox
| Traceback (most recent call last):
|   File "/opt/local/bin/tox", line 6, in <module>
|     from pkg_resources import load_entry_point
|   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3250, in <module>
|     @_call_aside
|   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3234, in _call_aside
|     f(*args, **kwargs)
|   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3263, in _initialize_master_working_set
|     working_set = WorkingSet._build_master()
|   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
|     ws.require(__requires__)
|   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
|     needed = self.resolve(parse_requirements(requirements))
|   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
|     raise DistributionNotFound(req, requirers)
| pkg_resources.DistributionNotFound: The 'more_itertools' distribution was not found and is required by zipp
```

See #5159.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.12.6 16G2128
Xcode 9.2 9C40b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files: tested tox.