### PR TITLE
clang_select: Add some more entries

### DIFF
--- a/lang/llvm-8.0/files/mp-clang-8.0
+++ b/lang/llvm-8.0/files/mp-clang-8.0
@@ -8,10 +8,16 @@ bin/scan-view-mp-8.0
 bin/clang-apply-replacements-mp-8.0
 bin/clang-check-mp-8.0
 bin/clang-cl-mp-8.0
--
+bin/clang-mp-8.0
 bin/clang-query-mp-8.0
 bin/clang-rename-mp-8.0
 bin/clang-tidy-mp-8.0
+libexec/llvm-8.0/libexec/clang-format/clang-format-diff.py
+libexec/llvm-8.0/share/clang/clang-tidy-diff.py
+bin/clangd-mp-8.0
+bin/git-clang-format-mp-8.0
+libexec/llvm-8.0/share/clang/run-clang-tidy.py
+bin/sancov-mp-8.0
 -
 -
 -
@@ -26,9 +32,3 @@ bin/clang-tidy-mp-8.0
 -
 -
 -
--
--
--
--
--
-

--- a/lang/llvm-9.0/files/mp-clang-9.0
+++ b/lang/llvm-9.0/files/mp-clang-9.0
@@ -8,10 +8,16 @@ bin/scan-view-mp-9.0
 bin/clang-apply-replacements-mp-9.0
 bin/clang-check-mp-9.0
 bin/clang-cl-mp-9.0
--
+bin/clang-mp-9.0
 bin/clang-query-mp-9.0
 bin/clang-rename-mp-9.0
 bin/clang-tidy-mp-9.0
+libexec/llvm-9.0/libexec/clang-format/clang-format-diff.py
+libexec/llvm-9.0/share/clang/clang-tidy-diff.py
+bin/clangd-mp-9.0
+bin/git-clang-format-mp-9.0
+libexec/llvm-9.0/share/clang/run-clang-tidy.py
+bin/sancov-mp-9.0
 -
 -
 -
@@ -26,9 +32,3 @@ bin/clang-tidy-mp-9.0
 -
 -
 -
--
--
--
--
--
-

--- a/sysutils/clang_select/Portfile
+++ b/sysutils/clang_select/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 PortGroup select 1.0
 
 name			clang_select
-version			2
+version			2.1
 categories		sysutils
 platforms		darwin
 license		BSD

--- a/sysutils/clang_select/files/base
+++ b/sysutils/clang_select/files/base
@@ -12,6 +12,12 @@ bin/clang-mp
 bin/clang-query
 bin/clang-rename
 bin/clang-tidy
+bin/clang-format-diff
+bin/clang-tidy-diff
+bin/clangd
+bin/git-clang-format
+bin/run-clang-tidy
+bin/sancov
 bin/clang-reserved1
 bin/clang-reserved2
 bin/clang-reserved3
@@ -26,9 +32,3 @@ bin/clang-reserved11
 bin/clang-reserved12
 bin/clang-reserved13
 bin/clang-reserved14
-bin/clang-reserved15
-bin/clang-reserved16
-bin/clang-reserved17
-bin/clang-reserved18
-bin/clang-reserved19
-bin/clang-reserved20


### PR DESCRIPTION
#### Description
clang_select: Add some more entries

- clang-format-diff
- clang-tidy-diff
- clangd
- git-clang-format
- run-clang-tidy
- sancov

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G8030
Xcode 9.3 9E145

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
