### PR TITLE
google-cloud-sdk: update to 265.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             264.0.0
+version             265.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -20,9 +20,9 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
 
-checksums           rmd160  f760f194d958c5b7c5ee6d4ecc9b45d911491e3d \
-                    sha256  2891d5f14e2de75a4f48d8c606555b0d45b8b1c36bdf23615c4720017f30abbc \
-                    size    21950446
+checksums           rmd160  4b686e6c7616225759f762f4d5a769ceb13c78bc \
+                    sha256  7cf6b3a0f971d1f5ade6e73dd3876ce77a69ff4065b06afddff530875ad33eaf \
+                    size    22090949
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 265.0.0.

###### Tested on

macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?