### PR TITLE
curl: update version to 7.66.0

### DIFF
--- a/net/curl/Portfile
+++ b/net/curl/Portfile
@@ -4,7 +4,7 @@ PortSystem                      1.0
 PortGroup                       clang_dependency 1.0
 
 name                            curl
-version                         7.65.3
+version                         7.66.0
 categories                      net www
 platforms                       darwin freebsd
 maintainers                     {ryandesign @ryandesign}
@@ -27,14 +27,14 @@ set curl_distfile               ${distfiles}
 distfiles                       ${curl_distfile}:curl
 
 checksums                       ${curl_distfile} \
-                                rmd160  20861c6d94be47e2228b67433ede00d02b106a0a \
-                                sha256  f2d98854813948d157f6a91236ae34ca4a1b4cb302617cebad263d79b0235fea \
-                                size    2392472
+                                rmd160  24b4a7432d117efcca0c1de95fb4797dcf186216 \
+                                sha256  dbb48088193016d079b97c5c3efde8efa56ada2ebf336e8a97d04eb8e2ed98c1 \
+                                size    2414840
 
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    1
+    revision                    0
 
     depends_build               port:pkgconfig
 


### PR DESCRIPTION


#### Description

- bump version to 7.66.0
- curl-ca-bundle is the last version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
