### PR TITLE
Update libarchive to 3.4.0

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -16,28 +16,20 @@ long_description \
 	also write shar archives.
 platforms        darwin
 
-version          3.3.3
-revision         1
-checksums        rmd160  c59dd17f764e33c2984058091ea00b5768e35ce4 \
-                 sha256  ba7eb1781c9fbbae178c4c6bad1c6eb08edab9a1496c64833d1715d022b30e2e \
-                 size    6535598
+version          3.4.0
+checksums        rmd160 7aa43082eeea7b72c1442b995ef9f69135cf7481 \
+                 sha256 8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e \
+                 size   6908093
 
 homepage         https://libarchive.org/
 master_sites     ${homepage}downloads/
 
-
+depends_build    port:pkgconfig
 depends_lib      port:bzip2 port:zlib port:libxml2 port:xz \
                  port:lzo2 port:libiconv \
-                 port:lz4 port:expat port:zstd
+                 port:lz4 port:zstd
 
 patchfiles       patch-libarchive__archive_read_support_format_lha.c.diff
-
-use_autoreconf   yes
-autoreconf.cmd   "build/autogen.sh"
-autoreconf.args  -fvi
-
-depends_build    port:autoconf port:automake port:libtool \
-                 port:pkgconfig
 
 configure.args   --enable-bsdtar=shared --enable-bsdcpio=shared \
                  --disable-silent-rules --without-nettle \


### PR DESCRIPTION
Remove autoreconf; it was only added because Makefile.am was being
patched, and that's no longer the case.

Also remove expat dependency; it is only used if libxml2 is not found.

Fixes: https://trac.macports.org/ticket/56563

###### Tested on
macOS 10.14.6
Xcode 10.3