### PR TITLE
py-yappi: update to version 0.98, add py37 / remove py3[45] subports

### DIFF
--- a/python/py-yappi/Portfile
+++ b/python/py-yappi/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 PortGroup           python 1.0
 

--- a/python/py-yappi/Portfile
+++ b/python/py-yappi/Portfile
@@ -4,7 +4,7 @@ PortGroup           python 1.0
 name                py-yappi
 categories-append   devel
 
-version             0.94
+version             0.98
 revision            0
 
 license             MIT
@@ -13,7 +13,7 @@ platforms           darwin
 maintainers         openmaintainer {adfernandes @adfernandes}
 
 supported_archs     noarch
-python.versions     27 34 35 36
+python.versions     27 36 37
 
 description         Yet Another Python Profiler.
 long_description    \
@@ -26,9 +26,9 @@ homepage            https://bitbucket.org/sumerc/yappi
 master_sites        pypi:[string index ${python.rootname} 0]/${python.rootname}
 distname            ${python.rootname}-${version}
 
-checksums           md5     a02c49efe783c4e31d6bbd805a37adec \
-                    sha1    3a64499d0a60f144128020b1d000868465d39499 \
-                    rmd160  52fbdea9892c3fc9187474b255163ef40a416f16
+checksums           rmd160  dc4ffb234b80e3c3f5241aa227a749cb51f6ada2 \
+                    sha256  5f657129e1b9b952379ffbc009357d0dcdb58c50f3bfe88ffbb992e4b27b263c \
+                    size    37074
 
 if {$subport ne $name} {
     depends_build-append \


### PR DESCRIPTION
See #5282 and #5436