### PR TITLE
nginx: add fancyindex module & variant, enabled by default

### DIFF
--- a/www/nginx/Portfile
+++ b/www/nginx/Portfile
@@ -32,7 +32,8 @@ master_sites        https://nginx.org/download:nginx \
                     https://github.com/simpl/ngx_devel_kit/archive/:devel_kit_module \
                     https://github.com/openresty/lua-nginx-module/archive/:lua_module \
                     https://github.com/openresty/headers-more-nginx-module/archive/:h_more_module \
-                    https://github.com/TeslaGov/ngx-http-auth-jwt-module/archive/:jwt_module
+                    https://github.com/TeslaGov/ngx-http-auth-jwt-module/archive/:jwt_module \
+                    https://github.com/aperezdc/ngx-fancyindex/archive/:fancyindex_module
 
 distfiles           ${name}-${version}${extract.suffix}:nginx
 checksums           ${name}-${version}${extract.suffix} \
@@ -121,7 +122,7 @@ notes "\
     Additionally, the files [join ${auto_activate_confs} ", "] have been copied to ${nginx_confdir} if they didn't exist yet.\n\
     Adjust these files to your needs before starting nginx."
 
-default_variants +mp4 +flv +secure_link +ssl +http2 +stream
+default_variants +mp4 +flv +secure_link +ssl +http2 +stream +fancyindex
 
 variant auth_request description {Add client authorization based on the result of a subrequest} {
     configure.args-append   --with-http_auth_request_module
@@ -416,6 +417,19 @@ variant jwt description {Add JWT (Javascript Web Token) support to server using 
 
     configure.args-append   --add-dynamic-module=${workpath}/${jwt_distname}
     depends_lib-append      port:libjwt
+}
+
+variant fancyindex description {Add fancy index support; file listings, like the built-in autoindex module does, but with a touch of style} {
+    set fancyindex_filename        ngx-fancyindex
+    set fancyindex_version         0.4.3
+    set fancyindex_distname        ${fancyindex_filename}-${fancyindex_version}
+    distfiles-append        v${fancyindex_version}.tar.gz:fancyindex_module
+    checksums-append        v${fancyindex_version}.tar.gz \
+                            rmd160  fa7be114c57883e38869a16091ea64573db208aa \
+                            sha256  81698fb0c1ec9f906ce308c055d5d248085caf390f4b92516c1ec93f87c886d4 \
+                            size    25274
+
+    configure.args-append   --add-module=${workpath}/${fancyindex_distname}
 }
 
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

This adds support for [fancy indices](https://www.nginx.com/resources/wiki/modules/fancy_index/) using [ngx-fancyindex](https://github.com/aperezdc/ngx-fancyindex). I've taken the liberty of enabling the variant by default, since it seems particularly relevant to Macs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.x
Xcode 8.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
