### PR TITLE
redland-bindings: update to 1.0.17.1, add python3 variants

### DIFF
--- a/www/redland-bindings/Portfile
+++ b/www/redland-bindings/Portfile
@@ -1,8 +1,9 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
 
 name                redland-bindings
-version             1.0.16.1
-revision            1
+version             1.0.17.1
 description         Redland RDF Language Bindings
 long_description    Redland is a set of free software libraries that provide \
                     support for the Resource Description Framework (RDF). \
@@ -11,20 +12,17 @@ long_description    Redland is a set of free software libraries that provide \
 maintainers         nomaintainer
 categories          www
 platforms           darwin
+license             Apache-2
 homepage            http://librdf.org/bindings/
 master_sites        http://download.librdf.org/source/
 
-checksums           sha1    98c20b64cf5e99cbf29fcb84490e73e2a828213a \
-                    rmd160  0f4ac6f67fd2ddfa842dc82c52e5c380d9fc95d3
- 
+checksums           sha256  ff72b587ab55f09daf81799cb3f9d263708fad5df7a5458f0c28566a2563b7f5 \
+                    rmd160  e2604f0c10ab6922b06e26fa1f1d62a8e53f4b6b \
+                    size    933290
+
 depends_lib         port:redland
 
 pre-configure {
-    if {![variant_isset perl5] && ![variant_isset php5] && ![variant_isset python26] && ![variant_isset python27] && ![variant_isset ruby] && ![variant_isset tcl] && ![variant_isset lua]} {
-        ui_error "You must select at least one variant."
-        return -code error "no variant selected"
-    }
-
     foreach {badport badfile} "raptor ${prefix}/include/raptor.h" {
         if {[file exists ${badfile}]} {
             ui_error "${name} cannot be built while ${badport} is active."
@@ -35,35 +33,45 @@ pre-configure {
     }
 }
 
-variant perl5 {
-	depends_lib-append path:bin/perl:perl5
-	configure.args-append --with-perl
-	configure.perl ${prefix}/bin/perl
+if {![variant_isset perl5] && ![variant_isset php5] && ![variant_isset python27] && ![variant_isset python36] &&
+    ![variant_isset ruby] && ![variant_isset tcl] && ![variant_isset lua]} {
+        default_variants +python37
 }
 
-variant php5 {
-	configure.args-append --with-php
-	depends_lib-append path:bin/php:php5
+variant perl5 description {Include Perl 5 binding} {
+    depends_lib-append path:bin/perl:perl5
+    configure.args-append --with-perl
+    configure.perl ${prefix}/bin/perl
 }
 
-variant python26 conflicts python27 {
-	configure.args-append --with-python --with-python-ldflags="-Wl,-F. -Wl,-F. -bundle ${frameworks_dir}/Python.framework/Versions/2.6/Python"
-	depends_lib-append port:python26
+variant php5 description {Include PHP 5 binding} {
+    configure.args-append --with-php
+    depends_lib-append path:bin/php:php5
 }
 
-variant python27 conflicts python26 {
-	configure.args-append --with-python --with-python-ldflags="-Wl,-F. -Wl,-F. -bundle ${frameworks_dir}/Python.framework/Versions/2.7/Python"
-	depends_lib-append port:python27
+variant python27 conflicts python36 python37 description {Include Python 2.7 binding} {
+    configure.args-append --with-python=${prefix}/bin/python2.7 --with-python-ldflags="-Wl,-F. -Wl,-F. -bundle ${frameworks_dir}/Python.framework/Versions/2.7/Python"
+    depends_lib-append port:python27
 }
 
-variant ruby {
-	configure.args-append --with-ruby
-	depends_lib-append port:ruby
+variant python36 conflicts python27 python37 description {Include Python 3.6 binding} {
+    configure.args-append --with-python=${prefix}/bin/python3.6 --with-python-ldflags="-Wl,-F. -Wl,-F. -bundle ${frameworks_dir}/Python.framework/Versions/3.6/Python"
+    depends_lib-append port:python36
 }
 
-variant tcl {
-	configure.args-append --with-tcl
-	depends_lib-append port:tcl
+variant python37 conflicts python27 python36 description {Include Python 3.7 binding} {
+    configure.args-append --with-python=${prefix}/bin/python3.7 --with-python-ldflags="-Wl,-F. -Wl,-F. -bundle ${frameworks_dir}/Python.framework/Versions/3.7/Python"
+    depends_lib-append port:python37
+}
+
+variant ruby description {Include Ruby binding} {
+    configure.args-append --with-ruby
+    depends_lib-append port:ruby
+}
+
+variant tcl description {Include Tcl binding} {
+    configure.args-append --with-tcl
+    depends_lib-append port:tcl
 }
 
 variant lua description {Include Lua binding} {


### PR DESCRIPTION
* update to version 1.0.17.1
* add variants for python36, python37
* add variant descriptions and license to make port lint happy

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
