### PR TITLE
gr-adapt: new port

### DIFF
--- a/science/gr-adapt/Portfile
+++ b/science/gr-adapt/Portfile
@@ -1,0 +1,84 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+categories          science comms
+platforms           darwin macosx
+license             GPL-3
+maintainers         {@ra1nb0w irh.it:rainbow} {michaelld @michaelld} openmaintainer
+description         Adaptive filters for GNU Radio
+long_description    ${description}
+
+github.setup karel gr-adapt 4bbdde4ce52e88365ab8f51c05b7f08f90573275
+git.branch   maint-3.7
+version   20191021-[string range ${github.version} 0 7]
+checksums rmd160 86f39d385400bbe039d0ebbdf46adfe7ecd172f0 \
+          sha256 4d6efa41c6192d15a7880b99f4f058dc4b2dcf23aeaf0a863bb5d968b9a1f5d1 \
+          size   477236
+revision  0
+
+# use C++11
+compiler.cxx_standard 2011
+
+depends_build-append \
+    port:cppunit \
+    port:pkgconfig \
+    port:swig-python \
+
+
+depends_lib-append \
+    port:boost \
+    path:lib/libgnuradio-runtime.dylib:gnuradio
+
+# specify the Python dependencies
+depends_lib-append port:python27
+# specify that Python version to use
+configure.args-append \
+    -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/2.7/bin/python2.7 \
+    -DPYTHON_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/2.7/Headers \
+    -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/2.7/Python \
+    -DGR_PYTHON_DIR=${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
+
+configure.args-append \
+    -DDOXYGEN_DOT_EXECUTABLE= \
+    -DDOXYGEN_EXECUTABLE= \
+    -DCMAKE_MODULES_DIR=share/cmake
+
+variant docs description "Install ${name} documentation" {
+
+    depends_build-append \
+        port:doxygen \
+        path:bin/dot:graphviz
+
+    configure.args-delete \
+        -DDOXYGEN_DOT_EXECUTABLE= \
+        -DDOXYGEN_EXECUTABLE=
+
+    configure.args-append \
+        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
+        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+
+}
+
+variant qr description "Enable QR decomposition on RLS filters" {
+    depends_lib-append \
+        port:lapack \
+        port:armadillo \
+        path:lib/libopenblas.dylib:openblas
+
+    configure.env-append BLA_VENDOR=OpenBLAS
+}
+
+default_variants +docs +qr
+
+post-destroot {
+    # copy GNU Radio examples
+    xinstall -m 755 -d ${destroot}${prefix}/share/gnuradio/examples/adapt
+    file copy {*}[glob ${worksrcpath}/examples/*] \
+        ${destroot}${prefix}/share/gnuradio/examples/adapt
+}
+
+# disabled because show the plot and wait user response
+#test.run yes


### PR DESCRIPTION
#### Description

Adaptive filters for GNU Radio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->