### PR TITLE
openjdk8: Add EOL support note for openjdk12 subports

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -346,9 +346,10 @@ by adding the following line to your Bash shell profile (~/.bash_profile):
     export JAVA_HOME=${target}/Contents/Home
 "
 
-if {${subport} eq "openjdk10"} {
+if {${subport} eq "openjdk10" || [string match openjdk12* ${subport}]} {
     notes-append "
     Warning: Support for OpenJDK ${major} has reached end of life and there will be no more updates.
              Please consider migrating to a supported OpenJDK version.
+             Currently OpenJDK 8, 11 and 13 are supported.
     "
 }


### PR DESCRIPTION
#### Description

OpenJDK 12 is no longer supported with updates. This change warns users about this.

###### Tested on

macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?