### PR TITLE
ipmitool: fix a bug that overwrites configure.args.

### DIFF
--- a/sysutils/ipmitool/Portfile
+++ b/sysutils/ipmitool/Portfile
@@ -51,5 +51,5 @@ post-patch {
     reinplace {/DOWNLOAD/s/ -#/ -L/} configure.ac
     reinplace "s|\$(INSTALL_DATA)|ginstall -m 0644|" Makefile.am
 }
-    
-configure.args  --mandir=${prefix}/share/man
+
+configure.args-append  --mandir=${prefix}/share/man


### PR DESCRIPTION
The last configure.args should be configure.args-append, otherwise it
overwrites the previously set --enable-intf-lanplus --enable-ipmishell.

Signed-off-by: Zi Yan <zi.yan@normal.zone>

#### Description

The configure.args at the last line overwrites the previously set "--enable-intf-lanplus --enable-ipmishell", so use configure.args-append instead.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
