### PR TITLE
php: php-zstd submission - add support for the zstd compression lib

### DIFF
--- a/php/php-zstd/Portfile
+++ b/php/php-zstd/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           php 1.1
+
+github.setup        kjdev php-ext-zstd 0.7.4
+
+name                php-zstd
+categories-append   devel
+platforms           darwin
+maintainers         nomaintainer
+license             MIT
+
+php.branches        7.0 7.1 7.2 7.3
+
+description         Zstandard compression
+
+long_description    This extension allows Zstandard compression from PHP
+
+checksums           rmd160  7f4db240b31dcd23e80d7f9a727f9c60a270ab03 \
+                    sha256  4755cb11e7189980877cbed0003c7b919a429e48aecc503980fad12b09190c23 \
+                    size    15306
+
+if {${name} ne ${subport}} {
+    depends_lib-append      port:zstd
+    depends_build-append    port:pkgconfig
+    configure.args-append   --with-libzstd
+}


### PR DESCRIPTION
Note I'm sending the PR with nomaintainer coz I cannot get on this.
But I'm happy if Ryan or anybody + openmaintainer get on it.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
