### PR TITLE
libcdio: update to 2.1.0 and revbump dependents

### DIFF
--- a/audio/cmus/Portfile
+++ b/audio/cmus/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
 
 github.setup        cmus cmus 2.8.0 v
-revision            0
+revision            1
 categories          audio
 maintainers         {@g5pw g5pw} \
                     {@Traace hotmail.de:xxtraacexx} \

--- a/audio/libcdio-paranoia/Portfile
+++ b/audio/libcdio-paranoia/Portfile
@@ -7,6 +7,7 @@ set cdio_version    0.94
 github.setup        rocky libcdio-paranoia 10.2+${cdio_version}+1 release-
 epoch               102
 version             ${cdio_version}
+revision            1
 
 categories          audio
 platforms           darwin

--- a/audio/xmms2/Portfile
+++ b/audio/xmms2/Portfile
@@ -5,7 +5,7 @@ PortGroup               waf 1.0
 
 name                    xmms2
 version                 0.8DrO_o
-revision                20
+revision                21
 categories              audio
 # Mostly LGPL, some plugins and clients are GPL
 license                 LGPL-2.1+ GPL-2+ GPL-2

--- a/devel/libcdio/Portfile
+++ b/devel/libcdio/Portfile
@@ -3,7 +3,14 @@
 PortSystem          1.0
 
 name                libcdio
-version             0.94
+version             2.1.0
+
+master_sites        http://git.savannah.gnu.org/cgit/libcdio.git/snapshot/
+distname            ${name}-release-${version}
+
+checksums           rmd160  d747bf4aacf9c57298478766cfe7a29a128692ee \
+                    sha256  3ab7973d88405a7d4aad05e547c3316ba196caa19826072174c3bc3c58145c61 \
+                    size    1628834
 
 categories          devel
 platforms           darwin
@@ -18,22 +25,25 @@ long_description    The libcdio package contains a library which \
                     can use this library.
 homepage            https://www.gnu.org/software/libcdio/
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    port:pkgconfig \
+                    port:help2man
+
 depends_lib         port:gettext \
                     port:libcddb \
                     port:libiconv \
                     port:ncurses \
                     port:popt
 
-master_sites        gnu
-checksums           rmd160  795a72a5fa0b6f23e969051f0f59ec9f1ca588c2 \
-                    sha256  96e2c903f866ae96f9f5b9048fa32db0921464a2286f5b586c0f02699710025a
 
 # Required to get a newer libtool that understands -stdlib.
 use_autoreconf          yes
 autoreconf.args-append  --force
 
-configure.args      --disable-silent-rules
+configure.args-append --disable-silent-rules \
+
+# needed to regeneration version.texi at least during build
+configure.args-append --enable-maintainer-mode
 
 # This is a hack because libcdio incorrectly registers the detected
 # libiconv linking options *for libtool* in its .pc files.

--- a/emulators/mednafen/Portfile
+++ b/emulators/mednafen/Portfile
@@ -18,7 +18,7 @@ PortGroup           muniversal 1.0
 name                mednafen
 epoch               1
 version             1.22.2
-revision            0
+revision            1
 checksums           rmd160  7dbec84f5802ac43a21646337de70ae21ca702be \
                     sha256  fad433ac694696d69ea38f6f4be1d0a6c1aa3609ec7f46ce75412be2f2df2f95 \
                     size    3270004

--- a/gnome/gstreamer010-gst-plugins-ugly/Portfile
+++ b/gnome/gstreamer010-gst-plugins-ugly/Portfile
@@ -8,7 +8,7 @@ PortGroup   muniversal 1.0
 name                gstreamer010-gst-plugins-ugly
 set my_name         gst-plugins-ugly
 version             0.10.19
-revision            10
+revision            11
 description         \
     A set of good-quality plug-ins for GStreamer that might pose distribution \
     problems.

--- a/gnome/gstreamer1-gst-plugins-ugly/Portfile
+++ b/gnome/gstreamer1-gst-plugins-ugly/Portfile
@@ -9,7 +9,7 @@ name                gstreamer1-gst-plugins-ugly
 set my_name         gst-plugins-ugly
 # please only commit stable updates (even numbered releases)
 version             1.14.4
-revision            2
+revision            3
 description         A set of good-quality plug-ins for GStreamer that might pose distribution \
                     problems.
 long_description    GStreamer Ugly Plug-ins is a set of plug-ins that have good quality and \

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -8,7 +8,7 @@ name                audacious-plugins
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
 version             3.8
-revision            5
+revision            6
 
 # FIXME: probably more licenses involved here...
 license             BSD GPL-2+

--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -7,7 +7,7 @@ PortGroup               legacysupport 1.0
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.29.1 v
-revision                8
+revision                9
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic}

--- a/multimedia/xine-lib/Portfile
+++ b/multimedia/xine-lib/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name		xine-lib
 version             1.2.9
-revision	4
+revision	5
 description	xine-lib is a free multimedia engine, released under the GPL.
 long_description        ${description}
 maintainers	{ryandesign @ryandesign} openmaintainer


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8 

After many years, libcdio was updated. At least vcdimager needs the new libcdio version, and this update will follow once this PR is committed, if acceptable. 

I rebuilt all the software that is rebumped in this PR against the new libcdio 2.1.0 version without issues, on macOS 10.14.

I rev-upgraded VLC2 without issue, but didn't rebuild it. @RJVB -- OK? 

I was frankly too intimidated by mythtv.N to try to rebuild that, so I'm hoping for some input from @ctreleaven on that one.

That would seem to cover all the obvious dependencies;
```
$ ag port:libcdio .
gnome/gstreamer010-gst-plugins-good/Portfile
43:    port:libcdio \
gnome/gstreamer010-gst-plugins-ugly/Portfile
36:                    port:libcdio \
gnome/gstreamer1-gst-plugins-ugly/Portfile
35:                    port:libcdio \
emulators/mednafen/Portfile
76:                    port:libcdio \
audio/libcdio-paranoia/Portfile
25:                    port:libcdio
audio/cmus/Portfile
130:    depends_lib-append    port:libcdio \
131:                          port:libcdio-paranoia \
audio/xmms2/Portfile
53:                        port:libcdio \
54:                        port:libcdio-paranoia
multimedia/mythtv.28/Portfile
79:                        port:libcdio \
multimedia/mythtv.27/Portfile
89:						port:libcdio \
multimedia/audacious-plugins/Portfile
244:    depends_lib-append      port:libcdio \
245:                            port:libcdio-paranoia \
multimedia/VLC/Portfile
91:                    port:libcdio \
multimedia/mpv/Portfile
448:    depends_lib-append      port:libcdio-paranoia
multimedia/xine-lib/Portfile
34:            port:libcdio \
multimedia/vcdimager/Portfile
27:depends_lib         port:libcdio \
multimedia/VLC2/Portfile
90:                        port:libcdio \
```
