### PR TITLE
blosc: use MacPorts snappy

### DIFF
--- a/archivers/blosc/Portfile
+++ b/archivers/blosc/Portfile
@@ -3,9 +3,11 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.0
 
 github.setup        Blosc c-blosc 1.17.0 v
-revision            0
+revision            1
+
 name                blosc
 categories          archivers devel
 platforms           darwin
@@ -28,13 +30,17 @@ checksums           rmd160  a9fec4b072aeeb12c35acb1dc61cd6d0bbc82723 \
                     sha256  6da0dbf0e2cdaa5eb4513f0222d77317dce383d7d1f201e37d0e217c25b9b1b9 \
                     size    864862
 
-depends_lib-append  port:lz4 \
-                    port:zlib \
-                    port:zstd
+depends_lib-append  port:lz4    \
+                    port:zlib   \
+                    port:zstd   \
+                    port:snappy
 
 configure.args-append \
                     -DPREFER_EXTERNAL_LZ4=ON \
                     -DPREFER_EXTERNAL_ZLIB=ON \
                     -DPREFER_EXTERNAL_ZSTD=ON \
-                    -DBUILD_TESTS=OFF \
-                    -DBUILD_BENCHMARKS=OFF
+                    -DPREFER_EXTERNAL_SNAPPY=ON
+
+test.run            yes
+# fix test run, doesn't affect install_names
+configure.args-append -DCMAKE_BUILD_WITH_INSTALL_RPATH=OFF

--- a/archivers/blosc/Portfile
+++ b/archivers/blosc/Portfile
@@ -35,6 +35,9 @@ depends_lib-append  port:lz4    \
                     port:zstd   \
                     port:snappy
 
+# error: ‘for’ loop initial declaration used outside C99 mode
+configure.cflags-append -std=c99
+
 configure.args-append \
                     -DPREFER_EXTERNAL_LZ4=ON \
                     -DPREFER_EXTERNAL_ZLIB=ON \


### PR DESCRIPTION
fixes build on older systems (fixes errors using internal snappy)
use legacysupport PG (fixes error for missing posix_memalign on < 10.6)
add support for running test suite and benchmarks
bump revision as now building against MP snappy

closes: https://trac.macports.org/ticket/56648

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 10.3 10G8 
all tests pass

**PPC**
macOS 10.5.8 9L31a
Xcode 3.1.4 DevToolsSupport-1186.0 9M2809 
100% tests passed, 0 tests failed out of 1641

I get 100% pass on every system, including i386-only Yonahs. 
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
