### PR TITLE
websocat: build with SSL

### DIFF
--- a/net/websocat/Portfile
+++ b/net/websocat/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        vi websocat 1.5.0 v
+revision            1
 
 categories          net
 license             MIT
@@ -14,6 +15,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
 description         Netcat, curl and socat for WebSockets.
 long_description    Command-line client for web sockets, like \
                     netcat/curl/socat for ws://. 
+
+depends_lib-append  path:lib/libssl.dylib:openssl
+build.args          --features=ssl
 
 destroot {
     xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
Enables SSL feature for `websocat`.

Addresses https://trac.macports.org/ticket/59033

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
