### PR TITLE
python38-devel: update to 3.8.0b4

### DIFF
--- a/lang/python38-devel/Portfile
+++ b/lang/python38-devel/Portfile
@@ -5,7 +5,7 @@ PortGroup           select 1.0
 
 name                python38-devel
 
-version             3.8.0b3
+version             3.8.0b4
 epoch               1
 revision            0
 set major           [lindex [split $version .] 0]
@@ -25,9 +25,9 @@ master_sites        ${homepage}ftp/python/3.8.0/
 
 distname            Python-${version}
 use_xz              yes
-checksums           rmd160  6315c906c7ff4412e3b7e166e82634135b0efccc \
-                    sha256  cd7a81efcc9f82e20f9d6a41fd6f9859ddc2a082dcbc3fa62932e53b6f41980f \
-                    size    17768608
+checksums           rmd160  dbae8fea1653c2b18a94920f1b8207cb3b53a2d8 \
+                    sha256  38196bbd24a0f026391009e0b668d0210987458a55f367a271307644489708ad \
+                    size    17788672
 
 patchfiles          patch-setup.py.diff \
                     patch-Lib-cgi.py.diff \


### PR DESCRIPTION
#### Description
Update to Python 3.8.0 beta 4

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

