### PR TITLE
VLC2: mark use xcode

### DIFF
--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -62,6 +62,9 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     master_sites        https://download.videolan.org/pub/videolan/vlc/${version}/
     distname            vlc-${version}
     use_xz              yes
+    if {[info exists use_xcode]} {
+        use_xcode yes
+    }
 
     checksums           rmd160  4434e91384520fe1fe129a52f5d66d61e4404a9a \
                         sha256  9bf046848fb56d93518881b39099b8288ee005d5ba0ddf705b6f6643b8d562ec


### PR DESCRIPTION
#### Description

VLC2 uses xcodebuild as referenced here: https://lists.macports.org/pipermail/macports-dev/2019-October/041264.html

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G87
Xcode 10.3 10G8

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint`?