### PR TITLE
prometheus: update to 2.13.0

### DIFF
--- a/net/prometheus/Portfile
+++ b/net/prometheus/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        prometheus prometheus 2.12.0 v
+github.setup        prometheus prometheus 2.13.0 v
 github.tarball_from archive
 
 description         The Prometheus monitoring system and time series database
@@ -41,9 +41,9 @@ set prom_share_dir  ${prefix}/share/${name}
 set prom_log_dir    ${prefix}/var/log/${name}
 set prom_log_file   ${prom_log_dir}/${name}.log
 
-checksums   rmd160  67d675dc3666b02d353441d34368c0c179b1b5f4 \
-            sha256  9bd9ae6df02777a9ba3f6f544338865861decabd02054aa64975449bd6009e5a \
-            size    15221347
+checksums   rmd160  0f420962162c7ed2dc22be439b6e45623d8dea60 \
+            sha256  0a11ecc28989ad984af551a5426e9989aa1ca628fc2e875bb913af445ab38288 \
+            size    15193225
 
 add_users           ${prom_user} \
                     group=${prom_user} \
@@ -85,6 +85,7 @@ destroot.keepdirs-append ${destroot}${prom_data_dir} \
 destroot {
     xinstall -m 755 ${worksrcpath}/${name}  ${destroot}${prefix}/bin/${name}
     xinstall -m 755 ${worksrcpath}/promtool ${destroot}${prefix}/bin/promtool
+    xinstall -m 755 ${worksrcpath}/tsdb/tsdb ${destroot}${prefix}/bin/tsdb
 
     xinstall -d 755 ${destroot}${prom_conf_dir}
     xinstall -d 755 ${destroot}${prom_doc_dir}


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
