### PR TITLE
cmake: Use clang_dependency PG

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -4,6 +4,9 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           xcodeversion 1.0
 
+# Cmake is a depedency of clang
+PortGroup           clang_dependency 1.0
+
 # use legacy support if OSX <= 10.11 && Xcode < 8.
 # Xcode 8 provides "clock_gettime" while Xcode 7 doesn't.
 # legacysupport is used for 10.11 just for this specific feature.
@@ -136,8 +139,6 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10 && ${cxx_stdlib} eq "libc++"
 if {${os.platform} eq "darwin" && ${os.major} == 11 && ${configure.cxx_stdlib} eq "libc++"} {
     compiler.whitelist macports-clang-3.4
 }
-# Clang 3.9 and later require cmake; avoid circular dependency.
-compiler.blacklist-append macports-clang-3.9 {macports-clang-[4-9].0}
 
 platform darwin {
     configure.env-append \


### PR DESCRIPTION

Switch cmake port to use clang_dependency PG.