### PR TITLE
rebar3: update to 3.12

### DIFF
--- a/erlang/rebar3/Portfile
+++ b/erlang/rebar3/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    erlang rebar3 3.7.5
+github.setup    erlang rebar3 3.12.0
 categories      erlang devel
 platforms       darwin
 maintainers     {ciserlohn @ci42}
@@ -24,9 +24,9 @@ long_description    Rebar3 will: respect and enforce standard Erlang/OTP \
                     treat documentation as a feature, and errors or lack of \
                     documentation as a bug.
 
-checksums           rmd160  10382bbe747d7b7a9d3b0b72dceb274d52406e24 \
-                    sha256  1f41a6ea8b8a1292e29a43e11f973284c51ed21a9b4d09cecb4c3d3a662fa034 \
-                    size    317161
+checksums           rmd160  fa943d981ba8bec93198355b91fc5af1b59bd2e2 \
+                    sha256  b90a29b88fdacc5eecac47e0ef0c0ac213925088221a4625d665a28402f56870 \
+                    size    378085
 
 depends_lib         port:erlang
 


### PR DESCRIPTION
update rebar3 to version 3.12.0.

#### Description

update rebar3 to latest stable verstion 3.12

###### Type(s)

- [ ] bugfix
- [x ] enhancement
- [ ] security fix

###### Tested on
macOS 10.x
Xcode 8.x
