### PR TITLE
iTerm2: update version to 3.3.4

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -16,11 +16,11 @@ if {[vercmp ${os.version} 17.0.0] < 0} {
         size    11969144
     patchfiles          patch-Makefile.diff
 } else {
-    version             3.3.2
+    version             3.3.4
     checksums \
-        rmd160  53f3dca62ca0b87ab493d636a63bc6d12d4f4f39 \
-        sha256  a1cd5130879a8a91c0be91557995968a924d0089ce9af27c70242937ea895dd5 \
-        size    18783370
+        rmd160  7b50a8adc8ebb70218f1d386b5964d51fae52fe6 \
+        sha256  c1805a79a7654a00b47fbbc37b4814d9b832f759536da8ffec382ef936f8a8bd \
+        size    18809046
     patchfiles          patch-Makefile-XC10.diff
 }
 


### PR DESCRIPTION
#### Description

- bump version to 3.3.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
