### PR TITLE
go: update to 1.13

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy 13
 
 name                go
 epoch               2
-version             1.12.9
+version             1.13
 categories          lang
 platforms           darwin freebsd linux
 license             BSD
@@ -30,9 +30,9 @@ master_sites        https://storage.googleapis.com/golang/
 distfiles           ${name}${version}.src.tar.gz
 worksrcdir          ${name}
 
-checksums           rmd160  dfea10b529b39189ea2ebaa2cd62d545ce621029 \
-                    sha256  ab0e56ed9c4732a653ed22e232652709afbf573e710f56a07f7fdeca578d62fc \
-                    size    21979950
+checksums           rmd160  50244f6be4dd3eaa6afc7e06a91b9f6c9cb3b5d7 \
+                    sha256  3fc0b8b6101d42efd7da1da3029c0a13f22079c0c37ef9730209d8ec665bf122 \
+                    size    21621948
 
 depends_build       port:go-1.4
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
