### PR TITLE
openhantek: create application bundle as default

### DIFF
--- a/science/openhantek/Portfile
+++ b/science/openhantek/Portfile
@@ -27,17 +27,11 @@ depends_lib-append \
     path:lib/libusb.dylib:libusb \
     port:fftw-3
 
-app.create no
-
-variant bundle description {Enable Application bundle} {
-    app.create yes
-    app.name OpenHantek
-    app.executable OpenHantek
-    app.icon openhantek/res/images/openhantek.icns
-    app.retina yes
-}
-
-default_variants +bundle
+app.create yes
+app.name OpenHantek
+app.executable OpenHantek
+app.icon openhantek/res/images/openhantek.icns
+app.retina yes
 
 test.run yes
 test.cmd ${cmake.build_dir}/openhantek/OpenHantek -v


### PR DESCRIPTION
#### Description

create application bundle as default

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A558d
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
