### PR TITLE
rclone: update version to 1.49.3

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ncw rclone 1.48.0 v
+github.setup        rclone rclone 1.49.3 rclone-v
 
-homepage            http://rclone.org
+homepage            https://rclone.org
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
 description         Rclone is a command line cloud-service sync program
@@ -15,24 +15,17 @@ long_description \
     Dropbox, Google Cloud Storage, Amazon Drive, Microsoft One Drive, Hubic, \
     Backblaze B2, Yandex Disk, SFTP, and the local filesystem.
 license             MIT
+github.master_sites ${github.homepage}/releases/download/v${github.version}
+distname            ${github.tag_prefix}${github.version}
 
 checksums \
-    rmd160  1632460202e6ec26b02fe4c07354b7e82e1e162f \
-    sha256  b822b9a3728f888800649caf6a6c8f515595a9f5084426fd75c98cb2ac92ac74 \
-    size    17681143
-
-set goproj          github.com/${github.author}/${github.project}
+    rmd160  867bc99a3a49588c705163d00cda7043ca4f82f8 \
+    sha256  1688a5c4e58ec74614c049a131290778b34b53d8a3ad339a891f8a7af5b37411 \
+    size    18125907
 
 depends_lib         port:go
 platforms           darwin
 use_configure       no
-worksrcdir          src/${goproj}
-
-post-extract {
-    xinstall -d ${workpath}/src/github.com/${github.author}
-    move ${workpath}/${name}-${github.version} \
-        ${worksrcpath}
-}
 
 build {
     system -W ${worksrcpath} "GOPATH=${workpath} \


### PR DESCRIPTION


#### Description

- bump version to 1.49.3
- move homepage to tls

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
