### PR TITLE
Remove myself (cdeil) as maintainer

### DIFF
--- a/python/py-gammapy/Portfile
+++ b/python/py-gammapy/Portfile
@@ -11,7 +11,7 @@ version             0.7
 categories-append   science
 platforms           darwin
 license             BSD
-maintainers         {gmail.com:Deil.Christoph @cdeil} openmaintainer
+maintainers         nomaintainer
 
 description         A Python package for gamma-ray astronomy
 long_description    ${description}

--- a/python/py-pyregion/Portfile
+++ b/python/py-pyregion/Portfile
@@ -10,7 +10,7 @@ name                py-${_name}
 version             2.0
 categories-append   science
 platforms           darwin
-maintainers         {gmail.com:Deil.Christoph @cdeil} openmaintainer
+maintainers         nomaintainer
 
 description         pyregion is a Python module to parse ds9 region files
 long_description    ${description}

--- a/python/py-regions/Portfile
+++ b/python/py-regions/Portfile
@@ -10,7 +10,7 @@ name                py-${_name}
 version             0.3
 categories-append   science
 platforms           darwin
-maintainers         {gmail.com:Deil.Christoph @cdeil} openmaintainer
+maintainers         nomaintainer
 
 description         Astropy affilated package for region handling
 long_description    ${description}

--- a/python/py-reproject/Portfile
+++ b/python/py-reproject/Portfile
@@ -10,7 +10,7 @@ name                py-${_name}
 version             0.4
 categories-append   science
 platforms           darwin
-maintainers         {gmail.com:Deil.Christoph @cdeil} openmaintainer
+maintainers         nomaintainer
 
 description         Astropy affiliated package for image reprojection
 long_description    ${description}


### PR DESCRIPTION
In this PR I remove myself as maintainer, setting `nomaintainer` for four Python ports.

I switched to using conda two or three years ago, so it doesn't make sense that I'm still listed as maintainer for these ports.

I had used Macports for many years and it served me well. Thank you all!