### PR TITLE
add py-trio and dependencies

### DIFF
--- a/python/py-contextvars/Portfile
+++ b/python/py-contextvars/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-contextvars
+version             2.4
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+
+python.versions     36
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         backport of Python 3.7 contextvars
+long_description    This package implements a backport of the Python 3.7 \
+                    contextvars module (see PEP 567) for Python 3.6.
+
+homepage            https://github.com/MagicStack/contextvars
+master_sites        pypi:c/contextvars
+
+distname            contextvars-${version}
+
+checksums           rmd160  8a93b02e1ca00c938a16ca579ac32801dd4e4cfb \
+                    sha256  f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e \
+                    size    9570
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-immutables
+    depends_test-append     port:py${python.version}-pytest
+
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type      none
+}

--- a/python/py-immutables/Portfile
+++ b/python/py-immutables/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-immutables
+version             0.9
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             Apache-2
+
+python.versions     35 36 37
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         A high-performance immutable mapping type for Python
+long_description    An immutable mapping type for Python.  The underlying \
+                    datastructure is a Hash Array Mapped Trie (HAMT) used \
+                    in Clojure, Scala, Haskell, and other functional \
+                    languages. This implementation is used in CPython 3.7 \
+                    in the contextvars module (see PEP 550 and PEP 567 for more details).
+
+homepage            https://github.com/MagicStack/immutables
+master_sites        pypi:i/immutables
+
+distname            immutables-${version}
+
+checksums           rmd160  40185d1e07091e051eb91caeddbe1f3cba3febfe \
+                    sha256  d71d1c822498646143270580dd6f743bb31ab89ae0ded8b2307c356d3a00f1c0 \
+                    size    37754
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_test-append     port:py${python.version}-pytest
+
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type      none
+}

--- a/python/py-outcome/Portfile
+++ b/python/py-outcome/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-outcome
+version             1.0.0
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             {Apache-2 MIT}
+
+python.versions     27 35 36 37
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         Capture the outcome of Python function calls
+long_description    Capture the outcome of Python function calls. Extracted \
+                    from the Trio project.
+
+homepage            https://github.com/python-trio/outcome
+master_sites        pypi:o/outcome
+
+distname            outcome-${version}
+
+checksums           rmd160  6b31076292a1a6ef4ee93bffb0d3cc109a63d515 \
+                    sha256  9d58c05db36a900ce60c6da0167d76e28869f64b338d60fa3a61841cfa54ac71 \
+                    size    17307
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-attrs
+    depends_test-append     port:py${python.version}-pytest \
+                            port:py${python.version}-async_generator \
+                            port:py${python.version}-pytest-asyncio
+
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type      none
+}

--- a/python/py-sniffio/Portfile
+++ b/python/py-sniffio/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-sniffio
+version             1.1.0
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             {Apache-2 MIT}
+
+python.versions     36 37
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         Sniff out which async library your code is running under
+long_description    This is a tiny package whose only purpose is to let you \
+                    detect which async library your code is running under.
+
+homepage            https://github.com/python-trio/sniffio
+master_sites        pypi:s/sniffio
+
+distname            sniffio-${version}
+
+checksums           rmd160  b7e4a4e9e6761ba5aabbe8839dae683e9c9abf92 \
+                    sha256  8e3810100f69fe0edd463d02ad407112542a11ffdc29f67db2bf3771afb87a21 \
+                    size    15285
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    livecheck.type          none
+}

--- a/python/py-trio/Portfile
+++ b/python/py-trio/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-trio
+version             0.12.1
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             {Apache-2 MIT}
+
+python.versions     36 37
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         Friendly Python library for async concurrency and I/O
+long_description    The Trio project's goal is to produce a \
+                    production-quality, permissively licensed, \
+                    async/await-native I/O library for Python. Like all \
+                    async libraries, its main purpose is to help you write \
+                    programs that do multiple things at the same time with \
+                    parallelized I/O.
+
+homepage            https://github.com/python-trio/trio/
+master_sites        pypi:t/trio
+
+distname            trio-${version}
+
+checksums           rmd160  6694bfcdc1241765e86e4c25cf53ea2e5f42dd81 \
+                    sha256  149a280a4c66ef08d058626e3f48bf979e6e079777d1fc5cae71676586ced672 \
+                    size    381536
+
+patchfiles          patch-trio-_socket.py-select-fix.diff
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-sortedcontainers \
+                            port:py${python.version}-async_generator \
+                            port:py${python.version}-attrs \
+                            port:py${python.version}-idna \
+                            port:py${python.version}-outcome \
+                            port:py${python.version}-sniffio
+    depends_test-append     port:py${python.version}-astor \
+                            port:py${python.version}-openssl \
+                            port:py${python.version}-yapf \
+                            port:py${python.version}-trustme \
+                            port:py${python.version}-jedi \
+                            port:py${python.version}-pylint \
+                            port:py${python.version}-pytest
+
+    if {${python.version} < 37} {
+        depends_lib-append  port:py${python.version}-contextvars
+    }
+
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type      none
+}

--- a/python/py-trio/files/patch-trio-_socket.py-select-fix.diff
+++ b/python/py-trio/files/patch-trio-_socket.py-select-fix.diff
@@ -1,0 +1,13 @@
+--- trio/_socket.py.orig	2019-08-31 12:37:40.000000000 +0200
++++ trio/_socket.py	2019-08-31 12:46:29.000000000 +0200
+@@ -479,8 +479,8 @@
+             self._did_shutdown_SHUT_WR = True
+ 
+     def is_readable(self):
+-        # use select.select on Windows, and select.poll everywhere else
+-        if _sys.platform == "win32":
++        # use select.select on Windows and Darwin, and select.poll everywhere else
++        if _sys.platform == "darwin" or _sys.platform == "win32":
+             rready, _, _ = select.select([self._sock], [], [], 0)
+             return bool(rready)
+         p = select.poll()

--- a/python/py-trustme/Portfile
+++ b/python/py-trustme/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-trustme
+version             0.5.2
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             {Apache-2 MIT}
+
+python.versions     27 35 36 37
+
+maintainers         {@jandemter demter.de:jan} openmaintainer
+
+description         #1 quality TLS certs while you wait, for the discerning tester
+long_description    trustme is a tiny Python package that does one thing: it \
+                    gives you a fake certificate authority (CA) that you can \
+                    use to generate fake TLS certs to use in your tests.
+
+homepage            https://github.com/python-trio/trustme/
+master_sites        pypi:t/trustme
+
+distname            trustme-${version}
+
+checksums           rmd160  1c5bc086145a8c0c51f2aa71250e5ff25412314f \
+                    sha256  8b804c55c7bcb5186f1f408c9da1e5fda915e6fe0142f4411ea900c380456e80 \
+                    size    21819
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+    depends_run-append      port:py${python.version}-cryptography \
+                            port:py${python.version}-idna
+    depends_test-append     port:py${python.version}-service_identity \
+                            port:py${python.version}-pytest \
+                            port:py${python.version}-openssl \
+
+
+    if {${python.version} < 33} {
+        depends_lib-append  port:py${python.version}-ipaddress
+        depends_lib-append  port:py${python.version}-futures
+    }
+
+    test.run            yes
+    test.cmd            py.test-${python.branch}
+    test.target
+    test.env            PYTHONPATH=${worksrcpath}/build/lib
+
+    livecheck.type      none
+}


### PR DESCRIPTION
#### Description
Trio is "a friendly Python library for async concurrency and I/O".

py-sniffio, py-outcome are the main dependencies,
py-trustme is needed to run the tests for py-trio,
py-contextvars and py-immutables for compatibility with Python 3.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
