### PR TITLE
golangci-lint: update to 1.18.0

### DIFF
--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golangci/golangci-lint 1.17.1 v
+go.setup            github.com/golangci/golangci-lint 1.18.0 v
 
 platforms           darwin
 categories          devel
@@ -19,9 +19,9 @@ long_description    GolangCI-Lint is a linters aggregator. It's fast: on \
                     integrate and use, has nice output and has a minimum \
                     number of false positives. It supports go modules.
 
-checksums           rmd160  2abb836c0258e23f21d2b5f6b837c4142ebba1f7 \
-                    sha256  610a199d74a1feb0f17c9331b7ab5f9454cdf594a419437fa672240c0a360d58 \
-                    size    3929522
+checksums           rmd160  274b8bb58c6e6d6d20d7995d41928f635010e7d0 \
+                    sha256  2d6c0f0e5f5e81ad6a72a150edfefad342a27ba92a045ca3a923af4a9f36fd0f \
+                    size    3927480
 
 build.args          ./cmd/golangci-lint
 


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
