### PR TITLE
new port: miller

### DIFF
--- a/textproc/miller/Portfile
+++ b/textproc/miller/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        johnkerl miller 5.6.2 v
+github.tarball_from archive
+
+platforms           darwin
+categories          textproc
+license             BSD
+
+maintainers         {gmail.com:herbygillot @herbygillot} openmaintainer
+
+description         Miller is like awk, sed, cut, join, and sort for \
+                    name-indexed data such as CSV, TSV, and tabular JSON
+
+long_description    Miller is like awk, sed, cut, join, and sort for \
+                    name-indexed data such as CSV, TSV, and tabular JSON. \
+                    You get to work with your data using named fields, without \
+                    needing to count positional column indices. It operates on \
+                    key-value-pair data while the familiar Unix tools operate \
+                    on integer-indexed fields: if the natural data structure \
+                    for the latter is the array, then Miller’s natural data \
+                    structure is the insertion-ordered hash map. This \
+                    encompasses a variety of data formats, including but not \
+                    limited to the familiar CSV, TSV, and JSON. (Miller can \
+                    handle positionally-indexed data as a special case.)
+
+homepage            https://johnkerl.org/miller/doc/
+
+checksums           rmd160  0a8c092b4716423635d5efdeeaead9d28d7ef64f \
+                    sha256  4a02dad2ea545a8085aec7fcf79b3987ddd8ce9d111d5cede488692bb0f49731 \
+                    size    5021788
+
+installs_libs       no
+
+set mlr_doc_dir     ${prefix}/share/doc/${name}
+
+test {
+    system -W "${worksrcpath}" "${build.cmd} check"
+}
+
+pre-destroot {
+    system -W "${worksrcpath}/doc" "${build.cmd} DESTDIR=\"${destroot}\" install-man"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/c/mlr ${destroot}${prefix}/bin/
+    xinstall -d 755 ${destroot}${mlr_doc_dir}
+    copy {*}[glob ${worksrcpath}/doc/*] ${destroot}${mlr_doc_dir}/
+}
+
+notes "miller is installed as mlr"


### PR DESCRIPTION
#### Description

New port for [miller](http://johnkerl.org/miller/doc/index.html): like awk, sed, cut, join, and sort for name-indexed data such as CSV, TSV, and tabular JSON.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
