### PR TITLE
lilypond-devel: fix assignments in `depends_build` vs. `depends_lib`

### DIFF
--- a/textproc/lilypond-devel/Portfile
+++ b/textproc/lilypond-devel/Portfile
@@ -7,7 +7,7 @@ PortGroup           cxx11 1.1
 name                lilypond-devel
 set my_name         lilypond
 version             2.19.83
-revision            1
+revision            2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          textproc
 maintainers         {snc @nerdling} openmaintainer
@@ -29,32 +29,32 @@ checksums           rmd160  6250667c2a2799ec404e10e3e141101d043ab7f6 \
                     sha256  96ba4f4b342d21057ad74d85d647aea7e47a5c24f895127c2b3553a252738fb3 \
                     size    17996428
 
-depends_build       port:autoconf \
-                    port:t1utils \
+depends_build-append \
+                    port:autoconf \
                     port:bison \
-                    port:texi2html \
-                    port:netpbm \
-                    port:pkgconfig \
+                    port:dblatex \
                     port:flex \
                     port:fontforge \
-                    port:libtool
-
-depends_lib         port:fontconfig \
-                    port:freetype \
-                    port:gettext \
-                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:ghostscript \
-                    port:gmp \
-                    port:guile18 \
+                    port:libtool \
+                    port:netpbm \
+                    port:pkgconfig \
                     port:texinfo \
-                    path:lib/pkgconfig/pango.pc:pango \
+                    port:texi2html \
                     port:texlive \
                     port:texlive-fonts-recommended \
                     port:texlive-lang-cyrillic \
                     port:texlive-metapost \
-                    port:dblatex \
-                    port:python27 \
+                    port:t1utils \
                     port:urw-core35-fonts
+
+depends_lib-append  path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/pango.pc:pango \
+                    port:fontconfig \
+                    port:freetype \
+                    port:gettext \
+                    port:ghostscript \
+                    port:guile18 \
+                    port:python27
 
 configure.cmd       autoconf -f && ./configure
 configure.python    ${frameworks_dir}/Python.framework/Versions/2.7/bin/python2.7
@@ -111,10 +111,10 @@ variant mactex description {Allow lilypond-devel to use MacTeX or another\
         }
     }
 
-    depends_lib-delete port:texlive \
-                       port:texlive-fonts-recommended \
-                       port:texlive-lang-cyrillic \
-                       port:texlive-metapost
+    depends_build-delete port:texlive \
+                         port:texlive-fonts-recommended \
+                         port:texlive-lang-cyrillic \
+                         port:texlive-metapost
 
     configure.args-append --with-texgyre-dir=${lilyponddevel.texgyredir}
 }
@@ -145,32 +145,36 @@ post-patch {
 # possible to circumvent this issue without rewriting a considerable
 # amount of code.
 
+# g++ uses libstdc++; setting this prevents the application from being
+# flagged as broken.
+configure.cxx_stdlib macports-libstdc++
+
 # blacklist any clang compiler and any old gcc (a better expression is needed)
-compiler.blacklist \
-    *clang* \
-    *llvm-gcc* \
-    *apple-gcc* \
-    gcc \
-    gcc-3.3 gcc-4.0 gcc-4.2
-compiler.whitelist \
-    macports-gcc-8 \
-    macports-gcc-7 \
-    macports-gcc-6 \
-    macports-gcc-5 \
-    macports-gcc-4.9 macports-gcc-4.8 macports-gcc-4.7
-configure.cxx_stdlib    macports-libstdc++
+compiler.blacklist  *clang* \
+                    *llvm-gcc* \
+                    *apple-gcc* \
+                    gcc \
+                    gcc-3.3 gcc-4.0 gcc-4.2
+
+compiler.fallback-append \
+                    macports-gcc-8 \
+                    macports-gcc-7 \
+                    macports-gcc-6 \
+                    macports-gcc-5 \
+                    macports-gcc-4.9 macports-gcc-4.8 macports-gcc-4.7
 
 configure.args-append \
-    --with-urwotf-dir=${prefix}/share/fonts/urw-core35-fonts \
-    --enable-documentation
+                    --with-urwotf-dir=${prefix}/share/fonts/urw-core35-fonts \
+                    --enable-documentation
 if {![variant_isset mactex]} {
     configure.args-append --with-texgyre-dir=${lilyponddevel.texgyredir}
 }
+
 configure.env       LTDL_LIBRARY_PATH=${prefix}/lib \
-    PYTHON_CONFIG=${configure.python}-config \
-    GUILE=${prefix}/bin/guile18 \
-    GUILE_CONFIG=${prefix}/bin/guile18-config \
-    GUILE_TOOLS=${prefix}/bin/guile18-tools
+                    PYTHON_CONFIG=${configure.python}-config \
+                    GUILE=${prefix}/bin/guile18 \
+                    GUILE_CONFIG=${prefix}/bin/guile18-config \
+                    GUILE_TOOLS=${prefix}/bin/guile18-tools
 
 build.env           LTDL_LIBRARY_PATH=${prefix}/lib
 
@@ -182,6 +186,6 @@ post-destroot {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${destroot}${prefix}/bin/lilypond
 }
 
-livecheck.type  regex
-livecheck.url   ${homepage}/development.html
-livecheck.regex ${my_name}-(\\d+(\\.\\d+)+)
+livecheck.type      regex
+livecheck.url       ${homepage}/development.html
+livecheck.regex     ${my_name}-(\\d+(\\.\\d+)+)


### PR DESCRIPTION
#### Description

Also do some formatting.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
