### PR TITLE
openjdk8: Add subport for openjdk13

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -87,6 +87,14 @@ subport openjdk12-openj9-large-heap {
     set openj9_version 0.15.1
 }
 
+subport openjdk13 {
+    version      13
+    revision     0
+
+    set build    33
+    set major    13
+}
+
 subport openjdk13-openj9 {
     version      13
     revision     0
@@ -286,6 +294,15 @@ if {${subport} eq "openjdk8"} {
                  suitable for running all workloads. \
                  \
                  This version uses non-compressed references and should be used for applications which require heaps that are over ~57 GB.
+} elseif {${subport} eq "openjdk13"} {
+    master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}/
+    distname     OpenJDK${major}U-jdk_x64_mac_hotspot_${version}_${build}
+
+    checksums    rmd160  542642959d04f0d43e7bc34e4d4f1615b68283fa \
+                 sha256  f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f \
+                 size    198189530
+
+    worksrcdir   jdk-${version}+${build}
 } elseif {${subport} eq "openjdk13-openj9"} {
     master_sites https://github.com/AdoptOpenJDK/openjdk${major}-binaries/releases/download/jdk-${version}%2B${build}_openj9-${openj9_version}/
     distname     OpenJDK${major}U-jdk_x64_mac_openj9_${version}_${build}_openj9-${openj9_version}


### PR DESCRIPTION
#### Description

Added a subport for AdoptOpenJDK 13 with HotSpot VM.

###### Tested on

macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?