### PR TITLE
spatialite: add rttopo support

### DIFF
--- a/databases/spatialite/Portfile
+++ b/databases/spatialite/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                spatialite
 version             4.99.0
+revision            1
 categories          databases gis
 platforms           darwin
 license             {MPL-1.1 GPL-2+ LGPL-2.1+}
@@ -34,9 +35,11 @@ patchfiles          patch-gaiageo_Makefile_in.diff \
 depends_build       port:pkgconfig
 depends_lib         port:sqlite3 \
                     port:geos \
+                    port:librttopo \
                     port:libxml2
 
 configure.args-append \
+                    --enable-rttopo \
                     --enable-libxml2 \
                     --disable-freexl
 
@@ -48,7 +51,7 @@ variant proj49      description {links with proj4 4.9 instead of 5+} {
 
     depends_lib-append          port:proj4
     configure.cppflags-append   -I${prefix}/lib/proj49/include
-    configure.ldflags-append    -L${prefix}/lib/proj49/lib 
+    configure.ldflags-append    -L${prefix}/lib/proj49/lib
 }
 
 if {![variant_isset proj49]} {


### PR DESCRIPTION
#### Description

* builds spatialite with librttopo support
* provides additional spatial operators

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on


macOS 10.14.6 18G95
Command Line Tools for Xcode 10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?