### PR TITLE
py-clang: update clang80 variant to 8.0.1

### DIFF
--- a/python/py-clang/Portfile
+++ b/python/py-clang/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 # meta-version; bump whenever underlying clangs are updated. Needed to support
 # portindex (variants can't have different versions.)
-version                 2
+version                 3
 # Needed for change to meta-versioning
 epoch                   1
 name                    py-clang
@@ -46,14 +46,14 @@ if {${name} ne ${subport}} {
      cfe-7.0.1.src.tar.xz \
       rmd160  914adafed7c97e5ebab15a437670906c404cb8bd \
       sha256  a45b62dde5d7d5fdcdfa876b0af92f164d434b06e9e89b5d0b1cbc65dfe3f418 \
-     cfe-8.0.0.src.tar.xz \
-      rmd160  bd4dd523edcde136156b773cc66bfad1fc52dbc4 \
-      sha256  084c115aab0084e63b23eee8c233abb6739c399e29966eaeccfc6e088e0b736b \
+     cfe-8.0.1.src.tar.xz \
+      rmd160  8bec1ef0e0e49000886d8caed5ef42fb56a418b2 \
+      sha256  70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646 \
 
     depends_build-append    port:py${python.version}-setuptools
 
     set clanglist       {37    39    40    50    60    70    80}
-    set clangvlist      {3.7.1 3.9.1 4.0.1 5.0.2 6.0.1 7.0.1 8.0.0}
+    set clangvlist      {3.7.1 3.9.1 4.0.1 5.0.2 6.0.1 7.0.1 8.0.1}
 
     foreach cvnum $clanglist {
         # Explictly use (and depend on) the libclang we select during install
@@ -67,7 +67,8 @@ if {${name} ne ${subport}} {
         variant clang${cvnum} description {
                Use clang${cvnum}'s libclang
         } conflicts {*}${cflist} "
-            master_sites        https://releases.llvm.org/${clang_version}
+            master_sites        https://releases.llvm.org/${clang_version} \
+                                https://github.com/llvm/llvm-project/releases/download/llvmorg-${clang_version}
             depends_lib-append  port:clang-${cvstr}
             distfiles           cfe-${clang_version}.src.tar.xz
             worksrcdir          cfe-${clang_version}.src/bindings/python


### PR DESCRIPTION
Maintainer update.

See also: #5237 