### PR TITLE
py-tensor*: minimize diffs between py-tensor* and py-tensor*1.

### DIFF
--- a/python/py-tensorboard/Portfile
+++ b/python/py-tensorboard/Portfile
@@ -33,7 +33,7 @@ if {${python.version} < 30} {
 
 livecheck.url   https://pypi.org/project/tensorboard/
 livecheck.type  regex
-livecheck.regex "tensorboard (\\d+(\\.\\d+)+)"
+livecheck.regex /project/tensorboard/(\\d+(\\.\\d+)+)/
 
 extract.suffix      .whl
 extract.only

--- a/python/py-tensorflow/Portfile
+++ b/python/py-tensorflow/Portfile
@@ -104,8 +104,8 @@ if {${name} ne ${subport}} {
     if {![variant_isset native]} {
         configure.env-append CC_OPT_FLAGS=${base_march}
         build.env-append     CC_OPT_FLAGS=${base_march}
-        notes "This version is built based on a base architecture for convenience, 
-              which may not be optimized for your system. To build a version 
+        notes "This version is built based on a base architecture for convenience,
+              which may not be optimized for your system. To build a version
               customized for your machine, use the +native variant"
     }
     # Disable Xcode detection on older OSes, as we want the

--- a/python/py-tensorflow_estimator/Portfile
+++ b/python/py-tensorflow_estimator/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  ee00e5c5d9e2d68a50b36f9d1a2ada69fd57f91e \
 
 livecheck.url   https://pypi.org/project/tensorflow-estimator/
 livecheck.type  regex
-livecheck.regex "tensorflow-estimator (\\d+(\\.\\d+)+)"
+livecheck.regex /project/tensorflow-estimator/(\\d+(\\.\\d+)+)/
 
 extract.suffix  .whl
 extract.only


### PR DESCRIPTION
Remove minor diffs as a result of the new py-tensor*1 ports. This minimizes diffs between `py-tensorflow{,1}/Portfile` and the other ports.

1. I had to switch the URL for livecheck to match on older releases, so use the same regex for the 2.0.0 ports.
1. Whitespace trimming.
