### PR TITLE
miller: fix tests

### DIFF
--- a/textproc/miller/Portfile
+++ b/textproc/miller/Portfile
@@ -37,9 +37,8 @@ installs_libs       no
 
 set mlr_doc_dir     ${prefix}/share/doc/${name}
 
-test {
-    system -W "${worksrcpath}" "${build.cmd} check"
-}
+test.run            yes
+test.target         check
 
 pre-destroot {
     system -W "${worksrcpath}/doc" "${build.cmd} DESTDIR=\"${destroot}\" install-man"


### PR DESCRIPTION
#### Description

Correct tests phase Portfile commands for miller

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
