### PR TITLE
dmg2img: update to 1.6.7

### DIFF
--- a/sysutils/dmg2img/Portfile
+++ b/sysutils/dmg2img/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                dmg2img
-version             1.6.5
-revision            2
+version             1.6.7
+revision            0
 categories          sysutils
 maintainers         puredarwin.org:probono openmaintainer
 license             GPL-2
@@ -16,10 +16,11 @@ homepage            http://vu1tur.eu.org/tools/
 master_sites        ${homepage}
 platforms           darwin
 
-checksums           rmd160  437048d16e5887c79008f2023256dccd176b3192 \
-                    sha256  400a16cbe5cb2bf8a9eec4a43ef3546e0329f248bbd2a79f6d9a1ebc0b503308
+checksums           rmd160  4b3dfa6b02f39cbe1020605e3c32c06936df6852 \
+                    sha256  02aea6d05c5b810074913b954296ddffaa43497ed720ac0a671da4791ec4d018 \
+                    size    23238
 
-depends_lib         path:lib/libssl.dylib:openssl \
+depends_lib         port:openssl10 \
                     port:zlib \
                     port:bzip2
 
@@ -28,6 +29,9 @@ patchfiles          patch-Makefile
 use_configure       no
 
 variant universal {}
+
+configure.cflags-prepend   -I${prefix}/include/openssl-1.0
+configure.ldflags-prepend  -L${prefix}/lib/openssl-1.0
 
 build.env           CC=${configure.cc}
 build.args          CFLAGS+="${configure.cflags} [get_canonical_archflags cc]" \


### PR DESCRIPTION
force build against openssl 1.0.x
software needs to be updated to build against openssl 1.1.1
closes: https://trac.macports.org/ticket/59011

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
