### PR TITLE
py-tz: update to 2019.2

### DIFF
--- a/python/py-tz/Portfile
+++ b/python/py-tz/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-tz
 set my_name         pytz
 conflicts           py-tz-gae
-version             2018.9
+version             2019.2
 revision            0
 
 categories-append   devel
@@ -20,13 +20,12 @@ long_description    pytz brings the Olson tz database into Python. This library 
                     accurate and cross platform timezone calculations.
 
 homepage            https://pypi.python.org/pypi/pytz
-master_sites        pypi:1b/50/4cdc62fc0753595fc16c8f722a89740f487c6e5670c644eb8983946777be \
-                    pypi:p/pytz/
+master_sites        pypi:p/pytz/
 distname            ${my_name}-${version}
 
-checksums           rmd160  60a5a4de522e3a4d8bed1f8f58f7bdcf0abfb157 \
-                    sha256  d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c \
-                    size    310705
+checksums           rmd160  a6ef26c8a6c9d5c927a5b3f0c052b09ac963f2aa \
+                    sha256  26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32 \
+                    size    307474
 
 python.versions     27 34 35 36 37
 

--- a/python/py-tz/Portfile
+++ b/python/py-tz/Portfile
@@ -1,50 +1,46 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
-PortGroup       python 1.0
+PortSystem          1.0
+PortGroup           python 1.0
 
-name            py-tz
-set my_name     pytz
-version         2018.9
-revision        0
-categories-append     devel
-platforms       darwin
-supported_archs noarch
-maintainers     {ram @skymoo} openmaintainer
-license         MIT
+name                py-tz
+set my_name         pytz
+conflicts           py-tz-gae
+version             2018.9
+revision            0
 
-description     World Timezone Definitions for Python
-long_description \
-    pytz brings the Olson tz database into Python. This library allows \
-    accurate and cross platform timezone calculations.
+categories-append   devel
+platforms           darwin
+supported_archs     noarch
+license             MIT
+maintainers         {ram @skymoo} openmaintainer
 
-homepage        https://pypi.python.org/pypi/pytz
-master_sites    pypi:1b/50/4cdc62fc0753595fc16c8f722a89740f487c6e5670c644eb8983946777be \
-                pypi:p/pytz/
-distname        ${my_name}-${version}
-#use_zip         yes
+description         World Timezone Definitions for Python
+long_description    pytz brings the Olson tz database into Python. This library allows \
+                    accurate and cross platform timezone calculations.
 
-python.versions 27 34 35 36 37
+homepage            https://pypi.python.org/pypi/pytz
+master_sites        pypi:1b/50/4cdc62fc0753595fc16c8f722a89740f487c6e5670c644eb8983946777be \
+                    pypi:p/pytz/
+distname            ${my_name}-${version}
 
-checksums       rmd160  60a5a4de522e3a4d8bed1f8f58f7bdcf0abfb157 \
-                sha256  d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c \
-                size    310705
+checksums           rmd160  60a5a4de522e3a4d8bed1f8f58f7bdcf0abfb157 \
+                    sha256  d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c \
+                    size    310705
 
-post-destroot {
-    if {${name} ne ${subport}} {
-    set docdir ${prefix}/share/doc/${subport}
-    xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W $worksrcpath LICENSE.txt README.txt \
-        ${destroot}${docdir}
+python.versions     27 34 35 36 37
+
+if {${name} ne ${subport}} {
+    conflicts       py${python.version}-tz-gae
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W $worksrcpath LICENSE.txt README.txt \
+            ${destroot}${docdir}
     }
-}
 
-if {${name} eq ${subport}} {
-  conflicts       py-tz-gae
-  livecheck.type  regex
-  livecheck.url   ${homepage}
-  livecheck.regex ${my_name}-(\\d+(?:\\.\\d+)*)
+    livecheck.type  none
 } else {
-  conflicts       py${python.version}-tz-gae
-  livecheck.type  none
+   livecheck.name   ${my_name}
 }


### PR DESCRIPTION
#### Description
- reorganize Portfiles and whitespace
- update to latest version

The port conflicts with ```py-tz-gae```, which hasn't been updated since 2011 and is unmaintained in the MacPorts tree. I think we should just obsolete ```py-tz-gae``` and set as ```replaced_by py-tz``` and remove the conflict - any opinions? If agreed, I can/will update this PR to include that change. 

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G95
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`? N/A
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
