### PR TITLE
vislcg3: update to version 1.3.0

### DIFF
--- a/textproc/vislcg3/Portfile
+++ b/textproc/vislcg3/Portfile
@@ -1,12 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+github.setup            TinoDidriksen cg3 1.3.0 v
+github.tarball_from     archive
 
 name                    vislcg3
-version                 0.9.7.5129
-revision                9
 categories              textproc
 platforms               darwin
+license                 GPL-3+
 maintainers             {tinodidriksen.com:consult @TinoDidriksen}
 
 description             Constraint Grammar parser for the VISL CG-3 formalism
@@ -25,14 +29,14 @@ long_description        Constraint Grammar (CG) is a methodological paradigm \
                         rule may be conditioned upon each other, negated or \
                         blocked by interfering words or tags.
 
-homepage                http://beta.visl.sdu.dk/constraint_grammar.html
-master_sites            http://beta.visl.sdu.dk/download/vislcg3/
+homepage                https://visl.sdu.dk/constraint_grammar.html
 
-checksums               md5    3875d7d36bedebe17317e32442c18b80 \
-                        sha1   8718fee3e8e9bb2edd58c11175b23661539309c1 \
-                        rmd160 fb0576a1f142bd47dfd35fb665408fe5dc9058e4
+checksums               rmd160 393f7cb49d40c265a1fcd29c13b999278712ee8d \
+                        sha256 ada9dd9f7cdd47d050f53fb87f5f4d590f899b7e5629e9fff694397a6b2bcd05 \
+                        size   357195
 
-depends_build           port:pkgconfig port:autoconf port:automake
-depends_lib             port:icu
+depends_build-append    port:boost
+depends_lib-append      port:icu port:p5.28-getopt-long
 
-configure.cmd           ./autogen.sh
+compiler.cxx_standard   2017
+test.run                yes


### PR DESCRIPTION
* update to version 1.3.0
* use github and cmake helpers
* explicitly state GPL-3+ license
* require at least C++17

###### Tested on
macOS 10.15 19A583
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
