### PR TITLE
PothosLiquidDSP: move to python37 as default

### DIFF
--- a/science/PothosLiquidDSP/Portfile
+++ b/science/PothosLiquidDSP/Portfile
@@ -33,7 +33,7 @@ variant python37 conflicts python35 python36 description {Build using Python 3.7
 if {![variant_isset python35] &&
     ![variant_isset python36] &&
     ![variant_isset python37]} {
-    default_variants +python36
+    default_variants +python37
 }
 
 if {![variant_isset python35] &&


### PR DESCRIPTION
#### Description

use python 37 as default python environment

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->