### PR TITLE
mysql8: fix build on older systems

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -64,8 +64,13 @@ if {$subport eq $name} {
 
     use_parallel_build  yes
 
-    # Requires c++14
-    compiler.blacklist-append *gcc* {clang < 900} macports-clang-3.* {macports-clang-[4-6].0}
+    # Requires c++14 (gcc 6.1 or newer, clang-3.4 or newer support c++14)
+    compiler.blacklist-append {*gcc-[3-5].*} {clang < 900} macports-clang-3.*
+
+    # clang 8.0+ are too strict to build this port
+    # version:1:1: error: C++ requires a type specifier for all declarations
+    # MYSQL_VERSION_MAJOR=8
+    compiler.blacklist-append {macports-clang-[8-9].0}
 
     # Use default CMake build_types
     if {[variant_isset debug]} {
@@ -125,7 +130,8 @@ if {$subport eq $name} {
     patch.pre_args  -p1
     patchfiles      patch-cmake-install_layout.cmake.diff \
                     patch-router-cmake-set_rpath.diff \
-                    patch-sql-local-boost.diff
+                    patch-sql-local-boost.diff \
+                    patch-mysql8-workaround-no-SC_PHYS_PAGES.diff
 
     post-extract {
         file mkdir ${cmake.build_dir}/macports
@@ -145,6 +151,10 @@ if {$subport eq $name} {
         reinplace "s|@PREFIX@|${prefix}|g" \
             ${cmake.build_dir}/macports/macports-default.cnf \
             ${cmake.build_dir}/macports/my.cnf
+
+        # don't force /usr/bin/libtool -- allow cctools' version to be used
+        reinplace "s|/usr/bin/libtool|libtool|g" \
+            ${worksrcpath}/cmake/libutils.cmake
     }
 
     post-destroot {

--- a/databases/mysql8/files/patch-mysql8-workaround-no-SC_PHYS_PAGES.diff
+++ b/databases/mysql8/files/patch-mysql8-workaround-no-SC_PHYS_PAGES.diff
@@ -1,0 +1,33 @@
+--- mysql-8.0.17/storage/innobase/handler/ha_innodb.cc.orig	2019-09-22 17:18:33.000000000 -0700
++++ mysql-8.0.17/storage/innobase/handler/ha_innodb.cc	2019-09-22 17:18:49.000000000 -0700
+@@ -57,6 +57,10 @@
+ #include <strfunc.h>
+ #include <time.h>
+ 
++#if defined __APPLE__ && (MAC_OS_X_VERSION_MIN_REQUIRED < 101100)
++#include <sys/sysctl.h>
++#endif
++
+ #include <sql_table.h>
+ #include "mysql/components/services/system_variable_source.h"
+ 
+@@ -294,10 +298,19 @@
+ #undef get_sys_mem
+ #define get_sys_mem get_mem_GlobalMemoryStatus
+ #else
++#if defined __APPLE__ && (MAC_OS_X_VERSION_MIN_REQUIRED < 101100)
++static double get_mem_sysconf() {
++     uint64_t mem_size;
++     size_t len = sizeof(mem_size);
++     sysctlbyname("hw.memsize", &mem_size, &len, NULL, 0);
++     return (((double)mem_size) / GB);
++}
++#else
+ static double get_mem_sysconf() {
+   return (((double)sysconf(_SC_PHYS_PAGES)) *
+           ((double)sysconf(_SC_PAGESIZE) / GB));
+ }
++#endif
+ #undef get_sys_mem
+ #define get_sys_mem get_mem_sysconf
+ #endif /* defined(_WIN32) || defined(_WIN64) */


### PR DESCRIPTION
add replacement for missing SC_PHYS_PAGES on older systems
allow a newer libtool to be used
relax the compiler blacklist to allow more c++14 compilers
especially as clang-8.0.1 is not building this right now

closes: https://trac.macports.org/ticket/59074

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.6.8 10K549
Xcode 4.2 4C199 


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
