### PR TITLE
gnucash: remove yelp dependency

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -88,15 +88,6 @@ depends_lib       port:guile \
                   port:libxml2
 
 depends_run       port:gnucash-docs
-# yelp currently requires X11 to build so disable dependency if building
-# with +quartz
-#
-# TODO: add +x11 +quartz variants to distinguish one build from the other
-# since they have different binary dependencies.  Otherwise, rev-upgrade
-# errors may occur
-if {![variant_isset quartz]} {
-    depends_run-append port:yelp
-}
 
 # aqbanking is not universal
 universal_variant no


### PR DESCRIPTION
* yelp dependency is brought in with gnucash-docs

#### Description

The yelp dependency should be (and is) brought in by the gnucash-docs dependency. This lets gnucash-docs resolve the current +quartz issue for yelp.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
