### PR TITLE
py-construct: update version to 2.9.45

### DIFF
--- a/python/py-construct/Portfile
+++ b/python/py-construct/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-construct
-version             2.8.16
+version             2.9.45
 revision            0
 categories-append   devel
 platforms           darwin
 license             MIT
 supported_archs     noarch
 
-python.versions     27 34 35 36
+python.versions     27 34 35 36 37
 
 maintainers         dckd.nl:macports openmaintainer
 
@@ -23,13 +23,14 @@ long_description    \
     structures in a declarative manner, rather than procedural code: more \
     complex constructs are composed of a hierarchy of simpler ones.
 
-homepage            http://construct.wikispaces.com/
+homepage            http://construct.readthedocs.org
 master_sites        pypi:c/construct/
 
 distname            construct-${version}
 
-checksums           rmd160  2e2ad50091f2bb194ba6ffb2ffdfda908f863d47 \
-                    sha256  9a5dbd459e26933bd572389d99c26a0db180b3e2f5fd06950a38b1944cff2548
+checksums           rmd160  b2bc3deb9c377cbb95f61caacf7ae0b5849baf96 \
+                    sha256  2271a0efd0798679dea825ff47e22a4c550456a5db0ba8baa82f7eae0af0118c \
+                    size    56397
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

- bump version to 2.9.45
- add python 3.7
- change the homepage to the new one

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->