### PR TITLE
alertmanager: update to 0.19.0, use promu from ports

### DIFF
--- a/net/alertmanager/Portfile
+++ b/net/alertmanager/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus alertmanager 0.18.0 v
+github.setup        prometheus alertmanager 0.19.0 v
 github.tarball_from archive
-set promu_version   0.5.0
 
 description         The Alertmanager handles alerts sent by client \
                     applications such as the Prometheus server.
@@ -23,7 +22,8 @@ license             Apache-2
 
 maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
 
-depends_build       port:go
+depends_build       port:go \
+                    port:promu
 
 build.env           GOPATH=${workpath} \
                     PATH=${workpath}/bin:$env(PATH)
@@ -34,23 +34,11 @@ use_configure       no
 installs_libs       no
 use_parallel_build  no
 
-set promu_distname  promu-${promu_version}.darwin-amd64
-set promu_distfile  ${promu_distname}${extract.suffix}
+distfiles           alertmanager-${version}${extract.suffix}:main
 
-master_sites-append https://github.com/prometheus/promu/releases/download/v${promu_version}:promu
-
-distfiles           alertmanager-${version}${extract.suffix}:main \
-                    ${promu_distfile}:promu
-
-checksums \
-  ${promu_distfile} \
-    rmd160  794fd1112584c13ae95506336578a96716377c8a \
-    sha256  17f9b9816e6a5b4304bda34d2ae025732e20837c27a431639731ebbd45eda08f \
-    size    7132062 \
-  alertmanager-${version}${extract.suffix} \
-    rmd160  1e8c16b606ca8f4e8cbeda2699a2c2993df022c1 \
-    sha256  aa9536f001c4c46ceb5aa1767c81922777b3a2740529d25d86c9f27554cbd466 \
-    size    5181819
+checksums   rmd160  c19ed98763ca6ff3e6ed131a3f2d2fb0c4c653e6 \
+            sha256  4730664f746173f89804df43b3f608cac030e79baae165d6d99df472eb52d36a \
+            size    5862442
 
 set svc_name        prometheus-alertmanager
 set prom_user       prometheus
@@ -68,7 +56,7 @@ add_users           ${prom_user} \
 post-extract {
     # Install promu
     xinstall -d ${workpath}/bin
-    ln -s ${workpath}/${promu_distname}/promu ${workpath}/bin/
+    ln -s ${prefix}/bin/promu ${workpath}/bin/
 
     copy  ${filespath}/org.macports.${name}.plist \
           ${workpath}/org.macports.${name}.plist


### PR DESCRIPTION
Update Prometheus' alertmanager to 0.19.0, use `promu` from MacPorts to build

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
