### PR TITLE
luajit: fix segfault when building with Xcode 11

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -31,6 +31,15 @@ use_configure       no
 
 compiler.blacklist  {clang < 700} macports-clang-3.3 macports-clang-3.4
 
+# Workaround for Xcode 11 issue
+# https://forums.developer.apple.com/thread/121887
+# Current information is that this should be fixed in Xcode 11.2
+if { ([vercmp ${os.major} 19] >= 0) && ([vercmp $xcodeversion 11.2] < 0) } {
+    if {[string match clang ${configure.compiler}]} {
+        configure.cc-append -fno-stack-check
+    }
+}
+
 build.target        amalg
 build.args-append   CC="${configure.cc}" \
                     CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags] -DLUAJIT_ENABLE_LUA52COMPAT" \


### PR DESCRIPTION
Fixes segfault when built with Catalina's system clang:

```
DEBUG: macOS 10.15 (darwin/19.0.0) arch i386
DEBUG: MacPorts 2.6.1
DEBUG: Xcode 11.1
DEBUG: SDK 10.15
DEBUG: MACOSX_DEPLOYMENT_TARGET: 10.15
DEBUG: luajit has no conflicts
DEBUG: Executing org.macports.main (luajit)
DEBUG: dropping privileges: euid changed to 504, egid changed to 501.
DEBUG: archivefetch phase started at Thu Oct 10 14:20:41 JST 2019
--->  Fetching archive for luajit
DEBUG: Executing org.macports.archivefetch (luajit)
DEBUG: euid/egid changed to: 0/0
DEBUG: chowned /opt/local/var/macports/incoming to macports
DEBUG: euid/egid changed to: 504/501
--->  luajit-2.0.5_2.darwin_19.x86_64.tbz2 doesn't seem to exist in /opt/local/var/macports/incoming/verified
--->  Attempting to fetch luajit-2.0.5_2.darwin_19.x86_64.tbz2 from http://kmq.jp.packages.macports.org/luajit
DEBUG: Fetching archive failed: The requested URL returned error: 404 Not Found
--->  Attempting to fetch luajit-2.0.5_2.darwin_19.x86_64.tbz2 from https://pek.cn.packages.macports.org/macports/packages/luajit
DEBUG: Fetching archive failed: The requested URL returned error: 404 
--->  Attempting to fetch luajit-2.0.5_2.darwin_19.x86_64.tbz2 from http://jog.id.packages.macports.org/macports/packages/luajit
DEBUG: Fetching archive failed: The requested URL returned error: 404 Not Found
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: fetch phase started at Thu Oct 10 14:21:27 JST 2019
--->  Fetching distfiles for luajit
DEBUG: elevating privileges for fetch: euid changed to 0, egid changed to 0.
DEBUG: dropping privileges: euid changed to 504, egid changed to 501.
DEBUG: Executing org.macports.fetch (luajit)
--->  LuaJIT-2.0.5.tar.gz does not exist in /opt/local/var/macports/distfiles/luajit
--->  Attempting to fetch LuaJIT-2.0.5.tar.gz from http://kmq.jp.distfiles.macports.org/luajit
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: checksum phase started at Thu Oct 10 14:21:29 JST 2019
--->  Verifying checksums for luajit
DEBUG: Executing org.macports.checksum (luajit)
--->  Checksumming LuaJIT-2.0.5.tar.gz
DEBUG: Calculated (rmd160) is 5176d34fa112c4586394398c3a5c9ce1ad4d4c72
DEBUG: Correct (rmd160) checksum for LuaJIT-2.0.5.tar.gz
DEBUG: Calculated (sha256) is 874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979
DEBUG: Correct (sha256) checksum for LuaJIT-2.0.5.tar.gz
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: extract phase started at Thu Oct 10 14:21:29 JST 2019
--->  Extracting luajit
DEBUG: Executing org.macports.extract (luajit)
--->  Extracting LuaJIT-2.0.5.tar.gz
DEBUG: setting option extract.args to '/opt/local/var/macports/distfiles/luajit/LuaJIT-2.0.5.tar.gz'
DEBUG: Environment: 
DEBUG: CC_PRINT_OPTIONS='YES'
DEBUG: CC_PRINT_OPTIONS_FILE='/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/.CC_PRINT_OPTIONS'
DEBUG: CPATH='/opt/local/include'
DEBUG: DEVELOPER_DIR='/Library/Developer/CommandLineTools'
DEBUG: LIBRARY_PATH='/opt/local/lib'
DEBUG: MACOSX_DEPLOYMENT_TARGET='10.15'
DEBUG: SDKROOT='/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk'
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/luajit/LuaJIT-2.0.5.tar.gz' | /usr/bin/tar -xf - 
DEBUG: system:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/luajit/LuaJIT-2.0.5.tar.gz' | /usr/bin/tar -xf - 
DEBUG: euid/egid changed to: 0/0
DEBUG: chowned /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work to macports
DEBUG: euid/egid changed to: 504/501
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: patch phase started at Thu Oct 10 14:21:30 JST 2019
DEBUG: Executing org.macports.patch (luajit)
DEBUG: Executing proc-post-org.macports.patch-patch-0
--->  Patching luajit.pc: s|/usr/local|/opt/local|
DEBUG: Executing reinplace: /usr/bin/sed s|/usr/local|/opt/local| </opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/etc/luajit.pc >@file12
DEBUG: euid/egid changed to: 0/0
DEBUG: chowned /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/etc/luajit.pc to macports
DEBUG: euid/egid changed to: 504/501
DEBUG: euid/egid changed to: 0/0
DEBUG: setting attributes on /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/etc/luajit.pc
DEBUG: euid/egid changed to: 504/501
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: configure phase started at Thu Oct 10 14:21:30 JST 2019
--->  Configuring luajit
DEBUG: Preferred compilers: clang macports-clang-9.0 macports-clang-8.0 macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
DEBUG: Using compiler 'Xcode Clang'
DEBUG: Executing org.macports.configure (luajit)
DEBUG: Privilege de-escalation not attempted as not running as root.
DEBUG: build phase started at Thu Oct 10 14:21:30 JST 2019
--->  Building luajit
DEBUG: Executing org.macports.build (luajit)
DEBUG: Environment: 
DEBUG: CC_PRINT_OPTIONS='YES'
DEBUG: CC_PRINT_OPTIONS_FILE='/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/.CC_PRINT_OPTIONS'
DEBUG: CPATH='/opt/local/include'
DEBUG: DEVELOPER_DIR='/Library/Developer/CommandLineTools'
DEBUG: LIBRARY_PATH='/opt/local/lib'
DEBUG: MACOSX_DEPLOYMENT_TARGET='10.15'
DEBUG: SDKROOT='/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk'
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5" && /usr/bin/make -j8 -w amalg CC="/usr/bin/clang" CFLAGS="-I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT" LDFLAGS="-L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64" PREFIX="/opt/local" Q="" 
DEBUG: system:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5" && /usr/bin/make -j8 -w amalg CC="/usr/bin/clang" CFLAGS="-I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT" LDFLAGS="-L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64" PREFIX="/opt/local" Q="" 
make: Entering directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5'
Building LuaJIT 2.0.5
/Library/Developer/CommandLineTools/usr/bin/make -C src amalg
make[1]: Entering directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/src'
+--------------------------------------------------------------------------+
| WARNING: Compiling the amalgamation needs a lot of virtual memory        |
| (around 300 MB with GCC 4.x)! If you don't have enough physical memory   |
| your machine will start swapping to disk and the compile will not finish |
| within a reasonable amount of time.                                      |
| So either compile on a bigger machine or use the non-amalgamated build.  |
+--------------------------------------------------------------------------+
/Library/Developer/CommandLineTools/usr/bin/make all "LJCORE_O=ljamalg.o"
make[2]: Entering directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/src'
HOSTCC    host/buildvm_asm.o
HOSTCC    host/minilua.o
HOSTCC    host/buildvm_peobj.o
HOSTCC    host/buildvm_lib.o
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0  -c -o host/buildvm_lib.o host/buildvm_lib.c
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0  -c -o host/buildvm_peobj.o host/buildvm_peobj.c
HOSTCC    host/buildvm_fold.o
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0  -c -o host/buildvm_fold.o host/buildvm_fold.c
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0  -c -o host/buildvm_asm.o host/buildvm_asm.c
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0  -c -o host/minilua.o host/minilua.c
CC        luajit.o
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -U_FORTIFY_SOURCE  -DLUA_ROOT=\"/opt/local\" -DLUA_MULTILIB=\"lib\" -fno-stack-protector   -c -o luajit.o luajit.c
HOSTLINK  host/minilua
/usr/bin/clang  -L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64   -o host/minilua host/minilua.o -lm   
DYNASM    host/buildvm_arch.h
host/minilua ../dynasm/dynasm.lua   -D P64 -D JIT -D FFI -D FPU -D HFABI -D VER= -o host/buildvm_arch.h vm_x86.dasc
HOSTCC    host/buildvm.o
/usr/bin/clang  -O2 -fomit-frame-pointer -Wall  -I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0  -c -o host/buildvm.o host/buildvm.c
HOSTLINK  host/buildvm
/usr/bin/clang  -L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64   -o host/buildvm host/buildvm.o host/buildvm_asm.o host/buildvm_peobj.o host/buildvm_lib.o host/buildvm_fold.o   
BUILDVM   lj_vm.s
host/buildvm -m machasm -o lj_vm.s
BUILDVM   lj_bcdef.h
BUILDVM   lj_ffdef.h
BUILDVM   lj_folddef.h
BUILDVM   lj_recdef.h
host/buildvm -m recdef -o lj_recdef.h lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
host/buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
host/buildvm -m bcdef -o lj_bcdef.h lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
host/buildvm -m ffdef -o lj_ffdef.h lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
BUILDVM   jit/vmdef.lua
BUILDVM   lj_libdef.h
host/buildvm -m vmdef -o jit/vmdef.lua lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
host/buildvm -m libdef -o lj_libdef.h lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c
make[2]: *** [lj_folddef.h] Segmentation fault: 11
make[2]: *** Deleting file `lj_folddef.h'
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/src'
make[1]: *** [amalg] Error 2
make[1]: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5/src'
make: *** [amalg] Error 2
make: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5'
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/work/LuaJIT-2.0.5" && /usr/bin/make -j8 -w amalg CC="/usr/bin/clang" CFLAGS="-I/opt/local/include -Os -arch x86_64 -DLUAJIT_ENABLE_LUA52COMPAT" LDFLAGS="-L/opt/local/lib -Wl,-headerpad_max_install_names -arch x86_64" PREFIX="/opt/local" Q="" 
Exit code: 2
Error: Failed to build luajit: command execution failed
DEBUG: Error code: CHILDSTATUS 21451 2
DEBUG: Backtrace: command execution failed
DEBUG:     while executing
DEBUG: "system {*}$notty {*}$nice $fullcmdstring"
DEBUG:     invoked from within
DEBUG: "command_exec build"
DEBUG:     (procedure "portbuild::build_main" line 8)
DEBUG:     invoked from within
DEBUG: "$procedure $targetname"
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_rsync.macports.org_release_tarballs_ports_lang_luajit/luajit/main.log for details.
```

I don't know if this is the "right" fix, but it worked for me.

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A583
Xcode 11.1 11A1027 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
