### PR TITLE
tor: update to 0.4.1.6

### DIFF
--- a/security/tor/Portfile
+++ b/security/tor/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                tor
 conflicts           tor-devel
-version             0.4.0.5
-revision            2
+version             0.4.1.6
+revision            0
 categories          security
 platforms           darwin
 maintainers         nomaintainer
@@ -23,9 +23,9 @@ long_description    Tor provides a distributed network of servers \
 homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 
-checksums           rmd160  cc0bead52c77d0cb7f65c7c083c48d3810514287 \
-                    sha256  b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e \
-                    size    7203877
+checksums           rmd160  4d4ccc798a057a75e6d5282d01ddaf306341e0f4 \
+                    sha256  2a88524ce426079fb9b828bc1b789f2c8ade3ed53c130851102debc3518bed71 \
+                    size    7390096
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor: update to 0.4.1.6

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.15 19A558d
Xcode 11.0 11A420a

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?