### PR TITLE
jtc: update patch to fix indentation

### DIFF
--- a/textproc/jtc/files/patch-jtc-cpp.diff
+++ b/textproc/jtc/files/patch-jtc-cpp.diff
@@ -5,7 +5,7 @@
                           // ready jinp_
                           jinp_.tab(opt_[CHR(OPT_IND)].hits() > 0 or not opt_[CHR(OPT_RAW)]?
 -                                    abs(opt_[CHR(OPT_IND)]): 1)
-+                                    abs(static_cast<int>(opt_[CHR(OPT_IND)].hits())): 1)
++                                    abs(static_cast<int>(opt_[CHR(OPT_IND)])): 1)
                                .raw(opt_[CHR(OPT_RAW)])
                                .quote_solidus(opt_[CHR(OPT_QUT)].hits() % 2 == 1);
  


### PR DESCRIPTION
One of our patches to support older platforms affects `jtc`'s indentation of JSON output.  This will fix.

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.14.6 18G103
Xcode 11.1 11A1027

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
