### PR TITLE
iperf3: disable profiling

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -17,6 +17,9 @@ long_description    ${name} is a tool for active measurements of the maximum \
 
 depends_lib-append  path:lib/libssl.dylib:openssl
 
+configure.args-append \
+    --disable-profiling
+
 test.run            yes
 test.target         check
 
@@ -29,7 +32,7 @@ post-destroot {
 
 if {${subport} eq ${name}} {
     github.setup        esnet iperf 3.7
-    revision            1
+    revision            2
 
     checksums           rmd160  fc8df90ccc9174cd7a7329056991cc4299244933 \
                         sha256  2a6dfafb6d7e225a7c5617d9b769fc70fb4f00a0586bda177a17ac01c4cefae9 \
@@ -41,7 +44,7 @@ if {${subport} eq ${name}} {
 subport ${name}-devel {
     github.setup        esnet iperf 2a7847a08154d5d224d1836e86afa06d26b512c5
     version             20190621
-    revision            1
+    revision            2
 
     checksums           rmd160  505fbf20b3b60d99b8a46b2a39900b8ee7243513 \
                         sha256  b8803c518dfa88c08d88c78b7e197e4e50ecfae41240521a69d5abc22e47fed8 \


### PR DESCRIPTION
#### Description

the build fails with the following error

:info:build clang: error: the clang compiler does not support -pg
option on versions of OS X 10.9 and later

the configure enables profiling by default and this could be avoided
for distribution therefore I disable that flag and -pg and -g is not
enabled anymore.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->