### PR TITLE
grig: new port

### DIFF
--- a/science/grig/Portfile
+++ b/science/grig/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+name                    grig
+version                 0.8.1
+categories              science
+license                 GPL-2+
+platforms               darwin
+maintainers             {mit.edu:quentin @quentinmit} \
+                        openmaintainer
+description             GUI Ham Radio control (CAT) program
+long_description        Grig is a simple Ham Radio control (CAT) program based on the Ham Radio Control Libraries (Hamlib).
+homepage                http://groundstation.sourceforge.net/grig/
+master_sites            sourceforge:groundstation
+
+depends_build           port:pkgconfig
+depends_lib             port:gtk2 \
+                        port:hamlib
+
+checksums           rmd160  01deadaea1ae2e6ed3e27ada07ad4557039ddf8c \
+                    sha256  be8687418fb23efa0468674c3fdd15340fed06eef09be9de21106cc17e033c25 \
+                    size    621728


### PR DESCRIPTION
grig is a GTK GUI for hamlib radio control

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
