### PR TITLE
py-graveyard: purge entries that are more than one year old

### DIFF
--- a/python/py-graveyard/Portfile
+++ b/python/py-graveyard/Portfile
@@ -48,341 +48,58 @@ proc unknown args {
 # otherwise the port is not considered outdated and replacement does not occur.
 
 # SUPERPORT             EPO@VER_REV REPLACED BRANCHES
-py-acor                 1.1.1_1     26 33
-py-acora                2.1_1       33
-py-alabaster            0.7.6_1     26 33
-py-appdirs              1.4.3_1     26 33
-py-asn1                 1@0.4.7     26 34
+py-asn1                 1@0.4.7     34
 py-asteval              0.9.14_1    34
-py-astrolibcoords       0.37_1      26
-py-astropy              3.0.3_1     33
-py-astropy-helpers      2.0.2_1     33 34
-py-astroquery           0.3.6_1     33 34
-py-async-task           0.6.2_1     26
 py-asynctest            0.12.2_1    36
-py-atpy                 0.9.7_3     26
-py-awscli               1.14.63     34
-py-babel                2.5.3_1     26 33
-py-backcall             0.1.0_1     33
-py-backports            1.0_1       33
-py-backports-ssl_match_hostname \
-                        3.5.0.1_1   33
-py-backports_abc        0.5_1       33
 py-barnaba              0.1.6       34 35
 py-bcolz                1.2.1_1     34
-py-beaker               1.10.0_1    26
-py-beautifulsoup        3.2.1_1     26
-py-beautifulsoup4       4.5.3_1     26 33
 py-blaze                0.10.1_1    34
 py-bokeh                1.2.0_1     34
-py-boto                 2.45.0_1    26
-py-boto3                1.6.16      34
-py-botocore             1.9.16      34
-py-bottle               0.12.9_1    26
 py-bottle               0.12.13_1   34 35
 py-bottle               0.12.16_1   36
-py-bottle-sqlalchemy    0.3_1       26
-py-bottleneck           1.2.1_1     26 33
-py-cairo                1.10.0_4    26 33
-py-celementtree         1.0.5-20051216_1 \
-                                    26
-py-cffi                 1.11.5_1    26 33
-py-chardet              3.0.4_1     33
-py-checker              0.8.18_2    26
-py-cheetah              3.1.0_1     26
-py-certifi              2018.04.16_1 \
-                                    26 33
-py-chronic              0.3.1_1     33
-py-cjson                1.1.0_1     26
-py-click                6.7_1       26 33
-py-clientform           0.2.9_1     26
-py-cogen                0.2.1_1     26
-py-colorama             0.3.7_1     26 33
-py-couchdb              0.9_1       26
-py-couchdbkit           0.6.5_1     26
-py-country              0.10_1      26
-py-cssutils             1.0.2_1     26
-py-ctags                1.0.5_1     26
 py-ctypeslib2           2.2.2       34 35
-py-curl                 7.19.0_2    26
 py-curl                 7.43.0.2_2  36
-py-cvxopt               1.1.9_1     33
-py-cycler               0.10.0_1    26 33
-py-deap                 1.2.2_1     26 33 34
-py-decorator            4.3.0_1     26 33
-py-distutils-extra      2.39_1      33
-py-django               1.11.11_1   34
+py-deap                 1.2.2_1     34
 py-django-htmlmin       0.10.0_1    34
 py-django-nose          1.2_1       34
-py-djvubind             1.2.1_2     33
-py-dnspython            1.15.0_1    26 33
-py-ecdsa                0.13_1      33
-py-elementtree          1.2.6-20050316_1 \
-                                    26
-py-elixir               0.7.1_1     26
-py-enthoughtbase        3.1.0_1     26
-py-enum34               1.1.6_1     26 33
-py-ephem                3.7.6.0_1   26 33
-py-epydoc               3.0.1_4     26
-py-erf                  1.0.1_1     33
-py-etsproxy             0.1.1_1     26
-py-eventlet             0.22.0      26
-py-eyed3                0.7.10_1    26
-py-ez_setup             0.9_1       26
 py-flaky                3.5.3_1     36
-py-flask                1.0.2_1     26 33 34
-py-flask-babel          0.8_1       26
-py-flask-frozen         0.9_1       26
-py-flask-login          0.4.1_1     26 33
-py-flask-script         2.0.5_1     33
-py-flask-uploads        0.1.3_1     26
-py-flup                 1.0.3.dev-20110405_1 \
-                                    26
-py-formalchemy          1.4.1_1     26
-py-fortranformat        0.2.3_1     26 33
-py-fpconst              0.7.2_3     26
-py-freeling             3.1_1       33
-py-ftputil              2.6_1       26
-py-funcsigs             1.0.2_1     26
-py-fuse                 0.2.1_4     26
+py-flask                1.0.2_1     34
 py-gdbm                 2.5.6_1     31
-py-generator            0.1.20120721_1 \
-                                    26 33
 py-gensim               3.5.0_1     34
-py-geoip                1.3.2_1     33
-py-gevent               1.3.3_1     26 33
-py-gflags               2.0_1       26
-py-gitdb                2.0.3_1     26
-py-gmpy2                1@2.0.7_1   26 31 32 33
-py-gnureadline          6.3.8_1     26
-py-gobject              20110613@2.28.6_3 \
-                                    26 33
-py-gobject3             3.28.1_1    34
-py-goocanvas            0.14.1_7    26
-py-graph-tool           20171109@2.27_1 \
-                                    34
-py-greenlet             0.4.14_1    26 33
-py-h5py                 2.8.0       26 33
-py-hat-trie             0.3_1       33
-py-hiredis              0.2.0_1     33
-py-html5lib             1.0b10_2    26 33
-py-httplib2             2-0.11.3_1  26 33
-py-id3lib               0.5.1_1     26
-py-idlsave              1.0.0_3     26
-py-igraph               0.7_1       26
-py-imagesize            1.1.0       26 33
-py-iniparse             0.4_1       26
-py-iso8601              0.1.12_1    26 33
-py-isodate              0.5.4_1     26
-py-itsdangerous         0.24_1      26 33
-py-jenkins-job-builder  0.8.1_2     26
-py-jinja                1.2_2       26
 py-jinja2               2.10_1      26 33
-py-jmespath             0.9.3       34
 py-jmespath-terminal    0.1.1_1     34
-py-jsbeautifier         1.4.0_1     26
 py-jsbeautifier         1.8.8_1     36
-py-jug                  1.6.7_1     33
 py-jupyterlab           0.35.6_1    27 34 35
 py-jupyterlab_server    0.3.4_1     35
-py-kcs11                1.2.4_1     26
-py-kivy                 1.10.1_1    26
-py-kyotocabinet         1.18_1      26
 py-ldap3                2.6_0       27 36
-py-lepl                 5.1.3_1     26
 py-libcloud             0.20.1_1    34 35
-py-liblzma              0.5.3_2     26
 py-lmfit                0.9.13_1    34
-py-logilab-common       1.4.2_1     33
-py-logilab-hmm          0.5.0_2     26
-py-lxml                 4.2.3_1     26 33
-py-lz4                  0.8.2_1     26
-py-macfsevents          0.8.1_1     33
-py-mako                 1.0.7_1     26
-py-managesieve          0.4.2_1     26
 py-markupsafe           1.0_1       26 33
 py-mdtraj               1.9.2       34 35
-py-mechanize            0.2.5_1     26
-py-meta                 0.4.1_1     26
-py-meta-devel           0.4.1_20130223 \
-                                    26 33
 py-metakernel           0.21.0      34 35
-py-milk                 0.6.1_1     26
-py-minfx                1.0.3_1     26
 py-mitmproxy            4.0.4_2     36
-py-mlpy                 3.5.0_2     26 33
-py-mongoengine          0.8.7_1     26
-py-montage              0.9.8_1     26 33
-py-mox                  0.5.1_1     26
-py-msgpack              0.6.1_1     26 33 34
-py-multipledispatch     0.5.0_1     33
-py-mustache             0.5.4_1     26 33
-py-mutagen              1.41.0_1    26
-py-mx-base              3.2.8_1     26
-py-netcdf4              1.2.9_2     26 33
-py-netifaces            0.8_1       26
-py-ngl                  1.3.0b1_2   26
-py-nio                  1.3.0b1_10  26
-py-novas                3.1.1.4_1   33
-py-novas_de405          1997_1      26 33
-py-ntplib               0.3.1_1     26
+py-msgpack              0.6.1_1     34
 py-nuitka               0.6.3.1_1   34 35
 py-numba                0.44.1_1    34
-py-numexpr              2.6.6_1     26 33
 py-nvchecker            1.1_1       36
-py-obspy                1.1.0       34
 py-oct2py               4.2.0_1     34 35
 py-octave_kernel        0.28.5_2    34 35
-py-openopt              0.29_2      26
 py-openslide            1.1.1_1     34
-py-packaging            17.1_1      26 33
-py-parsing              2.2.0_1     26 33
-py-paste                2.0.3_1     26
-py-pastedeploy          1.5.2_1     26
-py-patsy                0.5.0_1     26 33
-py-paver                1.2.1_1     26
-py-pdfminer             20131113_1  26
-py-pebl                 1.0.2_2     26
-py-pgsql                2.5.1_4     26
-py-phonenumbers         8.4.3_1     33
 py-photutils            0.6         27 34 35
-py-pika                 0.11.2_1    26
-py-pkgconfig            1.3.1_1     26 33
-py-pp                   1.6.6_1     26
-py-pptx                 0.6.9_1     26 33
-py-protobuf3            3.5.1       34
-py-prov                 1.1.5_1     34
-py-pyasdf               0.3.0_1     34
-py-pyavm                0.9.2_1     26 33
-py-pybox2d              2.0.2b2_1   26
-py-pybtex               1@0.21_2    26
-py-pycg                 0.14.1_12   26
-py-pycparser            2.18_1      26 33
-py-pyvcf                0.6.8_1     34 35
-py-pyds9                1.1_1       26
-py-pyfftw3              0.2.2_1     26
-py-pyflakes             1.6.0_1     26 33
-py-pyfsevents           0.2b1_1     26
-py-pyglet               1.2.4_1     26
-py-pygments             2.2.0_2     26 33
-py-pygmsh               4.3.6       34
-py-pygooglechart        0.4.0_1     26
-py-pygraph-core         1.8.0_1     26
-py-pygraph-dot          1.8.0_1     26
-py-pygtk                2.24.0_4    26
-py-pygtkhelpers         0.4.3_1     26
-py-pyhyphen             0.9.3_1     26
-py-pyinstaller          3.1_2       33
-py-pymc                 2.3.6_1     26 33
-py-pymongo              3.6.1_1     26 33
-py-pymunk               5.4.2_1     26 33 34
-py-pymvpa               2.6.4_1     33
-py-pynds                0.7.2_4     26
-py-pynifti              0.20100607.1_2 \
-                                    26
-py-pynzb                0.1.0_2     26
-py-pyorick              1.4_1       33
-py-pyqtgraph            0.9.10_1    34
-py-pyrant               0.6.5_1     26
-py-pyrfc3339            1.1         34
-py-pyro                 4.38_1      26 33
-py-pyrxp                2.1.0_1     33
-py-PyRSS2Gen            1.1_1       26
+py-pymunk               5.4.2_1     34
 py-pysam                0.12.0.1_2  34 35
-py-pystache             0.5.4_1     33
-py-pysvn                1.8.0_1     26
 py-pytest-asyncio       0.9.0_1     35
-py-python-jenkins       0.3.4_1     26
-py-pywavelets           0.5.2_1     26
-py-quadtree             0.1.2_2     26
-py-quantities           0.10.1_2    26 33
-py-queuelib             1.5.0_1     33
-py-rabbyt               0.8.3_1     26
-py-rdflib               4.2.2_1     26 33 34
-py-redis                2.10.6_1    26 33
 py-regex                2019.05.25_1 \
                                     34
-py-regions              0.3         34
 py-reportlab            3.5.23_1    34
-py-reproject            0.4         34
-py-robotremoteserver    1.0.1_1     26 33
-py-scientific           2.9.4_3     26
-py-scipy                1.1.0_1     26 33
-py-scrapy               1@1.5.0_1   34
-py-scgi                 1.14_1      26
-py-scikit-learn         0.19.1_1    26 33
-py-scikits-ann          0.2_2       26
-py-scikits-audiolab     0.11.0_1    26
-py-scikits-bootstrap    1.0.0_1     33
-py-scikits-module       0.1_1       26 33
-py-scikits-talkbox      0.2.5_1     26
-py-scikits-timeseries   0.91.1_1    26
-py-scoop                0.7.1.1_1   33
-py-scss                 1.3.4_1     26
-py-selenium             2.21.2_1    26
-py-serpent              1.11.2_1    26 33
-py-sh                   1.12.13_1   26 33
-py-shove                0.6.4_1     26
-py-simpy                3.0.5_1     33
-py-six                  1.11.0_1    26 33
 py-smart_open           1.7.1_1     34
-py-smisk                1.1.6_2     26
-py-smmap                2.0.3_1     26
-py-snowballstemmer      1.2.0_1     26 33
-py-soaplib              1@1.0.0_1   26
-py-soappy               0.11.6_3    26
-py-socketpool           0.5.3_1     26 33
-py-socks                1.6.8_1     26
-py-sparqlwrapper        1.6.4_1     34
-py-speaklater           1.3_1       26
-py-spectral             0.19_1      26
-py-sqlalchemy           1.2.11_1    26 33
 py-structlog            18.2.0_1    36
-py-subvertpy            0.10.1_1    26
-py-suds-jurko           0.6_1       26 33
-py-svipc                0.14_2      26
-py-swap                 3.1.3       26 33 34 35
 py-s3fs                 0.2.0_1     34
 py-s3transfer           0.1.13_1    34
-py-tahchee              0.9.8_1     26
-py-taskw                0.8.6_1     33
-py-tc                   0.7.2_1     26
-py-tensorflow           1.4.1       34
-py-tensorflow-tensorboard \
-                        0.4.0rc3    34
-py-tempita              0.5.2_1     26
-py-theano               1.0.2_1     33
 py-tkinter              2.5.6_1     31
-py-tornado              5.0.2_1     26 33
-py-tvdb                 1.9_1       26
-py-tvnamer              2.3_1       26
-py-typing               3.6.4_1     33
-py-twill                0.9_1       26
-py-twisted              18.7.0_1    34
-py-tz                   2018.5_1    26 33
-py-unittest2            0.5.1_2     26 33
-py-urllib3              1.23_1      26
-py-utidylib             0.2_3       26
-py-urwid                2.0.1_1     26 33
-py-virtualenv           15.1.0_1    26 33
-py-vo                   0.6.1       34
-py-voeventlib           0.3_1       26
-py-webhelpers           2@1.3_1     26
-py-webob                1.8.2_1     26
-py-werkzeug             0.14.1_1    26 33
 py-whoosh               2.5.7_1     34
-py-wordaxe              0.3.3_1     26
 py-wsproto              0.14.0      27 36
 py-xarray               0.11.0      34
-py-xdg                  0.25_1      26 33
-py-xmpppy               0.4.1_2     26
-py-XlsxWriter           0.9.6_1     26 33
-py-yaml                 3.13        26 33
-py-yum-metadata-parser  1.1.4_2     26
-py-zeroc-ice33          3.3.1_3     26
-py-zeroc-ice34          3.4.2_6     26
-py-zeroc-ice35          3.5.1_1     26
-py-zmq                  17.1.0_1    26 33
 py-zope-event           4.4         34
 py-zopecomponent        4.5_1       34
 


### PR DESCRIPTION
#### Description
Remove entries in that have been present for more than one year, compared to py-graveyard/Portfile at commit 754246c (30Sep2018).

We typically purge obsoleted ports after one year, so there is no reason to leave the replacement rules in place for longer than this. This should significantly speed up the parsing of the file.

See: https://trac.macports.org/ticket/59051

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`? Reported warnings/errors do not apply to the ```py-graveyard``` port
- [ ] tried existing tests with `sudo port test`? N/A
- [ ] tried a full install with `sudo port -vst install`? N/A
- [ ] tested basic functionality of all binary files? N/A

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
