### PR TITLE
gmt5: add a subport for gmt6

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -6,6 +6,12 @@ PortGroup           cmake 1.0
 name                gmt5
 version             5.4.5
 revision            0
+conflicts           gmt6
+subport gmt6 {
+    version         6.0.0rc4
+    revision        0
+    conflicts       gmt5
+}
 categories          science
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -30,9 +36,15 @@ use_xz              yes
 distname            gmt-${version}
 distfiles           ${distname}-src${extract.suffix}
 
-checksums           rmd160  900befd66ec4a9aea75c53d99ed83f7e25163e35 \
-                    sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
-                    size    59175704
+if {${subport} eq "gmt5"} {
+    checksums           rmd160  900befd66ec4a9aea75c53d99ed83f7e25163e35\
+                        sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
+                        size    59175704
+} else {
+    checksums           rmd160  c9d276100c5e78191ccbabd2ce084798a1f2046f \
+                        sha256  940ed0c49f18cd749edbe65ab84b28e2f6775b4529a71e9a8efd67bf94241b76 \
+                        size    65172968
+}
 
 depends_lib         port:dcw-gmt \
                     port:ghostscript \


### PR DESCRIPTION
#### Description

This PR add a subport for gmt6, so that users can install either gmt5 or gmt6 by:

```
port install gmt5
port install gmt6
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.5 18F132
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
