### PR TITLE
unbound: update to 1.9.4

### DIFF
--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
-version             1.9.3
+version             1.9.4
 categories          net
 license             BSD
 maintainers         {snc @nerdling} openmaintainer
@@ -31,9 +31,9 @@ long_description    Unbound is a validating, recursive, and caching DNS \
 
 master_sites        http://unbound.net/downloads/
 
-checksums           rmd160  2c589c79cf7ab5aa50b28f61d5f4e2ff62543af5 \
-                    sha256  1b55dd9170e4bfb327fb644de7bbf7f0541701149dff3adf1b63ffa785f16dfa \
-                    size    5686017
+checksums           rmd160  b566322d636513c89940b8ab18b787d739586ff6 \
+                    sha256  3d3e25fb224025f0e732c7970e5676f53fd1764c16d6a01be073a13e42954bb0 \
+                    size    5686242
 
 configure.args-append   --with-pidfile=${prefix}/var/run/${name}/${name}.pid \
                         --with-ssl=${prefix} \


### PR DESCRIPTION
#### Description

Unbound: update to 1.9.4

- [CVE-2019-16866](https://nlnetlabs.nl/projects/unbound/security-advisories/#vulnerability-in-parsing-notify-queries) (affects unbound 1.7.1 to 1.9.3)

###### Type(s)

- [x] update
- [X] security fix

###### Tested on

macOS 10.7.5 11G63
Xcode 4.6.3 4H1503

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?