### PR TITLE
Make gd2 redistributable

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -27,6 +27,10 @@ depends_lib         port:lz4 \
                     port:xz \
                     port:zlib
 
+# libzstd.dylib links to libSystem.B.dylib only. Dependencies like lz4 are
+# linked by CLI tools in ${prefix}/bin only.
+license_noconflict  lz4 xz zlib
+
 patchfiles          patch-zstd-tiger-no-backtrace.diff
 
 post-patch {

--- a/devel/ossp-uuid/Portfile
+++ b/devel/ossp-uuid/Portfile
@@ -82,6 +82,11 @@ perl5.conflict_variants yes
 perl5.branches 5.26 5.28
 perl5.create_variants ${perl5.branches}
 
+# Perl is used as an interpreter only
+foreach branch ${perl5.branches} {
+    license_noconflict perl${branch}
+}
+
 if {[variant_isset perl5_26] || [variant_isset perl5_28]} {
     configure.perl          ${perl5.bin}
     configure.args-delete   --without-perl


### PR DESCRIPTION
#### Description

Makes gd2 redistributable. See comments in individual ports for details.
```
$ ./jobs/port_binary_distributable.tcl -v gd2
"gd2" is distributable
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
Not tested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
