### PR TITLE
man-db: update to 2.8.7

### DIFF
--- a/textproc/man-db/Portfile
+++ b/textproc/man-db/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 
 name                man-db
-version             2.8.5
+version             2.8.7
 categories          textproc
 platforms           darwin linux
 license             GPL-3+
 maintainers         {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
 description         Modern, featureful implementation of the Unix man page system.
 homepage            http://man-db.nongnu.org
-master_sites        https://download.savannah.nongnu.org/releases/man-db/
+master_sites        https://quantum-mirror.hu/mirrors/pub/gnusavannah/man-db/
 use_xz              yes
+use_autoreconf      yes
+autoreconf.args     --install --verbose --force
 
 long_description    man-db is an implementation of the standard Unix documentation \
     system accessed using the man command. It uses a Berkeley DB database in place \
@@ -19,17 +21,16 @@ long_description    man-db is an implementation of the standard Unix documentati
     Linux distributions, including: Arch, Debian, Dragora, Fedora, Gentoo, openSUSE, \
     and Ubuntu.
 
-checksums           rmd160   20caab5f9584a27487f117802a3601e7d0a28525 \
-                    sha256   b64d52747534f1fe873b2876eb7f01319985309d5d7da319d2bc52ba1e73f6c1 \
-                    size     1787244
+checksums           rmd160   dd933f76d09159d3e4de25b1efcbec390874d208 \
+                    sha256   b9cd5bb996305d08bfe9e1114edc30b4c97be807093b88af8033ed1cf9beb326 \
+                    size     1839012
 
 depends_lib         port:libpipeline
-depends_build       port:pkgconfig
+depends_build       port:pkgconfig \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
 
 configure.args      --prefix=${prefix} \
-                    --with-systemdtmpfilesdir=no \
-                    --with-systemdsystemunitdir=no \
                     --disable-cache-owner \
                     --disable-setuid
-
-build.args-append CFLAGS="-Wl,-flat_namespace,-undefined,suppress"


### PR DESCRIPTION
#### Description

Updates `man-db` to 2.8.7, optimizing the Portfile accordingly. I changed the `master_sites` because sometimes https://download.savannah.nongnu.org/releases/man-db/man-db-2.8.7.tar.xz redirects to https://bigsearcher.com/mirrors/nongnu/man-db/man-db-2.8.7.tar.xz, which is a 404.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
