### PR TITLE
terraform: update to 0.12.10

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                terraform
-version             0.12.9
+version             0.12.10
 
 categories          sysutils
 license             MPL-2
@@ -25,9 +25,9 @@ homepage            https://www.terraform.io/downloads.html
 master_sites        https://releases.hashicorp.com/${name}/${version}
 distname            ${name}_${version}_darwin_amd64
 
-checksums           rmd160  926aa4fb360badb2f5bc29d984a68ef7c97b91a2 \
-                    sha256  dbb3c0ffb37a5e659e05b8c223a717f89ffda7761d23eaf596c31b9745557288 \
-                    size    16768906
+checksums           rmd160  a6369c3c97263eb3c16d88c367564aaf1cdcee1b \
+                    sha256  d97db2217c6050926eedf517b7b0427b1b5f1bda989742cfd33d8fe56c95bb05 \
+                    size    17095466
 
 use_configure       no
 use_zip             yes


### PR DESCRIPTION
###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
