### PR TITLE
mole: new port

### DIFF
--- a/net/mole/Portfile
+++ b/net/mole/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/davrodpin/mole 0.5.0 v
+categories          net
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         Mole is a cli application to create ssh tunnels
+long_description    Mole is a cli application to create ssh tunnels, \
+                    forwarding a local port to a remote address through a \
+                    ssh server.
+
+build.target        github.com/davrodpin/mole/cmd/mole
+
+checksums           rmd160  aeeab9fab1a96abf1e1b1ec72147a9b0ebd1504a \
+                    sha256  41558508d36ba47832633e2a1fa574eb02c49d5c0d32abc777bab715c055d60c \
+                    size    47221
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

New port for mole, a cli application to create SSH tunnels

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
