### PR TITLE
py-language-server: update to 0.28.3 and fix jedi requirement

### DIFF
--- a/python/py-language-server/Portfile
+++ b/python/py-language-server/Portfile
@@ -55,6 +55,10 @@ if {${subport} ne ${name}} {
     test.target
     test.env        PYTHONPATH=${worksrcpath}/build/lib
 
+    post-patch {
+        reinplace s|'jedi>=0.14.1,<0.15',|'jedi>=0.14.1',| ${worksrcpath}/setup.py
+    }
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}

--- a/python/py-language-server/Portfile
+++ b/python/py-language-server/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 PortGroup           select 1.0
 
-github.setup        palantir python-language-server 0.28.1
+github.setup        palantir python-language-server 0.28.3
 revision            0
 name                py-language-server
 categories-append   devel
@@ -17,9 +17,9 @@ long_description    ${description}
 platforms           darwin
 supported_archs     noarch
 
-checksums           rmd160  51dffc93120aad13ae083b610331e13011b9de72 \
-                    sha256  b9b3193231938ef6908a1d642a3a7dd088ec21622a5fa8d80ebc62ecc90ec4f6 \
-                    size    446276
+checksums           rmd160  41bba50f28d20dd17440ae09cb41d2c0181cec7f \
+                    sha256  c084a699b5ea3dfbe0c109adcb7f18ba5bdc417cc3edc535d802055311913a8a \
+                    size    445485
 
 python.versions     27 35 36 37
 


### PR DESCRIPTION
#### Description

In addition to the update, this fixes the current situation whereby pyls can't run due to a too-new version of jedi.

Running `port test py37-language-server` with the current py37-jedi port reveals no failures, and the [jedi changelog](https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst) indicates mostly additive changes, so this seems to be OK.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
