### PR TITLE
py-tensorflow: pass --expunge to 'bazel clean' to clean up more.

### DIFF
--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -186,7 +186,7 @@ if {${name} ne ${subport}} {
         # Build the python wheel
         system -W ${worksrcpath} "./bazel-bin/tensorflow/tools/pip_package/build_pip_package ${workpath}"
         # Clean up
-        system -W ${worksrcpath} "${tf_bazel_cmd} clean"
+        system -W ${worksrcpath} "${tf_bazel_cmd} clean --expunge"
     }
 
     set macos_minor_v [expr [lindex [split ${os.version} "."] 0] - 4]


### PR DESCRIPTION
This also stops the bazel server.

```
If '--expunge' is specified, the entire working tree will be removed
and the server stopped.
```

There's still stuff that's left over that hopefully this will help clean up:

```
# du -hs /private/var/tmp/_bazel_root/
 64M    /private/var/tmp/_bazel_root/
```
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
