### PR TITLE
gr-iridium: new port

### DIFF
--- a/science/gr-iridium/Portfile
+++ b/science/gr-iridium/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+categories          science comms
+platforms           darwin macosx
+license             GPL-3+
+maintainers         {@ra1nb0w irh.it:rainbow} openmaintainer
+description         Iridium burst detector and demodulator.
+long_description    ${description}
+
+github.setup muccc gr-iridium eeaf8157dd78d5394bd7feefa3a1a5dd67af8037
+version   20190722-[string range ${github.version} 0 7]
+checksums rmd160 909c3ad0e0bdb12d53666d0ad85b6b95d8dcab80 \
+          sha256 e0fe908b32e209b7b2e1a6b3f92d0a12ad4de5eb6ed517f632afdc8c5a87a9e5 \
+          size   143041
+revision  0
+
+# use C++11
+compiler.cxx_standard 2011
+
+depends_build-append \
+    port:pkgconfig \
+    port:swig-python
+
+depends_lib-append \
+    port:boost \
+    path:lib/libgnuradio-runtime.dylib:gnuradio
+
+# specify the Python dependencies
+depends_lib-append port:python27
+# specify that Python version to use
+configure.args-append \
+    -DPYTHON_EXECUTABLE=${frameworks_dir}/Python.framework/Versions/2.7/bin/python2.7 \
+    -DPYTHON_INCLUDE_DIR=${frameworks_dir}/Python.framework/Versions/2.7/Headers \
+    -DPYTHON_LIBRARY=${frameworks_dir}/Python.framework/Versions/2.7/Python \
+    -DGR_PYTHON_DIR=${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
+
+configure.args-append \
+    -DDOXYGEN_DOT_EXECUTABLE= \
+    -DDOXYGEN_EXECUTABLE= \
+    -DCMAKE_MODULES_DIR=share/cmake
+
+variant docs description "Install ${name} documentation" {
+
+    depends_build-append \
+        port:doxygen \
+        path:bin/dot:graphviz
+
+    configure.args-delete \
+        -DDOXYGEN_DOT_EXECUTABLE= \
+        -DDOXYGEN_EXECUTABLE=
+
+    configure.args-append \
+        -DDOXYGEN_DOT_EXECUTABLE=${prefix}/bin/dot \
+        -DDOXYGEN_EXECUTABLE=${prefix}/bin/doxygen
+
+}
+
+default_variants +docs
+
+post-destroot {
+    # copy GNU Radio examples
+    xinstall -m 755 -d ${destroot}${prefix}/share/gnuradio/examples/iridium
+    file copy {*}[glob ${worksrcpath}/examples/*] \
+        ${destroot}${prefix}/share/gnuradio/examples/iridium/
+}


### PR DESCRIPTION
#### Description

Iridium burst detector and demodulator

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15 19A582a
Xcode 11.2 11B41

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->