### PR TITLE
qt5*: update version 5.12.4->5.12.5

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -13,7 +13,7 @@ license             {LGPL-3 GPL-3 OpenSSLException}
 
 homepage            https://www.qt.io
 
-version             5.12.4
+version             5.12.5
 set middle_name     everywhere
 if { ${subport} eq "${name}-qtwebkit" ||
      ${subport} eq "${name}-qtwebkit-examples" ||
@@ -131,9 +131,9 @@ foreach {qt_test_name qt_test_info} [array get available_qt_versions] {
 array set modules {
     qt3d {
         {
-            b6b58e362fee7214741318199d8b512b929cec7f
-            cfad2e16f40fa07f8be59fa29c0c246743ee67db417ca29772a92f36fa322af3
-            84960856
+            416579f4d958d2a32a37a17b5675291f13e6d7e2
+            2a35b144768c7ad8a9265d16a04f038d9bc51016bd2c4b2b516e374f81ff29c4
+            82075068
         }
         ""
         "port:assimp"
@@ -146,9 +146,9 @@ array set modules {
     }
     qtbase {
         {
-            a37c9b301e4f0c87edb9adf0f1112ca9ddeca777
-            20fbc7efa54ff7db9552a7a2cdf9047b80253c1933c834f35b0bc5c1ae021195
-            48431020
+            bd49b61600b12e4dcb80b10c9cfa678c08a05c6c
+            fc8abffbbda9da3e593d8d62b56bc17dbaab13ff71b72915ddda11dabde4d625
+            48463288
         }
         ""
         "port:zlib port:libpng port:jpeg port:freetype path:bin/dbus-daemon:dbus port:tiff port:libmng path:lib/pkgconfig/glib-2.0.pc:glib2 port:icu port:pcre2 port:harfbuzz port:double-conversion"
@@ -161,9 +161,9 @@ array set modules {
     }
     qtcanvas3d {
         {
-            1ffa767ee2af66cdb81b9e299aa3b85835d86490
-            d7e0e8aa542d077a929fb7700411ca9de1f65ae4748d64168d2e7533facd7869
-            10915060
+            a45a6054de1723a1d635fe687a10ee4f415e3b38
+            1553e06ce3cc5afb36aed3698b85c00e734eac07f7f41895426bebd84216d80c
+            10914944
         }
         ""
         ""
@@ -176,9 +176,9 @@ array set modules {
     }
     qtcharts {
         {
-            e6b71de99ea731fe5f02052d77108e3def55c8c1
-            06ff68a80dc377847429cdd87d4e46465e1d6fbc417d52700a0a59d197669c9e
-            4242592
+            3dca2ab2515f5521c7920e3628d871091cc2f299
+            4c7c30a916ba0100a1635b89f48bc5a8af4cdedac79c3fc18456af54dc0a6608
+            4243464
         }
         ""
         ""
@@ -191,9 +191,9 @@ array set modules {
     }
     qtconnectivity {
         {
-            df0e07e659458b78370ff8087e0c3e7ac21216c2
-            749d05242b9fae12e80f569fb6b918dc011cb191eeb05147cbde474ca6b173ef
-            2751984
+            8a04d9e0a39a2cc6d81c2caecd8705fa96d559da
+            bdf62c72d689f47c4d17ecdde934d9f85a1164091e58fce02873de259e8de88b
+            2752252
         }
         ""
         ""
@@ -206,9 +206,9 @@ array set modules {
     }
     qtdatavis3d {
         {
-            74a66609d36cf8c5753e23d5871059c445945f00
-            1c160eeb430c8602aaee8ae4faa55bc62f880dae642be5fd1ac019f7886eb15a
-            5201284
+            0cb2a871f01d81eefa458391941be8deb0e4027b
+            1de165bf5330c7fb18c6fbb8c0e5cda47fa19c2eaba657b3792fd75e653444f3
+            5200204
         }
         ""
         ""
@@ -221,9 +221,9 @@ array set modules {
     }
     qtdeclarative {
         {
-            3d0b3b9243a82946b43539a05c7f229cf68d5137
-            614105ed73079d67d81b34fef31c9934c5e751342e4b2e0297128c8c301acda7
-            20502292
+            539a292c3f40a4bd9456ea6164b2802e0ca524ff
+            22c5323d4b01259e6e352eef1b54129d6dfee00a406f0312905fa7db322b9190
+            20512492
         }
         "port:python27"
         ""
@@ -236,9 +236,9 @@ array set modules {
     }
     qtdoc {
         {
-            94b62809c794d6619ae5d204ba3af6012f91ea81
-            93e6cb6abc0dad3a831a6e2c46d950bd7a99b59d60ce2d2b81c2ce893bfb41bb
-            5650368
+            26d00727d303c684fd37916236166a58ab1e6dd6
+            f1de30227b8854c284e9c23e9c0c44d9fe768880aef826b0f880a44dd7c7538d
+            5648572
         }
         ""
         ""
@@ -251,9 +251,9 @@ array set modules {
     }
     qtgamepad {
         {
-            1e3b8950d47eabfd1c5f0344f79b9a185793d2b2
-            25de6f10fb18f2484d1e569688bf33deb90ecbfb97ce41c2b5fb3521146e4c45
-            385888
+            76707b8113ee6183060703d980602d535f0efc77
+            de88f01d47f7cc5d54a1af783c5fae9f2b0101948ff33b8290f71b2657aded33
+            385864
         }
         ""
         "port:libsdl2"
@@ -266,9 +266,9 @@ array set modules {
     }
     qtgraphicaleffects {
         {
-            aa0eda03af0676270dbedbfe7f2993e3a6c808df
-            0bc38b168fa724411984525173d667aa47076c8cbd4eeb791d0da7fe4b9bdf73
-            14271080
+            52149f6f3e732422d8a5833616fea0be532d7e18
+            bdbddba7e0e0d041809a98d97c07da8be8936ec48537335cbaea9b0049c646ad
+            14271472
         }
         ""
         ""
@@ -281,9 +281,9 @@ array set modules {
     }
     qtimageformats {
         {
-            cc5bf3add5e8a65985f4dfea0a38c34b19433616
-            2dee25c3eea90d172cbd40f41450153322b902da1daa7d2370a55124b2307bb3
-            1793912
+            e7b5a6e80611f5a1c5633348579dea603fd72c84
+            9f19394830542fb9e6bde6806b6216b7207f96bff674b91e8e8a8f89699e1f0a
+            1795824
         }
         ""
         "port:jasper port:libmng port:tiff port:webp"
@@ -296,9 +296,9 @@ array set modules {
     }
     qtlocation {
         {
-            818a8ca3ad0a17c8945fd1fb347aad19d22d3e4d
-            127b40bd7679fead3fb98f4c9c1d71dde9d6d416e90a6000129b61a5f128b3a0
-            5909156
+            2432ef0eb0074a58d5c4b6e99fc59acf34597e66
+            12c8b59755abc4ca56e135e8ae3db7c6ba1bd95c779060f10a01393ae1040122
+            5905880
         }
         ""
         ""
@@ -311,9 +311,9 @@ array set modules {
     }
     qtmacextras {
         {
-            9d1eaba5883eb1e8c3cd2f75c4dce55813103944
-            3ea0b94f9b63e801f2ddafa2a908002d9529a3c65021d261627d21e07454acde
-            68816
+            24055815a7e6dd879e94477ceac809871d429aaf
+            984c3c95834aaa6fd85234ab1987a79662911c510e419611ce88fb4756313194
+            68808
         }
         ""
         ""
@@ -326,9 +326,9 @@ array set modules {
     }
     qtmultimedia {
         {
-            15b5b6b36f9f94d03d1f61f8730f01a571780f94
-            7c0759ab6fca2480b10b71a35beeffe0b847adeff5af94eacd1a4531d033423d
-            3743264
+            76d55cf62cf5203c181d1648b7e8ebca64d4b900
+            d5a0a4fddc5ef14d641160a1fc0011b190ff8d9f19009498d586516b8ee3479c
+            3744764
         }
         ""
         ""
@@ -341,9 +341,9 @@ array set modules {
     }
     qtnetworkauth {
         {
-            ab720760b4ab54b5e5df397f874d168f819195fe
-            e501eb46b8405a2b7db9fe90a1c224cf6676a07dc22c0662317ffe3dee1dbf55
-            139112
+            20e8e9c7321622b0843e5e55f379a5d8e10a6f86
+            0933475a2d30550c70ce4026c72678cbfdac73211593c78d442e038ef531a9f1
+            139116
         }
         ""
         ""
@@ -356,9 +356,9 @@ array set modules {
     }
     qtpurchasing {
         {
-            70f89ffe9a6acb21af4cdaa7801644e3c605597a
-            7804a111043d0e8d6d81a0d0ae465ce2c36eca73f2774ccb5fa7be8670211672
-            207964
+            8f24bb1e85b1eb7149b37b4a6eef2565cd520879
+            7bcebc4985d387f3fa4ffcc19eada1f4f0f000ed0fd3e1d1dc37eb1db0be615b
+            207960
         }
         ""
         ""
@@ -371,9 +371,9 @@ array set modules {
     }
     qtquickcontrols {
         {
-            dbc9a7d6e3dd74af4510639d558e161d001256c2
-            32d4c2505337c67b0bac26d7f565ec8fabdc616e61247e98674820769dda9858
-            6057224
+            dbacfae65be58269bba34a075da78ae39c187d64
+            46deaefbdac3daa576c748e807956f5f82b2318923b1a36e434a3ff32d1d2559
+            6056164
         }
         ""
         ""
@@ -386,9 +386,9 @@ array set modules {
     }
     qtquickcontrols2 {
         {
-            775265554adbd181f30bd9ddd1e72ce58a67a6cb
-            9a447eed38bc8c7d7be7bc407317f58940377c077ddca74c9a641b1ee6200331
-            9299120
+            5ce5c1534caf03e5c5b1c9ecf44e38f38134d48c
+            d744bdc492486db6cb521b1d4891e2358719399825ca1cf2a50968a80f6acb8f
+            9299520
         }
         ""
         ""
@@ -401,9 +401,9 @@ array set modules {
     }
     qtremoteobjects {
         {
-            957873cb777906312490877947625444c1f32c20
-            54dd0c782abff90bf0608771c2e90b36073d9bd8d6c61706a2873bb7c317f413
-            346144
+            5e2fa24bc1478f4a6b81f83ec9128ba8034ec0c9
+            acf131af93dd1fefbf30c7e03e29b8a1da3180e00c49f95c14a1cb6158cfeacd
+            346152
         }
         ""
         ""
@@ -416,9 +416,9 @@ array set modules {
     }
     qtscript {
         {
-            624660cb8b869e0f8c16f7058fd2759691f0581b
-            7adb3fe77638c7a6f2a26bca850b0ff54f5fb7e5561d2e4141d14a84305c2b6a
-            2675028
+            0957b17b4a210d1a4377d42e158571ed915abd85
+            0083734ae827840334b774decb15de37f1b4ea5c88e442e2f485c530f24f1df4
+            2675432
         }
         ""
         ""
@@ -431,9 +431,9 @@ array set modules {
     }
     qtscxml {
         {
-            5f6fdcddfa2b04e5a77e2c15cf7d8754bda46a78
-            696fb72a62018151275fe589fc80cb160d2becab9a3254321d40e2e11a0ad4f8
-            434312
+            073bfc5c16bd20d714b1cdf802b74453720a04b7
+            6f1ec74100cdb2e7dfc3535e09d356fc53ba42e61b32fc3b93d5a7efed49960c
+            434260
         }
         ""
         ""
@@ -446,9 +446,9 @@ array set modules {
     }
     qtsensors {
         {
-            023732af0cb758dc4e6c620457c4ae88165279a8
-            95873c7ea5960008d6eb41368ca64d68fbd05594ca8c2cd848b1612fc4aec0a9
-            2035464
+            85b04faa2ed2f09443a8fdd27d27409702590b6b
+            e3a86a706f475bb23fc874de56026482de223ebd24f8cb4e94a28d1985ca0b85
+            2035484
         }
         ""
         ""
@@ -461,9 +461,9 @@ array set modules {
     }
     qtserialbus {
         {
-            39dda808133d9dee36b1a5a6b65a792f12656b4b
-            69d56905f43ee13e670750e8f46d373835fae81d6343baa7c4004d2a2c6311fc
-            328808
+            b89b72589137eb655a10d346527c3952e9269080
+            8474ae61a703c56e327ae0755c27643f2eafe0d915e8c6afb21728548dc02c22
+            329052
         }
         ""
         ""
@@ -476,9 +476,9 @@ array set modules {
     }
     qtserialport {
         {
-            06e9c7dc26c7d6f371b1c3d43081ed93df267237
-            bf487df8a9fb2eddf103842b57a75b17ef4c498ee40306ae9997017c82b0ad39
-            302892
+            ed2e60e0e7e0868a25073fd4d4c021c2248f7e71
+            f8ef0321a59ecfe2c72adc2ee220e0047403439a3c7b9efb719b1476af1fb862
+            302940
         }
         ""
         ""
@@ -491,9 +491,9 @@ array set modules {
     }
     qtspeech {
         {
-            3fec1460df7d27d258953c4435796dcf7b332d6b
-            2ff9660fb3f5663c9161f491d1a304db62691720136ae22c145ef6a1c94b90ec
-            99832
+            4d1fc70b6f6b266d99325ce3f1f12c4a16e7391b
+            f94c0cd7236d1a20d97d314d2c17c45c967cd7f24b869c43f5f46253f436f25b
+            99840
         }
         ""
         ""
@@ -506,9 +506,9 @@ array set modules {
     }
     qtsvg {
         {
-            309a8b07980f24b69e4a900c25e4421339c6fcc6
-            110812515a73c650e5ebc41305d9a243dadeb21f485aaed773e394dd84ce0d04
-            1859476
+            075a1c3b948c4081a24a33a79b4a76da6de7a1f9
+            75a791cf749f671d7ea9090b403ca513f745795018db512e7eecbf418b679840
+            1860340
         }
         ""
         ""
@@ -521,9 +521,9 @@ array set modules {
     }
     qttools {
         {
-            31952279bd2fef5a1d6393d304e34616c8224061
-            3b0e353860a9c0cd4db9eeae5f94fef8811ed7d107e3e5e97e4a557f61bd6eb6
-            9810980
+            b316528a06fe79b41fc4cc40b2ee7d2c39eae926
+            28e095047b4985437dd66120cbcb49ac091bf4f12576ecad7ebc781b7dd44025
+            9759888
         }
         ""
         "port:clang-8.0"
@@ -536,9 +536,9 @@ array set modules {
     }
     qttranslations {
         {
-            315e2f4af5a2f09199b650b574ad7f5c9fd634e4
-            ab8dd55f5ca869cab51c3a6ce0888f854b96dc03c7f25d2bd3d2c50314ab60fb
-            1383576
+            b6afc7a69e2069a2a2a6f84c631a03db8e2f4133
+            72eb6317190fdcc3f8de37996adc646ab8772988766bacaab60a5bcc7d6a3f2a
+            1377740
         }
         ""
         ""
@@ -551,9 +551,9 @@ array set modules {
     }
     qtvirtualkeyboard {
         {
-            6a5c671dc15b020a89cdf1ef1746a0dac143ee95
-            33ac0356f916995fe5a91582e12b4c4f730c705808ea3c14e75c6e350e8131e6
-            10915036
+            246b6859985ff9cc46a68902d59827ec76dbe8f4
+            786d745b34b1f145073488d492325e98bcde81b07ab984032ea5eb2fb52e6e5e
+            10911944
         }
         ""
         "port:hunspell"
@@ -566,9 +566,9 @@ array set modules {
     }
     qtwebchannel {
         {
-            0560bbc3e5d6fd1e7020fac8e7fe021bd7b07a37
-            ab571a1b699e61a86be1a6b8d6ffd998d431c4850cc27e9a21f81fa5923bfdb7
-            183056
+            8ccef00c11f62c004a2e21038b99d3ed0cc4e87e
+            9f1d1ac20722ee053ecf071d4ec0070a45a765cb67b6e31add61004fb4b3c5e8
+            182944
         }
         ""
         ""
@@ -581,9 +581,9 @@ array set modules {
     }
     qtwebengine {
         {
-            390095314d153a8f8de58c0e264d29c187d4b555
-            fccf5c945412c19c3805323211b504ac8becbf191c638a2dc85ec91abfb1b331
-            249328292
+            38406181b27efae1d45658e7a4494de3387d2786
+            31881130e69eb8336e9480f9f33cd5a93e86de8d7323c0ae1893e1a72ce70743
+            249295448
         }
         "port:python27 port:py27-ply port:ninja port:gperf port:bison port:flex"
         "port:fontconfig port:dbus port:harfbuzz path:lib/pkgconfig/glib-2.0.pc:glib2 port:zlib port:minizip port:libevent port:libxml2 port:jsoncpp port:protobuf3-cpp port:poppler port:pulseaudio port:icu path:lib/libavcodec.dylib:ffmpeg port:libopus port:webp port:libpng port:lcms2 port:freetype port:re2 port:snappy"
@@ -596,9 +596,9 @@ array set modules {
     }
     qtwebglplugin {
         {
-            72ce8aba66cc8050f0cefd22190ec621b51932c9
-            756fa09893618029bb56605be3ac5756a1834255fb223f8e4b7de205846d3266
-            73368
+            c06565ede6c8e01e3254211126bab2feb9eae474
+            aac3b2b2e5b6f26dd7abba6eab616777fecbb4d06de05ddab68c1296652bc4f7
+            73400
         }
         ""
         ""
@@ -641,9 +641,9 @@ array set modules {
     }
     qtwebsockets {
         {
-            fa148990adffe607889f3bf6608615703efefa5e
-            b471eda2f486d21c51fc3bc53bb8844022117e746d5f15c5eabb82cd37eb2abe
-            235300
+            81b385edb8e00ffb3e98a16f4e0e344a58476749
+            5d58e697c49c0ea19a8299deba84b5360dca8c336a1636d38de0351757293262
+            235468
         }
         ""
         ""
@@ -656,9 +656,9 @@ array set modules {
     }
     qtwebview {
         {
-            a707e7488cf7d1368947bbe17fc4e29f6af252d9
-            1f244c6b774dd9d03d3c5cafe877381900b50a2775cef6487c8bb66e32ab5a5d
-            131184
+            9d318dd29f116a42622c3cc26939302eeb7f924b
+            a6d4d8c335cd6838f4638874fcd67655e80db569ed567a774a84f6bf7d332f26
+            131160
         }
         ""
         ""
@@ -671,9 +671,9 @@ array set modules {
     }
     qtxmlpatterns {
         {
-            9daaae319629250c064438f9819c0ffa8a06cfcf
-            0bea1719bb948f65cbed4375cc3e997a6464f35d25b631bafbd7a3161f8f5666
-            1389616
+            0d842442f3e961dbffd9371a0e33d30fd79bf57b
+            b905d9107f87798ef0f142942fc45c0f63fc113522ab041e791d3cb744a8babd
+            1390052
         }
         ""
         ""


### PR DESCRIPTION
#### Description

qt5*: update version 5.12.4->5.12.5

###### Type(s)

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 10.15 19A573a
Xcode 11.1 11A1027

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?