### PR TITLE
gmp: workaround bug in Xcode11

### DIFF
--- a/devel/gmp/Portfile
+++ b/devel/gmp/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem 1.0
 PortGroup  muniversal  1.0
+PortGroup  xcodeversion 1.0
 
 name            gmp
 version         6.1.2
-revision        1
+revision        2
 categories      devel math
 license         LGPL-3+
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -148,6 +149,14 @@ if { ${auto_cpu} } {
         if { ${build_cpu} eq "x86_64" || ${build_cpu} eq "i386" || ${build_cpu} eq "powerpc64" || ${build_cpu} eq "powerpc" } {
             ui_warn "No processor dependent assembly code being used. gmp might be slower."
         }
+    }
+}
+
+# jeremyhu@macports.org - bug in Xcode11 and likely Xcode11.1 on Catalina
+if {([vercmp ${os.major} 19] >=  0) && ([vercmp $xcodeversion 11.2] < 0)} {
+    if {[string match clang ${configure.compiler}]} {
+        configure.cc-append -fno-stack-check
+        configure.cxx-append -fno-stack-check
     }
 }
 


### PR DESCRIPTION
viz: jeremyhu@macports.org
bug should be fixed in xcode 11.2

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 10.3 10G8 

macOS 10.14.6 18G103
Xcode 11.0 11A420a 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
