### PR TITLE
bash: update to patch level 11

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 
 name                bash
 set bash_version    5.0
-set bash_patchlevel 7
+set bash_patchlevel 11
 subport bash44 {
    set bash_version    4.4
    set bash_patchlevel 23
@@ -71,7 +71,23 @@ if {${subport} eq ${name}} {
                        bash50-007 \
                        rmd160  75f55a086cb11db8fb0faa001a7fe8d77b17b30f \
                        sha256  17b41e7ee3673d8887dd25992417a398677533ab8827938aa41fad70df19af9b \
-                       size    1640
+                       size    1640 \
+							  bash50-008 \
+							  rmd160  e4076df3d86bb750c2fd72766fcdf855a92b9269 \
+							  sha256  eec64588622a82a5029b2776e218a75a3640bef4953f09d6ee1f4199670ad7e3 \
+							  size    2622 \
+							  bash50-009 \
+							  rmd160  55a8d44d5ef731d4996bdf69dcf6a80105ca168e \
+							  sha256  ed3ca21767303fc3de93934aa524c2e920787c506b601cc40a4897d4b094d903 \
+							  size    1095 \
+							  bash50-010 \
+							  rmd160  40599f5fe2f5a9cfa9324cd31c0487166ff68f5a \
+							  sha256  d6fbc325f0b5dc54ddbe8ee43020bced8bd589ddffea59d128db14b2e52a8a11 \
+							  size    6407 \
+							  bash50-011 \
+							  rmd160  d2866cbdf4f5a8e1f79ff4795b6045a45bea4627 \
+							  sha256  2c4de332b91eaf797abbbd6c79709690b5cbd48b12e8dfe748096dbd7bf474ea \
+							  size    1870
 
 } elseif {${subport} eq "bash44"} {
    checksums           ${distname}${extract.suffix} \


### PR DESCRIPTION
#### Description
Update the bash port to the latest patch level.

###### Type(s)
- [x] bugfix
- [x] enhancement

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
