### PR TITLE
angle-grinder: update to 0.11.0

### DIFF
--- a/sysutils/angle-grinder/Portfile
+++ b/sysutils/angle-grinder/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        rcoh angle-grinder 0.10.0 v
+github.setup        rcoh angle-grinder 0.11.0 v
 
 categories          sysutils
 license             MIT
@@ -21,6 +21,12 @@ long_description    Angle-grinder allows you to parse, aggregate, sum, \
                     but still want to be able to do sophisticated analytics.
 
 depends_lib-append  path:lib/libssl.dylib:openssl
+
+# logfmt is fetched via Git, but we fetch it manually here; we need to make
+# changes to the Cargo.toml and Cargo.lock files to trick cargo into using
+# the pre-fetched logfmt in MacPort's local cargo cache.
+patchfiles          patch-toml-logfmt.diff \
+                    patch-lock-logfmt.diff
 
 set bin_name        agrind
 
@@ -99,6 +105,7 @@ cargo.crates \
   hyper-tls                     0.3.1          32cd73f14ad370d3b4d4b7dce08f69b81536c82e39fcc89731930fe5788cd661  \
   idna                          0.1.5          38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e  \
   ignore                        0.4.5          d3a7927f029a610b866d545c488dd1fc403c4fed1cb4aea2ad568eaa9fc79cd9  \
+  im                            13.0.0         8db49f8bc08d5cc4e2bb0f7d25a6d1db2c79bc6f7d7c86c96c657eb3d214125f  \
   indexmap                      1.0.2          7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d  \
   iovec                         0.1.2          dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08  \
   itertools                     0.8.0          5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358  \
@@ -190,9 +197,11 @@ cargo.crates \
   serde_json                    1.0.33         c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811  \
   serde_urlencoded              0.5.4          d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2  \
   siphasher                     0.2.3          0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac  \
+  sized-chunks                  0.3.0          a2a2eb3fe454976eefb479f78f9b394d34d661b647c6326a3a6e66f68bb12c26  \
   slab                          0.4.1          5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d  \
   smallvec                      0.6.7          b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db  \
   stable_deref_trait            1.1.1          dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8  \
+  strfmt                        0.1.6          b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f  \
   string                        0.1.2          98998cced76115b1da46f63388b909d118a37ae0be0f82ad35773d4a4bc9d18d  \
   strsim                        0.7.0          bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550  \
   strsim                        0.8.0          8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a  \
@@ -224,6 +233,7 @@ cargo.crates \
   tokio-uds                     0.2.4          99ce87382f6c1a24b513a72c048b2c8efe66cb5161c9061d00bee510f08dc168  \
   toml                          0.4.10         758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f  \
   try-lock                      0.2.2          e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382  \
+  typenum                       1.10.0         612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169  \
   ucd-util                      0.1.3          535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86  \
   unicase                       1.4.2          7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33  \
   unicase                       2.2.0          9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90  \
@@ -255,10 +265,14 @@ cargo.crates \
   xattr                         0.2.2          244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c  \
   zip                           0.5.0          00acf1fafb786ff450b6726e5be41ef029142597b47a40ce80f952f1471730a0
 
+cargo.crates_github \
+  logfmt    brandur/logfmt      v0.0.2         ee7b87deb117715bb382f03e1b191e57c5071bbf \
+                                               a37a348c169be4c430f03b8dca2872e21ba8046a171448bbf892fdd1f84d10fd
+
 checksums-append    ${name}-${version}${extract.suffix} \
-                    rmd160  326d99ced778c5ddbbfca7bd818645d6df396715 \
-                    sha256  4483fa9cde09f274343a95743a9b03f808835ada480ca92113899d92377f9ad5 \
-                    size    916252 \
+                    rmd160  83759679a5314739e4e12a6daea5aca268522b79 \
+                    sha256  c06d94667292de243c1625f2adcd43022408cf51cfaeec914c68aa44cf43e30b \
+                    size    920017 \
                     MacTypes-sys-1.3.0.crate \
                     rmd160  e9cd809a80545d1d9ac89a57780f599c0f258626 \
                     size    8660 \
@@ -463,6 +477,9 @@ checksums-append    ${name}-${version}${extract.suffix} \
                     ignore-0.4.5.crate \
                     rmd160  3414b124370b76aa57e906c7f5efc14ec5dae13d \
                     size    45517 \
+                    im-13.0.0.crate \
+                    rmd160  d4dbf81b9c9424b47922770761cc38b6694d90fb \
+                    size    100016 \
                     indexmap-1.0.2.crate \
                     rmd160  c33801a950a85883e1b58dff9f50503613d201ca \
                     size    38255 \
@@ -736,6 +753,9 @@ checksums-append    ${name}-${version}${extract.suffix} \
                     siphasher-0.2.3.crate \
                     rmd160  377ddb77801a3170c19e427bc266b7ae3c6b4c28 \
                     size    8717 \
+                    sized-chunks-0.3.0.crate \
+                    rmd160  12220443b82d8989e80b6a45ffbfe62554194d21 \
+                    size    36092 \
                     slab-0.4.1.crate \
                     rmd160  6c3a417459c621d0390cd5ca5b2b90c31a3a4d89 \
                     size    9479 \
@@ -745,6 +765,9 @@ checksums-append    ${name}-${version}${extract.suffix} \
                     stable_deref_trait-1.1.1.crate \
                     rmd160  2864679bbc382223ef85944502118c744a22e703 \
                     size    8007 \
+                    strfmt-0.1.6.crate \
+                    rmd160  66b113e61155eec3c81baa84cd800862dd668827 \
+                    size    12357 \
                     string-0.1.2.crate \
                     rmd160  305b695d28efc4226ebf2c1f7da11c027b5d0a18 \
                     size    3989 \
@@ -838,6 +861,9 @@ checksums-append    ${name}-${version}${extract.suffix} \
                     try-lock-0.2.2.crate \
                     rmd160  772f07ca023eae6345c74f5b52296c437bceb144 \
                     size    3638 \
+                    typenum-1.10.0.crate \
+                    rmd160  a9ca122bae3880989eb6e1c0ef59fe39da73e317 \
+                    size    30009 \
                     ucd-util-0.1.3.crate \
                     rmd160  c9eeb795a73b8facbf7679e3877689eb2551fb90 \
                     size    25897 \
@@ -927,4 +953,8 @@ checksums-append    ${name}-${version}${extract.suffix} \
                     size    11750 \
                     zip-0.5.0.crate \
                     rmd160  3d95b44d1632282d04ef112077436dce6fe5ded7 \
-                    size    29345
+                    size    29345 \
+                    logfmt-ee7b87deb117715bb382f03e1b191e57c5071bbf.tar.gz \
+                    rmd160  c6365d5b785ae75943393e8173aff364aeb8b7db \
+                    size    1674
+

--- a/sysutils/angle-grinder/files/patch-lock-logfmt.diff
+++ b/sysutils/angle-grinder/files/patch-lock-logfmt.diff
@@ -1,0 +1,38 @@
+--- Cargo.lock.orig	2019-09-28 15:50:13.000000000 -0400
++++ Cargo.lock          2019-09-28 16:28:55.000000000 -0400
+@@ -15,7 +15,7 @@
+ 
+ [[package]]
+ name = "ag"
+-version = "0.10.0"
++version = "0.11.0"
+ dependencies = [
+  "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -26,7 +26,7 @@
+  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "logfmt 0.0.2 (git+https://github.com/brandur/logfmt?tag=v0.0.2)",
++ "logfmt 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "nom_locate 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -748,7 +748,7 @@
+ [[package]]
+ name = "logfmt"
+ version = "0.0.2"
+-source = "git+https://github.com/brandur/logfmt?tag=v0.0.2#ee7b87deb117715bb382f03e1b191e57c5071bbf"
++source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "maplit"
+@@ -2113,7 +2113,7 @@
+ "checksum libflate 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "bff3ac7d6f23730d3b533c35ed75eef638167634476a499feef16c428d74b57b"
+ "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+ "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+-"checksum logfmt 0.0.2 (git+https://github.com/brandur/logfmt?tag=v0.0.2)" = "<none>"
++"checksum logfmt 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "<none>"
+ "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
+ "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+ "checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"

--- a/sysutils/angle-grinder/files/patch-toml-logfmt.diff
+++ b/sysutils/angle-grinder/files/patch-toml-logfmt.diff
@@ -1,0 +1,11 @@
+--- Cargo.toml.orig	2019-09-27 07:41:59.000000000 -0400
++++ Cargo.toml	2019-09-27 07:42:11.000000000 -0400
+@@ -38,7 +38,7 @@
+ atty = "0.2.0"
+ lazy_static = "1.2.0"
+ im = "13.0.0"
+-logfmt = { git = "https://github.com/brandur/logfmt", tag = "v0.0.2" }
++logfmt = "0.0.2"
+ strfmt = "0.1.6"
+ 
+ [dev-dependencies]


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
