### PR TITLE
py-qtconsole: update to 4.5.5

### DIFF
--- a/python/py-qtconsole/Portfile
+++ b/python/py-qtconsole/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-qtconsole
-version             4.5.2
+version             4.5.5
 revision            0
 categories-append   devel
 platforms           darwin
@@ -15,17 +15,17 @@ python.versions     27 34 35 36 37
 
 maintainers         {stromnov @stromnov} openmaintainer
 
-description         Jupyter Qt console.
+description         Jupyter QtConsole
 long_description    ${description}
 
-homepage            http://jupyter.org
+homepage            https://jupyter.org
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 
 distname            ${python.rootname}-${version}
 
-checksums           rmd160  28fa20f184974b3285330ac3bc0760eddc53f505 \
-                    sha256  767eb9ec3f9943bc84270198b5ff95d2d86d68d6b57792fafa4df4fc6b16cd7c \
-                    size    424805
+checksums           rmd160  9657f52b200ef978df576f98b5305ed00000ab99 \
+                    sha256  b91e7412587e6cfe1644696538f73baf5611e837be5406633218443b2827c6d9 \
+                    size    426336
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-setuptools \
@@ -37,7 +37,14 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-ipykernel
 
     # Note: depends on one of py-pyqt4, py-pyqt5 or py-pyside (first available at runtime)
-    notes-append        "Please do not forget to install one of QT backends: py${python.version}-pyside, py${python.version}-pyqt5 or py${python.version}-pyqt4."
+    notes-append        "Please do not forget to install one of Qt backends: py${python.version}-pyside, py${python.version}-pyqt5 or py${python.version}-pyqt4."
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} CONTRIBUTING.md LICENSE \
+            README.MD ${destroot}${docdir}
+    }
 
     livecheck.type      none
 }


### PR DESCRIPTION
#### Description
- update to latest version, required for ```py-spyder-devel```
- install files in post-destroot

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
