### PR TITLE
graalvm: update to 19.2.0.1

### DIFF
--- a/java/graalvm/Portfile
+++ b/java/graalvm/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 name             graalvm
-version          19.2.0
+version          19.2.0.1
 revision         0
 
 categories       java devel
@@ -21,9 +21,9 @@ homepage         https://www.graalvm.org/
 
 master_sites     https://github.com/oracle/graal/releases/download/vm-${version}/
     
-checksums        rmd160  9f62f72b6a5bd6996f4fb4a0e46d0e642738ef10 \
-                 sha256  54bd7f7398ee0fb2d1c9eb8a939a5ccb05166cb9c544bc700020fc37dc661483 \
-                 size    347941204
+checksums        rmd160  36ddd552bfe8fa1dc76d83e40cbe35ccdc3eec17 \
+                 sha256  5973bd9899d6c23d640fbfe00e9f65a9e250e2ca1fc58a28e8e0d87879bd5c71 \
+                 size    347950241
 
 distname         ${name}-ce-darwin-amd64-${version}
 worksrcdir       ${name}-ce-${version}


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 19.2.0.1.

###### Tested on

macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?