### PR TITLE
spring-boot-cli: update to 2.1.9

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name            spring-boot-cli
-version         2.1.7
+version         2.1.9
 
 categories      java
 platforms       darwin
@@ -28,9 +28,9 @@ master_sites    https://repo.spring.io/release/org/springframework/boot/${name}/
 
 distname        ${name}-${version}.RELEASE-bin
 
-checksums       rmd160  f504fb987f6d0652f0bef8f379276d56dd851546 \
-                sha256  2dd4598bf2581f1f33d9eb96ea1d9a7be324f69f96fe160275562a11a49cc084 \
-                size    11144732
+checksums       rmd160  33118e5f946a542e727b15df15596386b5fe385d \
+                sha256  9c37e7a48dc43bfde21cf953dd129699e03dcb3099bdd14779a42cab87bfff24 \
+                size    11223614
 
 worksrcdir      spring-${version}.RELEASE
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 2.1.9.RELEASE.

###### Tested on

macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?