### PR TITLE
Add missing openssl dependencies

### DIFF
--- a/perl/p5-crypt-openssl-rsa/Portfile
+++ b/perl/p5-crypt-openssl-rsa/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.26 5.28
 perl5.setup         Crypt-OpenSSL-RSA 0.31
-revision            1
+revision            2
 categories-append   security
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
@@ -25,5 +25,6 @@ if {${perl5.major} != ""} {
 
     depends_lib-append \
                     port:p${perl5.major}-crypt-openssl-random \
-                    port:p${perl5.major}-crypt-openssl-bignum
+                    port:p${perl5.major}-crypt-openssl-bignum \
+                    path:lib/libssl.dylib:openssl
 }

--- a/sysutils/OpenIPMI/Portfile
+++ b/sysutils/OpenIPMI/Portfile
@@ -5,10 +5,10 @@ PortGroup           conflicts_build 1.0
 name                OpenIPMI
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     version             2.0.19
-    revision            7
+    revision            8
 } else {
     version             2.0.27
-    revision            0
+    revision            1
 }
 set branch          [join [lrange [split ${version} .] 0 1] .]
 license             {GPL-2 LGPL-2}
@@ -54,8 +54,9 @@ depends_build       port:gsed
 depends_lib         port:popt \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:net-snmp \
-                    port:tcl
-                        
+                    port:tcl \
+                    path:lib/libssl.dylib:openssl
+
 configure.args      --with-poptlibs=-lpopt \
                     --with-swig=no \
                     --with-python=no \


### PR DESCRIPTION
#### Description

Some ports have files linked to libssl and/or libcrypto, but depends_lib does not include openssl, so they are missed in previous big OpenSSL upgrade (#3822). In this PR I fixed those ports to avoid further accidents.

Note that there might be more similar ports. These 4 are what I observe from commits to macports-ports after the big OpenSSL upgrade.

See individual commit messages for details, especially the one for qt*-qtlocation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
