### PR TITLE
stack: Self-referential Portfile using portgroup haskell_stack

### DIFF
--- a/_resources/port1.0/group/haskell_stack-1.0.tcl
+++ b/_resources/port1.0/group/haskell_stack-1.0.tcl
@@ -53,7 +53,10 @@ proc haskell_stack.system_ghc_flags {} {
 }
 
 proc haskell_stack.add_dependencies {} {
-    depends_build-append port:stack
+    global name
+    if { ${name} ne "stack" } { 
+        depends_build-append port:stack
+    }
     if {[option haskell_stack.system_ghc]} {
         depends_build-append port:ghc
     }

--- a/lang/stack/Portfile
+++ b/lang/stack/Portfile
@@ -3,8 +3,10 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           gpg_verify 1.0
+PortGroup           haskell_stack 1.0
 
 github.setup        commercialhaskell stack 2.1.3 v
+revision            1
 
 name                stack
 categories          lang haskell
@@ -21,29 +23,40 @@ long_description    ${description}. \
 
 homepage            https://haskellstack.org
 
-variant bootstrap \
-	    description {Bootstrap a build of stack.} {}
-
-# make bootstrapping the default
-default_variants    +bootstrap
-
-master_sites        ${github.homepage}/releases/download/v${github.version}
+variant prebuilt \
+	    description {Do not bootstrap stack; install the pre-built binary.} {}
 
 distname            ${name}-${github.version}-osx-x86_64
 
-checksums           ${distfiles} \
+worksrcdir          ${name}-${github.version}
+
+set worksrcpath_prebuilt \
+                    ${workpath}/${distname}
+
+master_sites        \
+                    ${github.homepage}/releases/download/v${github.version} \
+                    ${github.homepage}/archive
+
+distfiles           \
+                    ${distname}${extract.suffix} \
+                    v${github.version}${extract.suffix}
+
+checksums           \
+                    [lindex ${distfiles} 0]\
                     rmd160  241f94e06add584b0b5883d7f68b7cc26a866749 \
                     sha256  84b05b9cdb280fbc4b3d5fe23d1fc82a468956c917e16af7eeeabec5e5815d9f \
-                    size    8329540
-
-extract.only        ${distfiles}
+                    size    8329540 \
+                    [lindex ${distfiles} 1] \
+                    rmd160  cee14c9989a7b4225ddf5f58408c4399e4b2f36a \
+                    sha256  6a5b07e06585133bd385632c610f38d0c225a887e1ccb697ab09fec387838976 \
+                    size    820569
 
 gpg_verify.use_gpg_verification \
                     yes
 
 if {[option gpg_verify.use_gpg_verification]} {
     distfiles-append \
-                    ${distfiles}.asc
+                    [lindex ${distfiles} 0].asc
     checksums-append \
                     [lindex ${distfiles} end] \
                     size    488
@@ -59,76 +72,28 @@ if {[option gpg_verify.use_gpg_verification]} {
     }
 }
 
-if {[variant_isset "bootstrap"]} {
-    master_sites-append \
-                    ${github.homepage}/archive
-    distfiles-append \
-                    v${github.version}${extract.suffix}
-    checksums-append \
-                    [lindex ${distfiles} end] \
-                    rmd160  cee14c9989a7b4225ddf5f58408c4399e4b2f36a \
-                    sha256  6a5b07e06585133bd385632c610f38d0c225a887e1ccb697ab09fec387838976 \
-                    size    820569
-    extract.only-append \
-                    [lindex ${distfiles} end]
-}
-
 supported_archs     x86_64
 
-set system_gcc      /usr/bin/gcc
+if { [variant_isset "prebuilt"] } {
+    use_configure   no
 
-use_configure       no
+    build {}
 
-# the PATH environment must provide /usr/bin/gcc, not ${prefix}/bin/gcc
-# note: this command does not change the destroot PATH environment, so export
-# PATH explicitly in the necessary system command below
-build.env \
-    PATH=/usr/bin:$env(PATH) \
-    PREFIX=${prefix} \
-    CC=${system_gcc}
-
-# stack must bootstrap itself
-# See: https://docs.haskellstack.org,
-#      https://github.com/commercialhaskell/stack/blob/master/doc/README.md
-pre-build {
-    # standard stack install with 'curl | sh'; don't use
-    # system -W ${worksrcpath} "/bin/mkdir ./bin && /usr/bin/curl -sSL https://get.haskellstack.org/ | /bin/sh -s - -d ./bin"
-    # copy the pre-built ./stack binary to ./bin, then write over if bootstrapping
-    xinstall -W ${worksrcpath} -d ./bin
-    xinstall -m 0755 -W ${worksrcpath} ./${name} ./bin
-}
-
-if {[variant_isset "bootstrap"]} {
-    build {
-        # build stack and overwrite ${worksrcpath}/bin/${name}
-        xinstall -m 0755 -d ${workpath}/.${name}
-        system -W ${worksrcpath}/../${name}-${github.version} "\
-            export PATH=/usr/bin:$env(PATH) \
-                PREFIX=${prefix} \
-                CC=${system_gcc} ; \
-            ${worksrcpath}/bin/${name} setup \
-                --stack-root ${workpath}/.${name} --with-gcc ${system_gcc} \
-                --allow-different-user \
-            && ${worksrcpath}/bin/${name} build \
-                --stack-root ${workpath}/.${name} --with-gcc ${system_gcc} \
-                --allow-different-user \
-            "
-        delete ${worksrcpath}/${name}
-        system -W ${worksrcpath}/../${name}-${github.version} "\
-            export PATH=/usr/bin:$env(PATH) \
-                PREFIX=${prefix} \
-                CC=${system_gcc} ; \
-            ${worksrcpath}/bin/${name} install \
-                --stack-root ${workpath}/.${name} --with-gcc ${system_gcc} \
-                --local-bin-path ${worksrcpath} --allow-different-user \
-            "
-        delete ${worksrcpath}/bin/${name}
-        copy ${worksrcpath}/${name} ${worksrcpath}/bin/${name}
+    destroot {
+        xinstall -m 0755 -W ${workpath}/${distname} \
+            ./${name} ${destroot}${prefix}/bin
     }
 } else {
-    build {}
-}
+    post-extract {
+        xinstall -m 0755 -d "[option haskell_stack.stack_root]"
 
-destroot {
-    xinstall -m 0755 -W ${worksrcpath} ./bin/${name} ${destroot}${prefix}/bin
+        # standard stack install with 'curl | sh'; don't use
+        # system -W ${worksrcpath} "/bin/mkdir ./bin && /usr/bin/curl -sSL https://get.haskellstack.org/ | /bin/sh -s - -d ./bin"
+        # copy the pre-built ./stack binary to ./bin, then bootstrap
+        xinstall -W ${workpath} -d ./bin
+        xinstall -m 0755 -W ${worksrcpath_prebuilt} \
+            ./${name} ${workpath}/bin
+    }
+
+    set haskell_stack.bin ${workpath}/bin/stack
 }


### PR DESCRIPTION
stack: Self-referential Portfile using portgroup haskell_stack

* Add port stack to portgroup haskell_stack
* Modify portgroup haskell_stack dependencies to exclude stack

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->