### PR TITLE
 opendkim: compile errors ; startupitem 

### DIFF
--- a/mail/opendkim/Portfile
+++ b/mail/opendkim/Portfile
@@ -30,8 +30,10 @@ post-patch {
         ${worksrcpath}/opendkim/opendkim.conf.simple-verify.in
 }
 
-configure.args      --with-openssl=${prefix} \
-                    --with-unbound=${prefix}
+# https://trac.macports.org/ticket/59024
+configure.args      --with-openssl=${prefix}/lib \
+                    --with-unbound=${prefix} \
+                    --with-milter=${prefix}
 
 destroot.keepdirs    ${destroot}${prefix}/var/db/${name} \
                      ${destroot}${prefix}/var/run/${name}
@@ -39,3 +41,7 @@ destroot.keepdirs    ${destroot}${prefix}/var/db/${name} \
 livecheck.url       http://sourceforge.net/projects/opendkim/files/
 livecheck.type      regex
 livecheck.regex     "${name}-(\\d+\\.\\d+(\[0-9rc.\]+)?)${extract.suffix}"
+
+# https://trac.macports.org/ticket/49648
+startupitem.create      yes
+startupitem.executable  ${prefix}/sbin/${name} -f


### PR DESCRIPTION
#### Description
Changes to be committed:
	modified:   mail/opendkim/Portfile

1) the configure arg for openssl is wrong
2) missing configure arg for libmilter
3) missing startupitem

resolves :
https://trac.macports.org/ticket/59024
https://trac.macports.org/ticket/49648

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G8030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
