### PR TITLE
aircrack-ng: update version to 1.5.2

### DIFF
--- a/security/aircrack-ng/Portfile
+++ b/security/aircrack-ng/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 epoch               1
-github.setup        aircrack-ng aircrack-ng 1.4
-revision            1
-checksums           rmd160  29353d7ec9052916ee3429e18ea04f01ab535f75 \
-                    sha256  96092a8af7af27cdc1923cd5167dfca4a17e9f5fd866973b7b6eb6d3b479e13b \
-                    size    7138756
+github.setup        aircrack-ng aircrack-ng 1.5.2
+revision            0
+checksums           rmd160  b95a3413b8949ad604e845a8e0f52a650bee7e62 \
+                    sha256  9e592fe7658046220e0ac0a6d05c4026903f3077b248893e0056ccbe4ee88241 \
+                    size    7138360
 
 categories          security
 license             GPL-2+ BSD OpenSSL
@@ -33,8 +33,7 @@ depends_build       port:autoconf \
                     port:automake \
                     port:gmake \
                     port:libtool \
-                    port:pkgconfig \
-                    port:python36
+                    port:pkgconfig
 
 depends_lib         port:libpcap \
                     path:lib/libssl.dylib:openssl \
@@ -56,8 +55,6 @@ configure.args      --disable-silent-rules \
                     --without-ext-scripts \
                     --without-gcrypt \
                     --without-xcode
-configure.python    ${prefix}/bin/python3.6
-configure.env       PYTHON_CONFIG=${configure.python}-config
 
 build.cmd           ${prefix}/bin/gmake
 


### PR DESCRIPTION


#### Description

- bump version to 1.5.2
- remove python; not needed seen that we disable ext-scripts

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
