### PR TITLE
pothosflow: enable hidpi and avoid dark mode

### DIFF
--- a/science/PothosFlow/Portfile
+++ b/science/PothosFlow/Portfile
@@ -30,3 +30,6 @@ depends_lib-append \
 
 configure.args-append \
     -DBUNDLE_DESTINATION=${applications_dir}
+
+patchfiles-append \
+    patch-info.plist.diff

--- a/science/PothosFlow/files/patch-info.plist.diff
+++ b/science/PothosFlow/files/patch-info.plist.diff
@@ -1,0 +1,75 @@
+From 9ab626f33b7a956c4c911b3deed501739264ee70 Mon Sep 17 00:00:00 2001
+From: Davide Gerhard <rainbow@irh.it>
+Date: Fri, 26 Apr 2019 08:46:45 +0200
+Subject: [PATCH] enable dark mode on MacOS Mojave
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CMake’s default Info.plist, tested on 3.13.3, is lacking the
+NSPrincipalClass key which enable dark mode on macos mojave.
+Unfortunately, the only way that I know is to create a new template
+file. Also add support for GPU automatic switching.
+---
+ CMakeLists.txt                          |  2 ++
+ cmake/Modules/MacOSXBundleInfo.plist.in | 36 +++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+ create mode 100644 cmake/Modules/MacOSXBundleInfo.plist.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ffe286e..980b83d 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -4,6 +4,8 @@
+ cmake_minimum_required(VERSION 2.8.9)
+ project(PothosFlow CXX)
+ 
++set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
++
+ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+     find_package(Pothos "0.6.0" CONFIG REQUIRED)
+ else()
+diff --git a/cmake/Modules/MacOSXBundleInfo.plist.in b/cmake/Modules/MacOSXBundleInfo.plist.in
+new file mode 100644
+index 0000000..3f7512e
+--- /dev/null
++++ cmake/Modules/MacOSXBundleInfo.plist.in
+@@ -0,0 +1,38 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++	<key>CFBundleDevelopmentRegion</key>
++	<string>English</string>
++	<key>CFBundleExecutable</key>
++	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
++	<key>CFBundleGetInfoString</key>
++	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
++	<key>CFBundleIconFile</key>
++	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
++	<key>CFBundleIdentifier</key>
++	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
++	<key>CFBundleInfoDictionaryVersion</key>
++	<string>6.0</string>
++	<key>CFBundleLongVersionString</key>
++	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
++	<key>CFBundleName</key>
++	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
++	<key>CFBundlePackageType</key>
++	<string>APPL</string>
++	<key>CFBundleShortVersionString</key>
++	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
++	<key>CFBundleVersion</key>
++	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
++	<key>CSResourcesFileMapped</key>
++	<true/>
++	<key>NSHumanReadableCopyright</key>
++	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
++        <key>NSPrincipalClass</key>
++        <string>NSApplication</string>
++        <key>NSSupportsAutomaticGraphicsSwitching</key>
++        <true/>
++        <key>NSRequiresAquaSystemAppearance</key>
++        <string>True</string>
++</dict>
++</plist>


### PR DESCRIPTION
#### Description

- enable HiDPI resolution
- avoid dark mode; in graphs and other visual objects it doesn't work
  correctly

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
