### PR TITLE
libcerf: update version to 1.13

### DIFF
--- a/math/libcerf/Portfile
+++ b/math/libcerf/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 
 name                libcerf
-version             1.11
+version             1.13
+set upload_tag      924b8d245ad3461107ec630734dfc781
 categories          math
 platforms           darwin
 license             MIT
@@ -13,14 +14,13 @@ description         Library for complex error functions
 long_description    The libcerf library is a self-contained numeric library that provides \
                     an efficient and accurate implementation of complex error functions, \
                     along with Dawson, Faddeeva, and Voigt functions.
-homepage            http://apps.jcns.fz-juelich.de/doku/sc/libcerf
-master_sites        http://apps.jcns.fz-juelich.de/src/libcerf \
-                    http://apps.jcns.fz-juelich.de/src/libcerf/old
+homepage            https://jugit.fz-juelich.de/mlz/libcerf
+master_sites        https://jugit.fz-juelich.de/mlz/libcerf/uploads/${upload_tag}/
 
 extract.suffix      .tgz
-checksums           rmd160  e8e2abf6455ab977421f3efb0a8ae0be06ccb549 \
-                    sha256  70101cac4a0d7863322d4d06cf95c507a9cfd64fc99ad1b31a8425204cfd9672 \
-                    size    60066
+checksums           rmd160  6bf9e6dea553fbd961f4ca02e3f047b7ea7f1c6f \
+                    sha256  011303e59ac63b280d3d8b10c66b07eb02140fcb75954d13ec26bf830e0ea2f9 \
+                    size    61589
 
 test.run            yes
 test.cmd            ctest
@@ -29,3 +29,8 @@ test.target
 livecheck.type      regex
 livecheck.url       http://apps.jcns.fz-juelich.de/src/libcerf
 livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+
+
+livecheck.type      regex
+livecheck.url       https://jugit.fz-juelich.de/mlz/libcerf/-/tags
+livecheck.regex     "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"


### PR DESCRIPTION


#### Description

- bump version to 1.13
- move homepage to new site
- update master_sites and livecheck to reflect new repository

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
