### PR TITLE
Add macports clang 9.0

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -6,8 +6,9 @@
 
 # does Clang work on all i386 and x86_64 systems?
 # according to https://packages.macports.org/clang-7.0/,
-#    clang builds back to Mac OS X 10.6
-lappend compilers macports-clang-8.0 \
+# clang builds back to Mac OS X 10.6
+lappend compilers macports-clang-9.0 \
+                  macports-clang-8.0 \
                   macports-clang-7.0 \
                   macports-clang-6.0 \
                   macports-clang-5.0

--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -14,4 +14,4 @@ proc clang_dependency.extra_versions {versions} {
     }
 }
 
-clang_dependency.extra_versions {8.0 7.0 6.0 5.0}
+clang_dependency.extra_versions {9.0 8.0 7.0 6.0 5.0}

--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -118,7 +118,7 @@ foreach v ${gcc_versions} {
     set cdb(gcc$v,f90)      ${prefix}/bin/gfortran-mp-$compiler_version
 }
 
-set clang_versions {33 34 37 39 40 50 60 70 80}
+set clang_versions {33 34 37 39 40 50 60 70 80 90}
 foreach v ${clang_versions} {
     # if the string is more than one character insert a '.' into it: e.g 33 -> 3.3
     set compiler_version $v

--- a/_resources/port1.0/group/cxx11-1.1.tcl
+++ b/_resources/port1.0/group/cxx11-1.1.tcl
@@ -58,6 +58,6 @@ if {${configure.cxx_stdlib} eq "libstdc++"} {
     # We do not know what "cc" is, so blacklist it as well.
     compiler.blacklist-append *gcc* {clang < 700} cc
     # add macports 7 and 8 to fallback list (can be removed once done by base in a public release)
-    compiler.fallback-append macports-clang-8.0 macports-clang-7.0
+    compiler.fallback-append macports-clang-8.0 macports-clang-7.0 macports-clang-9.0
 
 }

--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -6,7 +6,7 @@ name                    cctools
 # Xcode 10.0
 version                 921
 set ld64_version        409.12
-revision                3
+revision                4
 categories              devel
 platforms               darwin
 maintainers             {jeremyhu @jeremyhu} openmaintainer
@@ -44,14 +44,14 @@ if {${os.major} < 11} {
     patchfiles-append snowleopard-strnlen.patch
 }
 
-set all_llvm_variants {llvm50 llvm60 llvm70 llvm80 llvmdev}
+set all_llvm_variants {llvm50 llvm60 llvm70 llvm80 llvm90 llvmdev}
 if {${os.major} < 12} {
     lappend all_llvm_variants llvm34
 }
 if {${os.major} < 14} {
     lappend all_llvm_variants llvm37
 }
-array set llvm_variant_version {llvm34 3.4 llvm37 3.7 llvm50 5.0 llvm60 6.0 llvm70 7.0 llvm80 8.0 llvmdev devel}
+array set llvm_variant_version {llvm34 3.4 llvm37 3.7 llvm50 5.0 llvm60 6.0 llvm70 7.0 llvm80 8.0 llvm90 9.0 llvmdev devel}
 set llvm_version {}
 
 foreach variantname $all_llvm_variants {


### PR DESCRIPTION
Adds Macports clang 9.0 as a known compiler option.

@kencu @jeremyhu FYI