### PR TITLE
lilypond-devel: add gcc9 as fallback

### DIFF
--- a/textproc/lilypond-devel/Portfile
+++ b/textproc/lilypond-devel/Portfile
@@ -157,6 +157,7 @@ compiler.blacklist  *clang* \
                     gcc-3.3 gcc-4.0 gcc-4.2
 
 compiler.fallback-append \
+                    macports-gcc-9 \
                     macports-gcc-8 \
                     macports-gcc-7 \
                     macports-gcc-6 \


### PR DESCRIPTION
This is necessary since gcc8 doesn't compile with Catalina (yet).
