### PR TITLE
p5.28-dbd-mysql: Update: Add subports from variants

### DIFF
--- a/perl/p5-dbd-mysql/Portfile
+++ b/perl/p5-dbd-mysql/Portfile
@@ -5,6 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
 perl5.setup         DBD-mysql 4.050
+revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl5 Database Interface to the MySQL database
@@ -15,6 +16,24 @@ platforms           darwin
 checksums           rmd160  00ac33c18ab9560e3cf82c15d97510373e1f29e5 \
                     sha256  4f48541ff15a0a7405f76adc10f81627c33996fbf56c95c26c094444c0928d78 \
                     size    161579
+
+
+# Create subports to be used with dependencies,
+# to get the correct variant.
+set subports [list mysql4 mysql5 mysql51 mysql55 mysql56 mysql57 mariadb mariadb-10.0 mariadb-10.1 mariadb-10.2 percona]
+
+foreach sp ${subports} {
+    perl5.create_subports ${perl5.branches} dbd-mysql-${sp}
+}
+
+if {${subport} != 0} {
+    set base_string "p${perl5.major}-dbd-mysql-"
+    set base_var [string replace "${subport}" 0 [string length ${base_string}]-1]
+    set maria_var [regsub {([.])} ${base_var} {_}]  ;# clean up the mariadb string
+
+    default_variants +[string replace "${maria_var}" 7 7]
+}
+
 
 if {${perl5.major} != ""} {
 # use Time::HiRes 1.9739+ for Sierra compatibility


### PR DESCRIPTION
#### Description

Since we can't pass along variants for dependencies, we need subports instead - which makes it more functional to add a dependency and get the correct `+variant`.

Example: `port install p5.28-dbd-mysql-percona` will set `+percona` as default variant.

_Didn't know what to do about versioning, so I added a `revision 1`._


###### Type(s)

- [x] enhancement
- [x] update

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
