### PR TITLE
jtc: new port

### DIFF
--- a/textproc/jtc/Portfile
+++ b/textproc/jtc/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        ldn-softdev jtc 1.74
+github.tarball_from archive
+
+platforms           darwin
+categories          textproc
+license             MIT
+
+maintainers         {gmail.com:herby.gillot @herbygillot} openmaintainer
+
+description         cli tool to extract, manipulate and transform source JSON
+
+long_description    jtc stand for: JSON test console, but it's a legacy name, \
+                    don't get misled. jtc offers a powerful way to select one \
+                    or multiple elements from a source JSON and apply various \
+                    actions on the selected elements at once (wrap selected \
+                    elements into a new JSON, filter in/out, update elements, \
+                    insert new elements, remove, copy, move, compare, \
+                    transform and swap around).
+
+checksums           rmd160  84ec627b6b0b34ab68bbac9cbf126949e18c7538 \
+                    sha256  25a6da6d6d647f900a77d8271444015a62bee7ddef3140612e511312944d454c \
+                    size    171694
+
+installs_libs       no
+use_configure       no
+
+patchfiles          patch-jtc-cpp.diff \
+                    patch-json-hpp.diff \
+                    patch-streamstr-hpp.diff
+
+build.cmd           ${configure.cxx}
+build.args          -o jtc -Wall -std=c++14 -Ofast
+build.target        jtc.cpp
+
+set jtc_doc_dir     ${prefix}/share/doc/${name}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/jtc ${destroot}${prefix}/bin/
+    xinstall -d ${destroot}${jtc_doc_dir}
+    xinstall -m 644 "${worksrcpath}/User Guide.md" ${destroot}${jtc_doc_dir}/
+    xinstall -m 644 "${worksrcpath}/Walk-path tutorial.md" ${destroot}${jtc_doc_dir}/
+}

--- a/textproc/jtc/files/patch-json-hpp.diff
+++ b/textproc/jtc/files/patch-json-hpp.diff
@@ -1,0 +1,20 @@
+--- lib/Json.hpp.orig	2019-10-10 13:05:56.000000000 -0400
++++ lib/Json.hpp	2019-10-10 13:05:51.000000000 -0400
+@@ -3723,7 +3723,7 @@
+ 
+ bool Json::iterator::is_original_(const Jnode & jn, const WalkStep &ws) {
+  // match first-seen jsons: keep track of matched jsons in the namespaces
+- static const Jnode not_original;
++ static const Jnode not_original{};
+  std::string prefix = ws.stripped.front() + "\n";               // prevent clashing with user's NS
+ 
+  if(json().ojn_ptr_ == nullptr) {                               // first time, prepare
+@@ -3748,7 +3748,7 @@
+ 
+ bool Json::iterator::is_duplicate_(const Jnode & jn, const WalkStep &ws) {
+  // match duplicate jsons: keep track of matched jsons in the namespaces
+- static const Jnode original;
++ static const Jnode original{};
+  std::string prefix = ws.stripped.front() + "\n";               // prevent clashing with user's NS
+ 
+  if(json().djn_ptr_ == nullptr) {                               // first time, prepare

--- a/textproc/jtc/files/patch-jtc-cpp.diff
+++ b/textproc/jtc/files/patch-jtc-cpp.diff
@@ -1,0 +1,11 @@
+--- jtc.cpp.orig	2019-10-09 15:05:46.000000000 -0400
++++ jtc.cpp	2019-10-10 09:22:38.000000000 -0400
+@@ -239,7 +239,7 @@
+                                             opt_[CHR(OPT_TMP)].hits() == opt_[CHR(OPT_WLK)].hits();
+                          // ready jinp_
+                          jinp_.tab(opt_[CHR(OPT_IND)].hits() > 0 or not opt_[CHR(OPT_RAW)]?
+-                                    abs(opt_[CHR(OPT_IND)]): 1)
++                                    abs(static_cast<int>(opt_[CHR(OPT_IND)].hits())): 1)
+                               .raw(opt_[CHR(OPT_RAW)])
+                               .quote_solidus(opt_[CHR(OPT_QUT)].hits() % 2 == 1);
+ 

--- a/textproc/jtc/files/patch-streamstr-hpp.diff
+++ b/textproc/jtc/files/patch-streamstr-hpp.diff
@@ -1,0 +1,11 @@
+--- ./lib/Streamstr.hpp.orig	2019-10-09 15:09:01.000000000 -0400
++++ ./lib/Streamstr.hpp	2019-10-09 15:08:53.000000000 -0400
+@@ -42,7 +42,7 @@
+                              size_t offset = len <= cur_? hb_.size(): cur_ + hb_.size() - len;
+                              std::string s(&hb_[offset], hb_.size() - offset);
+                              offset = len <= cur_? cur_ - len: 0;
+-                             s += {&hb_[offset], cur_ - offset};
++                             s += std::string{&hb_[offset], cur_ - offset};
+                              return s;
+                             }
+         const char &        chr(size_t offset = 0) const {


### PR DESCRIPTION
#### Description

new port for jtc (JSON test console) - https://github.com/ldn-softdev/jtc

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
