### PR TITLE
binwalk: move to python37

### DIFF
--- a/cross/binwalk/Portfile
+++ b/cross/binwalk/Portfile
@@ -5,25 +5,24 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        ReFirmLabs binwalk 2.1.1 v
+
 categories          cross
 platforms           darwin
 license             MIT
 supported_archs     noarch
+maintainers         {stromnov @stromnov} openmaintainer
+description         Binwalk is a fast, easy to use tool for analyzing, reverse engineering, and extracting firmware images
+long_description    ${description}
+homepage            http://binwalk.org
+
+checksums           rmd160  e666b01813647e2d90d64900276a4f583afb8d0d \
+                    sha256  5115b736f5aebda7059ed0c538befde46807f66f8071e6769a87a9263c6907ac \
+                    size    264047
 
 # enable stealth update https://trac.macports.org/wiki/PortfileRecipes#stealth-updates
 dist_subdir        ${name}/${version}_1
 
-python.default_version  27
-
-maintainers         {stromnov @stromnov} openmaintainer
-
-description         Binwalk is a fast, easy to use tool for analyzing, reverse engineering, and extracting firmware images
-long_description    ${description}
-
-homepage            http://binwalk.org
-
-checksums           rmd160  e666b01813647e2d90d64900276a4f583afb8d0d \
-                    sha256  5115b736f5aebda7059ed0c538befde46807f66f8071e6769a87a9263c6907ac
+python.default_version  37
 
 depends_lib-append  port:py${python.default_version}-setuptools \
-                    port:py${python.default_version}-liblzma
+    port:py${python.default_version}-pylzma


### PR DESCRIPTION
#### Description

this is a proposal to start moving ports to python3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
