### PR TITLE
adblock2privoxy: Bugfix destroot issue, allow config initialization

### DIFF
--- a/www/adblock2privoxy/Portfile
+++ b/www/adblock2privoxy/Portfile
@@ -5,6 +5,7 @@ PortGroup           haskell_stack 1.0
 
 name                adblock2privoxy
 version             2.0.1
+revision            1
 categories          www haskell
 maintainers         @essandess
 license             GPL-3
@@ -39,18 +40,50 @@ depends_run-append \
                     port:nginx \
                     port:privoxy
 
+variant initialize \
+    description {Initialize all configuration files. Existing
+        configurations files are not overwritten by default.} {}
+
+# relative paths to ${prefix}
+set ab2p_datadir    share/${name}
+
+# Fix for cabal data-files hardcoded path in binary
+# See:
+# https://github.com/commercialhaskell/stack/issues/848
+# https://github.com/commercialhaskell/stack/issues/4857
+# https://github.com/haskell/cabal/issues/462
+# https://github.com/haskell/cabal/issues/3586
+post-extract {
+    xinstall -m 0644 -W ${worksrcpath} \
+        ${filespath}/Paths_${name}.hs ./src
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+}
+
 post-destroot {
-    xinstall -d ${destroot}${prefix}/etc/${name} \
+    xinstall -m 0755 -d \
+        ${destroot}${prefix}/share/${name}/templates \
+        ${destroot}${prefix}/etc/${name} \
         ${destroot}${prefix}/etc/${name}/privoxy \
         ${destroot}${prefix}/etc/${name}/css
+
+    # cabal's data-files datadir: ${name}_datadir from Paths_${name}.hs
+    fs-traverse f ${worksrcpath}/.stack-work {
+        if { [string match "ab2p.system.*" [file tail ${f}]] } {
+            xinstall -m 0644 ${f} \
+                ${destroot}${prefix}/share/${name}/templates
+        }
+    }
+
     xinstall -m 0644 -W ${filespath} \
         nginx.conf \
-        ${destroot}${prefix}/etc/${name}
+        ${destroot}${prefix}/etc/${name}/nginx.conf.macports
     xinstall -m 0644 -W ${filespath} \
         default.html \
-        ${destroot}${prefix}/etc/${name}/css
+        ${destroot}${prefix}/etc/${name}/css/default.html.macports
     reinplace "s|@PREFIX@|${prefix}|g" \
-        ${destroot}${prefix}/etc/${name}/nginx.conf
+        ${destroot}${prefix}/etc/${name}/nginx.conf.macports
 }
 
 startupitem.create  yes
@@ -104,6 +137,29 @@ post-activate {
 	</array>\\
 &|" \
         ${prefix}/etc/${startupitem.location}/org.macports.${name}/org.macports.${name}.plist
+
+    foreach f [list \
+        ${prefix}/etc/${name}/nginx.conf \
+        ${prefix}/etc/${name}/css/default.html \
+        ] {
+        if { [variant_isset "initialize"]
+             && [file exists ${f}]
+            } {
+            delete ${f}.previous
+            move \
+                ${f} \
+                ${f}.previous
+        }
+        if { [variant_isset "initialize"]
+             || ![file exists ${f}]
+            } {
+            if { [file isfile ${f}.macports] } {
+                xinstall -m 0644 \
+                    ${f}.macports \
+                    ${f}
+            }
+        }
+    }
 }
 
 notes "

--- a/www/adblock2privoxy/files/Paths_adblock2privoxy.hs
+++ b/www/adblock2privoxy/files/Paths_adblock2privoxy.hs
@@ -1,0 +1,62 @@
+{- Cabal data-files hardcoded path in binary fix.
+
+This file replaces the Paths_*.hs automatically created by cabal.
+
+See:
+* https://github.com/commercialhaskell/stack/issues/848
+* https://github.com/commercialhaskell/stack/issues/4857
+* https://github.com/haskell/cabal/issues/462
+* https://github.com/haskell/cabal/issues/3586
+
+-}
+        
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoRebindableSyntax #-}
+{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
+module Paths_adblock2privoxy (
+    version,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
+    getDataFileName, getSysconfDir
+  ) where
+
+import qualified Control.Exception as Exception
+import Data.Version (Version(..))
+import System.Environment (getEnv)
+import Prelude
+
+#if defined(VERSION_base)
+
+#if MIN_VERSION_base(4,0,0)
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#else
+catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
+#endif
+
+#else
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#endif
+catchIO = Exception.catch
+
+version :: Version
+version = Version [2,0,1] []
+bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
+
+bindir     = "@PREFIX@/bin"
+libdir     = "@PREFIX@/lib/adblock2privoxy"
+dynlibdir  = "@PREFIX@/lib/adblock2privoxy"
+datadir    = "@PREFIX@/share/adblock2privoxy"
+libexecdir = "@PREFIX@/lib/adblock2privoxy"
+sysconfdir = "@PREFIX@/etc"
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+getBinDir = catchIO (getEnv "adblock2privoxy_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "adblock2privoxy_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "adblock2privoxy_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "adblock2privoxy_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "adblock2privoxy_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "adblock2privoxy_sysconfdir") (\_ -> return sysconfdir)
+
+getDataFileName :: FilePath -> IO FilePath
+getDataFileName name = do
+  dir <- getDataDir
+  return (dir ++ "/" ++ name)


### PR DESCRIPTION
adblock2privoxy: Bugfix destroot issue, allow config initialization

* Fix destroot issue in binary caused by datadir in stack_root
* Allow initialization of proxy configuration files
* See https://github.com/commercialhaskell/stack/issues/848
* See https://github.com/commercialhaskell/stack/issues/4857

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->