### PR TITLE
py-tensorflow: move py27-future to a build dependency.

### DIFF
--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -64,6 +64,7 @@ python.default_version 37
 if {${name} ne ${subport}} {
 
     depends_build-append \
+        port:py${python.version}-future \
         port:py${python.version}-pip \
         port:py${python.version}-mock \
         port:bazel25 \
@@ -72,7 +73,6 @@ if {${name} ne ${subport}} {
     depends_lib-append \
         port:py${python.version}-absl \
         port:py${python.version}-astor \
-        port:py${python.version}-future \
         port:py${python.version}-gast \
         port:py${python.version}-google-pasta \
         port:py${python.version}-grpcio \
@@ -85,11 +85,6 @@ if {${name} ne ${subport}} {
         port:py${python.version}-termcolor \
         port:py${python.version}-wheel \
         port:py${python.version}-wrapt
-
-    if {${python.version} eq 27} {
-        depends_lib-append \
-            port:py${python.version}-futures
-    }
 
     if {${python.version} < 34} {
         depends_lib-append \


### PR DESCRIPTION
The builtins module is used during the build, such as in
tensorflow/tools/git/gen_git_source.py, but only Python 2.7 needs an
additional module for it.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
