### PR TITLE
ImageMagick: explicity disable openmp

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -10,7 +10,7 @@ PortGroup                   conflicts_build 1.0
 
 name                        ImageMagick
 version                     6.9.9-40
-revision                    6
+revision                    7
 set reasonable_version      [lindex [split ${version} -] 0]
 homepage                    http://www.imagemagick.org/
 categories                  graphics devel
@@ -107,7 +107,8 @@ configure.args              --enable-shared \
                             --without-lqr \
                             --without-pango \
                             --without-x \
-                            --with-gs-font-dir=${prefix}/share/fonts/urw-fonts
+                            --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \
+                            --disable-openmp
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     configure.args-append   --disable-opencl


### PR DESCRIPTION
ImageMagick's openmp detection is flawed, and manifests when build with newer llvm clang versions, resulting in flawed pkg-config files.

The issue can be reproduced on any system by installing ImageMagick using a macports clang compiler such as clang-8.0, and then trying to build something against ImageMagick like virtuoso-7.

Once openmp support in ImageMagick is properly sorted out, an openmp variant can be made available.

see: https://trac.macports.org/ticket/57009
see: https://trac.macports.org/ticket/24944


#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
