### PR TITLE
update erlang to 22.1

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -5,8 +5,8 @@ PortGroup           wxWidgets 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                erlang
-version             21.1
-revision            1
+version             22.1
+revision            0
 
 categories          lang erlang
 maintainers         {ciserlohn @ci42}
@@ -42,18 +42,18 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_man_${version}${extract.suffix}                \
                     otp_doc_html_${version}${extract.suffix}
 
-checksums           otp_src_21.1.tar.gz \
-                    rmd160  3a4359f144f78151e29a50b10665e51b27c677a1 \
-                    sha256  a489ca88d79422a165112120e0295bbd2f777533a81eae5610578d1bd8d89caf \
-                    size    85214629 \
-                    otp_doc_man_21.1.tar.gz \
-                    rmd160  ad58e4411b26f103f45b7cf37fbce7f9d180a6c1 \
-                    sha256  021e47b5036eaa4671b6d87a910403b775c967bfcb79b56a87f2183ddc5a5df5 \
-                    size    1317726 \
-                    otp_doc_html_21.1.tar.gz \
-                    rmd160  d1226eaebc8d406df3024ba5868a90f2b69edb6d \
-                    sha256  85333f77ad12c2065be4dc40dc7057d1d192f7cf15c416513f0b595583f820ce \
-                    size    32692731
+checksums           otp_src_22.1.tar.gz \
+                    rmd160 fc2110fcf820e2d47d265d17a7f75af2f3b9a20f \
+                    sha256  cd33a102cbac6dd1c7b1e7a9a0d82d13587771fac4e96e8fff92e403d15e32c8 \
+                    size    86643553 \
+                    otp_doc_man_22.1.tar.gz \
+                    rmd160  f20cba7986642bb65da0a7271909e071e722f677 \
+                    sha256  64f45909ed8332619055d424c32f8cc8987290a1ac4079269572fba6ef9c74d9 \
+                    size    1355169 \
+                    otp_doc_html_22.1.tar.gz \
+                    rmd160  d154d6f570c0bfb6e16e25e003a175deafa130a4 \
+                    sha256  3864ac1aa30084738d783d12c241c0a4943cf22a6d1d0f6c7bb9ba0a45ecb9eb \
+                    33824830
 
 worksrcdir          otp_src_${version}
 
@@ -82,9 +82,9 @@ post-destroot   {
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf ${distpath}/otp_doc_html_${version}${extract.suffix}"
     system "tar -C ${destroot}${prefix}/lib/erlang -zxvf ${distpath}/otp_doc_man_${version}${extract.suffix}"
  
-    set erts_dir            erts-10.1
-    set erl_interface_dir   erl_interface-3.10.4
-    set wx_dir              wx-1.8.5
+    set erts_dir            erts-10.5
+    set erl_interface_dir   erl_interface-3.13
+    set wx_dir              wx-1.8.9
 
     foreach x {dialyzer ear ecc elink epmd erl erlc escript run_erl start to_erl typer} { file delete -force ${destroot}${prefix}/bin/${x} }
     foreach x {dialyzer erl erlc escript run_erl start to_erl typer} { system "ln -s ../lib/erlang/bin/${x} ${destroot}${prefix}/bin/${x}" }


### PR DESCRIPTION
#### Description

update erlang port to latest version.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A583
Xcode 11.1 11A1027 
