### PR TITLE
py-pint: update to 0.9, add py37

### DIFF
--- a/python/py-pint/Portfile
+++ b/python/py-pint/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        hgrecco pint 0.8.1
+github.setup        hgrecco pint 0.9
+revision            0
 
 name                py-pint
 categories-append   science
@@ -22,13 +23,29 @@ long_description    Pint is Python module/package to define, operate and \
 
 homepage            https://pint.readthedocs.org/
 
-python.versions     27 34 35 36
+checksums           rmd160  e181cfa8aa84a47f930830e940f64d48831759b3 \
+                    sha256  4d7a3c78e68991ad1a254a2f792c0c2fdb27aeb0debb7fcecc529a9df3320ae4 \
+                    size    166980
+
+python.versions     27 34 35 36 37
 
 if {${name} ne ${subport}} {
-    depends_run-append      port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-setuptools
 
-    checksums               rmd160  cdf6eaf626d01224c202ae8a03644ee3234e59e9 \
-                            sha256  05b81801249543c3921ac9e031048f153cddb67deb9964577be96e9bfff9830a
+    if {${python.version} eq 27} {
+        depends_lib-append \
+                    port:py${python.version}-funcsigs
+    }
 
-    livecheck.type          none
+    test.run        yes
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} AUTHORS CHANGES LICENSE \
+           README ${destroot}${docdir}
+    }
+
+    livecheck.type none
 }


### PR DESCRIPTION
#### Description
- update to latest version, add PY37 subport
- enable tests
- install files in post-destroot

Finish up of: PR #5030
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->