### PR TITLE
freedv-gui: fix case sensitive file on patch-info.plist.diff

### DIFF
--- a/science/freedv-gui/files/patch-info.plist.diff
+++ b/science/freedv-gui/files/patch-info.plist.diff
@@ -1,11 +1,13 @@
-diff --git a/src/Info.plist b/src/Info.plist
-index 8f0d4c3..13003c2 100644
---- src/Info.plist
-+++ src/Info.plist
-@@ -2,103 +2,31 @@
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
+diff --git a/src/info.plist b/src/info.plist
+deleted file mode 100644
+index 8f0d4c3..0000000
+--- src/info.plist
++++ /dev/null
+@@ -1,104 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+-<plist version="1.0">
+-<dict>
 -	<key>CFBundleDevelopmentRegion</key>
 -	<string>en</string>
 -	<key>CFBundleExecutable</key>
@@ -14,8 +16,8 @@ index 8f0d4c3..13003c2 100644
 -	<string></string>
 -	<key>CFBundleIdentifier</key>
 -	<string>org.freedv.freedv</string>
- 	<key>CFBundleInfoDictionaryVersion</key>
- 	<string>6.0</string>
+-	<key>CFBundleInfoDictionaryVersion</key>
+-	<string>6.0</string>
 -	<key>CFBundleName</key>
 -	<string>FreeDV</string>
 -	<key>CFBundlePackageType</key>
@@ -48,14 +50,14 @@ index 8f0d4c3..13003c2 100644
 -	<string>freedv</string>
 -	<key>CFBundleIconFile</key>
 -	<string></string>
- 	<key>CFBundleIdentifier</key>
- 	<string>org.freedv.freedv</string>
+-	<key>CFBundleIdentifier</key>
+-	<string>org.freedv.freedv</string>
 -	<key>CFBundleInfoDictionaryVersion</key>
 -	<string>6.0</string>
- 	<key>CFBundleName</key>
- 	<string>FreeDV</string>
- 	<key>CFBundlePackageType</key>
- 	<string>APPL</string>
+-	<key>CFBundleName</key>
+-	<string>FreeDV</string>
+-	<key>CFBundlePackageType</key>
+-	<string>APPL</string>
 -	<key>CFBundleShortVersionString</key>
 -	<string>1.0</string>
 -	<key>CFBundleSignature</key>
@@ -76,10 +78,9 @@ index 8f0d4c3..13003c2 100644
 -<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 -<plist version="1.0">
 -<dict>
- 	<key>CFBundleDevelopmentRegion</key>
+-	<key>CFBundleDevelopmentRegion</key>
 -	<string>en</string>
-+	<string>English</string>
- 	<key>CFBundleExecutable</key>
+-	<key>CFBundleExecutable</key>
 -	<string>freedv</string>
 -	<key>CFBundleIconFile</key>
 -	<string></string>
@@ -88,35 +89,61 @@ index 8f0d4c3..13003c2 100644
 -	<key>CFBundleInfoDictionaryVersion</key>
 -	<string>6.0</string>
 -	<key>CFBundleName</key>
- 	<string>FreeDV</string>
+-	<string>FreeDV</string>
 -	<key>CFBundlePackageType</key>
 -	<string>APPL</string>
 -	<key>CFBundleShortVersionString</key>
 -	<string>1.0</string>
 -	<key>CFBundleSignature</key>
 -	<string>????</string>
- 	<key>CFBundleVersion</key>
+-	<key>CFBundleVersion</key>
 -	<string>1</string>
 -	<key>LSMinimumSystemVersion</key>
 -	<string>10.5</string>
+-	<key>NSHumanReadableCopyright</key>
+-	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
+-	<!--<key>NSMainNibFile</key>
+-	<string>MainMenu</string>-->
+-	<key>NSPrincipalClass</key>
+-	<string>NSApplication</string>
+-</dict>
+-</plist>
+\ No newline at end of file
+diff --git a/src/Info.plist b/src/Info.plist
+new file mode 100644
+index 0000000..13003c2
+--- /dev/null
++++ src/Info.plist
+@@ -0,0 +1,32 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++	<key>CFBundleInfoDictionaryVersion</key>
++	<string>6.0</string>
++	<key>CFBundleIdentifier</key>
++	<string>org.freedv.freedv</string>
++	<key>CFBundleName</key>
++	<string>FreeDV</string>
++	<key>CFBundlePackageType</key>
++	<string>APPL</string>
++	<key>CFBundleDevelopmentRegion</key>
++	<string>English</string>
++	<key>CFBundleExecutable</key>
++	<string>FreeDV</string>
++	<key>CFBundleVersion</key>
 +	<string>1.4</string>
 +	<key>CFBundleIconFile</key>
 +	<string>freedv.icns</string>
 +	<key>NSAppleScriptEnabled</key>
 +	<string>No</string>
- 	<key>NSHumanReadableCopyright</key>
- 	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
--	<!--<key>NSMainNibFile</key>
--	<string>MainMenu</string>-->
--	<key>NSPrincipalClass</key>
--	<string>NSApplication</string>
++	<key>NSHumanReadableCopyright</key>
++	<string>Copyright © 2012 FreeDV. All rights reserved.</string>
 +        <key>NSPrincipalClass</key>
 +        <string>NSApplication</string>
 +        <key>NSRequiresAquaSystemAppearance</key>
 +	<string>True</string>
 +        <key>NSMicrophoneUsageDescription</key>
 +        <string>Allow for using Sound input devices</string>
- </dict>
--</plist>
-\ No newline at end of file
++</dict>
 +</plist>


### PR DESCRIPTION

#### Description

support case sensitive file system

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->