### PR TITLE
rust: switch to llvm-9.0 from llvm-7.0.

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -6,6 +6,7 @@ PortGroup           active_variants 1.1
 
 name                rust
 version             1.38.0
+revision            1
 categories          lang devel
 platforms           darwin
 supported_archs     i386 x86_64
@@ -29,7 +30,7 @@ homepage            https://www.rust-lang.org/
 set ruststd_version 1.37.0
 set rustc_version   1.37.0
 set cargo_version   0.38.0
-set llvm_version    7.0
+set llvm_version    9.0
 
 # can use cmake or cmake-devel; default to cmake.
 depends_build       path:bin/cmake:cmake \


### PR DESCRIPTION
#### Description

To reduce the number of llvm and clang versions I need to keep, bump rust to use llvm-9.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G87
Xcode 10.1 10B61 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
