### PR TITLE
postgresql-jdbc: update to 42.2.8

### DIFF
--- a/java/postgresql-jdbc/Portfile
+++ b/java/postgresql-jdbc/Portfile
@@ -1,33 +1,48 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			postgresql-jdbc
-version			9.1-901
-categories		java databases
-license			BSD
-maintainers		nomaintainer
-description		PostgreSQL JDBC driver
-long_description	Pure Java JDBC driver for connecting to PostgreSQL databases.
-homepage		http://jdbc.postgresql.org/
+PortSystem          1.0
+PortGroup           java 1.0
 
-platforms		darwin
-supported_archs	noarch
+name                postgresql-jdbc
+set version_major   42
+set version_minor   2
+set version_patch   8
+version             ${version_major}.${version_minor}.${version_patch}
+categories          java databases
+license             BSD
+maintainers         nomaintainer
+description         PostgreSQL JDBC driver
+long_description    \
+    Pure Java JDBC driver for connecting to PostgreSQL databases.
+homepage            http://jdbc.postgresql.org/
 
-distname		${name}-${version}.src
-master_sites    ${homepage}/download/
-checksums 		md5 eab20a5cd5344a21f33a1768dd3f4f96 \
-				sha1 065e5cd45ace594e5e9c70df5da6e44b0361fb80 \
-				rmd160 7bbb6f92e2c7cd6ac8172b9d995146087e4b7a3b
+platforms           darwin
+supported_archs     noarch
 
-depends_build   bin:ant:apache-ant
+distname            ${name}-${version}.src
+worksrcdir          ${name}-${version_major}.${version_minor}-${version_patch}.src
 
-set workTarget	""
+master_sites        ${homepage}/download/
+checksums           md5     8e9fd73105f3c1ce20c7046ba75896f2 \
+                    sha1    1e72a4f1e34cac529e185f4d6e0a118c8b091561 \
+                    rmd160  215bcc04ce3aa41266fc1fcb27a31a95a710c7bc \
+                    sha256  97ee866689f0e6c45f3e71bcb88f42f16ea9a8a79965e6790efb15e133585029 \
+                    size    1404018
 
-use_configure	no
+java.version        1.8*
+java.fallback       openjdk8
+depends_build       port:maven32
 
-build.cmd 		ant
+use_configure       no
+
+build.cmd           mvn32
+build.target        package
+build.args          --define skipTests \
+                    --define maven.repo.local=${workpath}/m2/repository
 
 destroot {
-	xinstall -m 755 -d ${destroot}${prefix}/share/java
-	file copy ${worksrcpath}${workTarget}/jars/postgresql.jar \
-		${destroot}${prefix}/share/java/
+    xinstall -m 755 -d ${destroot}${prefix}/share/java
+    file copy \
+        ${worksrcpath}/pgjdbc/target/postgresql-${version}.jar \
+        ${destroot}${prefix}/share/java/
 }


### PR DESCRIPTION
#### Description

Update `postgresql-jdbc` from version 9.1-901 to 42.2.8.

Switch from Ant to Maven 3.2 for building.
Use Java PortGroup and set minimal Java version to 1.8+.
Set a `maven.local.repo` in `workpath`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

update

###### Tested on
macOS 10.14.6 18G103
Xcode 11.0 11A420a
openjdk11 @11.0.4_0
postgresql10-server @10.10_0
Eclipse 2019-09

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
