### PR TITLE
py-pyqt5: update version to 5.12.3 and fix build

### DIFF
--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -5,7 +5,8 @@ PortGroup               python 1.0
 PortGroup               cxx11  1.1
 
 name                    py-pyqt5
-version                 5.12.2
+# we the next bump check --allow-sip-warnings if needed
+version                 5.12.3
 revision                0
 categories-append       devel
 platforms               darwin
@@ -17,9 +18,9 @@ homepage                https://www.riverbankcomputing.com/software/pyqt/intro
 license                 GPL-3
 master_sites            https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/
 distname                PyQt5_gpl-${version}
-checksums               rmd160  9215967ed17e4b897d482a3d45c33e4ca900a596 \
-                        sha256  c565829e77dc9c281aa1a0cdf2eddaead4e0f844cbaf7a4408441967f03f5f0f \
-                        size    3147205
+checksums               rmd160  c6f93825a79000946f37a3724b48d99e35451517 \
+                        sha256  0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110 \
+                        size    3148196
 
 livecheck.type          regex
 livecheck.url           https://www.riverbankcomputing.com/software/pyqt/download5
@@ -115,7 +116,8 @@ if {${subport} eq "${name}-common"} {
                         --no-qsci-api \
                         --disable=QtWebKit \
                         --disable=QtWebKitWidgets \
-                        --no-dist-info
+                        --no-dist-info \
+                        --allow-sip-warnings
 
     # using --dbus means the compiler will find dbus-python.h but not
     # the DBus headers themselves


### PR DESCRIPTION
#### Description


- bump version to 5.12.3
  add support for Qt v5.12.4 and Python v3.8
- fix build error introduced by SIP v4.19.19 that deprecate the -B
  option; seen that py-pyqt5 use the -B option and the -f ("warning
  messages are treated as errors") the build fail.
  This is not an upstream bug because they release that SIP version
  after this pyqt5 version.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->