### PR TITLE
jython: use Ant 1.10.x for Java 8 compatibility

### DIFF
--- a/lang/jython/Portfile
+++ b/lang/jython/Portfile
@@ -62,7 +62,9 @@ if {![variant_isset installer]} {
     hg.url          https://hg.python.org/jython
     hg.tag          v${version}
 
-    depends_build   bin:ant:apache-ant
+    # Use Ant 1.10.x for Java 8 compatibility
+    depends_build-append \
+                    port:apache-ant
 
     build.cmd       ant
     build.target    developer-build


### PR DESCRIPTION
…instead of a possibly incompatible Ant version, such as 1.8 (included in older macOS versions).

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### ~~Tested on~~
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
~~macOS 10.x~~
~~Xcode 8.x~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
