### PR TITLE
torsocks: update to 2.3.0

### DIFF
--- a/net/torsocks/Portfile
+++ b/net/torsocks/Portfile
@@ -3,7 +3,7 @@
 PortSystem        1.0
 
 name              torsocks
-version           2.2.0
+version           2.3.0
 categories        net security
 license           GPL-2+
 platforms         darwin
@@ -20,20 +20,25 @@ homepage          https://git.torproject.org/torsocks.git
 master_sites      https://people.torproject.org/~dgoulet/torsocks/
 use_xz            yes
 
-checksums           rmd160  a16adc2120da9c846d4801ece60a43758a25f2e6 \
-                    sha256  29e8c8cefa677dfb493ea6f2449576a7a9abebd221547037f9381d9ed44bd92f
+# See https://trac.torproject.org/projects/tor/ticket/28538
+# This same patch is being used by the Homebrew torsocks formula
+patchfiles          0001-Fix-macros-for-accept4-2.patch
+
+checksums           rmd160  f8ca8158424b0befd272a136cd3f97416dff76dd \
+                    sha256  b9f1b981d6b3fd4e1820de1eee325f8a7038c84765d5a6cd9af12571d5cc3622 \
+                    size    313072
 
 depends_build       port:coreutils
 
 post-destroot {
     move ${destroot}${prefix}/etc/tor/torsocks.conf \
-        ${destroot}${prefix}/etc/torsocks.conf.default
+        ${destroot}${prefix}/etc/tor/torsocks.conf.default
 }
 
 post-activate {
-    if {![file exists ${prefix}/etc/torsocks.conf]} {
-        file copy ${prefix}/etc/torsocks.conf.default \
-            ${prefix}/etc/torsocks.conf
+    if {![file exists ${prefix}/etc/tor/torsocks.conf]} {
+        file copy ${prefix}/etc/tor/torsocks.conf.default \
+            ${prefix}/etc/tor/torsocks.conf
   }
 }
 

--- a/net/torsocks/files/0001-Fix-macros-for-accept4-2.patch
+++ b/net/torsocks/files/0001-Fix-macros-for-accept4-2.patch
@@ -1,0 +1,53 @@
+From fc5eafeb2886605d4de1546846f06a12a18c87ef Mon Sep 17 00:00:00 2001
+From: "J.W" <jakwings@gmail.com>
+Date: Mon, 22 Apr 2019 05:19:32 +0100
+Subject: [PATCH 1/2] Fix macros for accept4(2)
+
+Both accept(2) and accept4(2) exist on linux but accept4(2) does not
+exist on macos 10.11.6 (and maybe other distros).
+---
+ src/lib/torsocks.c | 9 ++++++++-
+ src/lib/torsocks.h | 4 +++-
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git src/lib/torsocks.c src/lib/torsocks.c
+index 16f2da0..9527513 100644
+--- src/lib/torsocks.c
++++ src/lib/torsocks.c
+@@ -234,9 +234,16 @@ static void init_libc_symbols(void)
+ 	tsocks_libc_socket = dlsym(libc_ptr, LIBC_SOCKET_NAME_STR);
+ 	tsocks_libc_syscall = dlsym(libc_ptr, LIBC_SYSCALL_NAME_STR);
+ 	tsocks_libc_execve = dlsym(libc_ptr, LIBC_EXECVE_NAME_STR);
++	tsocks_libc_accept = dlsym(libc_ptr, LIBC_ACCEPT_NAME_STR);
++#if (defined(__linux__))
+ 	tsocks_libc_accept4 = dlsym(libc_ptr, LIBC_ACCEPT4_NAME_STR);
++#endif
++
+ 	if (!tsocks_libc_connect || !tsocks_libc_close || !tsocks_libc_socket ||
+-			!tsocks_libc_syscall || !tsocks_libc_execve || ! tsocks_libc_accept4) {
++#if (defined(__linux__))
++			!tsocks_libc_accept4 ||
++#endif
++			!tsocks_libc_syscall || !tsocks_libc_execve || ! tsocks_libc_accept) {
+ 		ERR("Unable to lookup symbols in " LIBC_NAME "(%s)", dlerror());
+ 		goto error;
+ 	}
+diff --git src/lib/torsocks.h src/lib/torsocks.h
+index 33da526..bf9109d 100644
+--- src/lib/torsocks.h
++++ src/lib/torsocks.h
+@@ -30,8 +30,10 @@
+  * libc call outside of torsocks can be used. These are declared for each
+  * symbol torsocks hijacked.
+  */
++#define TSOCKS_LIBC_FUNC(name) \
++	tsocks_libc_##name
+ #define TSOCKS_LIBC_DECL(name, type, sig) \
+-	type (*tsocks_libc_##name)(sig);
++	type (*TSOCKS_LIBC_FUNC(name))(sig);
+ #define TSOCKS_DECL(name, type, sig) \
+ 	extern type tsocks_##name(sig);
+ 
+-- 
+2.21.0
+


### PR DESCRIPTION
#### Description

Update `torsocks` to [2.3.0.](https://github.com/dgoulet/torsocks/blob/v2.3.0/ChangeLog) With this version, there is now a patch necessary which I explained in a couple of comments. [The Homebrew `torsocks` formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/torsocks.rb#L19-L23) is also using this same patch right now. I also fixed the port so that it would place the config files under a `tor` subdirectory under the `etc` directory. Otherwise, the program complained when it was run with errors like: `Config file not found: /opt/local/etc/tor/torsocks.conf. Using default for Tor (in config_file_read() at config-file.c:548)`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
