### PR TITLE
tcptraceroute: fix homepage

### DIFF
--- a/net/tcptraceroute/Portfile
+++ b/net/tcptraceroute/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem 1.0
+PortGroup  github 1.0
 
-name            tcptraceroute
-version         1.5beta7
-revision        1
+github.setup    mct tcptraceroute 1.5beta7 tcptraceroute-
+
 categories      net
 platforms       darwin
 license         GPL-2
@@ -12,10 +12,10 @@ maintainers     nomaintainer
 description     a traceroute implementation using TCP packets
 long_description    ${description}
 
-homepage        http://michael.toren.net/code/tcptraceroute/
-master_sites    ${homepage}
-checksums       md5 65d1001509f971ea986fcbc2dd009643 \
-                sha1 78847ef4ba7031cee660c540593256fd384a1a62
+checksums       rmd160  fe937341f4ef1aa358b253c3af490419a689031f \
+                sha256  aed5b163ed4886f04242b46005a6cb4876ef38ad72001a94facb62a99dc99c57 \
+                size    119119
+revision        1
 
 depends_lib     port:libnet11 port:libpcap
 


### PR DESCRIPTION


#### Description

fix homepage url (down from 2017) and move to github repository of the
same author

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
