### PR TITLE
asymptote: update to 2.54

### DIFF
--- a/graphics/asymptote/Portfile
+++ b/graphics/asymptote/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                asymptote
-version             2.53
+version             2.55
 
 categories          graphics
 maintainers         {mojca @mojca} openmaintainer
@@ -27,9 +27,9 @@ set python.bin      ${prefix}/bin/python${python.branch}
 master_sites        sourceforge:asymptote
 extract.suffix      .src.tgz
 
-checksums           rmd160  2dd969aabee68fcefc929325c5a5b179239c1c18 \
-                    sha256  7ce2b34fe0b82060cc27d27323649478c056610ab0c7499dcacb45e7c632527b \
-                    size    4136665
+checksums           rmd160  5df7752c8f7f46958dd3f07031ee32a459fcce5d \
+                    sha256  cc94d85306f39d3c901f4a3123abf40d5ef68490da7494cf86ecaf74c324e01c \
+                    size    4117390
 
 patchfiles          patch-Makefile.diff
 

--- a/graphics/asymptote/Portfile
+++ b/graphics/asymptote/Portfile
@@ -37,7 +37,8 @@ post-patch {
     reinplace "s|@@PYTHON@@|${python.bin}|g" ${worksrcpath}/Makefile.in
 }
 
-configure.args      --with-latex=${texlive_texmfports}/tex/latex \
+configure.args      --enable-gc=system \
+                    --with-latex=${texlive_texmfports}/tex/latex \
                     --with-context=${texlive_texmfports}/tex/context/third \
                     --mandir=${prefix}/share/man \
                     --disable-offscreen

--- a/graphics/asymptote/files/patch-Makefile.diff
+++ b/graphics/asymptote/files/patch-Makefile.diff
@@ -18,7 +18,7 @@
 # 	if test -n "$(MSDOS)"; then \
 #           $(CXX) $(OPTS) -o $(NAME) $(FILES:=.o) revision.o asy.o $(DOSLIBS); \
 # 	else \
-@@ -131,7 +131,7 @@ version: $(GCLIB) $(FILES:=.o) $(UIFILES:.ui=.py)
+@@ -132,7 +132,7 @@ version: $(GCLIB) $(FILES:=.o) $(UIFILES:.ui=.py)
  	echo @set VERSION $(revision) > doc/version.texi
  	echo @set Datadir @datadir@ >> doc/version.texi
  


### PR DESCRIPTION
#### Description

I would have pushed this to the master already, if I didn't realize that for a strange reason the build is apparently picking the built-in `boehmg` now rather than the system one (which it used in the past). If this doesn't get resolved quickly, I'll close the PR.

@johncbowman: did something in that respect change recently?

Also:
```
$ asy teapot.asy # a window seems to open, but immediately close
$ asy -v teapot.asy # where is the nice OpenGL now?
Processing teapot
adjusting camera to (258.211421601238,-245.850065946418,245.301513985341)
adjusting target to (14.3635129589656,4.14993405358065,39.9471789853422)
Wrote teapot.eps
$ asy -V teapot.asy # it somehow worked the second time I tried, but starting with 100% black teapot
No handler for exception!
Abort trap: 6
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->