### PR TITLE
new port: angle-grinder

### DIFF
--- a/sysutils/angle-grinder/Portfile
+++ b/sysutils/angle-grinder/Portfile
@@ -1,0 +1,930 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cargo 1.0
+
+github.setup        rcoh angle-grinder 0.10.0 v
+
+categories          sysutils
+license             MIT
+platforms           darwin
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         Slice and dice log files on the command line.
+
+long_description    Angle-grinder allows you to parse, aggregate, sum, \
+                    average, percentile, and sort your data. You can see it, \
+                    live-updating, in your terminal. Angle grinder is \
+                    designed for when, for whatever reason, you don't have \
+                    your data in graphite/honeycomb/kibana/sumologic/splunk/etc. \
+                    but still want to be able to do sophisticated analytics.
+
+depends_lib-append  path:lib/libssl.dylib:openssl
+
+set bin_name        agrind
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/${bin_name} ${destroot}${prefix}/bin/
+}
+
+notes "angle-grinder is installed as ${bin_name}"
+
+cargo.crates \
+  MacTypes-sys                  1.3.0          7dbbe033994ae2198a18517c7132d952a29fb1db44249a1234779da7c50f4698  \
+  adler32                       1.0.3          7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c  \
+  aho-corasick                  0.6.9          1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e  \
+  annotate-snippets             0.5.0          e8bcdcd5b291ce85a78f2b9d082a8de9676c12b1840d386d67bc5eea6f9d2b4e  \
+  ansi_term                     0.11.0         ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b  \
+  arrayvec                      0.4.10         92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71  \
+  assert_cli                    0.6.3          a29ab7c0ed62970beb0534d637a8688842506d0ff9157de83286dacd065c8149  \
+  atty                          0.2.11         9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652  \
+  autocfg                       0.1.1          4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727  \
+  backtrace                     0.3.13         b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5  \
+  backtrace-sys                 0.1.28         797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6  \
+  base64                        0.9.3          489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643  \
+  bitflags                      1.0.4          228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12  \
+  build_const                   0.2.1          39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39  \
+  bytecount                     0.3.2          f861d9ce359f56dbcb6e0c2a1cb84e52ad732cadb57b806adeb3c7668caccbd8  \
+  byteorder                     1.2.7          94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d  \
+  bytes                         0.4.11         40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa  \
+  bzip2                         0.3.3          42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b  \
+  bzip2-sys                     0.1.7          6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f  \
+  cc                            1.0.28         bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749  \
+  cfg-if                        0.1.6          082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4  \
+  clap                          2.32.0         b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e  \
+  clap-verbosity-flag           0.2.0          bda14f5323b2b747f52908c5b7b8af7790784088bc7c2957a11695e39ad476dc  \
+  cloudabi                      0.0.3          ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f  \
+  colored                       1.6.1          dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533  \
+  core-foundation               0.5.1          286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980  \
+  core-foundation-sys           0.5.1          716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa  \
+  crc                           1.8.1          d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb  \
+  crc32fast                     1.1.2          e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192  \
+  crossbeam-channel             0.3.4          5b2a9ea8f77c7f9efd317a8a5645f515d903a2d86ee14d2337a5facd1bd52c12  \
+  crossbeam-deque               0.2.0          f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3  \
+  crossbeam-deque               0.6.3          05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13  \
+  crossbeam-epoch               0.3.1          927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150  \
+  crossbeam-epoch               0.7.0          f10a4f8f409aaac4b16a5474fb233624238fcdeefb9ba50d5ea059aab63ba31c  \
+  crossbeam-utils               0.2.2          2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9  \
+  crossbeam-utils               0.6.3          41ee4864f4797060e52044376f7d107429ce1fb43460021b126424b7180ee21a  \
+  difference                    2.0.0          524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198  \
+  dtoa                          0.4.3          6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd  \
+  either                        1.5.0          3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0  \
+  encoding_rs                   0.8.13         1a8fa54e6689eb2549c4efed8d00d7f3b2b994a064555b0e8df4ae3764bcc4be  \
+  env_logger                    0.5.13         15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38  \
+  environment                   0.1.1          1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee  \
+  exitfailure                   0.5.1          2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515  \
+  failure                       0.1.3          6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7  \
+  failure_derive                0.1.3          64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596  \
+  filetime                      0.2.4          a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646  \
+  flate2                        1.0.6          2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4  \
+  fnv                           1.0.6          2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3  \
+  foreign-types                 0.3.2          f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1  \
+  foreign-types-shared          0.1.1          00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b  \
+  fuchsia-zircon                0.3.3          2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82  \
+  fuchsia-zircon-sys            0.3.3          3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7  \
+  futures                       0.1.25         49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b  \
+  futures-cpupool               0.1.8          ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4  \
+  getopts                       0.2.18         0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797  \
+  globset                       0.4.2          4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865  \
+  globwalk                      0.3.1          ce5d04da8cf35b507b2cbec92bbf2d5085292d07cd87637994fd437fe1617bbb  \
+  h2                            0.1.14         1ac030ae20dee464c5d0f36544d8b914a6bc606da44a57e052d2b0f5dae129e0  \
+  heck                          0.3.1          20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205  \
+  http                          0.1.14         02096a6d2c55e63f7fcb800690e4f889a25f6ec342e3adb4594e293b625215ab  \
+  httparse                      1.3.3          e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83  \
+  human-panic                   1.0.1          21638c5955a6daf3ecc42cae702335fc37a72a4abcc6959ce457b31a7d43bbdd  \
+  humantime                     1.2.0          3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114  \
+  hyper                         0.12.19        f1ebec079129e43af5e234ef36ee3d7e6085687d145b7ea653b262d16c6b65f1  \
+  hyper-old-types               0.11.0         6896be51ecf3966c0fa14ff2da3233dbb9aef57ccea1be1afe55f105f4d4c9c4  \
+  hyper-tls                     0.3.1          32cd73f14ad370d3b4d4b7dce08f69b81536c82e39fcc89731930fe5788cd661  \
+  idna                          0.1.5          38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e  \
+  ignore                        0.4.5          d3a7927f029a610b866d545c488dd1fc403c4fed1cb4aea2ad568eaa9fc79cd9  \
+  indexmap                      1.0.2          7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d  \
+  iovec                         0.1.2          dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08  \
+  itertools                     0.8.0          5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358  \
+  itoa                          0.4.3          1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b  \
+  kernel32-sys                  0.2.2          7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d  \
+  language-tags                 0.2.2          a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a  \
+  lazy_static                   1.2.0          a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1  \
+  lazycell                      1.2.1          b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f  \
+  libc                          0.2.45         2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74  \
+  libflate                      0.1.19         bff3ac7d6f23730d3b533c35ed75eef638167634476a499feef16c428d74b57b  \
+  lock_api                      0.1.5          62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c  \
+  log                           0.4.6          c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6  \
+  maplit                        1.0.1          08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43  \
+  matches                       0.1.8          7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08  \
+  memchr                        2.1.2          db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9  \
+  memoffset                     0.2.1          0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3  \
+  mime                          0.3.12         0a907b83e7b9e987032439a387e187119cddafc92d5c2aaeb1d92580a793f630  \
+  mime_guess                    2.0.0-alpha.6  30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed  \
+  miniz-sys                     0.1.11         0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649  \
+  miniz_oxide                   0.2.0          5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c  \
+  miniz_oxide_c_api             0.2.0          28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e  \
+  mio                           0.6.16         71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432  \
+  mio-uds                       0.6.7          966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125  \
+  miow                          0.2.1          8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919  \
+  native-tls                    0.2.2          ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2  \
+  net2                          0.2.33         42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88  \
+  nodrop                        0.1.13         2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945  \
+  nom                           4.2.3          2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6  \
+  nom_locate                    0.3.1          6a47c112b3861d81f7fbf73892b9271af933af32bd5dee6889aa3c3fa9caed7e  \
+  num-derive                    0.2.3          8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d  \
+  num-traits                    0.2.6          0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1  \
+  num_cpus                      1.9.0          5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238  \
+  openssl                       0.10.16        ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9  \
+  openssl-probe                 0.1.2          77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de  \
+  openssl-sys                   0.9.40         1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6  \
+  ordered-float                 1.0.1          2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2  \
+  os_type                       2.2.0          7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb  \
+  owning_ref                    0.4.0          49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13  \
+  parking_lot                   0.6.4          f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5  \
+  parking_lot                   0.7.0          9723236a9525c757d9725b993511e3fc941e33f27751942232f0058298297edf  \
+  parking_lot_core              0.3.1          ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c  \
+  parking_lot_core              0.4.0          94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9  \
+  pbr                           1.0.1          deb73390ab68d81992bd994d145f697451bb0b54fd39738e72eef32458ad6907  \
+  percent-encoding              1.0.1          31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831  \
+  phf                           0.7.23         cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6  \
+  phf_codegen                   0.7.23         7d187f00cd98d5afbcd8898f6cf181743a449162aeb329dcd2f3849009e605ad  \
+  phf_generator                 0.7.23         03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b  \
+  phf_shared                    0.7.23         b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93  \
+  pkg-config                    0.3.14         676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c  \
+  podio                         0.1.6          780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd  \
+  proc-macro2                   0.4.24         77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09  \
+  pulldown-cmark                0.2.0          eef52fac62d0ea7b9b4dc7da092aa64ea7ec3d90af6679422d3d7e0e14b6ee15  \
+  quantiles                     0.7.1          c10fa813fb26fb6c321a6f3085b5ade4cb4730d08d0b9e70a3759136940957f2  \
+  quick-error                   1.2.2          9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0  \
+  quicli                        0.4.0          9e8539e98d5a5e3cb0398aedac3e9642ead7d3047a459893526710cb5ad86f6c  \
+  quote                         0.6.10         53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c  \
+  rand                          0.4.3          8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd  \
+  rand                          0.5.5          e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c  \
+  rand                          0.6.1          ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a  \
+  rand_chacha                   0.1.0          771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a  \
+  rand_core                     0.2.2          1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372  \
+  rand_core                     0.3.0          0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db  \
+  rand_hc                       0.1.0          7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4  \
+  rand_isaac                    0.1.1          ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08  \
+  rand_pcg                      0.1.1          086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05  \
+  rand_xorshift                 0.1.0          effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3  \
+  rayon                         1.0.3          373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473  \
+  rayon-core                    1.4.1          b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356  \
+  redox_syscall                 0.1.44         a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70  \
+  redox_termios                 0.1.1          7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76  \
+  regex                         1.1.0          37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f  \
+  regex-syntax                  0.6.4          4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1  \
+  remove_dir_all                0.5.1          3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5  \
+  reqwest                       0.9.5          ab52e462d1e15891441aeefadff68bdea005174328ce3da0a314f2ad313ec837  \
+  rustc-demangle                0.1.11         01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7  \
+  rustc_version                 0.2.3          138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a  \
+  ryu                           0.2.7          eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7  \
+  safemem                       0.3.0          8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9  \
+  same-file                     1.0.4          8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267  \
+  schannel                      0.1.14         0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56  \
+  scopeguard                    0.3.3          94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27  \
+  security-framework            0.2.1          697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0  \
+  security-framework-sys        0.2.2          40d95f3d7da09612affe897f320d78264f0d2320f3e8eea27d12bd1bd94445e2  \
+  self_update                   0.5.0          4a91301ec87d3925a64c06f667a2f244cf4edb7bd512b1e0aa72abc1963141e3  \
+  semver                        0.9.0          1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403  \
+  semver-parser                 0.7.0          388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3  \
+  serde                         1.0.82         6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6  \
+  serde_derive                  1.0.82         96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154  \
+  serde_json                    1.0.33         c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811  \
+  serde_urlencoded              0.5.4          d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2  \
+  siphasher                     0.2.3          0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac  \
+  slab                          0.4.1          5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d  \
+  smallvec                      0.6.7          b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db  \
+  stable_deref_trait            1.1.1          dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8  \
+  string                        0.1.2          98998cced76115b1da46f63388b909d118a37ae0be0f82ad35773d4a4bc9d18d  \
+  strsim                        0.7.0          bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550  \
+  strsim                        0.8.0          8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a  \
+  structopt                     0.2.14         670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3  \
+  structopt-derive              0.2.14         ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04  \
+  syn                           0.15.23        9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc  \
+  synstructure                  0.10.1         73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015  \
+  tar                           0.4.20         a303ba60a099fcd2aaa646b14d2724591a96a75283e4b7ed3d1a1658909d9ae2  \
+  tempdir                       0.3.7          15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8  \
+  tempfile                      3.0.5          7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2  \
+  termcolor                     0.3.6          adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83  \
+  termcolor                     1.0.4          4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f  \
+  terminal_size                 0.1.8          023345d35850b69849741bd9a5432aa35290e3d8eb76af8717026f270d1cf133  \
+  termion                       1.5.1          689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096  \
+  textwrap                      0.10.0         307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6  \
+  thread_local                  0.3.6          c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b  \
+  time                          0.1.41         847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c  \
+  tokio                         0.1.13         a7817d4c98cc5be21360b3b37d6036fe9b7aefa5b7a201b7b16ff33423822f7d  \
+  tokio-codec                   0.1.1          5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f  \
+  tokio-current-thread          0.1.4          331c8acc267855ec06eb0c94618dcbbfea45bed2d20b77252940095273fb58f6  \
+  tokio-executor                0.1.5          c117b6cf86bb730aab4834f10df96e4dd586eff2c3c27d3781348da49e255bde  \
+  tokio-fs                      0.1.4          60ae25f6b17d25116d2cba342083abe5255d3c2c79cb21ea11aa049c53bf7c75  \
+  tokio-io                      0.1.10         7392fe0a70d5ce0c882c4778116c519bd5dbaa8a7c3ae3d04578b3afafdcda21  \
+  tokio-reactor                 0.1.7          502b625acb4ee13cbb3b90b8ca80e0addd263ddacf6931666ef751e610b07fb5  \
+  tokio-tcp                     0.1.2          7ad235e9dadd126b2d47f6736f65aa1fdcd6420e66ca63f44177bc78df89f912  \
+  tokio-threadpool              0.1.9          56c5556262383032878afad66943926a1d1f0967f17e94bd7764ceceb3b70e7f  \
+  tokio-timer                   0.2.8          4f37f0111d76cc5da132fe9bc0590b9b9cfd079bc7e75ac3846278430a299ff8  \
+  tokio-udp                     0.1.3          66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92  \
+  tokio-uds                     0.2.4          99ce87382f6c1a24b513a72c048b2c8efe66cb5161c9061d00bee510f08dc168  \
+  toml                          0.4.10         758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f  \
+  try-lock                      0.2.2          e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382  \
+  ucd-util                      0.1.3          535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86  \
+  unicase                       1.4.2          7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33  \
+  unicase                       2.2.0          9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90  \
+  unicode-bidi                  0.3.4          49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5  \
+  unicode-normalization         0.1.7          6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25  \
+  unicode-segmentation          1.2.1          aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1  \
+  unicode-width                 0.1.5          882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526  \
+  unicode-xid                   0.1.0          fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc  \
+  unreachable                   1.0.0          382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56  \
+  url                           1.7.2          dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a  \
+  utf8-ranges                   1.0.2          796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737  \
+  uuid                          0.6.5          e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363  \
+  uuid                          0.7.1          dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6  \
+  vcpkg                         0.2.6          def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d  \
+  vec_map                       0.8.1          05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a  \
+  version_check                 0.1.5          914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd  \
+  void                          1.0.2          6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d  \
+  walkdir                       2.2.7          9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1  \
+  want                          0.0.6          797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3  \
+  winapi                        0.2.8          167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a  \
+  winapi                        0.3.6          92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0  \
+  winapi-build                  0.1.1          2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc  \
+  winapi-i686-pc-windows-gnu    0.4.0          ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6  \
+  winapi-util                   0.1.1          afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab  \
+  winapi-x86_64-pc-windows-gnu  0.4.0          712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f  \
+  wincolor                      0.1.6          eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767  \
+  wincolor                      1.0.1          561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba  \
+  ws2_32-sys                    0.2.1          d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e  \
+  xattr                         0.2.2          244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c  \
+  zip                           0.5.0          00acf1fafb786ff450b6726e5be41ef029142597b47a40ce80f952f1471730a0
+
+checksums-append    ${name}-${version}${extract.suffix} \
+                    rmd160  326d99ced778c5ddbbfca7bd818645d6df396715 \
+                    sha256  4483fa9cde09f274343a95743a9b03f808835ada480ca92113899d92377f9ad5 \
+                    size    916252 \
+                    MacTypes-sys-1.3.0.crate \
+                    rmd160  e9cd809a80545d1d9ac89a57780f599c0f258626 \
+                    size    8660 \
+                    adler32-1.0.3.crate \
+                    rmd160  2860e381b2c52325b1b8befb3b6db0727f0eb66b \
+                    size    5734 \
+                    aho-corasick-0.6.9.crate \
+                    rmd160  142faa94cfdadb1f547c9aca2409e8f869b6044f \
+                    size    25979 \
+                    annotate-snippets-0.5.0.crate \
+                    rmd160  76fba784d9d0b85b40d068260c20f8e9a32ae3cf \
+                    size    21506 \
+                    ansi_term-0.11.0.crate \
+                    rmd160  0bc10d826fc7a658ac1026dac333cc54f26f7c5b \
+                    size    17087 \
+                    arrayvec-0.4.10.crate \
+                    rmd160  c9053ff76d759abd696ec0c3c0439da4f00bc7f4 \
+                    size    26133 \
+                    assert_cli-0.6.3.crate \
+                    rmd160  c36c094df87038eb536cecb117733fe7ed79e2b8 \
+                    size    18660 \
+                    atty-0.2.11.crate \
+                    rmd160  3276365dae3731cadede9ced14185178cc6f4ef9 \
+                    size    5916 \
+                    autocfg-0.1.1.crate \
+                    rmd160  035241c8c510e551f7232115701e65eaa7c061e2 \
+                    size    10044 \
+                    backtrace-0.3.13.crate \
+                    rmd160  a732c613b1d4f99711de81dae33f17b6409d7764 \
+                    size    34101 \
+                    backtrace-sys-0.1.28.crate \
+                    rmd160  3225ba5733d0c28f3175486b016c915d5377e8a8 \
+                    size    522603 \
+                    base64-0.9.3.crate \
+                    rmd160  bcad6aa30bbf392479517b341b41909fbc969f40 \
+                    size    37993 \
+                    bitflags-1.0.4.crate \
+                    rmd160  fd720dba692f079a1c6662e43677533bb68654de \
+                    size    15282 \
+                    build_const-0.2.1.crate \
+                    rmd160  f33e3e64b89b8a7169c8fb81bdd82f4ea4505bf8 \
+                    size    4499 \
+                    bytecount-0.3.2.crate \
+                    rmd160  cda4f686cbfddf42f17bc10748ec51816345ca33 \
+                    size    11026 \
+                    byteorder-1.2.7.crate \
+                    rmd160  e220bb9ad58bf38faf3b0b72606f708601134e7a \
+                    size    19640 \
+                    bytes-0.4.11.crate \
+                    rmd160  c349b79d639a74ae8543a818f9cbf42b17efc2d0 \
+                    size    45988 \
+                    bzip2-0.3.3.crate \
+                    rmd160  a9dd828a3e90beed54ba64c7518609a927e8134d \
+                    size    15346 \
+                    bzip2-sys-0.1.7.crate \
+                    rmd160  ee33a69577c20ee407a4f3bc2544708152a5efcf \
+                    size    609563 \
+                    cc-1.0.28.crate \
+                    rmd160  bca754b4bf3e9acafb48e1c84d0f4d105458722f \
+                    size    42422 \
+                    cfg-if-0.1.6.crate \
+                    rmd160  f190c1846549b3ad88559ae471cf2828c0bf44d1 \
+                    size    7411 \
+                    clap-2.32.0.crate \
+                    rmd160  069963d76d9d566b3ec52976b30c798d564e198d \
+                    size    196073 \
+                    clap-verbosity-flag-0.2.0.crate \
+                    rmd160  4704a6b5f8e928253e2194e81dfc3f17f4edc010 \
+                    size    6463 \
+                    cloudabi-0.0.3.crate \
+                    rmd160  4da7ab080c1d18e5881dbcb419d250d0c38387eb \
+                    size    22156 \
+                    colored-1.6.1.crate \
+                    rmd160  52e20d82f9b7edf852c795a86e9e1125258e2a51 \
+                    size    17671 \
+                    core-foundation-0.5.1.crate \
+                    rmd160  fa15db28e2ad013125c308c21145abd5f86d6580 \
+                    size    22519 \
+                    core-foundation-sys-0.5.1.crate \
+                    rmd160  7cc63d488ef7510a2569b9c84fc09bac320c263e \
+                    size    15974 \
+                    crc-1.8.1.crate \
+                    rmd160  3ed84aa2ceb54ddc691479e756745d0eed09cfe3 \
+                    size    9114 \
+                    crc32fast-1.1.2.crate \
+                    rmd160  4412da5e699626e06695fee297ed23e72b19960e \
+                    size    38312 \
+                    crossbeam-channel-0.3.4.crate \
+                    rmd160  10fd9b7000adddad5b4a0adf14b5db8d587718b4 \
+                    size    78849 \
+                    crossbeam-deque-0.2.0.crate \
+                    rmd160  dc1109fafb6b49ec4435324eb12ae870f8defcd0 \
+                    size    12638 \
+                    crossbeam-deque-0.6.3.crate \
+                    rmd160  1ef5127cbe33bca38fb15d33b95a467c510f8af3 \
+                    size    14238 \
+                    crossbeam-epoch-0.3.1.crate \
+                    rmd160  e9a6255c2f50b8978cf713771d049ed2b42a369b \
+                    size    33093 \
+                    crossbeam-epoch-0.7.0.crate \
+                    rmd160  49bfad30940bb1c2cada17a6b4ea70ae88efda22 \
+                    size    34324 \
+                    crossbeam-utils-0.2.2.crate \
+                    rmd160  e26692f3b3cbcd5ea282393d77ba1b808667c4d5 \
+                    size    11901 \
+                    crossbeam-utils-0.6.3.crate \
+                    rmd160  0f25c67721643427350f42c686c68d41f450466b \
+                    size    22304 \
+                    difference-2.0.0.crate \
+                    rmd160  573fd617cb30fcee72a7ff608924460e532edc0d \
+                    size    147616 \
+                    dtoa-0.4.3.crate \
+                    rmd160  ca7571a6b977196010374cce2b91bc562e5f76e0 \
+                    size    14456 \
+                    either-1.5.0.crate \
+                    rmd160  30b45a3f110416c2dc85c263b3b577dd5b178e74 \
+                    size    10900 \
+                    encoding_rs-0.8.13.crate \
+                    rmd160  06e54d8797d232819a6636b228fb79a48f1ef8c3 \
+                    size    1428086 \
+                    env_logger-0.5.13.crate \
+                    rmd160  df0f5d9199b9111077b5b02cd5748d84e974c9af \
+                    size    25275 \
+                    environment-0.1.1.crate \
+                    rmd160  966b89665c66e1bdf2ef7abfb65f169a5a8f28cf \
+                    size    3227 \
+                    exitfailure-0.5.1.crate \
+                    rmd160  c17cd7a3b3a322efd1b4861786fb5c26df7946a9 \
+                    size    11425 \
+                    failure-0.1.3.crate \
+                    rmd160  0e17e145e6045d1dc9aa0b7ffac8ae2bf0a07630 \
+                    size    34107 \
+                    failure_derive-0.1.3.crate \
+                    rmd160  487996ef3aea5b083af10f7613655600888089e6 \
+                    size    4349 \
+                    filetime-0.2.4.crate \
+                    rmd160  93ed9d3d38c6accc84b57f62adbdf7ac62eeccfe \
+                    size    12044 \
+                    flate2-1.0.6.crate \
+                    rmd160  8e5017c5accbd35c137d37357db48975036416a2 \
+                    size    64769 \
+                    fnv-1.0.6.crate \
+                    rmd160  2dd59fa1942e8e496ea4e2e01dc98279a95b5dcf \
+                    size    11131 \
+                    foreign-types-0.3.2.crate \
+                    rmd160  a99c7ff186c330c0a433e24c0ed522b1825541f7 \
+                    size    7504 \
+                    foreign-types-shared-0.1.1.crate \
+                    rmd160  6b4724c5b5329e657a05dafbac7325d471612211 \
+                    size    5672 \
+                    fuchsia-zircon-0.3.3.crate \
+                    rmd160  1c6ff549ecff64347e4b53dc8eb95d1444b78647 \
+                    size    22565 \
+                    fuchsia-zircon-sys-0.3.3.crate \
+                    rmd160  4b9e5d77223362e647972d7ccc66f69236aa1e89 \
+                    size    7191 \
+                    futures-0.1.25.crate \
+                    rmd160  89f1b4a79d325158a8007584c5f6849ed2b192f2 \
+                    size    158626 \
+                    futures-cpupool-0.1.8.crate \
+                    rmd160  2c7f18cf2e951194b6363806812ede306010bdef \
+                    size    10583 \
+                    getopts-0.2.18.crate \
+                    rmd160  85ae376b4e0d2419907bcc3a6a853fedfccffc6c \
+                    size    18416 \
+                    globset-0.4.2.crate \
+                    rmd160  479b1c8ab9151802b37c9d7845606410385afc15 \
+                    size    22474 \
+                    globwalk-0.3.1.crate \
+                    rmd160  f319f6a43117ec492e6615309e6482b1af03a39c \
+                    size    8409 \
+                    h2-0.1.14.crate \
+                    rmd160  67379424a6e06cc9328042deeb830aa79ccdfc31 \
+                    size    140365 \
+                    heck-0.3.1.crate \
+                    rmd160  e1df454f4fb46feab9f869917f22e1ebcd3c3579 \
+                    size    54666 \
+                    http-0.1.14.crate \
+                    rmd160  7289d9d58c9e75e275a04a5705733fedfa7da0b5 \
+                    size    97027 \
+                    httparse-1.3.3.crate \
+                    rmd160  beb43d80099d3d01c91f5ed0d112a19b11e26438 \
+                    size    23689 \
+                    human-panic-1.0.1.crate \
+                    rmd160  8bfdbc59bd05cf2194a54b47a18bb07cdef9123c \
+                    size    14431 \
+                    humantime-1.2.0.crate \
+                    rmd160  b96ce801cfc4b6469d62c5de1758b66676c88249 \
+                    size    16795 \
+                    hyper-0.12.19.crate \
+                    rmd160  8e796f2f29cc43b826e79cf956caa42a0548ae7b \
+                    size    113017 \
+                    hyper-old-types-0.11.0.crate \
+                    rmd160  3a10bf795d8204af258a647221ebca98ba38faab \
+                    size    89127 \
+                    hyper-tls-0.3.1.crate \
+                    rmd160  cda2bcf614da04b206b8f9413e381f1f2de424e4 \
+                    size    8836 \
+                    idna-0.1.5.crate \
+                    rmd160  e4049ab9ac2f8338e23c55d1f948c55a7f265d02 \
+                    size    258735 \
+                    ignore-0.4.5.crate \
+                    rmd160  3414b124370b76aa57e906c7f5efc14ec5dae13d \
+                    size    45517 \
+                    indexmap-1.0.2.crate \
+                    rmd160  c33801a950a85883e1b58dff9f50503613d201ca \
+                    size    38255 \
+                    iovec-0.1.2.crate \
+                    rmd160  eb35790d17a2d6dab4353f57e6b1875b0e41ad4b \
+                    size    8565 \
+                    itertools-0.8.0.crate \
+                    rmd160  747db7475a299e2f181045a38275030c3ec9e875 \
+                    size    78917 \
+                    itoa-0.4.3.crate \
+                    rmd160  6de7c975f7c4522b2e6a4d1804e42bb0673bdeee \
+                    size    11061 \
+                    kernel32-sys-0.2.2.crate \
+                    rmd160  c25a6cce8b38dad557b1c21e41e688d43406389f \
+                    size    24537 \
+                    language-tags-0.2.2.crate \
+                    rmd160  7e3789f65f62c9c16bf98c0ddc9fb99b7a5a5a98 \
+                    size    12754 \
+                    lazy_static-1.2.0.crate \
+                    rmd160  92005f698356b188b35ae897b821137e61642966 \
+                    size    10840 \
+                    lazycell-1.2.1.crate \
+                    rmd160  aa0807dc6f3190c61f6525b601ade584e5f55cfa \
+                    size    11691 \
+                    libc-0.2.45.crate \
+                    rmd160  c17367aca854ffad6538751f8a0a00f6d3442416 \
+                    size    349425 \
+                    libflate-0.1.19.crate \
+                    rmd160  0c3506780c350566980ce58b8ee40e39e4489913 \
+                    size    35247 \
+                    lock_api-0.1.5.crate \
+                    rmd160  ba1a2e7fc818e0cdef3386da54a0041444173327 \
+                    size    16967 \
+                    log-0.4.6.crate \
+                    rmd160  af66860f529673c05c3a4b161d0290c2bbfb462c \
+                    size    22303 \
+                    maplit-1.0.1.crate \
+                    rmd160  d041c5dde5356725ac7fbc2984536ad3c1588f50 \
+                    size    8590 \
+                    matches-0.1.8.crate \
+                    rmd160  dc8239e015b64fbc488e1ea9ff74aad38f872a72 \
+                    size    2216 \
+                    memchr-2.1.2.crate \
+                    rmd160  1973ab2a3624060a2aa1990ccc9b8e4a5b7988df \
+                    size    19520 \
+                    memoffset-0.2.1.crate \
+                    rmd160  5920a7d0cbebb035c2e91fb056f54a48fd8ac2ee \
+                    size    4618 \
+                    mime-0.3.12.crate \
+                    rmd160  6a694488761f9d1fee27710681307b4330648129 \
+                    size    14815 \
+                    mime_guess-2.0.0-alpha.6.crate \
+                    rmd160  491e232857a7eddb3eb9cc2205f3c032904b1dde \
+                    size    17579 \
+                    miniz-sys-0.1.11.crate \
+                    rmd160  73ca271c2cdcb7be68cd9fd12eeac32fe79fc6ac \
+                    size    78188 \
+                    miniz_oxide-0.2.0.crate \
+                    rmd160  363d79e4a8201e8defef75a28accbd224bd3cb36 \
+                    size    49387 \
+                    miniz_oxide_c_api-0.2.0.crate \
+                    rmd160  c537553c64996b52295459ffd10b1300e3b792d5 \
+                    size    166923 \
+                    mio-0.6.16.crate \
+                    rmd160  6aa3bd58ab209388827c60b39373fe124c270f10 \
+                    size    126174 \
+                    mio-uds-0.6.7.crate \
+                    rmd160  3f4b14a55229a89af6113ed9cb6279399ba66156 \
+                    size    14389 \
+                    miow-0.2.1.crate \
+                    rmd160  cb287b2c09dcd951fb798144902df7b503dbed2b \
+                    size    21133 \
+                    native-tls-0.2.2.crate \
+                    rmd160  c23ad69ae2043b08d9fd8016c904721cfeb6438f \
+                    size    29238 \
+                    net2-0.2.33.crate \
+                    rmd160  d88b2fc1b694904e6dc6e13a829f659ef17452b7 \
+                    size    20936 \
+                    nodrop-0.1.13.crate \
+                    rmd160  6478a3dead0c72da1d32615205d0c2f4ab17734a \
+                    size    7508 \
+                    nom-4.2.3.crate \
+                    rmd160  9ae35d1053d833919e0caa545f38536182a872db \
+                    size    115343 \
+                    nom_locate-0.3.1.crate \
+                    rmd160  1a90c250778912edacc44082b9d68669e69245a2 \
+                    size    11834 \
+                    num-derive-0.2.3.crate \
+                    rmd160  c457a9c5b9326ec3596e59a8fccf5a8d08f9a490 \
+                    size    13362 \
+                    num-traits-0.2.6.crate \
+                    rmd160  b9711ea18adbc559a892b0741877f5a5a840e3e8 \
+                    size    39923 \
+                    num_cpus-1.9.0.crate \
+                    rmd160  4cc51dc6223098ddad4c1ded4ff1fd4affa5a66b \
+                    size    10599 \
+                    openssl-0.10.16.crate \
+                    rmd160  13827a92ceee5d10b91e9dee9456b500e150e0e2 \
+                    size    168681 \
+                    openssl-probe-0.1.2.crate \
+                    rmd160  1c34c57af386e16d9fedf37664faad661753c595 \
+                    size    6427 \
+                    openssl-sys-0.9.40.crate \
+                    rmd160  22965f82b6778f9a01ad89730c273f608c0c1562 \
+                    size    43360 \
+                    ordered-float-1.0.1.crate \
+                    rmd160  03d102580b2828999380e092c175af460cb7e0b8 \
+                    size    9276 \
+                    os_type-2.2.0.crate \
+                    rmd160  26ac614cb2141a9483a06b9b8f24b87bda24a974 \
+                    size    7653 \
+                    owning_ref-0.4.0.crate \
+                    rmd160  b3718973496355ca2de77e567f3cb2388ff203ba \
+                    size    12233 \
+                    parking_lot-0.6.4.crate \
+                    rmd160  90c4e6cec322cb5cbbdeb7755c1fcdbfb0c22625 \
+                    size    31890 \
+                    parking_lot-0.7.0.crate \
+                    rmd160  9d44486c08eea0813cc4d6c38e26e4337a05d53a \
+                    size    32324 \
+                    parking_lot_core-0.3.1.crate \
+                    rmd160  4f36cfbdd51c74d67574835a5feb7fb16decaff3 \
+                    size    26635 \
+                    parking_lot_core-0.4.0.crate \
+                    rmd160  fa8a0e4fbb236dfb080c3baf5deb2af2c98ee4a9 \
+                    size    26817 \
+                    pbr-1.0.1.crate \
+                    rmd160  76d3c1d2685444ecac0e7df8663c43b8b50e5c3b \
+                    size    3753253 \
+                    percent-encoding-1.0.1.crate \
+                    rmd160  68898d3983e831ac02ae8d440a5c6f5a8e395695 \
+                    size    10057 \
+                    phf-0.7.23.crate \
+                    rmd160  e0639100b32911acf0797534067cd47e8f8633ed \
+                    size    3841 \
+                    phf_codegen-0.7.23.crate \
+                    rmd160  dcba17e417997ebfdc182c0208a354d4bdd6613e \
+                    size    2866 \
+                    phf_generator-0.7.23.crate \
+                    rmd160  57fcec11b9c62d415bf080bad4450a3b1bd95636 \
+                    size    2219 \
+                    phf_shared-0.7.23.crate \
+                    rmd160  eec5f9b7ef810722d609e63a9004ca23745fa863 \
+                    size    2084 \
+                    pkg-config-0.3.14.crate \
+                    rmd160  71db4ba8eb80a327f21fc2d689233fd4cf825ae0 \
+                    size    13565 \
+                    podio-0.1.6.crate \
+                    rmd160  81b69b745caccff1c0f8b59cf75e396ea9d57d18 \
+                    size    10186 \
+                    proc-macro2-0.4.24.crate \
+                    rmd160  bbd92a79ca663073f20126fdabdc0edd386d0557 \
+                    size    30970 \
+                    pulldown-cmark-0.2.0.crate \
+                    rmd160  0410951fa27d0b1ec8365b924989ece401371a94 \
+                    size    119609 \
+                    quantiles-0.7.1.crate \
+                    rmd160  e94b4344c28f0fc17de9b6632c9751db15feb885 \
+                    size    24339 \
+                    quick-error-1.2.2.crate \
+                    rmd160  7edef98c346d4f12f0a1256335bb9a85f1cb305d \
+                    size    15132 \
+                    quicli-0.4.0.crate \
+                    rmd160  eec8fefe06fef43802332782a3b2975a0d0b4e41 \
+                    size    17807 \
+                    quote-0.6.10.crate \
+                    rmd160  baf3e1f9cce4dd4e92a8ae20c4b5ce8ed768b63f \
+                    size    15795 \
+                    rand-0.4.3.crate \
+                    rmd160  0911fc63ee17323176b7806d7ed6db412b32ac0f \
+                    size    76094 \
+                    rand-0.5.5.crate \
+                    rmd160  09a484f5c5e3501d87ec80eb4be990fcb421b9a9 \
+                    size    137359 \
+                    rand-0.6.1.crate \
+                    rmd160  bc44e065c78ffa042de1bf9e12284ec14f1dc9f5 \
+                    size    126613 \
+                    rand_chacha-0.1.0.crate \
+                    rmd160  9498af8a4982ffb828ad321616558f8e31ec5c43 \
+                    size    11637 \
+                    rand_core-0.2.2.crate \
+                    rmd160  333621510560ad7e8e982e5d6ef1dd5d2b932afb \
+                    size    15450 \
+                    rand_core-0.3.0.crate \
+                    rmd160  a19a998a918f95fcd70748ddd120089a022deda5 \
+                    size    20581 \
+                    rand_hc-0.1.0.crate \
+                    rmd160  067ca62839fb5cde9dc018dc0c95db5b6eb3387b \
+                    size    11644 \
+                    rand_isaac-0.1.1.crate \
+                    rmd160  5d0f0a1a2b0385cd7901ceeda695d31cfacd0cac \
+                    size    16020 \
+                    rand_pcg-0.1.1.crate \
+                    rmd160  533f5f25ebbaa1a055a09242d0b79246d8dd4933 \
+                    size    10881 \
+                    rand_xorshift-0.1.0.crate \
+                    rmd160  73d49641dd7df6353bd3dcdf00afa56de5f58010 \
+                    size    9194 \
+                    rayon-1.0.3.crate \
+                    rmd160  d2e2bf847c6169456fdaf116088ca660c91f3c45 \
+                    size    134391 \
+                    rayon-core-1.4.1.crate \
+                    rmd160  25e9b3af9fd22433f7183cf30ea49cec3323ed64 \
+                    size    53760 \
+                    redox_syscall-0.1.44.crate \
+                    rmd160  6f095223ff38aacfd3e0d7cad2ee344409901300 \
+                    size    15254 \
+                    redox_termios-0.1.1.crate \
+                    rmd160  4403f32fb5435279446c9b6acc54792d655d4f72 \
+                    size    3227 \
+                    regex-1.1.0.crate \
+                    rmd160  30c1df865aa99c31b45fcb92df7c2d0454d4f481 \
+                    size    241219 \
+                    regex-syntax-0.6.4.crate \
+                    rmd160  732c501a0998ae07b9e9387c0ef95ad4ff80bbc3 \
+                    size    272048 \
+                    remove_dir_all-0.5.1.crate \
+                    rmd160  13b7dcf0ae8c4100d53134d45c32539b7a4debfb \
+                    size    8726 \
+                    reqwest-0.9.5.crate \
+                    rmd160  dedc8ba3b3e4055a930edc281cdde931ce381708 \
+                    size    63819 \
+                    rustc-demangle-0.1.11.crate \
+                    rmd160  05d7b2b197b90dcce9159866a78f387a4a125dbe \
+                    size    11579 \
+                    rustc_version-0.2.3.crate \
+                    rmd160  6ca6aa5c736a1f88dd7579eb78d097ec40663173 \
+                    size    10210 \
+                    ryu-0.2.7.crate \
+                    rmd160  b0695d2b1ab622ab30322144f55983a2b6cf14ca \
+                    size    41382 \
+                    safemem-0.3.0.crate \
+                    rmd160  7a6ebe4c105f7a6ce43ed5e6710b586c3cf04802 \
+                    size    6947 \
+                    same-file-1.0.4.crate \
+                    rmd160  54aaf855c0d1dcc8a5c370c1629c09819fdfb0bf \
+                    size    8678 \
+                    schannel-0.1.14.crate \
+                    rmd160  ea162107e95079345e175130dba11a2901d2df96 \
+                    size    38833 \
+                    scopeguard-0.3.3.crate \
+                    rmd160  e77508e3d64bc39c22ac5c87f8937906d160019e \
+                    size    9605 \
+                    security-framework-0.2.1.crate \
+                    rmd160  6cceee99bf42de76ae5e6c16597b2a6c6b835567 \
+                    size    39220 \
+                    security-framework-sys-0.2.2.crate \
+                    rmd160  252d8498ffc4d2ef0ce865be1b254889cd9da822 \
+                    size    9352 \
+                    self_update-0.5.0.crate \
+                    rmd160  2ec1f78c01ce2d7e1845929b02f859e7f94cba94 \
+                    size    13972 \
+                    semver-0.9.0.crate \
+                    rmd160  f3ba6d2359a3690d316a22586db785538b0e09ac \
+                    size    17344 \
+                    semver-parser-0.7.0.crate \
+                    rmd160  63f826b792b17493186d587b9887efd93121294b \
+                    size    10268 \
+                    serde-1.0.82.crate \
+                    rmd160  42bcbb1f9cdd6c9a1caf3f81c69eb59264eb2d60 \
+                    size    71666 \
+                    serde_derive-1.0.82.crate \
+                    rmd160  905902984c1c9506b891e79c657c63aa91a52fd6 \
+                    size    47403 \
+                    serde_json-1.0.33.crate \
+                    rmd160  ffd4f6808828147cf2b1a33c264e4b586fa8a6e5 \
+                    size    69738 \
+                    serde_urlencoded-0.5.4.crate \
+                    rmd160  9f48f2d4b28f5c230de7c05439a73f575b28d645 \
+                    size    12552 \
+                    siphasher-0.2.3.crate \
+                    rmd160  377ddb77801a3170c19e427bc266b7ae3c6b4c28 \
+                    size    8717 \
+                    slab-0.4.1.crate \
+                    rmd160  6c3a417459c621d0390cd5ca5b2b90c31a3a4d89 \
+                    size    9479 \
+                    smallvec-0.6.7.crate \
+                    rmd160  5d41c043dd309a5529c38e38d66e54d18e250d84 \
+                    size    21450 \
+                    stable_deref_trait-1.1.1.crate \
+                    rmd160  2864679bbc382223ef85944502118c744a22e703 \
+                    size    8007 \
+                    string-0.1.2.crate \
+                    rmd160  305b695d28efc4226ebf2c1f7da11c027b5d0a18 \
+                    size    3989 \
+                    strsim-0.7.0.crate \
+                    rmd160  82c766cebe88a39e3058a21c730b43b3bf6e929d \
+                    size    8435 \
+                    strsim-0.8.0.crate \
+                    rmd160  980ec0eecba085ca6419d089af3743e23b27cd16 \
+                    size    9309 \
+                    structopt-0.2.14.crate \
+                    rmd160  60da9cbf89b8890a2429e974357c0636895c60f5 \
+                    size    25517 \
+                    structopt-derive-0.2.14.crate \
+                    rmd160  7a1d1b914a82a7b059f53fba6a4a737197007364 \
+                    size    12411 \
+                    syn-0.15.23.crate \
+                    rmd160  c1b6a1478ccf857727cf522d3b89b3385e936376 \
+                    size    145369 \
+                    synstructure-0.10.1.crate \
+                    rmd160  93582be7ce86406df4aeafce645bae173e7bec8c \
+                    size    17836 \
+                    tar-0.4.20.crate \
+                    rmd160  9aa5426ec3f5ba65acd77b266c579802e45d3618 \
+                    size    45525 \
+                    tempdir-0.3.7.crate \
+                    rmd160  196eae26810acca0e4a52f690c79a74c147a963c \
+                    size    11468 \
+                    tempfile-3.0.5.crate \
+                    rmd160  508e325878dc220f9b09aca8145d6a329bc5d553 \
+                    size    23272 \
+                    termcolor-0.3.6.crate \
+                    rmd160  531d4f2e0119ff307436878805768bdc24cc2a23 \
+                    size    13548 \
+                    termcolor-1.0.4.crate \
+                    rmd160  23dfcf330b265973b26e7491d1f13aeee66157db \
+                    size    14416 \
+                    terminal_size-0.1.8.crate \
+                    rmd160  b13ddbc3fbd30332cc7361d02459ecf889471206 \
+                    size    7289 \
+                    termion-1.5.1.crate \
+                    rmd160  1dd6b33cc0518b95da88648441807c210a2a498f \
+                    size    20659 \
+                    textwrap-0.10.0.crate \
+                    rmd160  93e9595c1e99d77cfa8f5111f40b52d6292e617b \
+                    size    15986 \
+                    thread_local-0.3.6.crate \
+                    rmd160  58db38e54f31dc4c247aae31770f73047b17a7db \
+                    size    12388 \
+                    time-0.1.41.crate \
+                    rmd160  b10dddebb7bc21556f278d9e79a0f7d366b9f269 \
+                    size    29991 \
+                    tokio-0.1.13.crate \
+                    rmd160  326f47fb23506b2660f2f2266ef5240a55b27600 \
+                    size    79248 \
+                    tokio-codec-0.1.1.crate \
+                    rmd160  5b62e89cbf3e2ffedd292463fe1699d888245a54 \
+                    size    7617 \
+                    tokio-current-thread-0.1.4.crate \
+                    rmd160  d0ab595f490e339f6c94e0bbbf20f13d9222aae4 \
+                    size    19400 \
+                    tokio-executor-0.1.5.crate \
+                    rmd160  89e2c0b0ae9287fd25c9a20de65b2f7647bd8913 \
+                    size    10540 \
+                    tokio-fs-0.1.4.crate \
+                    rmd160  f50ad35866de40ccc9af0f4f3fdccee345137f1c \
+                    size    12706 \
+                    tokio-io-0.1.10.crate \
+                    rmd160  621bdb4e6410e9b7773f6e11ab491624c148db9d \
+                    size    33143 \
+                    tokio-reactor-0.1.7.crate \
+                    rmd160  7026b4d727b51879816eb290826cc36f14c66659 \
+                    size    23740 \
+                    tokio-tcp-0.1.2.crate \
+                    rmd160  c29a529df4a3358ec1bea389896d3ae497a8870c \
+                    size    10633 \
+                    tokio-threadpool-0.1.9.crate \
+                    rmd160  05c0718aaeb16d1a948ff549a6225727327c3d33 \
+                    size    48778 \
+                    tokio-timer-0.2.8.crate \
+                    rmd160  a0e6fb7b9a624739903c96b84814a68bdcb02ff7 \
+                    size    36835 \
+                    tokio-udp-0.1.3.crate \
+                    rmd160  dcbb925a5a925e793752144f677c6fafd497e566 \
+                    size    10227 \
+                    tokio-uds-0.2.4.crate \
+                    rmd160  fe2361a45a8a40e39ee5956da34df1bce05931e1 \
+                    size    11837 \
+                    toml-0.4.10.crate \
+                    rmd160  e04d3ba90e847017fb151629c6912760e7c06fc8 \
+                    size    47534 \
+                    try-lock-0.2.2.crate \
+                    rmd160  772f07ca023eae6345c74f5b52296c437bceb144 \
+                    size    3638 \
+                    ucd-util-0.1.3.crate \
+                    rmd160  c9eeb795a73b8facbf7679e3877689eb2551fb90 \
+                    size    25897 \
+                    unicase-1.4.2.crate \
+                    rmd160  0b0793bceea1ff1c9e29f83a7f4a60aefeca9499 \
+                    size    3907 \
+                    unicase-2.2.0.crate \
+                    rmd160  1bac7d2650f43c3cf91633ac74ddb87ccf331e3f \
+                    size    19587 \
+                    unicode-bidi-0.3.4.crate \
+                    rmd160  7c16a80cb62bef8cc6d73eb6126d496b46dbad1d \
+                    size    32228 \
+                    unicode-normalization-0.1.7.crate \
+                    rmd160  4cbee8c9b2979aa0aa93f5a222fd0b72c46e97c6 \
+                    size    330545 \
+                    unicode-segmentation-1.2.1.crate \
+                    rmd160  5695c194d6f49bbb4a4e7a452fcbc5b03b8d80ce \
+                    size    68223 \
+                    unicode-width-0.1.5.crate \
+                    rmd160  360df9e831a6e20931c240d13747f3711dc568d9 \
+                    size    15761 \
+                    unicode-xid-0.1.0.crate \
+                    rmd160  fc5a8141e55bf6e2660b8c588e1107f179d24bb8 \
+                    size    16000 \
+                    unreachable-1.0.0.crate \
+                    rmd160  00c79ce6e523b3b09978db8766e3110a637c23ec \
+                    size    6355 \
+                    url-1.7.2.crate \
+                    rmd160  c46442b7903a874b0556861845d5121bfc3b5397 \
+                    size    68597 \
+                    utf8-ranges-1.0.2.crate \
+                    rmd160  472c5b94c5ca826c8788d2e6629b713a9df70fd6 \
+                    size    8510 \
+                    uuid-0.6.5.crate \
+                    rmd160  fa72651150ec7c1e864c6e0e1ca72f52dca09f43 \
+                    size    26185 \
+                    uuid-0.7.1.crate \
+                    rmd160  c1378fa1d213ee1413aaa1fad2e859d2dd56d654 \
+                    size    32775 \
+                    vcpkg-0.2.6.crate \
+                    rmd160  6bf4e1d4423173717dfb8ebc5cfde722331a8b85 \
+                    size    9866 \
+                    vec_map-0.8.1.crate \
+                    rmd160  60ade9d4a361db970dd5a27786e5de3b491a4b62 \
+                    size    14959 \
+                    version_check-0.1.5.crate \
+                    rmd160  0806190559062dc843ecf13393f6c1319367eac1 \
+                    size    8173 \
+                    void-1.0.2.crate \
+                    rmd160  5d76f91beb625f5b645c156ca45ee5138e984e80 \
+                    size    2356 \
+                    walkdir-2.2.7.crate \
+                    rmd160  9cfe458f37843894e0aa27db9e16af5b3acc74b1 \
+                    size    23507 \
+                    want-0.0.6.crate \
+                    rmd160  ac801122aa9cbb703dba7d394b028aa63da9a61d \
+                    size    5434 \
+                    winapi-0.2.8.crate \
+                    rmd160  a30e4a3792706281d7940240df05d7ef60c53ef9 \
+                    size    455145 \
+                    winapi-0.3.6.crate \
+                    rmd160  549ef0ff7cd1a0f2aabf915ae603ed2c3c920ab6 \
+                    size    1029391 \
+                    winapi-build-0.1.1.crate \
+                    rmd160  f1b6c5812fd6613c6e67e22c5f961963ae3ac5f2 \
+                    size    669 \
+                    winapi-i686-pc-windows-gnu-0.4.0.crate \
+                    rmd160  a7d1e9e7f940d2e376a1b6dede7f0a50ad191ab8 \
+                    size    2918815 \
+                    winapi-util-0.1.1.crate \
+                    rmd160  5249ad394eca9d272699ed0d8f4b05e6fb54985e \
+                    size    7635 \
+                    winapi-x86_64-pc-windows-gnu-0.4.0.crate \
+                    rmd160  300417853d251d91cadb9650992a6aa98248619f \
+                    size    2947998 \
+                    wincolor-0.1.6.crate \
+                    rmd160  c5f6537242c11ce937a412fc48355e94c4bf358b \
+                    size    4799 \
+                    wincolor-1.0.1.crate \
+                    rmd160  7f0592701f4e464e9b54be648fda3b06ebb651f1 \
+                    size    4737 \
+                    ws2_32-sys-0.2.1.crate \
+                    rmd160  883038c3ec6db615e0c96f0788f1a24892a855b2 \
+                    size    4697 \
+                    xattr-0.2.2.crate \
+                    rmd160  6d3668a1b5818aa07c3d40d4b6500abd6be89760 \
+                    size    11750 \
+                    zip-0.5.0.crate \
+                    rmd160  3d95b44d1632282d04ef112077436dce6fe5ded7 \
+                    size    29345


### PR DESCRIPTION
#### Description

New port for Russell Cohen's [angle-grinder](https://github.com/rcoh/angle-grinder); slice and dice logs on the command line.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
