### PR TITLE
PortGroup python 1.0 : default to python37 ; remove py24 & py25 cruft

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -63,13 +63,13 @@ proc python_get_version {} {
 proc python_get_default_version {} {
     global python.versions
     if {[info exists python.versions]} {
-        if {27 in ${python.versions}} {
-            return 27
+        if {37 in ${python.versions}} {
+            return 37
         } else {
             return [lindex ${python.versions} end]
         }
     } else {
-        return 27
+        return 37
     }
 }
 
@@ -291,20 +291,10 @@ proc python_get_defaults {var} {
         prefix {
             global build_arch frameworks_dir
             set ret "${frameworks_dir}/Python.framework/Versions/${python.branch}"
-            if {${python.version} == 25 || (${python.version} == 24 &&
-                ![file isfile ${ret}/include/python${python.branch}/Python.h] &&
-                ([file isfile ${prefix}/include/python${python.branch}/Python.h]
-                || [string match *64* $build_arch]))} {
-                set ret $prefix
-            }
             return $ret
         }
         bin {
-            if {${python.version} != 24} {
-                return "${python.prefix}/bin/python${python.branch}"
-            } else {
-                return "${prefix}/bin/python${python.branch}"
-            }
+            return "${prefix}/bin/python${python.branch}"
         }
         include {
             set inc_dir "${python.prefix}/include/python${python.branch}"
@@ -325,46 +315,22 @@ proc python_get_defaults {var} {
             }
         }
         lib {
-            if {${python.version} != 24 && ${python.version} != 25} {
-                return "${python.prefix}/Python"
-            } else {
-                return "${prefix}/lib/libpython${python.branch}.dylib"
-            }
+            return "${prefix}/lib/libpython${python.branch}.dylib"
         }
         pkgd {
-            if {${python.version} != 24} {
-                return "${python.prefix}/lib/python${python.branch}/site-packages"
-            } else {
-                return "${prefix}/lib/python${python.branch}/site-packages"
-            }
+            return "${prefix}/lib/python${python.branch}/site-packages"
         }
         setup_args {
-            if {${python.version} != 24} {
-                return "--no-user-cfg"
-            } else {
-                return ""
-            }
+            return "--no-user-cfg"
         }
         setup_prefix {
-            if {${python.version} != 24} {
-                return "${python.prefix}"
-            } else {
-                return "${prefix}"
-            }
+            return "${python.prefix}"
         }
         link_binaries {
-            if {${python.version} != 24 && ${python.version} != 25} {
-                return yes
-            } else {
-                return no
-            }
+            return yes
         }
         move_binaries {
-            if {${python.version} == 24 || ${python.version} == 25} {
-                return yes
-            } else {
-                return no
-            }
+            return no
         }
         binary_suffix {
             if {[string match py-* [option name]]} {


### PR DESCRIPTION
Changes to be committed:
	modified:   _resources/port1.0/group/python-1.0.tcl

- setting python37 as the default variant instead of python27
- remove remove old no longer needed py24 & py25 cruft as neither any longer is in macports

The reason for py27 -> py37 is, that py27 has been on the deathbed for several years now; and is being EOLed in 2020

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
