### PR TITLE
GPXSee: update to 7.13

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 7.12
+github.setup        tumic0 GPXSee 7.13
 categories          gis graphics
 platforms           darwin
 license             GPL-3
@@ -16,9 +16,9 @@ long_description    GPXSee is a Qt-based GPS log file viewer and analyzer \
 
 homepage            https://www.gpxsee.org/
 
-checksums           rmd160  f037e8cb4033beabf066dbebe885ff4968baad23 \
-                    sha256  ea7186143b92eff7381da7226544f9562133ae4cc4b944fdd875f952b97dd1a0 \
-                    size    4688218
+checksums           rmd160  5becab824809bce06fb043098d9f5122bc7c219f \
+                    sha256  03d7b000e3a3028cc5339b554fe4282d6bfaaa84374ce123bbdf4ea4536957b1 \
+                    size    4688920
 
 patchfiles          patch-src_GUI_app_cpp.diff
 


### PR DESCRIPTION
#### Description

Update to version 7.13

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for graph zooming.
>   * Several minor bug fixes.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

