### PR TITLE
wireguard-go: update to 0.0.20190908

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20190805
+version             0.0.20190908
 revision            0
-checksums           rmd160  f299e6d44951ddd01cdf5b20fe41ded580f82ec0 \
-                    sha256  2f56d2c4ebc3e50d581e92c046ebf3c884c703c4d5b3b484e45f55e50c0034da \
-                    size    76468
+checksums           rmd160  914f8e384c445af9fd749b7e7d36a7a74d5f79b9 \
+                    sha256  3c4cc802a521736d01d24bfb4fe29a5e74da07d69637ec7bcdee074decf62c6a \
+                    size    79212
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?