### PR TITLE
msmtp: update version to 1.8.5

### DIFF
--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                msmtp
-version             1.8.3
-revision            1
+version             1.8.5
+revision            0
 categories          mail
 platforms           darwin
-maintainers         nomaintainer
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
 license             GPL-3+
 description         SMTP client that can be used as an SMTP plugin for Mutt
 long_description    msmtp is an SMTP client that can be used as an SMTP \
@@ -21,9 +21,9 @@ homepage            https://marlam.de/msmtp/
 master_sites        ${homepage}releases/
 use_xz              yes
 
-checksums           rmd160  38a289c636a4b98e291a989bce6f1da9a16d6613 \
-                    sha256  3cb2eefd33d048f0f82de100ef39a494e44fd1485e376ead31f733d2f36b92b4 \
-                    size    336120
+checksums           rmd160  e5a0370cc89c045f6e20c0e27bd5ce1b07051db5 \
+                    sha256  1613daced9c47b8c028224fc076799c2a4d72923e242be4e9e5c984cbbbb9f39 \
+                    size    338840
 
 depends_build       port:pkgconfig
 depends_lib         port:gettext \

--- a/mail/msmtp/Portfile
+++ b/mail/msmtp/Portfile
@@ -39,10 +39,4 @@ platform macosx {
     configure.args-append   --with-macosx-keyring
 }
 
-variant openssl description {use openssl instead of gnutls} {
-    depends_lib-append    path:lib/libssl.dylib:openssl
-    depends_lib-delete    port:gnutls
-    configure.args-append --with-ssl=openssl
-}
-
 livecheck.url       https://marlam.de/msmtp/download/


### PR DESCRIPTION

#### Description

- bump version to 1.8.5
- remove unsupported openssl variant
- add me as maintainer

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
