### PR TITLE
Mssql: remove unnecessary openssl reference

### DIFF
--- a/databases/msodbcsql/Portfile
+++ b/databases/msodbcsql/Portfile
@@ -18,8 +18,7 @@ checksums           rmd160  56ea30fa0861d76d222f1428baa9d6e11a90fd84 \
                     sha256  0bfa5c3d2599e6a284add3d1d49b713e1fe2637433403135a7e931518201fbb5 \
                     size    843627
                     
-depends_run         port:unixODBC \
-                    path:lib/libssl.dylib:openssl
+depends_run         port:unixODBC
                     
 use_configure       no
 
@@ -29,8 +28,6 @@ patch {
                     
 build {
     system "install_name_tool -change /usr/local/lib/libodbcinst.2.dylib ${prefix}/lib/libodbcinst.2.dylib ${worksrcpath}/lib/libmsodbcsql.17.dylib"
-    system "install_name_tool -change /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib ${prefix}/lib/libcrypto.1.0.0.dylib ${worksrcpath}/lib/libmsodbcsql.17.dylib"
-    system "install_name_tool -change /usr/local/opt/openssl/lib/libssl.1.0.0.dylib ${prefix}/lib/libssl.1.0.0.dylib ${worksrcpath}/lib/libmsodbcsql.17.dylib"
 }
 
 destroot {


### PR DESCRIPTION
#### Description

Turns out Microsoft have removed the openssl dependency.
<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G8030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
