### PR TITLE
py-tensorflow: enable Intel MKL support by default on 10.12 and newer.

### DIFF
--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -12,7 +12,7 @@ PortGroup           conflicts_build                1.0
 
 name                py-tensorflow
 version             1.14.0
-revision            3
+revision            4
 github.setup        tensorflow tensorflow ${version} v
 platforms           darwin
 supported_archs     x86_64
@@ -48,6 +48,12 @@ if {${os.major} < 16} {
     # Work around for issues with clock_gettime(CLOCK_REALTIME, &ts);
     # https://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
     patchfiles-append CLOCK_REALTIME-Older-OSX.patch
+}
+
+variant mkl description {Enable Intel Math Kernel Library support} { }
+# Enable MKL by default on 10.12 and newer.
+if {${os.major} >= 16} {
+    default_variants-append +mkl
 }
 
 variant native description {Build from source for best native platform support} { }
@@ -168,6 +174,9 @@ if {${name} ne ${subport}} {
         if {[vercmp ${xcodeversion} ${tf_min_xcode}] < 0} {
             set tf_bazel_build_opts "${tf_bazel_build_opts} --action_env CC=${configure.cc}"
             set tf_bazel_cmd "BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 ${tf_bazel_cmd}"
+        }
+        if {[variant_isset mkl]} {
+            set tf_bazel_build_opts "${tf_bazel_build_opts} --config=mkl"
         }
         if {![variant_isset native]} {
             set tf_bazel_build_opts "${tf_bazel_build_opts} --copt=${base_march}"


### PR DESCRIPTION
#### Description

Enable Intel MKL support by default. Idea pulled from py-pytorch.

It appears that the build has MKL and builds an internal copy so no additional download is needed. The package has two new .so files:

```
$ port contents py37-tensorflow | g dylib
  /opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/_solib_darwin_x86_64/_U@mkl_Udarwin_S_S_Cmkl_Ulibs_Udarwin___Uexternal_Smkl_Udarwin_Slib/libiomp5.dylib
  /opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/_solib_darwin_x86_64/_U@mkl_Udarwin_S_S_Cmkl_Ulibs_Udarwin___Uexternal_Smkl_Udarwin_Slib/libmklml.dylib
...
...

```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
