### PR TITLE
ipmitool: Update to post-1.8.18

### DIFF
--- a/sysutils/ipmitool/Portfile
+++ b/sysutils/ipmitool/Portfile
@@ -1,10 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
+PortGroup       github 1.0
 
-name            ipmitool
-version         1.8.15
-revision        3
+github.setup    ipmitool ipmitool eed9d59
+
+# Using head of ipmitool until next release for openssl build fixes
+version         1.8.18.20190905
+revision        0
 
 categories      sysutils
 license         BSD
@@ -24,22 +27,29 @@ long_description \
   remote chassis power control.
 
 platforms       darwin
-homepage        http://ipmitool.sourceforge.net/
-master_sites    sourceforge
 
+depends_build   port:autoconf \
+                port:automake \
+                port:libtool \
+                port:curl \
+                port:coreutils
 depends_lib     path:lib/libssl.dylib:openssl
 
 checksums \
-    rmd160  2884232d29e441b8ee136d7a75019c8fbb5d3a49 \
-    sha256  f0964e644a8e693932a3e8da6929d5598ed24645bacd51fbb1a4a09b5e47cf78
+    rmd160  e2d76e0c1ca496d63e249e0e9204dbc992ed4e41 \
+    sha256  fb0438bac206b4fd9a53f5f66ef4ed8c17bce86c183c338f09d1e844db3f1347 \
+    size    618167
 
 configure.args --enable-intf-lanplus --enable-ipmishell
 configure.cppflags-append   -Ds6_addr16=__u6_addr.__u6_addr16
 
+pre-configure {
+    system -W ${worksrcpath} "./bootstrap"
+}
+
 post-patch {
-    # remove CFLAGS that gcc 4.2 doesn't support
-    reinplace "s|-Wno-unused-result||g" ${worksrcpath}/configure
-    reinplace "s|-Wno-packed-bitfield-compat||g" ${worksrcpath}/configure
+    reinplace {/DOWNLOAD/s/ -#/ -L/} configure.ac
+    reinplace "s|\$(INSTALL_DATA)|ginstall -m 0644|" Makefile.am
 }
     
 configure.args  --mandir=${prefix}/share/man


### PR DESCRIPTION
Update to a version compatible with openssl 1.1; See #3822

#### Description

Update needed one way or the other for openssl 1.1; 1.8.18 itself doesn't compile; move to current head for now.

An alternative approach using old_openssl instead is suggested here (no PR as of yet):
  https://trac.macports.org/ticket/59002

###### Type(s)

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
