### PR TITLE
fzf: copy fuzzy completion scripts

### DIFF
--- a/sysutils/fzf/Portfile
+++ b/sysutils/fzf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/junegunn/fzf 0.18.0
-revision            0
+revision            1
 checksums           rmd160  5db76ccaa47f93eef50328c81b55c3e060f88552 \
                     sha256  5b5c54f9d576f76cb1d679918fc01b277a896d0a51832fe54e6ddad9c8ecd120 \
                     size    143298
@@ -43,7 +43,7 @@ post-destroot {
 
     # make other files available, but not enabled
     xinstall -d ${destroot}${prefix}/share/fzf/shell/
-    xinstall -m 0644 {*}[glob ${worksrcpath}/shell/key-bindings.*] ${destroot}${prefix}/share/fzf/shell/
+    xinstall -m 0644 {*}[glob ${worksrcpath}/shell/*] ${destroot}${prefix}/share/fzf/shell/
     xinstall -d ${destroot}${prefix}/share/fzf/vim/doc/
     xinstall -m 644 ${worksrcpath}/doc/${name}.txt ${destroot}${prefix}/share/fzf/vim/doc/${name}.txt
     xinstall -d ${destroot}${prefix}/share/fzf/vim/plugin/


### PR DESCRIPTION
Copy all files from fzf's shells directory, insead of only the
key-binding.* scripts. This will pick up the newer fuzzy-complete
scripts.

#### Description

The existing Portfile misses a few of the shell extension scripts provided by fzf; this picks them up.

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6
Xcode 10.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
