### PR TITLE
OpenIPMI: update to 2.0.27 revbump for os<15

### DIFF
--- a/sysutils/OpenIPMI/Portfile
+++ b/sysutils/OpenIPMI/Portfile
@@ -5,9 +5,9 @@ PortGroup           conflicts_build 1.0
 name                OpenIPMI
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     version             2.0.19
-    revision            6
+    revision            7
 } else {
-    version             2.0.26
+    version             2.0.27
     revision            0
 }
 set branch          [join [lrange [split ${version} .] 0 1] .]
@@ -38,9 +38,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 15} {
                         configure.in.patch
 } else {
     checksums \
-        rmd160  2ee3c26183e0765af83a13ed0eea0c7cd90c16f9 \
-        sha256  83986368c30a1158303435ad5a2b1bd3c6a39664b46d10fc0b8f9d2a78e2f524 \
-        size    3124706
+        rmd160  386ca2973fe9f77420cf5dcd7ed06c82da1f51f6 \
+        sha256  f3b1fafaaec2e2bac32fec5a86941ad8b8cb64543470bd6d819d7b166713d20b \
+        size    3125193
     patchfiles          disable-lanserv.patch \
                         unix_posix_thread_os_hnd.c.patch \
                         unix_selector.c.patch


### PR DESCRIPTION
Maintainer update.

openssl dep needed revbump on os.major < 10.15; newer version available for recent OS also addresses dep change.