### PR TITLE
Add negative variants information to mpstats submissions

### DIFF
--- a/sysutils/mpstats/Portfile
+++ b/sysutils/mpstats/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                mpstats
 version             0.1.8
-revision            5
+revision            6
 categories          sysutils macports
 license             BSD
 platforms           darwin

--- a/sysutils/mpstats/files/mpstats.tcl
+++ b/sysutils/mpstats/files/mpstats.tcl
@@ -287,9 +287,6 @@ proc json_encode_stats {id os_dict ports_dict} {
     upvar 1 $os_dict os
     upvar 1 $ports_dict ports
 
-    set os_json [json_encode_dict os]
-    set active_ports_json [json_encode_portlist [dict get $ports "active"]]
-
     set json "\{"
     append json "\n  \"id\": \"$id\","
     append json "\n  \"os\": [json_encode_dict os "  "],"

--- a/sysutils/mpstats/files/mpstats.tcl
+++ b/sysutils/mpstats/files/mpstats.tcl
@@ -353,7 +353,12 @@ proc get_installed_ports {active} {
             } else {
                 set irequested ""
             }
-            set ivariantlist [split_variants $ivariants]
+
+            set nvariants [registry::property_retrieve $regref "negated_variants"]
+            if {$nvariants == 0} {
+                set nvariants ""
+            }
+            set ivariantlist [split_variants "$ivariants$nvariants"]
 
             lappend results [list name $iname version "${iversion}_${irevision}" requested $irequested variants $ivariantlist]
         }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Generate version information with this command in shell:
    echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)"; echo "Xcode $(xcodebuild -version | awk '{print $NF}' | tr '\n' ' ')"
-->
macOS 10.13.6 17G5019
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
