### PR TITLE
lang/fpc-cross: new port

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -77,6 +77,37 @@ subport "chmcmd-${name}" {
     }
 }
 
+subport "${name}-cross" {
+    description     FreePascal common cross-compiler binaries
+    long_description \
+                    Crosscompilers serving as starting points \
+                    for specific operating system targets.    \
+                    OS runtime libraries are not yet ready.
+    depends_build-append \
+                    port:${name}
+
+    worksrcdir      ${name}build-${version}/fpcsrc/compiler
+    use_configure   no
+    build.args      OPT="-ap -v0"
+    build.target    arm avr i386 i8086 jvm m68k mips mipsel powerpc powerpc64 sparc
+
+    destroot {
+      # delete unwanted files
+        file delete -force ${worksrcpath}/ppcgen
+        file delete        {*}[glob ${worksrcpath}/ppc*.*]
+
+      # create dirs
+        xinstall -m 755 -d ${destroot}${prefix}/bin
+        xinstall -m 755 -d ${destroot}${prefix}/lib/fpc/${version}
+
+      # loop over installing all cross-compilers
+        foreach PPCCROSS [glob -tails -directory ${worksrcpath} ppc*] {
+            xinstall -m 755 ${worksrcpath}/$PPCCROSS ${destroot}${prefix}/lib/fpc/${version}
+            ln -sf ../lib/fpc/${version}/$PPCCROSS ${destroot}${prefix}/bin/$PPCCROSS
+        }
+    }
+}
+
 if {${subport} eq "${name}"} {
     installs_libs       yes
 


### PR DESCRIPTION
FreePascal common cross-compiler binaries. No OS runtime libraries so far.

#### Description
FreePascal common cross-compiler binaries. The OS specific runtime libraries will be part of ports to come.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.14.6
Xcode 10.3

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
