### PR TITLE
gnudatalanguage: Fix build on 10.8 and earlier

### DIFF
--- a/math/gnudatalanguage/Portfile
+++ b/math/gnudatalanguage/Portfile
@@ -64,6 +64,7 @@ conflicts_build             antlr
 cmake.out_of_source yes
 
 patchfiles              patch-src-magick_cl.cpp.diff
+patchfiles-append       sincos.patch
 
 configure.args-append   -DEIGEN3DIR=${prefix} \
                         -DFFTW=ON \

--- a/math/gnudatalanguage/files/sincos.patch
+++ b/math/gnudatalanguage/files/sincos.patch
@@ -1,0 +1,18 @@
+Provide a fallback implementation of sincos for OS X 10.8 and earlier
+which don't have __sincos.
+https://github.com/gnudatalanguage/gdl/commit/a7dbf138ba4fda9e428ceab15b9ea7b7f7bc0948
+--- src/ssrfpack.c.orig	2018-12-01 08:19:52.000000000 -0600
++++ src/ssrfpack.c	2019-10-04 06:30:06.000000000 -0500
+@@ -3,8 +3,12 @@
+  * are not required to compile and link the sph supplement.
+  */
+ #ifdef __APPLE__
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1090
+ #define sincos(x, s, c) __sincos(x, s, c)
+ #define sincosf(x, s, c) __sincosf(x, s, c)
++#else
++#define sincos(x,s,c) (*s = sin(x), *c = cos(x))
++#endif
+ #endif
+ 
+ #ifdef __FreeBSD__


### PR DESCRIPTION
#### Description

Provide a fallback implementation of sincos for earlier systems that don't have `__sincos`.

This has already been [submitted to and accepted by](https://github.com/gnudatalanguage/gdl/pull/647) the GDL developers.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
OS X 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->