### PR TITLE
ngircd: update to 25.

### DIFF
--- a/irc/ngircd/Portfile
+++ b/irc/ngircd/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                ngircd
-version             24
-revision            1
+version             25
+revision            0
 categories          irc
 platforms           darwin
 license             GPL-2+
@@ -19,10 +19,12 @@ homepage            http://ngircd.barton.de/
 master_sites        http://arthur.barton.de/pub/ngircd/
 use_xz              yes
 
-checksums           rmd160  d76712a3057bb607a7886f55ed9e8f6e5aad9fa8 \
-                    sha256  173fa0ea10788a8ba08ef2f7e64ea8951d7c88862e744128c8b87bae424b1008
+checksums           rmd160  e28b418b3460b5e7f633b85bf68b41638144944d \
+                    sha256  c4997cae3e3dd6ff6a605ca274268f2b8c9ba0b1a96792c7402e5594222eee4e \
+                    size    349124
 
-depends_lib         port:libident \
+depends_lib         port:libiconv \
+                    port:libident \
                     port:tcp_wrappers \
                     port:zlib
 
@@ -32,6 +34,7 @@ patchfiles          patch-contrib-MacOSX-Makefile.in.diff \
 configure.args      --enable-ipv6 \
                     --enable-sniffer \
                     --with-tcp-wrappers \
+                    --with-iconv \
                     --with-ident
 
 # It's easier to create our own startup item than to patch and install


### PR DESCRIPTION
#### Description

* updated to the latest version
* enabled iconv support

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14
Xcode 11.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?