### PR TITLE
bfs: update to 1.5.1

### DIFF
--- a/sysutils/bfs/Portfile
+++ b/sysutils/bfs/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        tavianator bfs 1.5
+github.setup        tavianator bfs 1.5.1
 
 categories          sysutils
 platforms           darwin freebsd linux
@@ -16,9 +16,9 @@ long_description    bfs is a variant of the UNIX find command that operates brea
     versions of find, including: POSIX find, GNU find, BSD find and macOS find. \
     If you're not familiar with find, the GNU find manual provides a good introduction.
 
-checksums           rmd160   ff86f437b927f7e63abd841c4be0e37dbcebe582 \
-                    sha256   d7dfb4196ed1a5837cd3dff021a7cd3b85b28f6520ea1ce8e5b2067936606756 \
-                    size     110687
+checksums           rmd160   fb2eb5e5af44d23ceae31b9e690b63bcaae02377 \
+                    sha256   654a00a3fe15dbfaa0e5db38dfd75aefff825c032464f2dbc1f548701cb4ac44 \
+                    size     113871
 
 use_configure       no
 build.target        release


### PR DESCRIPTION
#### Description

Updates the `bfs` port to 1.5.1, a minor update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
