### PR TITLE
Patch cclient to work with OpenSSL v1.1

### DIFF
--- a/mail/cclient/Portfile
+++ b/mail/cclient/Portfile
@@ -70,6 +70,8 @@ variant ssl_plaintext description {Allow plaintext passwords over SSL} {
     build.args-append SSLTYPE=unix
 }
 
+patchfiles-append patch-03-openssl_1_1
+
 variant universal {
     build.args-append EXTRACFLAGS="${configure.universal_cflags}" EXTRALDFLAGS="${configure.universal_ldflags}"
 }

--- a/mail/cclient/files/patch-03-openssl_1_1
+++ b/mail/cclient/files/patch-03-openssl_1_1
@@ -1,0 +1,59 @@
+Description: Support OpenSSL 1.1
+ When building with OpenSSL 1.1 and newer, use the new built-in
+ hostname verification instead of code that doesn't compile due to
+ structs having been made opaque.
+
+Patch derived from https://bugs.freebsd.org/bugzilla/attachment.cgi?id=198493&action=edit
+which itself was obtained from: https://sources.debian.org/data/main/u/uw-imap/8:2007f~dfsg-5/debian/patches/1006_openssl1.1_autoverify.patch
+--- src/osdep/unix/ssl_unix.c.orig
++++ src/osdep/unix/ssl_unix.c
+@@ -227,8 +227,16 @@ static char *ssl_start_work (SSLSTREAM *
+ 				/* disable certificate validation? */
+   if (flags & NET_NOVALIDATECERT)
+     SSL_CTX_set_verify (stream->context,SSL_VERIFY_NONE,NIL);
+-  else SSL_CTX_set_verify (stream->context,SSL_VERIFY_PEER,ssl_open_verify);
++  else {
++#if OPENSSL_VERSION_NUMBER >= 0x10100000
++      X509_VERIFY_PARAM *param = SSL_CTX_get0_param(stream->context);
++      X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
++      X509_VERIFY_PARAM_set1_host(param, host, 0);
++#endif
++
++      SSL_CTX_set_verify (stream->context,SSL_VERIFY_PEER,ssl_open_verify);
+ 				/* set default paths to CAs... */
++  }
+   SSL_CTX_set_default_verify_paths (stream->context);
+ 				/* ...unless a non-standard path desired */
+   if (s = (char *) mail_parameters (NIL,GET_SSLCAPATH,NIL))
+@@ -266,6 +274,7 @@ static char *ssl_start_work (SSLSTREAM *
+   if (SSL_write (stream->con,"",0) < 0)
+     return ssl_last_error ? ssl_last_error : "SSL negotiation failed";
+ 				/* need to validate host names? */
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+   if (!(flags & NET_NOVALIDATECERT) &&
+       (err = ssl_validate_cert (cert = SSL_get_peer_certificate (stream->con),
+ 				host))) {
+@@ -275,6 +284,7 @@ static char *ssl_start_work (SSLSTREAM *
+     sprintf (tmp,"*%.128s: %.255s",err,cert ? cert->name : "???");
+     return ssl_last_error = cpystr (tmp);
+   }
++#endif
+   return NIL;
+ }
+ 
+@@ -313,6 +323,7 @@ static int ssl_open_verify (int ok,X509_
+  * Returns: NIL if validated, else string of error message
+  */
+
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+ static char *ssl_validate_cert (X509 *cert,char *host)
+ {
+   int i,n;
+@@ -342,6 +353,7 @@ static char *ssl_validate_cert (X509 *ce
+   else ret = "Unable to locate common name in certificate";
+   return ret;
+ }
++#endif
+ 
+ /* Case-independent wildcard pattern match
+  * Accepts: base string


### PR DESCRIPTION
Apply FreeBSD patch from https://bugs.freebsd.org/bugzilla/attachment.cgi?id=198493&action=edit
Closes https://trac.macports.org/ticket/58973

An alternative approach might be to switch dependency to `openssl10` to avoid the breaking changes, but that's only [LTS until 2019-12-31](https://www.openssl.org/policies/releasestrat.html) so would not be suitable in the long term. (v1.1 is LTS to 2023-09-11)

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
