### PR TITLE
wireshark3: new upstream 3.0.5 release.

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 
 name                wireshark3
-version             3.0.4
+version             3.0.5
 revision            0
 categories          net
 license             {GPL-2 GPL-3}
@@ -27,10 +27,10 @@ distfiles           wireshark-${version}${extract.suffix}
 
 worksrcdir          wireshark-${version}
 
-checksums           sha256  773bd57df2aeae1694a0b7fbfb34283ba24799cfd6299eed696630fc9ebeecbf \
-                    rmd160  01a98122fbe701946088e0924a73333c2c79654b \
-                    sha1    e7cda5bc6fe885887fb4cffedb565373c760c987 \
-                    size    30938336
+checksums           sha256  c551fce475c49cea317ccbf9d22404bc827dde9cee0ccdf6648bfed3ecd9f820 \
+                    rmd160  f4be43f526ae5ef4c42fc294a37418e360a565d4 \
+                    sha1    82883e96ee247d3fcacb0cafa0bed9112824ee3a \
+                    size    30929864
 
 conflicts           wireshark-devel wireshark wireshark2 wireshark22 wireshark24
 


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
