### PR TITLE
carthage: Mark as requiring Xcode

### DIFF
--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -2,6 +2,11 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           xcodeversion 1.0
+
+if {[info exists use_xcode]} {
+    use_xcode yes
+}
 
 github.setup        Carthage Carthage 0.33.0
 name                carthage


### PR DESCRIPTION
#### Description

It doesn't build anyways (https://trac.macports.org/ticket/59068), but without this it doesn't build for even more reasons. (Note: it does work with certain patches applied to it)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
