### PR TITLE
spatialite-tools: update proj dependency

### DIFF
--- a/databases/spatialite-tools/Portfile
+++ b/databases/spatialite-tools/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name                    spatialite-tools
 version                 4.3.0
-revision                3
+revision                4
 categories              databases gis
 license                 GPL-3
 platforms               darwin
@@ -19,19 +19,23 @@ master_sites            http://www.gaia-gis.it/gaia-sins/
 distname                spatialite-tools-${version}
 
 checksums               rmd160  97314411fc2a93e376ddd1e1b219e226fb6f68b8 \
-                        sha256  f739859bc04f38735591be2f75009b98a2359033675ae310dffc3114a17ccf89
+                        sha256  f739859bc04f38735591be2f75009b98a2359033675ae310dffc3114a17ccf89 \
+                        size    540811
 
 depends_build           port:pkgconfig
 depends_lib             port:spatialite\
                         port:libiconv\
                         port:geos\
-                        port:proj4\
+                        port:proj\
                         port:expat \
                         port:readosm
 
 # Readline seem to be unable to handle UTF8 inputs
 configure.args          --disable-readline
 configure.args-append   --disable-freexl
+
+configure.cppflags-append   -I${prefix}/lib/proj5/include
+configure.ldflags-append    -L${prefix}/lib/proj5/lib
 
 variant readline description {Uses readline for input} {
     configure.args-delete   --disable-readline


### PR DESCRIPTION
#### Description

* spatialite-tools did not build due to incorrect libproj location
* update proj dependency to match spatialite
* add cpp and ld flags for the correct proj library location

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G103
Command Line Tools for Xcode 10

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
