### PR TITLE
liboauth: switch to nss

### DIFF
--- a/net/liboauth/Portfile
+++ b/net/liboauth/Portfile
@@ -25,7 +25,9 @@ depends_build       port:autoconf \
                     port:libtool \
                     port:pkgconfig
 
-depends_lib         path:lib/libssl.dylib:openssl \
-                    port:curl
+depends_lib         port:curl \
+                    port:nss
+
+configure.args      --enable-nss
 
 livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION
liboauth did not build against openssl 1.1.1
closes: https://trac.macports.org/ticket/58957

this is a possible fix for this issue.
Port could perhaps be modified to build against newer openssl instead
upstream appears dormant on sourceforge

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

