### PR TITLE
py-tensor{board,flow_estimator}: force reinstall so don't conflict on self

### DIFF
--- a/python/py-tensorboard/Portfile
+++ b/python/py-tensorboard/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           conflicts_build 1.0
 
 name                py-tensorboard
 version             1.14.0
@@ -43,9 +42,6 @@ python.versions        27 35 36 37
 python.default_version 37
 
 if {${name} ne ${subport}} {
-
-    conflicts_build ${subport}
-
     depends_build-append \
         port:py${python.version}-pip
 
@@ -69,6 +65,7 @@ if {${name} ne ${subport}} {
 
     destroot.cmd        pip-${python.branch}
     destroot.args       \
+        --ignore-installed \
         --no-cache-dir \
         --no-dependencies \
         --root ${destroot} \
@@ -76,6 +73,4 @@ if {${name} ne ${subport}} {
     destroot.post_args
 
     livecheck.type      none
-
 }
-

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -8,7 +8,6 @@ PortGroup           github                         1.0
 PortGroup           compilers                      1.0
 PortGroup           xcodeversion                   1.0
 PortGroup           compiler_blacklist_versions    1.0
-PortGroup           conflicts_build                1.0
 
 name                py-tensorflow
 version             1.14.0
@@ -63,9 +62,6 @@ python.versions        27 35 36 37
 python.default_version 37
 
 if {${name} ne ${subport}} {
-
-    # Tensorflow cannot be built/desrooted whilst it is still installed
-    conflicts_build ${subport}
 
     depends_build-append \
         port:py${python.version}-pip \
@@ -195,8 +191,7 @@ if {${name} ne ${subport}} {
 
     destroot.cmd  pip-${python.branch}
     destroot.args           \
-        --upgrade           \
-        --force-reinstall   \
+        --ignore-installed  \
         --no-cache-dir      \
         --no-dependencies   \
         --root ${destroot}  \

--- a/python/py-tensorflow_estimator/Portfile
+++ b/python/py-tensorflow_estimator/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           conflicts_build 1.0
 
 name                py-tensorflow_estimator
 version             1.14.0
@@ -38,8 +37,6 @@ python.versions        27 35 36 37
 python.default_version 37
 
 if {${name} ne ${subport}} {
-    conflicts_build ${subport}
-
     depends_build-append \
         port:py${python.version}-pip
 
@@ -53,6 +50,7 @@ if {${name} ne ${subport}} {
 
     destroot.cmd        pip-${python.branch}
     destroot.args       \
+        --ignore-installed \
         --no-cache-dir \
         --no-dependencies \
         --root ${destroot} \


### PR DESCRIPTION
Pass --ignore-installed to pip so it will reinstall the package.

This makes it easier to upgrade the packages than having to deactivate
them.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
