### PR TITLE
haskell_cabal: Submission of portgroup, ports aeson-pretty, cpphs, hlint

### DIFF
--- a/_resources/port1.0/group/haskell_cabal-1.0.tcl
+++ b/_resources/port1.0/group/haskell_cabal-1.0.tcl
@@ -1,0 +1,132 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# Usage:
+# PortGroup         haskell_cabal 1.0
+#
+# This PortGroup configures the build to use the Haskell Cabal tool. It
+# modifies the defaults for a number of variables, so your Portfile should take
+# care not to accidentally overwrite them.
+#
+# The PortGroup will automatically add the required build dependencies for
+# port:cabal.
+#
+# The configure, build, destroot and test phases are set up (although the test
+# phase is not enabled automatically). A default livecheck is configured to
+# hackage.haskell.org using ${name}.
+#
+# This PortGroup offers the following options:
+#
+# haskell_cabal.bin
+#   The cabal binary. Defaults to ${prefix}/bin/cabal.
+#
+# haskell_cabal.default_args
+#   Default arguments for cabal used across invocations in configure, build, and
+#   destroot phases. Defaults to
+#       --prefix=${prefix}
+#       --bindir=${prefix}/bin
+#       --libdir=${prefix}/lib
+#       --libsubdir=${name}
+#       --dynlibdir=${prefix}/lib
+#       --libexecdir=${prefix}/libexec
+#       --libexecsubdir=${name}
+#       --datadir=${prefix}/share/${name}
+#       --docdir=${prefix}/share/doc/${name}
+#       --htmldir=${prefix}/share/doc/${name}
+#       --sysconfdir=${prefix}/etc/${name}
+#       --enable-documentation
+#       --enable-relocatable
+
+proc haskell_cabal.add_dependencies {} {
+    global name
+    if { ${name} ne "cabal" } {
+        depends_build-append port:cabal
+    }
+}
+port::register_callback haskell_cabal.add_dependencies
+
+# libHSbase shipped with GHC links against system libiconv, which provides the
+# 'iconv' symbol, but not the 'libiconv' symbol. Because the compilation
+# process statically links libHSbase.a, we must have /usr/lib in the library
+# search path first :/
+compiler.library_path
+compiler.cpath
+
+options haskell_cabal.bin haskell_cabal.default_args
+default haskell_cabal.bin   ${prefix}/bin/cabal
+default haskell_cabal.default_args \
+    {--prefix=${prefix} \
+        --bindir=${prefix}/bin \
+        --libdir=${prefix}/lib \
+        --libsubdir=${name} \
+        --dynlibdir=${prefix}/lib \
+        --libexecdir=${prefix}/libexec \
+        --libexecsubdir=${name} \
+        --datadir=${prefix}/share/${name} \
+        --docdir=${prefix}/share/doc/${name} \
+        --htmldir=${prefix}/share/doc/${name} \
+        --sysconfdir=${prefix}/etc/${name} \
+        --enable-documentation \
+        --enable-relocatable}
+
+pre-configure {
+    system -W ${worksrcpath} "${haskell_cabal.bin} new-update"
+}
+
+default configure.cmd       {${haskell_cabal.bin}}
+default configure.pre_args  {}
+default configure.args      {new-configure ${haskell_cabal.default_args}}
+
+default build.cmd           {${haskell_cabal.bin}}
+default build.target        {new-build}
+default build.args          {${haskell_cabal.default_args}}
+
+# Note: cabal new-install does *not* use the specified --prefix'ed datadir
+# Do not use new-install; rather, new-update / new-configure / new-build
+
+destroot {
+    # install binary
+    set cabal_build ${worksrcpath}/dist-newstyle/build
+    fs-traverse f ${cabal_build} {
+        if { [file isdirectory ${f}]
+            && [file tail ${f}] eq "${name}-${version}" } {
+            set cabal_build ${f}
+            break
+        }
+    }
+    fs-traverse f ${cabal_build} {
+        if { [file isfile ${f}]
+            && [file executable ${f}]
+            && [file tail ${f}] eq "${name}"
+            && [file tail [file dirname ${f}]] eq "${name}" } {
+            xinstall -m 0755 ${f} ${destroot}${prefix}/bin/${name}
+        }
+    }
+
+    # install documentation
+    if { [file isdirectory ${cabal_build}/doc] } {
+        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}
+        fs-traverse f_or_d ${cabal_build}/doc {
+            set subpath [strsed ${f_or_d} "s|${cabal_build}/doc||"]
+            if { ${subpath} ne "" } {
+                if { [file isdirectory ${f_or_d}] } {
+                    xinstall -m 0755 -d \
+                        ${destroot}${prefix}/share/doc/${name}${subpath}
+                } elseif { [file isfile ${f_or_d}] } {
+                    xinstall -m 0644 ${f_or_d} \
+                        ${destroot}${prefix}/share/doc/${name}${subpath}
+                }
+            }
+        }
+    }
+    
+    # install cabal data-files
+    if { [file exists ${worksrcpath}/data]
+        && [file isdirectory ${worksrcpath}/data] } {
+        xinstall -m 0644 {*}[glob ${worksrcpath}/data/*] \
+            ${destroot}${prefix}/share/${name}
+    }
+}
+
+default livecheck.type      {regex}
+default livecheck.url       {https://hackage.haskell.org/package/${name}}
+default livecheck.regex     {"/package/[quotemeta ${name}]-\\\[^/\\\]+/[quotemeta ${name}]-(\\\[^\\\"\\\]+)[quotemeta ${extract.suffix}]"}

--- a/devel/aeson-pretty/Portfile
+++ b/devel/aeson-pretty/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_stack 1.0
+
+name                aeson-pretty
+version             0.8.7
+categories          devel haskell
+maintainers         nomaintainer
+license             GPL-3
+platforms           macosx
+homepage            https://www.haskell.org/alex/
+
+description         JSON pretty-printing library and command-line tool.
+long_description    \
+    A JSON pretty-printing library compatible with aeson as well as a \
+    command-line tool to improve readabilty of streams of JSON data. \
+    The library provides the function \"encodePretty\". It is a drop-in \
+    replacement for aeson's \"encode\" function, producing JSON-ByteStrings \
+    for human readers.  The command-line tool reads JSON from stdin and \
+    writes prettified JSON to stdout. It also offers a complementary \
+    \"compact\"-mode, essentially the opposite of pretty-printing. 
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+checksums           rmd160  1d914a4ccf24ecce055c9a10a01c078655bdc2da \
+                    sha256  c1c1ecc5e3abd004a6c4c256ee6f61da2a43d7f1452ffa391dee250df43b27d5 \
+                    size    5610

--- a/devel/alex/Portfile
+++ b/devel/alex/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_stack 1.0
+
+name                alex
+version             3.2.4
+categories          devel haskell
+maintainers         nomaintainer
+license             GPL-3
+platforms           macosx
+homepage            https://www.haskell.org/alex/
+
+description         A tool for generating lexical analysers in Haskell
+long_description    \
+            Alex is a tool for generating lexical analysers in Haskell. \
+            It takes a description of tokens based on regular expressions \
+            and generates a Haskell module containing code for scanning \
+            text efficiently. It is similar to the tool lex or flex for C/C++.
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+conflicts           hs-alex
+
+checksums           rmd160  10bb2f2f5222b9d2288d694037df36f395dd00e4 \
+                    sha256  d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232 \
+                    size    110688
+
+# relative paths to ${prefix}
+set alex_datadir    share/${name}
+
+post-extract {
+    xinstall -o macports -m 0755 -d \
+        "[option haskell_stack.stack_root]" \
+        ${destroot}${prefix}/${alex_datadir}
+
+    # Fix for cabal data-files hardcoded path in binary
+    # See:
+    # https://github.com/commercialhaskell/stack/issues/848
+    # https://github.com/commercialhaskell/stack/issues/4857
+    # https://github.com/haskell/cabal/issues/462
+    # https://github.com/haskell/cabal/issues/3586
+    xinstall -m 0644 -W ${worksrcpath} \
+        ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+}
+
+post-destroot {
+    # install cabal data-files
+    fs-traverse f ${worksrcpath}/.stack-work {
+        if { [file isdirectory ${f}]
+            && [file tail ${f}] eq "${name}-${version}" } {
+            set stack_alex_datadir ${f}
+            xinstall -m 0644 {*}[glob ${stack_alex_datadir}/*] \
+                ${destroot}${prefix}/${alex_datadir}
+        }
+    }
+}

--- a/devel/alex/files/Paths_NAME.hs
+++ b/devel/alex/files/Paths_NAME.hs
@@ -13,7 +13,7 @@ See:
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoRebindableSyntax #-}
 {-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
-module Paths_ihaskell (
+module Paths_@NAME@ (
     version,
     getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
     getDataFileName, getSysconfDir
@@ -42,19 +42,19 @@ version = Version [2,0,1] []
 bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
 
 bindir     = "@PREFIX@/bin"
-libdir     = "@PREFIX@/lib/ihaskell"
-dynlibdir  = "@PREFIX@/lib/ihaskell"
-datadir    = "@PREFIX@/share/ihaskell"
-libexecdir = "@PREFIX@/lib/ihaskell"
+libdir     = "@PREFIX@/lib/@NAME@"
+dynlibdir  = "@PREFIX@/lib/@NAME@"
+datadir    = "@PREFIX@/share/@NAME@"
+libexecdir = "@PREFIX@/lib/@NAME@"
 sysconfdir = "@PREFIX@/etc"
 
 getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
-getBinDir = catchIO (getEnv "ihaskell_bindir") (\_ -> return bindir)
-getLibDir = catchIO (getEnv "ihaskell_libdir") (\_ -> return libdir)
-getDynLibDir = catchIO (getEnv "ihaskell_dynlibdir") (\_ -> return dynlibdir)
-getDataDir = catchIO (getEnv "ihaskell_datadir") (\_ -> return datadir)
-getLibexecDir = catchIO (getEnv "ihaskell_libexecdir") (\_ -> return libexecdir)
-getSysconfDir = catchIO (getEnv "ihaskell_sysconfdir") (\_ -> return sysconfdir)
+getBinDir = catchIO (getEnv "@NAME@_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "@NAME@_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "@NAME@_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "@NAME@_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "@NAME@_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "@NAME@_sysconfdir") (\_ -> return sysconfdir)
 
 getDataFileName :: FilePath -> IO FilePath
 getDataFileName name = do

--- a/devel/cpphs/Portfile
+++ b/devel/cpphs/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_stack 1.0
+
+name                cpphs
+version             1.20.8
+categories          devel haskell
+maintainers         nomaintainer
+license             GPL-3
+platforms           macosx
+homepage            https://www.haskell.org/alex/
+
+description         A liberalised re-implementation of cpp, the C pre-processor.
+long_description    \
+    Cpphs is a re-implementation of the C pre-processor that is both more \
+    compatible with Haskell, and itself written in Haskell so that it can be \
+    distributed with compilers.
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+conflicts           hs-cpphs
+
+checksums           rmd160  6f966d9ff14f8f485e7897a7cef3ae16766d2a5e \
+                    sha256  e56d64a7d8058e0fb63f0669397c1c861efb20a0376e0e74d86942ac151105ae \
+                    size    45108

--- a/devel/happy/Portfile
+++ b/devel/happy/Portfile
@@ -1,0 +1,61 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_stack 1.0
+
+name                happy
+version             1.19.12
+categories          devel haskell
+maintainers         nomaintainer
+license             GPL-3
+platforms           macosx
+homepage            https://github.com/simonmar/happy
+
+description         A parser generator for Haskell
+long_description    \
+            Happy is a parser generator for Haskell. Given a grammar \
+            specification in BNF, Happy generates Haskell code to parse \
+            the grammar. Happy works in a similar way to the yacc tool for C.
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+conflicts           hs-happy
+
+checksums           rmd160  34fff4797b87496a0493960b784df96385d4d6c0 \
+                    sha256  fb9a23e41401711a3b288f93cf0a66db9f97da1ce32ec4fffea4b78a0daeb40f \
+                    size    183254
+
+# relative paths to ${prefix}
+set happy_datadir   share/${name}
+
+post-extract {
+    xinstall -m 0755 -d \
+        "[option haskell_stack.stack_root]" \
+        ${destroot}${prefix}/${happy_datadir}
+
+    # Fix for cabal data-files hardcoded path in binary
+    # See:
+    # https://github.com/commercialhaskell/stack/issues/848
+    # https://github.com/commercialhaskell/stack/issues/4857
+    # https://github.com/haskell/cabal/issues/462
+    # https://github.com/haskell/cabal/issues/3586
+    xinstall -m 0644 -W ${worksrcpath} \
+        ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+}
+
+post-destroot {
+    # install cabal data-files
+    fs-traverse f ${worksrcpath}/.stack-work {
+        if { [file isdirectory ${f}]
+            && [file tail ${f}] eq "${name}-${version}" } {
+            set stack_happy_datadir ${f}
+            xinstall -m 0644 {*}[glob ${stack_happy_datadir}/*] \
+                ${destroot}${prefix}/${happy_datadir}
+        }
+    }
+}

--- a/devel/happy/files/Paths_NAME.hs
+++ b/devel/happy/files/Paths_NAME.hs
@@ -1,0 +1,62 @@
+{- Cabal data-files hardcoded path in binary fix.
+
+This file replaces the Paths_*.hs automatically created by cabal.
+
+See:
+* https://github.com/commercialhaskell/stack/issues/848
+* https://github.com/commercialhaskell/stack/issues/4857
+* https://github.com/haskell/cabal/issues/462
+* https://github.com/haskell/cabal/issues/3586
+
+-}
+        
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoRebindableSyntax #-}
+{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
+module Paths_@NAME@ (
+    version,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
+    getDataFileName, getSysconfDir
+  ) where
+
+import qualified Control.Exception as Exception
+import Data.Version (Version(..))
+import System.Environment (getEnv)
+import Prelude
+
+#if defined(VERSION_base)
+
+#if MIN_VERSION_base(4,0,0)
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#else
+catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
+#endif
+
+#else
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#endif
+catchIO = Exception.catch
+
+version :: Version
+version = Version [2,0,1] []
+bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
+
+bindir     = "@PREFIX@/bin"
+libdir     = "@PREFIX@/lib/@NAME@"
+dynlibdir  = "@PREFIX@/lib/@NAME@"
+datadir    = "@PREFIX@/share/@NAME@"
+libexecdir = "@PREFIX@/lib/@NAME@"
+sysconfdir = "@PREFIX@/etc"
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+getBinDir = catchIO (getEnv "@NAME@_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "@NAME@_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "@NAME@_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "@NAME@_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "@NAME@_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "@NAME@_sysconfdir") (\_ -> return sysconfdir)
+
+getDataFileName :: FilePath -> IO FilePath
+getDataFileName name = do
+  dir <- getDataDir
+  return (dir ++ "/" ++ name)

--- a/devel/hlint/Portfile
+++ b/devel/hlint/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_cabal 1.0
+
+name                hlint
+version             2.2.2
+categories          devel haskell
+maintainers         nomaintainer
+license             GPL-3
+platforms           macosx
+homepage            https://www.haskell.org/alex/
+
+description         A a tool for suggesting possible improvements to Haskell code.
+long_description    \
+    HLint is a tool for suggesting possible improvements to Haskell code. \
+    These suggestions include ideas such as using alternative functions, \
+    simplifying code and spotting redundancies.
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+checksums           rmd160  d2e7ae8bc0a53976ed1906b3649c8388911ed655 \
+                    sha256  d717f06091d4b651671ffa3c3d88115d353a595b7853f9860af3b74d3eeb20ec \
+                    size    129651
+
+# relative paths to ${prefix}
+set hlint_datadir    share/${name}
+
+post-extract {
+    xinstall -o macports -m 0755 -d \
+        ${destroot}${prefix}/${hlint_datadir}
+
+    # Fix for cabal data-files hardcoded path in binary
+    # See:
+    # https://github.com/commercialhaskell/stack/issues/848
+    # https://github.com/commercialhaskell/stack/issues/4857
+    # https://github.com/haskell/cabal/issues/462
+    # https://github.com/haskell/cabal/issues/3586
+    xinstall -m 0644 -W ${worksrcpath} \
+        ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
+
+    reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace "s|@NAME@|${name}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+}
+
+post-destroot {
+    # man page
+    xinstall -m 0644 ${destroot}${prefix}/share/${name}/${name}.1 \
+        ${destroot}${prefix}/share/man/man1
+}

--- a/devel/hlint/files/Paths_NAME.hs
+++ b/devel/hlint/files/Paths_NAME.hs
@@ -1,0 +1,62 @@
+{- Cabal data-files hardcoded path in binary fix.
+
+This file replaces the Paths_*.hs automatically created by cabal.
+
+See:
+* https://github.com/commercialhaskell/stack/issues/848
+* https://github.com/commercialhaskell/stack/issues/4857
+* https://github.com/haskell/cabal/issues/462
+* https://github.com/haskell/cabal/issues/3586
+
+-}
+        
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoRebindableSyntax #-}
+{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
+module Paths_@NAME@ (
+    version,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
+    getDataFileName, getSysconfDir
+  ) where
+
+import qualified Control.Exception as Exception
+import Data.Version (Version(..))
+import System.Environment (getEnv)
+import Prelude
+
+#if defined(VERSION_base)
+
+#if MIN_VERSION_base(4,0,0)
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#else
+catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
+#endif
+
+#else
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#endif
+catchIO = Exception.catch
+
+version :: Version
+version = Version [2,0,1] []
+bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
+
+bindir     = "@PREFIX@/bin"
+libdir     = "@PREFIX@/lib/@NAME@"
+dynlibdir  = "@PREFIX@/lib/@NAME@"
+datadir    = "@PREFIX@/share/@NAME@"
+libexecdir = "@PREFIX@/lib/@NAME@"
+sysconfdir = "@PREFIX@/etc"
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+getBinDir = catchIO (getEnv "@NAME@_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "@NAME@_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "@NAME@_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "@NAME@_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "@NAME@_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "@NAME@_sysconfdir") (\_ -> return sysconfdir)
+
+getDataFileName :: FilePath -> IO FilePath
+getDataFileName name = do
+  dir <- getDataDir
+  return (dir ++ "/" ++ name)

--- a/devel/hscolour/Portfile
+++ b/devel/hscolour/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           haskell_stack 1.0
+
+name                hscolour
+version             1.24.4
+categories          devel haskell
+maintainers         nomaintainer
+license             GPL-3
+platforms           macosx
+homepage            http://hackage.haskell.org/package/hscolour
+
+description         A small Haskell script to colourise Haskell code
+long_description    ${description}. \
+            It currently has six output formats: ANSI terminal codes \
+            (optionally XTerm-256colour codes), HTML 3.2 with font tags, \
+            HTML 4.01 with CSS, HTML 4.01 with CSS and mouseover \
+            annotations, XHTML 1.0 with inline CSS styling, LaTeX, \
+            and mIRC chat codes.
+
+master_sites        https://hackage.haskell.org/package/${name}-${version}
+
+checksums           rmd160  385831baaead9b6dd1d37bcf45a61c53160b3405 \
+                    sha256  243332b082294117f37b2c2c68079fa61af68b36223b3fc07594f245e0e5321d \
+                    size    28729

--- a/devel/ihaskell/Portfile
+++ b/devel/ihaskell/Portfile
@@ -16,7 +16,7 @@ platforms           darwin
 license             MIT
 maintainers         nomaintainer
 
-description         A Haskell kernel for IPython, with hlint.
+description         A Haskell kernel for IPython.
 long_description    \
     IHaskell is a kernel for the Jupyter project, which allows you to \
     use Haskell inside Jupyter frontends (including the console and \
@@ -25,9 +25,7 @@ long_description    \
     http://nbviewer.ipython.org/github/gibiansky/IHaskell/blob/master/notebooks/IHaskell.ipynb. More \
     example notebooks are available on the wiki at \
     https://github.com/gibiansky/IHaskell/wiki. The wiki also has more \
-    extensive documentation of IHaskell features. \
-    Additionally, the auxiliary tools hlint, aeson, and cpphs \
-    are installed.
+    extensive documentation of IHaskell features.
 
 checksums           rmd160  47cf8fed7674b0e2421019ff4c813ee4eea93882 \
                     sha256  c6e6c9a7d71ba6349027f1fb818608f8355acafe6fa7cbe57265ec9951a5ddb4 \
@@ -64,14 +62,13 @@ set ihaskell_datadir \
                     share/${name}
 set jupyter_dir     share/jupyter
 set hlint_datadir \
-                    share/hlint/datadir
+                    share/hlint
 
 post-extract {
     xinstall -m 0755 -d \
         "[option haskell_stack.stack_root]" \
         ${destroot}${prefix}/${ihaskell_datadir}/html \
-        ${destroot}${prefix}/${jupyter_dir} \
-        ${destroot}${prefix}/${hlint_datadir}
+        ${destroot}${prefix}/${jupyter_dir}
 
     # append configure-options to stack.yaml
     reinplace "\$ a\\
@@ -131,36 +128,6 @@ post-destroot {
         ${destroot}${prefix}/bin/ihaskell install \
             --prefix=${destroot}${prefix} \
         "
-
-    # install auxilliary binaries and data-files
-    fs-traverse f "[option haskell_stack.stack_root]" {
-        if { [file isfile ${f}] } {
-            foreach binary {
-                bin/aeson-pretty
-                bin/cpphs
-                bin/hlint
-                } {
-                if { [string match "*/${binary}" ${f}] } {
-                    xinstall -m 0755 ${f} \
-                        ${destroot}${prefix}/${binary}
-                }
-            }
-        }
-    }
-    fs-traverse f "[option haskell_stack.stack_root]" {
-        if { [file isfile ${f}] 
-            && [string match "hlint.yaml" [file tail ${f}]] } {
-            set stack_hlint_datadir [file dirname ${f}]
-            break
-        }
-    }
-    xinstall -m 0644 {*}[glob ${stack_hlint_datadir}/*] \
-        ${destroot}${prefix}/${hlint_datadir}
-
-    # install the hlint manpage
-    xinstall -m 0755 -d ${destroot}${prefix}/share/man/man1
-    xinstall -m 0644 ${destroot}${prefix}/${hlint_datadir}/hlint.1 \
-        ${destroot}${prefix}/share/man/man1
 
     # delete any destroot path appearing in text files
     fs-traverse f ${destroot}${prefix} {

--- a/devel/ihaskell/Portfile
+++ b/devel/ihaskell/Portfile
@@ -9,6 +9,7 @@ git.branch          master
 name                ihaskell
 # set the version to be the date of the last commit
 version             2019.08.30
+revision            1
 
 categories          devel haskell
 platforms           darwin
@@ -25,10 +26,8 @@ long_description    \
     example notebooks are available on the wiki at \
     https://github.com/gibiansky/IHaskell/wiki. The wiki also has more \
     extensive documentation of IHaskell features. \
-    Additionaly, the auxiallary tools hlint, HsColor, aeson, cpphs, \
-    and happy are installed.
-
-conflicts           hs-happy
+    Additionally, the auxiliary tools hlint, aeson, and cpphs \
+    are installed.
 
 checksums           rmd160  47cf8fed7674b0e2421019ff4c813ee4eea93882 \
                     sha256  c6e6c9a7d71ba6349027f1fb818608f8355acafe6fa7cbe57265ec9951a5ddb4 \
@@ -43,6 +42,7 @@ set python3_version_nickname \
 # https://github.com/gibiansky/IHaskell/blob/master/requirements.txt
 depends_lib-append  \
                     path:lib/pkgconfig/pango.pc:pango \
+                    port:ghc \
                     port:python${python3_version_nickname} \
                     port:py${python3_version_nickname}-cairo \
                     port:py${python3_version_nickname}-ipykernel \
@@ -67,7 +67,7 @@ set hlint_datadir \
                     share/hlint/datadir
 
 post-extract {
-    xinstall -o macports -m 0755 -d \
+    xinstall -m 0755 -d \
         "[option haskell_stack.stack_root]" \
         ${destroot}${prefix}/${ihaskell_datadir}/html \
         ${destroot}${prefix}/${jupyter_dir} \
@@ -90,9 +90,11 @@ extra-lib-dirs:\\
     # https://github.com/haskell/cabal/issues/462
     # https://github.com/haskell/cabal/issues/3586
     xinstall -m 0644 -W ${worksrcpath} \
-        ${filespath}/Paths_${name}.hs ./src
+        ${filespath}/Paths_NAME.hs ./src/Paths_${name}.hs
 
     reinplace "s|@PREFIX@|${prefix}|g" \
+        ${worksrcpath}/src/Paths_${name}.hs
+    reinplace "s|@NAME@|${name}|g" \
         ${worksrcpath}/src/Paths_${name}.hs
 }
 
@@ -101,7 +103,7 @@ extra-lib-dirs:\\
 # note: this command does not change the destroot PATH environment, so export
 # PATH explicitly in the necessary system command below
 destroot.env-append \
-    PATH=$env(PATH):${prefix}/Library/Frameworks/Python.framework/Versions/${python3_version}/bin \
+    PATH=$env(PATH):${frameworks_dir}/Python.framework/Versions/${python3_version}/bin \
     ${name}_datadir=${destroot}${prefix}/${ihaskell_datadir}
 
 post-destroot {
@@ -123,7 +125,7 @@ post-destroot {
     # run ihaskell to install the IPython files into destroot
     system -W ${worksrcpath} "\
         export \
-            PATH=$env(PATH):${prefix}/Library/Frameworks/Python.framework/Versions/${python3_version}/bin \
+            PATH=$env(PATH):${frameworks_dir}/Python.framework/Versions/${python3_version}/bin \
             ${name}_datadir=${destroot}${prefix}/${ihaskell_datadir} \
             ; \
         ${destroot}${prefix}/bin/ihaskell install \
@@ -134,10 +136,8 @@ post-destroot {
     fs-traverse f "[option haskell_stack.stack_root]" {
         if { [file isfile ${f}] } {
             foreach binary {
-                bin/HsColour
                 bin/aeson-pretty
                 bin/cpphs
-                bin/happy
                 bin/hlint
                 } {
                 if { [string match "*/${binary}" ${f}] } {

--- a/devel/ihaskell/files/Paths_NAME.hs
+++ b/devel/ihaskell/files/Paths_NAME.hs
@@ -1,0 +1,62 @@
+{- Cabal data-files hardcoded path in binary fix.
+
+This file replaces the Paths_*.hs automatically created by cabal.
+
+See:
+* https://github.com/commercialhaskell/stack/issues/848
+* https://github.com/commercialhaskell/stack/issues/4857
+* https://github.com/haskell/cabal/issues/462
+* https://github.com/haskell/cabal/issues/3586
+
+-}
+        
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoRebindableSyntax #-}
+{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
+module Paths_@NAME@ (
+    version,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
+    getDataFileName, getSysconfDir
+  ) where
+
+import qualified Control.Exception as Exception
+import Data.Version (Version(..))
+import System.Environment (getEnv)
+import Prelude
+
+#if defined(VERSION_base)
+
+#if MIN_VERSION_base(4,0,0)
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#else
+catchIO :: IO a -> (Exception.Exception -> IO a) -> IO a
+#endif
+
+#else
+catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
+#endif
+catchIO = Exception.catch
+
+version :: Version
+version = Version [2,0,1] []
+bindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath
+
+bindir     = "@PREFIX@/bin"
+libdir     = "@PREFIX@/lib/@NAME@"
+dynlibdir  = "@PREFIX@/lib/@NAME@"
+datadir    = "@PREFIX@/share/@NAME@"
+libexecdir = "@PREFIX@/lib/@NAME@"
+sysconfdir = "@PREFIX@/etc"
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+getBinDir = catchIO (getEnv "@NAME@_bindir") (\_ -> return bindir)
+getLibDir = catchIO (getEnv "@NAME@_libdir") (\_ -> return libdir)
+getDynLibDir = catchIO (getEnv "@NAME@_dynlibdir") (\_ -> return dynlibdir)
+getDataDir = catchIO (getEnv "@NAME@_datadir") (\_ -> return datadir)
+getLibexecDir = catchIO (getEnv "@NAME@_libexecdir") (\_ -> return libexecdir)
+getSysconfDir = catchIO (getEnv "@NAME@_sysconfdir") (\_ -> return sysconfdir)
+
+getDataFileName :: FilePath -> IO FilePath
+getDataFileName name = do
+  dir <- getDataDir
+  return (dir ++ "/" ++ name)

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-
 PortGroup           gpg_verify 1.0
 
 name                ghc
 version             8.6.5
+revision            1
 categories          lang haskell
 maintainers         {ieee.org:s.t.smith @essandess} openmaintainer
 license             BSD
@@ -27,11 +27,9 @@ long_description    \
 
 homepage        http://haskell.org/${name}
 
-variant bootstrap \
-	    description {Bootstrap a build of ghc.} {}
-
-# make bootstrapping the default when/if it works
-default_variants    +bootstrap
+# Bootstrapped ghc is the default build
+variant prebuilt \
+    description {Do not bootstrap ghc; install the pre-built binary.} {}
 
 # https://www.haskell.org/ghcup/
 # https://gitlab.haskell.org/haskell/ghcup/blob/master/README.md#manual-install
@@ -47,29 +45,6 @@ checksums           ${distname}-x86_64-apple-darwin${extract.suffix} \
                     rmd160  9e4cb087bc8163feab7793f835916bdfd277868b \
                     sha256  21391cb63a8a6b327f6c9519217a3dad39493e72c48967008ae35af142ca895f \
                     size    1910060
-
-if {[variant_isset "bootstrap"]} {
-    distfiles-append \
-                    ${distname}-src${extract.suffix}
-    checksums-append \
-                    ${distname}-src${extract.suffix} \
-                    rmd160  2640736ab93348a6f9550d914d811c0e62b77e50 \
-                    sha256  4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361 \
-                    size    19092168
-
-    # use these to specify python versions, python3 required
-    set python3_version 3.7
-    set python3_version_nickname \
-                    [join [lrange [split ${python3_version} .] 0 1] {}]
-
-    depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:python${python3_version_nickname} \
-                    port:texlive \
-                    port:texlive-fonts-extra \
-                    port:texlive-fonts-recommended
-}
 
 supported_archs     x86_64
 
@@ -109,47 +84,63 @@ compiler.cpath      /usr/bin/gcc
 compiler.library_path \
                     /usr/lib:${prefix}/lib
 
+# use these to specify python versions, python3 required
+set python3_version 3.7
+set python3_version_nickname \
+                    [join [lrange [split ${python3_version} .] 0 1] {}]
+
+set srcpath ${workpath}/src
+
 # Note: ghc has DESTDIR; however, specifying --prefix=${prefix} installs
 # binaries into ${prefix}, not DESTDIR.  Work around this by setting
 # --prefix=${destroot}${prefix} and not setting DESTDIR
 
-if {![variant_isset "bootstrap"]} {
+if { [variant_isset "prebuilt"] } {
     set bootstrap_dir ${destroot}${prefix}
 } else {
     set bootstrap_dir ${workpath}/bootstrap
 
+    distfiles-append \
+                    ${distname}-src${extract.suffix}
+    checksums-append \
+                    ${distname}-src${extract.suffix} \
+                    rmd160  2640736ab93348a6f9550d914d811c0e62b77e50 \
+                    sha256  4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361 \
+                    size    19092168
+
+    depends_build-append \
+                    port:alex \
+                    port:autoconf \
+                    port:automake \
+                    port:happy \
+                    port:HsColour \
+                    port:python${python3_version_nickname} \
+                    port:py${python3_version_nickname}-sphinx \
+                    port:texlive \
+                    port:texlive-fonts-extra \
+                    port:texlive-fonts-recommended \
+                    port:texlive-latex-extra
+
     pre-configure {
         xinstall -m 0755 -d ${bootstrap_dir}
     }
-}
 
-# install the initial bootstrap compiler to destroot
-configure.pre_args  --prefix=${bootstrap_dir}
+    # add the bootstrap binary and the sphinx-build binary to PATH
+    configure.env-append \
+        PATH=$env(PATH):${bootstrap_dir}/bin:${frameworks_dir}/Python.framework/Versions/${python3_version}/bin
 
-build.target        install
+    # overwrite `build.env`
+    build.env \
+        PATH=$env(PATH):${bootstrap_dir}/bin:${frameworks_dir}/Python.framework/Versions/${python3_version}/bin
 
-# Note: `make install` in bootstrap build cannot use a parallel build
-use_parallel_build  no
-
-# the PATH environment must provide the bootstrap path
-# note: this command does not change the destroot PATH environment, so export
-# PATH explicitly in the necessary system command below
-build.env \
-    PATH=$env(PATH):${bootstrap_dir}/bin
-
-set srcpath ${workpath}/src
-
-pre-build {
-    if {[variant_isset "bootstrap"]} {
+    pre-build {
         # test: move extracted testsuite directory to src
         xinstall -m 0755 -d ${srcpath}/${distname}
         move        ${test.dir} ${srcpath}/${distname}/testsuite
         test.dir    ${srcpath}/${distname}/testsuite
     }
-}
 
-post-build {
-    if {[variant_isset "bootstrap"]} {
+    post-build {
         # bootstrap build/destroot from ${distname}-src${extract.suffix}
 
         use_parallel_build yes
@@ -182,7 +173,7 @@ post-build {
 
         system -W ${srcpath}/${distname} "\
             export \
-                PATH=$env(PATH):${bootstrap_dir}/bin ; \
+                PATH=$env(PATH):${bootstrap_dir}/bin:${frameworks_dir}/Python.framework/Versions/${python3_version}/bin ; \
             ./boot \
             "
 
@@ -195,23 +186,43 @@ post-build {
         configure.dir ${srcpath}/${distname}
         system -W ${srcpath}/${distname} "\
             export \
-                PATH=/usr/bin:$env(PATH):${bootstrap_dir}/bin ; \
+                PATH=/usr/bin:$env(PATH):${bootstrap_dir}/bin:${frameworks_dir}/Python.framework/Versions/${python3_version}/bin ; \
             ${configure.cmd} ${configure.pre_args} ${configure_args} \
             "
 
         # build and destroot the second stage: `make && make install`
         system -W ${srcpath}/${distname} "\
             export \
-                PATH=/usr/bin:$env(PATH):${bootstrap_dir}/bin ; \
+                PATH=/usr/bin:$env(PATH):${bootstrap_dir}/bin:${frameworks_dir}/Python.framework/Versions/${python3_version}/bin ; \
             ${build.cmd} [portbuild::build_getjobsarg] \
             "
         system -W ${srcpath}/${distname} "\
             export \
-                PATH=/usr/bin:$env(PATH):${bootstrap_dir}/bin ; \
+                PATH=/usr/bin:$env(PATH):${bootstrap_dir}/bin:${frameworks_dir}/Python.framework/Versions/${python3_version}/bin ; \
             ${build.cmd} ${destroot.pre_args} \
             "
     }
+}
 
+# install the initial bootstrap compiler to destroot
+configure.pre_args  --prefix=${bootstrap_dir}
+
+# the PATH environment must provide the bootstrap path
+# note: this command does not change the destroot PATH environment, so export
+# PATH explicitly in the necessary system command below
+build.env-append \
+    PATH=$env(PATH):${bootstrap_dir}/bin
+
+# Note: `make install` in bootstrap build cannot use a parallel build
+use_parallel_build  no
+
+build.target        install
+
+destroot {
+    xinstall -W ${filespath} -m 0644 ./ghci.conf ${destroot}${prefix}/etc
+}
+
+post-destroot {
     # delete any destroot path appearing in text files
     fs-traverse f ${destroot}${prefix} {
         if {[file isfile ${f}]} {
@@ -220,10 +231,6 @@ post-build {
             }
         }
     }
-}
-
-destroot {
-    xinstall -W ${filespath} -m 0644 ./ghci.conf ${destroot}${prefix}/etc
 }
 
 post-activate {
@@ -237,6 +244,7 @@ test.run            yes
 notes "The GHC User Manual is available at:
 
     file://${prefix}/share/doc/${distname}/html/index.html
+    ${prefix}/share/doc/${distname}/users_guide.pdf
 
 Copy/edit ${prefix}/etc/ghci.conf to your directory ~/.ghc
 for a user-specific startup configuration."


### PR DESCRIPTION
haskell_cabal: Submission of portgroup `haskell_cabal `, ports `aeson-pretty`, `cpphs`, `hlint`

* Submission of portgroup `haskell_cabal` for building cabal projects
* Submission of Haskell ports `aeson-pretty`, `cpphs`, `hlint`
* Remove `ihaskell` installation of these binaries

Related/parent: https://github.com/macports/macports-ports/pull/5272

cc @neverpanic @amake 

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->