### PR TITLE
Update to py-fortranformat: Bump available python version number to 37

### DIFF
--- a/python/py-fortranformat/Portfile
+++ b/python/py-fortranformat/Portfile
@@ -17,7 +17,7 @@ long_description    Generates text from a Python list of variables or will \
 checksums           md5 d78c5a320fedcbdf21f823cd18e28ac0 \
                     rmd160 212edf59a6da06b8127322f30806e6559353ea79 \
                     sha256 ec76c1c7bc07972aa98e01ff2303bb0aefe77306be8ff2723bc40b7c7775292c
-python.versions     27 34 35 36
+python.versions     27 35 36 37
 
 bitbucket.tarball_from downloads
 distname            fortranformat-${version}


### PR DESCRIPTION
#### Description

Add python version 37 to py-fortranformat and remove version 34

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 11.0 11A420a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
