### PR TITLE
ondir: update version to 0.2.4

### DIFF
--- a/sysutils/ondir/Portfile
+++ b/sysutils/ondir/Portfile
@@ -3,7 +3,7 @@
 PortSystem       1.0
 
 name             ondir
-version          0.2.3
+version          0.2.4
 revision         0
 
 categories       sysutils
@@ -18,9 +18,9 @@ long_description OnDir is a program that automatically executes scripts as you t
 homepage         https://swapoff.org/ondir.html
 master_sites     https://swapoff.org/files/ondir/
 
-checksums        rmd160         784dbfa4425ff8f9e9e1db28ae81c9b59471ebc1 \
-                 sha256         504a677e5b7c47c907f478d00f52c8ea629f2bf0d9134ac2a3bf0bbe64157ba3 \
-                 size           17820
+checksums        rmd160         89f396a61987979d26a9726dda0f59a723790156 \
+                 sha256         52921cdcf02273e0d47cc6172df6a0d2c56980d724568276acb0591e0bda343a \
+                 size           52860
 
 patchfiles       patch-Makefile.diff
 
@@ -33,7 +33,7 @@ use_configure    no
 build.target     ondir
 
 post-destroot {
-    set docdir ${prefix}/share/doc/${name}-${version}
+    set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} \
         AUTHORS COPYING ChangeLog README.rst ondirrc.eg scripts.sh scripts.tcsh scripts.zsh TODO \
@@ -42,7 +42,7 @@ post-destroot {
 
 notes "
 
-${prefix}/share/doc/${name}-${version} contains docs and examples for fully configure ondir.
+${prefix}/share/doc/${name} contains docs and examples for fully configure ondir.
 
 ondirrc.eg is a configuration example file; you can modify it and copy to ~/.ondirrc \
 (per-user configuration) or to ${prefix}/etc/ondirrc (system-wide configuration).


### PR DESCRIPTION

#### Description

- bump version to 0.2.4
- livecheck fails because no directory listing is available.
  homepage and github can't be used.
  seems that upstream publish hidden versions
  https://github.com/alecthomas/ondir/issues/7
- set doc folder without version: avoid changes on zshrc/bashrc every
  update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
