### PR TITLE
isync: Add pkg-config dep to fix trace mode build

### DIFF
--- a/mail/isync/Portfile
+++ b/mail/isync/Portfile
@@ -24,7 +24,8 @@ checksums           rmd160  65ce1693e2eec5619fc9648e6c568eb4bf9679be \
                     sha256  68cb4643d58152097f01c9b3abead7d7d4c9563183d72f3c2a31d22bc168f0ea \
                     size    311868
 
-depends_build       port:perl5
+depends_build       port:perl5 \
+                    port:pkgconfig
 
 depends_lib         port:db53 \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

With the new OpenSSL version some symbols moved from libssl into libcrypto and are now no longer be found. However, isync's `configure.ac` uses pkg-config when it is available, and the output of pkg-config already contains `-lcrypto`, which avoids this issue.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
