### PR TITLE
tor-devel: update to 0.4.2.2-alpha

### DIFF
--- a/security/tor-devel/Portfile
+++ b/security/tor-devel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                tor-devel
 conflicts           tor
-version             0.4.2.1-alpha
+version             0.4.2.2-alpha
 revision            0
 categories          security
 platforms           darwin
@@ -24,9 +24,9 @@ homepage            https://www.torproject.org/
 master_sites        https://dist.torproject.org/
 distname            tor-${version}
 
-checksums           rmd160  8b8cd7244d3b5696fda3bd746353024ed8d3ccbc \
-                    sha256  ef71a32d588ca348fe0f74ba7c0368474c2c53ca201bf258b2c5139a1504ba47 \
-                    size    7457483
+checksums           rmd160  cf6ac26370a959004bb0479961a58e53aacc655f \
+                    sha256  81db998b9a81fd0900965e1196cf17b7f58abe07f8931f558a8d8b9afbd59284 \
+                    size    7532174
 
 depends_lib         port:libevent \
                     path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
#### Description

tor-devel: update to 0.4.2.2-alpha

###### Type(s)

- [X] bugfix
- [X] enhancement

###### Tested on

macOS 10.15 19A582a
Xcode 11.2 11B41 

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [X] tested basic functionality of all binary files?