### PR TITLE
ntpsec: update to 1.1.7

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -5,8 +5,7 @@ PortGroup           waf 1.0
 PortGroup           python 1.0
 
 name                ntpsec
-version             1.1.6
-revision            1
+version             1.1.7
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -19,9 +18,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  b539282b5d15c7541994c65ef24af1d890b25f9f \
-                    sha256  8d7c4e41206f7e23727b8b76e06ea0d7d5b13f0afe6ac4c52181c8522e38f79c \
-                    size    2600632
+checksums           rmd160  4f88807fc4652d2bb0608ca82df5b7e6be18eb63 \
+                    sha256  48eb3e0ed932fccc21373bc34a344b0c7164fda637f9b822b85b146f1aea398b \
+                    size    2534524
 
 depends_build       port:bison
 depends_lib         path:lib/libssl.dylib:openssl port:python${python.version}

--- a/sysutils/ntpsec/files/patch-PreHighSierra.diff
+++ b/sysutils/ntpsec/files/patch-PreHighSierra.diff
@@ -1,5 +1,5 @@
---- ./attic/backwards.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/backwards.c	2019-07-11 17:54:24.000000000 -0700
+--- ./attic/backwards.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./attic/backwards.c	2019-09-03 22:22:14.000000000 -0700
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- ./attic/clocks.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/clocks.c	2019-07-11 17:54:24.000000000 -0700
+--- ./attic/clocks.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./attic/clocks.c	2019-09-03 22:22:14.000000000 -0700
 @@ -5,6 +5,8 @@
  #include <stdio.h>
  #include <time.h>
@@ -20,8 +20,8 @@
  struct table {
    const int type;
    const char* name;
---- ./attic/digest-timing.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./attic/digest-timing.c	2019-07-11 17:54:24.000000000 -0700
+--- ./attic/digest-timing.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./attic/digest-timing.c	2019-09-03 22:22:14.000000000 -0700
 @@ -34,6 +34,8 @@
  #include <openssl/rand.h>
  #include <openssl/objects.h>
@@ -31,9 +31,9 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- ./include/ntp_machine.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_machine.h	2019-07-11 17:54:24.000000000 -0700
-@@ -13,14 +13,135 @@
+--- ./include/ntp_machine.h.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./include/ntp_machine.h	2019-09-03 22:22:14.000000000 -0700
+@@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
  /*
@@ -152,6 +152,16 @@
 +    }
 +}
 +
++/*
++ * Prototype for settimeofday() may suppressed by feature-test flags.
++ * Provide it here just in case, and get an error if it mismatches.
++ * Similarly, "struct timezone" definition may be suppressed, but the
++ * incomplete definition provided here is adequate given that the
++ * timezone argument is unused.
++ */
++struct timezone;
++int settimeofday(const struct timeval *, const struct timezone *);
++
 +static inline int clock_settime(clockid_t clk_id, const struct timespec *tp)
 +{
 +    switch (clk_id) {
@@ -175,9 +185,9 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- ./include/ntp_stdlib.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_stdlib.h	2019-07-11 17:54:24.000000000 -0700
-@@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
+--- ./include/ntp_stdlib.h.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./include/ntp_stdlib.h	2019-09-03 22:22:14.000000000 -0700
+@@ -96,7 +96,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
  extern	const char * res_access_flags(unsigned short);
@@ -187,8 +197,8 @@
  extern	char *	statustoa	(int, int);
  extern	sockaddr_u * netof6	(sockaddr_u *);
  extern	const char * socktoa	(const sockaddr_u *);
---- ./include/ntp_syscall.h.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./include/ntp_syscall.h	2019-07-11 17:54:24.000000000 -0700
+--- ./include/ntp_syscall.h.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./include/ntp_syscall.h	2019-09-03 22:22:14.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -201,8 +211,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- ./libntp/clockwork.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./libntp/clockwork.c	2019-07-11 17:54:24.000000000 -0700
+--- ./libntp/clockwork.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./libntp/clockwork.c	2019-09-03 22:22:14.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -216,8 +226,8 @@
  
  #include "ntp.h"
  #include "ntp_machine.h"
---- ./libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./libntp/statestr.c	2019-07-11 17:54:24.000000000 -0700
+--- ./libntp/statestr.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./libntp/statestr.c	2019-09-03 22:22:14.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -287,7 +297,7 @@
  
  /* Forwards */
  static const char *	getcode(int, const struct codestring *);
-@@ -314,10 +344,12 @@ decode_bitflags(
+@@ -318,10 +348,12 @@ decode_bitflags(
  		 "decode_bitflags(%s) can't decode 0x%x in %d bytes",
  		 (tab == peer_st_bits)
  		     ? "peer_st"
@@ -301,7 +311,7 @@
  			     "",
  		 (unsigned)bits, (int)LIB_BUFLENGTH);
  	errno = saved_errno;
-@@ -356,6 +388,7 @@ res_access_flags(
+@@ -360,6 +392,7 @@ res_access_flags(
  }
  
  
@@ -309,7 +319,7 @@
  const char *
  k_st_flags(
  	uint32_t st
-@@ -363,6 +396,8 @@ k_st_flags(
+@@ -367,6 +400,8 @@ k_st_flags(
  {
  	return decode_bitflags((int)st, " ", k_st_bits, COUNTOF(k_st_bits));
  }
@@ -318,9 +328,9 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ./ntpd/ntp_control.c.orig	2019-06-30 00:21:32.000000000 -0700
-+++ ./ntpd/ntp_control.c	2019-07-11 17:54:24.000000000 -0700
-@@ -1357,6 +1357,7 @@ ctl_putsys(
+--- ./ntpd/ntp_control.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./ntpd/ntp_control.c	2019-09-03 22:22:14.000000000 -0700
+@@ -1359,6 +1359,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
  	const char *ss;
@@ -328,7 +338,7 @@
  	static struct timex ntx;
  	static unsigned long ntp_adjtime_time;
  
-@@ -1372,6 +1373,7 @@ ctl_putsys(
+@@ -1374,6 +1375,7 @@ ctl_putsys(
  		else
                      ntp_adjtime_time = current_time;
  	}
@@ -336,7 +346,7 @@
  
  	switch (varid) {
  
-@@ -1767,50 +1769,93 @@ ctl_putsys(
+@@ -1769,50 +1771,93 @@ ctl_putsys(
  		break;
  
  		/*
@@ -442,8 +452,8 @@
  		break;
  
  	case CS_K_PPS_FREQ:
---- ./ntpd/ntp_loopfilter.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_loopfilter.c	2019-07-11 17:54:24.000000000 -0700
+--- ./ntpd/ntp_loopfilter.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./ntpd/ntp_loopfilter.c	2019-09-03 22:22:14.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -455,7 +465,7 @@
  
  /*
   * This is an implementation of the clock discipline algorithm described
-@@ -127,6 +129,7 @@ static void rstclock (int, double); /* t
+@@ -125,6 +127,7 @@ static void rstclock (int, double); /* t
  static double direct_freq(double); /* direct set frequency */
  static void set_freq(double);	/* set frequency */
  
@@ -463,7 +473,7 @@
  #ifndef PATH_MAX
  # define PATH_MAX MAX_PATH
  #endif
-@@ -140,6 +143,7 @@ static unsigned int loop_tai;	/* last TA
+@@ -138,6 +141,7 @@ static unsigned int loop_tai;	/* last TA
  #endif /* STA_NANO */
  static	void	start_kern_loop(void);
  static	void	stop_kern_loop(void);
@@ -471,7 +481,7 @@
  
  /*
   * Clock state machine control flags
-@@ -156,7 +160,9 @@ struct clock_control_flags clock_ctl = {
+@@ -154,7 +158,9 @@ struct clock_control_flags clock_ctl = {
  int	freq_cnt;		/* initial frequency clamp */
  
  static int freq_set;		/* initial set frequency switch */
@@ -481,7 +491,7 @@
  
  /*
   * Clock state machine variables
-@@ -174,6 +180,7 @@ static int sys_hufflen;		/* huff-n'-puff
+@@ -172,6 +178,7 @@ static int sys_hufflen;		/* huff-n'-puff
  static int sys_huffptr;		/* huff-n'-puff filter pointer */
  static double sys_mindly;	/* huff-n'-puff filter min delay */
  
@@ -489,7 +499,7 @@
  /* Emacs cc-mode goes nuts if we split the next line... */
  #define MOD_BITS (MOD_OFFSET | MOD_MAXERROR | MOD_ESTERROR | \
      MOD_STATUS | MOD_TIMECONST)
-@@ -183,7 +190,9 @@ static struct sigaction sigsys;	/* curre
+@@ -181,7 +188,9 @@ static struct sigaction sigsys;	/* curre
  static struct sigaction newsigsys; /* new sigaction status */
  static sigjmp_buf env;		/* environment var. for pll_trap() */
  #endif /* SIGSYS */
@@ -497,9 +507,9 @@
  
 +#ifdef HAVE_KERNEL_PLL
  static void
- sync_status(const char *what, int ostatus, int nstatus)
- {
-@@ -208,6 +217,7 @@ static char *file_name(void)
+ sync_status(const char *what, int ostatus, int nstatus) {
+ 	/* only used in non-lockclock case */
+@@ -205,6 +214,7 @@ static char *file_name(void) {
  	}
  	return this_file;
  }
@@ -507,7 +517,7 @@
  
  /*
   * init_loopfilter - initialize loop filter data
-@@ -223,6 +233,7 @@ init_loopfilter(void)
+@@ -219,6 +229,7 @@ init_loopfilter(void) {
  	freq_cnt = (int)clock_minstep;
  }
  
@@ -515,7 +525,7 @@
  /*
   * ntp_adjtime_error_handler - process errors from ntp_adjtime
   */
-@@ -421,6 +432,7 @@ or, from ntp_adjtime():
+@@ -417,6 +428,7 @@ or, from ntp_adjtime():
  	}
  	return;
  }
@@ -523,7 +533,7 @@
  
  /*
   * local_clock - the NTP logical clock loop filter.
-@@ -453,7 +465,9 @@ local_clock(
+@@ -450,7 +462,9 @@ local_clock(
  
  	int	rval;		/* return code */
  	int	osys_poll;	/* old system poll */
@@ -533,7 +543,7 @@
  	double	mu;		/* interval since last update */
  	double	clock_frequency; /* clock frequency */
  	double	dtemp, etemp;	/* double temps */
-@@ -705,6 +719,7 @@ local_clock(
+@@ -707,6 +721,7 @@ local_clock(
  		}
  	}
  
@@ -541,7 +551,7 @@
  	/*
  	 * This code segment works when clock adjustments are made using
  	 * precision time kernel support and the ntp_adjtime() system
-@@ -820,6 +835,7 @@ local_clock(
+@@ -823,6 +838,7 @@ local_clock(
  		}
  #endif /* STA_NANO */
  	}
@@ -549,7 +559,7 @@
  
  	/*
  	 * Clamp the frequency within the tolerance range and calculate
-@@ -929,8 +945,10 @@ adj_host_clock(
+@@ -934,8 +950,10 @@ adj_host_clock(
  	} else if (freq_cnt > 0) {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(1));
  		freq_cnt--;
@@ -558,9 +568,9 @@
  		offset_adj = 0.;
 +#endif /* HAVE_KERNEL_PLL */
  	} else {
- 		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(sys_poll));
+ 		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(clkstate.sys_poll));
  	}
-@@ -941,9 +959,11 @@ adj_host_clock(
+@@ -946,9 +964,11 @@ adj_host_clock(
  	 * set_freq().  Otherwise it is a component of the adj_systime()
  	 * offset.
  	 */
@@ -569,31 +579,31 @@
  		freq_adj = 0.;
  	else
 +#endif /* HAVE_KERNEL_PLL */
- 		freq_adj = drift_comp;
+ 		freq_adj = loop_data.drift_comp;
  
  	/* Bound absolute value of total adjustment to NTP_MAXFREQ. */
-@@ -1031,6 +1051,7 @@ set_freq(
+@@ -1037,6 +1057,7 @@ set_freq(
  
- 	drift_comp = freq;
+ 	loop_data.drift_comp = freq;
  	loop_desc = "ntpd";
 +#ifdef HAVE_KERNEL_PLL
  	if (clock_ctl.pll_control) {
  		int ntp_adj_ret;
  		ZERO(ntv);
-@@ -1043,10 +1064,12 @@ set_freq(
+@@ -1049,10 +1070,12 @@ set_freq(
  		    ntp_adjtime_error_handler(__func__, &ntv, ntp_adj_ret, errno, false, false, __LINE__ - 1);
  		}
  	}
 +#endif /* HAVE_KERNEL_PLL */
  	mprintf_event(EVNT_FSET, NULL, "%s %.6f PPM", loop_desc,
- 	    drift_comp * US_PER_S);
+ 	    loop_data.drift_comp * US_PER_S);
  }
  
 +#ifdef HAVE_KERNEL_PLL
  static void
  start_kern_loop(void)
  {
-@@ -1107,8 +1130,10 @@ start_kern_loop(void)
+@@ -1113,8 +1136,10 @@ start_kern_loop(void)
  	  	    "kernel time sync enabled");
  	}
  }
@@ -604,7 +614,7 @@
  static void
  stop_kern_loop(void)
  {
-@@ -1116,6 +1141,7 @@ stop_kern_loop(void)
+@@ -1122,6 +1147,7 @@ stop_kern_loop(void)
  		report_event(EVNT_KERN, NULL,
  		    "kernel time sync disabled");
  }
@@ -612,7 +622,7 @@
  
  
  /*
-@@ -1128,11 +1154,15 @@ select_loop(
+@@ -1134,11 +1160,15 @@ select_loop(
  {
  	if (clock_ctl.kern_enable == use_kern_loop)
  		return;
@@ -628,12 +638,12 @@
  	/*
  	 * If this loop selection change occurs after initial startup,
  	 * call set_freq() to switch the frequency compensation to or
-@@ -1186,10 +1216,12 @@ loop_config(
+@@ -1194,10 +1224,12 @@ loop_config(
  	 * variables. Otherwise, continue leaving no harm behind.
  	 */
  	case LOOP_DRIFTINIT:
 +#ifdef HAVE_KERNEL_PLL
- 		if (lockclock || clock_ctl.mode_ntpdate)
+ 		if (loop_data.lockclock || clock_ctl.mode_ntpdate)
  			break;
  
  		start_kern_loop();
@@ -641,7 +651,7 @@
  
  		/*
  		 * Initialize frequency if given; otherwise, begin frequency
-@@ -1207,11 +1239,14 @@ loop_config(
+@@ -1216,11 +1248,14 @@ loop_config(
  			rstclock(EVNT_FSET, 0);
  		else
  			rstclock(EVNT_NSET, 0);
@@ -653,10 +663,10 @@
  	case LOOP_KERN_CLEAR:
  #if 0		/* XXX: needs more review, and how can we get here? */
 +# ifdef HAVE_KERNEL_PLL
- 		if (!lockclock && (clock_ctl.pll_control && clock_ctl.kern_enable)) {
+ 		if (!loop_data.lockclock && (clock_ctl.pll_control && clock_ctl.kern_enable)) {
  			memset((char *)&ntv, 0, sizeof(ntv));
  			ntv.modes = MOD_STATUS;
-@@ -1221,6 +1256,7 @@ loop_config(
+@@ -1230,6 +1265,7 @@ loop_config(
  				pll_status,
  				ntv.status);
  		   }
@@ -664,7 +674,7 @@
  #endif
  		break;
  
-@@ -1299,7 +1335,7 @@ loop_config(
+@@ -1310,7 +1346,7 @@ loop_config(
  }
  
  
@@ -673,14 +683,14 @@
  /*
   * _trap - trap processor for undefined syscalls
   *
-@@ -1317,4 +1353,4 @@ pll_trap(
+@@ -1328,4 +1364,4 @@ pll_trap(
  	clock_ctl.pll_control = false;
  	siglongjmp(env, 1);
  }
 -#endif /* SIGSYS */
 +#endif /* HAVE_KERNEL_PLL && SIGSYS */
---- ./ntpd/ntp_timer.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/ntp_timer.c	2019-07-11 17:54:24.000000000 -0700
+--- ./ntpd/ntp_timer.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./ntpd/ntp_timer.c	2019-09-03 22:22:14.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -703,14 +713,14 @@
  #ifdef ENABLE_LEAP_SMEAR
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
---- ./ntpd/refclock_local.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpd/refclock_local.c	2019-07-11 17:54:24.000000000 -0700
+--- ./ntpd/refclock_local.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./ntpd/refclock_local.c	2019-09-03 22:22:14.000000000 -0700
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
  	 */
 +#ifdef HAVE_KERNEL_PLL
- 	if (lockclock) {
+ 	if (loop_data.lockclock) {
  		struct timex ntv;
  		memset(&ntv,  0, sizeof ntv);
 @@ -188,6 +189,13 @@ local_poll(
@@ -727,8 +737,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ./ntpfrob/precision.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./ntpfrob/precision.c	2019-07-11 17:54:24.000000000 -0700
+--- ./ntpfrob/precision.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./ntpfrob/precision.c	2019-09-03 22:22:14.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -737,8 +747,8 @@
  
  #define	DEFAULT_SYS_PRECISION	-99
  
---- ./tests/libntp/statestr.c.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./tests/libntp/statestr.c	2019-07-11 17:54:24.000000000 -0700
+--- ./tests/libntp/statestr.c.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./tests/libntp/statestr.c	2019-09-03 22:22:14.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -759,8 +769,8 @@
  }
  
  // statustoa
---- ./wafhelpers/bin_test.py.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wafhelpers/bin_test.py	2019-07-11 17:54:24.000000000 -0700
+--- ./wafhelpers/bin_test.py.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./wafhelpers/bin_test.py	2019-09-03 22:22:14.000000000 -0700
 @@ -91,6 +91,12 @@ def cmd_bin_test(ctx, config):
          for cmd in cmd_map3:
              cmd_map2[cmd] = cmd_map3[cmd]
@@ -774,8 +784,8 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd], False):
              fails += 1
---- ./wafhelpers/options.py.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wafhelpers/options.py	2019-07-11 17:54:24.000000000 -0700
+--- ./wafhelpers/options.py.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./wafhelpers/options.py	2019-09-03 22:22:14.000000000 -0700
 @@ -19,6 +19,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -785,8 +795,8 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- ./wscript.orig	2019-06-21 19:41:51.000000000 -0700
-+++ ./wscript	2019-07-11 17:54:24.000000000 -0700
+--- ./wscript.orig	2019-09-02 19:17:36.000000000 -0700
++++ ./wscript	2019-09-03 22:22:14.000000000 -0700
 @@ -593,7 +593,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
@@ -796,7 +806,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -795,6 +795,21 @@ int main(int argc, char **argv) {
+@@ -798,6 +798,21 @@ int main(int argc, char **argv) {
      ctx.define("HAVE_WORKING_FORK", 1,
                 comment="Whether a working fork() exists")
  


### PR DESCRIPTION
This includes the patches for compatibility with macOS<10.13,
which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports_1_1_7

TESTED:
Built and ran on MacPro 10.9, MacPro 10.14, MacBookPro 10.9,
PowerBook 10.5, and VMs for 10.5-10.13.  Built with default
variants, all single non-default variants, and all non-default
variants.

NOTE:
Does not address ticket 57272 (s/b low priority).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
