### PR TITLE
tmux-pasteboard: update version to 2.8

### DIFF
--- a/sysutils/tmux-pasteboard/Portfile
+++ b/sysutils/tmux-pasteboard/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ChrisJohnsen tmux-MacOSX-pasteboard 2.7 v
+github.setup        ChrisJohnsen tmux-MacOSX-pasteboard 2.8 v
 name                tmux-pasteboard
 categories          sysutils
 platforms           darwin
@@ -15,9 +15,9 @@ long_description    ${description}
 
 depends_run         path:bin/tmux:tmux
 
-checksums           rmd160  2cc454a397f3cc8b5b86a2140f85be97eee060e5 \
-                    sha256  e779a4a4f916484f15b9b384bbfa892030c70b65340da68f0d474df43889bcfd \
-                    size    16932
+checksums           rmd160  5b3ea963321510db15f38fd87efb80a39aec3b9c \
+                    sha256  c1d7c7a76f365a6e37fbe33ce2a5426d347b575cc9bf6c1917023a6f281eb1a9 \
+                    size    16934
 
 use_configure       no
 variant universal {}


### PR DESCRIPTION


#### Description

- bump version to 2.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
