### PR TITLE
boost @1.71.0: allow build with gcc

### DIFF
--- a/devel/boost/Portfile
+++ b/devel/boost/Portfile
@@ -117,6 +117,11 @@ configure.args      --without-libraries=python \
                     --without-libraries=mpi \
                     --with-icu=${prefix}
 
+# boost build scripts default to clang on darwin
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.args-append --with-toolset=gcc
+}
+
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     configure.args-append   --without-libraries=context \
                             --without-libraries=coroutine


### PR DESCRIPTION
the 1.7x boost versions assume darwin=clang and the default build
scripts do some clang tests that cause errors when building with gcc.

directing the build scripts that the toolset is gcc fixes the builds

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.4 PPC, 10.5 PPC, 10.14
Xcode 2.5, 3.2, 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
