### PR TITLE
libcdio: add livecheck

### DIFF
--- a/devel/libcdio/Portfile
+++ b/devel/libcdio/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                libcdio
 version             2.1.0
 
-master_sites        http://git.savannah.gnu.org/cgit/libcdio.git/snapshot/
+master_sites        https://git.savannah.gnu.org/cgit/libcdio.git/snapshot/
 distname            ${name}-release-${version}
 
 checksums           rmd160  d747bf4aacf9c57298478766cfe7a29a128692ee \
@@ -59,3 +59,7 @@ post-configure {
 
 test.run            yes
 test.target         check
+
+livecheck.type      regex
+livecheck.url       https://git.savannah.gnu.org/cgit/libcdio.git/
+livecheck.regex     ${name}-release-(\\d+\\.\\d+(\\.\\d+)*)${extract.suffix}


### PR DESCRIPTION


#### Description

- add livecheck regex
- move master_sites to tls

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
