### PR TITLE
ImageMagick: repair openmp detection with clang

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -10,7 +10,7 @@ PortGroup                   conflicts_build 1.0
 
 name                        ImageMagick
 version                     6.9.9-40
-revision                    6
+revision                    7
 set reasonable_version      [lindex [split ${version} -] 0]
 homepage                    http://www.imagemagick.org/
 categories                  graphics devel
@@ -74,6 +74,10 @@ depends_lib-append          port:pkgconfig
 depends_run                 port:urw-fonts
 
 configure.ccache            no
+
+# repair default openmp detection with clang compilers
+# see https://trac.macports.org/ticket/57009
+patchfiles                  patch-imagemagick-configure-ac-libomp-typo.diff
 
 use_autoreconf              yes
 autoreconf.args             -fvi

--- a/graphics/ImageMagick/files/patch-imagemagick-configure-ac-libomp-typo.diff
+++ b/graphics/ImageMagick/files/patch-imagemagick-configure-ac-libomp-typo.diff
@@ -1,0 +1,14 @@
+--- configure.ac.old	2019-09-11 21:50:21.000000000 -0700
++++ configure.ac	2019-09-11 21:50:52.000000000 -0700
+@@ -1413,9 +1413,9 @@
+       fi
+     fi
+     # Clang (passes for GCC but uses different OpenMP implementation)
+-    if test "x$LIB_OMP" = x ; then
++    if test "x$GOMP_LIBS" = x ; then
+       if $CC --version 2>&1 | grep clang > /dev/null ; then
+-        AC_CHECK_LIB(omp,GOMP_parallel_start,LIB_OMP="-lomp",,)
++        AC_CHECK_LIB(omp,GOMP_parallel_start,GOMP_LIBS="-lomp",,)
+       fi
+     fi
+     # GCC


### PR DESCRIPTION
detecting openmp with clang compilers has always been broken
a minor typo in configure.ac has prevented detection
this bug is still in ImageMagick trunk

closes: https://trac.macports.org/ticket/57009
see also:  many other ImageMagick tickets

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8
Xcode 4.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?  (one of them).
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

This patch should go upstream.