### PR TITLE
librttopo: update to 1.1.0

### DIFF
--- a/gis/librttopo/Portfile
+++ b/gis/librttopo/Portfile
@@ -5,7 +5,8 @@ PortSystem          1.0
 name                librttopo
 categories          gis
 license             GPL-2
-version             1.1.0-RC1
+version             1.1.0
+epoch               1
 platforms           darwin
 maintainers         nomaintainer
 
@@ -15,11 +16,11 @@ long_description    The RT Topology Library exposes an API to create and\
                     user-provided data stores.
 
 homepage            https://strk.kbt.io/projects/rttopo/
-master_sites        https://git.osgeo.org/gogs/rttopo/librttopo/archive/
+master_sites        https://git.osgeo.org/gitea/rttopo/librttopo/archive/
 
-checksums           rmd160  aa9212e9de49015ca88d35e156c4c30be17915d1 \
-                    sha256  ca7123e607c8bc10a30c2b2f4d36769b40f3d951920649ff9b5f5b11ec967597 \
-                    size    301074
+checksums           rmd160  5ceac88455837b482b0c06eac9f38786ff71f5ce \
+                    sha256  2e2fcabb48193a712a6c76ac9a9be2a53f82e32f91a2bc834d9f1b4fa9cd879f \
+                    size    301077
 
 extract.mkdir       yes
 extract.post_args   | tar -x -C ${worksrcpath} --strip-components 1


### PR DESCRIPTION
#### Description

Previously on 1.1.0-RC1 release candidate, updating to final 1.1.0 release.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G95
Command Line Tools for Xcode 10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
