### PR TITLE
ccache update version to 3.7.4

### DIFF
--- a/devel/ccache-devel/Portfile
+++ b/devel/ccache-devel/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 epoch               1
-github.setup        ccache ccache 3.7.2 v
+github.setup        ccache ccache 3.7.4 v
 revision            0
 # Use tarball, since the releases archive discourages running ./autogen.sh
 github.tarball_from tarball
-checksums           rmd160  a2aa777967d47700e6de73fc33e844c282222aeb \
-                    sha256  cbaafc73944864f76f910695b68ab82162b02c2ff0cec0e25292c553befaca0b \
-                    size    386099
+checksums           rmd160  d20bf418ee72ef8c3cdaeadc1d5ead6e3a951351 \
+                    sha256  82b101e0c5fb4ed26563a8668cf9d8d8f10017d79ba7e031e38ab93a26e9ffeb \
+                    size    386584
 
 name                ccache-devel
 categories          devel

--- a/devel/ccache/Portfile
+++ b/devel/ccache/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ccache ccache 3.7.2 v
+github.setup        ccache ccache 3.7.4 v
 revision            0
 # Use tarball, since the releases archive discourages running ./autogen.sh
 github.tarball_from tarball
-checksums           rmd160  a2aa777967d47700e6de73fc33e844c282222aeb \
-                    sha256  cbaafc73944864f76f910695b68ab82162b02c2ff0cec0e25292c553befaca0b \
-                    size    386099
+checksums           rmd160  d20bf418ee72ef8c3cdaeadc1d5ead6e3a951351 \
+                    sha256  82b101e0c5fb4ed26563a8668cf9d8d8f10017d79ba7e031e38ab93a26e9ffeb \
+                    size    386584
 
 categories          devel
 platforms           darwin freebsd


### PR DESCRIPTION
#### Description

ccache update version to 3.7.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
