### PR TITLE
wireguard-tools: update to 0.0.20190905

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190702
+version             0.0.20190905
 revision            0
-checksums           rmd160  1770c986502634e32f73755bbf991e2297226899 \
-                    sha256  1a1311bc71abd47a72c47d918be3bacc486b3de90734661858af75cc990dbaac \
-                    size    327632
+checksums           rmd160  e7a26b6abb2eea78eadb00108b5fdffe8af7966f \
+                    sha256  78767ceeb5286beaa851145f072d920a340a9f1b771a2943b8efd638cee1a8f6 \
+                    size    328440
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?