### PR TITLE
micronaut: update to 1.2.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.2.0 v
+github.setup    micronaut-projects micronaut-core 1.2.1 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  8b21d26aa7acf2d1ccd2a50c00a5c4802f25176f \
-                sha256  e349615499436919008ed936f1844e3816847ba14cabb47eec8b42c3c74415ea \
-                size    12924586
+checksums       rmd160  b214f264ca4480418385f45db2e358aaa9a22ca6 \
+                sha256  1493511d92fcf8c26849c25dab8e79b63a24ff05fc943dc3945c1d3529fb8751 \
+                size    12925809
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.2.1.

###### Tested on

macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?