### PR TITLE
FAudio: update to 19.10

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            FNA-XNA FAudio 19.09
+github.setup            FNA-XNA FAudio 19.10
 revision                0
 
 license                 zlib
@@ -18,9 +18,12 @@ long_description        an XAudio reimplementation that focuses solely on develo
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  29c4c20bdff4ee0c403dfc3a159ea58dc56a1c73 \
-                        sha256  a8eaeaceced8060d29c82c5ecf47bb263ba168d4f90941ae7c09c4c9910dd106 \
-                        size    901764
+checksums               rmd160  4d981d3bf268501a8301564de5beedc8b4bdee46 \
+                        sha256  1d6756336fc4b7b4a204a7a2c62304252af682871156be0fef7190ac0673b659 \
+                        size    901544
+
+# remove set deployment target
+patchfiles              patch-faudio-remove-deployment-target.diff
 
 configure.args          -DFFMPEG=OFF \
                         -DBUILD_UTILS=OFF \

--- a/audio/FAudio/files/patch-faudio-remove-deployment-target.diff
+++ b/audio/FAudio/files/patch-faudio-remove-deployment-target.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2019-10-05 15:20:41.000000000 -0700
++++ CMakeLists.txt	2019-10-05 15:21:17.000000000 -0700
+@@ -50,7 +50,7 @@
+ 
+ # Platform Flags
+ if(APPLE)
+-	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
++	# set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
+ elseif(WIN32)
+ 	# "FAudio.dll", not "libFAudio.dll"
+ 	set(CMAKE_SHARED_LIBRARY_PREFIX "")


### PR DESCRIPTION
and strip out the hard-coded deployment target

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 10.3 10G8 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
