### PR TITLE
py-pyqtgraph: add pyqt5 variant

### DIFF
--- a/python/py-pyqtgraph/Portfile
+++ b/python/py-pyqtgraph/Portfile
@@ -36,11 +36,15 @@ if {$subport ne $name} {
 
     depends_lib-append      port:py${python.version}-scipy
 
-    variant pyqt4 conflicts pyside description "Qt interface via PyQt4" {
+    variant pyqt4 conflicts pyqt5 pyside description "Qt interface via PyQt4" {
         depends_lib-append  port:py${python.version}-pyqt4
     }
 
-    variant pyside conflicts pyqt4 description "Qt interface via PySide" {
+    variant pyqt5 conflicts pyqt4 pyside description "Qt interface via PyQt5" {
+        depends_lib-append  port:py${python.version}-pyqt5
+    }
+
+    variant pyside conflicts pyqt4 pyqt5 description "Qt interface via PySide" {
         depends_lib-append  port:py${python.version}-pyside
     }
 
@@ -48,7 +52,7 @@ if {$subport ne $name} {
         depends_lib-append  port:py${python.version}-opengl
     }
 
-    if {![variant_isset pyside]} {
+    if {![variant_isset pyside] && ![variant_isset pyqt5]} {
         default_variants +pyqt4
     }
 


### PR DESCRIPTION
#### Description

- support pyqt5 flavor

useful to avoid qt4 dependency when installing gnuradio-next (or in
the future gnuradio-3.8) that it is based on qt5/gtk3.

with pyqtgraph-0.11.0 (in development) we can also enable pyside2

two notes:
- probably we can migrate to github
  https://github.com/pyqtgraph/pyqtgraph
- when we move gnuradio to 3.8 we can probably set pyqt5 as default
  and if needed create a subport for pyqt4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->