### PR TITLE
micronaut: update to 1.2.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-core 1.2.2 v
+github.setup    micronaut-projects micronaut-core 1.2.3 v
 name            micronaut
 categories      java
 platforms       darwin
@@ -41,9 +41,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        ${name}-${version}
 
-checksums       rmd160  bb264253e0086714f631ed770a1ae9698b1fbc47 \
-                sha256  0119281bc64001e4d66f4149a19133e5539ceeefe649156c6dd09b971946f8f3 \
-                size    12924396
+checksums       rmd160  bb6545c370548cacd78ca1c6b21b8a3d26b8f2fa \
+                sha256  313af68543211d4ed6e914e216b6a5343d23238111de4c14ea5008b1f5f11bb0 \
+                size    12924382
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 1.2.3.

###### Tested on

macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?