### PR TITLE
py-gsd: update to 1.8.1

### DIFF
--- a/python/py-gsd/Portfile
+++ b/python/py-gsd/Portfile
@@ -4,13 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        glotzerlab gsd 1.7.0 v
+github.setup        glotzerlab gsd 1.8.1 v
 name                py-gsd
 categories-append   science
 platforms           darwin
 license             BSD
 
 python.versions     27 36 37
+python.default_version 37
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 
@@ -20,9 +21,9 @@ long_description    ${description} \
 
 homepage            https://gsd.readthedocs.io/
 
-checksums           rmd160  d60cecfbffcb6c19382f814150e7c5795b876007 \
-                    sha256  de0eb4b1de8b633ed3ac045301f0564e0e676e582358a8d63ab2e8409bc32c8a \
-                    size    247106
+checksums           rmd160  da5285585d92dd49fd9980ded7da9484de5b3836 \
+                    sha256  573d8c534429ebb00668938e96d5c1949b76fe51a1a54de911850d9454f73e9e \
+                    size    167783
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-cython \
@@ -37,6 +38,14 @@ if {${name} ne ${subport}} {
         test.cmd            nosetests-${python.branch}
         test.target
     } else {
+        version             1.7.0
+        master_sites        https://github.com/glotzerlab/gsd/archive/
+        distname            v1.7.0
+        worksrcdir          gsd-1.7.0
+        checksums           rmd160  ec92677fb4ed0321205e238c06c8f58ad5054be4 \
+                            sha256  2e6e8d7cd6e9786b3d0594318fc665ab11cd5963d5bac115081eb46a3f4acca7 \
+                            size    247039
+
         test.run            no
     }
 


### PR DESCRIPTION
#### Description

update to 1.8.1.

Note: this version removed support for python 2. Is there a recommended way to handle this in the Portfile? So far I just removed 27 from the list of python versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.11.6 15G22010
Xcode 8.1 8B62 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
