### PR TITLE
fldigi: add variant for pulseaudio support

### DIFF
--- a/science/fldigi/Portfile
+++ b/science/fldigi/Portfile
@@ -36,6 +36,13 @@ depends_lib-append \
 configure.args-append \
     --without-pulseaudio
 
+variant pulseaudio description {Build fldigi with pulseaudio support} {
+    configure.args-delete --without-pulseaudio
+    configure.args-append --with-pulseaudio
+    depends_lib-append \
+        port:pulseaudio
+}
+
 # We put this into a pre-configure block so it can be evaluated _after_ platform selection.
 pre-configure {
     # enable optimization (SSE3) on all Intel hardwares


### PR DESCRIPTION
PulseAudio is very useful when combining fldigi with other SDR
applications.

#### Description

Adds a variant to build with PulseAudio support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
