### PR TITLE
limesuite-devel: update commit to 9b0c6bd9

### DIFF
--- a/science/limesuite/Portfile
+++ b/science/limesuite/Portfile
@@ -21,11 +21,11 @@ homepage            https://myriadrf.org/projects/lime-suite/
 subport limesuite-devel {}
 if {[string first "-devel" $subport] > 0} {
 
-    github.setup myriadrf LimeSuite be5f143f8b3be7fe629ddcb84056f5718f5f7555
-    version   20190919-[string range ${github.version} 0 7]
-    checksums rmd160 1e27f6692f64b5142efdece35585cf0b1550c0aa \
-              sha256 f92b74df9d9103e213608546f8557b2c13ef6fb48a0c1c5322e4a5a24c5d9494 \
-              size   5363981
+    github.setup myriadrf LimeSuite 9b0c6bd926e642dd1b63a758e81c515db8ae4a35
+    version   20191010-[string range ${github.version} 0 7]
+    checksums rmd160 5c2051ab67f3c64853a3b6e68b334a5c3e394edd \
+              sha256 d576f1388978ff34cda0df5a80fd922f7ca58f1ef7d8a280334e8c4573a3be6a \
+              size   5363787
     revision  0
 
     name            limesuite-devel


### PR DESCRIPTION
#### Description

- bump commit to 9b0c6bd9

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->