### PR TITLE
QtPBFImagePlugin: update to 2.0

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 1.4
-revision            1
+github.setup        tumic0 QtPBFImagePlugin 2.0
+revision            0
 categories          graphics
 platforms           darwin
 license             LGPL-3
@@ -14,9 +14,9 @@ maintainers         {@sikmir gmail.com:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  16c6a09359cb6bbca59c18aa857c4075fda8d5d4 \
-                    sha256  5aa0665b57a06811fbb3c935e0159e8dfe10448b6ec527de89c00e7d09d397a4 \
-                    size    195579
+checksums           rmd160  143f25087c7d59f9da2e4a11f261748461ba35be \
+                    sha256  4ed2f29c83ff6be79ee07cb6cd191fbd32c5a4053c204131004b12dd6ce438a9 \
+                    size    195596
 
 configure.args-append \
                     PROTOBUF=${prefix} ZLIB=${prefix}


### PR DESCRIPTION
#### Description

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:QtPBFImagePlugin/QtPBFImagePlugin/libqt5-qtpbfimageformat.changes)

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.13.6
Xcode 10.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
