### PR TITLE
epubcheck: use Java portgroup

### DIFF
--- a/textproc/epubcheck/Portfile
+++ b/textproc/epubcheck/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               java 1.0
 
 name                    epubcheck
 version                 1.2
@@ -24,10 +25,12 @@ distname                ${name}-${version}
 
 use_zip                 yes
 
-checksums               sha1    86036eadad8408070791b3da368958239ed8a410 \
-                        rmd160  a086609ba13ae36ec63759cf2f7f474b88c8ccdc
+checksums               sha256  2ad436aeaaa341f28e11fdb91256bc04e8b0747d50857f58f5bd97ec6a6cb265 \
+                        rmd160  a086609ba13ae36ec63759cf2f7f474b88c8ccdc \
+                        size    1399350
 
-depends_run             bin:java:kaffe
+java.version            1.5+
+java.fallback           openjdk11
 
 extract.mkdir           yes
 


### PR DESCRIPTION
Eliminate fallback dependency on `kaffe`
Use latest LTS Java (`openjdk11`) as fallback

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
