### PR TITLE
google-cloud-sdk: update to 263.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             262.0.0
+version             263.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  627cb2b46a840c5e87c97f870fbcd75fbc3fe931 \
-                    sha256  3654c502d0451a7b38b5391c6f2407b0d96895ebfea14098d321646eaec05297 \
-                    size    21774624
+checksums           rmd160  0d2b6892f0463a647d5908e1e836026c16e76faf \
+                    sha256  25c32408b936209ac6f8c2260a638a062ae15c0b381c6885c72017be070f5a2b \
+                    size    21874346
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 263.0.0.

###### Tested on

macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?