### PR TITLE
group/haskell_cabal: Use system gcc by setting build.env PATH

### DIFF
--- a/_resources/port1.0/group/haskell_cabal-1.0.tcl
+++ b/_resources/port1.0/group/haskell_cabal-1.0.tcl
@@ -80,6 +80,13 @@ default build.cmd           {${haskell_cabal.bin}}
 default build.target        {new-build}
 default build.args          {${haskell_cabal.default_args}}
 
+# ensure /usr/bin/gcc is used; see https://github.com/haskell/cabal/issues/1325
+default build.env           {PATH=${worksrcpath}/bin:$env(PATH)}
+pre-build {
+    xinstall -d ${worksrcpath}/bin
+    ln -s /usr/bin/gcc ${worksrcpath}/bin/gcc
+}
+
 # Note: cabal new-install does *not* use the specified --prefix'ed datadir
 # Do not use new-install; rather, new-update / new-configure / new-build
 
@@ -104,12 +111,12 @@ destroot {
 
     # install documentation
     if { [file isdirectory ${cabal_build}/doc] } {
-        xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}
+        xinstall -d ${destroot}${prefix}/share/doc/${name}
         fs-traverse f_or_d ${cabal_build}/doc {
             set subpath [strsed ${f_or_d} "s|${cabal_build}/doc||"]
             if { ${subpath} ne "" } {
                 if { [file isdirectory ${f_or_d}] } {
-                    xinstall -m 0755 -d \
+                    xinstall -d \
                         ${destroot}${prefix}/share/doc/${name}${subpath}
                 } elseif { [file isfile ${f_or_d}] } {
                     xinstall -m 0644 ${f_or_d} \


### PR DESCRIPTION
group/haskell_cabal: Use system gcc by setting build.env PATH

* Fix build fail when `port select --set gcc mp-gcc*` is set
* Change cabal dependency on ghc to depends_run

Related: https://github.com/haskell/cabal/issues/1325

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
