### PR TITLE
pxsl-tools: move to haskell_stack PortGroup

### DIFF
--- a/textproc/pxsl-tools/Portfile
+++ b/textproc/pxsl-tools/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           haskell 1.0
+PortGroup           haskell_stack 1.0
 
-haskell.setup       pxsl-tools 1.0.1 ghc no
 name                pxsl-tools
-revision            4
+version             1.0.1
+revision            5
 categories          textproc xml
 maintainers         {snc @nerdling} openmaintainer
 license             GPL-2
@@ -21,18 +21,18 @@ long_description    PXSL ("pixel") is a convenient shorthand for writing \
                     documents.
 
 platforms           darwin freebsd
-use_parallel_build  yes
+
 homepage            https://github.com/tmoertel/pxsl-tools
 master_sites        http://hackage.haskell.org/package/pxsl-tools
 
 checksums           rmd160  aff14de679d39e669418983879c8c2345fc8a0c9 \
-                    sha256  dc311c012b0b6b482cdd26337f44cff8259269d3dd83f482ab4049965fa085e0
+                    sha256  dc311c012b0b6b482cdd26337f44cff8259269d3dd83f482ab4049965fa085e0 \
+                    size    45096
 
-depends_lib-append  port:gmp \
-                    port:hs-mtl \
-                    port:hs-parsec \
-                    port:libiconv
-
-livecheck.type      regex
-livecheck.url       ${master_sites}
-livecheck.regex     ${name}-(\\d+(\\.\\d+)+)${extract.suffix}
+pre-build {
+    system -W ${workpath} \
+        "${prefix}/bin/stack init --stack-root [option haskell_stack.stack_root] \
+        --with-gcc ${configure.cc} \
+        --allow-different-user \
+        [haskell_stack.system_ghc_flags]"
+}


### PR DESCRIPTION
#### Description

This port doesn't build since the update to ghc; this PR moves it to the new `haskell_stack` PortGroup.

This is also part of effort to remove old Haskell ports (#5050).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
