### PR TITLE
py-h5py: Update to 2.10.0. Default to 37.

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -5,10 +5,10 @@ PortGroup               github 1.0
 PortGroup               python 1.0
 PortGroup               mpi 1.0
 
-github.setup            h5py h5py 2.9.0
+github.setup            h5py h5py 2.10.0
 name                    py-h5py
 # h5py needs to be re-built after hdf5 upgrades
-revision                1
+revision                0
 
 platforms               darwin
 license                 BSD
@@ -29,12 +29,12 @@ long_description  \
 homepage                https://www.h5py.org
 
 python.versions         27 34 35 36 37
-python.default_version  27
+python.default_version  37
 
 checksums \
-    rmd160  5e2c0025768dc4a0ef7ae53e11ebdd67c4224509 \
-    sha256  aa1ae897c63cfc62f600bb5ed2be7ba771eff42745e0bdfa08b668fdb11f86c6 \
-    size    296584
+    rmd160  43834284330c96de74b9998c440185ce79bafd91 \
+    sha256  f1a2ed05943845480a4bb9b5907600ffa24bb9c199f3b520f2b811b847e7178d \
+    size    314470
 
 # Only check against releases.
 livecheck.regex             "archive/(\[0-9.\]+)\.tar\.gz"


### PR DESCRIPTION
Maintainer update.