### PR TITLE
google-cloud-sdk: update to 262.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             261.0.0
+version             262.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  6b8cf88f47b1a2635b6f02b62187b41528cf6f6d \
-                    sha256  8e971ea5a1e5f391941ebfb53d740fe890a9f7d528516b883e9170b931ac4b55 \
-                    size    21609503
+checksums           rmd160  627cb2b46a840c5e87c97f870fbcd75fbc3fe931 \
+                    sha256  3654c502d0451a7b38b5391c6f2407b0d96895ebfea14098d321646eaec05297 \
+                    size    21774624
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 262.0.0.

###### Tested on

macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?