### PR TITLE
tor-devel: update to 0.4.2.1-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.1.5
-revision            1
+version             0.4.2.1-alpha
+revision            0
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -24,9 +24,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  3bb1881407e41725e9013739b71372712571be57 \
-                    sha256  a864e0b605fb933fcc167bf242eed4233949e8a1bf23ac8e0381b106cd920425 \
-                    size    7378436
+checksums           rmd160  8b8cd7244d3b5696fda3bd746353024ed8d3ccbc \
+                    sha256  ef71a32d588ca348fe0f74ba7c0368474c2c53ca201bf258b2c5139a1504ba47 \
+                    size    7457483
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.2.1-alpha

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?