### PR TITLE
librsvg: fix compilation error

### DIFF
--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -79,6 +79,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
     patchfiles-append \
                     patch-configure-rust_target_subdir.diff
 
+    # Fix for https://trac.macports.org/ticket/59244
+    patchfiles-append \
+                    future_compat_fix.diff
+
     if {![variant_isset viewer]} {
         patchfiles-append   patch-disable-viewer.diff
     }

--- a/graphics/librsvg/files/future_compat_fix.diff
+++ b/graphics/librsvg/files/future_compat_fix.diff
@@ -1,0 +1,64 @@
+--- vendor/cssparser/src/parser.rs.orig	2019-05-14 05:02:31.000000000 +0900
++++ vendor/cssparser/src/parser.rs	2019-10-11 14:36:52.000000000 +0900
+@@ -555,28 +555,34 @@
+         }
+
+         let token_start_position = self.input.tokenizer.position();
+-        let token;
+-        match self.input.cached_token {
+-            Some(ref cached_token)
+-            if cached_token.start_position == token_start_position => {
+-                self.input.tokenizer.reset(&cached_token.end_state);
+-                match cached_token.token {
+-                    Token::Function(ref name) => self.input.tokenizer.see_function(name),
+-                    _ => {}
+-                }
+-                token = &cached_token.token
+-            }
+-            _ => {
+-                let new_token = self.input.tokenizer.next()
+-                    .map_err(|()| self.new_basic_error(BasicParseErrorKind::EndOfInput))?;
+-                self.input.cached_token = Some(CachedToken {
+-                    token: new_token,
+-                    start_position: token_start_position,
+-                    end_state: self.input.tokenizer.state(),
+-                });
+-                token = self.input.cached_token_ref()
++        let using_cached_token = self
++            .input
++            .cached_token
++            .as_ref()
++            .map_or(false, |cached_token| {
++                cached_token.start_position == token_start_position
++            });
++        let token = if using_cached_token {
++            let cached_token = self.input.cached_token.as_ref().unwrap();
++            self.input.tokenizer.reset(&cached_token.end_state);
++            match cached_token.token {
++                Token::Function(ref name) => self.input.tokenizer.see_function(name),
++                _ => {}
+             }
+-        }
++            &cached_token.token
++        } else {
++            let new_token = self
++                .input
++                .tokenizer
++                .next()
++                .map_err(|()| self.new_basic_error(BasicParseErrorKind::EndOfInput))?;
++            self.input.cached_token = Some(CachedToken {
++                token: new_token,
++                start_position: token_start_position,
++                end_state: self.input.tokenizer.state(),
++            });
++            self.input.cached_token_ref()
++        };
+
+         if let Some(block_type) = BlockType::opening(token) {
+             self.at_start_of = Some(block_type);
+--- vendor/cssparser/.cargo-checksum.json.orig	2019-05-14 05:02:31.000000000 +0900
++++ vendor/cssparser/.cargo-checksum.json	2019-10-11 14:48:25.000000000 +0900
+@@ -1 +1 @@
+-{"files":{".travis.yml":"e8f586288c39dbaebefdd391f68376e58f3a4c568a8dc3cd97c4a362194716dd","Cargo.toml":"99d0445140451d806afb253209d7fb144fe0879f52b2ba69da621237f8dd546b","LICENSE":"fab3dd6bdab226f1c08630b1dd917e11fcb4ec5e1e020e2c16f83a0a13863e85","README.md":"c5781e673335f37ed3d7acb119f8ed33efdf6eb75a7094b7da2abe0c3230adb8","build.rs":"ce686e87cccb6aa85a8cd34688d809398c5a624f179fd9a172d1049892da3f4c","build/match_byte.rs":"31905ae3dba69fa82c1f13069df4cd056bb340d59ee5d177679425f105f203cf","docs/.nojekyll":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","docs/404.html":"025861f76f8d1f6d67c20ab624c6e418f4f824385e2dd8ad8732c4ea563c6a2e","docs/index.html":"025861f76f8d1f6d67c20ab624c6e418f4f824385e2dd8ad8732c4ea563c6a2e","src/color.rs":"c60f1b0ab7a2a6213e434604ee33f78e7ef74347f325d86d0b9192d8225ae1cc","src/cow_rc_str.rs":"541216f8ef74ee3cc5cbbc1347e5f32ed66588c401851c9a7d68b867aede1de0","src/from_bytes.rs":"331fe63af2123ae3675b61928a69461b5ac77799fff3ce9978c55cf2c558f4ff","src/lib.rs":"a474ee88ef8f73fcb7b7272d426e5eafb4ad10d104797a5a188d1676c8180972","src/macros.rs":"adb9773c157890381556ea83d7942dcc676f99eea71abbb6afeffee1e3f28960","src/nth.rs":"5c70fb542d1376cddab69922eeb4c05e4fcf8f413f27563a2af50f72a47c8f8c","src/parser.rs":"9ed4aec998221eb2d2ba99db2f9f82a02399fb0c3b8500627f68f5aab872adde","src/rules_and_declarations.rs":"622ce07c117a511d40ce595602d4f4730659a59273388f28553d1a2b0fac92ce","src/serializer.rs":"3e2dfc60613f885cb6f99abfc854fde2a1e00de507431bd2e51178b61abfd69b","src/size_of_tests.rs":"e5f63c8c18721cc3ff7a5407e84f9889ffa10e66da96e8510a696c3e00ad72d5","src/tests.rs":"4a9223b9d2dc982144499aee497515553fc3d9ec86ca7b2e62b6caa5d4a11570","src/tokenizer.rs":"429b2cba419cf8b923fbcc32d3bd34c0b39284ebfcb9fc29b8eb8643d8d5f312","src/unicode_range.rs":"191d50a1588e5c88608b84cfe9279def71f495f8e016fa093f90399bbd2b635f"},"package":"495beddc39b1987b8e9f029354eccbd5ef88eb5f1cd24badb764dce338acf2e0"}
+\ No newline at end of file
++{"files":{".travis.yml":"e8f586288c39dbaebefdd391f68376e58f3a4c568a8dc3cd97c4a362194716dd","Cargo.toml":"99d0445140451d806afb253209d7fb144fe0879f52b2ba69da621237f8dd546b","LICENSE":"fab3dd6bdab226f1c08630b1dd917e11fcb4ec5e1e020e2c16f83a0a13863e85","README.md":"c5781e673335f37ed3d7acb119f8ed33efdf6eb75a7094b7da2abe0c3230adb8","build.rs":"ce686e87cccb6aa85a8cd34688d809398c5a624f179fd9a172d1049892da3f4c","build/match_byte.rs":"31905ae3dba69fa82c1f13069df4cd056bb340d59ee5d177679425f105f203cf","docs/.nojekyll":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","docs/404.html":"025861f76f8d1f6d67c20ab624c6e418f4f824385e2dd8ad8732c4ea563c6a2e","docs/index.html":"025861f76f8d1f6d67c20ab624c6e418f4f824385e2dd8ad8732c4ea563c6a2e","src/color.rs":"c60f1b0ab7a2a6213e434604ee33f78e7ef74347f325d86d0b9192d8225ae1cc","src/cow_rc_str.rs":"541216f8ef74ee3cc5cbbc1347e5f32ed66588c401851c9a7d68b867aede1de0","src/from_bytes.rs":"331fe63af2123ae3675b61928a69461b5ac77799fff3ce9978c55cf2c558f4ff","src/lib.rs":"a474ee88ef8f73fcb7b7272d426e5eafb4ad10d104797a5a188d1676c8180972","src/macros.rs":"adb9773c157890381556ea83d7942dcc676f99eea71abbb6afeffee1e3f28960","src/nth.rs":"5c70fb542d1376cddab69922eeb4c05e4fcf8f413f27563a2af50f72a47c8f8c","src/parser.rs":"6bd16e08c29cb31c358f3cfeb9c6659227f24a95d399c14cf969c8b1a0e931fd","src/rules_and_declarations.rs":"622ce07c117a511d40ce595602d4f4730659a59273388f28553d1a2b0fac92ce","src/serializer.rs":"3e2dfc60613f885cb6f99abfc854fde2a1e00de507431bd2e51178b61abfd69b","src/size_of_tests.rs":"e5f63c8c18721cc3ff7a5407e84f9889ffa10e66da96e8510a696c3e00ad72d5","src/tests.rs":"4a9223b9d2dc982144499aee497515553fc3d9ec86ca7b2e62b6caa5d4a11570","src/tokenizer.rs":"429b2cba419cf8b923fbcc32d3bd34c0b39284ebfcb9fc29b8eb8643d8d5f312","src/unicode_range.rs":"191d50a1588e5c88608b84cfe9279def71f495f8e016fa093f90399bbd2b635f"},"package":"495beddc39b1987b8e9f029354eccbd5ef88eb5f1cd24badb764dce338acf2e0"}


### PR DESCRIPTION
Backport of fix pointed out in https://trac.macports.org/ticket/59244

I'm not sure this is really a Catalina error. It looks like it's a rust error that used to be handled as a warning, so maybe no one noticed it until now because they were using binaries built before our rustc got updated?

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.15 19A583
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
