### PR TITLE
mail-server and dns-server: Portfile simplifications

### DIFF
--- a/mail/mail-server/Portfile
+++ b/mail/mail-server/Portfile
@@ -5,7 +5,7 @@ PortGroup               active_variants 1.1
 
 name                    mail-server
 version                 1.0
-revision                1
+revision                2
 categories              mail net
 platforms               darwin
 supported_archs         noarch
@@ -31,6 +31,7 @@ set dovecot2_required_variants \
 depends_lib-append      port:dcc \
                         port:dovecot2 \
                         port:dovecot2-sieve \
+                        port:logrotate \
                         port:openssl \
                         port:postfix \
                         port:rspamd \
@@ -43,9 +44,7 @@ depends_lib-append      port:apache-solr8 \
                         port:expat \
                         port:pcre
 
-depends_run-append      port:clamav-server \
-                        port:dns-server \
-                        port:logrotate
+depends_run-append      port:clamav-server
 
 variant initialize \
     description {Initialize all configuration files. Existing
@@ -768,15 +767,13 @@ in ${prefix}/etc/dovecot/sieve*/*.sieve are compiled with sievec.
 
 startupitem.create     yes
 
-startupitem.start      "port load dns-server
-\tport load clamav-server
+startupitem.start      "port load clamav-server
 \tport load apache-solr8
 \tport load redis
 \tport load dcc
 \tport load postfix
 \tport load dovecot2
-\tport load rspamd
-\tport load logrotate"
+\tport load rspamd"
 
 startupitem.stop      "port unload apache-solr8
 \tport unload dcc
@@ -852,6 +849,14 @@ that must be changed before deployment.
     DKIM:
         ${prefix}/var/lib/rspamd/dkim
 
+The ports dns-server and logrotate provide necessary DNS service on the LAN
+and log rotation capabilities:
+
+        sudo port install dns-server logrotate
+
+This port assume indepedent installation and management of DNS and
+log rotation; mail-server includes example logrotate configuration files.
+
 The port's launch daemon controls launching for each of the dependendent
 services. These may be controlled independently, e.g.
 
@@ -862,6 +867,10 @@ services. These may be controlled independently, e.g.
         sudo port load postfix
         sudo port load dovecot2
         sudo port load rspamd
+
+and if installed independently,
+
+        sudo port load dns-server
         sudo port load logrotate
 
     References:
@@ -870,6 +879,13 @@ services. These may be controlled independently, e.g.
         * https://www.rspamd.com/doc/index.html
         * https://www.c0ffee.net/blog/mail-server-guide/
         * _The Book of Postfix_, by Patrick Koetter and Ralf Hildebrandt
+
+    Known issues:
+        * The Postfix service does not reliably start after reboot,
+          presumably due to an issue with launchd. A workaround
+          after rebooting is to issue the commands:
+
+          sudo port unload postfix ; sleep 5 ; sudo port load postfix
 "
 
 livecheck.type         none

--- a/net/dns-server/Portfile
+++ b/net/dns-server/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 name                    dns-server
 # use port:bind9's version as the version number
 version                 9.14.3
-revision                1
+revision                2
 categories              net
 platforms               darwin freebsd sunos
 supported_archs         noarch
@@ -60,11 +60,11 @@ destroot.keepdirs ${destroot}${prefix}/var/log/named
 
 # Network configuration
 # hard-coded examples
-set named_fullhost      host.domain.tld
 set named_host          host
-set named_domaintld     domain.tld
 set named_domain        domain
 set named_tld           tld
+set named_fullhost      ${named_host}.${named_domain}.${named_tld}
+set named_domaintld     ${named_domain}.${named_tld}
 set host_lan_ip_address 10.0.1.2
 set lan_reverse_ip_subnet 1.0.10
 set host_lan_reverse_ip_address 2.1.0.10
@@ -75,10 +75,10 @@ set client_lan_reverse_ip_address 3.1.0.10
 post-activate {
     # use network settings for installed example configuration
     set named_fullhost [exec /bin/hostname -f]
-    set named_host [exec /bin/sh -c "echo ${named_fullhost} | /usr/bin/sed -E -e 's|^(\[\[:alnum:\]_-\]+\\.)*((\[\[:alnum:\]_-\]+\\.)\[a-zA-Z0-9-\]{2,24})\\.?|\\1|' | /usr/bin/sed -E -e 's|^(\[\[:alnum:\]_-\]+)\\.?$|\\1|'"]
-    set named_domaintld [exec /bin/sh -c "echo ${named_fullhost} | /usr/bin/sed -E -e 's|^(\[\[:alnum:\]_-\]+\\.)*((\[\[:alnum:\]_-\]+\\.)\[a-zA-Z0-9-\]{2,24})\\.?|\\2|'"]
-    set named_domain [exec /bin/sh -c "echo ${named_domaintld} | /usr/bin/sed -E -e 's|^(\[\[:alnum:\]_-\]+)\\.\[a-zA-Z0-9-\]{2,24}\\.?|\\1|'"]
-    set named_tld [exec /bin/sh -c "echo ${named_domaintld} | /usr/bin/sed -E -e 's|^\[\[:alnum:\]_-\]+\\.(\[a-zA-Z0-9-\]{2,24})\\.?|\\1|'"]
+    set named_host [lindex [split ${named_fullhost} .] 0]
+    set named_domaintld [join [lrange [split ${named_fullhost} .] end-1 end] .]
+    set named_domain [lindex [split ${named_domaintld} .] 0]
+    set named_tld [lindex [split ${named_domaintld} .] end]
     set host_lan_ip_address [exec /bin/sh -c "/sbin/ifconfig `/usr/sbin/netstat -nr | /usr/bin/awk '{ if (\$1 ~/default/) { print \$NF} }' | /usr/bin/head -1` | /usr/bin/awk '{ if (\$1 ~/inet\$/) { print \$2} }'"]
     set lan_reverse_ip_subnet [exec /bin/sh -c "echo ${host_lan_ip_address} | /usr/bin/sed -E -e 's|(\[\[:digit:\]\]{1,3})\\.(\[\[:digit:\]\]{1,3})\\.(\[\[:digit:\]\]{1,3})\\.(\[\[:digit:\]\]{1,3})\$|\\3.\\2.\\1|'"]
     set host_lan_reverse_ip_address [exec /bin/sh -c "echo ${host_lan_ip_address} | /usr/bin/sed -E -e 's|(\[\[:digit:\]\]{1,3})\\.(\[\[:digit:\]\]{1,3})\\.(\[\[:digit:\]\]{1,3})\\.(\[\[:digit:\]\]{1,3})\$|\\4.\\3.\\2.\\1|'"]


### PR DESCRIPTION
mail-server and dns-server: Portfile simplifications

* Remove dns-server amd logrotate as mail-server dependencies because some user may use their own DNS and log rotation capabilities
* Simplify dns-server configuration modification code

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 11.0 11A420a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
