### PR TITLE
gmp: allow binary distribution

### DIFF
--- a/devel/gmp/Portfile
+++ b/devel/gmp/Portfile
@@ -38,12 +38,6 @@ patchfiles \
 
 configure.args  --enable-cxx
 
-# Prevent precompiled binaries.
-# See #41614.
-# might not be needed if we decide to add:
-#default_variants +core2
-archive_sites
-
 configure.universal_args-delete --disable-dependency-tracking
 
 # Clear all options that affect CFLAGS and CXXFLAGS, since the configure
@@ -94,30 +88,13 @@ configure.pipe  no
 test.run        yes
 test.target     check
 
-# see configure.ac for possible CPU values and what each does
-set processors {core2}
-
-foreach processor ${processors} {
-
-    # only one processor variant can be used, so create a list of every other processor variant to conflict with
-    set conflicts_list ""
-    foreach processor_conflict ${processors} {
-        if { ${processor_conflict} ne ${processor} } {
-            lappend conflicts_list ${processor_conflict}
-        }
-    }
-
-    variant ${processor} description "do not let ${name} determine CPU type; build for ${processor}" conflicts {*}${conflicts_list} "
-        configure.args-append --host=${processor}-apple-${os.platform}${os.version}
-    "
+variant native description {Build optimized for your machine's specific processor} {
+    archive_sites
 }
-
-# if any of the processor variants are active, CPU is not auto-detected
-set auto_cpu true
-foreach processor ${processors} {
-    if { [variant_isset ${processor}] } {
-        set auto_cpu false
-    }
+if {[variant_isset native]} {
+    set auto_cpu true
+} else {
+    set auto_cpu false
 }
 
 # config.guess: "Print the host system CPU-VENDOR-OS."
@@ -219,6 +196,20 @@ if {![variant_isset universal]} {
             } else {
                 configure.args-append --host=${build_processor}-apple-${os.platform}${os.version}
             }
+        }
+    } elseif {!${auto_cpu}} {
+        # Choose minimum spec so binaries should work for all users.
+        switch -- $build_arch {
+            x86_64  { set processor core2 }
+            i386    { set processor pentiumm }
+            ppc     { set processor powerpc750 }
+            ppc64   { set processor powerpc970 }
+            default { set processor "" }
+        }
+        if {$processor ne ""} {
+            configure.args-append --host=${processor}-apple-${os.platform}${os.version}
+        } else {
+            ui_warn "Unknown build_arch '$build_arch', can't set a fixed processor type"
         }
     }
 } else {


### PR DESCRIPTION
Build for a minimum spec CPU by default so binaries should work for all
users. Add a native variant that can be selected to get the former
behaviour of auto-detecting the build machine's CPU.