### PR TITLE
nbd: new port

### DIFF
--- a/sysutils/nbd/Portfile
+++ b/sysutils/nbd/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+name                nbd
+version             3.20
+categories          sysutils
+license             GPL-2
+platforms           darwin
+maintainers         {mit.edu:quentin @quentinmit} \
+                    openmaintainer
+description         Network Block Device server
+long_description    Network Block Device server. Only the server is available. \
+                    The NBD client does not support Darwin.
+homepage            https://nbd.sourceforge.io/
+master_sites        sourceforge
+use_xz              yes
+
+depends_build-append  port:pkgconfig
+depends_lib-append    port:glib2 \
+                      port:gnutls
+
+checksums           rmd160  49a4abd8cb2fc3cc5ddc01a0e85c272add7f34f2 \
+                    sha256  e0e1b3538ab7ae5accf56180afd1a9887d415b98d21223b8ad42592b4af7d6cd \
+                    size    535136
+
+livecheck.type      sourceforge
+livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+
+post-destroot {
+    # The configure script automatically detects that it can't build nbd-client,
+    # but it still installs the manpage.
+    delete ${destroot}${prefix}/share/man/man8/nbd-client.8
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

nbd is the Linux Network Block Device protocol drivers; on Darwin only the nbd server (which exposes block devices) builds and runs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.4 18E226
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
