### PR TITLE
sisc: use Java portgroup, mark as unsupported by upstream

### DIFF
--- a/lang/sisc/Portfile
+++ b/lang/sisc/Portfile
@@ -1,4 +1,9 @@
 PortSystem          1.0
+PortGroup           java 1.0
+PortGroup           deprecated 1.0
+
+# Last release (1.16.6) was on 2007-02-27
+deprecated.upstream_support no
 
 name                sisc
 version             1.16.6
@@ -18,7 +23,14 @@ checksums           md5     dda7b8bc5d998f1c37ef221c15ed0836 \
 worksrcdir          ${name}
 use_zip             yes
 use_configure       no
-depends_build       bin:ant:apache-ant \
+
+# Force Java 8 to be used; port will not build with Java 9 or later
+java.version        1.8
+java.fallback       openjdk8
+
+# Use Ant 1.10.x for Java 8 compatibility
+depends_build-append \
+                    port:apache-ant \
                     port:docbook-xsl-nons
 
 pre-build {

--- a/lang/sisc/Portfile
+++ b/lang/sisc/Portfile
@@ -1,56 +1,62 @@
-PortSystem	1.0
-name		sisc
-version		1.16.6
-categories	lang java scheme
-platforms	darwin
-maintainers	nomaintainer
-description	Second Interpreter of Scheme Code
-long_description	SISC is a Java based interpreter of Scheme.
-homepage	http://sisc.sourceforge.net/
-master_sites	sourceforge
-distfiles	${name}-${version}.jar
-checksums	md5 dda7b8bc5d998f1c37ef221c15ed0836 \
-		sha1 3301ede761cbb8841f457c50ea5ffccf02014777
-worksrcdir	${name}
-use_zip		yes
-use_configure	no
-depends_build	bin:ant:apache-ant port:docbook-xsl-nons
-pre-build	{
-	reinplace "s|/usr/share/xml/docbook/stylesheet/nwalsh/html|${prefix}/share/xsl/docbook-xsl-nons/html|" ${worksrcpath}/build.xml
+PortSystem          1.0
+
+name                sisc
+version             1.16.6
+categories          lang java scheme
+platforms           darwin
+maintainers         nomaintainer
+description         Second Interpreter of Scheme Code
+long_description    SISC is a Java based interpreter of Scheme.
+homepage            http://sisc.sourceforge.net/
+master_sites        sourceforge
+distfiles           ${name}-${version}.jar
+checksums           md5     dda7b8bc5d998f1c37ef221c15ed0836 \
+                    sha1    3301ede761cbb8841f457c50ea5ffccf02014777 \
+					rmd160  aa9bbd6b3c9d0a075508d9b33dc28c66cd1fa0ad \
+					sha256  771975b6b7c872b6fabe91850067f6a75b84737872deff9d5d0702df9eee4de0 \
+					size    1418512
+worksrcdir          ${name}
+use_zip             yes
+use_configure       no
+depends_build       bin:ant:apache-ant \
+                    port:docbook-xsl-nons
+
+pre-build {
+    reinplace "s|/usr/share/xml/docbook/stylesheet/nwalsh/html|${prefix}/share/xsl/docbook-xsl-nons/html|" ${worksrcpath}/build.xml
 }
-build.cmd	ant
-build.target	full-dist
-destroot	{
-	set siscdir ${worksrcpath}/dist/full/sisc-${version}
-	xinstall -m 755 ${siscdir}/sisc ${destroot}${prefix}/bin/sisc
-	reinplace "s|/usr/lib/sisc|\"${prefix}/share/java/sisc\"|" \
-		${destroot}${prefix}/bin/sisc
+build.cmd           ant
+build.target        full-dist
+destroot {
+    set siscdir ${worksrcpath}/dist/full/sisc-${version}
+    xinstall -m 755 ${siscdir}/sisc ${destroot}${prefix}/bin/sisc
+    reinplace "s|/usr/lib/sisc|\"${prefix}/share/java/sisc\"|" \
+        ${destroot}${prefix}/bin/sisc
 
-	xinstall -m 755 ${siscdir}/install-srfi22.sh \
-		${destroot}${prefix}/bin/install-srfi22.sh
-	reinplace "s|/usr/local/bin|${prefix}/bin|" \
-		${destroot}${prefix}/bin/install-srfi22.sh
-	reinplace "s|scheme-src|${prefix}/share/java/sisc/scheme-src|" \
-		${destroot}${prefix}/bin/install-srfi22.sh
+    xinstall -m 755 ${siscdir}/install-srfi22.sh \
+        ${destroot}${prefix}/bin/install-srfi22.sh
+    reinplace "s|/usr/local/bin|${prefix}/bin|" \
+        ${destroot}${prefix}/bin/install-srfi22.sh
+    reinplace "s|scheme-src|${prefix}/share/java/sisc/scheme-src|" \
+        ${destroot}${prefix}/bin/install-srfi22.sh
 
-	set javadir ${destroot}${prefix}/share/java/sisc
-	xinstall -d ${javadir}
-	file copy ${siscdir}/scheme-src ${javadir}
-	file copy ${siscdir}/sisc-lib.jar ${javadir}
-	file copy ${siscdir}/sisc-opt.jar ${javadir}
-	file copy ${siscdir}/sisc.jar ${javadir}
-	file copy ${siscdir}/sisc.shp ${javadir}
+    set javadir ${destroot}${prefix}/share/java/sisc
+    xinstall -d ${javadir}
+    file copy ${siscdir}/scheme-src ${javadir}
+    file copy ${siscdir}/sisc-lib.jar ${javadir}
+    file copy ${siscdir}/sisc-opt.jar ${javadir}
+    file copy ${siscdir}/sisc.jar ${javadir}
+    file copy ${siscdir}/sisc.shp ${javadir}
 
-	set docdir ${destroot}${prefix}/share/doc/sisc
-	xinstall -d ${docdir}
-	file copy ${siscdir}/ChangeLog ${docdir}
-	file copy ${siscdir}/COPYING ${docdir}
-	file copy ${siscdir}/GOALS ${docdir}
-	file copy ${siscdir}/README ${docdir}
-	file copy ${siscdir}/TODO ${docdir}
-	file copy ${siscdir}/doc ${docdir}
+    set docdir ${destroot}${prefix}/share/doc/sisc
+    xinstall -d ${docdir}
+    file copy ${siscdir}/ChangeLog ${docdir}
+    file copy ${siscdir}/COPYING ${docdir}
+    file copy ${siscdir}/GOALS ${docdir}
+    file copy ${siscdir}/README ${docdir}
+    file copy ${siscdir}/TODO ${docdir}
+    file copy ${siscdir}/doc ${docdir}
 
-	#put man page into place
-	file rename ${destroot}${prefix}/share/doc/sisc/doc/man/sisc.1 \
-		${destroot}${prefix}/share/man/man1/sisc.1
+    # put man page into place
+    file rename ${destroot}${prefix}/share/doc/sisc/doc/man/sisc.1 \
+        ${destroot}${prefix}/share/man/man1/sisc.1
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
