### PR TITLE
qemu: update to version 4.1.0

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -5,7 +5,7 @@ PortGroup compiler_blacklist_versions 1.0
 PortGroup legacysupport 1.0
 
 name                    qemu
-version                 4.0.0
+version                 4.1.0
 revision                0
 categories              emulators
 license                 GPL-2+
@@ -23,9 +23,9 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_bzip2               yes
 
-checksums               rmd160  7ec340477414d5faee5969532e1b0c57327292a6 \
-                        sha256  6d7f713f7400c8a636c770118957b13d6a7f72b0d2da4a925d10455d8e33af20 \
-                        size    75668251
+checksums               rmd160  8625c6175f58dc3b96c3bf90444af4ade6a5ff20 \
+                        sha256  49f0de77410d4d0f7d0321ff2c2888b281381f06e1e2dac9ec4d061e3934f4ae \
+                        size    66853497
 
 patchfiles              patch-configure.diff
 patch.pre_args          -p1
@@ -86,7 +86,7 @@ configure.args-append   --disable-cocoa \
                         --disable-linux-aio \
                         --disable-glusterfs \
                         --disable-rdma \
-                        --disable-libssh2 \
+                        --disable-libssh \
                         --disable-vnc \
                         --disable-gnutls \
                         --disable-gcrypt \
@@ -191,7 +191,7 @@ variant snappy description {Support Snappy compression} {
 }
 
 variant ssh description {Support remote block devices over SSH} {
-    configure.args-replace  --disable-libssh2 --enable-libssh2
+    configure.args-replace  --disable-libssh --enable-libssh
     depends_lib-append      port:libssh2
 }
 


### PR DESCRIPTION
#### Description

Updates QEMU from 4.0.0 to 4.1.0, including changes to the libssh configure-script option name (libssh2 to libssh).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6 17G8030
Xcode 10.1 10B61 

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
