### PR TITLE
kubectx: update to 0.7.0

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.6.3 v
-revision            1
+github.setup        ahmetb kubectx 0.7.0 v
+revision            0
 categories          sysutils
 platforms           darwin
 supported_archs     noarch
@@ -15,9 +15,9 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  35712f70bc6729e5126f6ae83a76744edc6e8f59 \
-                    sha256  3bfab7c5c5d2285afbdb74a6f7f46ab55561135a87a4bb8fc7d79e17bfdbd080 \
-                    size    483475
+checksums           rmd160  f6f011e466317cc1323954ac9e5b4f3cc4bd78f7 \
+                    sha256  f944d5677d82e10bc8fbdd70a835ffb0aa522402e0b57331cdc4b80f6aefeee6 \
+                    size    484008
 
 depends_run         port:bash-completion path:${prefix}/bin/kubectl:kubectl-1.15
 


### PR DESCRIPTION
#### Description

Update to kubectx 0.7.0.

###### Tested on

macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?