### PR TITLE
app-1.0.tcl: new keys (privacy and dark mode)

### DIFF
--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -137,6 +137,18 @@ default app.retina no
 options app.privacy_microphone
 default app.privacy_microphone ""
 
+
+# app.privacy_camera: whether the app needs camera access
+#
+# The default is empty and therefore disabled. To enable write a
+# message that tells the user why the app is requesting access to the
+# device’s camera.
+#
+# Info.plist key NSCameraUsageDescription.
+
+options app.privacy_camera
+default app.privacy_camera ""
+
 # app.hide_dock_icon: hide the Dock icon
 #
 # SDKs like SDL and Qt use the necessary macOS APIs to implement proper Dock
@@ -288,6 +300,10 @@ platform macosx {
             if {${app.privacy_microphone} != ""} {
                 puts ${fp} "    <key>NSMicrophoneUsageDescription</key>
     <string>${app.privacy_microphone}</string>"
+            }
+            if {${app.privacy_camera} != ""} {
+                puts ${fp} "    <key>NSCameraUsageDescription</key>
+    <string>${app.privacy_camera}</string>"
             }
             if {[tbool app.hide_dock_icon]} {
                 puts ${fp} "    <key>LSUIElement</key>

--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -126,6 +126,16 @@ proc app.get_default_identifier {} {
 options app.retina
 default app.retina no
 
+# app.privacy_microphone: whether the app needs microphone access
+#
+# The default is empty and therefore disabled. To enable write a
+# message that tells the user why the app is requesting access to the
+# device’s microphone.
+#
+# Info.plist key NSMicrophoneUsageDescription.
+
+options app.privacy_microphone
+default app.privacy_microphone ""
 
 # app.hide_dock_icon: hide the Dock icon
 #
@@ -274,6 +284,10 @@ platform macosx {
             if {[tbool app.retina]} {
                 puts ${fp} "    <key>NSHighResolutionCapable</key>
     <true/>"
+            }
+            if {${app.privacy_microphone} != ""} {
+                puts ${fp} "    <key>NSMicrophoneUsageDescription</key>
+    <string>${app.privacy_microphone}</string>"
             }
             if {[tbool app.hide_dock_icon]} {
                 puts ${fp} "    <key>LSUIElement</key>

--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -161,6 +161,18 @@ default app.privacy_camera ""
 options app.privacy_contacts
 default app.privacy_contacts ""
 
+
+# app.privacy_calendars: whether the app needs calendars access
+#
+# The default is empty and therefore disabled. To enable write a
+# message that tells the user why the app is requesting access to the
+# user’s calendar data.
+#
+# Info.plist key NSCalendarsUsageDescription.
+
+options app.privacy_calendars
+default app.privacy_calendars ""
+
 # app.hide_dock_icon: hide the Dock icon
 #
 # SDKs like SDL and Qt use the necessary macOS APIs to implement proper Dock
@@ -320,6 +332,10 @@ platform macosx {
             if {${app.privacy_contacts} != ""} {
                 puts ${fp} "    <key>NSContactsUsageDescription</key>
     <string>${app.privacy_contacts}</string>"
+            }
+            if {${app.privacy_calendars} != ""} {
+                puts ${fp} "    <key>NSCalendarsUsageDescription</key>
+    <string>${app.privacy_calendars}</string>"
             }
             if {[tbool app.hide_dock_icon]} {
                 puts ${fp} "    <key>LSUIElement</key>

--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -126,6 +126,17 @@ proc app.get_default_identifier {} {
 options app.retina
 default app.retina no
 
+
+# app.dark_mode: whether the app supports dark mode
+#
+# The default is yes.
+#
+# Info.plist key NSRequiresAquaSystemAppearance.
+
+options app.dark_mode
+default app.dark_mode yes
+
+
 # app.privacy_microphone: whether the app needs microphone access
 #
 # The default is empty and therefore disabled. To enable write a
@@ -332,6 +343,10 @@ platform macosx {
             }
             if {[tbool app.retina]} {
                 puts ${fp} "    <key>NSHighResolutionCapable</key>
+    <true/>"
+            }
+            if {![tbool app.dark_mode]} {
+                puts ${fp} "    <key>NSRequiresAquaSystemAppearance</key>
     <true/>"
             }
             if {${app.privacy_microphone} != ""} {

--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -149,6 +149,18 @@ default app.privacy_microphone ""
 options app.privacy_camera
 default app.privacy_camera ""
 
+
+# app.privacy_contacts: whether the app needs contacts access
+#
+# The default is empty and therefore disabled. To enable write a
+# message that tells the user why the app is requesting access to the
+# user’s contacts.
+#
+# Info.plist key NSContactsUsageDescription.
+
+options app.privacy_contacts
+default app.privacy_contacts ""
+
 # app.hide_dock_icon: hide the Dock icon
 #
 # SDKs like SDL and Qt use the necessary macOS APIs to implement proper Dock
@@ -304,6 +316,10 @@ platform macosx {
             if {${app.privacy_camera} != ""} {
                 puts ${fp} "    <key>NSCameraUsageDescription</key>
     <string>${app.privacy_camera}</string>"
+            }
+            if {${app.privacy_contacts} != ""} {
+                puts ${fp} "    <key>NSContactsUsageDescription</key>
+    <string>${app.privacy_contacts}</string>"
             }
             if {[tbool app.hide_dock_icon]} {
                 puts ${fp} "    <key>LSUIElement</key>

--- a/_resources/port1.0/group/app-1.0.tcl
+++ b/_resources/port1.0/group/app-1.0.tcl
@@ -173,6 +173,19 @@ default app.privacy_contacts ""
 options app.privacy_calendars
 default app.privacy_calendars ""
 
+
+# app.privacy_photo: whether the app needs photo access
+#
+# The default is empty and therefore disabled. To enable write a
+# message that tells the user why the app is requesting access to the
+# user’s photo library.
+#
+# Info.plist key NSPhotoLibraryUsageDescription.
+
+options app.privacy_photo
+default app.privacy_photo ""
+
+
 # app.hide_dock_icon: hide the Dock icon
 #
 # SDKs like SDL and Qt use the necessary macOS APIs to implement proper Dock
@@ -336,6 +349,10 @@ platform macosx {
             if {${app.privacy_calendars} != ""} {
                 puts ${fp} "    <key>NSCalendarsUsageDescription</key>
     <string>${app.privacy_calendars}</string>"
+            }
+            if {${app.privacy_photo} != ""} {
+                puts ${fp} "    <key>NSPhotoLibraryUsageDescription</key>
+    <string>${app.privacy_photo}</string>"
             }
             if {[tbool app.hide_dock_icon]} {
                 puts ${fp} "    <key>LSUIElement</key>


### PR DESCRIPTION
#### Description

Add the following keys to app-1.0:
- support to disable dark mode
  key NSRequiresAquaSystemAppearance
- support to access microphone
- support to access camera
- support to access contacts
- support to access calendars
- support to access photo

When macOS 10.15 will be available should be nice to support all
Folder Usage Description keys like, NSDownloadsFolderUsageDescription
and NSRemovableVolumesUsageDescription.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->