### PR TITLE
tcptraceroute: checksum mismatch

### DIFF
--- a/net/tcptraceroute/Portfile
+++ b/net/tcptraceroute/Portfile
@@ -12,10 +12,13 @@ maintainers     nomaintainer
 description     a traceroute implementation using TCP packets
 long_description    ${description}
 
-checksums       rmd160  fe937341f4ef1aa358b253c3af490419a689031f \
-                sha256  aed5b163ed4886f04242b46005a6cb4876ef38ad72001a94facb62a99dc99c57 \
-                size    119119
+checksums       rmd160  d8f2a04420ec13423210872a69fca2879b0473f2 \
+                sha256  3b27b7c67e2eb00ef800c83e496f1198b992f038de5d3d13aa530ee3b22c77bb \
+                size    119068
 revision        1
+
+# remove if new version
+dist_subdir     ${name}/${version}_1
 
 depends_lib     port:libnet11 port:libpcap
 


### PR DESCRIPTION
#### Description

fix wrong checksums; during update from md5/sha1 I used for mistake
the distfiles.macports.org version and not the github one.

Closes: https://trac.macports.org/ticket/59064

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A419c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
