### PR TITLE
wireguard-tools: update to 0.0.20190913

### DIFF
--- a/net/wireguard-tools/Portfile
+++ b/net/wireguard-tools/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-tools
-version             0.0.20190905
+version             0.0.20190913
 revision            0
-checksums           rmd160  e7a26b6abb2eea78eadb00108b5fdffe8af7966f \
-                    sha256  78767ceeb5286beaa851145f072d920a340a9f1b771a2943b8efd638cee1a8f6 \
-                    size    328440
+checksums           rmd160  c12a9519efe753f74c3851bbd37632e7147a1622 \
+                    sha256  997327185d2d1b597dc118f737c0c165e2a2c21453387ea02659f1159d148518 \
+                    size    330788
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
###### Tested on
macOS 10.14.6 18G84
Xcode 10.3 10G8

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
