### PR TITLE
cmake: deselect variants while bootstrapping

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -123,6 +123,13 @@ configure.env-append \
                     CMAKE_INCLUDE_PATH=${prefix}/include/ncurses \
                     CMAKE_LIBRARY_PATH=${prefix}/lib
 
+# Check if the default compiler has yet to be installed. Used to prevent
+# circular deps involving variants. Has to be tested here before our
+# blacklisting and whitelisting is applied.
+if {${os.platform} eq "darwin" && ${os.major} <= 10 && ${cxx_stdib} eq "libc++" && ![file exists ${configure.cxx}]} {
+    set cmake_bootstrapping yes
+}
+
 # On Lion, Clang 3.3 produces bad stream reading code when using libc++.
 # See https://trac.macports.org/ticket/44129
 # Clang 3.4 works. But Clang 3.7 doesn't work.
@@ -218,6 +225,24 @@ post-destroot {
         reinplace "s|@PREFIX@|${prefix}|g" ${destroot}${applications_dir}/${app}.app/Contents/Info.plist
         ln -s ${prefix}/bin/cmake-gui ${destroot}${applications_dir}/${app}.app/Contents/MacOS/cmake-gui
         xinstall -m 644 ${worksrcpath}/Source/QtDialog/CMakeSetup.icns ${destroot}${applications_dir}/${app}.app/Contents/Resources/CMakeSetup.icns
+    }
+}
+
+# All the variants create circular dependencies on 10.6 with libc++,
+# due to the default compiler needing cmake to build.
+if {[info exists cmake_bootstrapping]} {
+    set some_variant_disabled 0
+    foreach vname {gui qt4 qt5 docs python34 python35 python36 python37} {
+        if {[variant_isset $vname]} {
+            unset ::variations($vname)
+            set some_variant_disabled 1
+        }
+    }
+    if {$some_variant_disabled} {
+        notes-append "Installing $name with variants would create\
+            circular dependencies, so all variants have been\
+            deselected. You can install again with your desired\
+            variants after the default compiler has been installed."
     }
 }
 


### PR DESCRIPTION
On 10.6/libc++, all cmake's variants add dependencies that will depend
on the default compiler, which will be some recent macports-clang,
which will depend on cmake. So if the compiler isn't already installed,
turn off all variants and tell the user that we did.

#### Description

See thread starting with https://lists.macports.org/pipermail/macports-dev/2019-September/041075.html

###### Type(s)

- [x] enhancement
