### PR TITLE
libssh2: update version to 1.9.0

### DIFF
--- a/devel/libssh2/Portfile
+++ b/devel/libssh2/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                libssh2
-version             1.8.2
-revision            1
+version             1.9.0
+revision            0
 categories          devel net
 platforms           darwin
 maintainers         {wohner.eu:normen @Gminfly} openmaintainer
@@ -21,9 +21,9 @@ license             BSD
 homepage            https://www.libssh2.org/
 master_sites        ${homepage}download/
 
-checksums           rmd160  b2b84b3fe14e4e527db4a391abd8706a8e028e23 \
-                    sha256  088307d9f6b6c4b8c13f34602e8ff65d21c2dc4d55284dfe15d502c4ee190d67 \
-                    size    859587
+checksums           rmd160  eb3553a9b2c05d5b6a24159db8a1478f9aea3877 \
+                    sha256  d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd \
+                    size    888551
 
 depends_lib         path:lib/libssl.dylib:openssl port:zlib
 


### PR DESCRIPTION


#### Description

- bump version to 1.9.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
