### PR TITLE
Remove existence checks for use_xcode

### DIFF
--- a/_resources/port1.0/group/qmake5-1.0.tcl
+++ b/_resources/port1.0/group/qmake5-1.0.tcl
@@ -29,7 +29,7 @@ platform macosx {
     # Use Xcode on macOS <= 10.9 (os.major 13) because CLT doesn't ship with an SDK on 10.9-
     # Better way is to just check if CLT SDK works correctly rather than hardcode OS
     # See: https://trac.macports.org/ticket/58779
-    if { [info exists use_xcode] && ${os.major} <= 13 } {
+    if {${os.major} <= 13} {
         use_xcode yes
     }
 }

--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -3,10 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
-
-if {[info exists use_xcode]} {
-    use_xcode yes
-}
+use_xcode           yes
 
 if {[vercmp ${os.version} 17.0.0] < 0} {
     version             3.2.0

--- a/devel/SourceKitten/Portfile
+++ b/devel/SourceKitten/Portfile
@@ -3,10 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
-
-if {[info exists use_xcode]} {
-    use_xcode yes
-}
+use_xcode           yes
 
 github.setup        jpsim SourceKitten 0.23.2
 categories          devel

--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -130,9 +130,7 @@ set bazel_min_xcode   9.0
 # Even though bazel can build without Xcode, mark use Xcode for now since it fails to
 # build with tracemode on latest master if both CLT and Xcode are available.
 # Better solution is to respect MacPorts environment configure.developer_dir
-if {[info exists use_xcode]} {
-    use_xcode yes
-}
+use_xcode             yes
 
 # python versions. Build needs both 'python2' and 'python3'
 set py3ver 3.7

--- a/devel/carthage/Portfile
+++ b/devel/carthage/Portfile
@@ -3,10 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
-
-if {[info exists use_xcode]} {
-    use_xcode yes
-}
+use_xcode           yes
 
 github.setup        Carthage Carthage 0.33.0
 name                carthage

--- a/editors/textmate2/Portfile
+++ b/editors/textmate2/Portfile
@@ -23,9 +23,7 @@ long_description        ${description}\
 platforms               darwin
 supported_archs         x86_64
 license                 GPL-3+
-if {[info exists use_xcode]} {
-    use_xcode           yes
-}
+use_xcode               yes
 
 fetch.type              git
 post-fetch {

--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -140,9 +140,7 @@ depends_run-append  port:libaacs \
 
 platform darwin {
     # uses ibtool
-    if {[info commands use_xcode] ne ""} {
-        use_xcode   yes
-    }
+    use_xcode yes
     if {${os.major} < 13} {
         pre-fetch {
             ui_error "${name} ${version} requires Mac OS X 10.9 or greater."

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -62,9 +62,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     master_sites        https://download.videolan.org/pub/videolan/vlc/${version}/
     distname            vlc-${version}
     use_xz              yes
-    if {[info exists use_xcode]} {
-        use_xcode yes
-    }
+    use_xcode           yes
 
     checksums           rmd160  4434e91384520fe1fe129a52f5d66d61e4404a9a \
                         sha256  9bf046848fb56d93518881b39099b8288ee005d5ba0ddf705b6f6643b8d562ec

--- a/net/gpsd/Portfile
+++ b/net/gpsd/Portfile
@@ -116,9 +116,7 @@ depends_lib-append      port:ncurses
 depends_build-append    port:scons port:pkgconfig
 
 use_configure           no
-if {[info exists use_xcode]} {
-    use_xcode "yes"
-}
+use_xcode               yes
 
 set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}]} {


### PR DESCRIPTION
No longer necessary because the latest macports-base release supports use_xcode

#### Description

<!-- Note: it is best make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix