### PR TITLE
rclone: Upgrade to 1.49.3

### DIFF
--- a/net/rclone/Portfile
+++ b/net/rclone/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           golang 1.0
 
-github.setup        ncw rclone 1.48.0 v
-
+go.setup            github.com/ncw/rclone 1.49.3 v
 homepage            http://rclone.org
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
@@ -17,30 +16,14 @@ long_description \
 license             MIT
 
 checksums \
-    rmd160  1632460202e6ec26b02fe4c07354b7e82e1e162f \
-    sha256  b822b9a3728f888800649caf6a6c8f515595a9f5084426fd75c98cb2ac92ac74 \
-    size    17681143
+    rmd160  2e26d81d709f4c86916645e99c7961ff0181a0b5 \
+    sha256  9da313157d0a7629af890f8eb45388bdf4a4391d5123f3bd3a752153d8c91167 \
+    size    18201462
 
-set goproj          github.com/${github.author}/${github.project}
-
-depends_lib         port:go
 platforms           darwin
-use_configure       no
-worksrcdir          src/${goproj}
-
-post-extract {
-    xinstall -d ${workpath}/src/github.com/${github.author}
-    move ${workpath}/${name}-${github.version} \
-        ${worksrcpath}
-}
-
-build {
-    system -W ${worksrcpath} "GOPATH=${workpath} \
-      ${prefix}/bin/go build -v -o ${workpath}/${github.project}"
-}
 
 destroot {
-    xinstall ${workpath}/${github.project} ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}


### PR DESCRIPTION
Maintainer update.

Also migrated to golang portgroup.
