### PR TITLE
MenuMeters: update to 1.9.8

### DIFF
--- a/aqua/MenuMeters/Portfile
+++ b/aqua/MenuMeters/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           xcode 1.0
 PortGroup           xcodeversion 1.0
 
-github.setup        yujitach MenuMeters 1.9.7bis
+github.setup        yujitach MenuMeters 1.9.8
 categories          aqua sysutils
 maintainers         {stevenmyint.com:git @myint} openmaintainer
 license             GPL-2
@@ -20,14 +20,16 @@ long_description    The MenuMeters monitors are true SystemUIServer plugins     
                     using command-drag and remember their positions in the menubar  \
                     across logins and restarts.
 
-checksums           rmd160  61843c5aebc9550036c91674600f738e232982a4 \
-                    sha256  217c374ab5f324230e281bde8d424dbd0db016ce522e8d262845a55464b68ba5 \
-                    size    228098
+checksums           rmd160  a93d08d6e4a0bf180171550c97eaf27b970f3786 \
+                    sha256  3c6b3a22f095da6dccbe0f54211d1b6abd26491421a316b8128335000339be5e \
+                    size    234533
 
 patchfiles          patch-MenuMeters.xcodeproj-project.pbxproj.diff
 
 xcode.configuration Release
-xcode.target        PrefPane
+xcode.scheme        PrefPane
+destroot.pre_args   -derivedDataPath ./DerivedData
+build.pre_args      -derivedDataPath ./DerivedData
 
 destroot.violate_mtree \
                     yes


### PR DESCRIPTION
#### Description
Also include fixes for building under xcode 10. Not sure if this regresses xcode before version 10, guess I'll wait to see what the build server says?

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
