### PR TITLE
clamav: support systems < 10.7

### DIFF
--- a/sysutils/clamav/Portfile
+++ b/sysutils/clamav/Portfile
@@ -47,6 +47,19 @@ depends_lib		port:libiconv \
 #- hack to build even when chmlib is installed with its own lzx.h
 patchfiles	patch-libclamav-Makefile.diff
 
+## older systems support
+# use linux version of openssl cert util on systems < 10.7 that don't support the macOS version
+# ./shared/linux/cert_util_linux.c -> ./shared/mac/cert_util_mac.m
+# passes all tests. See: https://trac.macports.org/ticket/59168
+post-extract {
+ if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    ui_msg "replacing mac security with linux security"
+    delete ${worksrcpath}/shared/mac/cert_util_mac.m
+    copy   ${worksrcpath}/shared/linux/cert_util_linux.c \
+           ${worksrcpath}/shared/mac/cert_util_mac.m
+  }
+}
+
 test.run		yes
 test.target		check
 


### PR DESCRIPTION
the new certificate code is using 10.7+ API
the other implementation, for linux compiles without
issues on MacOSX, and passes all test

closes: https://trac.macports.org/ticket/59168

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
10.4 PPC, 10.5 PPC, 10.6.8 Intel

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
