### PR TITLE
wiggle: update to 1.1

### DIFF
--- a/devel/wiggle/Portfile
+++ b/devel/wiggle/Portfile
@@ -3,9 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        neilbrown wiggle eac35c077388
-version             1.0
-revision            5
+github.setup        neilbrown wiggle 1.1 v
+revision            0
+checksums           rmd160  933781094e9a3dd7beabb3a1156af689748cd50e \
+                    sha256  e9ddd860e871b83e552a6338146d866226bfeb0fcfdfec22f401f380395e8dd2 \
+                    size    852798
 
 categories          devel
 license             GPL-2+
@@ -15,9 +17,6 @@ maintainers         nomaintainer
 
 description         apply rejected patches and perform word-wise diffs
 long_description    ${description}
-
-checksums           rmd160  0282ad349783b1d57e24acd8b5a2bf14685bbe37 \
-                    sha256  2b406ccf4a03420bf7a7988c16fb943e19b1f0f9bc109a4e6999ec57bcf28c45
 
 depends_build       path:libexec/gnubin/install:coreutils
 depends_lib         port:ncurses


### PR DESCRIPTION
Bumping version also closes: https://trac.macports.org/ticket/56595

###### Tested on
macOS 10.13.6 17G8030
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?