### PR TITLE
radare2: possible stealth update

### DIFF
--- a/devel/radare2/Portfile
+++ b/devel/radare2/Portfile
@@ -19,9 +19,12 @@ depends_lib         port:capstone \
                     port:zlib \
                     port:libzip
 
-checksums           rmd160  1fa08634d2516ab1164503ee45bc2affb2fe42cc \
-                    sha256  11b1295ce8b11f900bfcc492e3490ddd2ff3c92ddccaa1aafc9fc16f00046447 \
-                    size    7518150
+# possible stealth update -- remove on next proper version release
+dist_subdir         ${name}/${version}_1
+
+checksums           rmd160  5f9fa14a8c251118c22f4b2e345aa12f992718e4 \
+                    sha256  c5c36fa9fa77120f9687e60ebedde9070e202d3fd56001a712309f0498f83900 \
+                    size    7517461
 
 configure.args-append \
                     --with-syscapstone \


### PR DESCRIPTION
Or maybe something worse?

At any rate, the current github distfile for 3.9.0 has different
checksums and size relative to those committed with the 3.9.0 update.

This PR treats it as a "stealth update" although the maintainer should
assert his due diligence to see that nothing improper is going on here
before merging.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
