### PR TITLE
google-cloud-sdk: fix support for 32-bit OS

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -14,15 +14,22 @@ long_description    ${description}
 platforms           darwin
 supported_archs     i386 x86_64
 
+if { ${configure.build_arch} eq "i386" } {
+    distname        ${name}-${version}-darwin-x86
+    checksums       rmd160  5688cea038bf1e0618f926637b9b1a050e9f4d34 \
+                    sha256  87d73c6bf8c8a62105780ab648820d40bed1d6b6afaee6245ea1757f004a647c \
+                    size    21949464
+} elseif { ${configure.build_arch} eq "x86_64" } {
+    distname        ${name}-${version}-darwin-x86_64
+    checksums       rmd160  f760f194d958c5b7c5ee6d4ecc9b45d911491e3d \
+                    sha256  2891d5f14e2de75a4f48d8c606555b0d45b8b1c36bdf23615c4720017f30abbc \
+                    size    21950446
+}
+
 homepage            https://cloud.google.com/sdk/
 master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 
-distname            ${name}-${version}-${os.platform}-${configure.build_arch}
 worksrcdir          ${name}
-
-checksums           rmd160  f760f194d958c5b7c5ee6d4ecc9b45d911491e3d \
-                    sha256  2891d5f14e2de75a4f48d8c606555b0d45b8b1c36bdf23615c4720017f30abbc \
-                    size    21950446
 
 python.default_version 27
 


### PR DESCRIPTION
#### Description

This change should fix support on i386. Closes https://trac.macports.org/ticket/59140

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?