### PR TITLE
pingus: update to 20180714

### DIFF
--- a/games/pingus/Portfile
+++ b/games/pingus/Portfile
@@ -5,9 +5,9 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 PortGroup           cxx11 1.1
 
-github.setup        Pingus pingus 06afdabb6b27c1314bb1d90a05d467697b72be58
-version             0.8.0-20170511
-revision            2
+github.setup        Pingus pingus ad462706e5fc2cd5bf1cf99b2d90f88fe9e6de6e
+version             0.8.0-20180714
+revision            0
 categories          games
 platforms           darwin
 maintainers         nomaintainer
@@ -40,8 +40,11 @@ cmake.out_of_source yes
 
 configure.args      -DCMAKE_INSTALL_PREFIX:PATH="${applications_dir}/Pingus.app/Contents/MacOS"
 
+# boost no longer has the signals library
+patchfiles-append   patch-pingus-no-boost-signals.diff
+
 platform darwin powerpc {
-    patchfiles          patch-cmakelists-gnu14.diff
+    patchfiles-append    patch-cmakelists-gnu14.diff
 }
 
 pre-destroot {

--- a/games/pingus/files/patch-pingus-no-boost-signals.diff
+++ b/games/pingus/files/patch-pingus-no-boost-signals.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2019-09-09 22:54:52.000000000 -0700
++++ CMakeLists.txt	2019-09-09 22:55:04.000000000 -0700
+@@ -27,7 +27,7 @@
+ find_package(Threads REQUIRED)
+ find_package(PkgConfig REQUIRED)
+ find_package(OpenGL REQUIRED)
+-find_package(Boost COMPONENTS system filesystem signals REQUIRED)
++find_package(Boost COMPONENTS system filesystem REQUIRED)
+ 
+ pkg_search_module(SDL2 REQUIRED sdl2)
+ pkg_search_module(SDL2IMAGE REQUIRED SDL2_image>=2.0.0)


### PR DESCRIPTION
remove boost signals library from cmake tests
(no longer provided, and apparently not needed)

(running this past the ci system prior to committing)