### PR TITLE
homebank: Update to version 5.2.8

### DIFF
--- a/x11/homebank/Portfile
+++ b/x11/homebank/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                homebank
-version             5.2.7
+version             5.2.8
 categories          x11 finance
 license             GPL-2+
 platforms           darwin
@@ -20,9 +20,9 @@ long_description    HomeBank is the free software you have always wanted to \
 homepage            http://homebank.free.fr/
 master_sites        ${homepage}public/
 
-checksums           rmd160  a9671e23cb6e0ab92a891b47523ce76874f4a2bd \
-                    sha256  8eedbe4246477935bd3882c1a628d7fd6036f6467be998c2558bdf4b39b0eb5f \
-                    size    2723372
+checksums           rmd160  b5e582e62d71410887b4eada4c17c54e8872fe8d \
+                    sha256  fe98a3585a23ed66695a96b9162dbf1872f4fd78c01471019b60786476bc558d \
+                    size    2730743
 
 depends_build       port:intltool \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
I updated from version 5.2.7 to 5.2.8 with newer upstream version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [X] update

###### Tested on
macOS 10.14.6 18G95
Xcode 11.0 11A420a

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
