### PR TITLE
limesuite: add bundle to wxgui variant

### DIFF
--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -26,7 +26,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums rmd160 bcec9bcd89202868eef75f568d1ff9cbbd6929c7 \
               sha256 3a72f23265737fb2495083cc017bf56a42ee3c7071baa351975f50aaaf476ec1 \
               size   5363954
-    revision  1
+    revision  2
 
     name            limesuite-devel
     long_description ${long_description} This port is kept up with the LimeSuite \
@@ -39,7 +39,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  9b702a15565df94169bb47538522c8cec3774645 \
                     sha256  1e4d5ac1b6f81ba730e46411a32eb93878f1eb8874574eb01d3c981c918add92 \
                     size    5357853
-    revision        1
+    revision        2
 
     conflicts       limesuite-devel
     configure.args-append -DLIME_SUITE_EXTVER=release
@@ -74,6 +74,11 @@ variant wxgui description {Enable wxWidgets LimeSuiteGUI} {
     configure.args-delete   -DENABLE_GUI=OFF
     configure.args-append   -DENABLE_GUI=ON \
         -DwxWidgets_CONFIG_EXECUTABLE=${wxWidgets.wxconfig}
+    app.create yes
+    app.name LimeSuiteGUI
+    app.executable LimeSuiteGUI
+    app.icon ${filespath}/limesuitegui.icns
+    app.retina yes
 }
 
 variant soapy description {Add Soapy support} {
@@ -89,12 +94,4 @@ variant octave description {Enable Octave support} {
     configure.args-append  -DENABLE_OCTAVE=ON
 }
 
-variant bundle description {Enable Application bundle} {
-    app.create yes
-    app.name LimeSuiteGUI
-    app.executable LimeSuiteGUI
-    app.icon ${filespath}/limesuitegui.icns
-    app.retina yes
-}
-
-default_variants +wxgui +soapy +bundle
+default_variants +wxgui +soapy


### PR DESCRIPTION


#### Description

simplify variants and connect app to wxgui therefore when
the gui is built the user get also the app.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
