### PR TITLE
Drop maintainership of gildas and slatec

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -9,8 +9,7 @@ version             201908a
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 categories          science
 platforms           darwin
-maintainers         {smaret @smaret} \
-                    {bardeau @bardeau}
+maintainers         {bardeau @bardeau}
 license             permissive
 
 description         Radioastronomy data analysis software

--- a/science/slatec/Portfile
+++ b/science/slatec/Portfile
@@ -8,7 +8,7 @@ version             4.1
 revision            2
 categories          science math
 platforms           darwin
-maintainers         gmail.com:sebastien.maret
+maintainers         nomaintainer
 license             public-domain
 
 description         Common Mathematical Library


### PR DESCRIPTION
I'm dropping maintainership of these package, due to a lack of time. @bardeau will continue to maintain `gildas`, and I'm listing `slatec` as "unmaintained".