### PR TITLE
google-cloud-sdk: update to 266.0.0, added long description

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,26 +4,30 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             265.0.0
+version             266.0.0
 categories          devel python
 license             Apache-2
 maintainers         {breun.nl:nils @breun} openmaintainer
 description         Command-line interface for Google Cloud Platform products and services
-long_description    ${description}
+long_description    Google Cloud SDK is a set of tools for Google Cloud Platform. \
+                    It contains gcloud, gsutil, and bq command-line tools, which you can \
+                    use to access Compute Engine, Cloud Storage, BigQuery, and other \
+                    products and services from the command-line. You can run these tools \
+                    interactively or in your automated scripts.
 
 platforms           darwin
 supported_archs     i386 x86_64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a8138356280b1e591b22d2f735077ee6b0d89fc2 \
-                    sha256  183bb7d099f9c756a68240ac5c236798057abbc7ea170d6264902cbdd4baf1af \
-                    size    22092420
+    checksums       rmd160  b993053abf5ff9fd639e3c98921f2c3fb5108394 \
+                    sha256  b3291b2c560a9644f16acf1661620544391557f7b318f11a4752a8ee290c21e4 \
+                    size    22158956
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4b686e6c7616225759f762f4d5a769ceb13c78bc \
-                    sha256  7cf6b3a0f971d1f5ade6e73dd3876ce77a69ff4065b06afddff530875ad33eaf \
-                    size    22090949
+    checksums       rmd160  a74921bf360f89e96793a5f0cc8597fc7a39d5fe \
+                    sha256  6e60c5a22fe9694f8802ee3dce7ad0191c23c33f3f02993af7e720a5fa429251 \
+                    size    22159143
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 266.0.0 and added a long description.

###### Tested on

macOS 10.14.6 18G103
Xcode 11.0 11A420a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?